### PR TITLE
chore: ruff auto-fix UP006 — non-pep585-annotation

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -115,8 +115,8 @@ def make_tool_progress_cb(
     conn: acp.Client,
     session_id: str,
     loop: asyncio.AbstractEventLoop,
-    tool_call_ids: Dict[str, Deque[str]],
-    tool_call_meta: Dict[str, Dict[str, Any]],
+    tool_call_ids: dict[str, deque[str]],
+    tool_call_meta: dict[str, dict[str, Any]],
     edit_approval_policy_getter: Callable[[], tuple[str, str | None]] | None = None,
 ) -> Callable:
     """Create a ``tool_progress_callback`` for AIAgent.
@@ -210,8 +210,8 @@ def make_step_cb(
     conn: acp.Client,
     session_id: str,
     loop: asyncio.AbstractEventLoop,
-    tool_call_ids: Dict[str, Deque[str]],
-    tool_call_meta: Dict[str, Dict[str, Any]],
+    tool_call_ids: dict[str, deque[str]],
+    tool_call_meta: dict[str, dict[str, Any]],
 ) -> Callable:
     """Create a ``step_callback`` for AIAgent.
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1339,7 +1339,7 @@ class HermesACPAgent(acp.Agent):
         if state.cancel_event:
             state.cancel_event.clear()
 
-        tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
+        tool_call_ids: dict[str, deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
         previous_approval_cb = None
         edit_approval_requester = None

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -138,11 +138,11 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
 
 
 def _expand_acp_enabled_toolsets(
-    toolsets: List[str] | None = None,
-    mcp_server_names: List[str] | None = None,
-) -> List[str]:
+    toolsets: list[str] | None = None,
+    mcp_server_names: list[str] | None = None,
+) -> list[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
-    expanded: List[str] = []
+    expanded: list[str] = []
     for name in list(toolsets or ["hermes-acp"]):
         if name and name not in expanded:
             expanded.append(name)
@@ -174,10 +174,10 @@ class SessionState:
     agent: Any  # AIAgent instance
     cwd: str = "."
     model: str = ""
-    history: List[Dict[str, Any]] = field(default_factory=list)
+    history: list[dict[str, Any]] = field(default_factory=list)
     cancel_event: Any = None  # threading.Event
     is_running: bool = False
-    queued_prompts: List[str] = field(default_factory=list)
+    queued_prompts: list[str] = field(default_factory=list)
     runtime_lock: Any = field(default_factory=Lock)
     current_prompt_text: str = ""
     interrupted_prompt_text: str = ""
@@ -200,7 +200,7 @@ class SessionManager:
             db:            Optional SessionDB instance. When omitted, the default
                            SessionDB (``~/.hermes/state.db``) is lazily created.
         """
-        self._sessions: Dict[str, SessionState] = {}
+        self._sessions: dict[str, SessionState] = {}
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
@@ -280,7 +280,7 @@ class SessionManager:
         logger.info("Forked ACP session %s -> %s", session_id, new_id)
         return state
 
-    def list_sessions(self, cwd: str | None = None) -> List[Dict[str, Any]]:
+    def list_sessions(self, cwd: str | None = None) -> list[dict[str, Any]]:
         """Return lightweight info dicts for all sessions (memory + database)."""
         normalized_cwd = _normalize_cwd_for_compare(cwd) if cwd else None
         db = self._get_db()

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -18,7 +18,7 @@ from acp.schema import (
 # Map hermes tool names -> ACP ToolKind
 # ---------------------------------------------------------------------------
 
-TOOL_KIND_MAP: Dict[str, ToolKind] = {
+TOOL_KIND_MAP: dict[str, ToolKind] = {
     # File operations
     "read_file": "read",
     "write_file": "edit",
@@ -88,7 +88,7 @@ def make_tool_call_id() -> str:
     return f"tc-{uuid.uuid4().hex[:12]}"
 
 
-def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
+def build_tool_title(tool_name: str, args: dict[str, Any]) -> str:
     """Build a human-readable title for a tool call."""
     if tool_name == "terminal":
         cmd = args.get("command", "")
@@ -285,7 +285,7 @@ def _format_todo_result(result: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _format_read_file_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_read_file_result(result: Optional[str], args: Optional[dict[str, Any]]) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -432,7 +432,7 @@ def _format_skill_view_result(result: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _format_skill_manage_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_skill_manage_result(result: Optional[str], args: Optional[dict[str, Any]]) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -513,7 +513,7 @@ def _format_web_extract_result(result: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _format_process_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_process_result(result: Optional[str], args: Optional[dict[str, Any]]) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -637,7 +637,7 @@ def _format_session_search_result(result: Optional[str]) -> Optional[str]:
     return _truncate_text("\n".join(lines), limit=7000)
 
 
-def _format_memory_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_memory_result(result: Optional[str], args: Optional[dict[str, Any]]) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -664,7 +664,7 @@ def _format_memory_result(result: Optional[str], args: Optional[Dict[str, Any]])
     return "\n".join(lines)
 
 
-def _format_edit_result(tool_name: str, result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_edit_result(tool_name: str, result: Optional[str], args: Optional[dict[str, Any]]) -> Optional[str]:
     data = _json_loads_maybe(result)
     path = str((args or {}).get("path") or "file").strip()
     if isinstance(data, dict):
@@ -687,7 +687,7 @@ def _format_edit_result(tool_name: str, result: Optional[str], args: Optional[Di
     return f"✅ {tool_name} completed" + (f" for `{path}`" if path else "")
 
 
-def _format_browser_result(tool_name: str, result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_browser_result(tool_name: str, result: Optional[str], args: Optional[dict[str, Any]]) -> Optional[str]:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -733,7 +733,7 @@ def _format_structured_value(
     indent: int = 0,
     max_depth: int = 3,
     max_items: int = 8,
-) -> List[str]:
+) -> list[str]:
     """Render nested JSON-ish values as compact Markdown bullets, not inline blobs."""
     prefix = "  " * indent
     bullet = f"{prefix}- "
@@ -871,8 +871,8 @@ def _format_generic_structured_result(
 def _build_polished_completion_content(
     tool_name: str,
     result: Optional[str],
-    function_args: Optional[Dict[str, Any]],
-) -> Optional[List[Any]]:
+    function_args: Optional[dict[str, Any]],
+) -> Optional[list[Any]]:
     formatter = {
         "todo": lambda: _format_todo_result(result),
         "read_file": lambda: _format_read_file_result(result, function_args),
@@ -907,7 +907,7 @@ def _build_polished_completion_content(
     return [_text(text)]
 
 
-def _build_patch_mode_content(patch_text: str) -> List[Any]:
+def _build_patch_mode_content(patch_text: str) -> list[Any]:
     """Parse V4A patch mode input into ACP diff blocks when possible."""
     if not patch_text:
         return [acp.tool_content(acp.text_block(""))]
@@ -919,7 +919,7 @@ def _build_patch_mode_content(patch_text: str) -> List[Any]:
         if error or not operations:
             return [acp.tool_content(acp.text_block(patch_text))]
 
-        content: List[Any] = []
+        content: list[Any] = []
         for op in operations:
             if op.operation == OperationType.UPDATE:
                 old_chunks: list[str] = []
@@ -980,12 +980,12 @@ def _strip_diff_prefix(path: str) -> str:
     return raw
 
 
-def _parse_unified_diff_content(diff_text: str) -> List[Any]:
+def _parse_unified_diff_content(diff_text: str) -> list[Any]:
     """Convert unified diff text into ACP diff content blocks."""
     if not diff_text:
         return []
 
-    content: List[Any] = []
+    content: list[Any] = []
     current_old_path: Optional[str] = None
     current_new_path: Optional[str] = None
     old_lines: list[str] = []
@@ -1043,9 +1043,9 @@ def _build_tool_complete_content(
     tool_name: str,
     result: Optional[str],
     *,
-    function_args: Optional[Dict[str, Any]] = None,
+    function_args: Optional[dict[str, Any]] = None,
     snapshot: Any = None,
-) -> List[Any]:
+) -> list[Any]:
     """Build structured ACP completion content, falling back to plain text."""
     display_result = result or ""
     if len(display_result) > 5000:
@@ -1083,7 +1083,7 @@ def _build_tool_complete_content(
 def build_tool_start(
     tool_call_id: str,
     tool_name: str,
-    arguments: Dict[str, Any],
+    arguments: dict[str, Any],
     *,
     edit_diff: Any = None,
 ) -> ToolCallStart:
@@ -1316,7 +1316,7 @@ def build_tool_complete(
     tool_call_id: str,
     tool_name: str,
     result: Optional[str] = None,
-    function_args: Optional[Dict[str, Any]] = None,
+    function_args: Optional[dict[str, Any]] = None,
     snapshot: Any = None,
 ) -> ToolCallProgress:
     """Create a ToolCallUpdate (progress) event for a completed tool call."""
@@ -1346,10 +1346,10 @@ def build_tool_complete(
 
 
 def extract_locations(
-    arguments: Dict[str, Any],
-) -> List[ToolCallLocation]:
+    arguments: dict[str, Any],
+) -> list[ToolCallLocation]:
     """Extract file-system locations from tool arguments."""
-    locations: List[ToolCallLocation] = []
+    locations: list[ToolCallLocation] = []
     path = arguments.get("path")
     if path:
         line = arguments.get("offset") or arguments.get("line")

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -77,7 +77,7 @@ def _normalized_custom_base_url(value: Any) -> str:
     return value.strip().rstrip("/")
 
 
-def _custom_provider_model_matches(agent_model: str, entry: Dict[str, Any]) -> bool:
+def _custom_provider_model_matches(agent_model: str, entry: dict[str, Any]) -> bool:
     provider_model = str(entry.get("model", "") or "").strip().lower()
     if not provider_model:
         return True
@@ -89,8 +89,8 @@ def _custom_provider_extra_body_for_agent(
     provider: str,
     model: str,
     base_url: str,
-    custom_providers: List[Dict[str, Any]],
-) -> Optional[Dict[str, Any]]:
+    custom_providers: list[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
     if (provider or "").strip().lower() != "custom":
         return None
 
@@ -98,7 +98,7 @@ def _custom_provider_extra_body_for_agent(
     if not target_url:
         return None
 
-    fallback: Optional[Dict[str, Any]] = None
+    fallback: Optional[dict[str, Any]] = None
     for entry in custom_providers or []:
         if not isinstance(entry, dict):
             continue
@@ -117,7 +117,7 @@ def _custom_provider_extra_body_for_agent(
     return fallback
 
 
-def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, Any]]) -> None:
+def _merge_custom_provider_extra_body(agent, custom_providers: list[dict[str, Any]]) -> None:
     extra_body = _custom_provider_extra_body_for_agent(
         provider=agent.provider,
         model=agent.model,
@@ -149,17 +149,17 @@ def init_agent(
     model: str = "",
     max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
     tool_delay: float = 1.0,
-    enabled_toolsets: List[str] = None,
-    disabled_toolsets: List[str] = None,
+    enabled_toolsets: list[str] = None,
+    disabled_toolsets: list[str] = None,
     save_trajectories: bool = False,
     verbose_logging: bool = False,
     quiet_mode: bool = False,
     ephemeral_system_prompt: str = None,
     log_prefix_chars: int = 100,
     log_prefix: str = "",
-    providers_allowed: List[str] = None,
-    providers_ignored: List[str] = None,
-    providers_order: List[str] = None,
+    providers_allowed: list[str] = None,
+    providers_ignored: list[str] = None,
+    providers_order: list[str] = None,
     provider_sort: str = None,
     provider_require_parameters: bool = False,
     provider_data_collection: str = None,
@@ -177,10 +177,10 @@ def init_agent(
     tool_gen_callback: callable = None,
     status_callback: callable = None,
     max_tokens: int = None,
-    reasoning_config: Dict[str, Any] = None,
+    reasoning_config: dict[str, Any] = None,
     service_tier: str = None,
-    request_overrides: Dict[str, Any] = None,
-    prefill_messages: List[Dict[str, Any]] = None,
+    request_overrides: dict[str, Any] = None,
+    prefill_messages: list[dict[str, Any]] = None,
     platform: str = None,
     user_id: str = None,
     user_name: str = None,
@@ -195,7 +195,7 @@ def init_agent(
     session_db=None,
     parent_session_id: str = None,
     iteration_budget: "IterationBudget" = None,
-    fallback_model: Dict[str, Any] = None,
+    fallback_model: dict[str, Any] = None,
     credential_pool=None,
     checkpoints_enabled: bool = False,
     checkpoint_max_snapshots: int = 20,
@@ -566,7 +566,7 @@ def init_agent(
     # Cache anthropic image-to-text fallbacks per image payload/URL so a
     # single tool loop does not repeatedly re-run auxiliary vision on the
     # same image history.
-    agent._anthropic_image_fallback_cache: Dict[str, str] = {}
+    agent._anthropic_image_fallback_cache: dict[str, str] = {}
 
     # Initialize LLM client via centralized provider router.
     # The router handles auth resolution, base URL, headers, and
@@ -1004,7 +1004,7 @@ def init_agent(
     # breadcrumb path written by agent_runtime_helpers.dump_api_request_debug).
     
     # Track conversation messages for session logging
-    agent._session_messages: List[Dict[str, Any]] = []
+    agent._session_messages: list[dict[str, Any]] = []
     agent._memory_write_origin = "assistant_tool"
     agent._memory_write_context = "foreground"
     

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -54,7 +54,7 @@ def _ra():
 
 
 
-def convert_to_trajectory_format(agent, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
+def convert_to_trajectory_format(agent, messages: list[dict[str, Any]], user_query: str, completed: bool) -> list[dict[str, Any]]:
     """
     Convert internal message format to trajectory format for saving.
     
@@ -335,7 +335,7 @@ def sanitize_tool_call_arguments(
 
 
 
-def repair_message_sequence(agent, messages: List[Dict]) -> int:
+def repair_message_sequence(agent, messages: list[dict]) -> int:
     """Collapse malformed role-alternation left in the live history.
 
     Providers (OpenAI, OpenRouter, Anthropic) expect strict alternation:
@@ -374,7 +374,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # assistant tool_call_id. Uses a rolling set of known ids refreshed
     # on each assistant message.
     known_tool_ids: set = set()
-    filtered: List[Dict] = []
+    filtered: list[dict] = []
     for msg in messages:
         if not isinstance(msg, dict):
             filtered.append(msg)
@@ -403,7 +403,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
 
     # Pass 2: merge consecutive user messages. Preserves all user input
     # so nothing the user typed is lost.
-    merged: List[Dict] = []
+    merged: list[dict] = []
     for msg in filtered:
         if (
             merged
@@ -539,7 +539,7 @@ def recover_with_credential_pool(
     status_code: Optional[int],
     has_retried_429: bool,
     classified_reason: Optional[FailoverReason] = None,
-    error_context: Optional[Dict[str, Any]] = None,
+    error_context: Optional[dict[str, Any]] = None,
 ) -> tuple[bool, bool]:
     """Attempt credential recovery via pool rotation.
 
@@ -755,8 +755,8 @@ def try_recover_primary_transport(
 
 
 def drop_thinking_only_and_merge_users(
-    messages: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
     """Drop thinking-only assistant turns; merge any adjacent user messages left behind.
 
     Runs on the per-call ``api_messages`` copy only. The stored
@@ -783,7 +783,7 @@ def drop_thinking_only_and_merge_users(
         return messages
 
     # Pass 2: merge any newly-adjacent user messages.
-    merged: List[Dict[str, Any]] = []
+    merged: list[dict[str, Any]] = []
     merges = 0
     for m in kept:
         prev = merged[-1] if merged else None
@@ -815,7 +815,7 @@ def drop_thinking_only_and_merge_users(
                 else:
                     prev_copy["content"] = list(prev_content)
             elif isinstance(prev_content, str) and isinstance(cur_content, list):
-                new_blocks: List[Dict[str, Any]] = []
+                new_blocks: list[dict[str, Any]] = []
                 if prev_content:
                     new_blocks.append({"type": "text", "text": prev_content})
                 new_blocks.extend(cur_content)
@@ -1020,7 +1020,7 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
 
 def dump_api_request_debug(
     agent,
-    api_kwargs: Dict[str, Any],
+    api_kwargs: dict[str, Any],
     *,
     reason: str,
     error: Optional[Exception] = None,
@@ -1043,7 +1043,7 @@ def dump_api_request_debug(
         except Exception as e:
             _ra().logger.debug("Could not extract API key for debug dump: %s", e)
 
-        dump_payload: Dict[str, Any] = {
+        dump_payload: dict[str, Any] = {
             "timestamp": datetime.now().isoformat(),
             "session_id": agent.session_id,
             "reason": reason,
@@ -1059,7 +1059,7 @@ def dump_api_request_debug(
         }
 
         if error is not None:
-            error_info: Dict[str, Any] = {
+            error_info: dict[str, Any] = {
                 "type": type(error).__name__,
                 "message": str(error),
             }
@@ -1685,7 +1685,7 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
 
 
 
-def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def sanitize_api_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Fix orphaned tool_call / tool_result pairs before every LLM call.
 
     Runs unconditionally — not gated on whether the context compressor
@@ -1735,7 +1735,7 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # 2. Inject stub results for calls whose result was dropped
     missing_results = surviving_call_ids - result_call_ids
     if missing_results:
-        patched: List[Dict[str, Any]] = []
+        patched: list[dict[str, Any]] = []
         for msg in messages:
             patched.append(msg)
             if msg.get("role") == "assistant":
@@ -1761,7 +1761,7 @@ def looks_like_codex_intermediate_ack(
     agent,
     user_message: str,
     assistant_content: str,
-    messages: List[Dict[str, Any]],
+    messages: list[dict[str, Any]],
 ) -> bool:
     """Detect a planning/ack message that should continue instead of ending the turn."""
     if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
@@ -2018,9 +2018,9 @@ def cleanup_dead_connections(agent) -> bool:
 
 
 
-def extract_api_error_context(error: Exception) -> Dict[str, Any]:
+def extract_api_error_context(error: Exception) -> dict[str, Any]:
     """Extract structured rate-limit details from provider errors."""
-    context: Dict[str, Any] = {}
+    context: dict[str, Any] = {}
 
     body = getattr(error, "body", None)
     payload = None

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -795,7 +795,7 @@ def build_anthropic_bedrock_client(region: str):
     )
 
 
-def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
+def _read_claude_code_credentials_from_keychain() -> Optional[dict[str, Any]]:
     """Read Claude Code OAuth credentials from the macOS Keychain.
 
     Claude Code >=2.1.114 stores credentials in the macOS Keychain under the
@@ -852,7 +852,7 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     return None
 
 
-def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
+def read_claude_code_credentials() -> Optional[dict[str, Any]]:
     """Read refreshable Claude Code OAuth credentials.
 
     Checks two sources in order:
@@ -906,7 +906,7 @@ def read_claude_managed_key() -> Optional[str]:
     return None
 
 
-def is_claude_code_token_valid(creds: Dict[str, Any]) -> bool:
+def is_claude_code_token_valid(creds: dict[str, Any]) -> bool:
     """Check if Claude Code credentials have a non-expired access token."""
     import time
 
@@ -921,7 +921,7 @@ def is_claude_code_token_valid(creds: Dict[str, Any]) -> bool:
     return now_ms < (expires_at - 60_000)
 
 
-def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) -> Dict[str, Any]:
+def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) -> dict[str, Any]:
     """Refresh an Anthropic OAuth token without mutating local credential files."""
     import time
     import urllib.parse
@@ -985,7 +985,7 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
     raise ValueError("Anthropic token refresh failed")
 
 
-def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
+def _refresh_oauth_token(creds: dict[str, Any]) -> Optional[str]:
     """Attempt to refresh an expired Claude Code OAuth token."""
     refresh_token = creds.get("refreshToken", "")
     if not refresh_token:
@@ -1027,7 +1027,7 @@ def _write_claude_code_credentials(
         if cred_path.exists():
             existing = json.loads(cred_path.read_text(encoding="utf-8"))
 
-        oauth_data: Dict[str, Any] = {
+        oauth_data: dict[str, Any] = {
             "accessToken": access_token,
             "refreshToken": refresh_token,
             "expiresAt": expires_at_ms,
@@ -1074,7 +1074,7 @@ def _write_claude_code_credentials(
         logger.debug("Failed to write refreshed credentials: %s", e)
 
 
-def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] = None) -> Optional[str]:
+def _resolve_claude_code_token_from_credentials(creds: Optional[dict[str, Any]] = None) -> Optional[str]:
     """Resolve a token from Claude Code credential files, refreshing if needed."""
     creds = creds or read_claude_code_credentials()
     if creds and is_claude_code_token_valid(creds):
@@ -1089,7 +1089,7 @@ def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] 
     return None
 
 
-def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[str, Any]]) -> Optional[str]:
+def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[dict[str, Any]]) -> Optional[str]:
     """Prefer Claude Code creds when a persisted env OAuth token would shadow refresh.
 
     Hermes historically persisted setup tokens into ANTHROPIC_TOKEN. That makes
@@ -1219,7 +1219,7 @@ def _generate_pkce() -> tuple:
     return verifier, challenge
 
 
-def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
+def run_hermes_oauth_login_pure() -> Optional[dict[str, Any]]:
     """Run Hermes-native OAuth PKCE flow and return credential state."""
     import secrets
     import time
@@ -1324,7 +1324,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     }
 
 
-def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
+def read_hermes_oauth_credentials() -> Optional[dict[str, Any]]:
     """Read Hermes-managed OAuth credentials from ~/.hermes/.anthropic_oauth.json."""
     if _HERMES_OAUTH_FILE.exists():
         try:
@@ -1403,7 +1403,7 @@ def _sanitize_tool_id(tool_id: str) -> str:
     return sanitized or "tool_0"
 
 
-def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
+def _normalize_tool_input_schema(schema: Any) -> dict[str, Any]:
     """Normalize tool schemas before sending them to Anthropic.
 
     Anthropic's tool schema validator rejects nullable unions such as
@@ -1444,7 +1444,7 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
     return normalized
 
 
-def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
+def convert_tools_to_anthropic(tools: list[dict]) -> list[dict]:
     """Convert OpenAI tool definitions to Anthropic format."""
     if not tools:
         return []
@@ -1465,7 +1465,7 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
             continue
         if name:
             seen_names.add(name)
-        anthropic_tool: Dict[str, Any] = {
+        anthropic_tool: dict[str, Any] = {
             "name": name,
             "description": fn.get("description", ""),
             "input_schema": _normalize_tool_input_schema(
@@ -1482,7 +1482,7 @@ def convert_tools_to_anthropic(tools: List[Dict]) -> List[Dict]:
     return result
 
 
-def _image_source_from_openai_url(url: str) -> Dict[str, str]:
+def _image_source_from_openai_url(url: str) -> dict[str, str]:
     """Convert an OpenAI-style image URL/data URL into Anthropic image source."""
     url = str(url or "").strip()
     if not url:
@@ -1504,7 +1504,7 @@ def _image_source_from_openai_url(url: str) -> Dict[str, str]:
     return {"type": "url", "url": url}
 
 
-def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
+def _convert_content_part_to_anthropic(part: Any) -> Optional[dict[str, Any]]:
     """Convert a single OpenAI-style content part to Anthropic format."""
     if part is None:
         return None
@@ -1516,7 +1516,7 @@ def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
     ptype = part.get("type")
 
     if ptype == "input_text":
-        block: Dict[str, Any] = {"type": "text", "text": part.get("text", "")}
+        block: dict[str, Any] = {"type": "text", "text": part.get("text", "")}
     elif ptype in {"image_url", "input_image"}:
         image_value = part.get("image_url", {})
         url = image_value.get("url", "") if isinstance(image_value, dict) else str(image_value or "")
@@ -1575,13 +1575,13 @@ def _to_plain_data(value: Any, *, _depth: int = 0, _path: Optional[set] = None) 
     return value
 
 
-def _extract_preserved_thinking_blocks(message: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _extract_preserved_thinking_blocks(message: dict[str, Any]) -> list[dict[str, Any]]:
     """Return Anthropic thinking blocks previously preserved on the message."""
     raw_details = message.get("reasoning_details")
     if not isinstance(raw_details, list):
         return []
 
-    preserved: List[Dict[str, Any]] = []
+    preserved: list[dict[str, Any]] = []
     for detail in raw_details:
         if not isinstance(detail, dict):
             continue
@@ -1605,7 +1605,7 @@ def _convert_content_to_anthropic(content: Any) -> Any:
     return converted
 
 
-def _content_parts_to_anthropic_blocks(parts: Any) -> List[Dict[str, Any]]:
+def _content_parts_to_anthropic_blocks(parts: Any) -> list[dict[str, Any]]:
     """Convert OpenAI-style tool-message content parts → Anthropic tool_result inner blocks.
 
     Used for multimodal tool results (e.g. computer_use screenshots). Each
@@ -1614,7 +1614,7 @@ def _content_parts_to_anthropic_blocks(parts: Any) -> List[Dict[str, Any]]:
     """
     if not isinstance(parts, list):
         return []
-    out: List[Dict[str, Any]] = []
+    out: list[dict[str, Any]] = []
     for part in parts:
         block = _convert_content_part_to_anthropic(part)
         if not block:
@@ -1631,7 +1631,7 @@ def _content_parts_to_anthropic_blocks(parts: Any) -> List[Dict[str, Any]]:
     return out
 
 
-def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
+def _convert_assistant_message(m: dict[str, Any]) -> dict[str, Any]:
     """Convert an assistant message to Anthropic content blocks.
 
     Handles thinking blocks, regular content, tool calls, and
@@ -1694,7 +1694,7 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _convert_tool_message_to_result(
-    result: List[Dict[str, Any]], m: Dict[str, Any]
+    result: list[dict[str, Any]], m: dict[str, Any]
 ) -> None:
     """Convert a tool message to an Anthropic tool_result, merging consecutive
     results into one user message.
@@ -1703,7 +1703,7 @@ def _convert_tool_message_to_result(
     the trailing user message's tool_result list.
     """
     content = m.get("content", "")
-    multimodal_blocks: Optional[List[Dict[str, Any]]] = None
+    multimodal_blocks: Optional[list[dict[str, Any]]] = None
     if isinstance(content, dict) and content.get("_multimodal"):
         multimodal_blocks = _content_parts_to_anthropic_blocks(
             content.get("content") or []
@@ -1755,7 +1755,7 @@ def _convert_tool_message_to_result(
         result.append({"role": "user", "content": [tool_result]})
 
 
-def _convert_user_message(content: Any) -> Dict[str, Any]:
+def _convert_user_message(content: Any) -> dict[str, Any]:
     """Validate and convert a user message to anthropic format."""
     if isinstance(content, list):
         converted_blocks = _convert_content_to_anthropic(content)
@@ -1772,7 +1772,7 @@ def _convert_user_message(content: Any) -> Dict[str, Any]:
         return {"role": "user", "content": content}
 
 
-def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
+def _strip_orphaned_tool_blocks(result: list[dict[str, Any]]) -> None:
     """Strip tool_use blocks with no matching tool_result, and vice versa.
 
     Context compression or session truncation can remove either side of a
@@ -1815,7 +1815,7 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
                 m["content"] = [{"type": "text", "text": "(tool result removed)"}]
 
 
-def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _merge_consecutive_roles(result: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Merge consecutive same-role messages to enforce Anthropic alternation.
 
     Returns a new list (caller must rebind ``result``).
@@ -1864,7 +1864,7 @@ def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any
 
 
 def _manage_thinking_signatures(
-    result: List[Dict[str, Any]], base_url: str | None, model: str | None
+    result: list[dict[str, Any]], base_url: str | None, model: str | None
 ) -> None:
     """Strip or preserve thinking blocks based on endpoint type.
 
@@ -1951,7 +1951,7 @@ def _manage_thinking_signatures(
                 b.pop("cache_control", None)
 
 
-def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:
+def _evict_old_screenshots(result: list[dict[str, Any]]) -> None:
     """Keep only the most recent ``_MAX_KEEP_IMAGES`` computer-use screenshots.
 
     Base64 images cost ~1,465 tokens each and accumulate across tool calls.
@@ -1987,10 +1987,10 @@ def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:
 
 
 def convert_messages_to_anthropic(
-    messages: List[Dict],
+    messages: list[dict],
     base_url: str | None = None,
     model: str | None = None,
-) -> Tuple[Optional[Any], List[Dict]]:
+) -> tuple[Optional[Any], list[dict]]:
     """Convert OpenAI-format messages to Anthropic format.
 
     Returns (system_prompt, anthropic_messages).
@@ -2009,7 +2009,7 @@ def convert_messages_to_anthropic(
     if empty.
     """
     system = None
-    result: List[Dict[str, Any]] = []
+    result: list[dict[str, Any]] = []
 
     for m in messages:
         role = m.get("role", "user")
@@ -2052,10 +2052,10 @@ def convert_messages_to_anthropic(
 
 def build_anthropic_kwargs(
     model: str,
-    messages: List[Dict],
-    tools: Optional[List[Dict]],
+    messages: list[dict],
+    tools: Optional[list[dict]],
     max_tokens: Optional[int],
-    reasoning_config: Optional[Dict[str, Any]],
+    reasoning_config: Optional[dict[str, Any]],
     tool_choice: Optional[str] = None,
     is_oauth: bool = False,
     preserve_dots: bool = False,
@@ -2063,7 +2063,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
     Naming note — two distinct concepts, easily confused:
@@ -2168,7 +2168,7 @@ def build_anthropic_kwargs(
                         elif block.get("type") == "tool_result" and "tool_use_id" in block:
                             pass  # tool_result uses ID, not name
 
-    kwargs: Dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "model": model,
         "messages": anthropic_messages,
         "max_tokens": effective_max_tokens,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -258,7 +258,7 @@ def _get_aux_model_for_provider(provider_id: str) -> str:
 # Fallback for providers not yet migrated to ProviderProfile.default_aux_model,
 # plus providers we intentionally keep pinned here (e.g. Anthropic predates
 # profiles). New providers should set default_aux_model on their profile instead.
-_API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
+_API_KEY_PROVIDER_AUX_MODELS_FALLBACK: dict[str, str] = {
     "gemini": "gemini-3-flash-preview",
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
@@ -279,13 +279,13 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
 
 # Legacy alias — callers that haven't been updated to _get_aux_model_for_provider()
 # can still use this dict directly. Kept in sync with _FALLBACK above.
-_API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALLBACK
+_API_KEY_PROVIDER_AUX_MODELS: dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALLBACK
 
 # Vision-specific model overrides for direct providers.
 # When the user's main provider has a dedicated vision/multimodal model that
 # differs from their main chat model, map it here.  The vision auto-detect
 # "exotic provider" branch checks this before falling back to the main model.
-_PROVIDER_VISION_MODELS: Dict[str, str] = {
+_PROVIDER_VISION_MODELS: dict[str, str] = {
     "xiaomi": "mimo-v2.5",
     "zai": "glm-5v-turbo",
 }
@@ -441,7 +441,7 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
-def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
+def _codex_cloudflare_headers(access_token: str) -> dict[str, str]:
     """Headers required to avoid Cloudflare 403s on chatgpt.com/backend-api/codex.
 
     The Cloudflare layer in front of the Codex endpoint whitelists a small set of
@@ -510,7 +510,7 @@ def _to_openai_base_url(base_url: str) -> str:
     return url
 
 
-def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
+def _select_pool_entry(provider: str) -> tuple[bool, Optional[Any]]:
     """Return (pool_exists_for_provider, selected_entry)."""
     try:
         pool = load_pool(provider)
@@ -597,7 +597,7 @@ def _convert_content_for_responses(content: Any) -> Any:
     if not isinstance(content, list):
         return str(content) if content else ""
 
-    converted: List[Dict[str, Any]] = []
+    converted: list[dict[str, Any]] = []
     for part in content:
         if not isinstance(part, dict):
             continue
@@ -608,7 +608,7 @@ def _convert_content_for_responses(content: Any) -> Any:
             # chat.completions nests the URL: {"image_url": {"url": "..."}}
             image_data = part.get("image_url", {})
             url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data)
-            entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
+            entry: dict[str, Any] = {"type": "input_image", "image_url": url}
             # Preserve detail if specified
             detail = image_data.get("detail") if isinstance(image_data, dict) else None
             if detail:
@@ -642,7 +642,7 @@ class _CodexCompletionsAdapter:
         # Convert chat.completions multimodal content blocks to Responses
         # API format (input_text / input_image instead of text / image_url).
         instructions = "You are a helpful assistant."
-        input_msgs: List[Dict[str, Any]] = []
+        input_msgs: list[dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
@@ -654,7 +654,7 @@ class _CodexCompletionsAdapter:
                     "content": _convert_content_for_responses(content),
                 })
 
-        resp_kwargs: Dict[str, Any] = {
+        resp_kwargs: dict[str, Any] = {
             "model": model,
             "instructions": instructions,
             "input": input_msgs or [{"role": "user", "content": ""}],
@@ -738,8 +738,8 @@ class _CodexCompletionsAdapter:
                 resp_kwargs["tools"] = converted
 
         # Stream and collect the response
-        text_parts: List[str] = []
-        tool_calls_raw: List[Any] = []
+        text_parts: list[str] = []
+        tool_calls_raw: list[Any] = []
         usage = None
         total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
@@ -788,8 +788,8 @@ class _CodexCompletionsAdapter:
             # Collect output items and text deltas during streaming —
             # the Codex backend can return empty response.output from
             # get_final_response() even when items were streamed.
-            collected_output_items: List[Any] = []
-            collected_text_deltas: List[str] = []
+            collected_output_items: list[Any] = []
+            collected_text_deltas: list[str] = []
             has_function_calls = False
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
@@ -1293,7 +1293,7 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
     return api_key, base_url
 
 
-def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
+def _resolve_xai_oauth_for_aux() -> Optional[tuple[str, str]]:
     """Resolve a fresh xAI OAuth (api_key, base_url) for auxiliary clients.
 
     Prefer the credential pool, matching the main runtime/provider status
@@ -1391,7 +1391,7 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
-def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
+def _resolve_api_key_provider() -> tuple[Optional[OpenAI], Optional[str]]:
     """Try each API-key provider in PROVIDER_REGISTRY order.
 
     Returns (client, model) for the first provider with usable runtime
@@ -1500,7 +1500,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 
-def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_openrouter(explicit_api_key: str = None, model: str = None) -> tuple[Optional[OpenAI], Optional[str]]:
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
@@ -1534,7 +1534,7 @@ def _describe_openrouter_unavailable() -> str:
     return "no usable OpenRouter credentials found"
 
 
-def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_nous(vision: bool = False) -> tuple[Optional[OpenAI], Optional[str]]:
     # Check cross-session rate limit guard before attempting Nous —
     # if another session already recorded a 429, skip Nous entirely
     # to avoid piling more requests onto the tapped RPH bucket.
@@ -1696,7 +1696,7 @@ def clear_runtime_main() -> None:
     _RUNTIME_MAIN_MODEL = ""
 
 
-def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
+def _resolve_custom_runtime() -> tuple[Optional[str], Optional[str], Optional[str]]:
     """Resolve the active custom/main endpoint the same way the main CLI does.
 
     This covers both env-driven OPENAI_BASE_URL setups and config-saved custom
@@ -1798,7 +1798,7 @@ def _validate_base_url(base_url: str) -> None:
         ) from exc
 
 
-def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
+def _try_custom_endpoint() -> tuple[Optional[Any], Optional[str]]:
     runtime = _resolve_custom_runtime()
     if len(runtime) == 2:
         custom_base, custom_key = runtime
@@ -1842,7 +1842,7 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     return _fallback_client, model
 
 
-def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_xai_oauth_aux_client(model: str) -> tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an xAI Grok OAuth-authenticated session.
 
     xAI's ``/v1/responses`` endpoint speaks the OpenAI Responses API, so we
@@ -1868,7 +1868,7 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
-def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_codex_client(model: str) -> tuple[Optional[Any], Optional[str]]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
     There is no auto-selection of the Codex model: the ChatGPT-account
@@ -1915,7 +1915,7 @@ def _try_azure_foundry(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     api_mode: Optional[str] = None,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> tuple[Optional[Any], Optional[str]]:
     """Resolve an Azure Foundry auxiliary client via the runtime resolver.
 
     Mirrors the ``_try_anthropic`` / ``_try_nous`` shape but delegates to
@@ -1996,7 +1996,7 @@ def _try_azure_foundry(
     # Azure pre-v1 endpoints sometimes carry api-version query params
     # in the base URL; the OpenAI SDK drops them when joining paths,
     # so lift them out and pass via default_query.
-    extra: Dict[str, Any] = {}
+    extra: dict[str, Any] = {}
     _clean_base, _dq = _extract_url_query_params(base_url)
     if _dq:
         extra["default_query"] = _dq
@@ -2023,7 +2023,7 @@ def _try_azure_foundry(
     return client, final_model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _try_anthropic(explicit_api_key: str = None) -> tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
     except ImportError:
@@ -2081,7 +2081,7 @@ _AUTO_PROVIDER_LABELS = {
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
 
 
-def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _normalize_main_runtime(main_runtime: Optional[dict[str, Any]]) -> dict[str, Any]:
     """Return a sanitized copy of a live main-runtime override.
 
     Most fields are stripped strings. ``api_key`` may legitimately be a
@@ -2092,7 +2092,7 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     """
     if not isinstance(main_runtime, dict):
         return {}
-    normalized: Dict[str, Any] = {}
+    normalized: dict[str, Any] = {}
     for field in _MAIN_RUNTIME_FIELDS:
         value = main_runtime.get(field)
         # Preserve a callable api_key (Entra ID bearer provider) unchanged.
@@ -2107,7 +2107,7 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     return normalized
 
 
-def _get_provider_chain() -> List[tuple]:
+def _get_provider_chain() -> list[tuple]:
     """Return the ordered provider detection chain.
 
     Built at call time (not module level) so that test patches
@@ -2149,8 +2149,8 @@ def _get_provider_chain() -> List[tuple]:
 # the user might be running two profiles with different OpenRouter keys.
 
 _AUX_UNHEALTHY_TTL_SECONDS = 600  # 10 minutes
-_aux_unhealthy_until: Dict[str, float] = {}
-_aux_unhealthy_logged_at: Dict[str, float] = {}
+_aux_unhealthy_until: dict[str, float] = {}
+_aux_unhealthy_logged_at: dict[str, float] = {}
 
 # Map provider names that show up in resolved_provider / explicit-config
 # back to the chain labels used by _get_provider_chain(). Keep in sync
@@ -2452,7 +2452,7 @@ def _evict_cached_client_instance(target: Any) -> bool:
 def _pool_cache_hint(
     provider: str,
     *,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Optional[dict[str, Any]] = None,
 ) -> str:
     """Return a stable cache discriminator for pooled providers."""
     normalized = _normalize_aux_provider(provider)
@@ -2470,9 +2470,9 @@ def _pool_cache_hint(
     return f"{normalized}:{entry_id}"
 
 
-def _pool_error_context(exc: Exception) -> Dict[str, Any]:
+def _pool_error_context(exc: Exception) -> dict[str, Any]:
     status = getattr(exc, "status_code", None)
-    payload: Dict[str, Any] = {"message": str(exc)}
+    payload: dict[str, Any] = {"message": str(exc)}
     if status is not None:
         payload["status_code"] = status
     return payload
@@ -2547,7 +2547,7 @@ def _retry_same_provider_sync(
     resolved_base_url: Optional[str],
     resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str],
-    main_runtime: Optional[Dict[str, Any]],
+    main_runtime: Optional[dict[str, Any]],
     final_model: Optional[str],
     messages: list,
     temperature: Optional[float],
@@ -2702,7 +2702,7 @@ def _try_payment_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "payment error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> tuple[Optional[Any], Optional[str], str]:
     """Try alternative providers after a payment/credit or connection error.
 
     Iterates the standard auto-detection chain, skipping the provider that
@@ -2753,7 +2753,7 @@ def _try_main_agent_model_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> tuple[Optional[Any], Optional[str], str]:
     """Last-resort fallback to the user's main agent provider + model.
 
     Used after the configured fallback_chain is exhausted (or empty) for
@@ -2802,7 +2802,7 @@ def _try_configured_fallback_chain(
     task: str,
     failed_provider: str,
     reason: str = "error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> tuple[Optional[Any], Optional[str], str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
     Reads auxiliary.<task>.fallback_chain from config.yaml and tries each
@@ -2876,7 +2876,7 @@ def _resolve_single_provider(
     )
     return client
 
-def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _resolve_auto(main_runtime: Optional[dict[str, Any]] = None) -> tuple[Optional[OpenAI], Optional[str]]:
     """Full auto-detection chain.
 
     Priority:
@@ -3073,9 +3073,9 @@ def resolve_provider_client(
     explicit_base_url: str = None,
     explicit_api_key: str = None,
     api_mode: str = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Optional[dict[str, Any]] = None,
     is_vision: bool = False,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.
 
@@ -3683,8 +3683,8 @@ def resolve_provider_client(
 def get_text_auxiliary_client(
     task: str = "",
     *,
-    main_runtime: Optional[Dict[str, Any]] = None,
-) -> Tuple[Optional[OpenAI], Optional[str]]:
+    main_runtime: Optional[dict[str, Any]] = None,
+) -> tuple[Optional[OpenAI], Optional[str]]:
     """Return (client, default_model_slug) for text-only auxiliary tasks.
 
     Args:
@@ -3705,7 +3705,7 @@ def get_text_auxiliary_client(
     )
 
 
-def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Dict[str, Any]] = None):
+def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[dict[str, Any]] = None):
     """Return (async_client, model_slug) for async consumers.
 
     For standard providers returns (AsyncOpenAI, model). For Codex returns
@@ -3768,7 +3768,7 @@ def _normalize_vision_provider(provider: Optional[str]) -> str:
 def _resolve_strict_vision_backend(
     provider: str,
     model: Optional[str] = None,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> tuple[Optional[Any], Optional[str]]:
     provider = _normalize_vision_provider(provider)
     if provider == "copilot":
         return resolve_provider_client("copilot", model, is_vision=True)
@@ -3792,14 +3792,14 @@ def _strict_vision_backend_available(provider: str) -> bool:
     return _resolve_strict_vision_backend(provider)[0] is not None
 
 
-def get_available_vision_backends() -> List[str]:
+def get_available_vision_backends() -> list[str]:
     """Return the currently available vision backends in auto-selection order.
 
     Order: active provider → OpenRouter → Nous → stop.  This is the single
     source of truth for setup, tool gating, and runtime auto-routing of
     vision tasks.
     """
-    available: List[str] = []
+    available: list[str] = []
     # 1. Active provider — if the user configured a provider, try it first.
     main_provider = _read_main_provider()
     if main_provider and main_provider not in {"auto", ""}:
@@ -3824,7 +3824,7 @@ def resolve_vision_provider_client(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     async_mode: bool = False,
-) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
+) -> tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
 
     Direct endpoint overrides take precedence over provider selection. Explicit
@@ -4030,7 +4030,7 @@ def auxiliary_max_tokens_param(value: int) -> dict:
 # replaced in-place.  This bounds cache growth to one entry per unique
 # provider config rather than one per (config × event-loop), which previously
 # caused unbounded fd accumulation in long-running gateway processes (#10200).
-_client_cache: Dict[tuple, tuple] = {}
+_client_cache: dict[tuple, tuple] = {}
 _client_cache_lock = threading.Lock()
 _CLIENT_CACHE_MAX_SIZE = 64  # safety belt — evict oldest when exceeded
 
@@ -4042,7 +4042,7 @@ def _client_cache_key(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     api_mode: Optional[str] = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Optional[dict[str, Any]] = None,
     is_vision: bool = False,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
@@ -4073,9 +4073,9 @@ def _refresh_nous_auxiliary_client(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     api_mode: Optional[str] = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Optional[dict[str, Any]] = None,
     is_vision: bool = False,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> tuple[Optional[Any], Optional[str]]:
     """Refresh Nous runtime creds, rebuild the client, and replace the cache entry."""
     runtime = _resolve_nous_runtime_api(force_refresh=True)
     if runtime is None:
@@ -4239,9 +4239,9 @@ def _get_cached_client(
     base_url: str = None,
     api_key: str = None,
     api_mode: str = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Optional[dict[str, Any]] = None,
     is_vision: bool = False,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> tuple[Optional[Any], Optional[str]]:
     """Get or create a cached client for the given provider.
 
     Async clients (AsyncOpenAI) use httpx.AsyncClient internally, which
@@ -4341,7 +4341,7 @@ def _get_cached_client(
 # silently fell back to the user's main provider, sending OpenAI model names
 # to e.g. DeepSeek and producing cryptic ``unknown variant 'image_url'``
 # errors (issue #31179).
-_AUX_DIRECT_API_BASE_URLS: Dict[str, str] = {
+_AUX_DIRECT_API_BASE_URLS: dict[str, str] = {
     "openai": "https://api.openai.com/v1",
 }
 
@@ -4352,7 +4352,7 @@ def _resolve_task_provider_model(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
-) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
+) -> tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Determine provider + model for a call.
 
     Priority:
@@ -4388,7 +4388,7 @@ def _resolve_task_provider_model(
     # has already supplied a base_url we keep their endpoint but still rewrite
     # the provider to ``custom`` so resolution doesn't hit the
     # PROVIDER_REGISTRY-only path (which has no ``openai`` entry).
-    def _expand_direct_api_alias(prov: Optional[str], existing_base: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    def _expand_direct_api_alias(prov: Optional[str], existing_base: Optional[str]) -> tuple[Optional[str], Optional[str]]:
         if not prov:
             return prov, existing_base
         target_base = _AUX_DIRECT_API_BASE_URLS.get(prov.strip().lower())
@@ -4427,7 +4427,7 @@ def _resolve_task_provider_model(
 _DEFAULT_AUX_TIMEOUT = 30.0
 
 
-def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
+def _get_auxiliary_task_config(task: str) -> dict[str, Any]:
     """Return the config dict for auxiliary.<task>, or {} when unavailable.
 
     For plugin-registered auxiliary tasks (see
@@ -4485,7 +4485,7 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
-def _get_task_extra_body(task: str) -> Dict[str, Any]:
+def _get_task_extra_body(task: str) -> dict[str, Any]:
     """Read auxiliary.<task>.extra_body and return a shallow copy when valid."""
     task_config = _get_auxiliary_task_config(task)
     raw = task_config.get("extra_body")
@@ -4575,7 +4575,7 @@ def _build_call_kwargs(
     base_url: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
-    kwargs: Dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "model": model,
         "messages": messages,
         "timeout": timeout,
@@ -4690,7 +4690,7 @@ def call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Optional[dict[str, Any]] = None,
     messages: list,
     temperature: float = None,
     max_tokens: int = None,

--- a/agent/azure_identity_adapter.py
+++ b/agent/azure_identity_adapter.py
@@ -153,14 +153,14 @@ class EntraIdentityConfig:
         scope = str(self.scope or "").strip() or SCOPE_AI_AZURE_DEFAULT
         object.__setattr__(self, "scope", scope)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "scope": self.scope,
             "exclude_interactive_browser": self.exclude_interactive_browser,
         }
 
     @classmethod
-    def from_dict(cls, data: Optional[Dict[str, Any]],
+    def from_dict(cls, data: Optional[dict[str, Any]],
                   *, default_scope: Optional[str] = None) -> "EntraIdentityConfig":
         data = data or {}
         scope = str(data.get("scope") or "").strip() or default_scope or SCOPE_AI_AZURE_DEFAULT
@@ -182,7 +182,7 @@ def _build_default_credential(config: EntraIdentityConfig) -> Any:
     ``~/.hermes/.env`` or the deployment environment.
     """
     ai = _require_azure_identity()
-    kwargs: Dict[str, Any] = {}
+    kwargs: dict[str, Any] = {}
     # SDK default is True (browser excluded); only pass when the user
     # explicitly opts in to interactive browser auth.
     if not config.exclude_interactive_browser:
@@ -317,7 +317,7 @@ def describe_active_credential(config: Optional[EntraIdentityConfig] = None,
                                scope: Optional[str] = None,
                                timeout_seconds: float = 10.0,
                                allow_install: bool = True,
-                               **overrides: Any) -> Dict[str, Any]:
+                               **overrides: Any) -> dict[str, Any]:
     """Return diagnostic info about the active credential chain.
 
     Best-effort: runs ``get_token()`` and inspects what came back.
@@ -336,7 +336,7 @@ def describe_active_credential(config: Optional[EntraIdentityConfig] = None,
     class name. Users wanting the precise class can run with
     ``AZURE_LOG_LEVEL=DEBUG``.
     """
-    info: Dict[str, Any] = {"ok": False}
+    info: dict[str, Any] = {"ok": False}
     if not has_azure_identity_installed():
         if not allow_install:
             info["error"] = "azure-identity not installed"
@@ -379,7 +379,7 @@ def describe_active_credential(config: Optional[EntraIdentityConfig] = None,
     info["env_sources"] = env_sources
 
     # Now try minting.
-    result: Dict[str, Any] = {}
+    result: dict[str, Any] = {}
 
     def _probe() -> None:
         try:

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -235,9 +235,9 @@ _COMBINED_REVIEW_PROMPT = (
 
 
 def summarize_background_review_actions(
-    review_messages: List[Dict],
-    prior_snapshot: List[Dict],
-) -> List[str]:
+    review_messages: list[dict],
+    prior_snapshot: list[dict],
+) -> list[str]:
     """Build the human-facing action summary for a background review pass.
 
     Walks the review agent's session messages and collects "successful tool
@@ -262,7 +262,7 @@ def summarize_background_review_actions(
             if isinstance(content, str):
                 existing_tool_contents.add(content)
 
-    actions: List[str] = []
+    actions: list[str] = []
     for msg in review_messages or []:
         if not isinstance(msg, dict) or msg.get("role") != "tool":
             continue
@@ -304,9 +304,9 @@ def build_memory_write_metadata(
     execution_context: Optional[str] = None,
     task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build provenance metadata for external memory-provider mirrors."""
-    metadata: Dict[str, Any] = {
+    metadata: dict[str, Any] = {
         "write_origin": write_origin or getattr(agent, "_memory_write_origin", "assistant_tool"),
         "execution_context": (
             execution_context
@@ -326,7 +326,7 @@ def build_memory_write_metadata(
 
 def _run_review_in_thread(
     agent: Any,
-    messages_snapshot: List[Dict],
+    messages_snapshot: list[dict],
     prompt: str,
 ) -> None:
     """Worker function executed in the background-review daemon thread.
@@ -356,7 +356,7 @@ def _run_review_in_thread(
         pass
 
     review_agent = None
-    review_messages: List[Dict] = []
+    review_messages: list[dict] = []
     try:
         with open(os.devnull, "w", encoding="utf-8") as _devnull, \
              contextlib.redirect_stdout(_devnull), \
@@ -557,7 +557,7 @@ def _run_review_in_thread(
 
 def spawn_background_review_thread(
     agent: Any,
-    messages_snapshot: List[Dict],
+    messages_snapshot: list[dict],
     review_memory: bool = False,
     review_skills: bool = False,
 ):

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -54,8 +54,8 @@ except Exception:
 # This keeps startup fast for users who don't use Bedrock.
 # ---------------------------------------------------------------------------
 
-_bedrock_runtime_client_cache: Dict[str, Any] = {}
-_bedrock_control_client_cache: Dict[str, Any] = {}
+_bedrock_runtime_client_cache: dict[str, Any] = {}
+_bedrock_control_client_cache: dict[str, Any] = {}
 
 
 def _require_boto3():
@@ -228,7 +228,7 @@ _AWS_CREDENTIAL_ENV_VARS = [
 ]
 
 
-def resolve_aws_auth_env_var(env: Optional[Dict[str, str]] = None) -> Optional[str]:
+def resolve_aws_auth_env_var(env: Optional[dict[str, str]] = None) -> Optional[str]:
     """Return the name of the AWS auth source that is active, or None.
 
     Checks environment variables first, then falls back to boto3's credential
@@ -270,7 +270,7 @@ def resolve_aws_auth_env_var(env: Optional[Dict[str, str]] = None) -> Optional[s
     return None
 
 
-def has_aws_credentials(env: Optional[Dict[str, str]] = None) -> bool:
+def has_aws_credentials(env: Optional[dict[str, str]] = None) -> bool:
     """Return True if any AWS credential source is detected.
 
     Checks environment variables first (fast, no I/O), then falls back to
@@ -301,7 +301,7 @@ def has_aws_credentials(env: Optional[Dict[str, str]] = None) -> bool:
     return False
 
 
-def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
+def resolve_bedrock_region(env: Optional[dict[str, str]] = None) -> str:
     """Resolve the AWS region for Bedrock API calls.
 
     Priority:
@@ -332,7 +332,7 @@ def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
     return "us-east-1"
 
 
-def bedrock_model_ids_or_none() -> Optional[List[str]]:
+def bedrock_model_ids_or_none() -> Optional[list[str]]:
     """Live-discover Bedrock model IDs for the active region.
 
     Returns a list of model ID strings if discovery succeeds and yields
@@ -407,7 +407,7 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
 # Message format conversion: OpenAI → Bedrock Converse
 # ---------------------------------------------------------------------------
 
-def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
+def convert_tools_to_converse(tools: list[dict]) -> list[dict]:
     """Convert OpenAI-format tool definitions to Bedrock Converse ``toolConfig``.
 
     OpenAI format::
@@ -438,7 +438,7 @@ def convert_tools_to_converse(tools: List[Dict]) -> List[Dict]:
     return result
 
 
-def _convert_content_to_converse(content) -> List[Dict]:
+def _convert_content_to_converse(content) -> list[dict]:
     """Convert OpenAI message content (string or list) to Converse content blocks.
 
     Handles:
@@ -491,8 +491,8 @@ def _convert_content_to_converse(content) -> List[Dict]:
 
 
 def convert_messages_to_converse(
-    messages: List[Dict],
-) -> Tuple[Optional[List[Dict]], List[Dict]]:
+    messages: list[dict],
+) -> tuple[Optional[list[dict]], list[dict]]:
     """Convert OpenAI-format messages to Bedrock Converse format.
 
     Returns ``(system_prompt, converse_messages)`` where:
@@ -509,8 +509,8 @@ def convert_messages_to_converse(
     Converse requires strict user/assistant alternation. Consecutive messages
     with the same role are merged into a single message.
     """
-    system_blocks: List[Dict] = []
-    converse_msgs: List[Dict] = []
+    system_blocks: list[dict] = []
+    converse_msgs: list[dict] = []
 
     for msg in messages:
         role = msg.get("role", "")
@@ -626,7 +626,7 @@ def _converse_stop_reason_to_openai(stop_reason: str) -> str:
     return mapping.get(stop_reason, "stop")
 
 
-def normalize_converse_response(response: Dict) -> SimpleNamespace:
+def normalize_converse_response(response: dict) -> SimpleNamespace:
     """Convert a Bedrock Converse API response to an OpenAI-compatible object.
 
     The agent loop in ``run_agent.py`` expects responses shaped like
@@ -752,14 +752,14 @@ def stream_converse_with_callbacks(
         An OpenAI-compatible SimpleNamespace response, identical in shape to
         ``normalize_converse_response()``.
     """
-    text_parts: List[str] = []
-    reasoning_parts: List[str] = []
-    tool_calls: List[SimpleNamespace] = []
-    current_tool: Optional[Dict] = None
-    current_text_buffer: List[str] = []
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[SimpleNamespace] = []
+    current_tool: Optional[dict] = None
+    current_text_buffer: list[str] = []
     has_tool_use = False
     stop_reason = "end_turn"
-    usage_data: Dict[str, int] = {}
+    usage_data: dict[str, int] = {}
 
     for event in event_stream.get("stream", []):
         # Check for interrupt
@@ -875,21 +875,21 @@ def stream_converse_with_callbacks(
 
 def build_converse_kwargs(
     model: str,
-    messages: List[Dict],
-    tools: Optional[List[Dict]] = None,
+    messages: list[dict],
+    tools: Optional[list[dict]] = None,
     max_tokens: int = 4096,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
-    stop_sequences: Optional[List[str]] = None,
-    guardrail_config: Optional[Dict] = None,
-) -> Dict[str, Any]:
+    stop_sequences: Optional[list[str]] = None,
+    guardrail_config: Optional[dict] = None,
+) -> dict[str, Any]:
     """Build kwargs for ``bedrock-runtime.converse()`` or ``converse_stream()``.
 
     Converts OpenAI-format inputs to Converse API parameters.
     """
     system_prompt, converse_messages = convert_messages_to_converse(messages)
 
-    kwargs: Dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "modelId": model,
         "messages": converse_messages,
         "inferenceConfig": {
@@ -934,13 +934,13 @@ def build_converse_kwargs(
 def call_converse(
     region: str,
     model: str,
-    messages: List[Dict],
-    tools: Optional[List[Dict]] = None,
+    messages: list[dict],
+    tools: Optional[list[dict]] = None,
     max_tokens: int = 4096,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
-    stop_sequences: Optional[List[str]] = None,
-    guardrail_config: Optional[Dict] = None,
+    stop_sequences: Optional[list[str]] = None,
+    guardrail_config: Optional[dict] = None,
 ) -> SimpleNamespace:
     """Call Bedrock Converse API (non-streaming) and return an OpenAI-compatible response.
 
@@ -975,13 +975,13 @@ def call_converse(
 def call_converse_stream(
     region: str,
     model: str,
-    messages: List[Dict],
-    tools: Optional[List[Dict]] = None,
+    messages: list[dict],
+    tools: Optional[list[dict]] = None,
     max_tokens: int = 4096,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
-    stop_sequences: Optional[List[str]] = None,
-    guardrail_config: Optional[Dict] = None,
+    stop_sequences: Optional[list[str]] = None,
+    guardrail_config: Optional[dict] = None,
 ) -> SimpleNamespace:
     """Call Bedrock ConverseStream API and return an OpenAI-compatible response.
 
@@ -1018,7 +1018,7 @@ def call_converse_stream(
 # Model discovery
 # ---------------------------------------------------------------------------
 
-_discovery_cache: Dict[str, Any] = {}
+_discovery_cache: dict[str, Any] = {}
 _DISCOVERY_CACHE_TTL_SECONDS = 3600
 
 
@@ -1029,8 +1029,8 @@ def reset_discovery_cache():
 
 def discover_bedrock_models(
     region: str,
-    provider_filter: Optional[List[str]] = None,
-) -> List[Dict[str, Any]]:
+    provider_filter: Optional[list[str]] = None,
+) -> list[dict[str, Any]]:
     """Discover available Bedrock foundation models and inference profiles.
 
     Returns a list of model info dicts with keys:
@@ -1169,7 +1169,7 @@ def _extract_provider_from_arn(arn: str) -> str:
     return match.group(1) if match else ""
 
 
-def get_bedrock_model_ids(region: str) -> List[str]:
+def get_bedrock_model_ids(region: str) -> list[str]:
     """Return a flat list of available Bedrock model IDs for the given region.
 
     Convenience wrapper around ``discover_bedrock_models()`` for use in
@@ -1242,7 +1242,7 @@ def classify_bedrock_error(error_message: str) -> str:
 # context window sizes.  Used by agent/model_metadata.py when dynamic
 # detection is unavailable.
 
-BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
+BEDROCK_CONTEXT_LENGTHS: dict[str, int] = {
     # Anthropic Claude models on Bedrock
     "anthropic.claude-opus-4-6":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,

--- a/agent/browser_provider.py
+++ b/agent/browser_provider.py
@@ -87,7 +87,7 @@ class BrowserProvider(abc.ABC):
         """
 
     @abc.abstractmethod
-    def create_session(self, task_id: str) -> Dict[str, object]:
+    def create_session(self, task_id: str) -> dict[str, object]:
         """Create a cloud browser session and return session metadata.
 
         Must return a dict with at least::
@@ -124,7 +124,7 @@ class BrowserProvider(abc.ABC):
         credentials, network errors, etc. — log and move on. Must not raise.
         """
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         """Return provider metadata for the ``hermes tools`` picker.
 
         Used by :mod:`hermes_cli.tools_config` to inject this provider as a

--- a/agent/browser_registry.py
+++ b/agent/browser_registry.py
@@ -45,7 +45,7 @@ from agent.browser_provider import BrowserProvider
 logger = logging.getLogger(__name__)
 
 
-_providers: Dict[str, BrowserProvider] = {}
+_providers: dict[str, BrowserProvider] = {}
 _lock = threading.Lock()
 
 
@@ -79,7 +79,7 @@ def register_provider(provider: BrowserProvider) -> None:
         )
 
 
-def list_providers() -> List[BrowserProvider]:
+def list_providers() -> list[BrowserProvider]:
     """Return all registered providers, sorted by name."""
     with _lock:
         items = list(_providers.values())

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -401,7 +401,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         _fixed_temp = None
 
     # Provider preferences (OpenRouter-style)
-    _prefs: Dict[str, Any] = {}
+    _prefs: dict[str, Any] = {}
     if agent.providers_allowed:
         _prefs["only"] = agent.providers_allowed
     if agent.providers_ignored:

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -44,7 +44,7 @@ _TOOL_CALL_LEAK_PATTERN = re.compile(
 # Multimodal content helpers
 # ---------------------------------------------------------------------------
 
-def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> List[Dict[str, Any]]:
+def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> list[dict[str, Any]]:
     """Convert chat-style multimodal content to Responses API input parts.
 
     Input:  ``[{"type":"text"|"image_url", ...}]`` (native OpenAI Chat format)
@@ -64,7 +64,7 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
     text_type = "output_text" if role == "assistant" else "input_text"
     if not isinstance(content, list):
         return []
-    converted: List[Dict[str, Any]] = []
+    converted: list[dict[str, Any]] = []
     for part in content:
         if isinstance(part, str):
             if part:
@@ -88,7 +88,7 @@ def _chat_content_to_responses_parts(content: Any, *, role: str = "user") -> Lis
                 url = image_ref
             if not isinstance(url, str) or not url:
                 continue
-            image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
+            image_part: dict[str, Any] = {"type": "input_image", "image_url": url}
             if isinstance(detail, str) and detail.strip():
                 image_part["detail"] = detail.strip()
             converted.append(image_part)
@@ -109,7 +109,7 @@ def _summarize_user_message_for_log(content: Any) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, list):
-        text_bits: List[str] = []
+        text_bits: list[str] = []
         image_count = 0
         for part in content:
             if isinstance(part, str):
@@ -202,12 +202,12 @@ def _derive_responses_function_call_id(
 # Schema conversion
 # ---------------------------------------------------------------------------
 
-def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
+def _responses_tools(tools: Optional[list[dict[str, Any]]] = None) -> Optional[list[dict[str, Any]]]:
     """Convert chat-completions tool schemas to Responses function-tool schemas."""
     if not tools:
         return None
 
-    converted: List[Dict[str, Any]] = []
+    converted: list[dict[str, Any]] = []
     for item in tools:
         fn = item.get("function", {}) if isinstance(item, dict) else {}
         name = fn.get("name")
@@ -245,10 +245,10 @@ def _normalize_responses_message_status(value: Any, *, default: str = "completed
 
 
 def _chat_messages_to_responses_input(
-    messages: List[Dict[str, Any]],
+    messages: list[dict[str, Any]],
     *,
     is_xai_responses: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Convert internal chat-style messages to Responses input items.
 
     ``is_xai_responses`` is kept for transport signature compatibility but
@@ -262,7 +262,7 @@ def _chat_messages_to_responses_input(
     transport (xAI, native Codex, custom relays) and let xAI tell us
     explicitly if a specific surface ever rejects a payload.
     """
-    items: List[Dict[str, Any]] = []
+    items: list[dict[str, Any]] = []
     seen_item_ids: set = set()
 
     for msg in messages:
@@ -461,11 +461,11 @@ def _chat_messages_to_responses_input(
 # Input preflight / validation
 # ---------------------------------------------------------------------------
 
-def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
+def _preflight_codex_input_items(raw_items: Any) -> list[dict[str, Any]]:
     if not isinstance(raw_items, list):
         raise ValueError("Codex Responses input must be a list of input items.")
 
-    normalized: List[Dict[str, Any]] = []
+    normalized: list[dict[str, Any]] = []
     seen_ids: set = set()
     for idx, item in enumerate(raw_items):
         if not isinstance(item, dict):
@@ -511,7 +511,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             if isinstance(output, list):
                 # Validate each item is a recognised content shape; drop
                 # anything else to avoid 4xx from the API.
-                cleaned: List[Dict[str, Any]] = []
+                cleaned: list[dict[str, Any]] = []
                 for part in output:
                     if not isinstance(part, dict):
                         continue
@@ -523,7 +523,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                     elif ptype == "input_image":
                         url = part.get("image_url")
                         if isinstance(url, str) and url:
-                            entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
+                            entry: dict[str, Any] = {"type": "input_image", "image_url": url}
                             detail = part.get("detail")
                             if isinstance(detail, str) and detail.strip():
                                 entry["detail"] = detail.strip()
@@ -595,7 +595,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 normalized_content.append({"type": "output_text", "text": text})
             if not normalized_content:
                 raise ValueError(f"Codex Responses input[{idx}] message item must contain at least one text part.")
-            normalized_item: Dict[str, Any] = {
+            normalized_item: dict[str, Any] = {
                 "type": "message",
                 "role": "assistant",
                 "status": _normalize_responses_message_status(item.get("status")),
@@ -622,7 +622,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 # Use the correct text type for the role — ``output_text`` for
                 # assistant messages, ``input_text`` for user messages.
                 text_type = "output_text" if role == "assistant" else "input_text"
-                validated: List[Dict[str, Any]] = []
+                validated: list[dict[str, Any]] = []
                 for part_idx, part in enumerate(content):
                     if isinstance(part, str):
                         if part:
@@ -648,7 +648,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                             url = image_ref
                         if not isinstance(url, str):
                             url = str(url or "")
-                        image_part: Dict[str, Any] = {"type": "input_image", "image_url": url}
+                        image_part: dict[str, Any] = {"type": "input_image", "image_url": url}
                         if isinstance(detail, str) and detail.strip():
                             image_part["detail"] = detail.strip()
                         validated.append(image_part)
@@ -675,7 +675,7 @@ def _preflight_codex_api_kwargs(
     api_kwargs: Any,
     *,
     allow_stream: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     if not isinstance(api_kwargs, dict):
         raise ValueError("Codex Responses request must be a dict.")
 
@@ -747,7 +747,7 @@ def _preflight_codex_api_kwargs(
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
         "extra_headers", "extra_body",
     }
-    normalized: Dict[str, Any] = {
+    normalized: dict[str, Any] = {
         "model": model,
         "instructions": instructions,
         "input": normalized_input,
@@ -785,7 +785,7 @@ def _preflight_codex_api_kwargs(
     if extra_headers is not None:
         if not isinstance(extra_headers, dict):
             raise ValueError("Codex Responses request 'extra_headers' must be an object.")
-        normalized_headers: Dict[str, str] = {}
+        normalized_headers: dict[str, str] = {}
         for key, value in extra_headers.items():
             if not isinstance(key, str) or not key.strip():
                 raise ValueError("Codex Responses request 'extra_headers' keys must be non-empty strings.")
@@ -837,7 +837,7 @@ def _extract_responses_message_text(item: Any) -> str:
     if not isinstance(content, list):
         return ""
 
-    chunks: List[str] = []
+    chunks: list[str] = []
     for part in content:
         ptype = getattr(part, "type", None)
         if ptype not in {"output_text", "text"}:
@@ -852,7 +852,7 @@ def _extract_responses_reasoning_text(item: Any) -> str:
     """Extract a compact reasoning text from a Responses reasoning item."""
     summary = getattr(item, "summary", None)
     if isinstance(summary, list):
-        chunks: List[str] = []
+        chunks: list[str] = []
         for part in summary:
             text = getattr(part, "text", None)
             if isinstance(text, str) and text:
@@ -904,11 +904,11 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             error_msg = str(error_obj) if error_obj else f"Responses API returned status '{response_status}'"
         raise RuntimeError(error_msg)
 
-    content_parts: List[str] = []
-    reasoning_parts: List[str] = []
-    reasoning_items_raw: List[Dict[str, Any]] = []
-    message_items_raw: List[Dict[str, Any]] = []
-    tool_calls: List[Any] = []
+    content_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    reasoning_items_raw: list[dict[str, Any]] = []
+    message_items_raw: list[dict[str, Any]] = []
+    tool_calls: list[Any] = []
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
     saw_commentary_phase = False
     saw_final_answer_phase = False
@@ -936,7 +936,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             message_text = _extract_responses_message_text(item)
             if message_text:
                 content_parts.append(message_text)
-                raw_message_item: Dict[str, Any] = {
+                raw_message_item: dict[str, Any] = {
                     "type": "message",
                     "role": "assistant",
                     "status": _normalize_responses_message_status(item_status),

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -30,10 +30,10 @@ def run_codex_app_server_turn(
     *,
     user_message: str,
     original_user_message: Any,
-    messages: List[Dict[str, Any]],
+    messages: list[dict[str, Any]],
     effective_task_id: str,
     should_review_memory: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
     app-server` subprocess and projects its events back into Hermes'
     messages list so memory/skill review keep working.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -260,7 +260,7 @@ def _strip_images_from_content(content: Any) -> Any:
     if not any(_is_image_part(p) for p in content):
         return content
 
-    new_parts: List[Any] = []
+    new_parts: list[Any] = []
     for p in content:
         if _is_image_part(p):
             new_parts.append({
@@ -272,7 +272,7 @@ def _strip_images_from_content(content: Any) -> Any:
     return new_parts
 
 
-def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _strip_historical_media(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Replace image parts in older messages with placeholder text.
 
     The anchor is the *last* user message that has any image content. Every
@@ -312,7 +312,7 @@ def _strip_historical_media(messages: List[Dict[str, Any]]) -> List[Dict[str, An
         return messages
 
     changed = False
-    result: List[Dict[str, Any]] = []
+    result: list[dict[str, Any]] = []
     for i, msg in enumerate(messages):
         if i >= anchor or not isinstance(msg, dict):
             result.append(msg)
@@ -605,7 +605,7 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_error: Optional[str] = None
         self._last_aux_model_failure_model: Optional[str] = None
 
-    def update_from_response(self, usage: Dict[str, Any]):
+    def update_from_response(self, usage: dict[str, Any]):
         """Update tracked token usage from API response."""
         self.last_prompt_tokens = usage.get("prompt_tokens", 0)
         self.last_completion_tokens = usage.get("completion_tokens", 0)
@@ -638,9 +638,9 @@ class ContextCompressor(ContextEngine):
     # ------------------------------------------------------------------
 
     def _prune_old_tool_results(
-        self, messages: List[Dict[str, Any]], protect_tail_count: int,
+        self, messages: list[dict[str, Any]], protect_tail_count: int,
         protect_tail_tokens: int | None = None,
-    ) -> tuple[List[Dict[str, Any]], int]:
+    ) -> tuple[list[dict[str, Any]], int]:
         """Replace old tool result contents with informative 1-line summaries.
 
         Instead of a generic placeholder, generates a summary like::
@@ -667,7 +667,7 @@ class ContextCompressor(ContextEngine):
         pruned = 0
 
         # Build index: tool_call_id -> (tool_name, arguments_json)
-        call_id_to_tool: Dict[str, tuple] = {}
+        call_id_to_tool: dict[str, tuple] = {}
         for msg in result:
             if msg.get("role") == "assistant":
                 for tc in msg.get("tool_calls") or []:
@@ -809,7 +809,7 @@ class ContextCompressor(ContextEngine):
     # Summarization
     # ------------------------------------------------------------------
 
-    def _compute_summary_budget(self, turns_to_summarize: List[Dict[str, Any]]) -> int:
+    def _compute_summary_budget(self, turns_to_summarize: list[dict[str, Any]]) -> int:
         """Scale summary token budget with the amount of content being compressed.
 
         The maximum scales with the model's context window (5% of context,
@@ -829,7 +829,7 @@ class ContextCompressor(ContextEngine):
     _TOOL_ARGS_MAX = 1500     # tool call argument chars
     _TOOL_ARGS_HEAD = 1200    # kept from the start of tool args
 
-    def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
+    def _serialize_for_summary(self, turns: list[dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
 
         Includes tool call arguments and result content (up to
@@ -911,7 +911,7 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
-    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
+    def _generate_summary(self, turns_to_summarize: list[dict[str, Any]], focus_topic: str = None) -> Optional[str]:
         """Generate a structured summary of conversation turns.
 
         Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
@@ -1214,7 +1214,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     @classmethod
     def _find_latest_context_summary(
         cls,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         start: int,
         end: int,
     ) -> tuple[Optional[int], str]:
@@ -1236,7 +1236,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             return tc.get("call_id", "") or tc.get("id", "") or ""
         return getattr(tc, "call_id", "") or getattr(tc, "id", "") or ""
 
-    def _sanitize_tool_pairs(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _sanitize_tool_pairs(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Fix orphaned tool_call / tool_result pairs after compression.
 
         Two failure modes:
@@ -1278,7 +1278,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # 2. Add stub results for assistant tool_calls whose results were dropped
         missing_results = surviving_call_ids - result_call_ids
         if missing_results:
-            patched: List[Dict[str, Any]] = []
+            patched: list[dict[str, Any]] = []
             for msg in messages:
                 patched.append(msg)
                 if msg.get("role") == "assistant":
@@ -1296,7 +1296,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         return messages
 
-    def _align_boundary_forward(self, messages: List[Dict[str, Any]], idx: int) -> int:
+    def _align_boundary_forward(self, messages: list[dict[str, Any]], idx: int) -> int:
         """Push a compress-start boundary forward past any orphan tool results.
 
         If ``messages[idx]`` is a tool result, slide forward until we hit a
@@ -1306,7 +1306,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             idx += 1
         return idx
 
-    def _protect_head_size(self, messages: List[Dict[str, Any]]) -> int:
+    def _protect_head_size(self, messages: list[dict[str, Any]]) -> int:
         """Total count of head messages to protect.
 
         ``protect_first_n`` is defined as *additional* messages protected
@@ -1326,7 +1326,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             head = 1
         return head + self.protect_first_n
 
-    def _align_boundary_backward(self, messages: List[Dict[str, Any]], idx: int) -> int:
+    def _align_boundary_backward(self, messages: list[dict[str, Any]], idx: int) -> int:
         """Pull a compress-end boundary backward to avoid splitting a
         tool_call / result group.
 
@@ -1355,7 +1355,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     # ------------------------------------------------------------------
 
     def _find_last_user_message_idx(
-        self, messages: List[Dict[str, Any]], head_end: int
+        self, messages: list[dict[str, Any]], head_end: int
     ) -> int:
         """Return the index of the last user-role message at or after *head_end*, or -1."""
         for i in range(len(messages) - 1, head_end - 1, -1):
@@ -1365,7 +1365,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
     def _ensure_last_user_message_in_tail(
         self,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         cut_idx: int,
         head_end: int,
     ) -> int:
@@ -1411,7 +1411,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         return max(last_user_idx, head_end + 1)
 
     def _find_tail_cut_by_tokens(
-        self, messages: List[Dict[str, Any]], head_end: int,
+        self, messages: list[dict[str, Any]], head_end: int,
         token_budget: int | None = None,
     ) -> int:
         """Walk backward from the end of messages, accumulating tokens until
@@ -1477,7 +1477,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     # ContextEngine: manual /compress preflight
     # ------------------------------------------------------------------
 
-    def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:
+    def has_content_to_compress(self, messages: list[dict[str, Any]]) -> bool:
         """Return True if there is a non-empty middle region to compact.
 
         Overrides the ABC default so the gateway ``/compress`` guard can
@@ -1492,7 +1492,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     # Main compression entry point
     # ------------------------------------------------------------------
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
+    def compress(self, messages: list[dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> list[dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
         Algorithm:

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -68,7 +68,7 @@ class ContextEngine(ABC):
     # -- Core interface ----------------------------------------------------
 
     @abstractmethod
-    def update_from_response(self, usage: Dict[str, Any]) -> None:
+    def update_from_response(self, usage: dict[str, Any]) -> None:
         """Update tracked token usage from an API response.
 
         Called after every LLM call with the usage dict from the response.
@@ -81,10 +81,10 @@ class ContextEngine(ABC):
     @abstractmethod
     def compress(
         self,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         current_tokens: int = None,
         focus_topic: str = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Compact the message list and return the new message list.
 
         This is the main entry point. The engine receives the full message
@@ -102,7 +102,7 @@ class ContextEngine(ABC):
 
     # -- Optional: pre-flight check ----------------------------------------
 
-    def should_compress_preflight(self, messages: List[Dict[str, Any]]) -> bool:
+    def should_compress_preflight(self, messages: list[dict[str, Any]]) -> bool:
         """Quick rough check before the API call (no real token count yet).
 
         Default returns False (skip pre-flight). Override if your engine
@@ -112,7 +112,7 @@ class ContextEngine(ABC):
 
     # -- Optional: manual /compress preflight ------------------------------
 
-    def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:
+    def has_content_to_compress(self, messages: list[dict[str, Any]]) -> bool:
         """Quick check: is there anything in ``messages`` that can be compacted?
 
         Used by the gateway ``/compress`` command as a preflight guard —
@@ -134,7 +134,7 @@ class ContextEngine(ABC):
         kwargs may include hermes_home, platform, model, etc.
         """
 
-    def on_session_end(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+    def on_session_end(self, session_id: str, messages: list[dict[str, Any]]) -> None:
         """Called at real session boundaries (CLI exit, /reset, gateway expiry).
 
         Use this to flush state, close DB connections, etc.
@@ -153,7 +153,7 @@ class ContextEngine(ABC):
 
     # -- Optional: tools ---------------------------------------------------
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         """Return tool schemas this engine provides to the agent.
 
         Default returns empty list (no tools). LCM would return schemas
@@ -161,7 +161,7 @@ class ContextEngine(ABC):
         """
         return []
 
-    def handle_tool_call(self, name: str, args: Dict[str, Any], **kwargs) -> str:
+    def handle_tool_call(self, name: str, args: dict[str, Any], **kwargs) -> str:
         """Handle a tool call from the agent.
 
         Only called for tool names returned by get_tool_schemas().
@@ -175,7 +175,7 @@ class ContextEngine(ABC):
 
     # -- Optional: status / display ----------------------------------------
 
-    def get_status(self) -> Dict[str, Any]:
+    def get_status(self) -> dict[str, Any]:
         """Return status dict for display/logging.
 
         Default returns the standard fields run_agent.py expects.

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -257,7 +257,7 @@ def compress_context(
     task_id: str = "default",
     focus_topic: Optional[str] = None,
     force: bool = False,
-) -> Tuple[list, str]:
+) -> tuple[list, str]:
     """Compress conversation context and split the session in SQLite.
 
     Args:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -233,11 +233,11 @@ def run_conversation(
     agent,
     user_message: str,
     system_message: str = None,
-    conversation_history: List[Dict[str, Any]] = None,
+    conversation_history: list[dict[str, Any]] = None,
     task_id: str = None,
     stream_callback: Optional[callable] = None,
     persist_user_message: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
 
@@ -576,7 +576,7 @@ def run_conversation(
     codex_ack_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
-    truncated_response_parts: List[str] = []
+    truncated_response_parts: list[str] = []
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
@@ -586,7 +586,7 @@ def run_conversation(
     # entry (the model recovered).  At end-of-turn, any entries still
     # present are surfaced in an advisory footer so the model cannot
     # over-claim success while the file is actually unchanged on disk.
-    agent._turn_failed_file_mutations: Dict[str, Dict[str, Any]] = {}
+    agent._turn_failed_file_mutations: dict[str, dict[str, Any]] = {}
     
     # Record the execution thread so interrupt()/clear_interrupt() can
     # scope the tool-level interrupt signal to THIS agent's thread only.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -114,7 +114,7 @@ class PooledCredential:
     agent_key: Optional[str] = None
     agent_key_expires_at: Optional[str] = None
     request_count: int = 0
-    extra: Dict[str, Any] = None  # type: ignore[assignment]
+    extra: dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
         if self.extra is None:
@@ -126,7 +126,7 @@ class PooledCredential:
         raise AttributeError(f"'{type(self).__name__}' object has no attribute {name!r}")
 
     @classmethod
-    def from_dict(cls, provider: str, payload: Dict[str, Any]) -> "PooledCredential":
+    def from_dict(cls, provider: str, payload: dict[str, Any]) -> "PooledCredential":
         field_names = {f.name for f in fields(cls) if f.name != "provider"}
         data = {k: payload.get(k) for k in field_names if k in payload}
         # Rehydrated last_status_at may be an ISO string from to_dict() — normalize to float epoch
@@ -142,7 +142,7 @@ class PooledCredential:
         data.setdefault("access_token", "")
         return cls(provider=provider, **data)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         _ALWAYS_EMIT = {
             "last_status",
             "last_status_at",
@@ -151,7 +151,7 @@ class PooledCredential:
             "last_error_message",
             "last_error_reset_at",
         }
-        result: Dict[str, Any] = {}
+        result: dict[str, Any] = {}
         for field_def in fields(self):
             if field_def.name in {"provider", "extra"}:
                 continue
@@ -187,7 +187,7 @@ def label_from_token(token: str, fallback: str) -> str:
     return fallback
 
 
-def _next_priority(entries: List[PooledCredential]) -> int:
+def _next_priority(entries: list[PooledCredential]) -> int:
     return max((entry.priority for entry in entries), default=-1) + 1
 
 
@@ -248,10 +248,10 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     return None
 
 
-def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _normalize_error_context(error_context: Optional[dict[str, Any]]) -> dict[str, Any]:
     if not isinstance(error_context, dict):
         return {}
-    normalized: Dict[str, Any] = {}
+    normalized: dict[str, Any] = {}
     reason = error_context.get("reason")
     if isinstance(reason, str) and reason.strip():
         normalized["reason"] = reason.strip()
@@ -345,7 +345,7 @@ def get_custom_provider_pool_key(base_url: str, provider_name: Optional[str] = N
     return None
 
 
-def list_custom_pool_providers() -> List[str]:
+def list_custom_pool_providers() -> list[str]:
     """Return all 'custom:*' pool keys that have entries in auth.json."""
     pool_data = read_credential_pool(None)
     return sorted(
@@ -356,7 +356,7 @@ def list_custom_pool_providers() -> List[str]:
     )
 
 
-def _get_custom_provider_config(pool_key: str) -> Optional[Dict[str, Any]]:
+def _get_custom_provider_config(pool_key: str) -> Optional[dict[str, Any]]:
     """Return the custom_providers config entry matching a pool key like 'custom:together.ai'."""
     if not pool_key.startswith(CUSTOM_POOL_PREFIX):
         return None
@@ -387,13 +387,13 @@ DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL = 1
 
 
 class CredentialPool:
-    def __init__(self, provider: str, entries: List[PooledCredential]):
+    def __init__(self, provider: str, entries: list[PooledCredential]):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
         self._lock = threading.Lock()
-        self._active_leases: Dict[str, int] = {}
+        self._active_leases: dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
 
     def has_credentials(self) -> bool:
@@ -403,7 +403,7 @@ class CredentialPool:
         """True if at least one entry is not currently in exhaustion cooldown."""
         return bool(self._available_entries())
 
-    def entries(self) -> List[PooledCredential]:
+    def entries(self) -> list[PooledCredential]:
         return list(self._entries)
 
     def current(self) -> Optional[PooledCredential]:
@@ -428,7 +428,7 @@ class CredentialPool:
         self,
         entry: PooledCredential,
         status_code: Optional[int],
-        error_context: Optional[Dict[str, Any]] = None,
+        error_context: Optional[dict[str, Any]] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
         updated = replace(
@@ -525,7 +525,7 @@ class CredentialPool:
                     "(refreshed by another process)",
                     entry.id,
                 )
-                field_updates: Dict[str, Any] = {
+                field_updates: dict[str, Any] = {
                     "access_token": store_access,
                     "refresh_token": store_refresh or entry.refresh_token,
                     "last_status": None,
@@ -583,7 +583,7 @@ class CredentialPool:
                     "(refreshed by another process)",
                     entry.id,
                 )
-                field_updates: Dict[str, Any] = {
+                field_updates: dict[str, Any] = {
                     "access_token": store_access,
                     "refresh_token": store_refresh or entry.refresh_token,
                     "last_status": None,
@@ -640,7 +640,7 @@ class CredentialPool:
                     "Pool entry %s: syncing Nous state from auth.json",
                     entry.id,
                 )
-                field_updates: Dict[str, Any] = {
+                field_updates: dict[str, Any] = {
                     "last_status": None,
                     "last_status_at": None,
                     "last_error_code": None,
@@ -1135,7 +1135,7 @@ class CredentialPool:
         with self._lock:
             return self._select_unlocked()
 
-    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
+    def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> list[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
@@ -1144,7 +1144,7 @@ class CredentialPool:
         """
         now = time.time()
         cleared_any = False
-        available: List[PooledCredential] = []
+        available: list[PooledCredential] = []
         for entry in self._entries:
             # For anthropic claude_code entries, sync from the credentials file
             # before any status/refresh checks. This picks up tokens refreshed
@@ -1260,7 +1260,7 @@ class CredentialPool:
         self,
         *,
         status_code: Optional[int],
-        error_context: Optional[Dict[str, Any]] = None,
+        error_context: Optional[dict[str, Any]] = None,
     ) -> Optional[PooledCredential]:
         with self._lock:
             entry = self.current() or self._select_unlocked()
@@ -1369,7 +1369,7 @@ class CredentialPool:
             self._current_id = None
         return removed
 
-    def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
+    def resolve_target(self, target: Any) -> tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:
             return None, None, "No credential target provided."
@@ -1401,7 +1401,7 @@ class CredentialPool:
         return entry
 
 
-def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]) -> bool:
+def _upsert_entry(entries: list[PooledCredential], provider: str, source: str, payload: dict[str, Any]) -> bool:
     existing_idx = None
     for idx, entry in enumerate(entries):
         if entry.source == source:
@@ -1438,7 +1438,7 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     return False
 
 
-def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -> bool:
+def _normalize_pool_priorities(provider: str, entries: list[PooledCredential]) -> bool:
     if provider != "anthropic":
         return False
 
@@ -1472,9 +1472,9 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
     return changed
 
 
-def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _seed_from_singletons(provider: str, entries: list[PooledCredential]) -> tuple[bool, set[str]]:
     changed = False
-    active_sources: Set[str] = set()
+    active_sources: set[str] = set()
     auth_store = _load_auth_store()
 
     # Shared suppression gate — used at every upsert site so
@@ -1749,9 +1749,9 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
     return changed, active_sources
 
 
-def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _seed_from_env(provider: str, entries: list[PooledCredential]) -> tuple[bool, set[str]]:
     changed = False
-    active_sources: Set[str] = set()
+    active_sources: set[str] = set()
 
     # Prefer ~/.hermes/.env over os.environ — the user's config file is the
     # authoritative source for Hermes credentials. Stale env vars from parent
@@ -1840,7 +1840,7 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     return changed, active_sources
 
 
-def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources: Set[str]) -> bool:
+def _prune_stale_seeded_entries(entries: list[PooledCredential], active_sources: set[str]) -> bool:
     retained = [
         entry
         for entry in entries
@@ -1857,10 +1857,10 @@ def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources:
     return True
 
 
-def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _seed_custom_pool(pool_key: str, entries: list[PooledCredential]) -> tuple[bool, set[str]]:
     """Seed a custom endpoint pool from custom_providers config and model config."""
     changed = False
-    active_sources: Set[str] = set()
+    active_sources: set[str] = set()
 
     # Shared suppression gate — same pattern as _seed_from_env/_seed_from_singletons.
     try:

--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -70,8 +70,8 @@ class RemovalResult:
             seeded from anywhere external.
     """
 
-    cleaned: List[str] = field(default_factory=list)
-    hints: List[str] = field(default_factory=list)
+    cleaned: list[str] = field(default_factory=list)
+    hints: list[str] = field(default_factory=list)
     suppress: bool = True
 
 
@@ -109,7 +109,7 @@ class RemovalStep:
         return source == self.source_id
 
 
-_REGISTRY: List[RemovalStep] = []
+_REGISTRY: list[RemovalStep] = []
 
 
 def register(step: RemovalStep) -> RemovalStep:

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -67,7 +67,7 @@ def _state_file() -> Path:
     return get_hermes_home() / "skills" / ".curator_state"
 
 
-def _default_state() -> Dict[str, Any]:
+def _default_state() -> dict[str, Any]:
     return {
         "last_run_at": None,
         "last_run_duration_seconds": None,
@@ -79,7 +79,7 @@ def _default_state() -> Dict[str, Any]:
     }
 
 
-def load_state() -> Dict[str, Any]:
+def load_state() -> dict[str, Any]:
     path = _state_file()
     if not path.exists():
         return _default_state()
@@ -94,7 +94,7 @@ def load_state() -> Dict[str, Any]:
     return _default_state()
 
 
-def save_state(data: Dict[str, Any]) -> None:
+def save_state(data: dict[str, Any]) -> None:
     path = _state_file()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -129,7 +129,7 @@ def is_paused() -> bool:
 # Config access
 # ---------------------------------------------------------------------------
 
-def _load_config() -> Dict[str, Any]:
+def _load_config() -> dict[str, Any]:
     """Read curator.* config from ~/.hermes/config.yaml. Tolerates missing file."""
     try:
         from hermes_cli.config import load_config
@@ -253,7 +253,7 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
 # Automatic state transitions (pure function, no LLM)
 # ---------------------------------------------------------------------------
 
-def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int]:
+def apply_automatic_transitions(now: Optional[datetime] = None) -> dict[str, int]:
     """Walk every agent-created skill and move active/stale/archived based on
     the latest real activity timestamp. Pinned skills are never touched.
     Returns a counter dict describing what changed."""
@@ -490,11 +490,11 @@ def _needle_in_path_component(needle: str, path: str) -> bool:
 
 
 def _classify_removed_skills(
-    removed: List[str],
-    added: List[str],
-    after_names: Set[str],
-    tool_calls: List[Dict[str, Any]],
-) -> Dict[str, List[Dict[str, Any]]]:
+    removed: list[str],
+    added: list[str],
+    after_names: set[str],
+    tool_calls: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
     """Split ``removed`` into consolidated vs pruned.
 
     A removed skill is "consolidated" when the curator absorbed its content
@@ -513,11 +513,11 @@ def _classify_removed_skills(
     Returns ``{"consolidated": [{"name", "into", "evidence"}, ...],
                "pruned":       [{"name"}, ...]}``.
     """
-    consolidated: List[Dict[str, Any]] = []
-    pruned: List[Dict[str, Any]] = []
+    consolidated: list[dict[str, Any]] = []
+    pruned: list[dict[str, Any]] = []
 
     # Pre-parse tool calls: we only care about skill_manage.
-    parsed_calls: List[Dict[str, Any]] = []
+    parsed_calls: list[dict[str, Any]] = []
     for tc in tool_calls or []:
         if not isinstance(tc, dict):
             continue
@@ -525,7 +525,7 @@ def _classify_removed_skills(
             continue
         raw = tc.get("arguments") or ""
         # Arguments can be a JSON string (standard) or a dict (defensive).
-        args: Dict[str, Any] = {}
+        args: dict[str, Any] = {}
         if isinstance(raw, dict):
             args = raw
         elif isinstance(raw, str):
@@ -573,7 +573,7 @@ def _classify_removed_skills(
             #     falsely match "references/api-design.md".
             #   content fields — word-boundary regex so "test" does NOT
             #     falsely match "latest" or "testing".
-            haystacks: List[tuple[str, str]] = []
+            haystacks: list[tuple[str, str]] = []
             for key in ("file_path", "file_content", "content", "new_string", "_raw"):
                 v = args.get(key)
                 if isinstance(v, str):
@@ -613,7 +613,7 @@ def _classify_removed_skills(
 
 def _parse_structured_summary(
     llm_final: str,
-) -> Dict[str, List[Dict[str, str]]]:
+) -> dict[str, list[dict[str, str]]]:
     """Extract the structured YAML block from the curator's final response.
 
     The curator prompt requires a fenced ```yaml block under
@@ -656,7 +656,7 @@ def _parse_structured_summary(
     if not isinstance(data, dict):
         return empty
 
-    out: Dict[str, List[Dict[str, str]]] = {"consolidations": [], "prunings": []}
+    out: dict[str, list[dict[str, str]]] = {"consolidations": [], "prunings": []}
     cons_raw = data.get("consolidations") or []
     prun_raw = data.get("prunings") or []
 
@@ -693,8 +693,8 @@ def _parse_structured_summary(
 
 
 def _extract_absorbed_into_declarations(
-    tool_calls: List[Dict[str, Any]],
-) -> Dict[str, Dict[str, Any]]:
+    tool_calls: list[dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
     """Walk this run's tool calls and extract model-declared absorption targets.
 
     The curator prompt requires every ``skill_manage(action='delete')`` call
@@ -711,14 +711,14 @@ def _extract_absorbed_into_declarations(
     the existing heuristic/YAML logic for those (backward compat with older
     curator runs and any callers that don't populate the arg).
     """
-    out: Dict[str, Dict[str, Any]] = {}
+    out: dict[str, dict[str, Any]] = {}
     for tc in tool_calls or []:
         if not isinstance(tc, dict):
             continue
         if tc.get("name") != "skill_manage":
             continue
         raw = tc.get("arguments") or ""
-        args: Dict[str, Any] = {}
+        args: dict[str, Any] = {}
         if isinstance(raw, dict):
             args = raw
         elif isinstance(raw, str):
@@ -747,12 +747,12 @@ def _extract_absorbed_into_declarations(
 
 
 def _reconcile_classification(
-    removed: List[str],
-    heuristic: Dict[str, List[Dict[str, Any]]],
-    model_block: Dict[str, List[Dict[str, str]]],
-    destinations: Set[str],
-    absorbed_declarations: Optional[Dict[str, Dict[str, Any]]] = None,
-) -> Dict[str, List[Dict[str, Any]]]:
+    removed: list[str],
+    heuristic: dict[str, list[dict[str, Any]]],
+    model_block: dict[str, list[dict[str, str]]],
+    destinations: set[str],
+    absorbed_declarations: Optional[dict[str, dict[str, Any]]] = None,
+) -> dict[str, list[dict[str, Any]]]:
     """Merge heuristic (tool-call evidence) with the model's structured block.
 
     Rules (evaluated in order; first match wins):
@@ -784,8 +784,8 @@ def _reconcile_classification(
 
     declared = absorbed_declarations or {}
 
-    consolidated: List[Dict[str, Any]] = []
-    pruned: List[Dict[str, Any]] = []
+    consolidated: list[dict[str, Any]] = []
+    pruned: list[dict[str, Any]] = []
 
     for name in removed:
         mc = model_cons.get(name)
@@ -797,7 +797,7 @@ def _reconcile_classification(
         if dec is not None:
             into_claim = dec.get("into", "")
             if into_claim and into_claim in destinations:
-                entry: Dict[str, Any] = {
+                entry: dict[str, Any] = {
                     "name": name,
                     "into": into_claim,
                     "source": "absorbed_into (model-declared at delete)",
@@ -824,7 +824,7 @@ def _reconcile_classification(
 
         # Model says consolidated — trust it if the destination is real.
         if mc and mc.get("into") in destinations:
-            entry: Dict[str, Any] = {
+            entry: dict[str, Any] = {
                 "name": name,
                 "into": mc["into"],
                 "source": "model" + ("+audit" if hc else ""),
@@ -879,9 +879,9 @@ def _reconcile_classification(
 
 def _build_rename_summary(
     *,
-    before_names: Set[str],
-    after_report: List[Dict[str, Any]],
-    tool_calls: List[Dict[str, Any]],
+    before_names: set[str],
+    after_report: list[dict[str, Any]],
+    tool_calls: list[dict[str, Any]],
     model_final: str,
 ) -> str:
     """Format the user-visible rename map for a curator run.
@@ -933,7 +933,7 @@ def _build_rename_summary(
     pruned = classification["pruned"]
 
     SHOW = 10
-    lines: List[str] = []
+    lines: list[str] = []
     total = len(consolidated) + len(pruned)
     lines.append(f"archived {total} skill(s):")
     shown = 0
@@ -971,12 +971,12 @@ def _write_run_report(
     *,
     started_at: datetime,
     elapsed_seconds: float,
-    auto_counts: Dict[str, int],
+    auto_counts: dict[str, int],
     auto_summary: str,
-    before_report: List[Dict[str, Any]],
-    before_names: Set[str],
-    after_report: List[Dict[str, Any]],
-    llm_meta: Dict[str, Any],
+    before_report: list[dict[str, Any]],
+    before_names: set[str],
+    after_report: list[dict[str, Any]],
+    llm_meta: dict[str, Any],
 ) -> Optional[Path]:
     """Write run.json + REPORT.md under logs/curator/{YYYYMMDD-HHMMSS}/.
 
@@ -1011,7 +1011,7 @@ def _write_run_report(
     before_by_name = {r.get("name"): r for r in before_report if isinstance(r, dict)}
 
     # State transitions between the two snapshots (e.g. active -> stale)
-    transitions: List[Dict[str, str]] = []
+    transitions: list[dict[str, str]] = []
     for name in sorted(after_names & before_names):
         s_before = (before_by_name.get(name) or {}).get("state")
         s_after = (after_by_name.get(name) or {}).get("state")
@@ -1019,7 +1019,7 @@ def _write_run_report(
             transitions.append({"name": name, "from": s_before, "to": s_after})
 
     # Classify LLM tool calls
-    tc_counts: Dict[str, int] = {}
+    tc_counts: dict[str, int] = {}
     for tc in llm_meta.get("tool_calls", []) or []:
         name = tc.get("name", "unknown")
         tc_counts[name] = tc_counts.get(name, 0) + 1
@@ -1071,7 +1071,7 @@ def _write_run_report(
     # references in-place keeps scheduled jobs working across
     # consolidation passes. Best-effort: never let a cron-module issue
     # break the curator.
-    cron_rewrites: Dict[str, Any] = {"rewrites": [], "jobs_updated": 0, "jobs_scanned": 0}
+    cron_rewrites: dict[str, Any] = {"rewrites": [], "jobs_updated": 0, "jobs_scanned": 0}
     try:
         consolidated_map = {
             e["name"]: e["into"]
@@ -1159,9 +1159,9 @@ def _write_run_report(
     return run_dir
 
 
-def _render_report_markdown(p: Dict[str, Any]) -> str:
+def _render_report_markdown(p: dict[str, Any]) -> str:
     """Render the human-readable report."""
-    lines: List[str] = []
+    lines: list[str] = []
     started = p.get("started_at", "")
     duration = p.get("duration_seconds", 0) or 0
     mins, secs = divmod(int(duration), 60)
@@ -1370,7 +1370,7 @@ def run_curator_review(
     on_summary: Optional[Callable[[str], None]] = None,
     synchronous: bool = False,
     dry_run: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Execute a single curator review pass.
 
     Steps:
@@ -1451,7 +1451,7 @@ def run_curator_review(
             before_report = []
         before_names = {r.get("name") for r in before_report if isinstance(r, dict)}
 
-        llm_meta: Dict[str, Any] = {}
+        llm_meta: dict[str, Any] = {}
         try:
             candidate_list = _render_candidate_list()
             if "No agent-created skills" in candidate_list:
@@ -1554,7 +1554,7 @@ def run_curator_review(
     }
 
 
-def _resolve_review_runtime(cfg: Dict[str, Any]) -> _ReviewRuntimeBinding:
+def _resolve_review_runtime(cfg: dict[str, Any]) -> _ReviewRuntimeBinding:
     """Resolve provider/model and per-slot credentials for the curator review fork.
 
     Same precedence as `_resolve_review_model()`. Non-empty ``api_key`` /
@@ -1600,7 +1600,7 @@ def _resolve_review_runtime(cfg: Dict[str, Any]) -> _ReviewRuntimeBinding:
     return _ReviewRuntimeBinding(_main_provider, _main_model, None, None)
 
 
-def _resolve_review_model(cfg: Dict[str, Any]) -> tuple[str, str]:
+def _resolve_review_model(cfg: dict[str, Any]) -> tuple[str, str]:
     """Pick (provider, model) for the curator review fork.
 
     Curator is a regular auxiliary task slot — ``auxiliary.curator.{provider,model}``
@@ -1619,7 +1619,7 @@ def _resolve_review_model(cfg: Dict[str, Any]) -> tuple[str, str]:
     return b.provider, b.model
 
 
-def _run_llm_review(prompt: str) -> Dict[str, Any]:
+def _run_llm_review(prompt: str) -> dict[str, Any]:
     """Spawn an AIAgent fork to run the curator review prompt.
 
     Returns a dict with:
@@ -1633,7 +1633,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     Never raises; callers get a structured failure instead.
     """
     import contextlib
-    result_meta: Dict[str, Any] = {
+    result_meta: dict[str, Any] = {
         "final": "",
         "summary": "",
         "model": "",
@@ -1729,7 +1729,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # session messages and extract every tool_call made during the
         # pass. Truncate argument payloads so a giant skill_manage create
         # doesn't blow up the report.
-        _calls: List[Dict[str, Any]] = []
+        _calls: list[dict[str, Any]] = []
         for msg in getattr(review_agent, "_session_messages", []) or []:
             if not isinstance(msg, dict):
                 continue
@@ -1764,7 +1764,7 @@ def maybe_run_curator(
     *,
     idle_for_seconds: Optional[float] = None,
     on_summary: Optional[Callable[[str], None]] = None,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     """Best-effort: run a curator pass if all gates pass. Returns the result
     dict if a pass was started, else None. Never raises."""
     try:

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -84,7 +84,7 @@ def _cron_jobs_file() -> Path:
 CRON_JOBS_FILENAME = "cron-jobs.json"
 
 
-def _backup_cron_jobs_into(dest: Path) -> Dict[str, Any]:
+def _backup_cron_jobs_into(dest: Path) -> dict[str, Any]:
     """Copy the live cron jobs.json into ``dest`` as ``cron-jobs.json``.
 
     Returns a small dict describing what was captured so the caller can
@@ -94,7 +94,7 @@ def _backup_cron_jobs_into(dest: Path) -> Dict[str, Any]:
     useful for rolling back skills).
     """
     src = _cron_jobs_file()
-    info: Dict[str, Any] = {"backed_up": False, "jobs_count": 0}
+    info: dict[str, Any] = {"backed_up": False, "jobs_count": 0}
     if not src.exists():
         info["reason"] = "no cron/jobs.json present"
         return info
@@ -141,7 +141,7 @@ def _utc_id(now: Optional[datetime] = None) -> str:
     return s.replace(":", "-") + "Z"
 
 
-def _load_config() -> Dict[str, Any]:
+def _load_config() -> dict[str, Any]:
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
@@ -186,7 +186,7 @@ def _count_skill_files(base: Path) -> int:
 
 def _write_manifest(dest: Path, reason: str, archive_path: Path,
                     skills_counted: int,
-                    cron_info: Optional[Dict[str, Any]] = None) -> None:
+                    cron_info: Optional[dict[str, Any]] = None) -> None:
     manifest = {
         "id": dest.name,
         "reason": reason,
@@ -282,15 +282,15 @@ def snapshot_skills(reason: str = "manual") -> Optional[Path]:
     return dest
 
 
-def _prune_old(keep: int) -> List[str]:
+def _prune_old(keep: int) -> list[str]:
     """Delete regular snapshots beyond the newest *keep*. Returns deleted
     ids. Staging dirs (``.rollback-staging-*``) are implementation detail
     and pruned independently on every call."""
     backups = _backups_dir()
     if not backups.exists():
         return []
-    entries: List[Tuple[str, Path]] = []
-    stale_staging: List[Path] = []
+    entries: list[tuple[str, Path]] = []
+    stale_staging: list[Path] = []
     for child in backups.iterdir():
         if not child.is_dir():
             continue
@@ -304,7 +304,7 @@ def _prune_old(keep: int) -> List[str]:
             entries.append((child.name, child))
     # Newest first (lexicographic works because the id is UTC ISO).
     entries.sort(key=lambda t: t[0], reverse=True)
-    deleted: List[str] = []
+    deleted: list[str] = []
     for _, path in entries[keep:]:
         try:
             shutil.rmtree(path)
@@ -323,7 +323,7 @@ def _prune_old(keep: int) -> List[str]:
 # List + rollback
 # ---------------------------------------------------------------------------
 
-def _read_manifest(snap_dir: Path) -> Dict[str, Any]:
+def _read_manifest(snap_dir: Path) -> dict[str, Any]:
     mf = snap_dir / "manifest.json"
     if not mf.exists():
         return {}
@@ -333,7 +333,7 @@ def _read_manifest(snap_dir: Path) -> Dict[str, Any]:
         return {}
 
 
-def list_backups() -> List[Dict[str, Any]]:
+def list_backups() -> list[dict[str, Any]]:
     """Return all restorable snapshots, newest first. Only entries with a
     real ``skills.tar.gz`` tarball are listed — transient
     ``.rollback-staging-*`` directories created mid-rollback are
@@ -341,7 +341,7 @@ def list_backups() -> List[Dict[str, Any]]:
     backups = _backups_dir()
     if not backups.exists():
         return []
-    out: List[Dict[str, Any]] = []
+    out: list[dict[str, Any]] = []
     for child in sorted(backups.iterdir(), reverse=True):
         if not child.is_dir():
             continue
@@ -384,7 +384,7 @@ def _resolve_backup(backup_id: Optional[str]) -> Optional[Path]:
     return candidates[0] if candidates else None
 
 
-def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
+def _restore_cron_skill_links(snapshot_dir: Path) -> dict[str, Any]:
     """Reconcile backed-up cron skill links into the live ``cron/jobs.json``.
 
     We do NOT overwrite the whole cron file. Only the ``skills`` and
@@ -406,7 +406,7 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
     ``cron.jobs`` to pick up the same lock + atomic-write path that tick()
     uses, so we don't race the scheduler.
     """
-    report: Dict[str, Any] = {
+    report: dict[str, Any] = {
         "attempted": False,
         "restored": [],
         "skipped_missing": [],
@@ -438,7 +438,7 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
     # Build a lookup of the backed-up skill state keyed by job id.
     # We only need the two skill-ish fields (legacy single and modern list).
-    backup_by_id: Dict[str, Dict[str, Any]] = {}
+    backup_by_id: dict[str, dict[str, Any]] = {}
     for job in backup_jobs:
         if not isinstance(job, dict):
             continue
@@ -527,7 +527,7 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 
-def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]]:
+def rollback(backup_id: Optional[str] = None) -> tuple[bool, str, Optional[Path]]:
     """Restore ``~/.hermes/skills/`` from a snapshot.
 
     Strategy:
@@ -579,7 +579,7 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
     except OSError as e:
         return (False, f"failed to create staging dir: {e}", None)
 
-    moved: List[Tuple[Path, Path]] = []
+    moved: list[tuple[Path, Path]] = []
     try:
         for entry in list(skills.iterdir()):
             if entry.name in _EXCLUDE_TOP_LEVEL:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -73,7 +73,7 @@ class ClassifiedError:
     provider: Optional[str] = None
     model: Optional[str] = None
     message: str = ""
-    error_context: Dict[str, Any] = field(default_factory=dict)
+    error_context: dict[str, Any] = field(default_factory=dict)
 
     # Recovery action hints — the retry loop checks these instead of
     # re-classifying the error itself.

--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -69,7 +69,7 @@ def _coerce_content_to_text(content: Any) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, list):
-        pieces: List[str] = []
+        pieces: list[str] = []
         for p in content:
             if isinstance(p, str):
                 pieces.append(p)
@@ -83,7 +83,7 @@ def _coerce_content_to_text(content: Any) -> str:
     return str(content)
 
 
-def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
+def _translate_tool_call_to_gemini(tool_call: dict[str, Any]) -> dict[str, Any]:
     """OpenAI tool_call -> Gemini functionCall part."""
     fn = tool_call.get("function") or {}
     args_raw = fn.get("arguments", "")
@@ -105,7 +105,7 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def _translate_tool_result_to_gemini(message: Dict[str, Any]) -> Dict[str, Any]:
+def _translate_tool_result_to_gemini(message: dict[str, Any]) -> dict[str, Any]:
     """OpenAI tool-role message -> Gemini functionResponse part.
 
     The function name isn't in the OpenAI tool message directly; it must be
@@ -131,11 +131,11 @@ def _translate_tool_result_to_gemini(message: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _build_gemini_contents(
-    messages: List[Dict[str, Any]],
-) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    messages: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], Optional[dict[str, Any]]]:
     """Convert OpenAI messages[] to Gemini contents[] + systemInstruction."""
-    system_text_parts: List[str] = []
-    contents: List[Dict[str, Any]] = []
+    system_text_parts: list[str] = []
+    contents: list[dict[str, Any]] = []
 
     for msg in messages:
         if not isinstance(msg, dict):
@@ -155,7 +155,7 @@ def _build_gemini_contents(
             continue
 
         gemini_role = _ROLE_MAP_OPENAI_TO_GEMINI.get(role, "user")
-        parts: List[Dict[str, Any]] = []
+        parts: list[dict[str, Any]] = []
 
         text = _coerce_content_to_text(msg.get("content"))
         if text:
@@ -174,7 +174,7 @@ def _build_gemini_contents(
 
         contents.append({"role": gemini_role, "parts": parts})
 
-    system_instruction: Optional[Dict[str, Any]] = None
+    system_instruction: Optional[dict[str, Any]] = None
     joined_system = "\n".join(p for p in system_text_parts if p).strip()
     if joined_system:
         system_instruction = {
@@ -185,11 +185,11 @@ def _build_gemini_contents(
     return contents, system_instruction
 
 
-def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
+def _translate_tools_to_gemini(tools: Any) -> list[dict[str, Any]]:
     """OpenAI tools[] -> Gemini tools[].functionDeclarations[]."""
     if not isinstance(tools, list) or not tools:
         return []
-    declarations: List[Dict[str, Any]] = []
+    declarations: list[dict[str, Any]] = []
     for t in tools:
         if not isinstance(t, dict):
             continue
@@ -211,7 +211,7 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
     return [{"functionDeclarations": declarations}]
 
 
-def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any]]:
+def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[dict[str, Any]]:
     """OpenAI tool_choice -> Gemini toolConfig.functionCallingConfig."""
     if tool_choice is None:
         return None
@@ -235,14 +235,14 @@ def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any
     return None
 
 
-def _normalize_thinking_config(config: Any) -> Optional[Dict[str, Any]]:
+def _normalize_thinking_config(config: Any) -> Optional[dict[str, Any]]:
     """Accept thinkingBudget / thinkingLevel / includeThoughts (+ snake_case)."""
     if not isinstance(config, dict) or not config:
         return None
     budget = config.get("thinkingBudget", config.get("thinking_budget"))
     level = config.get("thinkingLevel", config.get("thinking_level"))
     include = config.get("includeThoughts", config.get("include_thoughts"))
-    normalized: Dict[str, Any] = {}
+    normalized: dict[str, Any] = {}
     if isinstance(budget, (int, float)):
         normalized["thinkingBudget"] = int(budget)
     if isinstance(level, str) and level.strip():
@@ -254,7 +254,7 @@ def _normalize_thinking_config(config: Any) -> Optional[Dict[str, Any]]:
 
 def build_gemini_request(
     *,
-    messages: List[Dict[str, Any]],
+    messages: list[dict[str, Any]],
     tools: Any = None,
     tool_choice: Any = None,
     temperature: Optional[float] = None,
@@ -262,11 +262,11 @@ def build_gemini_request(
     top_p: Optional[float] = None,
     stop: Any = None,
     thinking_config: Any = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build the inner Gemini request body (goes inside ``request`` wrapper)."""
     contents, system_instruction = _build_gemini_contents(messages)
 
-    body: Dict[str, Any] = {"contents": contents}
+    body: dict[str, Any] = {"contents": contents}
     if system_instruction is not None:
         body["systemInstruction"] = system_instruction
 
@@ -277,7 +277,7 @@ def build_gemini_request(
     if tool_cfg is not None:
         body["toolConfig"] = tool_cfg
 
-    generation_config: Dict[str, Any] = {}
+    generation_config: dict[str, Any] = {}
     if isinstance(temperature, (int, float)):
         generation_config["temperature"] = float(temperature)
     if isinstance(max_tokens, int) and max_tokens > 0:
@@ -301,9 +301,9 @@ def wrap_code_assist_request(
     *,
     project_id: str,
     model: str,
-    inner_request: Dict[str, Any],
+    inner_request: dict[str, Any],
     user_prompt_id: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Wrap the inner Gemini request in the Code Assist envelope."""
     return {
         "project": project_id,
@@ -318,7 +318,7 @@ def wrap_code_assist_request(
 # =============================================================================
 
 def _translate_gemini_response(
-    resp: Dict[str, Any],
+    resp: dict[str, Any],
     model: str,
 ) -> SimpleNamespace:
     """Non-streaming Gemini response -> OpenAI-shaped SimpleNamespace.
@@ -336,9 +336,9 @@ def _translate_gemini_response(
     content_obj = cand.get("content") if isinstance(cand, dict) else {}
     parts = content_obj.get("parts") if isinstance(content_obj, dict) else []
 
-    text_pieces: List[str] = []
-    reasoning_pieces: List[str] = []
-    tool_calls: List[SimpleNamespace] = []
+    text_pieces: list[str] = []
+    reasoning_pieces: list[str] = []
+    tool_calls: list[SimpleNamespace] = []
 
     for i, part in enumerate(parts or []):
         if not isinstance(part, dict):
@@ -446,11 +446,11 @@ def _make_stream_chunk(
     *,
     model: str,
     content: str = "",
-    tool_call_delta: Optional[Dict[str, Any]] = None,
+    tool_call_delta: Optional[dict[str, Any]] = None,
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {
+    delta_kwargs: dict[str, Any] = {
         "role": "assistant",
         "content": None,
         "tool_calls": None,
@@ -484,7 +484,7 @@ def _make_stream_chunk(
     )
 
 
-def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
+def _iter_sse_events(response: httpx.Response) -> Iterator[dict[str, Any]]:
     """Parse Server-Sent Events from an httpx streaming response."""
     buffer = ""
     for chunk in response.iter_text():
@@ -507,10 +507,10 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
 
 
 def _translate_stream_event(
-    event: Dict[str, Any],
+    event: dict[str, Any],
     model: str,
-    tool_call_counter: List[int],
-) -> List[_GeminiStreamChunk]:
+    tool_call_counter: list[int],
+) -> list[_GeminiStreamChunk]:
     """Unwrap Code Assist envelope and emit OpenAI-shaped chunk(s).
 
     ``tool_call_counter`` is a single-element list used as a mutable counter
@@ -527,7 +527,7 @@ def _translate_stream_event(
     if not isinstance(cand, dict):
         return []
 
-    chunks: List[_GeminiStreamChunk] = []
+    chunks: list[_GeminiStreamChunk] = []
 
     content = cand.get("content") or {}
     parts = content.get("parts") if isinstance(content, dict) else []
@@ -596,7 +596,7 @@ class GeminiCloudCodeClient:
         *,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
-        default_headers: Optional[Dict[str, str]] = None,
+        default_headers: Optional[dict[str, str]] = None,
         project_id: str = "",
         **_: Any,
     ):
@@ -666,7 +666,7 @@ class GeminiCloudCodeClient:
         self,
         *,
         model: str = "gemini-2.5-flash",
-        messages: Optional[List[Dict[str, Any]]] = None,
+        messages: Optional[list[dict[str, Any]]] = None,
         stream: bool = False,
         tools: Any = None,
         tool_choice: Any = None,
@@ -674,7 +674,7 @@ class GeminiCloudCodeClient:
         max_tokens: Optional[int] = None,
         top_p: Optional[float] = None,
         stop: Any = None,
-        extra_body: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
         timeout: Any = None,
         **_: Any,
     ) -> Any:
@@ -731,8 +731,8 @@ class GeminiCloudCodeClient:
         self,
         *,
         model: str,
-        wrapped: Dict[str, Any],
-        headers: Dict[str, str],
+        wrapped: dict[str, Any],
+        headers: dict[str, str],
     ) -> Iterator[_GeminiStreamChunk]:
         """Generator that yields OpenAI-shaped streaming chunks."""
         url = f"{CODE_ASSIST_ENDPOINT}/v1internal:streamGenerateContent?alt=sse"
@@ -746,7 +746,7 @@ class GeminiCloudCodeClient:
                         # Materialize error body for better diagnostics
                         response.read()
                         raise _gemini_http_error(response)
-                    tool_call_counter: List[int] = [0]
+                    tool_call_counter: list[int] = [0]
                     for event in _iter_sse_events(response):
                         for chunk in _translate_stream_event(event, model, tool_call_counter):
                             yield chunk
@@ -780,7 +780,7 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
 
     # Parse the body once, surviving any weird encodings.
     body_text = ""
-    body_json: Dict[str, Any] = {}
+    body_json: dict[str, Any] = {}
     try:
         body_text = response.text
     except Exception:
@@ -809,7 +809,7 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
     # Extract google.rpc.ErrorInfo reason + metadata.  There may be more
     # than one ErrorInfo (rare), so we pick the first one with a reason.
     error_reason = ""
-    error_metadata: Dict[str, Any] = {}
+    error_metadata: dict[str, Any] = {}
     retry_delay_seconds: Optional[float] = None
     for detail in err_details_list:
         if not isinstance(detail, dict):

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -146,7 +146,7 @@ class GeminiAPIError(Exception):
         status_code: Optional[int] = None,
         response: Optional[httpx.Response] = None,
         retry_after: Optional[float] = None,
-        details: Optional[Dict[str, Any]] = None,
+        details: Optional[dict[str, Any]] = None,
     ) -> None:
         super().__init__(message)
         self.code = code
@@ -162,7 +162,7 @@ def _coerce_content_to_text(content: Any) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, list):
-        pieces: List[str] = []
+        pieces: list[str] = []
         for part in content:
             if isinstance(part, str):
                 pieces.append(part)
@@ -174,12 +174,12 @@ def _coerce_content_to_text(content: Any) -> str:
     return str(content)
 
 
-def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
+def _extract_multimodal_parts(content: Any) -> list[dict[str, Any]]:
     if not isinstance(content, list):
         text = _coerce_content_to_text(content)
         return [{"text": text}] if text else []
 
-    parts: List[Dict[str, Any]] = []
+    parts: list[dict[str, Any]] = []
     for item in content:
         if isinstance(item, str):
             parts.append({"text": item})
@@ -212,7 +212,7 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
     return parts
 
 
-def _tool_call_extra_signature(tool_call: Dict[str, Any]) -> Optional[str]:
+def _tool_call_extra_signature(tool_call: dict[str, Any]) -> Optional[str]:
     extra = tool_call.get("extra_content") or {}
     if not isinstance(extra, dict):
         return None
@@ -225,7 +225,7 @@ def _tool_call_extra_signature(tool_call: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
+def _translate_tool_call_to_gemini(tool_call: dict[str, Any]) -> dict[str, Any]:
     fn = tool_call.get("function") or {}
     args_raw = fn.get("arguments", "")
     try:
@@ -235,7 +235,7 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(args, dict):
         args = {"_value": args}
 
-    part: Dict[str, Any] = {
+    part: dict[str, Any] = {
         "functionCall": {
             "name": str(fn.get("name") or ""),
             "args": args,
@@ -248,9 +248,9 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _translate_tool_result_to_gemini(
-    message: Dict[str, Any],
-    tool_name_by_call_id: Optional[Dict[str, str]] = None,
-) -> Dict[str, Any]:
+    message: dict[str, Any],
+    tool_name_by_call_id: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
     tool_name_by_call_id = tool_name_by_call_id or {}
     tool_call_id = str(message.get("tool_call_id") or "")
     name = str(
@@ -273,10 +273,10 @@ def _translate_tool_result_to_gemini(
     }
 
 
-def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
-    system_text_parts: List[str] = []
-    contents: List[Dict[str, Any]] = []
-    tool_name_by_call_id: Dict[str, str] = {}
+def _build_gemini_contents(messages: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], Optional[dict[str, Any]]]:
+    system_text_parts: list[str] = []
+    contents: list[dict[str, Any]] = []
+    tool_name_by_call_id: dict[str, str] = {}
 
     for msg in messages:
         if not isinstance(msg, dict):
@@ -302,7 +302,7 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
             continue
 
         gemini_role = "model" if role == "assistant" else "user"
-        parts: List[Dict[str, Any]] = []
+        parts: list[dict[str, Any]] = []
 
         content_parts = _extract_multimodal_parts(msg.get("content"))
         parts.extend(content_parts)
@@ -327,10 +327,10 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
     return contents, system_instruction
 
 
-def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
+def _translate_tools_to_gemini(tools: Any) -> list[dict[str, Any]]:
     if not isinstance(tools, list):
         return []
-    declarations: List[Dict[str, Any]] = []
+    declarations: list[dict[str, Any]] = []
     for tool in tools:
         if not isinstance(tool, dict):
             continue
@@ -340,7 +340,7 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
         name = fn.get("name")
         if not isinstance(name, str) or not name:
             continue
-        decl: Dict[str, Any] = {"name": name}
+        decl: dict[str, Any] = {"name": name}
         description = fn.get("description")
         if isinstance(description, str) and description:
             decl["description"] = description
@@ -351,7 +351,7 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
     return [{"functionDeclarations": declarations}] if declarations else []
 
 
-def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any]]:
+def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[dict[str, Any]]:
     if tool_choice is None:
         return None
     if isinstance(tool_choice, str):
@@ -369,13 +369,13 @@ def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any
     return None
 
 
-def _normalize_thinking_config(config: Any) -> Optional[Dict[str, Any]]:
+def _normalize_thinking_config(config: Any) -> Optional[dict[str, Any]]:
     if not isinstance(config, dict) or not config:
         return None
     budget = config.get("thinkingBudget", config.get("thinking_budget"))
     include = config.get("includeThoughts", config.get("include_thoughts"))
     level = config.get("thinkingLevel", config.get("thinking_level"))
-    normalized: Dict[str, Any] = {}
+    normalized: dict[str, Any] = {}
     if isinstance(budget, (int, float)):
         normalized["thinkingBudget"] = int(budget)
     if isinstance(include, bool):
@@ -387,7 +387,7 @@ def _normalize_thinking_config(config: Any) -> Optional[Dict[str, Any]]:
 
 def build_gemini_request(
     *,
-    messages: List[Dict[str, Any]],
+    messages: list[dict[str, Any]],
     tools: Any = None,
     tool_choice: Any = None,
     temperature: Optional[float] = None,
@@ -395,9 +395,9 @@ def build_gemini_request(
     top_p: Optional[float] = None,
     stop: Any = None,
     thinking_config: Any = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     contents, system_instruction = _build_gemini_contents(messages)
-    request: Dict[str, Any] = {"contents": contents}
+    request: dict[str, Any] = {"contents": contents}
     if system_instruction:
         request["systemInstruction"] = system_instruction
 
@@ -409,7 +409,7 @@ def build_gemini_request(
     if tool_config:
         request["toolConfig"] = tool_config
 
-    generation_config: Dict[str, Any] = {}
+    generation_config: dict[str, Any] = {}
     if temperature is not None:
         generation_config["temperature"] = temperature
     if max_tokens is not None:
@@ -438,7 +438,7 @@ def _map_gemini_finish_reason(reason: str) -> str:
     return mapping.get(str(reason or "").upper(), "stop")
 
 
-def _tool_call_extra_from_part(part: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _tool_call_extra_from_part(part: dict[str, Any]) -> Optional[dict[str, Any]]:
     sig = part.get("thoughtSignature")
     if isinstance(sig, str) and sig:
         return {"google": {"thought_signature": sig}}
@@ -471,7 +471,7 @@ def _empty_response(model: str) -> SimpleNamespace:
     )
 
 
-def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespace:
+def translate_gemini_response(resp: dict[str, Any], model: str) -> SimpleNamespace:
     candidates = resp.get("candidates") or []
     if not isinstance(candidates, list) or not candidates:
         return _empty_response(model)
@@ -480,9 +480,9 @@ def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespa
     content_obj = cand.get("content") if isinstance(cand, dict) else {}
     parts = content_obj.get("parts") if isinstance(content_obj, dict) else []
 
-    text_pieces: List[str] = []
-    reasoning_pieces: List[str] = []
-    tool_calls: List[SimpleNamespace] = []
+    text_pieces: list[str] = []
+    reasoning_pieces: list[str] = []
+    tool_calls: list[SimpleNamespace] = []
 
     for index, part in enumerate(parts or []):
         if not isinstance(part, dict):
@@ -548,11 +548,11 @@ def _make_stream_chunk(
     *,
     model: str,
     content: str = "",
-    tool_call_delta: Optional[Dict[str, Any]] = None,
+    tool_call_delta: Optional[dict[str, Any]] = None,
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {
+    delta_kwargs: dict[str, Any] = {
         "role": "assistant",
         "content": None,
         "tool_calls": None,
@@ -590,7 +590,7 @@ def _make_stream_chunk(
     )
 
 
-def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
+def _iter_sse_events(response: httpx.Response) -> Iterator[dict[str, Any]]:
     buffer = ""
     for chunk in response.iter_text():
         if not chunk:
@@ -615,13 +615,13 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[Dict[str, Any]]:
                 yield payload
 
 
-def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices: Dict[str, Dict[str, Any]]) -> List[_GeminiStreamChunk]:
+def translate_stream_event(event: dict[str, Any], model: str, tool_call_indices: dict[str, dict[str, Any]]) -> list[_GeminiStreamChunk]:
     candidates = event.get("candidates") or []
     if not candidates:
         return []
     cand = candidates[0] if isinstance(candidates[0], dict) else {}
     parts = ((cand.get("content") or {}).get("parts") or []) if isinstance(cand, dict) else []
-    chunks: List[_GeminiStreamChunk] = []
+    chunks: list[_GeminiStreamChunk] = []
 
     for part_index, part in enumerate(parts):
         if not isinstance(part, dict):
@@ -700,7 +700,7 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
 def gemini_http_error(response: httpx.Response) -> GeminiAPIError:
     status = response.status_code
     body_text = ""
-    body_json: Dict[str, Any] = {}
+    body_json: dict[str, Any] = {}
     try:
         body_text = response.text
     except Exception:
@@ -723,7 +723,7 @@ def gemini_http_error(response: httpx.Response) -> GeminiAPIError:
 
     reason = ""
     retry_after: Optional[float] = None
-    metadata: Dict[str, Any] = {}
+    metadata: dict[str, Any] = {}
     for detail in details_list:
         if not isinstance(detail, dict):
             continue
@@ -810,7 +810,7 @@ class GeminiNativeClient:
         *,
         api_key: str,
         base_url: Optional[str] = None,
-        default_headers: Optional[Dict[str, str]] = None,
+        default_headers: Optional[dict[str, str]] = None,
         timeout: Any = None,
         http_client: Optional[httpx.Client] = None,
         **_: Any,
@@ -847,7 +847,7 @@ class GeminiNativeClient:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
-    def _headers(self) -> Dict[str, str]:
+    def _headers(self) -> dict[str, str]:
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
@@ -868,7 +868,7 @@ class GeminiNativeClient:
         self,
         *,
         model: str = "gemini-2.5-flash",
-        messages: Optional[List[Dict[str, Any]]] = None,
+        messages: Optional[list[dict[str, Any]]] = None,
         stream: bool = False,
         tools: Any = None,
         tool_choice: Any = None,
@@ -876,7 +876,7 @@ class GeminiNativeClient:
         max_tokens: Optional[int] = None,
         top_p: Optional[float] = None,
         stop: Any = None,
-        extra_body: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
         timeout: Any = None,
         **_: Any,
     ) -> Any:
@@ -913,7 +913,7 @@ class GeminiNativeClient:
             ) from exc
         return translate_gemini_response(payload, model=model)
 
-    def _stream_completion(self, *, model: str, request: Dict[str, Any], timeout: Any = None) -> Iterator[_GeminiStreamChunk]:
+    def _stream_completion(self, *, model: str, request: dict[str, Any], timeout: Any = None) -> Iterator[_GeminiStreamChunk]:
         url = f"{self.base_url}/models/{model}:streamGenerateContent?alt=sse"
         stream_headers = dict(self._headers())
         stream_headers["Accept"] = "text/event-stream"
@@ -924,7 +924,7 @@ class GeminiNativeClient:
                     if response.status_code != 200:
                         response.read()
                         raise gemini_http_error(response)
-                    tool_call_indices: Dict[str, Dict[str, Any]] = {}
+                    tool_call_indices: dict[str, dict[str, Any]] = {}
                     for event in _iter_sse_events(response):
                         for chunk in translate_stream_event(event, model, tool_call_indices):
                             yield chunk

--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -33,7 +33,7 @@ _GEMINI_SCHEMA_ALLOWED_KEYS = {
 }
 
 
-def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
+def sanitize_gemini_schema(schema: Any) -> dict[str, Any]:
     """Return a Gemini-compatible copy of a tool parameter schema.
 
     Hermes tool schemas are OpenAI-flavored JSON Schema and may contain keys
@@ -46,14 +46,14 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     if not isinstance(schema, dict):
         return {}
 
-    cleaned: Dict[str, Any] = {}
+    cleaned: dict[str, Any] = {}
     for key, value in schema.items():
         if key not in _GEMINI_SCHEMA_ALLOWED_KEYS:
             continue
         if key == "properties":
             if not isinstance(value, dict):
                 continue
-            props: Dict[str, Any] = {}
+            props: dict[str, Any] = {}
             for prop_name, prop_schema in value.items():
                 if not isinstance(prop_name, str):
                     continue
@@ -90,7 +90,7 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
     return cleaned
 
 
-def sanitize_gemini_tool_parameters(parameters: Any) -> Dict[str, Any]:
+def sanitize_gemini_tool_parameters(parameters: Any) -> dict[str, Any]:
     """Normalize tool parameters to a valid Gemini object schema."""
 
     cleaned = sanitize_gemini_schema(parameters)

--- a/agent/google_code_assist.py
+++ b/agent/google_code_assist.py
@@ -84,7 +84,7 @@ class CodeAssistError(RuntimeError):
         status_code: Optional[int] = None,
         response: Any = None,
         retry_after: Optional[float] = None,
-        details: Optional[Dict[str, Any]] = None,
+        details: Optional[dict[str, Any]] = None,
     ) -> None:
         super().__init__(message)
         self.code = code
@@ -117,7 +117,7 @@ class ProjectIdRequiredError(CodeAssistError):
 # HTTP primitive (auth via Bearer token passed per-call)
 # =============================================================================
 
-def _build_headers(access_token: str, *, user_agent_model: str = "") -> Dict[str, str]:
+def _build_headers(access_token: str, *, user_agent_model: str = "") -> dict[str, str]:
     ua = _GEMINI_CLI_USER_AGENT
     if user_agent_model:
         ua = f"{ua} model/{user_agent_model}"
@@ -131,7 +131,7 @@ def _build_headers(access_token: str, *, user_agent_model: str = "") -> Dict[str
     }
 
 
-def _client_metadata() -> Dict[str, str]:
+def _client_metadata() -> dict[str, str]:
     """Match Google's gemini-cli exactly — unrecognized metadata may be rejected."""
     return {
         "ideType": "IDE_UNSPECIFIED",
@@ -142,12 +142,12 @@ def _client_metadata() -> Dict[str, str]:
 
 def _post_json(
     url: str,
-    body: Dict[str, Any],
+    body: dict[str, Any],
     access_token: str,
     *,
     timeout: float = _DEFAULT_REQUEST_TIMEOUT,
     user_agent_model: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     data = json.dumps(body).encode("utf-8")
     request = urllib.request.Request(
         url, data=data, method="POST",
@@ -212,8 +212,8 @@ class CodeAssistProjectInfo:
     """Result from ``load_code_assist``."""
     current_tier_id: str = ""
     cloudaicompanion_project: str = ""   # Google-managed project (free tier)
-    allowed_tiers: List[str] = field(default_factory=list)
-    raw: Dict[str, Any] = field(default_factory=dict)
+    allowed_tiers: list[str] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
 
 
 def load_code_assist(
@@ -227,7 +227,7 @@ def load_code_assist(
     Returns whatever tier + project info Google reports. On VPC-SC violations,
     returns a synthetic ``standard-tier`` result so the chain can continue.
     """
-    body: Dict[str, Any] = {
+    body: dict[str, Any] = {
         "metadata": {
             "duetProject": project_id,
             **_client_metadata(),
@@ -258,12 +258,12 @@ def load_code_assist(
     return CodeAssistProjectInfo()
 
 
-def _parse_load_response(resp: Dict[str, Any]) -> CodeAssistProjectInfo:
+def _parse_load_response(resp: dict[str, Any]) -> CodeAssistProjectInfo:
     current_tier = resp.get("currentTier") or {}
     tier_id = str(current_tier.get("id") or "") if isinstance(current_tier, dict) else ""
     project = str(resp.get("cloudaicompanionProject") or "")
     allowed = resp.get("allowedTiers") or []
-    allowed_ids: List[str] = []
+    allowed_ids: list[str] = []
     if isinstance(allowed, list):
         for t in allowed:
             if isinstance(t, dict):
@@ -288,7 +288,7 @@ def onboard_user(
     tier_id: str,
     project_id: str = "",
     user_agent_model: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Call ``POST /v1internal:onboardUser`` to provision the user.
 
     For paid tiers, ``project_id`` is REQUIRED (raises ProjectIdRequiredError).
@@ -304,7 +304,7 @@ def onboard_user(
             "Set HERMES_GEMINI_PROJECT_ID or GOOGLE_CLOUD_PROJECT."
         )
 
-    body: Dict[str, Any] = {
+    body: dict[str, Any] = {
         "tierId": tier_id,
         "metadata": _client_metadata(),
     }
@@ -344,7 +344,7 @@ class QuotaBucket:
     token_type: str = ""
     remaining_fraction: float = 0.0
     reset_time_iso: str = ""
-    raw: Dict[str, Any] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
 
 
 def retrieve_user_quota(
@@ -352,15 +352,15 @@ def retrieve_user_quota(
     *,
     project_id: str = "",
     user_agent_model: str = "",
-) -> List[QuotaBucket]:
+) -> list[QuotaBucket]:
     """Call ``POST /v1internal:retrieveUserQuota`` and parse ``buckets[]``."""
-    body: Dict[str, Any] = {}
+    body: dict[str, Any] = {}
     if project_id:
         body["project"] = project_id
     url = f"{CODE_ASSIST_ENDPOINT}/v1internal:retrieveUserQuota"
     resp = _post_json(url, body, access_token, user_agent_model=user_agent_model)
     raw_buckets = resp.get("buckets") or []
-    buckets: List[QuotaBucket] = []
+    buckets: list[QuotaBucket] = []
     if not isinstance(raw_buckets, list):
         return buckets
     for b in raw_buckets:

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -246,7 +246,7 @@ def _credentials_lock(timeout_seconds: float = LOCK_TIMEOUT_SECONDS):
 # Client ID resolution
 # =============================================================================
 
-_scraped_creds_cache: Dict[str, str] = {}
+_scraped_creds_cache: dict[str, str] = {}
 
 
 def _locate_gemini_cli_oauth_js() -> Optional[Path]:
@@ -301,7 +301,7 @@ def _locate_gemini_cli_oauth_js() -> Optional[Path]:
     return None
 
 
-def _scrape_client_credentials() -> Tuple[str, str]:
+def _scrape_client_credentials() -> tuple[str, str]:
     """Extract client_id + client_secret from the local gemini-cli install."""
     if _scraped_creds_cache.get("resolved"):
         return _scraped_creds_cache.get("client_id", ""), _scraped_creds_cache.get("client_secret", "")
@@ -377,7 +377,7 @@ def _require_client_id() -> str:
 # PKCE
 # =============================================================================
 
-def _generate_pkce_pair() -> Tuple[str, str]:
+def _generate_pkce_pair() -> tuple[str, str]:
     """Generate a (verifier, challenge) pair using S256."""
     verifier = secrets.token_urlsafe(64)
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
@@ -427,7 +427,7 @@ class GoogleCredentials:
     project_id: str = ""
     managed_project_id: str = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "refresh": RefreshParts(
                 refresh_token=self.refresh_token,
@@ -440,7 +440,7 @@ class GoogleCredentials:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GoogleCredentials":
+    def from_dict(cls, data: dict[str, Any]) -> "GoogleCredentials":
         refresh_packed = str(data.get("refresh", "") or "")
         parts = RefreshParts.parse(refresh_packed)
         return cls(
@@ -536,7 +536,7 @@ def clear_credentials() -> None:
 # HTTP helpers
 # =============================================================================
 
-def _post_form(url: str, data: Dict[str, str], timeout: float) -> Dict[str, Any]:
+def _post_form(url: str, data: dict[str, str], timeout: float) -> dict[str, Any]:
     """POST x-www-form-urlencoded and return parsed JSON response."""
     body = urllib.parse.urlencode(data).encode("ascii")
     request = urllib.request.Request(
@@ -581,7 +581,7 @@ def exchange_code(
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
     timeout: float = TOKEN_REQUEST_TIMEOUT_SECONDS,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Exchange authorization code for access + refresh tokens."""
     cid = client_id if client_id is not None else _get_client_id()
     csecret = client_secret if client_secret is not None else _get_client_secret()
@@ -603,7 +603,7 @@ def refresh_access_token(
     client_id: Optional[str] = None,
     client_secret: Optional[str] = None,
     timeout: float = TOKEN_REQUEST_TIMEOUT_SECONDS,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Refresh the access token."""
     if not refresh_token:
         raise GoogleOAuthError(
@@ -642,7 +642,7 @@ def _fetch_user_email(access_token: str, timeout: float = TOKEN_REQUEST_TIMEOUT_
 # In-flight refresh deduplication
 # =============================================================================
 
-_refresh_inflight: Dict[str, threading.Event] = {}
+_refresh_inflight: dict[str, threading.Event] = {}
 _refresh_inflight_lock = threading.Lock()
 
 
@@ -811,7 +811,7 @@ h1 {{ color: #b42318; }} p {{ color: #555; }}
 """
 
 
-def _bind_callback_server(preferred_port: int = DEFAULT_REDIRECT_PORT) -> Tuple[http.server.HTTPServer, int]:
+def _bind_callback_server(preferred_port: int = DEFAULT_REDIRECT_PORT) -> tuple[http.server.HTTPServer, int]:
     try:
         server = http.server.HTTPServer((REDIRECT_HOST, preferred_port), _OAuthCallbackHandler)
         return server, preferred_port
@@ -1001,7 +1001,7 @@ def _prompt_paste_fallback() -> Optional[str]:
 
 
 def _persist_token_response(
-    token_resp: Dict[str, Any],
+    token_resp: dict[str, Any],
     *,
     project_id: str = "",
 ) -> GoogleCredentials:
@@ -1030,7 +1030,7 @@ def _persist_token_response(
 # Pool-compatible variant
 # =============================================================================
 
-def run_gemini_oauth_login_pure() -> Dict[str, Any]:
+def run_gemini_oauth_login_pure() -> dict[str, Any]:
     """Run the login flow and return a dict matching the credential pool shape."""
     creds = start_oauth_flow(force_relogin=True)
     return {

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -39,7 +39,7 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
-VALID_ASPECT_RATIOS: Tuple[str, ...] = ("landscape", "square", "portrait")
+VALID_ASPECT_RATIOS: tuple[str, ...] = ("landscape", "square", "portrait")
 DEFAULT_ASPECT_RATIO = "landscape"
 
 
@@ -76,7 +76,7 @@ class ImageGenProvider(abc.ABC):
         """
         return True
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         """Return catalog entries for ``hermes tools`` model picker.
 
         Each entry::
@@ -93,7 +93,7 @@ class ImageGenProvider(abc.ABC):
         """
         return []
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         """Return provider metadata for the ``hermes tools`` picker.
 
         Used by ``tools_config.py`` to inject this provider as a row in
@@ -133,7 +133,7 @@ class ImageGenProvider(abc.ABC):
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate an image.
 
         Implementations should return the dict from :func:`success_response`
@@ -280,15 +280,15 @@ def success_response(
     prompt: str,
     aspect_ratio: str,
     provider: str,
-    extra: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    extra: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """Build a uniform success response dict.
 
     ``image`` may be an HTTP URL or an absolute filesystem path (for b64
     providers like OpenAI). Callers that need to pass through additional
     backend-specific fields can supply ``extra``.
     """
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "success": True,
         "image": image,
         "model": model,
@@ -310,7 +310,7 @@ def error_response(
     model: str = "",
     prompt: str = "",
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build a uniform error response dict."""
     return {
         "success": False,

--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -29,7 +29,7 @@ from agent.image_gen_provider import ImageGenProvider
 logger = logging.getLogger(__name__)
 
 
-_providers: Dict[str, ImageGenProvider] = {}
+_providers: dict[str, ImageGenProvider] = {}
 _lock = threading.Lock()
 
 
@@ -57,7 +57,7 @@ def register_provider(provider: ImageGenProvider) -> None:
         logger.debug("Registered image gen provider '%s' (%s)", name, type(provider).__name__)
 
 
-def list_providers() -> List[ImageGenProvider]:
+def list_providers() -> list[ImageGenProvider]:
     """Return all registered providers, sorted by name."""
     with _lock:
         items = list(_providers.values())

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -76,7 +76,7 @@ def _coerce_capability_bool(raw: Any) -> Optional[bool]:
 
 
 def _supports_vision_override(
-    cfg: Optional[Dict[str, Any]],
+    cfg: Optional[dict[str, Any]],
     provider: str,
     model: str,
 ) -> Optional[bool]:
@@ -98,7 +98,7 @@ def _supports_vision_override(
 
     # 1. Top-level shortcut
     model_cfg_raw = cfg.get("model")
-    model_cfg: Dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
+    model_cfg: dict[str, Any] = model_cfg_raw if isinstance(model_cfg_raw, dict) else {}
     top = _coerce_capability_bool(model_cfg.get("supports_vision"))
     if top is not None:
         return top
@@ -110,14 +110,14 @@ def _supports_vision_override(
     # both as candidate provider keys.
     config_provider = str(model_cfg.get("provider") or "").strip()
     providers_raw = cfg.get("providers")
-    providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
+    providers_cfg: dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
     for p in dict.fromkeys(filter(None, (provider, config_provider))):
         entry_raw = providers_cfg.get(p)
-        entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
+        entry: dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
         models_raw = entry.get("models")
-        models_cfg: Dict[str, Any] = models_raw if isinstance(models_raw, dict) else {}
+        models_cfg: dict[str, Any] = models_raw if isinstance(models_raw, dict) else {}
         per_model_raw = models_cfg.get(model)
-        per_model: Dict[str, Any] = per_model_raw if isinstance(per_model_raw, dict) else {}
+        per_model: dict[str, Any] = per_model_raw if isinstance(per_model_raw, dict) else {}
         coerced = _coerce_capability_bool(per_model.get("supports_vision"))
         if coerced is not None:
             return coerced
@@ -134,7 +134,7 @@ def _coerce_mode(raw: Any) -> str:
     return "auto"
 
 
-def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
+def _explicit_aux_vision_override(cfg: Optional[dict[str, Any]]) -> bool:
     """True when the user configured a specific auxiliary vision backend.
 
     An explicit override means the user *wants* the text pipeline (they're
@@ -162,7 +162,7 @@ def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
 def _lookup_supports_vision(
     provider: str,
     model: str,
-    cfg: Optional[Dict[str, Any]] = None,
+    cfg: Optional[dict[str, Any]] = None,
 ) -> Optional[bool]:
     """Return True/False if we can resolve caps, None if unknown.
 
@@ -189,7 +189,7 @@ def _lookup_supports_vision(
 def decide_image_input_mode(
     provider: str,
     model: str,
-    cfg: Optional[Dict[str, Any]],
+    cfg: Optional[dict[str, Any]],
 ) -> str:
     """Return ``"native"`` or ``"text"`` for the given turn.
 
@@ -319,8 +319,8 @@ def _file_to_data_url(path: Path) -> Optional[str]:
 
 def build_native_content_parts(
     user_text: str,
-    image_paths: List[str],
-) -> Tuple[List[Dict[str, Any]], List[str]]:
+    image_paths: list[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
     """Build an OpenAI-style ``content`` list for a user turn.
 
     Shape:
@@ -345,9 +345,9 @@ def build_native_content_parts(
     Returns (content_parts, skipped_paths). Skipped paths are files that
     couldn't be read from disk and are NOT advertised in the path hints.
     """
-    skipped: List[str] = []
-    image_parts: List[Dict[str, Any]] = []
-    attached_paths: List[str] = []
+    skipped: list[str] = []
+    image_parts: list[dict[str, Any]] = []
+    attached_paths: list[str] = []
 
     for raw_path in image_paths:
         p = Path(raw_path)
@@ -374,7 +374,7 @@ def build_native_content_parts(
             f"[Image attached at: {p}]" for p in attached_paths
         )
         combined_text = f"{base_text}\n\n{path_hints}"
-        parts: List[Dict[str, Any]] = [{"type": "text", "text": combined_text}]
+        parts: list[dict[str, Any]] = [{"type": "text", "text": combined_text}]
         parts.extend(image_parts)
         return parts, skipped
 

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -39,7 +39,7 @@ def _has_known_pricing(model_name: str, provider: str = None, base_url: str = No
 
 
 def _estimate_cost(
-    session_or_model: Dict[str, Any] | str,
+    session_or_model: dict[str, Any] | str,
     input_tokens: int = 0,
     output_tokens: int = 0,
     *,
@@ -82,7 +82,7 @@ def _format_duration(seconds: float) -> str:
     return format_duration_compact(seconds)
 
 
-def _bar_chart(values: List[int], max_width: int = 20) -> List[str]:
+def _bar_chart(values: list[int], max_width: int = 20) -> list[str]:
     """Create simple horizontal bar chart strings from values."""
     peak = max(values) if values else 1
     if peak == 0:
@@ -108,7 +108,7 @@ class InsightsEngine:
         self.db = db
         self._conn = db._conn
 
-    def generate(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+    def generate(self, days: int = 30, source: str = None) -> dict[str, Any]:
         """
         Generate a complete insights report.
 
@@ -196,7 +196,7 @@ class InsightsEngine:
         " ORDER BY started_at DESC"
     )
 
-    def _get_sessions(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_sessions(self, cutoff: float, source: str = None) -> list[dict]:
         """Fetch sessions within the time window."""
         if source:
             cursor = self._conn.execute(self._GET_SESSIONS_WITH_SOURCE, (cutoff, source))
@@ -204,7 +204,7 @@ class InsightsEngine:
             cursor = self._conn.execute(self._GET_SESSIONS_ALL, (cutoff,))
         return [dict(row) for row in cursor.fetchall()]
 
-    def _get_tool_usage(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_tool_usage(self, cutoff: float, source: str = None) -> list[dict]:
         """Get tool call counts from messages.
 
         Uses two sources:
@@ -296,9 +296,9 @@ class InsightsEngine:
             for name, count in tool_counts.most_common()
         ]
 
-    def _get_skill_usage(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_skill_usage(self, cutoff: float, source: str = None) -> list[dict]:
         """Extract per-skill usage from assistant tool calls."""
-        skill_counts: Dict[str, Dict[str, Any]] = {}
+        skill_counts: dict[str, dict[str, Any]] = {}
 
         if source:
             cursor = self._conn.execute(
@@ -372,7 +372,7 @@ class InsightsEngine:
 
         return list(skill_counts.values())
 
-    def _get_message_stats(self, cutoff: float, source: str = None) -> Dict:
+    def _get_message_stats(self, cutoff: float, source: str = None) -> dict:
         """Get aggregate message statistics."""
         if source:
             cursor = self._conn.execute(
@@ -408,7 +408,7 @@ class InsightsEngine:
     # Computation
     # =========================================================================
 
-    def _compute_overview(self, sessions: List[Dict], message_stats: Dict) -> Dict:
+    def _compute_overview(self, sessions: list[dict], message_stats: dict) -> dict:
         """Compute high-level overview statistics."""
         total_input = sum(s.get("input_tokens") or 0 for s in sessions)
         total_output = sum(s.get("output_tokens") or 0 for s in sessions)
@@ -482,7 +482,7 @@ class InsightsEngine:
             "included_cost_sessions": included_cost_sessions,
         }
 
-    def _compute_model_breakdown(self, sessions: List[Dict]) -> List[Dict]:
+    def _compute_model_breakdown(self, sessions: list[dict]) -> list[dict]:
         """Break down usage by model."""
         model_data = defaultdict(lambda: {
             "sessions": 0, "input_tokens": 0, "output_tokens": 0,
@@ -519,7 +519,7 @@ class InsightsEngine:
         result.sort(key=lambda x: (x["total_tokens"], x["sessions"]), reverse=True)
         return result
 
-    def _compute_platform_breakdown(self, sessions: List[Dict]) -> List[Dict]:
+    def _compute_platform_breakdown(self, sessions: list[dict]) -> list[dict]:
         """Break down usage by platform/source."""
         platform_data = defaultdict(lambda: {
             "sessions": 0, "messages": 0, "input_tokens": 0,
@@ -550,7 +550,7 @@ class InsightsEngine:
         result.sort(key=lambda x: x["sessions"], reverse=True)
         return result
 
-    def _compute_tool_breakdown(self, tool_usage: List[Dict]) -> List[Dict]:
+    def _compute_tool_breakdown(self, tool_usage: list[dict]) -> list[dict]:
         """Process tool usage data into a ranked list with percentages."""
         total_calls = sum(t["count"] for t in tool_usage) if tool_usage else 0
         result = []
@@ -563,7 +563,7 @@ class InsightsEngine:
             })
         return result
 
-    def _compute_skill_breakdown(self, skill_usage: List[Dict]) -> Dict[str, Any]:
+    def _compute_skill_breakdown(self, skill_usage: list[dict]) -> dict[str, Any]:
         """Process per-skill usage into summary + ranked list."""
         total_skill_loads = sum(s["view_count"] for s in skill_usage) if skill_usage else 0
         total_skill_edits = sum(s["manage_count"] for s in skill_usage) if skill_usage else 0
@@ -603,7 +603,7 @@ class InsightsEngine:
             "top_skills": top_skills,
         }
 
-    def _compute_activity_patterns(self, sessions: List[Dict]) -> Dict:
+    def _compute_activity_patterns(self, sessions: list[dict]) -> dict:
         """Analyze activity patterns by day of week and hour."""
         day_counts = Counter()  # 0=Monday ... 6=Sunday
         hour_counts = Counter()
@@ -661,7 +661,7 @@ class InsightsEngine:
             "max_streak": max_streak,
         }
 
-    def _compute_top_sessions(self, sessions: List[Dict]) -> List[Dict]:
+    def _compute_top_sessions(self, sessions: list[dict]) -> list[dict]:
         """Find notable sessions (longest, most messages, most tokens)."""
         top = []
 
@@ -723,7 +723,7 @@ class InsightsEngine:
     # Formatting
     # =========================================================================
 
-    def format_terminal(self, report: Dict) -> str:
+    def format_terminal(self, report: dict) -> str:
         """Format the insights report for terminal display (CLI)."""
         if report.get("empty"):
             days = report.get("days", 30)
@@ -863,7 +863,7 @@ class InsightsEngine:
 
         return "\n".join(lines)
 
-    def format_gateway(self, report: Dict) -> str:
+    def format_gateway(self, report: dict) -> str:
         """Format the insights report for gateway/messaging (shorter)."""
         if report.get("empty"):
             days = report.get("days", 30)

--- a/agent/lmstudio_reasoning.py
+++ b/agent/lmstudio_reasoning.py
@@ -23,7 +23,7 @@ _LM_EFFORT_ALIASES = {"off": "none", "on": "medium"}
 
 def resolve_lmstudio_effort(
     reasoning_config: Optional[dict],
-    allowed_options: Optional[List[str]],
+    allowed_options: Optional[list[str]],
 ) -> Optional[str]:
     """Return the ``reasoning_effort`` string to send to LM Studio, or ``None``.
 

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -103,7 +103,7 @@ def uri_to_path(uri: str) -> str:
     return os.path.normpath(unquote(raw))
 
 
-def _end_position(text: str) -> Dict[str, int]:
+def _end_position(text: str) -> dict[str, int]:
     """Return the LSP Position at the end of ``text``.
 
     Used to construct a single-range "replace whole document" change
@@ -145,10 +145,10 @@ class LSPClient:
         *,
         server_id: str,
         workspace_root: str,
-        command: List[str],
-        env: Optional[Dict[str, str]] = None,
+        command: list[str],
+        env: Optional[dict[str, str]] = None,
         cwd: Optional[str] = None,
-        initialization_options: Optional[Dict[str, Any]] = None,
+        initialization_options: Optional[dict[str, Any]] = None,
         seed_diagnostics_on_first_push: bool = False,
     ) -> None:
         self.server_id = server_id
@@ -166,11 +166,11 @@ class LSPClient:
 
         # Request/response correlation
         self._next_id: int = 0
-        self._pending: Dict[int, asyncio.Future] = {}
+        self._pending: dict[int, asyncio.Future] = {}
 
         # Server-side request handlers (server → client requests).
         # Kept small and explicit; everything else returns method-not-found.
-        self._request_handlers: Dict[str, Callable[[Any], Awaitable[Any]]] = {
+        self._request_handlers: dict[str, Callable[[Any], Awaitable[Any]]] = {
             "window/workDoneProgress/create": self._handle_work_done_create,
             "workspace/configuration": self._handle_workspace_configuration,
             "client/registerCapability": self._handle_register_capability,
@@ -179,30 +179,30 @@ class LSPClient:
             "workspace/diagnostic/refresh": self._handle_diagnostic_refresh,
         }
         # Notifications (server → client) we care about.
-        self._notification_handlers: Dict[str, Callable[[Any], None]] = {
+        self._notification_handlers: dict[str, Callable[[Any], None]] = {
             "textDocument/publishDiagnostics": self._handle_publish_diagnostics,
             # Everything else (window/showMessage, $/progress, etc.)
             # is silently dropped by default.
         }
 
         # Tracked file state — required for didChange version bumps.
-        self._files: Dict[str, Dict[str, Any]] = {}
+        self._files: dict[str, dict[str, Any]] = {}
         # Diagnostic stores, keyed by file path (NOT URI).
-        self._push_diagnostics: Dict[str, List[Dict[str, Any]]] = {}
-        self._pull_diagnostics: Dict[str, List[Dict[str, Any]]] = {}
+        self._push_diagnostics: dict[str, list[dict[str, Any]]] = {}
+        self._pull_diagnostics: dict[str, list[dict[str, Any]]] = {}
         # Per-path "last published" time so wait-for-fresh logic works.
-        self._published: Dict[str, float] = {}
+        self._published: dict[str, float] = {}
         # Per-path version of the latest push (matches our didChange
         # version when the server respects it).
-        self._published_version: Dict[str, int] = {}
+        self._published_version: dict[str, int] = {}
         # First-push seen flag, for typescript-style seed-on-first-push.
-        self._first_push_seen: Set[str] = set()
+        self._first_push_seen: set[str] = set()
         # Capability registrations — only diagnostic ones are tracked.
-        self._diagnostic_registrations: Dict[str, Dict[str, Any]] = {}
+        self._diagnostic_registrations: dict[str, dict[str, Any]] = {}
 
         # State machine
         self._state: str = "stopped"
-        self._initialize_result: Optional[Dict[str, Any]] = None
+        self._initialize_result: Optional[dict[str, Any]] = None
         self._sync_kind: int = 1  # 1=Full, 2=Incremental
         self._stopping: bool = False
 
@@ -561,7 +561,7 @@ class LSPClient:
         if not isinstance(params, dict):
             return [None]
         items = params.get("items") or []
-        out: List[Any] = []
+        out: list[Any] = []
         for item in items:
             if not isinstance(item, dict):
                 out.append(None)
@@ -683,7 +683,7 @@ class LSPClient:
             )
             new_version = existing["version"] + 1
             old_text = existing["text"]
-            content_changes: List[Dict[str, Any]]
+            content_changes: list[dict[str, Any]]
             if self._sync_kind == 2:
                 content_changes = [
                     {
@@ -752,7 +752,7 @@ class LSPClient:
         no-ops on errors (server may not support the pull endpoint).
         """
         try:
-            params: Dict[str, Any] = {
+            params: dict[str, Any] = {
                 "textDocument": {"uri": file_uri(os.path.abspath(path))}
             }
             result = await self._send_request_with_retry(
@@ -867,7 +867,7 @@ class LSPClient:
             except asyncio.TimeoutError:
                 continue
 
-    def diagnostics_for(self, path: str) -> List[Dict[str, Any]]:
+    def diagnostics_for(self, path: str) -> list[dict[str, Any]]:
         """Return current merged + deduped diagnostics for one file.
 
         Diagnostics from push and pull stores are concatenated and
@@ -880,9 +880,9 @@ class LSPClient:
         return _dedupe(push, pull)
 
 
-def _dedupe(*lists: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    seen: Set[str] = set()
-    out: List[Dict[str, Any]] = []
+def _dedupe(*lists: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
     for lst in lists:
         for d in lst:
             if not isinstance(d, dict):
@@ -895,7 +895,7 @@ def _dedupe(*lists: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return out
 
 
-def _diagnostic_key(d: Dict[str, Any]) -> str:
+def _diagnostic_key(d: dict[str, Any]) -> str:
     """Content-equality key for a diagnostic.
 
     Matches the structural-equality used in claude-code's

--- a/agent/lsp/eventlog.py
+++ b/agent/lsp/eventlog.py
@@ -79,7 +79,7 @@ def _emit(server_id: str, level: int, message: str) -> None:
     event_log.log(level, "lsp[%s] %s", server_id, message)
 
 
-def _announce_once(bucket: set, key: Tuple) -> bool:
+def _announce_once(bucket: set, key: tuple) -> bool:
     """Return True if *key* has not been announced for *bucket* yet.
 
     Atomically marks the key as announced so concurrent callers

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -47,7 +47,7 @@ logger = logging.getLogger("agent.lsp.install")
 #     ``pkg`` in the same node_modules tree.  Used when an LSP server
 #     has a runtime peer dependency that npm doesn't auto-pull (e.g.
 #     typescript-language-server needs ``typescript``).
-INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
+INSTALL_RECIPES: dict[str, dict[str, Any]] = {
     # Python
     "pyright": {"strategy": "npm", "pkg": "pyright", "bin": "pyright-langserver"},
     # JS/TS family
@@ -105,8 +105,8 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
 }
 
 
-_install_locks: Dict[str, threading.Lock] = {}
-_install_results: Dict[str, Optional[str]] = {}
+_install_locks: dict[str, threading.Lock] = {}
+_install_results: dict[str, Optional[str]] = {}
 _install_lock_meta = threading.Lock()
 
 

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -155,10 +155,10 @@ class LSPService:
         wait_mode: str,
         wait_timeout: float,
         install_strategy: str,
-        binary_overrides: Optional[Dict[str, List[str]]] = None,
-        env_overrides: Optional[Dict[str, Dict[str, str]]] = None,
-        init_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
-        disabled_servers: Optional[List[str]] = None,
+        binary_overrides: Optional[dict[str, list[str]]] = None,
+        env_overrides: Optional[dict[str, dict[str, str]]] = None,
+        init_overrides: Optional[dict[str, dict[str, Any]]] = None,
+        disabled_servers: Optional[list[str]] = None,
         idle_timeout: float = DEFAULT_IDLE_TIMEOUT,
     ) -> None:
         self._enabled = enabled
@@ -176,17 +176,17 @@ class LSPService:
             self._loop.start()
 
         # Per-(server_id, workspace_root) state
-        self._clients: Dict[Tuple[str, str], LSPClient] = {}
+        self._clients: dict[tuple[str, str], LSPClient] = {}
         self._broken: set = set()
-        self._spawning: Dict[Tuple[str, str], asyncio.Future] = {}
-        self._last_used: Dict[Tuple[str, str], float] = {}
+        self._spawning: dict[tuple[str, str], asyncio.Future] = {}
+        self._last_used: dict[tuple[str, str], float] = {}
         self._state_lock = threading.Lock()
 
         # Delta baseline: file path → snapshot of diagnostics taken
         # immediately before a write.  ``get_diagnostics_sync`` filters
         # out anything in the baseline so the agent only sees errors
         # introduced by the current edit.
-        self._delta_baseline: Dict[str, List[Dict[str, Any]]] = {}
+        self._delta_baseline: dict[str, list[dict[str, Any]]] = {}
 
     @classmethod
     def create_from_config(cls) -> Optional["LSPService"]:
@@ -212,9 +212,9 @@ class LSPService:
         install_strategy = lsp_cfg.get("install_strategy", "auto")
         servers_cfg = lsp_cfg.get("servers") or {}
         disabled = []
-        binary_overrides: Dict[str, List[str]] = {}
-        env_overrides: Dict[str, Dict[str, str]] = {}
-        init_overrides: Dict[str, Dict[str, Any]] = {}
+        binary_overrides: dict[str, list[str]] = {}
+        env_overrides: dict[str, dict[str, str]] = {}
+        init_overrides: dict[str, dict[str, Any]] = {}
         if isinstance(servers_cfg, dict):
             for name, sub in servers_cfg.items():
                 if not isinstance(sub, dict):
@@ -311,7 +311,7 @@ class LSPService:
         delta: bool = True,
         timeout: Optional[float] = None,
         line_shift: Optional[Callable[[int], Optional[int]]] = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Synchronously open ``file_path`` in the right server, wait for
         diagnostics, return them.
 
@@ -451,7 +451,7 @@ class LSPService:
     # async internals
     # ------------------------------------------------------------------
 
-    async def _snapshot_async(self, file_path: str) -> List[Dict[str, Any]]:
+    async def _snapshot_async(self, file_path: str) -> list[dict[str, Any]]:
         client = await self._get_or_spawn(file_path)
         if client is None:
             return []
@@ -464,7 +464,7 @@ class LSPService:
         self._last_used[(client.server_id, client.workspace_root)] = time.time()
         return list(client.diagnostics_for(file_path))
 
-    async def _open_and_wait_async(self, file_path: str) -> List[Dict[str, Any]]:
+    async def _open_and_wait_async(self, file_path: str) -> list[dict[str, Any]]:
         client = await self._get_or_spawn(file_path)
         if client is None:
             return []
@@ -478,7 +478,7 @@ class LSPService:
         self._last_used[(client.server_id, client.workspace_root)] = time.time()
         return list(client.diagnostics_for(file_path))
 
-    async def _current_diags_async(self, file_path: str) -> List[Dict[str, Any]]:
+    async def _current_diags_async(self, file_path: str) -> list[dict[str, Any]]:
         ws, gated = resolve_workspace_for_file(file_path)
         srv = find_server_for_file(file_path)
         if not (ws and gated and srv):
@@ -586,7 +586,7 @@ class LSPService:
     # status / introspection (used by ``hermes lsp status``)
     # ------------------------------------------------------------------
 
-    def get_status(self) -> Dict[str, Any]:
+    def get_status(self) -> dict[str, Any]:
         """Return a snapshot of the service for the CLI status command."""
         with self._state_lock:
             clients = [
@@ -610,7 +610,7 @@ class LSPService:
         }
 
 
-def _diag_key(d: Dict[str, Any]) -> str:
+def _diag_key(d: dict[str, Any]) -> str:
     """Content equality key used for cross-edit delta filtering.
 
     Includes the diagnostic's position range — when used together

--- a/agent/lsp/protocol.py
+++ b/agent/lsp/protocol.py
@@ -158,7 +158,7 @@ def make_error_response(req_id: Any, code: int, message: str, data: Any = None) 
     return {"jsonrpc": "2.0", "id": req_id, "error": err}
 
 
-def classify_message(msg: dict) -> Tuple[str, Any]:
+def classify_message(msg: dict) -> tuple[str, Any]:
     """Return ``(kind, key)`` where kind is one of ``request``,
     ``response``, ``notification``, ``invalid``.
 

--- a/agent/lsp/range_shift.py
+++ b/agent/lsp/range_shift.py
@@ -88,8 +88,8 @@ def build_line_shift(pre_text: str, post_text: str) -> Callable[[int], Optional[
     return shift
 
 
-def shift_diagnostic_range(diag: Dict[str, Any],
-                           shift: Callable[[int], Optional[int]]) -> Optional[Dict[str, Any]]:
+def shift_diagnostic_range(diag: dict[str, Any],
+                           shift: Callable[[int], Optional[int]]) -> Optional[dict[str, Any]]:
     """Return a copy of ``diag`` with its line range remapped through ``shift``.
 
     Returns ``None`` if the diagnostic's start line maps to ``None``
@@ -133,10 +133,10 @@ def shift_diagnostic_range(diag: Dict[str, Any],
     return shifted
 
 
-def shift_baseline(baseline: List[Dict[str, Any]],
-                   shift: Callable[[int], Optional[int]]) -> List[Dict[str, Any]]:
+def shift_baseline(baseline: list[dict[str, Any]],
+                   shift: Callable[[int], Optional[int]]) -> list[dict[str, Any]]:
     """Apply ``shift`` to every diagnostic in ``baseline``, dropping deleted entries."""
-    out: List[Dict[str, Any]] = []
+    out: list[dict[str, Any]] = []
     for d in baseline:
         if not isinstance(d, dict):
             continue

--- a/agent/lsp/reporter.py
+++ b/agent/lsp/reporter.py
@@ -19,7 +19,7 @@ MAX_PER_FILE = 20
 MAX_TOTAL_CHARS = 4000
 
 
-def format_diagnostic(d: Dict[str, Any]) -> str:
+def format_diagnostic(d: dict[str, Any]) -> str:
     """One-line representation of a single diagnostic."""
     sev = SEVERITY_NAMES.get(d.get("severity") or 1, "ERROR")
     rng = d.get("range") or {}
@@ -36,7 +36,7 @@ def format_diagnostic(d: Dict[str, Any]) -> str:
 
 def report_for_file(
     file_path: str,
-    diagnostics: List[Dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
     *,
     severities: frozenset = DEFAULT_SEVERITIES,
     max_per_file: int = MAX_PER_FILE,

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -32,7 +32,7 @@ logger = logging.getLogger("agent.lsp.servers")
 # Language IDs per LSP spec.  Used for ``textDocument/didOpen.languageId``.
 # Most servers don't care exactly, but a few (typescript-language-server,
 # vue-language-server) refuse files with the wrong ID.
-LANGUAGE_BY_EXT: Dict[str, str] = {
+LANGUAGE_BY_EXT: dict[str, str] = {
     ".py": "python",
     ".pyi": "python",
     ".ts": "typescript",
@@ -115,11 +115,11 @@ class SpawnSpec:
     marker not found, exclude marker hit, etc.).
     """
 
-    command: List[str]
+    command: list[str]
     workspace_root: str
     cwd: str
-    env: Dict[str, str] = field(default_factory=dict)
-    initialization_options: Dict[str, Any] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict)
+    initialization_options: dict[str, Any] = field(default_factory=dict)
     seed_diagnostics_on_first_push: bool = False
 
 
@@ -138,7 +138,7 @@ class ServerDef:
     """
 
     server_id: str
-    extensions: Tuple[str, ...]
+    extensions: tuple[str, ...]
     resolve_root: Callable[[str, str], Optional[str]]
     build_spawn: Callable[[str, "ServerContext"], Optional[SpawnSpec]]
     seed_first_push: bool = False
@@ -161,9 +161,9 @@ class ServerContext:
 
     workspace_root: str
     install_strategy: str = "auto"  # "auto" | "manual" | "off"
-    binary_overrides: Dict[str, List[str]] = field(default_factory=dict)
-    env_overrides: Dict[str, Dict[str, str]] = field(default_factory=dict)
-    init_overrides: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    binary_overrides: dict[str, list[str]] = field(default_factory=dict)
+    env_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
+    init_overrides: dict[str, dict[str, Any]] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +241,7 @@ def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
         sibling = os.path.join(os.path.dirname(bin_path), "pyright-langserver")
         if os.path.exists(sibling):
             bin_path = sibling
-    init: Dict[str, Any] = {}
+    init: dict[str, Any] = {}
     # Pick the project's venv interpreter if there is one — otherwise
     # pyright defaults to "python on PATH" which is rarely the venv.
     py = _detect_python(root)
@@ -828,7 +828,7 @@ def _root_java(file_path: str, workspace: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
-SERVERS: List[ServerDef] = [
+SERVERS: list[ServerDef] = [
     ServerDef(
         server_id="pyright",
         extensions=(".py", ".pyi"),

--- a/agent/lsp/workspace.py
+++ b/agent/lsp/workspace.py
@@ -174,7 +174,7 @@ def resolve_workspace_for_file(
     file_path: str,
     *,
     cwd: Optional[str] = None,
-) -> Tuple[Optional[str], bool]:
+) -> tuple[Optional[str], bool]:
     """Resolve the workspace root for a file.
 
     Returns ``(workspace_root, gated_in)`` where ``gated_in`` is True

--- a/agent/markdown_tables.py
+++ b/agent/markdown_tables.py
@@ -62,7 +62,7 @@ def _pad_to_width(s: str, target: int) -> str:
     return s + " " * max(0, target - _disp_width(s))
 
 
-def split_table_row(row: str) -> List[str]:
+def split_table_row(row: str) -> list[str]:
     """Split ``| a | b | c |`` into ``["a", "b", "c"]`` with trims."""
 
     s = row.strip()
@@ -102,7 +102,7 @@ def looks_like_table_row(row: str) -> bool:
     return stripped.count("|") >= 2
 
 
-def _render_block(rows: List[List[str]], available_width: int | None = None) -> List[str]:
+def _render_block(rows: list[list[str]], available_width: int | None = None) -> list[str]:
     """Render ``rows`` (header + body, divider implied) at uniform widths.
 
     If ``available_width`` is given and the rebuilt horizontal table
@@ -128,7 +128,7 @@ def _render_block(rows: List[List[str]], available_width: int | None = None) -> 
     if available_width is not None and horizontal_width > max(available_width, 20):
         return _render_vertical(rows, ncols, available_width)
 
-    def _row(cells: List[str]) -> str:
+    def _row(cells: list[str]) -> str:
         return (
             "| "
             + " | ".join(_pad_to_width(c, widths[k]) for k, c in enumerate(cells))
@@ -142,7 +142,7 @@ def _render_block(rows: List[List[str]], available_width: int | None = None) -> 
     return out
 
 
-def _wrap_to_width(text: str, width: int) -> List[str]:
+def _wrap_to_width(text: str, width: int) -> list[str]:
     """Soft-wrap ``text`` at word boundaries to fit ``width`` display cells.
 
     Falls back to hard-breaking the longest word if a single token is
@@ -157,12 +157,12 @@ def _wrap_to_width(text: str, width: int) -> List[str]:
     if not words:
         return [""]
 
-    lines: List[str] = []
+    lines: list[str] = []
     current = ""
     current_w = 0
 
-    def _hard_break(word: str, w: int) -> List[str]:
-        out: List[str] = []
+    def _hard_break(word: str, w: int) -> list[str]:
+        out: list[str] = []
         buf = ""
         bw = 0
         for ch in word:
@@ -209,8 +209,8 @@ def _wrap_to_width(text: str, width: int) -> List[str]:
 
 
 def _render_vertical(
-    rows: List[List[str]], ncols: int, available_width: int
-) -> List[str]:
+    rows: list[list[str]], ncols: int, available_width: int
+) -> list[str]:
     """Render a too-wide table as vertical ``Header: value`` rows.
 
     Mirrors Claude Code's narrow-terminal fallback in
@@ -234,7 +234,7 @@ def _render_vertical(
     indent = "  "
     indent_w = _disp_width(indent)
 
-    out: List[str] = []
+    out: list[str] = []
     for ri, row in enumerate(body):
         if ri > 0:
             out.append(separator)
@@ -277,7 +277,7 @@ def realign_markdown_tables(text: str, available_width: int | None = None) -> st
         return text
 
     lines = text.split("\n")
-    out: List[str] = []
+    out: list[str] = []
     i = 0
     n = len(lines)
 
@@ -290,7 +290,7 @@ def realign_markdown_tables(text: str, available_width: int | None = None) -> st
             and is_table_divider(lines[i + 1])
         ):
             header = split_table_row(line)
-            body: List[List[str]] = []
+            body: list[list[str]] = []
             j = i + 2
             while j < n and "|" in lines[j] and lines[j].strip():
                 if is_table_divider(lines[j]):

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -249,8 +249,8 @@ class MemoryManager:
     """
 
     def __init__(self) -> None:
-        self._providers: List[MemoryProvider] = []
-        self._tool_to_provider: Dict[str, MemoryProvider] = {}
+        self._providers: list[MemoryProvider] = []
+        self._tool_to_provider: dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
 
     # -- Registration --------------------------------------------------------
@@ -302,7 +302,7 @@ class MemoryManager:
         )
 
     @property
-    def providers(self) -> List[MemoryProvider]:
+    def providers(self) -> list[MemoryProvider]:
         """All registered providers in order."""
         return list(self._providers)
 
@@ -381,7 +381,7 @@ class MemoryManager:
 
     # -- Tools ---------------------------------------------------------------
 
-    def get_all_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_all_tool_schemas(self) -> list[dict[str, Any]]:
         """Collect tool schemas from all providers."""
         schemas = []
         seen = set()
@@ -408,7 +408,7 @@ class MemoryManager:
         return tool_name in self._tool_to_provider
 
     def handle_tool_call(
-        self, tool_name: str, args: Dict[str, Any], **kwargs
+        self, tool_name: str, args: dict[str, Any], **kwargs
     ) -> str:
         """Route a tool call to the correct provider.
 
@@ -443,7 +443,7 @@ class MemoryManager:
                     provider.name, e,
                 )
 
-    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
         """Notify all providers of session end."""
         for provider in self._providers:
             try:
@@ -489,7 +489,7 @@ class MemoryManager:
                     provider.name, e,
                 )
 
-    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:
         """Notify all providers before context compression.
 
         Returns combined text from providers to include in the compression
@@ -539,7 +539,7 @@ class MemoryManager:
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Notify external providers when the built-in memory tool writes.
 

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -119,7 +119,7 @@ class MemoryProvider(ABC):
         """
 
     @abstractmethod
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         """Return tool schemas this provider exposes.
 
         Each schema follows the OpenAI function calling format:
@@ -128,7 +128,7 @@ class MemoryProvider(ABC):
         Return empty list if this provider has no tools (context-only).
         """
 
-    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs) -> str:
         """Handle a tool call for one of this provider's tools.
 
         Must return a JSON string (the tool result).
@@ -150,7 +150,7 @@ class MemoryProvider(ABC):
         Providers use what they need; extras are ignored.
         """
 
-    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
         """Called when a session ends (explicit exit or timeout).
 
         Use for end-of-session fact extraction, summarization, etc.
@@ -199,7 +199,7 @@ class MemoryProvider(ABC):
         Default is no-op for backward compatibility.
         """
 
-    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:
         """Called before context compression discards old messages.
 
         Use to extract insights from messages about to be compressed.
@@ -224,7 +224,7 @@ class MemoryProvider(ABC):
         child_session_id: the subagent's session_id
         """
 
-    def get_config_schema(self) -> List[Dict[str, Any]]:
+    def get_config_schema(self) -> list[dict[str, Any]]:
         """Return config fields this provider needs for setup.
 
         Used by 'hermes memory setup' to walk the user through configuration.
@@ -242,7 +242,7 @@ class MemoryProvider(ABC):
         """
         return []
 
-    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+    def save_config(self, values: dict[str, Any], hermes_home: str) -> None:
         """Write non-secret config to the provider's native location.
 
         Called by 'hermes memory setup' after collecting user inputs.
@@ -264,7 +264,7 @@ class MemoryProvider(ABC):
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Called when the built-in memory tool writes an entry.
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -102,13 +102,13 @@ def _strip_provider_prefix(model: str) -> str:
         return suffix
     return model
 
-_model_metadata_cache: Dict[str, Dict[str, Any]] = {}
+_model_metadata_cache: dict[str, dict[str, Any]] = {}
 _model_metadata_cache_time: float = 0
-_novita_metadata_cache: Dict[str, Dict[str, Any]] = {}
+_novita_metadata_cache: dict[str, dict[str, Any]] = {}
 _novita_metadata_cache_time: float = 0
 _MODEL_CACHE_TTL = 3600
-_endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
-_endpoint_model_metadata_cache_time: Dict[str, float] = {}
+_endpoint_model_metadata_cache: dict[str, dict[str, dict[str, Any]]] = {}
+_endpoint_model_metadata_cache_time: dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
 
 # Descending tiers for context length probing when the model is unknown.
@@ -322,7 +322,7 @@ def _normalize_base_url(base_url: str) -> str:
     return (base_url or "").strip().rstrip("/")
 
 
-def _auth_headers(api_key: str = "") -> Dict[str, str]:
+def _auth_headers(api_key: str = "") -> dict[str, str]:
     token = str(api_key or "").strip()
     if not token:
         return {}
@@ -338,7 +338,7 @@ def _is_custom_endpoint(base_url: str) -> bool:
     return bool(normalized) and not _is_openrouter_base_url(normalized)
 
 
-_URL_TO_PROVIDER: Dict[str, str] = {
+_URL_TO_PROVIDER: dict[str, str] = {
     "api.openai.com": "openai",
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
@@ -549,7 +549,7 @@ def _coerce_reasonable_int(value: Any, minimum: int = 1024, maximum: int = 10_00
     return None
 
 
-def _extract_first_int(payload: Dict[str, Any], keys: tuple[str, ...]) -> Optional[int]:
+def _extract_first_int(payload: dict[str, Any], keys: tuple[str, ...]) -> Optional[int]:
     keyset = {key.lower() for key in keys}
     for mapping in _iter_nested_dicts(payload):
         for key, value in mapping.items():
@@ -561,19 +561,19 @@ def _extract_first_int(payload: Dict[str, Any], keys: tuple[str, ...]) -> Option
     return None
 
 
-def _extract_context_length(payload: Dict[str, Any]) -> Optional[int]:
+def _extract_context_length(payload: dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _CONTEXT_LENGTH_KEYS)
 
 
-def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
+def _extract_max_completion_tokens(payload: dict[str, Any]) -> Optional[int]:
     return _extract_first_int(payload, _MAX_COMPLETION_KEYS)
 
 
-def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
+def _extract_pricing(payload: dict[str, Any]) -> dict[str, Any]:
     novita_input = payload.get("input_token_price_per_m")
     novita_output = payload.get("output_token_price_per_m")
     if novita_input is not None or novita_output is not None:
-        pricing: Dict[str, Any] = {}
+        pricing: dict[str, Any] = {}
         if novita_input is not None:
             pricing["prompt"] = str(float(novita_input) / 10_000 / 1_000_000)
         if novita_output is not None:
@@ -591,7 +591,7 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         normalized = {str(key).lower(): value for key, value in mapping.items()}
         if not any(any(alias in normalized for alias in aliases) for aliases in alias_map.values()):
             continue
-        pricing: Dict[str, Any] = {}
+        pricing: dict[str, Any] = {}
         for target, aliases in alias_map.items():
             for alias in aliases:
                 if alias in normalized and normalized[alias] not in {None, ""}:
@@ -602,14 +602,14 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
     return {}
 
 
-def _add_model_aliases(cache: Dict[str, Dict[str, Any]], model_id: str, entry: Dict[str, Any]) -> None:
+def _add_model_aliases(cache: dict[str, dict[str, Any]], model_id: str, entry: dict[str, Any]) -> None:
     cache[model_id] = entry
     if "/" in model_id:
         bare_model = model_id.split("/", 1)[1]
         cache.setdefault(bare_model, entry)
 
 
-def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any]]:
+def fetch_model_metadata(force_refresh: bool = False) -> dict[str, dict[str, Any]]:
     """Fetch model metadata from OpenRouter (cached for 1 hour)."""
     global _model_metadata_cache, _model_metadata_cache_time
 
@@ -649,7 +649,7 @@ def fetch_endpoint_model_metadata(
     base_url: str,
     api_key: str = "",
     force_refresh: bool = False,
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     """Fetch model metadata from an OpenAI-compatible ``/models`` endpoint.
 
     This is used for explicit custom endpoints where hardcoded global model-name
@@ -688,14 +688,14 @@ def fetch_endpoint_model_metadata(
                 )
                 response.raise_for_status()
                 payload = response.json()
-                cache: Dict[str, Dict[str, Any]] = {}
+                cache: dict[str, dict[str, Any]] = {}
                 for model in payload.get("models", []):
                     if not isinstance(model, dict):
                         continue
                     model_id = model.get("key") or model.get("id")
                     if not model_id:
                         continue
-                    entry: Dict[str, Any] = {"name": model.get("name", model_id)}
+                    entry: dict[str, Any] = {"name": model.get("name", model_id)}
 
                     context_length = None
                     for inst in model.get("loaded_instances", []) or []:
@@ -734,14 +734,14 @@ def fetch_endpoint_model_metadata(
             response = requests.get(url, headers=headers, timeout=10, verify=_resolve_requests_verify())
             response.raise_for_status()
             payload = response.json()
-            cache: Dict[str, Dict[str, Any]] = {}
+            cache: dict[str, dict[str, Any]] = {}
             for model in payload.get("data", []):
                 if not isinstance(model, dict):
                     continue
                 model_id = model.get("id")
                 if not model_id:
                     continue
-                entry: Dict[str, Any] = {"name": model.get("name", model_id)}
+                entry: dict[str, Any] = {"name": model.get("name", model_id)}
                 context_length = _extract_context_length(model)
                 if context_length is not None:
                     entry["context_length"] = context_length
@@ -818,7 +818,7 @@ def _get_context_cache_path() -> Path:
     return get_hermes_home() / "context_length_cache.yaml"
 
 
-def _load_context_cache() -> Dict[str, int]:
+def _load_context_cache() -> dict[str, int]:
     """Load the model+provider -> context_length cache from disk."""
     path = _get_context_cache_path()
     if not path.exists():
@@ -1245,7 +1245,7 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
 #
 # Used as a fallback when the live probe fails (no token, network error).
 # Longest keys first so substring match picks the most specific entry.
-_CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
+_CODEX_OAUTH_CONTEXT_FALLBACK: dict[str, int] = {
     "gpt-5.1-codex-max": 272_000,
     "gpt-5.1-codex-mini": 272_000,
     "gpt-5.3-codex": 272_000,
@@ -1264,12 +1264,12 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
 }
 
 
-_codex_oauth_context_cache: Dict[str, int] = {}
+_codex_oauth_context_cache: dict[str, int] = {}
 _codex_oauth_context_cache_time: float = 0.0
 _CODEX_OAUTH_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
-def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
+def _fetch_codex_oauth_context_lengths(access_token: str) -> dict[str, int]:
     """Probe the ChatGPT Codex /models endpoint for per-slug context windows.
 
     Codex OAuth imposes its own context limits that differ from the direct
@@ -1305,7 +1305,7 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
         return {}
 
     entries = data.get("models", []) if isinstance(data, dict) else []
-    result: Dict[str, int] = {}
+    result: dict[str, int] = {}
     for item in entries:
         if not isinstance(item, dict):
             continue
@@ -1357,7 +1357,7 @@ def _resolve_nous_context_length(
     model: str,
     base_url: str = "",
     api_key: str = "",
-) -> Tuple[Optional[int], str]:
+) -> tuple[Optional[int], str]:
     """Resolve Nous Portal model context length.
 
     Tries the live Nous inference endpoint first (authoritative), then falls
@@ -1728,7 +1728,7 @@ def estimate_tokens_rough(text: str) -> int:
     return (len(text) + 3) // 4
 
 
-def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
+def estimate_messages_tokens_rough(messages: list[dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only).
 
     Image parts (base64 PNG/JPEG) are counted as a flat ~1500 tokens per
@@ -1745,7 +1745,7 @@ def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     return ((total_chars + 3) // 4) + image_tokens
 
 
-def _count_image_tokens(msg: Dict[str, Any], cost_per_image: int) -> int:
+def _count_image_tokens(msg: dict[str, Any], cost_per_image: int) -> int:
     """Count image-like content parts in a message; return their token cost."""
     count = 0
     content = msg.get("content") if isinstance(msg, dict) else None
@@ -1771,7 +1771,7 @@ def _count_image_tokens(msg: Dict[str, Any], cost_per_image: int) -> int:
     return count * cost_per_image
 
 
-def _estimate_message_chars(msg: Dict[str, Any]) -> int:
+def _estimate_message_chars(msg: dict[str, Any]) -> int:
     """Char count for token estimation, excluding base64 image data.
 
     Base64 images are counted via `_count_image_tokens` instead; including
@@ -1779,7 +1779,7 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
     """
     if not isinstance(msg, dict):
         return len(str(msg))
-    shadow: Dict[str, Any] = {}
+    shadow: dict[str, Any] = {}
     for k, v in msg.items():
         if k == "_anthropic_content_blocks":
             continue
@@ -1805,10 +1805,10 @@ def _estimate_message_chars(msg: Dict[str, Any]) -> int:
 
 
 def estimate_request_tokens_rough(
-    messages: List[Dict[str, Any]],
+    messages: list[dict[str, Any]],
     *,
     system_prompt: str = "",
-    tools: Optional[List[Dict[str, Any]]] = None,
+    tools: Optional[list[dict[str, Any]]] = None,
 ) -> int:
     """Rough token estimate for a full chat-completions request.
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -35,7 +35,7 @@ MODELS_DEV_URL = "https://models.dev/api.json"
 _MODELS_DEV_CACHE_TTL = 3600  # 1 hour in-memory
 
 # In-memory cache
-_models_dev_cache: Dict[str, Any] = {}
+_models_dev_cache: dict[str, Any] = {}
 _models_dev_cache_time: float = 0
 
 
@@ -61,8 +61,8 @@ class ModelInfo:
     open_weights: bool = False
 
     # Modalities
-    input_modalities: Tuple[str, ...] = ()    # ("text", "image", "pdf", ...)
-    output_modalities: Tuple[str, ...] = ()
+    input_modalities: tuple[str, ...] = ()    # ("text", "image", "pdf", ...)
+    output_modalities: tuple[str, ...] = ()
 
     # Limits
     context_window: int = 0
@@ -128,7 +128,7 @@ class ProviderInfo:
 
     id: str                         # models.dev provider ID
     name: str                       # display name
-    env: Tuple[str, ...]            # env var names for API key
+    env: tuple[str, ...]            # env var names for API key
     api: str                        # base URL
     doc: str = ""                   # documentation URL
     model_count: int = 0
@@ -139,7 +139,7 @@ class ProviderInfo:
 # ---------------------------------------------------------------------------
 
 # Hermes provider names → models.dev provider IDs
-PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
+PROVIDER_TO_MODELS_DEV: dict[str, str] = {
     "openrouter": "openrouter",
     "novita": "novita-ai",
     "anthropic": "anthropic",
@@ -181,7 +181,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
 }
 
 # Reverse mapping: models.dev → Hermes (built lazily)
-_MODELS_DEV_TO_PROVIDER: Optional[Dict[str, str]] = None
+_MODELS_DEV_TO_PROVIDER: Optional[dict[str, str]] = None
 
 
 
@@ -191,7 +191,7 @@ def _get_cache_path() -> Path:
     return get_hermes_home() / "models_dev_cache.json"
 
 
-def _load_disk_cache() -> Dict[str, Any]:
+def _load_disk_cache() -> dict[str, Any]:
     """Load models.dev data from disk cache."""
     try:
         cache_path = _get_cache_path()
@@ -229,7 +229,7 @@ def _disk_cache_age_seconds() -> Optional[float]:
         return None
 
 
-def _save_disk_cache(data: Dict[str, Any]) -> None:
+def _save_disk_cache(data: dict[str, Any]) -> None:
     """Save models.dev data to disk cache atomically."""
     try:
         cache_path = _get_cache_path()
@@ -238,7 +238,7 @@ def _save_disk_cache(data: Dict[str, Any]) -> None:
         logger.debug("Failed to save models.dev disk cache: %s", e)
 
 
-def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
+def fetch_models_dev(force_refresh: bool = False) -> dict[str, Any]:
     """Fetch models.dev registry. Cache hierarchy: in-mem → disk → network.
 
     Returns the full registry dict keyed by provider ID, or empty dict on failure.
@@ -378,7 +378,7 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     return None
 
 
-def _extract_context(entry: Dict[str, Any]) -> Optional[int]:
+def _extract_context(entry: dict[str, Any]) -> Optional[int]:
     """Extract context_length from a models.dev model entry.
 
     Returns None for invalid/zero values (some audio/image models have context=0).
@@ -411,7 +411,7 @@ class ModelCapabilities:
     model_family: str = ""
 
 
-def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
+def _get_provider_models(provider: str) -> Optional[dict[str, Any]]:
     """Resolve a Hermes provider ID to its models dict from models.dev.
 
     Returns the models dict or None if the provider is unknown or has no data.
@@ -432,7 +432,7 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
     return models
 
 
-def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
+def _find_model_entry(models: dict[str, Any], model: str) -> Optional[dict[str, Any]]:
     """Find a model entry by exact match, then case-insensitive fallback."""
     # Exact match
     entry = models.get(model)
@@ -509,7 +509,7 @@ def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilit
     )
 
 
-def list_provider_models(provider: str) -> List[str]:
+def list_provider_models(provider: str) -> list[str]:
     """Return all model IDs for a provider from models.dev.
 
     Returns an empty list if the provider is unknown or has no data.
@@ -573,7 +573,7 @@ def _should_hide_from_provider_catalog(provider: str, model_id: str) -> bool:
     return False
 
 
-def list_agentic_models(provider: str) -> List[str]:
+def list_agentic_models(provider: str) -> list[str]:
     """Return model IDs suitable for agentic use from models.dev.
 
     Filters for tool_call=True and excludes noise (TTS, embedding,
@@ -603,7 +603,7 @@ def list_agentic_models(provider: str) -> List[str]:
 # Rich dataclass constructors — parse raw models.dev JSON into dataclasses
 # ---------------------------------------------------------------------------
 
-def _parse_model_info(model_id: str, raw: Dict[str, Any], provider_id: str) -> ModelInfo:
+def _parse_model_info(model_id: str, raw: dict[str, Any], provider_id: str) -> ModelInfo:
     """Convert a raw models.dev model entry dict into a ModelInfo dataclass."""
     limit = raw.get("limit") or {}
     if not isinstance(limit, dict):
@@ -654,7 +654,7 @@ def _parse_model_info(model_id: str, raw: Dict[str, Any], provider_id: str) -> M
     )
 
 
-def _parse_provider_info(provider_id: str, raw: Dict[str, Any]) -> ProviderInfo:
+def _parse_provider_info(provider_id: str, raw: dict[str, Any]) -> ProviderInfo:
     """Convert a raw models.dev provider entry dict into a ProviderInfo."""
     env = raw.get("env") or []
     models = raw.get("models") or {}

--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -67,7 +67,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
     # Walk the dict, deciding per-key whether recursion is into a schema
     # node, a container map, or a scalar.
-    repaired: Dict[str, Any] = {}
+    repaired: dict[str, Any] = {}
     for key, value in node.items():
         if key in _SCHEMA_MAP_KEYS and isinstance(value, dict):
             # Map of name → schema.  Don't treat the map itself as a schema
@@ -164,7 +164,7 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
     return repaired
 
 
-def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
+def _fill_missing_type(node: dict[str, Any]) -> dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
     if "type" in node and node["type"] not in {None, ""}:
         return node
@@ -191,7 +191,7 @@ def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     return {**node, "type": inferred}
 
 
-def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
+def sanitize_moonshot_tool_parameters(parameters: Any) -> dict[str, Any]:
     """Normalize tool parameters to a Moonshot-compatible object schema.
 
     Returns a deep-copied schema with the two flavored-JSON-Schema repairs
@@ -213,12 +213,12 @@ def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     return repaired
 
 
-def sanitize_moonshot_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def sanitize_moonshot_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Apply ``sanitize_moonshot_tool_parameters`` to every tool's parameters."""
     if not tools:
         return tools
 
-    sanitized: List[Dict[str, Any]] = []
+    sanitized: list[dict[str, Any]] = []
     any_change = False
     for tool in tools:
         if not isinstance(tool, dict):

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -99,7 +99,7 @@ class PluginLlmImageInput:
     type: str = "image"
 
 
-PluginLlmInput = Union[PluginLlmTextInput, PluginLlmImageInput, Dict[str, Any]]
+PluginLlmInput = Union[PluginLlmTextInput, PluginLlmImageInput, dict[str, Any]]
 """A single structured input block.
 
 Plugins may pass either the dataclasses above or plain dicts with the
@@ -133,7 +133,7 @@ class PluginLlmCompleteResult:
     model: str
     agent_id: str
     usage: PluginLlmUsage = field(default_factory=PluginLlmUsage)
-    audit: Dict[str, Any] = field(default_factory=dict)
+    audit: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -152,7 +152,7 @@ class PluginLlmStructuredResult:
     usage: PluginLlmUsage = field(default_factory=PluginLlmUsage)
     parsed: Optional[Any] = None
     content_type: str = "text"
-    audit: Dict[str, Any] = field(default_factory=dict)
+    audit: dict[str, Any] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -334,13 +334,13 @@ def _check_overrides(
 # ---------------------------------------------------------------------------
 
 
-def _normalize_input_block(block: PluginLlmInput) -> Dict[str, Any]:
+def _normalize_input_block(block: PluginLlmInput) -> dict[str, Any]:
     """Coerce a structured input block to a plain dict the message
     builder understands. Unknown shapes raise ``ValueError``."""
     if isinstance(block, PluginLlmTextInput):
         return {"type": "text", "text": block.text}
     if isinstance(block, PluginLlmImageInput):
-        d: Dict[str, Any] = {
+        d: dict[str, Any] = {
             "type": "image",
             "mime_type": block.mime_type,
             "file_name": block.file_name,
@@ -379,7 +379,7 @@ def _build_structured_messages(
     json_schema: Optional[Any],
     schema_name: Optional[str],
     system_prompt: Optional[str],
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Build the OpenAI-style messages list for a structured call.
 
     The instructions become the first text part of the user message,
@@ -387,8 +387,8 @@ def _build_structured_messages(
     JSON-only directive when JSON output is requested. Image inputs are
     encoded as ``image_url`` parts.
     """
-    messages: List[Dict[str, Any]] = []
-    sys_parts: List[str] = []
+    messages: list[dict[str, Any]] = []
+    sys_parts: list[str] = []
     if system_prompt:
         sys_parts.append(system_prompt.strip())
     if json_mode or json_schema is not None:
@@ -399,7 +399,7 @@ def _build_structured_messages(
     if sys_parts:
         messages.append({"role": "system", "content": "\n\n".join(sys_parts)})
 
-    user_parts: List[Dict[str, Any]] = []
+    user_parts: list[dict[str, Any]] = []
     header = instructions.strip()
     if schema_name:
         header = f"{header}\n\nSchema name: {schema_name}"
@@ -525,7 +525,7 @@ def _extract_text(response: Any) -> str:
         if isinstance(content, str):
             return content
         if isinstance(content, list):
-            parts: List[str] = []
+            parts: list[str] = []
             for part in content:
                 if isinstance(part, dict):
                     if part.get("type") == "text" and isinstance(part.get("text"), str):
@@ -621,7 +621,7 @@ class PluginLlm:
 
     def complete(
         self,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         *,
         provider: Optional[str] = None,
         model: Optional[str] = None,
@@ -776,7 +776,7 @@ class PluginLlm:
 
     async def acomplete(
         self,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         *,
         provider: Optional[str] = None,
         model: Optional[str] = None,
@@ -897,7 +897,7 @@ class PluginLlm:
     @staticmethod
     def _json_response_format(
         *, json_mode: bool, json_schema: Optional[Any]
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         """Build the ``extra_body.response_format`` payload for the
         provider request. Falls back to ``json_object`` when no schema
         is given so providers that ignore json_schema still get a hint."""
@@ -919,14 +919,14 @@ class PluginLlm:
     def _invoke_sync(
         self,
         *,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         provider_override: Optional[str],
         model_override: Optional[str],
         profile_override: Optional[str],
         temperature: Optional[float],
         max_tokens: Optional[int],
         timeout: Optional[float],
-        extra_body: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
     ) -> tuple[str, str, Any]:
         """Invoke the host's ``call_llm``. Lazy-imports
         ``agent.auxiliary_client`` to avoid circular deps at plugin
@@ -966,14 +966,14 @@ class PluginLlm:
     async def _invoke_async(
         self,
         *,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         provider_override: Optional[str],
         model_override: Optional[str],
         profile_override: Optional[str],
         temperature: Optional[float],
         max_tokens: Optional[int],
         timeout: Optional[float],
-        extra_body: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[dict[str, Any]] = None,
     ) -> tuple[str, str, Any]:
         if self._async_caller is not None:
             return await self._async_caller(

--- a/agent/portal_tags.py
+++ b/agent/portal_tags.py
@@ -55,7 +55,7 @@ def hermes_client_tag() -> str:
     return f"client=hermes-client-v{_hermes_version()}"
 
 
-def nous_portal_tags() -> List[str]:
+def nous_portal_tags() -> list[str]:
     """Return the canonical list of Nous Portal product tags.
 
     Always returns a fresh list so callers can mutate it freely

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -38,19 +38,19 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
             last["cache_control"] = cache_marker
 
 
-def _build_marker(ttl: str) -> Dict[str, str]:
+def _build_marker(ttl: str) -> dict[str, str]:
     """Build a cache_control marker dict for the given TTL ('5m' or '1h')."""
-    marker: Dict[str, str] = {"type": "ephemeral"}
+    marker: dict[str, str] = {"type": "ephemeral"}
     if ttl == "1h":
         marker["ttl"] = "1h"
     return marker
 
 
 def apply_anthropic_cache_control(
-    api_messages: List[Dict[str, Any]],
+    api_messages: list[dict[str, Any]],
     cache_ttl: str = "5m",
     native_anthropic: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Apply system_and_3 caching strategy to messages for Anthropic models.
 
     Places up to 4 cache_control breakpoints: system prompt + last 3 non-system

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -70,13 +70,13 @@ _BWS_RUN_TIMEOUT = 30
 
 # In-process cache so repeated load_hermes_dotenv() calls (CLI startup,
 # gateway hot-reload, test suites) don't re-fetch from BSM.
-_CacheKey = Tuple[str, str, str]  # (access_token_fingerprint, project_id, server_url)
-_CACHE: Dict[_CacheKey, "_CachedFetch"] = {}
+_CacheKey = tuple[str, str, str]  # (access_token_fingerprint, project_id, server_url)
+_CACHE: dict[_CacheKey, "_CachedFetch"] = {}
 
 
 @dataclass
 class _CachedFetch:
-    secrets: Dict[str, str]
+    secrets: dict[str, str]
     fetched_at: float
 
     def is_fresh(self, ttl_seconds: float) -> bool:
@@ -94,10 +94,10 @@ class _CachedFetch:
 class FetchResult:
     """Outcome of a single BSM pull."""
 
-    secrets: Dict[str, str] = field(default_factory=dict)
-    applied: List[str] = field(default_factory=list)   # set into os.environ
-    skipped: List[str] = field(default_factory=list)   # already set, not overridden
-    warnings: List[str] = field(default_factory=list)  # non-fatal issues
+    secrets: dict[str, str] = field(default_factory=dict)
+    applied: list[str] = field(default_factory=list)   # set into os.environ
+    skipped: list[str] = field(default_factory=list)   # already set, not overridden
+    warnings: list[str] = field(default_factory=list)  # non-fatal issues
     error: Optional[str] = None                        # fatal: nothing was fetched
     binary_path: Optional[Path] = None
 
@@ -318,7 +318,7 @@ def fetch_bitwarden_secrets(
     cache_ttl_seconds: float = 300,
     use_cache: bool = True,
     server_url: str = "",
-) -> Tuple[Dict[str, str], List[str]]:
+) -> tuple[dict[str, str], list[str]]:
     """Pull the secrets for ``project_id`` from Bitwarden Secrets Manager.
 
     Returns ``(secrets_dict, warnings_list)``.
@@ -361,7 +361,7 @@ def fetch_bitwarden_secrets(
 
 def _run_bws_list(
     bws: Path, access_token: str, project_id: str, server_url: str = ""
-) -> Tuple[Dict[str, str], List[str]]:
+) -> tuple[dict[str, str], list[str]]:
     cmd = [str(bws), "secret", "list", project_id, "--output", "json"]
     env = os.environ.copy()
     env["BWS_ACCESS_TOKEN"] = access_token
@@ -412,8 +412,8 @@ def _run_bws_list(
             f"bws returned unexpected shape: {type(payload).__name__}"
         )
 
-    secrets: Dict[str, str] = {}
-    warnings: List[str] = []
+    secrets: dict[str, str] = {}
+    warnings: list[str] = []
     for item in payload:
         if not isinstance(item, dict):
             continue

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -91,7 +91,7 @@ _DEFAULT_BLOCK_MESSAGE = "Blocked by shell hook."
 # the same event (e.g. one entry per tool the user wants to gate).
 # Second registration attempts for the exact same triple become no-ops
 # so the CLI and gateway can both call register_from_config() safely.
-_registered: Set[Tuple[str, Optional[str], str]] = set()
+_registered: set[tuple[str, Optional[str], str]] = set()
 _registered_lock = threading.Lock()
 
 # Intra-process lock for allowlist read-modify-write on platforms that
@@ -147,10 +147,10 @@ class ShellHookSpec:
 # ---------------------------------------------------------------------------
 
 def register_from_config(
-    cfg: Optional[Dict[str, Any]],
+    cfg: Optional[dict[str, Any]],
     *,
     accept_hooks: bool = False,
-) -> List[ShellHookSpec]:
+) -> list[ShellHookSpec]:
     """Register every configured shell hook on the plugin manager.
 
     ``cfg`` is the full parsed config dict (``hermes_cli.config.load_config``
@@ -176,7 +176,7 @@ def register_from_config(
     if not specs:
         return []
 
-    registered: List[ShellHookSpec] = []
+    registered: list[ShellHookSpec] = []
 
     # Import lazily — avoids circular imports at module-load time.
     from hermes_cli.plugins import get_plugin_manager
@@ -221,7 +221,7 @@ def register_from_config(
     return registered
 
 
-def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
+def iter_configured_hooks(cfg: Optional[dict[str, Any]]) -> list[ShellHookSpec]:
     """Return the parsed ``ShellHookSpec`` entries from config without
     registering anything.  Used by ``hermes hooks list`` and ``doctor``."""
     if not isinstance(cfg, dict):
@@ -239,7 +239,7 @@ def reset_for_tests() -> None:
 # Config parsing
 # ---------------------------------------------------------------------------
 
-def _parse_hooks_block(hooks_cfg: Any) -> List[ShellHookSpec]:
+def _parse_hooks_block(hooks_cfg: Any) -> list[ShellHookSpec]:
     """Normalise the ``hooks:`` dict into a flat list of ``ShellHookSpec``.
 
     Malformed entries warn-and-skip — we never raise from config parsing
@@ -250,7 +250,7 @@ def _parse_hooks_block(hooks_cfg: Any) -> List[ShellHookSpec]:
     if not isinstance(hooks_cfg, dict):
         return []
 
-    specs: List[ShellHookSpec] = []
+    specs: list[ShellHookSpec] = []
 
     for event_name, entries in hooks_cfg.items():
         if event_name not in VALID_HOOKS:
@@ -361,7 +361,7 @@ def _parse_single_entry(
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
 
 
-def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
+def _spawn(spec: ShellHookSpec, stdin_json: str) -> dict[str, Any]:
     """Run ``spec.command`` as a subprocess with ``stdin_json`` on stdin.
 
     Returns a diagnostic dict with the same keys for every outcome
@@ -371,7 +371,7 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     (:func:`_make_callback`) and the CLI test helper (:func:`run_once`)
     go through it.
     """
-    result: Dict[str, Any] = {
+    result: dict[str, Any] = {
         "returncode": None,
         "stdout": "",
         "stderr": "",
@@ -419,10 +419,10 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     return result
 
 
-def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]]]:
+def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[dict[str, Any]]]:
     """Build the closure that ``invoke_hook()`` will call per firing."""
 
-    def _callback(**kwargs: Any) -> Optional[Dict[str, Any]]:
+    def _callback(**kwargs: Any) -> Optional[dict[str, Any]]:
         # Matcher gate — only meaningful for tool-scoped events.
         if spec.event in {"pre_tool_call", "post_tool_call"}:
             if not spec.matches_tool(kwargs.get("tool_name")):
@@ -463,7 +463,7 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
     return _callback
 
 
-def _serialize_payload(event: str, kwargs: Dict[str, Any]) -> str:
+def _serialize_payload(event: str, kwargs: dict[str, Any]) -> str:
     """Render the stdin JSON payload.  Unserialisable values are
     stringified via ``default=str`` rather than dropped."""
     extras = {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS}
@@ -493,7 +493,7 @@ def _block_message(primary: Any, secondary: Any) -> str:
     return raw if isinstance(raw, str) and raw else _DEFAULT_BLOCK_MESSAGE
 
 
-def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
+def _parse_response(event: str, stdout: str) -> Optional[dict[str, Any]]:
     """Translate stdout JSON into a Hermes wire-shape dict.
 
     For ``pre_tool_call`` the Claude-Code-style ``{"decision": "block",
@@ -548,7 +548,7 @@ def allowlist_path() -> Path:
     return get_hermes_home() / ALLOWLIST_FILENAME
 
 
-def load_allowlist() -> Dict[str, Any]:
+def load_allowlist() -> dict[str, Any]:
     """Return the parsed allowlist, or an empty skeleton if absent."""
     try:
         raw = json.loads(allowlist_path().read_text())
@@ -562,7 +562,7 @@ def load_allowlist() -> Dict[str, Any]:
     return raw
 
 
-def save_allowlist(data: Dict[str, Any]) -> None:
+def save_allowlist(data: dict[str, Any]) -> None:
     """Atomically persist the allowlist via per-process ``mkstemp`` +
     ``os.replace``.  Cross-process read-modify-write races are handled
     by :func:`_locked_update_approvals` (``fcntl.flock``).  On OSError
@@ -605,7 +605,7 @@ def _is_allowlisted(event: str, command: str) -> bool:
 
 
 @contextmanager
-def _locked_update_approvals() -> Iterator[Dict[str, Any]]:
+def _locked_update_approvals() -> Iterator[dict[str, Any]]:
     """Serialise read-modify-write on the allowlist across processes.
 
     Holds an exclusive ``flock`` on a sibling lock file for the duration
@@ -715,7 +715,7 @@ def revoke(command: str) -> int:
     return before - after
 
 
-_SCRIPT_EXTENSIONS: Tuple[str, ...] = (
+_SCRIPT_EXTENSIONS: tuple[str, ...] = (
     ".sh", ".bash", ".zsh", ".fish",
     ".py", ".pyw",
     ".rb", ".pl", ".lua",
@@ -751,7 +751,7 @@ def _command_script_path(command: str) -> str:
 # ---------------------------------------------------------------------------
 
 def _resolve_effective_accept(
-    cfg: Dict[str, Any], accept_hooks_arg: bool,
+    cfg: dict[str, Any], accept_hooks_arg: bool,
 ) -> bool:
     """Combine all three opt-in channels into a single boolean.
 
@@ -777,7 +777,7 @@ def _resolve_effective_accept(
 # Introspection (used by `hermes hooks` CLI)
 # ---------------------------------------------------------------------------
 
-def allowlist_entry_for(event: str, command: str) -> Optional[Dict[str, Any]]:
+def allowlist_entry_for(event: str, command: str) -> Optional[dict[str, Any]]:
     """Return the allowlist record for this pair, if any."""
     for e in load_allowlist().get("approvals", []):
         if (
@@ -828,8 +828,8 @@ def script_is_executable(command: str) -> bool:
 
 
 def run_once(
-    spec: ShellHookSpec, kwargs: Dict[str, Any],
-) -> Dict[str, Any]:
+    spec: ShellHookSpec, kwargs: dict[str, Any],
+) -> dict[str, Any]:
     """Fire a single shell-hook invocation with a synthetic payload.
     Used by ``hermes hooks test`` and ``hermes hooks doctor``.
 

--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__name__)
 _BUNDLE_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _BUNDLE_MULTI_HYPHEN = re.compile(r"-{2,}")
 
-_bundles_cache: Dict[str, Dict[str, Any]] = {}
+_bundles_cache: dict[str, dict[str, Any]] = {}
 _bundles_cache_mtime: Optional[float] = None
 
 
@@ -82,17 +82,17 @@ def _slugify(name: str) -> str:
     return cmd
 
 
-def _iter_bundle_files() -> List[Path]:
+def _iter_bundle_files() -> list[Path]:
     base = _bundles_dir()
     if not base.exists():
         return []
-    files: List[Path] = []
+    files: list[Path] = []
     for ext in ("*.yaml", "*.yml"):
         files.extend(sorted(base.glob(ext)))
     return files
 
 
-def _max_mtime(files: List[Path]) -> float:
+def _max_mtime(files: list[Path]) -> float:
     """Highest mtime across the bundle files plus the dir itself.
 
     Watching the directory mtime catches deletions; watching individual
@@ -113,7 +113,7 @@ def _max_mtime(files: List[Path]) -> float:
     return max(mtimes) if mtimes else 0.0
 
 
-def _load_bundle_file(path: Path) -> Optional[Dict[str, Any]]:
+def _load_bundle_file(path: Path) -> Optional[dict[str, Any]]:
     """Parse a single bundle YAML file. Returns ``None`` on any error.
 
     Errors are logged at WARNING level. We don't raise — a broken bundle
@@ -165,7 +165,7 @@ def _load_bundle_file(path: Path) -> Optional[Dict[str, Any]]:
     }
 
 
-def scan_bundles() -> Dict[str, Dict[str, Any]]:
+def scan_bundles() -> dict[str, dict[str, Any]]:
     """Scan the bundles directory and rebuild the cache.
 
     Returns the same mapping as :func:`get_skill_bundles` — ``"/slug"`` →
@@ -174,7 +174,7 @@ def scan_bundles() -> Dict[str, Dict[str, Any]]:
     """
     global _bundles_cache, _bundles_cache_mtime
     files = _iter_bundle_files()
-    out: Dict[str, Dict[str, Any]] = {}
+    out: dict[str, dict[str, Any]] = {}
     for f in files:
         info = _load_bundle_file(f)
         if not info:
@@ -192,7 +192,7 @@ def scan_bundles() -> Dict[str, Dict[str, Any]]:
     return out
 
 
-def get_skill_bundles() -> Dict[str, Dict[str, Any]]:
+def get_skill_bundles() -> dict[str, dict[str, Any]]:
     """Return the current bundle mapping, rescanning when disk changed.
 
     Cheap to call repeatedly: only rescans when the bundles directory or
@@ -218,14 +218,14 @@ def resolve_bundle_command_key(command: str) -> Optional[str]:
     return cmd_key if cmd_key in get_skill_bundles() else None
 
 
-def reload_bundles() -> Dict[str, Any]:
+def reload_bundles() -> dict[str, Any]:
     """Re-scan the bundles directory and return a diff.
 
     Mirrors :func:`agent.skill_commands.reload_skills` so callers can use
     the same display logic. Returns a dict with ``added``, ``removed``,
     ``unchanged``, and ``total`` keys.
     """
-    def _snapshot(cmds: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
+    def _snapshot(cmds: dict[str, dict[str, Any]]) -> dict[str, str]:
         return {k.lstrip("/"): (v or {}).get("description", "") for k, v in cmds.items()}
 
     before = _snapshot(_bundles_cache)
@@ -244,7 +244,7 @@ def reload_bundles() -> Dict[str, Any]:
     }
 
 
-def list_bundles() -> List[Dict[str, Any]]:
+def list_bundles() -> list[dict[str, Any]]:
     """Return a sorted list of bundle info dicts for display."""
     bundles = get_skill_bundles()
     return sorted(bundles.values(), key=lambda b: b["slug"])
@@ -254,7 +254,7 @@ def build_bundle_invocation_message(
     cmd_key: str,
     user_instruction: str = "",
     task_id: str | None = None,
-) -> Optional[Tuple[str, List[str], List[str]]]:
+) -> Optional[tuple[str, list[str], list[str]]]:
     """Build the user message content for a bundle slash command invocation.
 
     Returns ``(message, loaded_skill_names, missing_skill_names)`` or
@@ -274,9 +274,9 @@ def build_bundle_invocation_message(
     # keep skill_bundles cheap to import in test environments.
     from agent.skill_commands import _load_skill_payload, _build_skill_message
 
-    loaded_names: List[str] = []
-    missing: List[str] = []
-    skill_blocks: List[str] = []
+    loaded_names: list[str] = []
+    missing: list[str] = []
+    skill_blocks: list[str] = []
     seen: set[str] = set()
 
     bundle_name = info["name"]
@@ -355,7 +355,7 @@ def bundle_path_for(name: str) -> Path:
 
 def save_bundle(
     name: str,
-    skills: List[str],
+    skills: list[str],
     description: str = "",
     instruction: str = "",
     overwrite: bool = False,
@@ -377,7 +377,7 @@ def save_bundle(
         raise FileExistsError(f"Bundle already exists at {path}")
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload: Dict[str, Any] = {"name": name, "skills": cleaned_skills}
+    payload: dict[str, Any] = {"name": name, "skills": cleaned_skills}
     if description:
         payload["description"] = description
     if instruction:
@@ -404,7 +404,7 @@ def delete_bundle(name: str) -> Path:
     return path
 
 
-def get_bundle(name: str) -> Optional[Dict[str, Any]]:
+def get_bundle(name: str) -> Optional[dict[str, Any]]:
     """Look up a bundle by name (slug-normalized)."""
     slug = _slugify(name)
     return get_skill_bundles().get(f"/{slug}")

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -20,7 +20,7 @@ from agent.skill_preprocessing import (
 
 logger = logging.getLogger(__name__)
 
-_skill_commands: Dict[str, Dict[str, Any]] = {}
+_skill_commands: dict[str, dict[str, Any]] = {}
 _skill_commands_platform: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
@@ -260,7 +260,7 @@ def _build_skill_message(
     return "\n".join(parts)
 
 
-def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
+def scan_skill_commands() -> dict[str, dict[str, Any]]:
     """Scan ~/.hermes/skills/ and return a mapping of /command -> skill info.
 
     Returns:
@@ -326,7 +326,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     return _skill_commands
 
 
-def get_skill_commands() -> Dict[str, Dict[str, Any]]:
+def get_skill_commands() -> dict[str, dict[str, Any]]:
     """Return the current skill commands mapping (scan first if empty).
 
     Rescans when the active platform scope changes (e.g. a gateway
@@ -341,7 +341,7 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     return _skill_commands
 
 
-def reload_skills() -> Dict[str, Any]:
+def reload_skills() -> dict[str, Any]:
     """Re-scan the skills directory and return a diff of what changed.
 
     Rescans ``~/.hermes/skills/`` and any ``skills.external_dirs`` so the
@@ -373,8 +373,8 @@ def reload_skills() -> Dict[str, Any]:
     # slash-command cache. Using dicts lets the post-rescan diff carry
     # descriptions for newly-visible or just-removed skills without a
     # second disk walk.
-    def _snapshot(cmds: Dict[str, Dict[str, Any]]) -> Dict[str, str]:
-        out: Dict[str, str] = {}
+    def _snapshot(cmds: dict[str, dict[str, Any]]) -> dict[str, str]:
+        out: dict[str, str] = {}
         for slash_key, info in cmds.items():
             bare = slash_key.lstrip("/")
             out[bare] = (info or {}).get("description") or ""

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -85,7 +85,7 @@ def yaml_load(content: str):
 # ── Frontmatter parsing ──────────────────────────────────────────────────
 
 
-def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
+def parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     """Parse YAML frontmatter from a markdown string.
 
     Uses yaml with CSafeLoader for full YAML support (nested metadata, lists)
@@ -94,7 +94,7 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     Returns:
         (frontmatter_dict, remaining_body)
     """
-    frontmatter: Dict[str, Any] = {}
+    frontmatter: dict[str, Any] = {}
     body = content
 
     if not content.startswith("---"):
@@ -125,7 +125,7 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
 # ── Platform matching ─────────────────────────────────────────────────────
 
 
-def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
+def skill_matches_platform(frontmatter: dict[str, Any]) -> bool:
     """Return True when the skill is compatible with the current OS.
 
     Skills declare platform requirements via a top-level ``platforms`` list
@@ -172,7 +172,7 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
 # ── Disabled skills ───────────────────────────────────────────────────────
 
 
-def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
+def get_disabled_skill_names(platform: str | None = None) -> set[str]:
     """Read disabled skill names from config.yaml.
 
     Args:
@@ -214,7 +214,7 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     return _normalize_string_set(skills_cfg.get("disabled"))
 
 
-def _normalize_string_set(values) -> Set[str]:
+def _normalize_string_set(values) -> set[str]:
     if values is None:
         return set()
     if isinstance(values, str):
@@ -230,7 +230,7 @@ def _normalize_string_set(values) -> Set[str]:
 # which becomes the dominant cost of ``hermes`` startup when ~120 skills
 # each trigger a category lookup during banner construction (10+ seconds
 # of pure waste).
-_EXTERNAL_DIRS_CACHE: Dict[Tuple[str, int], List[Path]] = {}
+_EXTERNAL_DIRS_CACHE: dict[tuple[str, int], list[Path]] = {}
 
 
 def _external_dirs_cache_clear() -> None:
@@ -238,7 +238,7 @@ def _external_dirs_cache_clear() -> None:
     _EXTERNAL_DIRS_CACHE.clear()
 
 
-def get_external_skills_dirs() -> List[Path]:
+def get_external_skills_dirs() -> list[Path]:
     """Read ``skills.external_dirs`` from config.yaml and return validated paths.
 
     Each entry is expanded (``~`` and ``${VAR}``) and resolved to an absolute
@@ -258,7 +258,7 @@ def get_external_skills_dirs() -> List[Path]:
     # the full YAML parse, so the fast path is nearly free.
     try:
         stat = config_path.stat()
-        cache_key: Tuple[str, int] = (str(config_path), stat.st_mtime_ns)
+        cache_key: tuple[str, int] = (str(config_path), stat.st_mtime_ns)
     except OSError:
         cache_key = None  # type: ignore[assignment]
 
@@ -281,7 +281,7 @@ def get_external_skills_dirs() -> List[Path]:
 
     raw_dirs = skills_cfg.get("external_dirs")
     if not raw_dirs:
-        result: List[Path] = []
+        result: list[Path] = []
         if cache_key is not None:
             _EXTERNAL_DIRS_CACHE[cache_key] = list(result)
         return result
@@ -294,7 +294,7 @@ def get_external_skills_dirs() -> List[Path]:
 
     hermes_home = get_hermes_home()
     local_skills = get_skills_dir().resolve()
-    seen: Set[Path] = set()
+    seen: set[Path] = set()
     result = []
 
     for entry in raw_dirs:
@@ -324,7 +324,7 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
-def get_all_skills_dirs() -> List[Path]:
+def get_all_skills_dirs() -> list[Path]:
     """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
 
     The local dir is always first (and always included even if it doesn't exist
@@ -338,7 +338,7 @@ def get_all_skills_dirs() -> List[Path]:
 # ── Condition extraction ──────────────────────────────────────────────────
 
 
-def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
+def extract_skill_conditions(frontmatter: dict[str, Any]) -> dict[str, list]:
     """Extract conditional activation fields from parsed frontmatter."""
     metadata = frontmatter.get("metadata")
     # Handle cases where metadata is not a dict (e.g., a string from malformed YAML)
@@ -358,7 +358,7 @@ def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
 # ── Skill config extraction ───────────────────────────────────────────────
 
 
-def extract_skill_config_vars(frontmatter: Dict[str, Any]) -> List[Dict[str, Any]]:
+def extract_skill_config_vars(frontmatter: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract config variable declarations from parsed frontmatter.
 
     Skills declare config.yaml settings they need via::
@@ -388,7 +388,7 @@ def extract_skill_config_vars(frontmatter: Dict[str, Any]) -> List[Dict[str, Any
     if not isinstance(raw, list):
         return []
 
-    result: List[Dict[str, Any]] = []
+    result: list[dict[str, Any]] = []
     seen: set = set()
     for item in raw:
         if not isinstance(item, dict):
@@ -400,7 +400,7 @@ def extract_skill_config_vars(frontmatter: Dict[str, Any]) -> List[Dict[str, Any
         desc = str(item.get("description", "")).strip()
         if not desc:
             continue
-        entry: Dict[str, Any] = {
+        entry: dict[str, Any] = {
             "key": key,
             "description": desc,
         }
@@ -417,7 +417,7 @@ def extract_skill_config_vars(frontmatter: Dict[str, Any]) -> List[Dict[str, Any
     return result
 
 
-def discover_all_skill_config_vars() -> List[Dict[str, Any]]:
+def discover_all_skill_config_vars() -> list[dict[str, Any]]:
     """Scan all enabled skills and collect their config variable declarations.
 
     Walks every skills directory, parses each SKILL.md frontmatter, and returns
@@ -426,7 +426,7 @@ def discover_all_skill_config_vars() -> List[Dict[str, Any]]:
 
     Disabled and platform-incompatible skills are excluded.
     """
-    all_vars: List[Dict[str, Any]] = []
+    all_vars: list[dict[str, Any]] = []
     seen_keys: set = set()
 
     disabled = get_disabled_skill_names()
@@ -462,7 +462,7 @@ def discover_all_skill_config_vars() -> List[Dict[str, Any]]:
 SKILL_CONFIG_PREFIX = "skills.config"
 
 
-def _resolve_dotpath(config: Dict[str, Any], dotted_key: str):
+def _resolve_dotpath(config: dict[str, Any], dotted_key: str):
     """Walk a nested dict following a dotted key.  Returns None if any part is missing."""
     parts = dotted_key.split(".")
     current = config
@@ -475,8 +475,8 @@ def _resolve_dotpath(config: Dict[str, Any], dotted_key: str):
 
 
 def resolve_skill_config_values(
-    config_vars: List[Dict[str, Any]],
-) -> Dict[str, Any]:
+    config_vars: list[dict[str, Any]],
+) -> dict[str, Any]:
     """Resolve current values for skill config vars from config.yaml.
 
     Skill config is stored under ``skills.config.<key>`` in config.yaml.
@@ -485,7 +485,7 @@ def resolve_skill_config_values(
     Path values are expanded via ``os.path.expanduser``.
     """
     config_path = get_config_path()
-    config: Dict[str, Any] = {}
+    config: dict[str, Any] = {}
     if config_path.exists():
         try:
             parsed = yaml_load(config_path.read_text(encoding="utf-8"))
@@ -494,7 +494,7 @@ def resolve_skill_config_values(
         except Exception:
             pass
 
-    resolved: Dict[str, Any] = {}
+    resolved: dict[str, Any] = {}
     for var in config_vars:
         logical_key = var["key"]
         storage_key = f"{SKILL_CONFIG_PREFIX}.{logical_key}"
@@ -515,7 +515,7 @@ def resolve_skill_config_values(
 # ── Description extraction ────────────────────────────────────────────────
 
 
-def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
+def extract_skill_description(frontmatter: dict[str, Any]) -> str:
     """Extract a truncated description from parsed frontmatter."""
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
@@ -549,7 +549,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
 _NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
-def parse_qualified_name(name: str) -> Tuple[Optional[str], str]:
+def parse_qualified_name(name: str) -> tuple[Optional[str], str]:
     """Split ``'namespace:skill-name'`` into ``(namespace, bare_name)``.
 
     Returns ``(None, name)`` when there is no ``':'``.

--- a/agent/stream_diag.py
+++ b/agent/stream_diag.py
@@ -38,7 +38,7 @@ STREAM_DIAG_HEADERS = (
 )
 
 
-def stream_diag_init() -> Dict[str, Any]:
+def stream_diag_init() -> dict[str, Any]:
     """Return a fresh per-attempt diagnostic dict.
 
     Mutated in-place by the streaming functions and read from the retry
@@ -55,7 +55,7 @@ def stream_diag_init() -> Dict[str, Any]:
     }
 
 
-def stream_diag_capture_response(agent: Any, diag: Dict[str, Any], http_response: Any) -> None:
+def stream_diag_capture_response(agent: Any, diag: dict[str, Any], http_response: Any) -> None:
     """Snapshot interesting headers + HTTP status from the live stream.
 
     Called once at stream open (before iterating chunks) so the metadata
@@ -70,7 +70,7 @@ def stream_diag_capture_response(agent: Any, diag: Dict[str, Any], http_response
         pass
     try:
         headers = getattr(http_response, "headers", None) or {}
-        captured: Dict[str, str] = {}
+        captured: dict[str, str] = {}
         # Allow per-agent override of the headers list (back-compat).
         target_headers = getattr(agent, "_STREAM_DIAG_HEADERS", STREAM_DIAG_HEADERS)
         for name in target_headers:
@@ -96,7 +96,7 @@ def flatten_exception_chain(error: BaseException) -> str:
     died.  Walks ``__cause__`` then ``__context__`` (deduped, max 4
     deep) to surface the chain in one line.
     """
-    seen: List[BaseException] = []
+    seen: list[BaseException] = []
     link: Optional[BaseException] = error
     while link is not None and len(seen) < 4:
         if link in seen:
@@ -108,7 +108,7 @@ def flatten_exception_chain(error: BaseException) -> str:
         if nxt is None or nxt is link:
             break
         link = nxt
-    parts: List[str] = []
+    parts: list[str] = []
     for e in seen:
         msg = str(e).strip().replace("\n", " ")
         if len(msg) > 140:
@@ -125,7 +125,7 @@ def log_stream_retry(
     attempt: int,
     max_attempts: int,
     mid_tool_call: bool,
-    diag: Optional[Dict[str, Any]] = None,
+    diag: Optional[dict[str, Any]] = None,
 ) -> None:
     """Record a transient stream-drop and retry to ``agent.log``.
 
@@ -218,7 +218,7 @@ def emit_stream_drop(
     attempt: int,
     max_attempts: int,
     mid_tool_call: bool,
-    diag: Optional[Dict[str, Any]] = None,
+    diag: Optional[dict[str, Any]] = None,
 ) -> None:
     """Emit a single user-visible line for a stream drop+retry.
 

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -60,14 +60,14 @@ class SubdirectoryHintTracker:
 
     def __init__(self, working_dir: Optional[str] = None):
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
-        self._loaded_dirs: Set[Path] = set()
+        self._loaded_dirs: set[Path] = set()
         # Pre-mark the working dir as loaded (startup context handles it)
         self._loaded_dirs.add(self.working_dir)
 
     def check_tool_call(
         self,
         tool_name: str,
-        tool_args: Dict[str, Any],
+        tool_args: dict[str, Any],
     ) -> Optional[str]:
         """Check tool call arguments for new directories and load any hint files.
 
@@ -89,10 +89,10 @@ class SubdirectoryHintTracker:
         return "\n\n" + "\n\n".join(all_hints)
 
     def _extract_directories(
-        self, tool_name: str, args: Dict[str, Any]
+        self, tool_name: str, args: dict[str, Any]
     ) -> list:
         """Extract directory paths from tool call arguments."""
-        candidates: Set[Path] = set()
+        candidates: set[Path] = set()
 
         # Direct path arguments
         for key in _PATH_ARG_KEYS:
@@ -108,7 +108,7 @@ class SubdirectoryHintTracker:
 
         return list(candidates)
 
-    def _add_path_candidate(self, raw_path: str, candidates: Set[Path]):
+    def _add_path_candidate(self, raw_path: str, candidates: set[Path]):
         """Resolve a raw path and add its directory + ancestors to candidates.
 
         Walks up from the resolved directory toward the filesystem root,
@@ -138,7 +138,7 @@ class SubdirectoryHintTracker:
         except (OSError, ValueError):
             pass
 
-    def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
+    def _extract_paths_from_command(self, cmd: str, candidates: set[Path]):
         """Extract path-like tokens from a shell command string."""
         try:
             tokens = shlex.split(cmd)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -57,7 +57,7 @@ def _ra():
     return run_agent
 
 
-def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
+def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> dict[str, str]:
     """Assemble the system prompt as three ordered parts.
 
     Returns a dict with three keys:
@@ -81,7 +81,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _r = _ra()
 
     # ── Stable tier ────────────────────────────────────────────────
-    stable_parts: List[str] = []
+    stable_parts: list[str] = []
 
     # Try SOUL.md as primary identity unless the caller explicitly skipped it.
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
@@ -253,7 +253,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             pass
 
     # ── Context tier (cwd-dependent, may change between sessions) ─
-    context_parts: List[str] = []
+    context_parts: list[str] = []
 
     # Note: ephemeral_system_prompt is NOT included here. It's injected at
     # API-call time only so it stays out of the cached/stored system prompt.
@@ -272,7 +272,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             context_parts.append(context_files_prompt)
 
     # ── Volatile tier (changes per session/turn — never cached) ───
-    volatile_parts: List[str] = []
+    volatile_parts: list[str] = []
 
     if agent._memory_store:
         if agent._memory_enabled:

--- a/agent/think_scrubber.py
+++ b/agent/think_scrubber.py
@@ -76,7 +76,7 @@ class StreamingThinkScrubber:
         block boundary.
     """
 
-    _OPEN_TAG_NAMES: Tuple[str, ...] = (
+    _OPEN_TAG_NAMES: tuple[str, ...] = (
         "think",
         "thinking",
         "reasoning",
@@ -86,8 +86,8 @@ class StreamingThinkScrubber:
 
     # Materialise literal tag strings so the hot path does string
     # operations, not regex compilation per feed().
-    _OPEN_TAGS: Tuple[str, ...] = tuple(f"<{name}>" for name in _OPEN_TAG_NAMES)
-    _CLOSE_TAGS: Tuple[str, ...] = tuple(f"</{name}>" for name in _OPEN_TAG_NAMES)
+    _OPEN_TAGS: tuple[str, ...] = tuple(f"<{name}>" for name in _OPEN_TAG_NAMES)
+    _CLOSE_TAGS: tuple[str, ...] = tuple(f"</{name}>" for name in _OPEN_TAG_NAMES)
 
     # Pre-compute the longest tag (for partial-tag hold-back bound).
     _MAX_TAG_LEN: int = max(len(tag) for tag in _OPEN_TAGS + _CLOSE_TAGS)
@@ -226,8 +226,8 @@ class StreamingThinkScrubber:
 
     @staticmethod
     def _find_first_tag(
-        buf: str, tags: Tuple[str, ...],
-    ) -> Tuple[int, int]:
+        buf: str, tags: tuple[str, ...],
+    ) -> tuple[int, int]:
         """Return (earliest_index, tag_length) over *tags*, or (-1, 0).
 
         Case-insensitive match.
@@ -272,7 +272,7 @@ class StreamingThinkScrubber:
 
     def _find_open_at_boundary(
         self, buf: str, already_emitted: list[str],
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Return the earliest block-boundary open-tag (idx, len).
 
         Returns (-1, 0) if no boundary-legal opener is present.
@@ -332,7 +332,7 @@ class StreamingThinkScrubber:
 
     @classmethod
     def _max_partial_suffix(
-        cls, buf: str, tags: Tuple[str, ...],
+        cls, buf: str, tags: tuple[str, ...],
     ) -> int:
         """Return the longest buf-suffix that is a prefix of any tag.
 

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -213,7 +213,7 @@ def _multimodal_text_summary(value: Any) -> str:
         return str(value)
 
 
-def _append_subdir_hint_to_multimodal(value: Dict[str, Any], hint: str) -> None:
+def _append_subdir_hint_to_multimodal(value: dict[str, Any], hint: str) -> None:
     """Mutate a multimodal tool-result envelope to append a subdir hint.
 
     The hint is added to the first text part so the model sees it; image
@@ -234,7 +234,7 @@ def _append_subdir_hint_to_multimodal(value: Dict[str, Any], hint: str) -> None:
         value["text_summary"] = value["text_summary"] + hint
 
 
-def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List[str]:
+def _extract_file_mutation_targets(tool_name: str, args: dict[str, Any]) -> list[str]:
     """Return the file paths a ``write_file`` or ``patch`` call is targeting.
 
     For ``write_file`` and ``patch`` in replace mode this is just ``args["path"]``.
@@ -256,7 +256,7 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
         body = args.get("patch") or ""
         if not isinstance(body, str) or not body:
             return []
-        paths: List[str] = []
+        paths: list[str] = []
         for _m in re.finditer(
             r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$',
             body,
@@ -294,7 +294,7 @@ def _extract_error_preview(result: Any, max_len: int = 180) -> str:
     return text
 
 
-def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
+def _trajectory_normalize_msg(msg: dict[str, Any]) -> dict[str, Any]:
     """Strip image blobs from a message for trajectory saving.
 
     Returns a shallow copy with multimodal tool results replaced by their

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -27,7 +27,7 @@ def has_incomplete_scratchpad(content: str) -> bool:
     return "<REASONING_SCRATCHPAD>" in content and "</REASONING_SCRATCHPAD>" not in content
 
 
-def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
+def save_trajectory(trajectory: list[dict[str, Any]], model: str,
                     completed: bool, filename: str = None):
     """Append a trajectory entry to a JSONL file.
 

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -21,7 +21,7 @@ class AnthropicTransport(ProviderTransport):
     def api_mode(self) -> str:
         return "anthropic_messages"
 
-    def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> Any:
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> Any:
         """Convert OpenAI messages to Anthropic (system, messages) tuple.
 
         kwargs:
@@ -32,7 +32,7 @@ class AnthropicTransport(ProviderTransport):
         base_url = kwargs.get("base_url")
         return convert_messages_to_anthropic(messages, base_url=base_url)
 
-    def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
+    def convert_tools(self, tools: list[dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Anthropic input_schema format."""
         from agent.anthropic_adapter import convert_tools_to_anthropic
 
@@ -41,10 +41,10 @@ class AnthropicTransport(ProviderTransport):
     def build_kwargs(
         self,
         model: str,
-        messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        messages: list[dict[str, Any]],
+        tools: Optional[list[dict[str, Any]]] = None,
         **params,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Build Anthropic messages.create() kwargs.
 
         Calls convert_messages and convert_tools internally.
@@ -157,7 +157,7 @@ class AnthropicTransport(ProviderTransport):
             return getattr(response, "stop_reason", None) == "end_turn"
         return True
 
-    def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
+    def extract_cache_stats(self, response: Any) -> Optional[dict[str, int]]:
         """Extract Anthropic cache_read and cache_creation token counts."""
         usage = getattr(response, "usage", None)
         if usage is None:

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -23,7 +23,7 @@ class ProviderTransport(ABC):
         ...
 
     @abstractmethod
-    def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> Any:
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> Any:
         """Convert OpenAI-format messages to provider-native format.
 
         Returns provider-specific structure (e.g. (system, messages) for Anthropic,
@@ -32,7 +32,7 @@ class ProviderTransport(ABC):
         ...
 
     @abstractmethod
-    def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
+    def convert_tools(self, tools: list[dict[str, Any]]) -> Any:
         """Convert OpenAI-format tool definitions to provider-native format.
 
         Returns provider-specific tool list (e.g. Anthropic input_schema format).
@@ -43,10 +43,10 @@ class ProviderTransport(ABC):
     def build_kwargs(
         self,
         model: str,
-        messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        messages: list[dict[str, Any]],
+        tools: Optional[list[dict[str, Any]]] = None,
         **params,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Build the complete API call kwargs dict.
 
         This is the primary entry point — it typically calls convert_messages()
@@ -72,7 +72,7 @@ class ProviderTransport(ABC):
         """
         return True
 
-    def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
+    def extract_cache_stats(self, response: Any) -> Optional[dict[str, int]]:
         """Optional: extract provider-specific cache hit/creation stats.
 
         Returns dict with 'cached_tokens' and 'creation_tokens', or None.

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -19,12 +19,12 @@ class BedrockTransport(ProviderTransport):
     def api_mode(self) -> str:
         return "bedrock_converse"
 
-    def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> Any:
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> Any:
         """Convert OpenAI messages to Bedrock Converse format."""
         from agent.bedrock_adapter import convert_messages_to_converse
         return convert_messages_to_converse(messages)
 
-    def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
+    def convert_tools(self, tools: list[dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Bedrock Converse toolConfig."""
         from agent.bedrock_adapter import convert_tools_to_converse
         return convert_tools_to_converse(tools)
@@ -32,10 +32,10 @@ class BedrockTransport(ProviderTransport):
     def build_kwargs(
         self,
         model: str,
-        messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        messages: list[dict[str, Any]],
+        tools: Optional[list[dict[str, Any]]] = None,
         **params,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Build Bedrock converse() kwargs.
 
         Calls convert_messages and convert_tools internally.

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -45,7 +45,7 @@ def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> 
     if effort == "none":
         return {"includeThoughts": False}
 
-    thinking_config: Dict[str, Any] = {"includeThoughts": True}
+    thinking_config: dict[str, Any] = {"includeThoughts": True}
 
     # Gemini 2.5 accepts thinkingBudget; don't guess a budget from Hermes'
     # coarse effort levels. ``includeThoughts`` alone is enough to surface
@@ -80,7 +80,7 @@ def _snake_case_gemini_thinking_config(config: dict | None) -> dict | None:
     if not isinstance(config, dict) or not config:
         return None
 
-    translated: Dict[str, Any] = {}
+    translated: dict[str, Any] = {}
     if isinstance(config.get("includeThoughts"), bool):
         translated["include_thoughts"] = config["includeThoughts"]
     if isinstance(config.get("thinkingLevel"), str) and config["thinkingLevel"].strip():
@@ -599,7 +599,7 @@ class ChatCompletionsTransport(ProviderTransport):
             if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
                 reasoning_content = model_extra["reasoning_content"]
 
-        provider_data: Dict[str, Any] = {}
+        provider_data: dict[str, Any] = {}
         if reasoning_content is not None:
             provider_data["reasoning_content"] = reasoning_content
         rd = getattr(msg, "reasoning_details", None)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -21,7 +21,7 @@ class ResponsesApiTransport(ProviderTransport):
     def api_mode(self) -> str:
         return "codex_responses"
 
-    def convert_messages(self, messages: List[Dict[str, Any]], **kwargs) -> Any:
+    def convert_messages(self, messages: list[dict[str, Any]], **kwargs) -> Any:
         """Convert OpenAI chat messages to Responses API input items."""
         from agent.codex_responses_adapter import _chat_messages_to_responses_input
         return _chat_messages_to_responses_input(
@@ -29,7 +29,7 @@ class ResponsesApiTransport(ProviderTransport):
             is_xai_responses=bool(kwargs.get("is_xai_responses")),
         )
 
-    def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
+    def convert_tools(self, tools: list[dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Responses API function definitions."""
         from agent.codex_responses_adapter import _responses_tools
         return _responses_tools(tools)
@@ -37,10 +37,10 @@ class ResponsesApiTransport(ProviderTransport):
     def build_kwargs(
         self,
         model: str,
-        messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        messages: list[dict[str, Any]],
+        tools: Optional[list[dict[str, Any]]] = None,
         **params,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Build Responses API kwargs.
 
         Calls convert_messages and convert_tools internally.
@@ -148,7 +148,7 @@ class ResponsesApiTransport(ProviderTransport):
             cache_scope_id = str(prompt_cache_key or session_id or "").strip()
             if cache_scope_id:
                 existing_extra_headers = kwargs.get("extra_headers")
-                merged_extra_headers: Dict[str, str] = {}
+                merged_extra_headers: dict[str, str] = {}
                 if isinstance(existing_extra_headers, dict):
                     merged_extra_headers.update(
                         {
@@ -167,7 +167,7 @@ class ResponsesApiTransport(ProviderTransport):
 
         if is_xai_responses and session_id:
             existing_extra_headers = kwargs.get("extra_headers")
-            merged_extra_headers: Dict[str, str] = {}
+            merged_extra_headers: dict[str, str] = {}
             if isinstance(existing_extra_headers, dict):
                 merged_extra_headers.update(
                     {
@@ -184,7 +184,7 @@ class ResponsesApiTransport(ProviderTransport):
             # Sent via extra_body (not the typed kwarg) so it survives openai
             # SDK builds whose Responses.stream() signature has dropped the field.
             existing_extra_body = kwargs.get("extra_body")
-            merged_extra_body: Dict[str, Any] = {}
+            merged_extra_body: dict[str, Any] = {}
             if isinstance(existing_extra_body, dict):
                 merged_extra_body.update(existing_extra_body)
             merged_extra_body.setdefault("prompt_cache_key", session_id)

--- a/agent/tts_provider.py
+++ b/agent/tts_provider.py
@@ -101,7 +101,7 @@ class TTSProvider(abc.ABC):
         """
         return True
 
-    def list_voices(self) -> List[Dict[str, Any]]:
+    def list_voices(self) -> list[dict[str, Any]]:
         """Return voice catalog entries.
 
         Each entry::
@@ -119,7 +119,7 @@ class TTSProvider(abc.ABC):
         """
         return []
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         """Return model catalog entries.
 
         Each entry::
@@ -136,7 +136,7 @@ class TTSProvider(abc.ABC):
         """
         return []
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         """Return provider metadata for the ``hermes tools`` picker.
 
         Used by ``tools_config.py`` to inject this provider as a row in

--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -59,7 +59,7 @@ _BUILTIN_NAMES = frozenset({
 })
 
 
-_providers: Dict[str, TTSProvider] = {}
+_providers: dict[str, TTSProvider] = {}
 _lock = threading.Lock()
 
 
@@ -108,7 +108,7 @@ def register_provider(provider: TTSProvider) -> None:
         )
 
 
-def list_providers() -> List[TTSProvider]:
+def list_providers() -> list[TTSProvider]:
     """Return all registered providers, sorted by name."""
     with _lock:
         items = list(_providers.values())

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -82,7 +82,7 @@ _UTC_NOW = lambda: datetime.now(timezone.utc)
 
 # Official docs snapshot entries. Models whose published pricing and cache
 # semantics are stable enough to encode exactly.
-_OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
+_OFFICIAL_DOCS_PRICING: dict[tuple[str, str], PricingEntry] = {
     # ── Anthropic Claude 4.7 ─────────────────────────────────────────────
     # Opus 4.5/4.6/4.7 share $5/$25 pricing (new tokenizer, up to 35% more
     # tokens for the same text).
@@ -596,7 +596,7 @@ def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
 
 
 def _pricing_entry_from_metadata(
-    metadata: Dict[str, Dict[str, Any]],
+    metadata: dict[str, dict[str, Any]],
     model_id: str,
     *,
     source_url: str,

--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -60,10 +60,10 @@ logger = logging.getLogger(__name__)
 # Common aspect ratios across providers (Veo / Kling / xAI / Pixverse). The
 # tool schema advertises this set as an enum hint, but providers may accept
 # a narrower or wider set — they are responsible for clamping.
-COMMON_ASPECT_RATIOS: Tuple[str, ...] = ("16:9", "9:16", "1:1", "4:3", "3:4", "3:2", "2:3")
+COMMON_ASPECT_RATIOS: tuple[str, ...] = ("16:9", "9:16", "1:1", "4:3", "3:4", "3:2", "2:3")
 DEFAULT_ASPECT_RATIO = "16:9"
 
-COMMON_RESOLUTIONS: Tuple[str, ...] = ("480p", "540p", "720p", "1080p")
+COMMON_RESOLUTIONS: tuple[str, ...] = ("480p", "540p", "720p", "1080p")
 DEFAULT_RESOLUTION = "720p"
 
 
@@ -100,7 +100,7 @@ class VideoGenProvider(abc.ABC):
         """
         return True
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         """Return catalog entries for ``hermes tools`` model picker.
 
         Each entry represents a **model family** that supports text-to-video
@@ -119,7 +119,7 @@ class VideoGenProvider(abc.ABC):
         """
         return []
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         """Return provider metadata for the ``hermes tools`` picker."""
         return {
             "name": self.display_name,
@@ -135,7 +135,7 @@ class VideoGenProvider(abc.ABC):
             return models[0].get("id")
         return None
 
-    def capabilities(self) -> Dict[str, Any]:
+    def capabilities(self) -> dict[str, Any]:
         """Return what this provider supports.
 
         Returned dict (all keys optional)::
@@ -172,7 +172,7 @@ class VideoGenProvider(abc.ABC):
         *,
         model: Optional[str] = None,
         image_url: Optional[str] = None,
-        reference_image_urls: Optional[List[str]] = None,
+        reference_image_urls: Optional[list[str]] = None,
         duration: Optional[int] = None,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         resolution: str = DEFAULT_RESOLUTION,
@@ -180,7 +180,7 @@ class VideoGenProvider(abc.ABC):
         audio: Optional[bool] = None,
         seed: Optional[int] = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate a video from a prompt (text-to-video) or animate an image
         (image-to-video).
 
@@ -253,15 +253,15 @@ def success_response(
     aspect_ratio: str = "",
     duration: int = 0,
     provider: str,
-    extra: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    extra: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """Build a uniform success response dict.
 
     ``video`` may be an HTTP URL or an absolute filesystem path.
     ``modality`` is ``"text"`` (text-to-video) or ``"image"`` (image-to-video) —
     indicates which endpoint was actually hit, useful for diagnostics.
     """
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "success": True,
         "video": video,
         "model": model,
@@ -285,7 +285,7 @@ def error_response(
     model: str = "",
     prompt: str = "",
     aspect_ratio: str = "",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build a uniform error response dict."""
     return {
         "success": False,

--- a/agent/video_gen_registry.py
+++ b/agent/video_gen_registry.py
@@ -30,7 +30,7 @@ from agent.video_gen_provider import VideoGenProvider
 logger = logging.getLogger(__name__)
 
 
-_providers: Dict[str, VideoGenProvider] = {}
+_providers: dict[str, VideoGenProvider] = {}
 _lock = threading.Lock()
 
 
@@ -58,7 +58,7 @@ def register_provider(provider: VideoGenProvider) -> None:
         logger.debug("Registered video gen provider '%s' (%s)", name, type(provider).__name__)
 
 
-def list_providers() -> List[VideoGenProvider]:
+def list_providers() -> list[VideoGenProvider]:
     """Return all registered providers, sorted by name."""
     with _lock:
         items = list(_providers.values())

--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -129,7 +129,7 @@ class WebSearchProvider(abc.ABC):
         """
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a web search.
 
         Override when :meth:`supports_search` returns True. The default
@@ -140,7 +140,7 @@ class WebSearchProvider(abc.ABC):
             f"{self.name} does not support search (override supports_search)"
         )
 
-    def extract(self, urls: List[str], **kwargs: Any) -> Any:
+    def extract(self, urls: list[str], **kwargs: Any) -> Any:
         """Extract content from one or more URLs.
 
         Override when :meth:`supports_extract` returns True. The default
@@ -193,7 +193,7 @@ class WebSearchProvider(abc.ABC):
             f"{self.name} does not support crawl (override supports_crawl)"
         )
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         """Return provider metadata for the ``hermes tools`` picker.
 
         Used by ``hermes_cli/tools_config.py`` to inject this provider as a

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -41,7 +41,7 @@ from agent.web_search_provider import WebSearchProvider
 logger = logging.getLogger(__name__)
 
 
-_providers: Dict[str, WebSearchProvider] = {}
+_providers: dict[str, WebSearchProvider] = {}
 _lock = threading.Lock()
 
 
@@ -75,7 +75,7 @@ def register_provider(provider: WebSearchProvider) -> None:
         )
 
 
-def list_providers() -> List[WebSearchProvider]:
+def list_providers() -> list[WebSearchProvider]:
     """Return all registered providers, sorted by name."""
     with _lock:
         items = list(_providers.values())

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -68,7 +68,7 @@ ALL_POSSIBLE_TOOLS = set(TOOL_TO_TOOLSET_MAP.keys())
 DEFAULT_TOOL_STATS = {'count': 0, 'success': 0, 'failure': 0}
 
 
-def _normalize_tool_stats(tool_stats: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:
+def _normalize_tool_stats(tool_stats: dict[str, dict[str, int]]) -> dict[str, dict[str, int]]:
     """
     Normalize tool_stats to include all possible tools with consistent schema.
     
@@ -98,7 +98,7 @@ def _normalize_tool_stats(tool_stats: Dict[str, Dict[str, int]]) -> Dict[str, Di
     return normalized
 
 
-def _normalize_tool_error_counts(tool_error_counts: Dict[str, int]) -> Dict[str, int]:
+def _normalize_tool_error_counts(tool_error_counts: dict[str, int]) -> dict[str, int]:
     """
     Normalize tool_error_counts to include all possible tools.
     
@@ -122,7 +122,7 @@ def _normalize_tool_error_counts(tool_error_counts: Dict[str, int]) -> Dict[str,
     return normalized
 
 
-def _extract_tool_stats(messages: List[Dict[str, Any]]) -> Dict[str, Dict[str, int]]:
+def _extract_tool_stats(messages: list[dict[str, Any]]) -> dict[str, dict[str, int]]:
     """
     Extract tool usage statistics from message history.
     
@@ -205,7 +205,7 @@ def _extract_tool_stats(messages: List[Dict[str, Any]]) -> Dict[str, Dict[str, i
     return tool_stats
 
 
-def _extract_reasoning_stats(messages: List[Dict[str, Any]]) -> Dict[str, int]:
+def _extract_reasoning_stats(messages: list[dict[str, Any]]) -> dict[str, int]:
     """
     Count how many assistant turns have reasoning vs no reasoning.
     
@@ -243,10 +243,10 @@ def _extract_reasoning_stats(messages: List[Dict[str, Any]]) -> Dict[str, int]:
 
 def _process_single_prompt(
     prompt_index: int,
-    prompt_data: Dict[str, Any],
+    prompt_data: dict[str, Any],
     batch_num: int,
-    config: Dict[str, Any]
-) -> Dict[str, Any]:
+    config: dict[str, Any]
+) -> dict[str, Any]:
     """
     Process a single prompt with the agent.
     
@@ -397,7 +397,7 @@ def _process_single_prompt(
         }
 
 
-def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
+def _process_batch_worker(args: tuple) -> dict[str, Any]:
     """
     Worker function to process a single batch of prompts.
     
@@ -543,14 +543,14 @@ class BatchRunner:
         verbose: bool = False,
         ephemeral_system_prompt: str = None,
         log_prefix_chars: int = 100,
-        providers_allowed: List[str] = None,
-        providers_ignored: List[str] = None,
-        providers_order: List[str] = None,
+        providers_allowed: list[str] = None,
+        providers_ignored: list[str] = None,
+        providers_order: list[str] = None,
         provider_sort: str = None,
         openrouter_min_coding_score: Optional[float] = None,
         max_tokens: int = None,
-        reasoning_config: Dict[str, Any] = None,
-        prefill_messages: List[Dict[str, Any]] = None,
+        reasoning_config: dict[str, Any] = None,
+        prefill_messages: list[dict[str, Any]] = None,
         max_samples: int = None,
     ):
         """
@@ -639,7 +639,7 @@ class BatchRunner:
             prompt_preview = self.ephemeral_system_prompt[:60] + "..." if len(self.ephemeral_system_prompt) > 60 else self.ephemeral_system_prompt
             print(f"   🔒 Ephemeral system prompt: '{prompt_preview}'")
     
-    def _load_dataset(self) -> List[Dict[str, Any]]:
+    def _load_dataset(self) -> list[dict[str, Any]]:
         """
         Load dataset from JSONL file.
         
@@ -671,7 +671,7 @@ class BatchRunner:
         
         return dataset
     
-    def _create_batches(self) -> List[List[Tuple[int, Dict[str, Any]]]]:
+    def _create_batches(self) -> list[list[tuple[int, dict[str, Any]]]]:
         """
         Split dataset into batches with indices.
         
@@ -685,7 +685,7 @@ class BatchRunner:
         
         return batches
     
-    def _load_checkpoint(self) -> Dict[str, Any]:
+    def _load_checkpoint(self) -> dict[str, Any]:
         """
         Load checkpoint data if it exists.
         
@@ -712,7 +712,7 @@ class BatchRunner:
                 "last_updated": None
             }
     
-    def _save_checkpoint(self, checkpoint_data: Dict[str, Any], lock: Optional[Lock] = None):
+    def _save_checkpoint(self, checkpoint_data: dict[str, Any], lock: Optional[Lock] = None):
         """
         Save checkpoint data.
         
@@ -773,7 +773,7 @@ class BatchRunner:
         
         return completed_prompts
     
-    def _filter_dataset_by_completed(self, completed_prompts: set) -> Tuple[List[Dict], List[int]]:
+    def _filter_dataset_by_completed(self, completed_prompts: set) -> tuple[list[dict], list[int]]:
         """
         Filter the dataset to exclude prompts that have already been completed.
         

--- a/cli.py
+++ b/cli.py
@@ -279,7 +279,7 @@ def _assistant_copy_text(content: Any) -> str:
 # Configuration Loading
 # =============================================================================
 
-def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
+def _load_prefill_messages(file_path: str) -> list[dict[str, Any]]:
     """Load ephemeral prefill messages from a JSON file.
     
     The file should contain a JSON array of {role, content} dicts, e.g.:
@@ -327,7 +327,7 @@ def _parse_service_tier_config(raw: str) -> str | None:
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
 
-def load_cli_config() -> Dict[str, Any]:
+def load_cli_config() -> dict[str, Any]:
     """
     Load CLI configuration from config files.
     
@@ -962,7 +962,7 @@ def _run_cleanup():
 # =============================================================================
 
 # Tracks the active worktree for cleanup on exit
-_active_worktree: Optional[Dict[str, str]] = None
+_active_worktree: Optional[dict[str, str]] = None
 
 
 def _normalize_git_bash_path(p: Optional[str]) -> Optional[str]:
@@ -1024,7 +1024,7 @@ def _path_is_within_root(path: Path, root: Path) -> bool:
         return False
 
 
-def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
+def _setup_worktree(repo_root: str = None) -> Optional[dict[str, str]]:
     """Create an isolated git worktree for this CLI session.
 
     Returns a dict with worktree metadata on success, None on failure.
@@ -1183,7 +1183,7 @@ def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> boo
         return True
 
 
-def _cleanup_worktree(info: Dict[str, str] = None) -> None:
+def _cleanup_worktree(info: dict[str, str] = None) -> None:
     """Remove a worktree and its branch on exit.
 
     Preserves the worktree only if it has unpushed commits (real work
@@ -2807,7 +2807,7 @@ class HermesCLI:
     def __init__(
         self,
         model: str = None,
-        toolsets: List[str] = None,
+        toolsets: list[str] = None,
         provider: str = None,
         api_key: str = None,
         base_url: str = None,
@@ -3070,7 +3070,7 @@ class HermesCLI:
         self._app = None  # prompt_toolkit Application (set in run())
         
         # Conversation state
-        self.conversation_history: List[Dict[str, Any]] = []
+        self.conversation_history: list[dict[str, Any]] = []
         self.session_start = datetime.now()
         self._resumed = False
         # Per-prompt elapsed timer — started at the beginning of each chat turn,
@@ -3185,7 +3185,7 @@ class HermesCLI:
         self._resize_recovery_pending = False
 
         # Background task tracking: {task_id: threading.Thread}
-        self._background_tasks: Dict[str, threading.Thread] = {}
+        self._background_tasks: dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
@@ -3384,7 +3384,7 @@ class HermesCLI:
         emoji = "⏱" if live else "⏲"
         return f"{emoji} {time_str}"
 
-    def _get_status_bar_snapshot(self) -> Dict[str, Any]:
+    def _get_status_bar_snapshot(self) -> dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
         # changes mid-session, so the TUI would show a stale name after

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -46,7 +46,7 @@ OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
 
-def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
+def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> list[str]:
     """Normalize legacy/single-skill and multi-skill inputs into a unique ordered list."""
     if skills is None:
         raw_items = [skill] if skill else []
@@ -55,7 +55,7 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     else:
         raw_items = list(skills)
 
-    normalized: List[str] = []
+    normalized: list[str] = []
     for item in raw_items:
         text = str(item or "").strip()
         if text and text not in normalized:
@@ -63,7 +63,7 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     return normalized
 
 
-def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
+def _apply_skill_fields(job: dict[str, Any]) -> dict[str, Any]:
     """Return a job dict with canonical `skills` and legacy `skill` fields aligned."""
     normalized = dict(job)
     skills = _normalize_skill_list(normalized.get("skill"), normalized.get("skills"))
@@ -79,7 +79,7 @@ def _coerce_job_text(value: Any, fallback: str = "") -> str:
     return str(value)
 
 
-def _schedule_display_for_job(job: Dict[str, Any]) -> str:
+def _schedule_display_for_job(job: dict[str, Any]) -> str:
     display = _coerce_job_text(job.get("schedule_display")).strip()
     if display:
         return display
@@ -96,7 +96,7 @@ def _schedule_display_for_job(job: Dict[str, Any]) -> str:
     return "?"
 
 
-def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_job_record(job: dict[str, Any]) -> dict[str, Any]:
     """Return a read-safe cron job shape for UI/API/tool/scheduler consumers.
 
     Older or hand-edited jobs can have nullable fields like ``prompt``,
@@ -184,7 +184,7 @@ def parse_duration(s: str) -> int:
     return value * multipliers[unit]
 
 
-def parse_schedule(schedule: str) -> Dict[str, Any]:
+def parse_schedule(schedule: str) -> dict[str, Any]:
     """
     Parse schedule string into structured format.
     
@@ -293,7 +293,7 @@ def _ensure_aware(dt: datetime) -> datetime:
 
 
 def _recoverable_oneshot_run_at(
-    schedule: Dict[str, Any],
+    schedule: dict[str, Any],
     now: datetime,
     *,
     last_run_at: Optional[str] = None,
@@ -351,7 +351,7 @@ def _compute_grace_seconds(schedule: dict) -> int:
     return MIN_GRACE
 
 
-def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:
+def compute_next_run(schedule: dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:
     """
     Compute the next run time for a schedule.
 
@@ -401,7 +401,7 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 # Job CRUD Operations
 # =============================================================================
 
-def load_jobs() -> List[Dict[str, Any]]:
+def load_jobs() -> list[dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
     if not JOBS_FILE.exists():
@@ -430,7 +430,7 @@ def load_jobs() -> List[Dict[str, Any]]:
         raise RuntimeError(f"Failed to read cron database: {e}") from e
 
 
-def save_jobs(jobs: List[Dict[str, Any]]):
+def save_jobs(jobs: list[dict[str, Any]]):
     """Save all jobs to storage."""
     ensure_dirs()
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
@@ -512,19 +512,19 @@ def create_job(
     name: Optional[str] = None,
     repeat: Optional[int] = None,
     deliver: Optional[str] = None,
-    origin: Optional[Dict[str, Any]] = None,
+    origin: Optional[dict[str, Any]] = None,
     skill: Optional[str] = None,
-    skills: Optional[List[str]] = None,
+    skills: Optional[list[str]] = None,
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     script: Optional[str] = None,
-    context_from: Optional[Union[str, List[str]]] = None,
-    enabled_toolsets: Optional[List[str]] = None,
+    context_from: Optional[Union[str, list[str]]] = None,
+    enabled_toolsets: Optional[list[str]] = None,
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create a new cron job.
 
@@ -671,7 +671,7 @@ def create_job(
     return job
 
 
-def get_job(job_id: str) -> Optional[Dict[str, Any]]:
+def get_job(job_id: str) -> Optional[dict[str, Any]]:
     """Get a job by ID."""
     jobs = load_jobs()
     for job in jobs:
@@ -683,7 +683,7 @@ def get_job(job_id: str) -> Optional[Dict[str, Any]]:
 class AmbiguousJobReference(LookupError):
     """Raised when a job name matches more than one job."""
 
-    def __init__(self, ref: str, matches: List[Dict[str, Any]]):
+    def __init__(self, ref: str, matches: list[dict[str, Any]]):
         self.ref = ref
         self.matches = matches
         ids = ", ".join(m["id"] for m in matches)
@@ -693,7 +693,7 @@ class AmbiguousJobReference(LookupError):
         )
 
 
-def resolve_job_ref(ref: str) -> Optional[Dict[str, Any]]:
+def resolve_job_ref(ref: str) -> Optional[dict[str, Any]]:
     """Resolve a job reference (ID or name) to a job record.
 
     - Exact ID match wins (works even if a different job's name equals this ID).
@@ -718,7 +718,7 @@ def resolve_job_ref(ref: str) -> Optional[Dict[str, Any]]:
     return _normalize_job_record(name_matches[0])
 
 
-def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
+def list_jobs(include_disabled: bool = False) -> list[dict[str, Any]]:
     """List all jobs, optionally including disabled ones."""
     jobs = [_normalize_job_record(j) for j in load_jobs()]
     if not include_disabled:
@@ -726,7 +726,7 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
     return jobs
 
 
-def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def update_job(job_id: str, updates: dict[str, Any]) -> Optional[dict[str, Any]]:
     """Update a job by ID, refreshing derived schedule fields when needed."""
     jobs = load_jobs()
     for i, job in enumerate(jobs):
@@ -783,7 +783,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return None
 
 
-def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
+def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[dict[str, Any]]:
     """Pause a job without deleting it. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
@@ -799,7 +799,7 @@ def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, A
     )
 
 
-def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
+def resume_job(job_id: str) -> Optional[dict[str, Any]]:
     """Resume a paused job and compute the next future run from now. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
@@ -818,7 +818,7 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
     )
 
 
-def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
+def trigger_job(job_id: str) -> Optional[dict[str, Any]]:
     """Schedule a job to run on the next scheduler tick. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
@@ -956,7 +956,7 @@ def advance_next_run(job_id: str) -> bool:
         return False
 
 
-def get_due_jobs() -> List[Dict[str, Any]]:
+def get_due_jobs() -> list[dict[str, Any]]:
     """Get all jobs that are due to run now.
 
     For recurring jobs (cron/interval), if the scheduled time is stale
@@ -968,7 +968,7 @@ def get_due_jobs() -> List[Dict[str, Any]]:
         return _get_due_jobs_locked()
 
 
-def _get_due_jobs_locked() -> List[Dict[str, Any]]:
+def _get_due_jobs_locked() -> list[dict[str, Any]]:
     """Inner implementation of get_due_jobs(); must be called with _jobs_file_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
@@ -1091,9 +1091,9 @@ def save_job_output(job_id: str, output: str):
 # =============================================================================
 
 def rewrite_skill_refs(
-    consolidated: Optional[Dict[str, str]] = None,
-    pruned: Optional[List[str]] = None,
-) -> Dict[str, Any]:
+    consolidated: Optional[dict[str, str]] = None,
+    pruned: Optional[list[str]] = None,
+) -> dict[str, Any]:
     """Rewrite cron job skill references after a curator consolidation pass.
 
     When the curator consolidates a skill X into umbrella Y (or archives X
@@ -1151,7 +1151,7 @@ def rewrite_skill_refs(
 
     with _jobs_file_lock:
         jobs = load_jobs()
-        rewrites: List[Dict[str, Any]] = []
+        rewrites: list[dict[str, Any]] = []
         changed = False
 
         for job in jobs:
@@ -1159,9 +1159,9 @@ def rewrite_skill_refs(
             if not skills_before:
                 continue
 
-            mapped: Dict[str, str] = {}
-            dropped: List[str] = []
-            new_skills: List[str] = []
+            mapped: dict[str, str] = {}
+            dropped: list[str] = []
+            new_skills: list[str] = []
 
             for name in skills_before:
                 if name in consolidated:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -449,7 +449,7 @@ def _normalize_deliver_value(deliver) -> str:
 _ROUTING_TOKENS = frozenset({"all"})
 
 
-def _expand_routing_tokens(part: str) -> List[str]:
+def _expand_routing_tokens(part: str) -> list[str]:
     """Expand a routing-intent token to concrete platform names.
 
     ``all`` expands to every platform in ``_iter_home_target_platforms()``
@@ -460,14 +460,14 @@ def _expand_routing_tokens(part: str) -> List[str]:
     token = part.lower()
     if token not in _ROUTING_TOKENS:
         return [part]
-    expanded: List[str] = []
+    expanded: list[str] = []
     for platform_name in _iter_home_target_platforms():
         if _get_home_target_chat_id(platform_name):
             expanded.append(platform_name)
     return expanded
 
 
-def _resolve_delivery_targets(job: dict) -> List[dict]:
+def _resolve_delivery_targets(job: dict) -> list[dict]:
     """Resolve all concrete auto-delivery targets for a cron job.
 
     Accepts the legacy comma-separated ``deliver`` string plus the
@@ -484,7 +484,7 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     raw_parts = [p.strip() for p in deliver.split(",") if p.strip()]
 
     # Expand routing intents.
-    parts: List[str] = []
+    parts: list[str] = []
     for raw in raw_parts:
         parts.extend(_expand_routing_tokens(raw))
 

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -23,7 +23,7 @@ def _normalize_channel_query(value: str) -> str:
     return value.lstrip("#").strip().lower()
 
 
-def _channel_target_name(platform_name: str, channel: Dict[str, Any]) -> str:
+def _channel_target_name(platform_name: str, channel: dict[str, Any]) -> str:
     """Return the human-facing target label shown to users for a channel entry."""
     name = channel["name"]
     if platform_name == "discord" and channel.get("guild"):
@@ -33,7 +33,7 @@ def _channel_target_name(platform_name: str, channel: Dict[str, Any]) -> str:
     return name
 
 
-def _session_entry_id(origin: Dict[str, Any]) -> Optional[str]:
+def _session_entry_id(origin: dict[str, Any]) -> Optional[str]:
     chat_id = origin.get("chat_id")
     if not chat_id:
         return None
@@ -43,7 +43,7 @@ def _session_entry_id(origin: Dict[str, Any]) -> Optional[str]:
     return str(chat_id)
 
 
-def _session_entry_name(origin: Dict[str, Any]) -> str:
+def _session_entry_name(origin: dict[str, Any]) -> str:
     base_name = origin.get("chat_name") or origin.get("user_name") or str(origin.get("chat_id"))
     thread_id = origin.get("thread_id")
     if not thread_id:
@@ -57,7 +57,7 @@ def _session_entry_name(origin: Dict[str, Any]) -> str:
 # Build / refresh
 # ---------------------------------------------------------------------------
 
-async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
+async def build_channel_directory(adapters: dict[Any, Any]) -> dict[str, Any]:
     """
     Build a channel directory from connected platform adapters and session data.
 
@@ -65,7 +65,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     """
     from gateway.config import Platform
 
-    platforms: Dict[str, List[Dict[str, str]]] = {}
+    platforms: dict[str, list[dict[str, str]]] = {}
 
     for platform, adapter in adapters.items():
         try:
@@ -109,7 +109,7 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     return directory
 
 
-def _build_discord(adapter) -> List[Dict[str, str]]:
+def _build_discord(adapter) -> list[dict[str, str]]:
     """Enumerate all text channels and forum channels the Discord bot can see."""
     channels = []
     client = getattr(adapter, "_client", None)
@@ -146,7 +146,7 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
     return channels
 
 
-async def _build_slack(adapter) -> List[Dict[str, Any]]:
+async def _build_slack(adapter) -> list[dict[str, Any]]:
     """List Slack channels the bot has joined across all workspaces.
 
     Uses ``users.conversations`` against each workspace's web client. Pulls
@@ -158,7 +158,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
     if not team_clients:
         return _build_from_sessions("slack")
 
-    channels: List[Dict[str, Any]] = []
+    channels: list[dict[str, Any]] = []
     seen_ids: set = set()
 
     for team_id, client in team_clients.items():
@@ -208,7 +208,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
     return channels
 
 
-def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
+def _build_from_sessions(platform_name: str) -> list[dict[str, str]]:
     """Pull known channels/contacts from sessions.json origin data."""
     sessions_path = get_hermes_home() / "sessions" / "sessions.json"
     if not sessions_path.exists():
@@ -244,7 +244,7 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
 # Read / resolve
 # ---------------------------------------------------------------------------
 
-def load_directory() -> Dict[str, Any]:
+def load_directory() -> dict[str, Any]:
     """Load the cached channel directory from disk."""
     if not DIRECTORY_PATH.exists():
         return {"updated_at": None, "platforms": {}}
@@ -327,8 +327,8 @@ def format_directory_for_display() -> str:
 
         # Group Discord channels by guild
         if plat_name == "discord":
-            guilds: Dict[str, List] = {}
-            dms: List = []
+            guilds: dict[str, list] = {}
+            dms: list = []
             for ch in channels:
                 guild = ch.get("guild")
                 if guild:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -214,7 +214,7 @@ class HomeChannel:
     name: str  # Human-readable name for display
     thread_id: Optional[str] = None
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = {
             "platform": self.platform.value,
             "chat_id": self.chat_id,
@@ -225,7 +225,7 @@ class HomeChannel:
         return result
     
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "HomeChannel":
+    def from_dict(cls, data: dict[str, Any]) -> "HomeChannel":
         return cls(
             platform=Platform(data["platform"]),
             chat_id=str(data["chat_id"]),
@@ -251,7 +251,7 @@ class SessionResetPolicy:
     notify: bool = True  # Send a notification to the user when auto-reset occurs
     notify_exclude_platforms: tuple = ("api_server", "webhook")  # Platforms that don't get reset notifications
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "mode": self.mode,
             "at_hour": self.at_hour,
@@ -261,7 +261,7 @@ class SessionResetPolicy:
         }
     
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SessionResetPolicy":
+    def from_dict(cls, data: dict[str, Any]) -> "SessionResetPolicy":
         # Handle both missing keys and explicit null values (YAML null → None)
         mode = data.get("mode")
         at_hour = data.get("at_hour")
@@ -299,9 +299,9 @@ class PlatformConfig:
     gateway_restart_notification: bool = True
 
     # Platform-specific settings
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = {
             "enabled": self.enabled,
             "extra": self.extra,
@@ -317,7 +317,7 @@ class PlatformConfig:
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
+    def from_dict(cls, data: dict[str, Any]) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
@@ -377,7 +377,7 @@ class StreamingConfig:
     # matches the OpenClaw rollout.  Set to 0 to disable.
     fresh_final_after_seconds: float = 60.0
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "enabled": self.enabled,
             "transport": self.transport,
@@ -388,7 +388,7 @@ class StreamingConfig:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "StreamingConfig":
+    def from_dict(cls, data: dict[str, Any]) -> "StreamingConfig":
         if not data:
             return cls()
         return cls(
@@ -456,18 +456,18 @@ class GatewayConfig:
     Manages all platform connections, session policies, and delivery settings.
     """
     # Platform configurations
-    platforms: Dict[Platform, PlatformConfig] = field(default_factory=dict)
+    platforms: dict[Platform, PlatformConfig] = field(default_factory=dict)
     
     # Session reset policies by type
     default_reset_policy: SessionResetPolicy = field(default_factory=SessionResetPolicy)
-    reset_by_type: Dict[str, SessionResetPolicy] = field(default_factory=dict)
-    reset_by_platform: Dict[Platform, SessionResetPolicy] = field(default_factory=dict)
+    reset_by_type: dict[str, SessionResetPolicy] = field(default_factory=dict)
+    reset_by_platform: dict[Platform, SessionResetPolicy] = field(default_factory=dict)
     
     # Reset trigger commands
-    reset_triggers: List[str] = field(default_factory=lambda: ["/new", "/reset"])
+    reset_triggers: list[str] = field(default_factory=lambda: ["/new", "/reset"])
 
     # User-defined quick commands (slash commands that bypass the agent loop)
-    quick_commands: Dict[str, Any] = field(default_factory=dict)
+    quick_commands: dict[str, Any] = field(default_factory=dict)
     
     # Storage paths
     sessions_dir: Path = field(default_factory=lambda: get_hermes_home() / "sessions")
@@ -495,7 +495,7 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
-    def get_connected_platforms(self) -> List[Platform]:
+    def get_connected_platforms(self) -> list[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
         for platform, config in self.platforms.items():
@@ -566,7 +566,7 @@ class GatewayConfig:
         
         return self.default_reset_policy
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "platforms": {
                 p.value: c.to_dict() for p, c in self.platforms.items()
@@ -591,7 +591,7 @@ class GatewayConfig:
         }
     
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GatewayConfig":
+    def from_dict(cls, data: dict[str, Any]) -> "GatewayConfig":
         platforms = {}
         for platform_name, platform_data in data.get("platforms", {}).items():
             try:

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -114,7 +114,7 @@ class DeliveryRouter:
     messages to the right platform adapters.
     """
     
-    def __init__(self, config: GatewayConfig, adapters: Dict[Platform, Any] = None):
+    def __init__(self, config: GatewayConfig, adapters: dict[Platform, Any] = None):
         """
         Initialize the delivery router.
         
@@ -129,11 +129,11 @@ class DeliveryRouter:
     async def deliver(
         self,
         content: str,
-        targets: List[DeliveryTarget],
+        targets: list[DeliveryTarget],
         job_id: Optional[str] = None,
         job_name: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+        metadata: Optional[dict[str, Any]] = None
+    ) -> dict[str, Any]:
         """
         Deliver content to all specified targets.
         
@@ -173,8 +173,8 @@ class DeliveryRouter:
         content: str,
         job_id: Optional[str],
         job_name: Optional[str],
-        metadata: Optional[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        metadata: Optional[dict[str, Any]]
+    ) -> dict[str, Any]:
         """Save content to local files."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         
@@ -227,8 +227,8 @@ class DeliveryRouter:
         self,
         target: DeliveryTarget,
         content: str,
-        metadata: Optional[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        metadata: Optional[dict[str, Any]]
+    ) -> dict[str, Any]:
         """Deliver content to a messaging platform."""
         adapter = self.adapters.get(target.platform)
         

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -44,11 +44,11 @@ class HookRegistry:
 
     def __init__(self):
         # event_type -> [handler_fn, ...]
-        self._handlers: Dict[str, List[Callable]] = {}
-        self._loaded_hooks: List[dict] = []  # metadata for listing
+        self._handlers: dict[str, list[Callable]] = {}
+        self._loaded_hooks: list[dict] = []  # metadata for listing
 
     @property
-    def loaded_hooks(self) -> List[dict]:
+    def loaded_hooks(self) -> list[dict]:
         """Return metadata about all loaded hooks."""
         return list(self._loaded_hooks)
 
@@ -142,7 +142,7 @@ class HookRegistry:
             except Exception as e:
                 print(f"[hooks] Error loading hook {hook_dir.name}: {e}", flush=True)
 
-    def _resolve_handlers(self, event_type: str) -> List[Callable]:
+    def _resolve_handlers(self, event_type: str) -> list[Callable]:
         """Return all handlers that should fire for ``event_type``.
 
         Exact matches fire first, followed by wildcard matches (e.g.
@@ -155,7 +155,7 @@ class HookRegistry:
             handlers.extend(self._handlers.get(wildcard_key, []))
         return handlers
 
-    async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
+    async def emit(self, event_type: str, context: Optional[dict[str, Any]] = None) -> None:
         """
         Fire all handlers registered for an event, discarding return values.
 
@@ -183,8 +183,8 @@ class HookRegistry:
     async def emit_collect(
         self,
         event_type: str,
-        context: Optional[Dict[str, Any]] = None,
-    ) -> List[Any]:
+        context: Optional[dict[str, Any]] = None,
+    ) -> list[Any]:
         """Fire handlers and return their non-None return values in order.
 
         Like :meth:`emit` but captures each handler's return value. Used for
@@ -197,7 +197,7 @@ class HookRegistry:
         if context is None:
             context = {}
 
-        results: List[Any] = []
+        results: list[Any] = []
         for fn in self._resolve_handlers(event_type):
             try:
                 result = fn(event_type, context)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -125,7 +125,7 @@ def _normalize_chat_content(
         return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
 
     if isinstance(content, list):
-        parts: List[str] = []
+        parts: list[str] = []
         items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
         for item in items:
             if isinstance(item, str):
@@ -196,7 +196,7 @@ def _normalize_multimodal_content(content: Any) -> Any:
         return _normalize_chat_content(content)
 
     items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
-    normalized_parts: List[Dict[str, Any]] = []
+    normalized_parts: list[dict[str, Any]] = []
     text_accum_len = 0
 
     for part in items:
@@ -253,7 +253,7 @@ def _normalize_multimodal_content(content: Any) -> Any:
                 raise ValueError(
                     "invalid_image_url:Image inputs must use http(s) URLs or data:image/... URLs."
                 )
-            image_part: Dict[str, Any] = {"type": "image_url", "image_url": {"url": url_value}}
+            image_part: dict[str, Any] = {"type": "image_url", "image_url": {"url": url_value}}
             if detail is not None:
                 if not isinstance(detail, str) or not detail.strip():
                     raise ValueError("invalid_content_part:Image detail must be a non-empty string when provided.")
@@ -390,7 +390,7 @@ class ResponseStore:
                     exc_info=True,
                 )
 
-    def get(self, response_id: str) -> Optional[Dict[str, Any]]:
+    def get(self, response_id: str) -> Optional[dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
         row = self._conn.execute(
             "SELECT data FROM responses WHERE response_id = ?", (response_id,)
@@ -404,7 +404,7 @@ class ResponseStore:
         self._conn.commit()
         return json.loads(row[0])
 
-    def put(self, response_id: str, data: Dict[str, Any]) -> None:
+    def put(self, response_id: str, data: dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
         self._conn.execute(
             "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
@@ -509,7 +509,7 @@ else:
     cors_middleware = None  # type: ignore[assignment]
 
 
-def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
+def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> dict[str, Any]:
     """OpenAI-style error envelope."""
     return {
         "error": {
@@ -565,7 +565,7 @@ class _IdempotencyCache:
     def __init__(self, max_items: int = 1000, ttl_seconds: int = 300):
         from collections import OrderedDict
         self._store = OrderedDict()
-        self._inflight: Dict[tuple[str, str], "asyncio.Task[Any]"] = {}
+        self._inflight: dict[tuple[str, str], "asyncio.Task[Any]"] = {}
         self._ttl = ttl_seconds
         self._max = max_items
 
@@ -608,7 +608,7 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(body: dict[str, Any], keys: list[str]) -> str:
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
     return sha256(repr(subset).encode("utf-8")).hexdigest()
@@ -684,18 +684,18 @@ class APIServerAdapter(BasePlatformAdapter):
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
-        self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
+        self._run_streams: dict[str, "asyncio.Queue[Optional[dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
-        self._run_streams_created: Dict[str, float] = {}
+        self._run_streams_created: dict[str, float] = {}
         # Active run agent/task references for stop support
-        self._active_run_agents: Dict[str, Any] = {}
-        self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        self._active_run_agents: dict[str, Any] = {}
+        self._active_run_tasks: dict[str, "asyncio.Task"] = {}
         # Pollable run status for dashboards and external control-plane UIs.
-        self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        self._run_statuses: dict[str, dict[str, Any]] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
-        self._run_approval_sessions: Dict[str, str] = {}
+        self._run_approval_sessions: dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
 
     @staticmethod
@@ -733,7 +733,7 @@ class APIServerAdapter(BasePlatformAdapter):
             pass
         return "hermes-agent"
 
-    def _cors_headers_for_origin(self, origin: str) -> Optional[Dict[str, str]]:
+    def _cors_headers_for_origin(self, origin: str) -> Optional[dict[str, str]]:
         """Return CORS headers for an allowed browser origin."""
         if not origin or not self._cors_origins:
             return None
@@ -1071,7 +1071,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: list[dict[str, str]] = []
 
         for idx, msg in enumerate(messages):
             role = msg.get("role", "")
@@ -1530,7 +1530,7 @@ class APIServerAdapter(BasePlatformAdapter):
         stream_q,
         agent_task,
         agent_ref,
-        conversation_history: List[Dict[str, str]],
+        conversation_history: list[dict[str, str]],
         user_message: str,
         instructions: Optional[str],
         conversation: Optional[str],
@@ -1585,13 +1585,13 @@ class APIServerAdapter(BasePlatformAdapter):
         await response.prepare(request)
 
         # State accumulated during the stream
-        final_text_parts: List[str] = []
+        final_text_parts: list[str] = []
         # Track open function_call items by name so we can emit a matching
         # ``done`` event when the tool completes.  Order preserved.
-        pending_tool_calls: List[Dict[str, Any]] = []
+        pending_tool_calls: list[dict[str, Any]] = []
         # Output items we've emitted so far (used to build the terminal
         # response.completed payload).  Kept in the order they appeared.
-        emitted_items: List[Dict[str, Any]] = []
+        emitted_items: list[dict[str, Any]] = []
         # Monotonic counter for output_index (spec requires it).
         output_index = 0
         # Monotonic counter for call_id generation if the agent doesn't
@@ -1607,7 +1607,7 @@ class APIServerAdapter(BasePlatformAdapter):
         message_output_index: Optional[int] = None
         message_opened = False
 
-        async def _write_event(event_type: str, data: Dict[str, Any]) -> None:
+        async def _write_event(event_type: str, data: dict[str, Any]) -> None:
             nonlocal sequence_number
             if "sequence_number" not in data:
                 data["sequence_number"] = sequence_number
@@ -1615,8 +1615,8 @@ class APIServerAdapter(BasePlatformAdapter):
             payload = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
             await response.write(payload.encode())
 
-        def _envelope(status: str) -> Dict[str, Any]:
-            env: Dict[str, Any] = {
+        def _envelope(status: str) -> dict[str, Any]:
+            env: dict[str, Any] = {
                 "id": response_id,
                 "object": "response",
                 "status": status,
@@ -1627,13 +1627,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response_text = ""
         agent_error: Optional[str] = None
-        usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
 
         def _persist_response_snapshot(
-            response_env: Dict[str, Any],
+            response_env: dict[str, Any],
             *,
-            conversation_history_snapshot: Optional[List[Dict[str, Any]]] = None,
+            conversation_history_snapshot: Optional[list[dict[str, Any]]] = None,
         ) -> None:
             if not store:
                 return
@@ -1660,7 +1660,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if not store or terminal_snapshot_persisted:
                 return
             incomplete_text = "".join(final_text_parts) or final_response_text
-            incomplete_items: List[Dict[str, Any]] = list(emitted_items)
+            incomplete_items: list[dict[str, Any]] = list(emitted_items)
             if incomplete_text:
                 incomplete_items.append({
                     "type": "message",
@@ -1728,7 +1728,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "logprobs": [],
                 })
 
-            async def _emit_tool_started(payload: Dict[str, Any]) -> str:
+            async def _emit_tool_started(payload: dict[str, Any]) -> str:
                 """Emit response.output_item.added for a function_call.
 
                 Returns the call_id so the matching completion event can
@@ -1774,7 +1774,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 })
                 return call_id
 
-            async def _emit_tool_completed(payload: Dict[str, Any]) -> None:
+            async def _emit_tool_completed(payload: dict[str, Any]) -> None:
                 """Emit response.output_item.done (function_call) followed
                 by response.output_item.added (function_call_output)."""
                 nonlocal output_index
@@ -1862,7 +1862,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 # Other types are silently dropped.
 
             # ── Batching state ──
-            _batch_buf: List[str] = []
+            _batch_buf: list[str] = []
             _batch_timer: Optional[asyncio.Task] = None
             _batch_lock = asyncio.Lock()
 
@@ -1974,7 +1974,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # response envelope so clients that only parse the terminal
             # payload still see the assistant text.  This mirrors the
             # shape produced by _extract_output_items in the batch path.
-            final_items: List[Dict[str, Any]] = list(emitted_items)
+            final_items: list[dict[str, Any]] = list(emitted_items)
 
             # Trim large content from tool call arguments to keep the
             # response.completed event under ~100KB.  Clients already
@@ -2156,7 +2156,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # No error if conversation doesn't exist yet — it's a new conversation
 
         # Normalize input to message list
-        input_messages: List[Dict[str, Any]] = []
+        input_messages: list[dict[str, Any]] = []
         if isinstance(raw_input, str):
             input_messages = [{"role": "user", "content": raw_input}]
         elif isinstance(raw_input, list):
@@ -2177,7 +2177,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # This lets stateless clients supply their own history instead of
         # relying on server-side response chaining via previous_response_id.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, Any]] = []
+        conversation_history: list[dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -2656,11 +2656,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _build_response_conversation_history(
-        conversation_history: List[Dict[str, Any]],
+        conversation_history: list[dict[str, Any]],
         user_message: Any,
-        result: Dict[str, Any],
+        result: dict[str, Any],
         final_response: Any,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Build the stored Responses transcript without duplicating history."""
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}
@@ -2687,9 +2687,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _response_messages_turn_start_index(
-        conversation_history: List[Dict[str, Any]],
+        conversation_history: list[dict[str, Any]],
         user_message: Any,
-        result: Dict[str, Any],
+        result: dict[str, Any],
     ) -> int:
         """Detect transcript-shaped result["messages"] and return turn start."""
         agent_messages = result.get("messages") if isinstance(result, dict) else None
@@ -2706,7 +2706,7 @@ class APIServerAdapter(BasePlatformAdapter):
         return 0
 
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any], start_index: int = 0) -> List[Dict[str, Any]]:
+    def _extract_output_items(result: dict[str, Any], start_index: int = 0) -> list[dict[str, Any]]:
         """
         Build the output item array from the agent's messages.
 
@@ -2715,7 +2715,7 @@ class APIServerAdapter(BasePlatformAdapter):
         - ``function_call_output`` items for each tool-role message
         - a final ``message`` item with the assistant's text reply
         """
-        items: List[Dict[str, Any]] = []
+        items: list[dict[str, Any]] = []
         messages = result.get("messages", [])
         if start_index > 0:
             messages = messages[start_index:]
@@ -2762,7 +2762,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _run_agent(
         self,
         user_message: str,
-        conversation_history: List[Dict[str, str]],
+        conversation_history: list[dict[str, str]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
@@ -2826,7 +2826,7 @@ class APIServerAdapter(BasePlatformAdapter):
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
 
-    def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
+    def _set_run_status(self, run_id: str, status: str, **fields: Any) -> dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
         current = self._run_statuses.get(run_id, {})
@@ -2843,7 +2843,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
-        def _push(event: Dict[str, Any]) -> None:
+        def _push(event: dict[str, Any]) -> None:
             self._set_run_status(
                 run_id,
                 self._run_statuses.get(run_id, {}).get("status", "running"),
@@ -2923,7 +2923,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: list[dict[str, str]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -2970,7 +2970,7 @@ class APIServerAdapter(BasePlatformAdapter):
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
-        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
+        q: "asyncio.Queue[Optional[dict]]" = asyncio.Queue()
         created_at = time.time()
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = created_at
@@ -3012,7 +3012,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 self._active_run_agents[run_id] = agent
 
-                def _approval_notify(approval_data: Dict[str, Any]) -> None:
+                def _approval_notify(approval_data: dict[str, Any]) -> None:
                     event = dict(approval_data or {})
                     event.update({
                         "event": "approval.request",
@@ -3535,14 +3535,14 @@ class APIServerAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """
         Not used — HTTP request/response cycle handles delivery directly.
         """
         return SendResult(success=False, error="API server uses HTTP request/response, not send()")
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic info about the API server."""
         return {
             "name": "API Server",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -841,7 +841,7 @@ MEDIA_DELIVERY_SAFE_ROOTS = (
 )
 
 
-def _media_delivery_allowed_roots() -> List[Path]:
+def _media_delivery_allowed_roots() -> list[Path]:
     """Return roots from which model-emitted local media may be delivered."""
     roots = [Path(root) for root in MEDIA_DELIVERY_SAFE_ROOTS]
     extra_roots = os.environ.get(MEDIA_DELIVERY_ALLOW_DIRS_ENV, "")
@@ -1057,8 +1057,8 @@ class MessageEvent:
     
     # Media attachments
     # media_urls: local file paths (for vision tool access)
-    media_urls: List[str] = field(default_factory=list)
-    media_types: List[str] = field(default_factory=list)
+    media_urls: list[str] = field(default_factory=list)
+    media_types: list[str] = field(default_factory=list)
     
     # Reply context
     reply_to_message_id: Optional[str] = None
@@ -1214,7 +1214,7 @@ class EphemeralReply(str):
 
 
 def merge_pending_message_event(
-    pending_messages: Dict[str, MessageEvent],
+    pending_messages: dict[str, MessageEvent],
     session_key: str,
     event: MessageEvent,
     *,
@@ -1414,9 +1414,9 @@ class BasePlatformAdapter(ABC):
         # right task and release the adapter-level guard deterministically.
         # Without the owner-task map, an old task's finally block could delete
         # a newer task's guard, leaving stale busy state.
-        self._active_sessions: Dict[str, asyncio.Event] = {}
-        self._pending_messages: Dict[str, MessageEvent] = {}
-        self._session_tasks: Dict[str, asyncio.Task] = {}
+        self._active_sessions: dict[str, asyncio.Event] = {}
+        self._pending_messages: dict[str, MessageEvent] = {}
+        self._session_tasks: dict[str, asyncio.Task] = {}
         self._busy_text_mode: str = (
             os.environ.get("HERMES_GATEWAY_BUSY_TEXT_MODE", "queue").strip().lower()
             or "queue"
@@ -1437,7 +1437,7 @@ class BasePlatformAdapter(ABC):
         # a ``(generation, callback)`` tuple so GatewayRunner can make deferred
         # deliveries generation-aware and avoid stale runs clearing callbacks
         # registered by a fresher run for the same session.
-        self._post_delivery_callbacks: Dict[str, Any] = {}
+        self._post_delivery_callbacks: dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
@@ -1471,7 +1471,7 @@ class BasePlatformAdapter(ABC):
     def supports_draft_streaming(
         self,
         chat_type: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> bool:
         """Whether this adapter supports native streaming-draft updates.
 
@@ -1492,7 +1492,7 @@ class BasePlatformAdapter(ABC):
         chat_id: str,
         draft_id: int,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send or update an animated streaming-draft preview.
 
@@ -1690,7 +1690,7 @@ class BasePlatformAdapter(ABC):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[dict[str, Any]] = None
     ) -> SendResult:
         """
         Send a message to a chat.
@@ -1856,7 +1856,7 @@ class BasePlatformAdapter(ABC):
         message: str,
         session_key: str,
         confirm_id: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a three-option slash-command confirmation prompt.
 
@@ -1891,7 +1891,7 @@ class BasePlatformAdapter(ABC):
         choices: Optional[list],
         clarify_id: str,
         session_key: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a clarify prompt to the user.
 
@@ -1947,7 +1947,7 @@ class BasePlatformAdapter(ABC):
         user_id: Optional[str],
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a notice privately when the platform supports it.
 
@@ -1981,8 +1981,8 @@ class BasePlatformAdapter(ABC):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        images: list[tuple[str, str]],
+        metadata: Optional[dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images.
@@ -2041,7 +2041,7 @@ class BasePlatformAdapter(ABC):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send an image natively via the platform API.
@@ -2060,7 +2060,7 @@ class BasePlatformAdapter(ABC):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """
         Send an animated GIF natively via the platform API.
@@ -2078,7 +2078,7 @@ class BasePlatformAdapter(ABC):
         return lower.endswith('.gif')
 
     @staticmethod
-    def extract_images(content: str) -> Tuple[List[Tuple[str, str]], str]:
+    def extract_images(content: str) -> tuple[list[tuple[str, str]], str]:
         """
         Extract image URLs from markdown and HTML image tags in a response.
         
@@ -2131,7 +2131,7 @@ class BasePlatformAdapter(ABC):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2173,7 +2173,7 @@ class BasePlatformAdapter(ABC):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2194,7 +2194,7 @@ class BasePlatformAdapter(ABC):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2214,7 +2214,7 @@ class BasePlatformAdapter(ABC):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2235,9 +2235,9 @@ class BasePlatformAdapter(ABC):
         return validate_media_delivery_path(path)
 
     @staticmethod
-    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
+    def filter_media_delivery_paths(media_files) -> list[tuple[str, bool]]:
         """Drop unsafe MEDIA paths and normalize accepted paths."""
-        safe_media: List[Tuple[str, bool]] = []
+        safe_media: list[tuple[str, bool]] = []
         for media_path, is_voice in media_files or []:
             safe_path = validate_media_delivery_path(str(media_path))
             if safe_path:
@@ -2247,9 +2247,9 @@ class BasePlatformAdapter(ABC):
         return safe_media
 
     @staticmethod
-    def filter_local_delivery_paths(file_paths) -> List[str]:
+    def filter_local_delivery_paths(file_paths) -> list[str]:
         """Drop unsafe bare local file paths and normalize accepted paths."""
-        safe_paths: List[str] = []
+        safe_paths: list[str] = []
         for file_path in file_paths or []:
             safe_path = validate_media_delivery_path(str(file_path))
             if safe_path:
@@ -2259,7 +2259,7 @@ class BasePlatformAdapter(ABC):
         return safe_paths
 
     @staticmethod
-    def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
+    def extract_media(content: str) -> tuple[list[tuple[str, bool]], str]:
         """
         Extract MEDIA:<path> tags and [[audio_as_voice]] directives from response text.
 
@@ -2316,7 +2316,7 @@ class BasePlatformAdapter(ABC):
         return media, cleaned
 
     @staticmethod
-    def extract_local_files(content: str) -> Tuple[List[str], str]:
+    def extract_local_files(content: str) -> tuple[list[str], str]:
         """
         Detect bare local file paths in response text for native delivery.
 
@@ -2635,7 +2635,7 @@ class BasePlatformAdapter(ABC):
         lowered = error.lower()
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
 
-    def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
+    def _unwrap_ephemeral(self, response: Any) -> tuple[Optional[str], int]:
         """Unwrap a handler response into (text, ttl_seconds).
 
         Accepts a plain string, ``None``, or an :class:`EphemeralReply`.
@@ -3972,7 +3972,7 @@ class BasePlatformAdapter(ABC):
         )
     
     @abstractmethod
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """
         Get information about a chat/channel.
         
@@ -3998,7 +3998,7 @@ class BasePlatformAdapter(ABC):
         content: str,
         max_length: int = 4096,
         len_fn: Optional["Callable[[str], int]"] = None,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Split a long message into chunks, preserving code block boundaries.
 
@@ -4025,7 +4025,7 @@ class BasePlatformAdapter(ABC):
         INDICATOR_RESERVE = 10   # room for " (XX/XX)"
         FENCE_CLOSE = "\n```"
 
-        chunks: List[str] = []
+        chunks: list[str] = []
         remaining = content
         # When the previous chunk ended mid-code-block, this holds the
         # language tag (possibly "") so we can reopen the fence.

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -128,7 +128,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
-        self._guid_cache: Dict[str, str] = {}
+        self._guid_cache: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # API helpers
@@ -138,13 +138,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         sep = "&" if "?" in path else "?"
         return f"{self.server_url}{path}{sep}password={quote(self.password, safe='')}"
 
-    async def _api_get(self, path: str) -> Dict[str, Any]:
+    async def _api_get(self, path: str) -> dict[str, Any]:
         assert self.client is not None
         res = await self.client.get(self._api_url(path))
         res.raise_for_status()
         return res.json()
 
-    async def _api_post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    async def _api_post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
         assert self.client is not None
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
@@ -408,7 +408,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def truncate_message(content: str, max_length: int = MAX_TEXT_LENGTH) -> List[str]:
+    def truncate_message(content: str, max_length: int = MAX_TEXT_LENGTH) -> list[str]:
         # Use the base splitter but skip pagination indicators — iMessage
         # bubbles flow naturally without "(1/3)" suffixes.
         chunks = BasePlatformAdapter.truncate_message(content, max_length)
@@ -419,7 +419,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         text = self.format_message(content)
         if not text:
@@ -428,7 +428,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # becomes its own iMessage bubble, then truncate any that are still
         # too long.
         paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()]
-        chunks: List[str] = []
+        chunks: list[str] = []
         for para in (paragraphs or [text]):
             if len(para) <= self.MAX_MESSAGE_LENGTH:
                 chunks.append(para)
@@ -447,7 +447,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     success=False,
                     error=f"BlueBubbles chat not found for target: {chat_id}",
                 )
-            payload: Dict[str, Any] = {
+            payload: dict[str, Any] = {
                 "chatGuid": guid,
                 "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
                 "message": chunk,
@@ -493,7 +493,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         try:
             with open(file_path, "rb") as f:
                 files = {"attachment": (fname, f, "application/octet-stream")}
-                data: Dict[str, str] = {
+                data: dict[str, str] = {
                     "chatGuid": guid,
                     "name": fname,
                     "tempGuid": uuid.uuid4().hex,
@@ -531,7 +531,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         try:
             from gateway.platforms.base import cache_image_from_url
@@ -592,7 +592,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         return await self.send_image(
             chat_id, animation_url, caption, reply_to, metadata
@@ -655,9 +655,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Chat info
     # ------------------------------------------------------------------
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         is_group = ";+;" in (chat_id or "")
-        info: Dict[str, Any] = {
+        info: dict[str, Any] = {
             "name": chat_id,
             "type": "group" if is_group else "dm",
         }
@@ -694,7 +694,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _download_attachment(
-        self, att_guid: str, att_meta: Dict[str, Any]
+        self, att_guid: str, att_meta: dict[str, Any]
     ) -> Optional[str]:
         """Download an attachment from BlueBubbles and cache it locally.
 
@@ -758,8 +758,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _extract_payload_record(
-        self, payload: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
+        self, payload: dict[str, Any]
+    ) -> Optional[dict[str, Any]]:
         data = payload.get("data")
         if isinstance(data, dict):
             return data
@@ -841,8 +841,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         # --- Inbound attachment handling ---
         attachments = record.get("attachments") or []
-        media_urls: List[str] = []
-        media_types: List[str] = []
+        media_urls: list[str] = []
+        media_types: list[str] = []
         msg_type = MessageType.TEXT
 
         for att in attachments:

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -193,8 +193,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         # Mention state is the structured ``is_in_at_list`` attribute from the
         # dingtalk-stream SDK (set from the callback's ``isInAtList`` flag),
         # not text parsing.
-        self._mention_patterns: List[re.Pattern] = self._compile_mention_patterns()
-        self._allowed_users: Set[str] = self._load_allowed_users()
+        self._mention_patterns: list[re.Pattern] = self._compile_mention_patterns()
+        self._allowed_users: set[str] = self._load_allowed_users()
 
         self._stream_client: Any = None
         self._stream_task: Optional[asyncio.Task] = None
@@ -206,18 +206,18 @@ class DingTalkAdapter(BasePlatformAdapter):
         # Message deduplication
         self._dedup = MessageDeduplicator(max_size=1000)
         # Map chat_id -> (session_webhook, expired_time_ms) for reply routing
-        self._session_webhooks: Dict[str, tuple[str, int]] = {}
+        self._session_webhooks: dict[str, tuple[str, int]] = {}
         # Map chat_id -> last inbound ChatbotMessage. Keyed by chat_id instead
         # of a single class attribute to avoid cross-message clobbering when
         # multiple conversations run concurrently.
-        self._message_contexts: Dict[str, Any] = {}
+        self._message_contexts: dict[str, Any] = {}
         self._card_template_id: Optional[str] = extra.get("card_template_id")
 
         # Chats for which we've already fired the Done reaction — prevents
         # double-firing across segment boundaries or parallel flows
         # (tool-progress + stream-consumer both finalizing their cards).
         # Reset each inbound message.
-        self._done_emoji_fired: Set[str] = set()
+        self._done_emoji_fired: set[str] = set()
         # Cards in streaming state per chat: chat_id -> { out_track_id -> last_content }.
         # Every `send()` creates+finalizes a card (closed state).  A subsequent
         # `edit_message(finalize=False)` re-opens the card (DingTalk's API
@@ -225,10 +225,10 @@ class DingTalkAdapter(BasePlatformAdapter):
         # streaming).  We track those reopened cards so the next `send()` can
         # auto-close them as siblings — otherwise tool-progress cards get
         # stuck in streaming state forever.
-        self._streaming_cards: Dict[str, Dict[str, str]] = {}
+        self._streaming_cards: dict[str, dict[str, str]] = {}
         # Track fire-and-forget emoji/reaction coroutines so Python's GC
         # doesn't drop them mid-flight, and we can cancel them on disconnect.
-        self._bg_tasks: Set[asyncio.Task] = set()
+        self._bg_tasks: set[asyncio.Task] = set()
 
     # -- Connection lifecycle -----------------------------------------------
 
@@ -394,7 +394,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DINGTALK_REQUIRE_MENTION", "false").lower() in {"true", "1", "yes", "on"}
 
-    def _dingtalk_free_response_chats(self) -> Set[str]:
+    def _dingtalk_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
             raw = os.getenv("DINGTALK_FREE_RESPONSE_CHATS", "")
@@ -402,7 +402,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
-    def _dingtalk_allowed_chats(self) -> Set[str]:
+    def _dingtalk_allowed_chats(self) -> set[str]:
         """Return the whitelist of group chat IDs the bot will respond in.
 
         When non-empty, group messages from chats NOT in this set are silently
@@ -416,7 +416,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
-    def _compile_mention_patterns(self) -> List[re.Pattern]:
+    def _compile_mention_patterns(self) -> list[re.Pattern]:
         """Compile optional regex wake-word patterns for group triggers."""
         patterns = self.config.extra.get("mention_patterns") if self.config.extra else None
         if patterns is None:
@@ -442,7 +442,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
             return []
 
-        compiled: List[re.Pattern] = []
+        compiled: list[re.Pattern] = []
         for pattern in patterns:
             if not isinstance(pattern, str) or not pattern.strip():
                 continue
@@ -454,7 +454,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             logger.info("[%s] Loaded %d DingTalk mention pattern(s)", self.name, len(compiled))
         return compiled
 
-    def _load_allowed_users(self) -> Set[str]:
+    def _load_allowed_users(self) -> set[str]:
         """Load allowed-users list from config.extra or env var.
 
         IDs are matched case-insensitively against the sender's ``staff_id`` and
@@ -823,7 +823,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a markdown reply via DingTalk session webhook."""
         metadata = metadata or {}
@@ -936,7 +936,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image via DingTalk markdown.
 
@@ -960,7 +960,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """DingTalk webhook replies cannot send local image files directly."""
@@ -979,7 +979,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """DingTalk webhook replies cannot send local file attachments directly."""
@@ -991,7 +991,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             ),
         )
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic info about a DingTalk conversation."""
         return {
             "name": chat_id,

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -185,7 +185,7 @@ def _extract_email_address(raw: str) -> str:
 def _extract_attachments(
     msg: email_lib.message.Message,
     skip_attachments: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Extract attachment metadata and cache files locally.
 
     When *skip_attachments* is True, all attachment/inline parts are ignored
@@ -269,7 +269,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._poll_task: Optional[asyncio.Task] = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
-        self._thread_context: Dict[str, Dict[str, str]] = {}
+        self._thread_context: dict[str, dict[str, str]] = {}
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -361,7 +361,7 @@ class EmailAdapter(BasePlatformAdapter):
         for msg_data in messages:
             await self._dispatch_message(msg_data)
 
-    def _fetch_new_messages(self) -> List[Dict[str, Any]]:
+    def _fetch_new_messages(self) -> list[dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
         try:
@@ -428,7 +428,7 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] IMAP fetch error: %s", e)
         return results
 
-    async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:
+    async def _dispatch_message(self, msg_data: dict[str, Any]) -> None:
         """Convert a fetched email into a MessageEvent and dispatch it."""
         sender_addr = msg_data["sender_addr"]
 
@@ -505,7 +505,7 @@ class EmailAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
         try:
@@ -562,7 +562,7 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Optional[dict[str, Any]] = None) -> None:
         """Email has no typing indicator — no-op."""
 
     async def send_image(
@@ -580,8 +580,8 @@ class EmailAdapter(BasePlatformAdapter):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        images: list[tuple[str, str]],
+        metadata: Optional[dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single email with multiple MIME attachments.
@@ -596,8 +596,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         from urllib.parse import unquote as _unquote
 
-        body_parts: List[str] = []
-        local_paths: List[str] = []
+        body_parts: list[str] = []
+        local_paths: list[str] = []
         for image_url, alt_text in images:
             if alt_text:
                 body_parts.append(alt_text)
@@ -633,7 +633,7 @@ class EmailAdapter(BasePlatformAdapter):
         self,
         to_addr: str,
         body: str,
-        file_paths: List[str],
+        file_paths: list[str],
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -762,7 +762,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         return msg_id
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic info about the email chat."""
         ctx = self._thread_context.get(chat_id, {})
         return {

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -214,13 +214,13 @@ _FEISHU_WEBHOOK_ANOMALY_THRESHOLD = 25             # consecutive error responses
 _FEISHU_WEBHOOK_ANOMALY_TTL_SECONDS = 6 * 60 * 60  # anomaly tracker TTL (6 hours) — matches openclaw
 _FEISHU_CARD_ACTION_DEDUP_TTL_SECONDS = 15 * 60    # card action token dedup window (15 min)
 
-_APPROVAL_CHOICE_MAP: Dict[str, str] = {
+_APPROVAL_CHOICE_MAP: dict[str, str] = {
     "approve_once": "once",
     "approve_session": "session",
     "approve_always": "always",
     "deny": "deny",
 }
-_APPROVAL_LABEL_MAP: Dict[str, str] = {
+_APPROVAL_LABEL_MAP: dict[str, str] = {
     "once": "Approved once",
     "session": "Approved for session",
     "always": "Approved permanently",
@@ -342,8 +342,8 @@ class _FeishuBotIdentity:
 @dataclass(frozen=True)
 class FeishuPostParseResult:
     text_content: str
-    image_keys: List[str] = field(default_factory=list)
-    media_refs: List[FeishuPostMediaRef] = field(default_factory=list)
+    image_keys: list[str] = field(default_factory=list)
+    media_refs: list[FeishuPostMediaRef] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -351,11 +351,11 @@ class FeishuNormalizedMessage:
     raw_type: str
     text_content: str
     preferred_message_type: str = "text"
-    image_keys: List[str] = field(default_factory=list)
-    media_refs: List[FeishuPostMediaRef] = field(default_factory=list)
-    mentions: List[FeishuMentionRef] = field(default_factory=list)
+    image_keys: list[str] = field(default_factory=list)
+    media_refs: list[FeishuPostMediaRef] = field(default_factory=list)
+    mentions: list[FeishuMentionRef] = field(default_factory=list)
     relation_kind: str = "plain"
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -390,7 +390,7 @@ class FeishuAdapterSettings:
     ws_ping_timeout: Optional[int] = None
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
-    group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
+    group_rules: dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
 
@@ -407,9 +407,9 @@ class FeishuGroupRule:
 
 @dataclass
 class FeishuBatchState:
-    events: Dict[str, MessageEvent] = field(default_factory=dict)
-    tasks: Dict[str, asyncio.Task] = field(default_factory=dict)
-    counts: Dict[str, int] = field(default_factory=dict)
+    events: dict[str, MessageEvent] = field(default_factory=dict)
+    tasks: dict[str, asyncio.Task] = field(default_factory=dict)
+    counts: dict[str, int] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------
@@ -459,7 +459,7 @@ def _to_boolean(value: Any) -> bool:
     return value is True or value == 1 or value == "true"
 
 
-def _is_style_enabled(style: Dict[str, Any] | None, key: str) -> bool:
+def _is_style_enabled(style: dict[str, Any] | None, key: str) -> bool:
     if not style:
         return False
     return _to_boolean(style.get(key))
@@ -476,7 +476,7 @@ def _sanitize_fence_language(language: str) -> str:
     return language.strip().replace("\n", " ").replace("\r", " ")
 
 
-def _render_text_element(element: Dict[str, Any]) -> str:
+def _render_text_element(element: dict[str, Any]) -> str:
     text = str(element.get("text", "") or "")
     style = element.get("style")
     style_dict = style if isinstance(style, dict) else None
@@ -498,7 +498,7 @@ def _render_text_element(element: Dict[str, Any]) -> str:
     return rendered
 
 
-def _render_code_block_element(element: Dict[str, Any]) -> str:
+def _render_code_block_element(element: dict[str, Any]) -> str:
     language = _sanitize_fence_language(
         str(element.get("language", "") or "") or str(element.get("lang", "") or "")
     )
@@ -558,7 +558,7 @@ def _build_markdown_post_payload(content: str) -> str:
     )
 
 
-def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
+def _build_markdown_post_rows(content: str) -> list[list[dict[str, str]]]:
     """Build Feishu post rows while isolating fenced code blocks.
 
     Feishu's `md` renderer can swallow trailing content when a fenced code block
@@ -571,8 +571,8 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     if "```" not in content:
         return [[{"tag": "md", "text": content}]]
 
-    rows: List[List[Dict[str, str]]] = []
-    current: List[str] = []
+    rows: list[list[dict[str, str]]] = []
+    current: list[str] = []
     in_code_block = False
 
     def _flush_current() -> None:
@@ -610,15 +610,15 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
 def parse_feishu_post_payload(
     payload: Any,
     *,
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    mentions_map: Optional[dict[str, FeishuMentionRef]] = None,
 ) -> FeishuPostParseResult:
     resolved = _resolve_post_payload(payload)
     if not resolved:
         return FeishuPostParseResult(text_content=FALLBACK_POST_TEXT)
 
-    image_keys: List[str] = []
-    media_refs: List[FeishuPostMediaRef] = []
-    parts: List[str] = []
+    image_keys: list[str] = []
+    media_refs: list[FeishuPostMediaRef] = []
+    parts: list[str] = []
 
     title = _normalize_feishu_text(str(resolved.get("title", "")).strip())
     if title:
@@ -643,7 +643,7 @@ def parse_feishu_post_payload(
     )
 
 
-def _resolve_post_payload(payload: Any) -> Dict[str, Any]:
+def _resolve_post_payload(payload: Any) -> dict[str, Any]:
     direct = _to_post_payload(payload)
     if direct:
         return direct
@@ -657,7 +657,7 @@ def _resolve_post_payload(payload: Any) -> Dict[str, Any]:
     return _resolve_locale_payload(payload)
 
 
-def _resolve_locale_payload(payload: Any) -> Dict[str, Any]:
+def _resolve_locale_payload(payload: Any) -> dict[str, Any]:
     direct = _to_post_payload(payload)
     if direct:
         return direct
@@ -675,7 +675,7 @@ def _resolve_locale_payload(payload: Any) -> Dict[str, Any]:
     return {}
 
 
-def _to_post_payload(candidate: Any) -> Dict[str, Any]:
+def _to_post_payload(candidate: Any) -> dict[str, Any]:
     if not isinstance(candidate, dict):
         return {}
     content = candidate.get("content")
@@ -689,9 +689,9 @@ def _to_post_payload(candidate: Any) -> Dict[str, Any]:
 
 def _render_post_element(
     element: Any,
-    image_keys: List[str],
-    media_refs: List[FeishuPostMediaRef],
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    image_keys: list[str],
+    media_refs: list[FeishuPostMediaRef],
+    mentions_map: Optional[dict[str, FeishuMentionRef]] = None,
 ) -> str:
     if isinstance(element, str):
         return element
@@ -759,7 +759,7 @@ def _render_post_element(
     if tag in {"code_block", "pre"}:
         return _render_code_block_element(element)
 
-    nested_parts: List[str] = []
+    nested_parts: list[str] = []
     for key in ("text", "title", "content", "children", "elements"):
         extracted = _render_nested_post(element.get(key), image_keys, media_refs, mentions_map)
         if extracted:
@@ -769,9 +769,9 @@ def _render_post_element(
 
 def _render_nested_post(
     value: Any,
-    image_keys: List[str],
-    media_refs: List[FeishuPostMediaRef],
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    image_keys: list[str],
+    media_refs: list[FeishuPostMediaRef],
+    mentions_map: Optional[dict[str, FeishuMentionRef]] = None,
 ) -> str:
     if isinstance(value, str):
         return _escape_markdown_text(value)
@@ -873,7 +873,7 @@ def normalize_feishu_message(
     return FeishuNormalizedMessage(raw_type=normalized_type, text_content="")
 
 
-def _load_feishu_payload(raw_content: str) -> Dict[str, Any]:
+def _load_feishu_payload(raw_content: str) -> dict[str, Any]:
     try:
         parsed = json.loads(raw_content) if raw_content else {}
     except json.JSONDecodeError:
@@ -881,7 +881,7 @@ def _load_feishu_payload(raw_content: str) -> Dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {"content": parsed}
 
 
-def _normalize_merge_forward_message(payload: Dict[str, Any]) -> FeishuNormalizedMessage:
+def _normalize_merge_forward_message(payload: dict[str, Any]) -> FeishuNormalizedMessage:
     title = _first_non_empty_text(
         payload.get("title"),
         payload.get("summary"),
@@ -889,7 +889,7 @@ def _normalize_merge_forward_message(payload: Dict[str, Any]) -> FeishuNormalize
         _find_first_text(payload, keys=("title", "summary", "preview", "description")),
     )
     entries = _collect_forward_entries(payload)
-    lines: List[str] = []
+    lines: list[str] = []
     if title:
         lines.append(title)
     lines.extend(entries[:8])
@@ -902,7 +902,7 @@ def _normalize_merge_forward_message(payload: Dict[str, Any]) -> FeishuNormalize
     )
 
 
-def _normalize_share_chat_message(payload: Dict[str, Any]) -> FeishuNormalizedMessage:
+def _normalize_share_chat_message(payload: dict[str, Any]) -> FeishuNormalizedMessage:
     chat_name = _first_non_empty_text(
         payload.get("chat_name"),
         payload.get("name"),
@@ -930,7 +930,7 @@ def _normalize_share_chat_message(payload: Dict[str, Any]) -> FeishuNormalizedMe
     )
 
 
-def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -> FeishuNormalizedMessage:
+def _normalize_interactive_message(message_type: str, payload: dict[str, Any]) -> FeishuNormalizedMessage:
     card_payload = payload.get("card") if isinstance(payload.get("card"), dict) else payload
     title = _first_non_empty_text(
         _find_header_title(card_payload),
@@ -940,7 +940,7 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
     body_lines = _collect_card_lines(card_payload)
     actions = _collect_action_labels(card_payload)
 
-    lines: List[str] = []
+    lines: list[str] = []
     if title:
         lines.append(title)
     for line in body_lines:
@@ -963,13 +963,13 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
 # ---------------------------------------------------------------------------
 
 
-def _collect_forward_entries(payload: Dict[str, Any]) -> List[str]:
-    candidates: List[Any] = []
+def _collect_forward_entries(payload: dict[str, Any]) -> list[str]:
+    candidates: list[Any] = []
     for key in ("messages", "items", "message_list", "records", "content"):
         value = payload.get(key)
         if isinstance(value, list):
             candidates.extend(value)
-    entries: List[str] = []
+    entries: list[str] = []
     for item in candidates:
         if not isinstance(item, dict):
             text = _normalize_feishu_text(str(item or ""))
@@ -1001,14 +1001,14 @@ def _collect_forward_entries(payload: Dict[str, Any]) -> List[str]:
     return _unique_lines(entries)
 
 
-def _collect_card_lines(payload: Any) -> List[str]:
+def _collect_card_lines(payload: Any) -> list[str]:
     lines = _collect_text_segments(payload, in_rich_block=False)
     normalized = [_normalize_feishu_text(line) for line in lines]
     return _unique_lines([line for line in normalized if line])
 
 
-def _collect_action_labels(payload: Any) -> List[str]:
-    labels: List[str] = []
+def _collect_action_labels(payload: Any) -> list[str]:
+    labels: list[str] = []
     for item in _walk_nodes(payload):
         if not isinstance(item, dict):
             continue
@@ -1026,11 +1026,11 @@ def _collect_action_labels(payload: Any) -> List[str]:
     return _unique_lines(labels)
 
 
-def _collect_text_segments(value: Any, *, in_rich_block: bool) -> List[str]:
+def _collect_text_segments(value: Any, *, in_rich_block: bool) -> list[str]:
     if isinstance(value, str):
         return [_normalize_feishu_text(value)] if in_rich_block else []
     if isinstance(value, list):
-        segments: List[str] = []
+        segments: list[str] = []
         for item in value:
             segments.extend(_collect_text_segments(item, in_rich_block=in_rich_block))
         return segments
@@ -1052,7 +1052,7 @@ def _collect_text_segments(value: Any, *, in_rich_block: bool) -> List[str]:
         "date_picker",
     }
 
-    segments: List[str] = []
+    segments: list[str] = []
     for key in _SUPPORTED_CARD_TEXT_KEYS:
         item = value.get(key)
         if isinstance(item, str) and next_in_rich_block:
@@ -1067,7 +1067,7 @@ def _collect_text_segments(value: Any, *, in_rich_block: bool) -> List[str]:
     return segments
 
 
-def _build_media_ref_from_payload(payload: Dict[str, Any], *, resource_type: str) -> FeishuPostMediaRef:
+def _build_media_ref_from_payload(payload: dict[str, Any], *, resource_type: str) -> FeishuPostMediaRef:
     file_key = str(payload.get("file_key", "") or "").strip()
     file_name = _first_non_empty_text(
         payload.get("file_name"),
@@ -1138,7 +1138,7 @@ def _first_non_empty_text(*values: Any) -> str:
 
 def _normalize_feishu_text(
     text: str,
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    mentions_map: Optional[dict[str, FeishuMentionRef]] = None,
 ) -> str:
     def _sub(match: "re.Match[str]") -> str:
         key = match.group(0)
@@ -1157,9 +1157,9 @@ def _normalize_feishu_text(
     return cleaned.strip()
 
 
-def _unique_lines(lines: List[str]) -> List[str]:
+def _unique_lines(lines: list[str]) -> list[str]:
     seen: set[str] = set()
-    unique: List[str] = []
+    unique: list[str] = []
     for line in lines:
         if not line or line in seen:
             continue
@@ -1196,8 +1196,8 @@ def _extract_mention_ids(mention: Any) -> tuple[str, str]:
 def _build_mentions_map(
     mentions: Optional[Sequence[Any]],
     bot: _FeishuBotIdentity,
-) -> Dict[str, FeishuMentionRef]:
-    result: Dict[str, FeishuMentionRef] = {}
+) -> dict[str, FeishuMentionRef]:
+    result: dict[str, FeishuMentionRef] = {}
     for mention in mentions or []:
         key = str(getattr(mention, "key", "") or "")
         if not key:
@@ -1216,7 +1216,7 @@ def _build_mentions_map(
 
 
 def _build_mention_hint(mentions: Sequence[FeishuMentionRef]) -> str:
-    parts: List[str] = []
+    parts: list[str] = []
     seen: set = set()
     for ref in mentions:
         if ref.is_self:
@@ -1430,26 +1430,26 @@ class FeishuAdapter(BasePlatformAdapter):
         self._webhook_runner: Optional[Any] = None
         self._webhook_site: Optional[Any] = None
         self._event_handler: Optional[Any] = None
-        self._seen_message_ids: Dict[str, float] = {}  # message_id → seen_at (time.time())
-        self._seen_message_order: List[str] = []
+        self._seen_message_ids: dict[str, float] = {}  # message_id → seen_at (time.time())
+        self._seen_message_order: list[str] = []
         self._dedup_state_path = get_hermes_home() / "feishu_seen_message_ids.json"
         self._dedup_lock = threading.Lock()
-        self._sender_name_cache: Dict[str, tuple[str, float]] = {}  # sender_id → (name, expire_at)
-        self._webhook_rate_counts: Dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
-        self._webhook_anomaly_counts: Dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
-        self._card_action_tokens: Dict[str, float] = {}  # token → first_seen_time
+        self._sender_name_cache: dict[str, tuple[str, float]] = {}  # sender_id → (name, expire_at)
+        self._webhook_rate_counts: dict[str, tuple[int, float]] = {}  # rate_key → (count, window_start)
+        self._webhook_anomaly_counts: dict[str, tuple[int, str, float]] = {}  # ip → (count, last_status, first_seen)
+        self._card_action_tokens: dict[str, float] = {}  # token → first_seen_time
         # Inbound events that arrived before the adapter loop was ready
         # (e.g. during startup/restart or network-flap reconnect). A single
         # drainer thread replays them as soon as the loop becomes available.
-        self._pending_inbound_events: List[Any] = []
+        self._pending_inbound_events: list[Any] = []
         self._pending_inbound_lock = threading.Lock()
         self._pending_drain_scheduled = False
         self._pending_inbound_max_depth = 1000  # cap queue; drop oldest beyond
-        self._chat_locks: Dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
-        self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
-        self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
-        self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
-        self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._chat_locks: dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
+        self._sent_message_ids_to_chat: dict[str, str] = {}  # message_id → chat_id (for reaction routing)
+        self._sent_message_id_order: list[str] = []  # LRU order for _sent_message_ids_to_chat
+        self._chat_info_cache: dict[str, dict[str, Any]] = {}
+        self._message_text_cache: dict[str, Optional[str]] = {}
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -1459,10 +1459,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_media_batches = self._media_batch_state.events
         self._pending_media_batch_tasks = self._media_batch_state.tasks
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
-        self._approval_state: Dict[int, Dict[str, str]] = {}
+        self._approval_state: dict[int, dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
-        self._update_prompt_state: Dict[int, Dict[str, str]] = {}
+        self._update_prompt_state: dict[int, dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
@@ -1470,10 +1470,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self._load_seen_message_ids()
 
     @staticmethod
-    def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
+    def _load_settings(extra: dict[str, Any]) -> FeishuAdapterSettings:
         # Parse per-group rules from config
         raw_group_rules = extra.get("group_rules", {})
-        group_rules: Dict[str, FeishuGroupRule] = {}
+        group_rules: dict[str, FeishuGroupRule] = {}
         if isinstance(raw_group_rules, dict):
             for chat_id, rule_cfg in raw_group_rules.items():
                 if not isinstance(rule_cfg, dict):
@@ -1725,7 +1725,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[Feishu] Disconnected")
 
-    async def _cancel_pending_tasks(self, tasks: Dict[str, asyncio.Task]) -> None:
+    async def _cancel_pending_tasks(self, tasks: dict[str, asyncio.Task]) -> None:
         pending = [task for task in tasks.values() if task and not task.done()]
         for task in pending:
             task.cancel()
@@ -1766,7 +1766,7 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Feishu message."""
         if not self._client:
@@ -1856,7 +1856,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive card with approval buttons.
 
@@ -1924,7 +1924,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
-    def _build_update_prompt_card(*, prompt: str, default: str, prompt_id: int) -> Dict[str, Any]:
+    def _build_update_prompt_card(*, prompt: str, default: str, prompt_id: int) -> dict[str, Any]:
         default_hint = f"\n\nDefault: `{default}`" if default else ""
 
         def _btn(label: str, answer: str, btn_type: str) -> dict:
@@ -1959,7 +1959,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive update prompt with Yes/No buttons."""
         if not self._client:
@@ -1992,7 +1992,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
-    def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+    def _build_resolved_approval_card(*, choice: str, user_name: str) -> dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
@@ -2011,7 +2011,7 @@ class FeishuAdapter(BasePlatformAdapter):
         }
 
     @staticmethod
-    def _build_resolved_update_prompt_card(*, answer: str, user_name: str) -> Dict[str, Any]:
+    def _build_resolved_update_prompt_card(*, answer: str, user_name: str) -> dict[str, Any]:
         yes = answer == "y"
         label = "Yes" if yes else "No"
         return {
@@ -2038,7 +2038,7 @@ class FeishuAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send audio to Feishu as a file attachment plus optional caption."""
@@ -2058,7 +2058,7 @@ class FeishuAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file attachment to Feishu."""
@@ -2077,7 +2077,7 @@ class FeishuAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a video file to Feishu."""
@@ -2096,7 +2096,7 @@ class FeishuAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a local image file to Feishu."""
@@ -2161,7 +2161,7 @@ class FeishuAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Download a remote image then send it through the native Feishu image flow."""
         try:
@@ -2189,7 +2189,7 @@ class FeishuAdapter(BasePlatformAdapter):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Feishu has no native GIF bubble; degrade to a downloadable file."""
         try:
@@ -2217,7 +2217,7 @@ class FeishuAdapter(BasePlatformAdapter):
             metadata=metadata,
         )
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return real chat metadata from Feishu when available."""
         fallback = {
             "chat_id": chat_id,
@@ -2354,7 +2354,7 @@ class FeishuAdapter(BasePlatformAdapter):
                                 return
                         continue
                     dispatched = 0
-                    requeue: List[Any] = []
+                    requeue: list[Any] = []
                     for event in batch:
                         if self._submit_on_loop(
                             loop, self._handle_message_event_data(event)
@@ -2564,7 +2564,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return True
         return "*" in allowed_ids or normalized in allowed_ids
 
-    def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+    def _handle_approval_card_action(self, *, event: Any, action_value: dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
         approval_id = action_value.get("approval_id")
         if approval_id is None:
@@ -2620,7 +2620,7 @@ class FeishuAdapter(BasePlatformAdapter):
             response.card = card
         return response
 
-    def _handle_update_prompt_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+    def _handle_update_prompt_card_action(self, *, event: Any, action_value: dict[str, Any], loop: Any) -> Any:
         """Schedule update prompt resolution and build the synchronous callback response."""
         prompt_id = action_value.get("update_prompt_id")
         if prompt_id is None:
@@ -3464,7 +3464,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _reschedule_batch_task(
-        task_map: Dict[str, asyncio.Task],
+        task_map: dict[str, asyncio.Task],
         key: str,
         flush_fn: Any,
     ) -> None:
@@ -3514,7 +3514,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _extract_message_content(
         self, message: Any
-    ) -> tuple[str, MessageType, List[str], List[str], List[FeishuMentionRef]]:
+    ) -> tuple[str, MessageType, list[str], list[str], list[FeishuMentionRef]]:
         raw_content = getattr(message, "content", "") or ""
         raw_type = getattr(message, "message_type", "") or ""
         message_id = str(getattr(message, "message_id", "") or "")
@@ -3549,9 +3549,9 @@ class FeishuAdapter(BasePlatformAdapter):
         *,
         message_id: str,
         normalized: FeishuNormalizedMessage,
-    ) -> tuple[List[str], List[str]]:
-        media_urls: List[str] = []
-        media_types: List[str] = []
+    ) -> tuple[list[str], list[str]]:
+        media_urls: list[str] = []
+        media_types: list[str] = []
 
         for image_key in normalized.image_keys:
             cached_path, media_type = await self._download_feishu_image(
@@ -3589,7 +3589,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _resolve_normalized_message_type(
         self,
         normalized: FeishuNormalizedMessage,
-        media_types: List[str],
+        media_types: list[str],
     ) -> MessageType:
         preferred = normalized.preferred_message_type
         if preferred == "photo":
@@ -3797,7 +3797,7 @@ class FeishuAdapter(BasePlatformAdapter):
         return "dm"
 
     @staticmethod
-    def _resolve_source_chat_type(*, chat_info: Dict[str, Any], event_chat_type: str) -> str:
+    def _resolve_source_chat_type(*, chat_info: dict[str, Any], event_chat_type: str) -> str:
         resolved = str(chat_info.get("type") or "").strip().lower()
         if resolved in {"group", "forum"}:
             return resolved
@@ -3810,7 +3810,7 @@ class FeishuAdapter(BasePlatformAdapter):
         sender_id: Any,
         *,
         is_bot: bool = False,
-    ) -> Dict[str, Optional[str]]:
+    ) -> dict[str, Optional[str]]:
         """Map Feishu's three-tier user IDs onto Hermes' SessionSource fields.
 
         Preference order for the primary ``user_id`` field:
@@ -3906,7 +3906,7 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Failed to resolve sender name for %s", sender_id, exc_info=True)
         return None
 
-    async def _fetch_bot_names(self, bot_ids: List[str]) -> Optional[Dict[str, str]]:
+    async def _fetch_bot_names(self, bot_ids: list[str]) -> Optional[dict[str, str]]:
         if not self._client or not bot_ids:
             return None
         try:
@@ -4106,7 +4106,7 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         return self._post_mentions_bot(normalized.mentions)
 
-    def _message_mentions_bot(self, mentions: List[Any]) -> bool:
+    def _message_mentions_bot(self, mentions: list[Any]) -> bool:
         # IDs trump names: when both sides have open_id (or both user_id),
         # match requires equal IDs. Name fallback only when either side
         # lacks an ID.
@@ -4129,7 +4129,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         return False
 
-    def _post_mentions_bot(self, mentions: List[FeishuMentionRef]) -> bool:
+    def _post_mentions_bot(self, mentions: list[FeishuMentionRef]) -> bool:
         return any(m.is_self for m in mentions)
 
     def _bot_identity(self) -> _FeishuBotIdentity:
@@ -4230,7 +4230,7 @@ class FeishuAdapter(BasePlatformAdapter):
         ttl = _FEISHU_DEDUP_TTL_SECONDS
         # Backward-compat: old format stored a plain list of IDs (no timestamps).
         if isinstance(seen_data, list):
-            entries: Dict[str, float] = {str(item).strip(): 0.0 for item in seen_data if str(item).strip()}
+            entries: dict[str, float] = {str(item).strip(): 0.0 for item in seen_data if str(item).strip()}
         elif isinstance(seen_data, dict):
             entries = {}
             for key, value in seen_data.items():
@@ -4244,7 +4244,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return
         # Filter out TTL-expired entries (entries saved with ts=0.0 are treated as immortal
         # for one migration cycle to avoid nuking old data on first upgrade).
-        valid: Dict[str, float] = {
+        valid: dict[str, float] = {
             msg_id: ts for msg_id, ts in entries.items()
             if ts == 0.0 or ttl <= 0 or now - ts < ttl
         }
@@ -4301,7 +4301,7 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id: str,
         file_path: str,
         reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
+        metadata: Optional[dict[str, Any]],
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         outbound_message_type: str = "file",
@@ -4366,7 +4366,7 @@ class FeishuAdapter(BasePlatformAdapter):
         msg_type: str,
         payload: str,
         reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
+        metadata: Optional[dict[str, Any]],
     ) -> Any:
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
@@ -4530,7 +4530,7 @@ class FeishuAdapter(BasePlatformAdapter):
         msg_type: str,
         payload: str,
         reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
+        metadata: Optional[dict[str, Any]],
     ) -> Any:
         last_error: Optional[Exception] = None
         active_reply_to = reply_to
@@ -4758,7 +4758,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _build_post_payload(self, content: str) -> str:
         return _build_markdown_post_payload(content)
 
-    def _build_media_post_payload(self, *, caption: str, media_tag: Dict[str, str]) -> str:
+    def _build_media_post_payload(self, *, caption: str, media_tag: dict[str, str]) -> str:
         payload = json.loads(self._build_post_payload(caption))
         content = payload.setdefault("zh_cn", {}).setdefault("content", [])
         content.append([media_tag])
@@ -4804,7 +4804,7 @@ def _onboard_open_base_url(domain: str) -> str:
     return _ONBOARD_OPEN_URLS.get(domain, _ONBOARD_OPEN_URLS["feishu"])
 
 
-def _post_registration(base_url: str, body: Dict[str, str]) -> dict:
+def _post_registration(base_url: str, body: dict[str, str]) -> dict:
     """POST form-encoded data to the registration endpoint, return parsed JSON.
 
     The registration endpoint returns JSON even on 4xx (e.g. poll returns

--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -100,7 +100,7 @@ async def _exec_request(client, method, uri, paths=None, queries=None, body=None
 # ---------------------------------------------------------------------------
 
 
-def parse_drive_comment_event(data: Any) -> Optional[Dict[str, Any]]:
+def parse_drive_comment_event(data: Any) -> Optional[dict[str, Any]]:
     """Extract structured fields from a ``drive.notice.comment_add_v1`` payload.
 
     *data* may be a ``CustomizedEvent`` (WebSocket) whose ``.event`` is a dict,
@@ -257,7 +257,7 @@ _ADD_COMMENT_URI = "/open-apis/drive/v1/files/:file_token/new_comments"
 
 async def query_document_meta(
     client: Any, file_token: str, file_type: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Fetch document title and URL via batch_query meta API.
 
     Returns ``{"title": "...", "url": "...", "doc_type": "..."}`` or empty dict.
@@ -303,7 +303,7 @@ _COMMENT_RETRY_DELAY_S = 1.0
 
 async def batch_query_comment(
     client: Any, file_token: str, file_type: str, comment_id: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Fetch comment details via batch_query comment API.
 
     Retries up to 6 times on failure (handles eventual consistency).
@@ -354,10 +354,10 @@ async def batch_query_comment(
 
 async def list_whole_comments(
     client: Any, file_token: str, file_type: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List all whole-document comments (paginated, up to 500)."""
     logger.debug("[Feishu-Comment] list_whole_comments: file_token=%s", file_token)
-    all_comments: List[Dict[str, Any]] = []
+    all_comments: list[dict[str, Any]] = []
     page_token = ""
 
     for _ in range(5):  # max 5 pages
@@ -398,7 +398,7 @@ async def list_whole_comments(
 async def list_comment_replies(
     client: Any, file_token: str, file_type: str, comment_id: str,
     *, expect_reply_id: str = "",
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List all replies in a comment thread (paginated, up to 500).
 
     If *expect_reply_id* is set and not found in the first fetch,
@@ -407,7 +407,7 @@ async def list_comment_replies(
     logger.debug("[Feishu-Comment] list_comment_replies: file_token=%s comment_id=%s", file_token, comment_id)
 
     for attempt in range(_COMMENT_RETRY_LIMIT):
-        all_replies: List[Dict[str, Any]] = []
+        all_replies: list[dict[str, Any]] = []
         page_token = ""
         fetch_ok = True
 
@@ -469,7 +469,7 @@ def _sanitize_comment_text(text: str) -> str:
 
 async def reply_to_comment(
     client: Any, file_token: str, file_type: str, comment_id: str, text: str,
-) -> Tuple[bool, int]:
+) -> tuple[bool, int]:
     """Post a reply to a local comment thread.
 
     Returns ``(success, code)``.
@@ -533,7 +533,7 @@ async def add_whole_comment(
 _REPLY_CHUNK_SIZE = 4000
 
 
-def _chunk_text(text: str, limit: int = _REPLY_CHUNK_SIZE) -> List[str]:
+def _chunk_text(text: str, limit: int = _REPLY_CHUNK_SIZE) -> list[str]:
     """Split text into chunks for delivery, preferring line breaks."""
     if len(text) <= limit:
         return [text]
@@ -599,7 +599,7 @@ async def deliver_comment_reply(
 # ---------------------------------------------------------------------------
 
 
-def _extract_reply_text(reply: Dict[str, Any]) -> str:
+def _extract_reply_text(reply: dict[str, Any]) -> str:
     """Extract plain text from a comment reply's content structure."""
     content = reply.get("content", {})
     if isinstance(content, str):
@@ -623,7 +623,7 @@ def _extract_reply_text(reply: Dict[str, Any]) -> str:
     return "".join(parts)
 
 
-def _get_reply_user_id(reply: Dict[str, Any]) -> str:
+def _get_reply_user_id(reply: dict[str, Any]) -> str:
     """Extract user_id from a reply dict."""
     user_id = reply.get("user_id", "")
     if isinstance(user_id, dict):
@@ -631,7 +631,7 @@ def _get_reply_user_id(reply: Dict[str, Any]) -> str:
     return str(user_id)
 
 
-def _extract_semantic_text(reply: Dict[str, Any], self_open_id: str = "") -> str:
+def _extract_semantic_text(reply: dict[str, Any], self_open_id: str = "") -> str:
     """Extract semantic text from a reply, stripping self @mentions and extra whitespace."""
     content = reply.get("content", {})
     if isinstance(content, str):
@@ -675,7 +675,7 @@ _FEISHU_DOC_URL_RE = _re.compile(
 _WIKI_GET_NODE_URI = "/open-apis/wiki/v2/spaces/get_node"
 
 
-def _extract_docs_links(replies: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+def _extract_docs_links(replies: list[dict[str, Any]]) -> list[dict[str, str]]:
     """Extract unique document links from a list of comment replies.
 
     Returns list of ``{"url": "...", "doc_type": "...", "token": "..."}`` dicts.
@@ -731,8 +731,8 @@ async def _reverse_lookup_wiki_token(
 
 async def _resolve_wiki_nodes(
     client: Any,
-    links: List[Dict[str, str]],
-) -> List[Dict[str, str]]:
+    links: list[dict[str, str]],
+) -> list[dict[str, str]]:
     """Resolve wiki links to their underlying document type and token.
 
     Mutates entries in *links* in-place: replaces ``doc_type`` and ``token``
@@ -768,7 +768,7 @@ async def _resolve_wiki_nodes(
 
 
 def _format_referenced_docs(
-    links: List[Dict[str, str]], current_file_token: str = "",
+    links: list[dict[str, str]], current_file_token: str = "",
 ) -> str:
     """Format resolved document links for prompt embedding."""
     if not links:
@@ -800,9 +800,9 @@ def _truncate(text: str, limit: int = _PROMPT_TEXT_LIMIT) -> str:
 
 
 def _select_local_timeline(
-    timeline: List[Tuple[str, str, bool]],
+    timeline: list[tuple[str, str, bool]],
     target_index: int,
-) -> List[Tuple[str, str, bool]]:
+) -> list[tuple[str, str, bool]]:
     """Select up to _LOCAL_TIMELINE_LIMIT entries centered on target_index.
 
     Always keeps first, target, and last entries.
@@ -831,10 +831,10 @@ def _select_local_timeline(
 
 
 def _select_whole_timeline(
-    timeline: List[Tuple[str, str, bool]],
+    timeline: list[tuple[str, str, bool]],
     current_index: int,
     nearest_self_index: int,
-) -> List[Tuple[str, str, bool]]:
+) -> list[tuple[str, str, bool]]:
     """Select up to _WHOLE_TIMELINE_LIMIT entries for whole-doc comments.
 
     Prioritizes current entry and nearest self reply.
@@ -891,7 +891,7 @@ def build_local_comment_prompt(
     quote_text: str,
     root_comment_text: str,
     target_reply_text: str,
-    timeline: List[Tuple[str, str, bool]],  # [(user_id, text, is_self)]
+    timeline: list[tuple[str, str, bool]],  # [(user_id, text, is_self)]
     self_open_id: str,
     target_index: int = -1,
     referenced_docs: str = "",
@@ -933,7 +933,7 @@ def build_whole_comment_prompt(
     file_token: str,
     file_type: str,
     comment_text: str,
-    timeline: List[Tuple[str, str, bool]],  # [(user_id, text, is_self)]
+    timeline: list[tuple[str, str, bool]],  # [(user_id, text, is_self)]
     self_open_id: str,
     current_index: int = -1,
     nearest_self_index: int = -1,
@@ -972,7 +972,7 @@ def build_whole_comment_prompt(
 # ---------------------------------------------------------------------------
 
 
-def _resolve_model_and_runtime() -> Tuple[str, dict]:
+def _resolve_model_and_runtime() -> tuple[str, dict]:
     """Resolve model and provider credentials, same as gateway message handling."""
     from gateway.run import _load_gateway_config, _resolve_gateway_model
 
@@ -1004,14 +1004,14 @@ _SESSION_MAX_MESSAGES = 50  # keep last N messages per document session
 _SESSION_TTL_S = 3600       # expire sessions after 1 hour of inactivity
 
 _session_cache_lock = threading.Lock()
-_session_cache: Dict[str, Dict] = {}  # key -> {"messages": [...], "last_access": float}
+_session_cache: dict[str, dict] = {}  # key -> {"messages": [...], "last_access": float}
 
 
 def _session_key(file_type: str, file_token: str) -> str:
     return f"comment-doc:{file_type}:{file_token}"
 
 
-def _load_session_history(key: str) -> List[Dict[str, Any]]:
+def _load_session_history(key: str) -> list[dict[str, Any]]:
     """Load conversation history for a document session."""
     with _session_cache_lock:
         entry = _session_cache.get(key)
@@ -1026,7 +1026,7 @@ def _load_session_history(key: str) -> List[Dict[str, Any]]:
         return list(entry["messages"])
 
 
-def _save_session_history(key: str, messages: List[Dict[str, Any]]) -> None:
+def _save_session_history(key: str, messages: list[dict[str, Any]]) -> None:
     """Save conversation history for a document session (keeps last N messages)."""
     # Only keep user/assistant messages (strip system messages and tool internals)
     cleaned = [
@@ -1220,7 +1220,7 @@ async def handle_drive_comment_event(
         logger.info("[Feishu-Comment] Fetching whole-document comments for timeline...")
         whole_comments = await list_whole_comments(client, file_token, file_type)
 
-        timeline: List[Tuple[str, str, bool]] = []
+        timeline: list[tuple[str, str, bool]] = []
         current_text = ""
         current_index = -1
         nearest_self_index = -1

--- a/gateway/platforms/feishu_comment_rules.py
+++ b/gateway/platforms/feishu_comment_rules.py
@@ -53,7 +53,7 @@ class CommentsConfig:
     enabled: bool = True
     policy: str = "pairing"
     allow_from: frozenset = field(default_factory=frozenset)
-    documents: Dict[str, CommentDocumentRule] = field(default_factory=dict)
+    documents: dict[str, CommentDocumentRule] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -139,7 +139,7 @@ def load_config() -> CommentsConfig:
     if not raw:
         return CommentsConfig()
 
-    documents: Dict[str, CommentDocumentRule] = {}
+    documents: dict[str, CommentDocumentRule] = {}
     raw_docs = raw.get("documents", {})
     if isinstance(raw_docs, dict):
         for key, rule_raw in raw_docs.items():
@@ -271,7 +271,7 @@ def pairing_remove(user_open_id: str) -> bool:
     return True
 
 
-def pairing_list() -> Dict[str, Any]:
+def pairing_list() -> dict[str, Any]:
     """Return the approved dict  {user_open_id: {approved_at: ...}}."""
     data = _pairing_cache.load()
     approved = data.get("approved", {})

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -41,7 +41,7 @@ class MessageDeduplicator:
     """
 
     def __init__(self, max_size: int = 2000, ttl_seconds: float = 300):
-        self._seen: Dict[str, float] = {}
+        self._seen: dict[str, float] = {}
         self._max_size = max_size
         self._ttl = ttl_seconds
 
@@ -110,8 +110,8 @@ class TextBatchAggregator:
         self._batch_delay = batch_delay
         self._split_delay = split_delay
         self._split_threshold = split_threshold
-        self._pending: Dict[str, "MessageEvent"] = {}
-        self._pending_tasks: Dict[str, asyncio.Task] = {}
+        self._pending: dict[str, "MessageEvent"] = {}
+        self._pending_tasks: dict[str, asyncio.Task] = {}
 
     def is_enabled(self) -> bool:
         """Return True if batching is active (delay > 0)."""

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -80,14 +80,14 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._hass_token: str = token
 
         # Event filtering
-        self._watch_domains: Set[str] = set(extra.get("watch_domains", []))
-        self._watch_entities: Set[str] = set(extra.get("watch_entities", []))
-        self._ignore_entities: Set[str] = set(extra.get("ignore_entities", []))
+        self._watch_domains: set[str] = set(extra.get("watch_domains", []))
+        self._watch_entities: set[str] = set(extra.get("watch_entities", []))
+        self._ignore_entities: set[str] = set(extra.get("ignore_entities", []))
         self._watch_all: bool = bool(extra.get("watch_all", False))
         self._cooldown_seconds: int = int(extra.get("cooldown_seconds", 30))
 
         # Cooldown tracking: entity_id -> last_event_timestamp
-        self._last_event_time: Dict[str, float] = {}
+        self._last_event_time: dict[str, float] = {}
 
     def _next_id(self) -> int:
         """Return the next WebSocket message ID."""
@@ -259,7 +259,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             elif ws_msg.type in {aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR}:
                 break
 
-    async def _handle_ha_event(self, event: Dict[str, Any]) -> None:
+    async def _handle_ha_event(self, event: dict[str, Any]) -> None:
         """Process a state_changed event from Home Assistant."""
         event_data = event.get("data", {})
         entity_id: str = event_data.get("entity_id", "")
@@ -320,8 +320,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
     @staticmethod
     def _format_state_change(
         entity_id: str,
-        old_state: Dict[str, Any],
-        new_state: Dict[str, Any],
+        old_state: dict[str, Any],
+        new_state: dict[str, Any],
     ) -> Optional[str]:
         """Convert a state_changed event into a human-readable description."""
         if not new_state:
@@ -388,7 +388,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a notification via HA REST API (persistent_notification.create).
 
@@ -440,7 +440,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """No typing indicator for Home Assistant."""
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic info about the HA event channel."""
         return {
             "name": "Home Assistant Events",

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -395,9 +395,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self._clock_skew_warned: bool = False
 
         # Cache: room_id → bool (is DM)
-        self._dm_rooms: Dict[str, bool] = {}
+        self._dm_rooms: dict[str, bool] = {}
         # Set of room IDs we've joined
-        self._joined_rooms: Set[str] = set()
+        self._joined_rooms: set[str] = set()
         # Event deduplication (bounded deque keeps newest entries)
         from collections import deque
 
@@ -419,11 +419,11 @@ class MatrixAdapter(BasePlatformAdapter):
         if free_rooms_raw is None:
             free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
         if isinstance(free_rooms_raw, list):
-            self._free_rooms: Set[str] = {
+            self._free_rooms: set[str] = {
                 str(r).strip() for r in free_rooms_raw if str(r).strip()
             }
         else:
-            self._free_rooms: Set[str] = {
+            self._free_rooms: set[str] = {
                 r.strip() for r in str(free_rooms_raw).split(",") if r.strip()
             }
         # If non-empty, bot ONLY responds in these rooms (whitelist); DMs exempt.
@@ -431,11 +431,11 @@ class MatrixAdapter(BasePlatformAdapter):
         if allowed_rooms_raw is None:
             allowed_rooms_raw = os.getenv("MATRIX_ALLOWED_ROOMS", "")
         if isinstance(allowed_rooms_raw, list):
-            self._allowed_rooms: Set[str] = {
+            self._allowed_rooms: set[str] = {
                 str(r).strip() for r in allowed_rooms_raw if str(r).strip()
             }
         else:
-            self._allowed_rooms: Set[str] = {
+            self._allowed_rooms: set[str] = {
                 r.strip() for r in str(allowed_rooms_raw).split(",") if r.strip()
             }
         self._auto_thread: bool = os.getenv("MATRIX_AUTO_THREAD", "true").lower() in {
@@ -460,7 +460,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # errors in some clients.  5s is empirically safe; not user-tunable —
         # if that changes, add a config.yaml entry rather than an env var.
         self._reaction_redaction_delay_seconds = 5.0
-        self._reaction_redaction_tasks: Set[asyncio.Task] = set()
+        self._reaction_redaction_tasks: set[asyncio.Task] = set()
 
         # Proxy support — resolve once at init, reuse for all HTTP traffic.
         self._proxy_url: str | None = resolve_proxy_url(platform_env_var="MATRIX_PROXY")
@@ -475,18 +475,18 @@ class MatrixAdapter(BasePlatformAdapter):
         self._text_batch_split_delay_seconds = float(
             os.getenv("HERMES_MATRIX_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
         )
-        self._pending_text_batches: Dict[str, MessageEvent] = {}
-        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_text_batches: dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: dict[str, asyncio.Task] = {}
 
         # Matrix reaction-based dangerous command approvals.
         self._approval_reaction_map = {
             "✅": "once",
             "❎": "deny",
         }
-        self._approval_prompts_by_event: Dict[str, _MatrixApprovalPrompt] = {}
-        self._approval_prompt_by_session: Dict[str, str] = {}
+        self._approval_prompts_by_event: dict[str, _MatrixApprovalPrompt] = {}
+        self._approval_prompt_by_session: dict[str, str] = {}
         allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
-        self._allowed_user_ids: Set[str] = {
+        self._allowed_user_ids: set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
         }
 
@@ -1003,7 +1003,7 @@ class MatrixAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a message to a Matrix room."""
 
@@ -1075,7 +1075,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         return SendResult(success=True, message_id=last_event_id)
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return room name and type (dm/group)."""
         name = chat_id
         chat_type = "dm" if await self._is_dm_room(chat_id) else "group"
@@ -1098,7 +1098,7 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(
-        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+        self, chat_id: str, metadata: Optional[dict[str, Any]] = None
     ) -> None:
         """Send a typing indicator."""
         if self._client:
@@ -1123,7 +1123,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         formatted = self.format_message(content)
         new_content = self._build_text_message_content(formatted)
-        msg_content: Dict[str, Any] = {
+        msg_content: dict[str, Any] = {
             "msgtype": "m.text",
             "body": f"* {formatted}",
             "m.new_content": new_content,
@@ -1154,7 +1154,7 @@ class MatrixAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Download an image URL and upload it to Matrix."""
         from tools.url_safety import is_safe_url
@@ -1209,7 +1209,7 @@ class MatrixAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local image file to Matrix."""
         return await self._send_local_file(
@@ -1223,7 +1223,7 @@ class MatrixAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
@@ -1236,7 +1236,7 @@ class MatrixAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload an audio file as a voice message (MSC3245 native voice)."""
         return await self._send_local_file(
@@ -1255,7 +1255,7 @@ class MatrixAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
@@ -1331,7 +1331,7 @@ class MatrixAdapter(BasePlatformAdapter):
         msgtype: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         is_voice: bool = False,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
@@ -1366,7 +1366,7 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
         # Build media message content.
-        msg_content: Dict[str, Any] = {
+        msg_content: dict[str, Any] = {
             "msgtype": msgtype,
             "body": caption or filename,
             "info": {
@@ -1414,7 +1414,7 @@ class MatrixAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         file_name: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         is_voice: bool = False,
     ) -> SendResult:
         """Read a local file and upload it."""
@@ -2074,7 +2074,7 @@ class MatrixAdapter(BasePlatformAdapter):
             logger.warning("Matrix: error joining %s: %s", room_id, exc)
             return False
 
-    async def _join_pending_invites(self, sync_data: Dict[str, Any]) -> None:
+    async def _join_pending_invites(self, sync_data: dict[str, Any]) -> None:
         """Join rooms still present in rooms.invite after sync processing."""
         rooms = sync_data.get("rooms", {}) if isinstance(sync_data, dict) else {}
         invites = rooms.get("invite", {})
@@ -2536,7 +2536,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return
 
-        dm_data: Optional[Dict] = None
+        dm_data: Optional[dict] = None
 
         try:
             resp = await self._client.get_account_data("m.direct")
@@ -2550,7 +2550,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if dm_data is None:
             return
 
-        dm_room_ids: Set[str] = set()
+        dm_room_ids: set[str] = set()
         for user_id, rooms in dm_data.items():
             if isinstance(rooms, list):
                 dm_room_ids.update(str(r) for r in rooms)
@@ -2561,9 +2561,9 @@ class MatrixAdapter(BasePlatformAdapter):
     # Mention detection helpers
     # ------------------------------------------------------------------
 
-    def _build_text_message_content(self, text: str, msgtype: str = "m.text") -> Dict[str, Any]:
+    def _build_text_message_content(self, text: str, msgtype: str = "m.text") -> dict[str, Any]:
         """Build Matrix text content with HTML and outbound mention metadata."""
-        msg_content: Dict[str, Any] = {"msgtype": msgtype, "body": text}
+        msg_content: dict[str, Any] = {"msgtype": msgtype, "body": text}
         mention_user_ids = self._extract_outbound_mentions(text)
         if mention_user_ids:
             msg_content["m.mentions"] = {"user_ids": mention_user_ids}
@@ -2579,7 +2579,7 @@ class MatrixAdapter(BasePlatformAdapter):
     def _extract_outbound_mentions(self, text: str) -> list[str]:
         """Return unique Matrix user IDs mentioned in outbound text."""
         protected, _ = self._protect_outbound_mention_regions(text)
-        seen: Set[str] = set()
+        seen: set[str] = set()
         mentions: list[str] = []
         for match in _OUTBOUND_MENTION_RE.finditer(protected):
             user_id = match.group(1)

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -33,7 +33,7 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8646
 DEFAULT_WEBHOOK_PATH = "/msgraph/webhook"
 DEFAULT_MAX_SEEN_RECEIPTS = 5000
-NotificationScheduler = Callable[[Dict[str, Any], MessageEvent], Awaitable[None] | None]
+NotificationScheduler = Callable[[dict[str, Any], MessageEvent], Awaitable[None] | None]
 
 
 def check_msgraph_webhook_requirements() -> bool:
@@ -85,7 +85,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         return raw if raw.startswith("/") else f"/{raw}"
 
     @staticmethod
-    def _build_receipt_key(notification: Dict[str, Any]) -> Optional[str]:
+    def _build_receipt_key(notification: dict[str, Any]) -> Optional[str]:
         explicit_id = str(notification.get("id") or "").strip()
         if explicit_id:
             return f"id:{explicit_id}"
@@ -168,12 +168,12 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         logger.info("[msgraph_webhook] Response for %s: %s", chat_id, content[:200])
         return SendResult(success=True)
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
@@ -305,7 +305,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
                 return True
         return False
 
-    def _verify_client_state(self, notification: Dict[str, Any]) -> bool:
+    def _verify_client_state(self, notification: dict[str, Any]) -> bool:
         """Verify the Graph-supplied clientState matches the configured secret.
 
         Uses ``hmac.compare_digest`` instead of ``==`` so that a mismatch
@@ -334,7 +334,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
 
     def _build_message_event(
         self,
-        notification: Dict[str, Any],
+        notification: dict[str, Any],
         receipt_key: Optional[str],
     ) -> MessageEvent:
         message_id = receipt_key or f"sha1:{sha1(json.dumps(notification, sort_keys=True).encode('utf-8')).hexdigest()}"
@@ -354,7 +354,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             internal=True,
         )
 
-    def _render_prompt(self, notification: Dict[str, Any]) -> str:
+    def _render_prompt(self, notification: dict[str, Any]) -> str:
         template = self.config.extra.get("prompt", "")
         if template:
             payload = {
@@ -367,7 +367,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         rendered = json.dumps(notification, indent=2, sort_keys=True)[:4000]
         return f"Microsoft Graph change notification:\n\n```json\n{rendered}\n```"
 
-    def _render_template(self, template: str, payload: Dict[str, Any]) -> str:
+    def _render_template(self, template: str, payload: dict[str, Any]) -> str:
         import re
 
         def _resolve(match: "re.Match[str]") -> str:
@@ -386,7 +386,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
 
     def _schedule_notification(
         self,
-        notification: Dict[str, Any],
+        notification: dict[str, Any],
         event: MessageEvent,
     ) -> None:
         scheduler = self._notification_scheduler

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -142,7 +142,7 @@ def check_qq_requirements() -> bool:
     return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
 
 
-def _coerce_list(value: Any) -> List[str]:
+def _coerce_list(value: Any) -> list[str]:
     """Coerce config values into a trimmed string list."""
     return _coerce_list_impl(value)
 
@@ -227,16 +227,16 @@ class QQAdapter(BasePlatformAdapter):
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
-        self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
+        self._chat_type_map: dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
 
         # Request/response correlation
-        self._pending_responses: Dict[str, asyncio.Future] = {}
-        self._seen_messages: Dict[str, float] = {}
+        self._pending_responses: dict[str, asyncio.Future] = {}
+        self._seen_messages: dict[str, float] = {}
 
         # Last inbound message ID per chat — used by send_typing
-        self._last_msg_id: Dict[str, str] = {}
+        self._last_msg_id: dict[str, str] = {}
         # Typing debounce: chat_id → last send_typing timestamp
-        self._typing_sent_at: Dict[str, float] = {}
+        self._typing_sent_at: dict[str, float] = {}
 
         # Token cache
         self._access_token: Optional[str] = None
@@ -244,7 +244,7 @@ class QQAdapter(BasePlatformAdapter):
         self._token_lock = asyncio.Lock()
 
         # Upload cache: content_hash -> {file_info, file_uuid, expires_at}
-        self._upload_cache: Dict[str, Dict[str, Any]] = {}
+        self._upload_cache: dict[str, dict[str, Any]] = {}
 
         # Inline-keyboard interaction routing. The callback (if set) is invoked
         # for every INTERACTION_CREATE event after the adapter has already
@@ -794,7 +794,7 @@ class QQAdapter(BasePlatformAdapter):
         except RuntimeError:
             return None
 
-    def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
+    def _dispatch_payload(self, payload: dict[str, Any]) -> None:
         """Route inbound WebSocket payloads (dispatch synchronously, spawn async handlers)."""
         op = payload.get("op")
         t = payload.get("t")
@@ -886,7 +886,7 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _parse_json(raw: Any) -> Optional[Dict[str, Any]]:
+    def _parse_json(raw: Any) -> Optional[dict[str, Any]]:
         try:
             payload = json.loads(raw)
         except Exception:
@@ -1055,7 +1055,7 @@ class QQAdapter(BasePlatformAdapter):
     }
 
     @staticmethod
-    def _parse_gateway_session_key(session_key: str) -> Optional[Dict[str, str]]:
+    def _parse_gateway_session_key(session_key: str) -> Optional[dict[str, str]]:
         """Parse ``agent:main:<platform>:<chat_type>:<chat_id>[:<user_id>]``."""
         parts = str(session_key or "").split(":")
         if len(parts) < 5 or parts[0] != "agent" or parts[1] != "main":
@@ -1194,10 +1194,10 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _handle_c2c_message(
             self,
-            d: Dict[str, Any],
+            d: dict[str, Any],
             msg_id: str,
             content: str,
-            author: Dict[str, Any],
+            author: dict[str, Any],
             timestamp: str,
     ) -> None:
         """Handle a C2C (private) message event."""
@@ -1289,10 +1289,10 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _handle_group_message(
             self,
-            d: Dict[str, Any],
+            d: dict[str, Any],
             msg_id: str,
             content: str,
-            author: Dict[str, Any],
+            author: dict[str, Any],
             timestamp: str,
     ) -> None:
         """Handle a group @-message event."""
@@ -1354,10 +1354,10 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _handle_guild_message(
             self,
-            d: Dict[str, Any],
+            d: dict[str, Any],
             msg_id: str,
             content: str,
-            author: Dict[str, Any],
+            author: dict[str, Any],
             timestamp: str,
     ) -> None:
         """Handle a guild/channel message event."""
@@ -1429,10 +1429,10 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _handle_dm_message(
             self,
-            d: Dict[str, Any],
+            d: dict[str, Any],
             msg_id: str,
             content: str,
-            author: Dict[str, Any],
+            author: dict[str, Any],
             timestamp: str,
     ) -> None:
         """Handle a guild DM message event."""
@@ -1503,8 +1503,8 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _process_quoted_context(
             self,
-            d: Dict[str, Any],
-    ) -> Dict[str, Any]:
+            d: dict[str, Any],
+    ) -> dict[str, Any]:
         """Process the quoted message a user is replying to.
 
         When a user replies while quoting another message, the platform sets
@@ -1551,8 +1551,8 @@ class QQAdapter(BasePlatformAdapter):
         # msg_elements[0] carries the referenced message. Additional elements
         # (if any) are very rare in practice; we concatenate their text and
         # union their attachments for completeness.
-        quoted_text_parts: List[str] = []
-        all_attachments: List[Dict[str, Any]] = []
+        quoted_text_parts: list[str] = []
+        all_attachments: list[dict[str, Any]] = []
         for elem in elements:
             if not isinstance(elem, dict):
                 continue
@@ -1571,7 +1571,7 @@ class QQAdapter(BasePlatformAdapter):
         quoted_images = att_result.get("image_urls") or []
         quoted_image_types = att_result.get("image_media_types") or []
 
-        lines: List[str] = []
+        lines: list[str] = []
         if quoted_text_parts:
             lines.append(" ".join(quoted_text_parts))
         for t in quoted_voice:
@@ -1631,7 +1631,7 @@ class QQAdapter(BasePlatformAdapter):
     async def _process_attachments(
             self,
             attachments: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Process inbound attachments (all message types).
 
         Mirrors OpenClaw's ``processAttachments`` — handles images, voice, and
@@ -1651,10 +1651,10 @@ class QQAdapter(BasePlatformAdapter):
                 "attachment_info": "",
             }
 
-        image_urls: List[str] = []
-        image_media_types: List[str] = []
-        voice_transcripts: List[str] = []
-        other_attachments: List[str] = []
+        image_urls: list[str] = []
+        image_media_types: list[str] = []
+        voice_transcripts: list[str] = []
+        other_attachments: list[str] = []
 
         for att in attachments:
             if not isinstance(att, dict):
@@ -1808,7 +1808,7 @@ class QQAdapter(BasePlatformAdapter):
             return True
         return False
 
-    def _qq_media_headers(self) -> Dict[str, str]:
+    def _qq_media_headers(self) -> dict[str, str]:
         """Return Authorization headers for QQ multimedia CDN downloads.
 
         QQ's multimedia URLs (multimedia.nt.qq.com.cn) require the bot's
@@ -2136,7 +2136,7 @@ class QQAdapter(BasePlatformAdapter):
         )
         return wav_path
 
-    def _resolve_stt_config(self) -> Optional[Dict[str, str]]:
+    def _resolve_stt_config(self) -> Optional[dict[str, str]]:
         """Resolve STT backend configuration from config/environment.
 
         Priority:
@@ -2312,9 +2312,9 @@ class QQAdapter(BasePlatformAdapter):
             self,
             method: str,
             path: str,
-            body: Optional[Dict[str, Any]] = None,
+            body: Optional[dict[str, Any]] = None,
             timeout: float = DEFAULT_API_TIMEOUT,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Make an authenticated REST API request to QQ Bot API."""
         if not self._http_client:
             raise RuntimeError("HTTP client not initialized — not connected?")
@@ -2353,7 +2353,7 @@ class QQAdapter(BasePlatformAdapter):
             file_data: Optional[str] = None,
             srv_send_msg: bool = False,
             file_name: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Upload media and return file_info."""
         path = (
             f"/v2/users/{target_id}/files"
@@ -2361,7 +2361,7 @@ class QQAdapter(BasePlatformAdapter):
             else f"/v2/groups/{target_id}/files"
         )
 
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "file_type": file_type,
             "srv_send_msg": srv_send_msg,
         }
@@ -2422,7 +2422,7 @@ class QQAdapter(BasePlatformAdapter):
             chat_id: str,
             content: str,
             reply_to: Optional[str] = None,
-            metadata: Optional[Dict[str, Any]] = None,
+            metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a text or markdown message to a QQ user or group.
 
@@ -2550,7 +2550,7 @@ class QQAdapter(BasePlatformAdapter):
             self, channel_id: str, content: str, reply_to: Optional[str] = None
     ) -> SendResult:
         """Send text to a guild channel via REST API."""
-        body: Dict[str, Any] = {"content": content[: self.MAX_MESSAGE_LENGTH]}
+        body: dict[str, Any] = {"content": content[: self.MAX_MESSAGE_LENGTH]}
         if reply_to:
             body["msg_id"] = reply_to
 
@@ -2649,7 +2649,7 @@ class QQAdapter(BasePlatformAdapter):
             command: str,
             session_key: str,
             description: str = "dangerous command",
-            metadata: Optional[Dict[str, Any]] = None,
+            metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a button-based exec-approval prompt for a dangerous command.
 
@@ -2684,7 +2684,7 @@ class QQAdapter(BasePlatformAdapter):
             prompt: str,
             default: str = "",
             session_key: str = "",
-            metadata: Optional[Dict[str, Any]] = None,
+            metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Yes/No update-confirmation prompt with inline buttons.
 
@@ -2710,12 +2710,12 @@ class QQAdapter(BasePlatformAdapter):
 
     def _build_text_body(
             self, content: str, reply_to: Optional[str] = None
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Build the message body for C2C/group text sending."""
         msg_seq = self._next_msg_seq(reply_to or "default")
 
         if self._markdown_support:
-            body: Dict[str, Any] = {
+            body: dict[str, Any] = {
                 "markdown": {"content": content[: self.MAX_MESSAGE_LENGTH]},
                 "msg_type": MSG_TYPE_MARKDOWN,
                 "msg_seq": msg_seq,
@@ -2744,7 +2744,7 @@ class QQAdapter(BasePlatformAdapter):
             image_url: str,
             caption: Optional[str] = None,
             reply_to: Optional[str] = None,
-            metadata: Optional[Dict[str, Any]] = None,
+            metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively via QQ Bot API upload."""
         del metadata
@@ -2897,7 +2897,7 @@ class QQAdapter(BasePlatformAdapter):
 
             # Send media message
             msg_seq = self._next_msg_seq(chat_id)
-            body: Dict[str, Any] = {
+            body: dict[str, Any] = {
                 "msg_type": MSG_TYPE_MEDIA,
                 "media": {"file_info": file_info},
                 "msg_seq": msg_seq,
@@ -2960,7 +2960,7 @@ class QQAdapter(BasePlatformAdapter):
             media_source: str,
             file_type: int,
             file_name: Optional[str],
-    ) -> Tuple[str, Dict[str, Any]]:
+    ) -> tuple[str, dict[str, Any]]:
         """Chunked-upload a local file and return ``(resolved_name, complete_response)``.
 
         The returned ``complete_response`` contains the ``file_info`` token
@@ -3003,7 +3003,7 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _load_media(
             self, source: str, file_name: Optional[str] = None
-    ) -> Tuple[str, str, str]:
+    ) -> tuple[str, str, str]:
         """Load media from URL or local path. Returns (base64_or_url, content_type, filename)."""
         source = str(source).strip()
         if not source:
@@ -3101,7 +3101,7 @@ class QQAdapter(BasePlatformAdapter):
     # Chat info
     # ------------------------------------------------------------------
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return chat info based on chat type heuristics."""
         chat_type = self._guess_chat_type(chat_id)
         return {
@@ -3147,7 +3147,7 @@ class QQAdapter(BasePlatformAdapter):
         return True
 
     @staticmethod
-    def _entry_matches(entries: List[str], target: str) -> bool:
+    def _entry_matches(entries: list[str], target: str) -> bool:
         normalized_target = str(target).strip().lower()
         for entry in entries:
             normalized = str(entry).strip().lower()

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -143,12 +143,12 @@ class _PreparePart:
 class _PrepareResult:
     upload_id: str
     block_size: int
-    parts: List[_PreparePart]
+    parts: list[_PreparePart]
     concurrency: int = _DEFAULT_CONCURRENT_PARTS
     retry_timeout: float = 0.0
 
 
-def _parse_prepare_response(raw: Dict[str, Any]) -> _PrepareResult:
+def _parse_prepare_response(raw: dict[str, Any]) -> _PrepareResult:
     """Parse the upload_prepare API response into a normalized shape.
 
     The API may return the response directly or wrapped in ``data``.
@@ -165,7 +165,7 @@ def _parse_prepare_response(raw: Dict[str, Any]) -> _PrepareResult:
         raise ValueError(
             f"upload_prepare response missing parts: {str(raw)[:200]}"
         )
-    parts: List[_PreparePart] = []
+    parts: list[_PreparePart] = []
     for p in raw_parts:
         if not isinstance(p, dict):
             continue
@@ -189,7 +189,7 @@ def _parse_prepare_response(raw: Dict[str, Any]) -> _PrepareResult:
 
 # ── Chunked upload driver ────────────────────────────────────────────
 
-ApiRequestFn = Callable[..., Awaitable[Dict[str, Any]]]
+ApiRequestFn = Callable[..., Awaitable[dict[str, Any]]]
 """Signature of the adapter's ``_api_request`` callable.
 
 We pass the bound method in rather than importing the adapter, to avoid
@@ -225,7 +225,7 @@ class ChunkedUploader:
         file_path: str,
         file_type: int,
         file_name: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Run the full chunked upload and return the ``complete_upload`` response.
 
         :param chat_type: ``'c2c'`` or ``'group'``.
@@ -278,7 +278,7 @@ class ChunkedUploader:
         )
 
         # Step 3: PUT each part + notify.
-        tasks: List[Callable[[], Awaitable[None]]] = [
+        tasks: list[Callable[[], Awaitable[None]]] = [
             functools.partial(
                 self._upload_one_part,
                 chat_type=chat_type,
@@ -314,7 +314,7 @@ class ChunkedUploader:
         file_type: int,
         file_name: str,
         file_size: int,
-        hashes: Dict[str, str],
+        hashes: dict[str, str],
     ) -> _PrepareResult:
         base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
         path = f"{base}/{target_id}/upload_prepare"
@@ -496,7 +496,7 @@ class ChunkedUploader:
         chat_type: str,
         target_id: str,
         upload_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Call ``complete_upload`` with retry.
 
         This reuses the ``/files`` endpoint (same as the simple URL-based upload)
@@ -556,7 +556,7 @@ def _read_file_chunk(file_path: str, offset: int, length: int) -> bytes:
         return data
 
 
-def _compute_file_hashes(file_path: str, file_size: int) -> Dict[str, str]:
+def _compute_file_hashes(file_path: str, file_size: int) -> dict[str, str]:
     """Compute md5, sha1, and md5_10m in a single pass."""
     md5 = hashlib.md5()
     sha1 = hashlib.sha1()
@@ -588,7 +588,7 @@ def _compute_file_hashes(file_path: str, file_size: int) -> Dict[str, str]:
 
 
 async def _run_with_concurrency(
-    tasks: List[Callable[[], Awaitable[None]]],
+    tasks: list[Callable[[], Awaitable[None]]],
     concurrency: int,
 ) -> None:
     """Run a list of thunks with a bounded number in flight at once."""

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -59,7 +59,7 @@ class KeyboardButtonPermission:
     """Button permission metadata. ``type=2`` means all users can click."""
     type: int = 2
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {"type": self.type}
 
 
@@ -81,7 +81,7 @@ class KeyboardButtonAction:
     )
     click_limit: int = 1
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "type": self.type,
             "data": self.data,
@@ -102,7 +102,7 @@ class KeyboardButtonRenderData:
     visited_label: str
     style: int = 1
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "label": self.label,
             "visited_label": self.visited_label,
@@ -122,7 +122,7 @@ class KeyboardButton:
     action: KeyboardButtonAction
     group_id: str = "default"
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "render_data": self.render_data.to_dict(),
@@ -133,17 +133,17 @@ class KeyboardButton:
 
 @dataclass
 class KeyboardRow:
-    buttons: List[KeyboardButton] = field(default_factory=list)
+    buttons: list[KeyboardButton] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {"buttons": [b.to_dict() for b in self.buttons]}
 
 
 @dataclass
 class KeyboardContent:
-    rows: List[KeyboardRow] = field(default_factory=list)
+    rows: list[KeyboardRow] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {"rows": [r.to_dict() for r in self.rows]}
 
 
@@ -152,7 +152,7 @@ class InlineKeyboard:
     """Top-level keyboard payload — goes into ``MessageToCreate.keyboard``."""
     content: KeyboardContent = field(default_factory=KeyboardContent)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {"content": self.content.to_dict()}
 
 
@@ -305,7 +305,7 @@ def build_approval_text(req: ApprovalRequest) -> str:
 
 
 def _build_exec_text(req: ApprovalRequest) -> str:
-    lines: List[str] = ["🔐 **命令执行审批**", ""]
+    lines: list[str] = ["🔐 **命令执行审批**", ""]
     if req.command_preview:
         preview = req.command_preview[:300]
         lines.append(f"```\n{preview}\n```")
@@ -326,7 +326,7 @@ def _build_plugin_text(req: ApprovalRequest) -> str:
         else "🔵" if req.severity == "info"
         else "🟡"
     )
-    lines: List[str] = [f"{icon} **审批请求**", ""]
+    lines: list[str] = [f"{icon} **审批请求**", ""]
     lines.append(f"📋 {req.title}")
     if req.description:
         lines.append(f"📝 {req.description}")
@@ -339,7 +339,7 @@ def _build_plugin_text(req: ApprovalRequest) -> str:
 
 # ── ApprovalSender ───────────────────────────────────────────────────
 
-PostMessageFn = Callable[..., Awaitable[Dict[str, Any]]]
+PostMessageFn = Callable[..., Awaitable[dict[str, Any]]]
 """Signature of an async POST to ``/v2/{users|groups}/{id}/messages``.
 
 Implementations accept a body dict and return the raw API response.
@@ -451,7 +451,7 @@ class InteractionEvent:
         )
 
 
-def parse_interaction_event(raw: Dict[str, Any]) -> InteractionEvent:
+def parse_interaction_event(raw: dict[str, Any]) -> InteractionEvent:
     """Parse a raw ``INTERACTION_CREATE`` dispatch payload (``d``)."""
     data_raw = raw.get("data") or {}
     resolved = data_raw.get("resolved") or {}

--- a/gateway/platforms/qqbot/onboard.py
+++ b/gateway/platforms/qqbot/onboard.py
@@ -81,7 +81,7 @@ def _render_qr(url: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _create_bind_task(timeout: float = ONBOARD_API_TIMEOUT) -> Tuple[str, str]:
+def _create_bind_task(timeout: float = ONBOARD_API_TIMEOUT) -> tuple[str, str]:
     """Create a bind task and return *(task_id, aes_key_base64)*.
 
     Raises:
@@ -111,7 +111,7 @@ def _create_bind_task(timeout: float = ONBOARD_API_TIMEOUT) -> Tuple[str, str]:
 def _poll_bind_result(
     task_id: str,
     timeout: float = ONBOARD_API_TIMEOUT,
-) -> Tuple[BindStatus, str, str, str]:
+) -> tuple[BindStatus, str, str, str]:
     """Poll the bind result for *task_id*.
 
     Returns:

--- a/gateway/platforms/qqbot/utils.py
+++ b/gateway/platforms/qqbot/utils.py
@@ -39,7 +39,7 @@ def build_user_agent() -> str:
     return f"QQBotAdapter/{QQBOT_VERSION} (Python/{py_version}; {os_name}; Hermes/{hermes_version})"
 
 
-def get_api_headers() -> Dict[str, str]:
+def get_api_headers() -> dict[str, str]:
     """Return standard HTTP headers for QQBot API requests.
 
     Includes ``Content-Type``, ``Accept``, and a dynamic ``User-Agent``.
@@ -57,7 +57,7 @@ def get_api_headers() -> Dict[str, str]:
 # Config helpers
 # ---------------------------------------------------------------------------
 
-def coerce_list(value: Any) -> List[str]:
+def coerce_list(value: Any) -> list[str]:
     """Coerce config values into a trimmed string list.
 
     Accepts comma-separated strings, lists, tuples, sets, or single values.

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -70,7 +70,7 @@ HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before conc
 # ---------------------------------------------------------------------------
 
 
-def _parse_comma_list(value: str) -> List[str]:
+def _parse_comma_list(value: str) -> list[str]:
     """Split a comma-separated string into a list, stripping whitespace."""
     return [v.strip() for v in value.split(",") if v.strip()]
 
@@ -215,15 +215,15 @@ class SignalAdapter(BasePlatformAdapter):
         # Background tasks
         self._sse_task: Optional[asyncio.Task] = None
         self._health_monitor_task: Optional[asyncio.Task] = None
-        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._typing_tasks: dict[str, asyncio.Task] = {}
         # Per-chat typing-indicator backoff. When signal-cli reports
         # NETWORK_FAILURE (recipient offline / unroutable), base.py's
         # _keep_typing refresh loop would otherwise hammer sendTyping every
         # ~2s indefinitely, producing WARNING-level log spam and pointless
         # RPC traffic. We track consecutive failures per chat and skip the
         # RPC during a cooldown window instead.
-        self._typing_failures: Dict[str, int] = {}
-        self._typing_skip_until: Dict[str, float] = {}
+        self._typing_failures: dict[str, int] = {}
+        self._typing_skip_until: dict[str, float] = {}
         self._running = False
         self._last_sse_activity = 0.0
         self._sse_response: Optional[httpx.Response] = None
@@ -238,8 +238,8 @@ class SignalAdapter(BasePlatformAdapter):
         # Signal increasingly exposes ACI/PNI UUIDs as stable recipient IDs.
         # Keep a best-effort mapping so outbound sends can upgrade from a
         # phone number to the corresponding UUID when signal-cli prefers it.
-        self._recipient_uuid_by_number: Dict[str, str] = {}
-        self._recipient_number_by_uuid: Dict[str, str] = {}
+        self._recipient_uuid_by_number: dict[str, str] = {}
+        self._recipient_number_by_uuid: dict[str, str] = {}
         self._recipient_cache_lock = asyncio.Lock()
 
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
@@ -971,14 +971,14 @@ class SignalAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a text message with native Signal formatting."""
         await self._stop_typing_indicator(chat_id)
 
         plain_text, text_styles = self._markdown_to_signal(content)
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "account": self.account,
             "message": plain_text,
         }
@@ -1035,7 +1035,7 @@ class SignalAdapter(BasePlatformAdapter):
         if now < skip_until:
             return
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "account": self.account,
         }
 
@@ -1068,8 +1068,8 @@ class SignalAdapter(BasePlatformAdapter):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        images: list[tuple[str, str]],
+        metadata: Optional[dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images via chunked Signal RPC calls.
@@ -1092,7 +1092,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         await self._stop_typing_indicator(chat_id)
 
-        attachments: List[str] = []
+        attachments: list[str] = []
         skipped_download = 0
         skipped_missing = 0
         skipped_oversize = 0
@@ -1135,7 +1135,7 @@ class SignalAdapter(BasePlatformAdapter):
             len(attachments), len(images),
         )
 
-        base_params: Dict[str, Any] = {
+        base_params: dict[str, Any] = {
             "account": self.account,
             "message": "",
         }
@@ -1266,7 +1266,7 @@ class SignalAdapter(BasePlatformAdapter):
         if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
             return SendResult(success=False, error=f"Image too large ({file_size} bytes)")
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "account": self.account,
             "message": caption or "",
             "attachments": [file_path],
@@ -1305,7 +1305,7 @@ class SignalAdapter(BasePlatformAdapter):
         if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
             return SendResult(success=False, error=f"{media_label} too large ({file_size} bytes)")
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "account": self.account,
             "message": caption or "",
             "attachments": [file_path],
@@ -1416,7 +1416,7 @@ class SignalAdapter(BasePlatformAdapter):
             target_author: Phone number / UUID of the message author
             target_timestamp: Signal timestamp (ms) of the message to react to
         """
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "account": self.account,
             "emoji": emoji,
             "targetAuthor": target_author,
@@ -1441,7 +1441,7 @@ class SignalAdapter(BasePlatformAdapter):
         target_timestamp: int,
     ) -> bool:
         """Remove a reaction by sending an empty-string emoji."""
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "account": self.account,
             "emoji": "",
             "targetAuthor": target_author,
@@ -1527,7 +1527,7 @@ class SignalAdapter(BasePlatformAdapter):
     # Chat Info
     # ------------------------------------------------------------------
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Get information about a chat/contact."""
         if chat_id.startswith("group:"):
             return {

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -309,18 +309,18 @@ class SlackAdapter(BasePlatformAdapter):
         self._app: Optional[Any] = None
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
-        self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        self._user_name_cache: dict[str, str] = {}  # user_id → display name
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
-        self._team_clients: Dict[str, Any] = {}   # team_id → WebClient
-        self._team_bot_user_ids: Dict[str, str] = {}          # team_id → bot_user_id
-        self._channel_team: Dict[str, str] = {}                # channel_id → team_id
+        self._team_clients: dict[str, Any] = {}   # team_id → WebClient
+        self._team_bot_user_ids: dict[str, str] = {}          # team_id → bot_user_id
+        self._channel_team: dict[str, str] = {}                # channel_id → team_id
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events.
         self._dedup = MessageDeduplicator()
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
-        self._approval_resolved: Dict[str, bool] = {}
+        self._approval_resolved: dict[str, bool] = {}
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -333,23 +333,23 @@ class SlackAdapter(BasePlatformAdapter):
         # AI Assistant lifecycle events can arrive before/alongside message
         # events, and they carry the user/thread identity needed for stable
         # session + memory scoping.
-        self._assistant_threads: Dict[Tuple[str, str], Dict[str, str]] = {}
+        self._assistant_threads: dict[tuple[str, str], dict[str, str]] = {}
         self._ASSISTANT_THREADS_MAX = 5000
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
-        self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
+        self._thread_context_cache: dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
         # clear them (chat_id → thread_ts).
-        self._active_status_threads: Dict[str, str] = {}
+        self._active_status_threads: dict[str, str] = {}
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
         # Each value: {"response_url": str, "ts": float}
-        self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._slash_command_contexts: dict[tuple[str, str], dict[str, Any]] = {}
 
-    def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[dict[str, Any]] = None) -> Optional[str]:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
         if response is None or not hasattr(response, "get"):
             return None
@@ -375,7 +375,7 @@ class SlackAdapter(BasePlatformAdapter):
             return f"Slack attachment access failed for {file_label} because the bot does not have permission ({error}). Check workspace permissions/scopes and reinstall if needed."
         return None
 
-    def _describe_slack_download_failure(self, exc: Exception, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    def _describe_slack_download_failure(self, exc: Exception, *, file_obj: Optional[dict[str, Any]] = None) -> Optional[str]:
         """Translate Slack download exceptions into user-facing attachment diagnostics."""
         file_label = str((file_obj or {}).get("name") or (file_obj or {}).get("id") or "this attachment")
 
@@ -416,7 +416,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     def _pop_slash_context(
         self, chat_id: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         """Return and remove the slash-command context for *chat_id*, if fresh.
 
         Contexts older than ``_SLASH_CTX_TTL`` seconds are silently discarded.
@@ -455,7 +455,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _send_slash_ephemeral(
         self,
-        ctx: Dict[str, Any],
+        ctx: dict[str, Any],
         content: str,
     ) -> "SendResult":
         """Replace the initial ephemeral ack via ``response_url``.
@@ -760,7 +760,7 @@ class SlackAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a message to a Slack channel or DM."""
         if not self._app:
@@ -838,7 +838,7 @@ class SlackAdapter(BasePlatformAdapter):
         user_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Slack ephemeral message visible only to one user."""
         if not self._app:
@@ -961,7 +961,7 @@ class SlackAdapter(BasePlatformAdapter):
     def _resolve_thread_ts(
         self,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> Optional[str]:
         """Resolve the correct thread_ts for a Slack API call.
 
@@ -1002,7 +1002,7 @@ class SlackAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file to Slack."""
         if not self._app:
@@ -1041,8 +1041,8 @@ class SlackAdapter(BasePlatformAdapter):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        images: list[tuple[str, str]],
+        metadata: Optional[dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single Slack message with multiple file uploads.
@@ -1076,8 +1076,8 @@ class SlackAdapter(BasePlatformAdapter):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
 
-            file_uploads: List[Dict[str, Any]] = []
-            initial_comment_parts: List[str] = []
+            file_uploads: list[dict[str, Any]] = []
+            initial_comment_parts: list[str] = []
             try:
                 async with _httpx.AsyncClient(timeout=30.0, follow_redirects=True) as http_client:
                     for image_url, alt_text in chunk:
@@ -1389,7 +1389,7 @@ class SlackAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local image file to Slack by uploading it."""
         try:
@@ -1415,7 +1415,7 @@ class SlackAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image to Slack by uploading the URL as a file."""
         if not self._app:
@@ -1479,7 +1479,7 @@ class SlackAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send an audio file to Slack."""
@@ -1502,7 +1502,7 @@ class SlackAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a video file to Slack."""
         if not self._app:
@@ -1559,7 +1559,7 @@ class SlackAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a document/file attachment to Slack."""
         if not self._app:
@@ -1611,7 +1611,7 @@ class SlackAdapter(BasePlatformAdapter):
                 text = f"{caption}\n{text}"
             return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Get information about a Slack channel."""
         if not self._app:
             return {"name": chat_id, "type": "unknown"}
@@ -1635,13 +1635,13 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Internal handlers -----
 
-    def _assistant_thread_key(self, channel_id: str, thread_ts: str) -> Optional[Tuple[str, str]]:
+    def _assistant_thread_key(self, channel_id: str, thread_ts: str) -> Optional[tuple[str, str]]:
         """Return a stable cache key for Slack assistant thread metadata."""
         if not channel_id or not thread_ts:
             return None
         return (str(channel_id), str(thread_ts))
 
-    def _extract_assistant_thread_metadata(self, event: dict) -> Dict[str, str]:
+    def _extract_assistant_thread_metadata(self, event: dict) -> dict[str, str]:
         """Extract Slack Assistant thread identity data from an event payload."""
         assistant_thread = event.get("assistant_thread") or {}
         context = assistant_thread.get("context") or event.get("context") or {}
@@ -1680,7 +1680,7 @@ class SlackAdapter(BasePlatformAdapter):
             "context_channel_id": str(context_channel_id) if context_channel_id else "",
         }
 
-    def _cache_assistant_thread_metadata(self, metadata: Dict[str, str]) -> None:
+    def _cache_assistant_thread_metadata(self, metadata: dict[str, str]) -> None:
         """Remember assistant thread identity data for later message events."""
         channel_id = metadata.get("channel_id", "")
         thread_ts = metadata.get("thread_ts", "")
@@ -1708,7 +1708,7 @@ class SlackAdapter(BasePlatformAdapter):
         event: dict,
         channel_id: str = "",
         thread_ts: str = "",
-    ) -> Dict[str, str]:
+    ) -> dict[str, str]:
         """Load cached assistant-thread metadata that matches the current event."""
         metadata = self._extract_assistant_thread_metadata(event)
         if channel_id and not metadata.get("channel_id"):
@@ -1727,7 +1727,7 @@ class SlackAdapter(BasePlatformAdapter):
             return merged
         return metadata
 
-    def _seed_assistant_thread_session(self, metadata: Dict[str, str]) -> None:
+    def _seed_assistant_thread_session(self, metadata: dict[str, str]) -> None:
         """Prime the session store so assistant threads get stable user scoping."""
         session_store = getattr(self, "_session_store", None)
         if not session_store:
@@ -2032,7 +2032,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Handle file attachments
         media_urls = []
         media_types = []
-        attachment_notices: List[str] = []
+        attachment_notices: list[str] = []
         files = event.get("files", [])
         for f in files:
             # Slack Connect channels return stub file objects with
@@ -2242,7 +2242,7 @@ class SlackAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
 
@@ -2301,7 +2301,7 @@ class SlackAdapter(BasePlatformAdapter):
                 },
             ]
 
-            kwargs: Dict[str, Any] = {
+            kwargs: dict[str, Any] = {
                 "channel": chat_id,
                 "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
                 "blocks": blocks,
@@ -2321,7 +2321,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
-        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+        confirm_id: str, metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Block Kit three-option slash-command confirmation prompt."""
         if not self._app:
@@ -2369,7 +2369,7 @@ class SlackAdapter(BasePlatformAdapter):
                 },
             ]
 
-            kwargs: Dict[str, Any] = {
+            kwargs: dict[str, Any] = {
                 "channel": chat_id,
                 "text": f"{title or 'Confirm'}: {body[:100]}",
                 "blocks": blocks,
@@ -2465,7 +2465,7 @@ class SlackAdapter(BasePlatformAdapter):
             from tools import slash_confirm as _slash_confirm_mod
             result_text = await _slash_confirm_mod.resolve(session_key, confirm_id, choice)
             if result_text:
-                post_kwargs: Dict[str, Any] = {
+                post_kwargs: dict[str, Any] = {
                     "channel": channel_id,
                     "text": result_text,
                 }

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -155,7 +155,7 @@ class SmsAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         import aiohttp
 
@@ -206,7 +206,7 @@ class SmsAdapter(BasePlatformAdapter):
 
         return last_result
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         return {"name": chat_id, "type": "dm"}
 
     # ------------------------------------------------------------------

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -400,10 +400,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
-        self._pending_photo_batches: Dict[str, MessageEvent] = {}
-        self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
-        self._media_group_events: Dict[str, MessageEvent] = {}
-        self._media_group_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_photo_batches: dict[str, MessageEvent] = {}
+        self._pending_photo_batch_tasks: dict[str, asyncio.Task] = {}
+        self._media_group_events: dict[str, MessageEvent] = {}
+        self._media_group_tasks: dict[str, asyncio.Task] = {}
         # Buffer rapid text messages so Telegram client-side splits of long
         # messages are aggregated into a single MessageEvent.  Lower defaults
         # (0.3s / 1.0s instead of 0.6s / 2.0s) let short replies stream
@@ -423,8 +423,8 @@ class TelegramAdapter(BasePlatformAdapter):
             min_value=self._text_batch_delay_seconds,
             max_value=4.0,
         )
-        self._pending_text_batches: Dict[str, MessageEvent] = {}
-        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_text_batches: dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
@@ -437,13 +437,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # (cron live-adapter branch) fall through to standalone delivery.
         self._send_path_degraded: bool = False
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
-        self._dm_topics: Dict[str, int] = {}
+        self._dm_topics: dict[str, int] = {}
         # Track forum chats where we've already registered bot commands
         self._forum_command_registered: set[int] = set()
         # Lock per la registrazione sicura dei comandi nei forum supergroup
         self._forum_lock = asyncio.Lock()
         # DM Topics config from extra.dm_topics
-        self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        self._dm_topics_config: list[dict[str, Any]] = self.config.extra.get("dm_topics", [])
         # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
         self._dm_topic_chat_ids: Set[str] = {
             str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
@@ -457,15 +457,15 @@ class TelegramAdapter(BasePlatformAdapter):
             else 20 * 1024 * 1024
         )
         # Interactive model picker state per chat
-        self._model_picker_state: Dict[str, dict] = {}
+        self._model_picker_state: dict[str, dict] = {}
         # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        self._approval_state: dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
-        self._slash_confirm_state: Dict[str, str] = {}
+        self._slash_confirm_state: dict[str, str] = {}
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
-        self._clarify_state: Dict[str, str] = {}
+        self._clarify_state: dict[str, str] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -478,11 +478,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # send_or_update_status() bookkeeping: {(chat_id, status_key) -> bot message_id}
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
-        self._status_message_ids: Dict[tuple, str] = {}
+        self._status_message_ids: dict[tuple, str] = {}
 
     def _notification_kwargs(
-        self, metadata: Optional[Dict[str, Any]]
-    ) -> Dict[str, Any]:
+        self, metadata: Optional[dict[str, Any]]
+    ) -> dict[str, Any]:
         """Return disable_notification kwargs when the adapter is in silent mode.
 
         In "important" mode, all message sends are silently delivered
@@ -548,21 +548,21 @@ class TelegramAdapter(BasePlatformAdapter):
         return "*" in allowed_ids or normalized_user_id in allowed_ids
 
     @classmethod
-    def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    def _metadata_thread_id(cls, metadata: Optional[dict[str, Any]]) -> Optional[str]:
         if not metadata:
             return None
         thread_id = metadata.get("thread_id") or metadata.get("message_thread_id")
         return str(thread_id) if thread_id is not None else None
 
     @classmethod
-    def _metadata_direct_messages_topic_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    def _metadata_direct_messages_topic_id(cls, metadata: Optional[dict[str, Any]]) -> Optional[str]:
         if not metadata:
             return None
         topic_id = metadata.get("direct_messages_topic_id") or metadata.get("telegram_direct_messages_topic_id")
         return str(topic_id) if topic_id is not None else None
 
     @classmethod
-    def _metadata_reply_to_message_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[int]:
+    def _metadata_reply_to_message_id(cls, metadata: Optional[dict[str, Any]]) -> Optional[int]:
         if not metadata:
             return None
         reply_to = metadata.get("telegram_reply_to_message_id")
@@ -572,7 +572,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _reply_to_message_id_for_send(
         cls,
         reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         reply_to_mode: Optional[str] = None,
     ) -> Optional[int]:
         if reply_to:
@@ -588,10 +588,10 @@ class TelegramAdapter(BasePlatformAdapter):
         cls,
         chat_id: str,
         thread_id: Optional[str],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         reply_to_message_id: Optional[int] = None,
         reply_to_mode: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Return Telegram send kwargs for forum and direct-message topic routing.
 
         Supergroup/forum topics use ``message_thread_id``. True Bot API Direct
@@ -666,7 +666,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def _should_retry_without_dm_topic_reply_anchor(
         cls,
         error: Exception,
-        metadata: Optional[Dict[str, Any]],
+        metadata: Optional[dict[str, Any]],
         reply_to_message_id: Optional[int],
     ) -> bool:
         """True when a DM-topic send should be retried with routing stripped.
@@ -709,8 +709,8 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _send_with_dm_topic_reply_anchor_retry(
         self,
         send_fn: Any,
-        send_kwargs: Dict[str, Any],
-        metadata: Optional[Dict[str, Any]],
+        send_kwargs: dict[str, Any],
+        metadata: Optional[dict[str, Any]],
         reply_to_message_id: Optional[int],
         media_label: str,
         reset_media: Optional[Any] = None,
@@ -811,7 +811,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return default
         return bool(value)
 
-    def _link_preview_kwargs(self) -> Dict[str, Any]:
+    def _link_preview_kwargs(self) -> dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
             return {}
         if LinkPreviewOptions is not None:
@@ -1108,7 +1108,7 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return None
         try:
-            kwargs: Dict[str, Any] = {"chat_id": chat_id, "name": name}
+            kwargs: dict[str, Any] = {"chat_id": chat_id, "name": name}
             if icon_color is not None:
                 kwargs["icon_color"] = icon_color
             if icon_custom_emoji_id:
@@ -1687,7 +1687,7 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[dict[str, Any]] = None
     ) -> SendResult:
         """Send a message to a Telegram chat."""
         if not self._bot:
@@ -1931,7 +1931,7 @@ class TelegramAdapter(BasePlatformAdapter):
         status_key: str,
         content: str,
         *,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a status message, or edit the previous one with the same key.
 
@@ -1966,7 +1966,7 @@ class TelegramAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Edit a previously sent Telegram message.
 
@@ -2101,7 +2101,7 @@ class TelegramAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Split an oversized edit across the existing message + continuations.
 
@@ -2287,7 +2287,7 @@ class TelegramAdapter(BasePlatformAdapter):
     def supports_draft_streaming(
         self,
         chat_type: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> bool:
         """Telegram supports sendMessageDraft for private chats only.
 
@@ -2308,7 +2308,7 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: str,
         draft_id: int,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Stream a partial message via Telegram's native sendMessageDraft.
 
@@ -2329,7 +2329,7 @@ class TelegramAdapter(BasePlatformAdapter):
         text = content if len(content) <= self.MAX_MESSAGE_LENGTH else \
             self.truncate_message(content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len)[0]
 
-        kwargs: Dict[str, Any] = {
+        kwargs: dict[str, Any] = {
             "chat_id": int(chat_id),
             "draft_id": int(draft_id),
             "text": text,
@@ -2390,7 +2390,7 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an inline-keyboard update prompt (Yes / No buttons).
 
@@ -2433,7 +2433,7 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
 
@@ -2473,7 +2473,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 ],
             ])
 
-            kwargs: Dict[str, Any] = {
+            kwargs: dict[str, Any] = {
                 "chat_id": int(chat_id),
                 "text": text,
                 "parse_mode": ParseMode.HTML,
@@ -2504,7 +2504,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
-        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+        confirm_id: str, metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Render a three-button slash-command confirmation prompt."""
         if not self._bot:
@@ -2524,7 +2524,7 @@ class TelegramAdapter(BasePlatformAdapter):
             ])
 
             thread_id = self._metadata_thread_id(metadata)
-            kwargs: Dict[str, Any] = {
+            kwargs: dict[str, Any] = {
                 "chat_id": int(chat_id),
                 "text": preview,
                 "parse_mode": ParseMode.MARKDOWN_V2,
@@ -2557,7 +2557,7 @@ class TelegramAdapter(BasePlatformAdapter):
         choices: Optional[list],
         clarify_id: str,
         session_key: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Render a clarify prompt with one inline button per choice.
 
@@ -2588,7 +2588,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 text += f"\n\n{option_lines}"
 
-            kwargs: Dict[str, Any] = {
+            kwargs: dict[str, Any] = {
                 "chat_id": int(chat_id),
                 "text": text,
                 "parse_mode": ParseMode.HTML,
@@ -2640,7 +2640,7 @@ class TelegramAdapter(BasePlatformAdapter):
         current_provider: str,
         session_key: str,
         on_model_selected,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive inline-keyboard model picker.
 
@@ -3108,7 +3108,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         chat = getattr(query.message, "chat", None)
                         chat_type = getattr(chat, "type", None)
                         prompt_message_id = getattr(query.message, "message_id", None)
-                        send_kwargs: Dict[str, Any] = {
+                        send_kwargs: dict[str, Any] = {
                             "chat_id": int(query.message.chat_id),
                             "text": self.format_message(result_text),
                             "parse_mode": ParseMode.MARKDOWN_V2,
@@ -3427,7 +3427,7 @@ class TelegramAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send audio as a native Telegram voice message or audio file."""
@@ -3515,8 +3515,8 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[tuple],
-        metadata: Optional[Dict[str, Any]] = None,
+        images: list[tuple],
+        metadata: Optional[dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images natively via Telegram's media group API.
@@ -3546,8 +3546,8 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         # Peel off animations — they need send_animation, not send_media_group
-        animations: List[tuple] = []
-        photos: List[tuple] = []
+        animations: list[tuple] = []
+        photos: list[tuple] = []
         for image_url, alt_text in images:
             if not image_url.startswith("file://") and self._is_animation_url(image_url):
                 animations.append((image_url, alt_text))
@@ -3574,8 +3574,8 @@ class TelegramAdapter(BasePlatformAdapter):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
 
-            media: List[Any] = []
-            opened_files: List[Any] = []
+            media: list[Any] = []
+            opened_files: list[Any] = []
             try:
                 for image_url, alt_text in chunk:
                     caption = alt_text[:1024] if alt_text else None
@@ -3653,7 +3653,7 @@ class TelegramAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a local image file natively as a Telegram photo."""
@@ -3747,7 +3747,7 @@ class TelegramAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file natively as a Telegram file attachment."""
@@ -3797,7 +3797,7 @@ class TelegramAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a video natively as a Telegram video message."""
@@ -3844,7 +3844,7 @@ class TelegramAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively as a Telegram photo.
         
@@ -3938,7 +3938,7 @@ class TelegramAdapter(BasePlatformAdapter):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Telegram animation (auto-plays inline)."""
         if not self._bot:
@@ -3979,7 +3979,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # Fallback: try as a regular photo
             return await self.send_image(chat_id, animation_url, caption, reply_to, metadata=metadata)
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Optional[dict[str, Any]] = None) -> None:
         """Send typing indicator."""
         if self._bot:
             _is_dm_topic: bool = False
@@ -4014,7 +4014,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     exc_info=True,
                 )
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Get information about a Telegram chat."""
         if not self._bot:
             return {"name": "Unknown", "type": "dm"}
@@ -4349,7 +4349,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Ignoring invalid Telegram thread id: %r", self.name, value)
         return ignored
 
-    def _compile_mention_patterns(self) -> List[re.Pattern]:
+    def _compile_mention_patterns(self) -> list[re.Pattern]:
         """Compile optional regex wake-word patterns for group triggers."""
         patterns = self.config.extra.get("mention_patterns")
         if patterns is None:
@@ -4375,7 +4375,7 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return []
 
-        compiled: List[re.Pattern] = []
+        compiled: list[re.Pattern] = []
         for pattern in patterns:
             if not isinstance(pattern, str) or not pattern.strip():
                 continue
@@ -5435,7 +5435,7 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[%s] Failed to reload dm_topics from config: %s", self.name, e)
 
-    def _get_dm_topic_info(self, chat_id: str, thread_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    def _get_dm_topic_info(self, chat_id: str, thread_id: Optional[str]) -> Optional[dict[str, Any]]:
         """Look up DM topic config by chat_id and thread_id.
 
         Returns the topic config dict (name, skill, etc.) if this thread_id

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -105,10 +105,10 @@ class WebhookAdapter(BasePlatformAdapter):
         self._host: str = config.extra.get("host", DEFAULT_HOST)
         self._port: int = int(config.extra.get("port", DEFAULT_PORT))
         self._global_secret: str = config.extra.get("secret", "")
-        self._static_routes: Dict[str, dict] = config.extra.get("routes", {})
-        self._dynamic_routes: Dict[str, dict] = {}
+        self._static_routes: dict[str, dict] = config.extra.get("routes", {})
+        self._dynamic_routes: dict[str, dict] = {}
         self._dynamic_routes_mtime: float = 0.0
-        self._routes: Dict[str, dict] = dict(self._static_routes)
+        self._routes: dict[str, dict] = dict(self._static_routes)
         self._runner = None
 
         # Delivery info keyed by session chat_id.
@@ -120,19 +120,19 @@ class WebhookAdapter(BasePlatformAdapter):
         # context-pressure warnings) will consume the entry before the
         # final response arrives, causing the response to silently fall
         # back to the "log" deliver type.
-        self._delivery_info: Dict[str, dict] = {}
-        self._delivery_info_created: Dict[str, float] = {}
+        self._delivery_info: dict[str, dict] = {}
+        self._delivery_info_created: dict[str, float] = {}
 
         # Reference to gateway runner for cross-platform delivery (set externally)
         self.gateway_runner = None
 
         # Idempotency: TTL cache of recently processed delivery IDs.
         # Prevents duplicate agent runs when webhook providers retry.
-        self._seen_deliveries: Dict[str, float] = {}
+        self._seen_deliveries: dict[str, float] = {}
         self._idempotency_ttl: int = 3600  # 1 hour
 
         # Rate limiting: per-route timestamps in a fixed window.
-        self._rate_counts: Dict[str, List[float]] = {}
+        self._rate_counts: dict[str, list[float]] = {}
         self._rate_limit: int = int(config.extra.get("rate_limit", 30))  # per minute
 
         # Body size limit (auth-before-body pattern)
@@ -224,7 +224,7 @@ class WebhookAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Deliver the agent's response to the configured destination.
 
@@ -281,7 +281,7 @@ class WebhookAdapter(BasePlatformAdapter):
             self._delivery_info.pop(k, None)
             self._delivery_info_created.pop(k, None)
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
     # ------------------------------------------------------------------
@@ -314,7 +314,7 @@ class WebhookAdapter(BasePlatformAdapter):
             # Reject any dynamic route whose effective secret is empty —
             # an empty secret would cause _handle_webhook to skip HMAC
             # validation entirely, letting unauthenticated callers in.
-            new_dynamic: Dict[str, dict] = {}
+            new_dynamic: dict[str, dict] = {}
             for k, v in data.items():
                 if k in self._static_routes:
                     continue
@@ -785,7 +785,7 @@ class WebhookAdapter(BasePlatformAdapter):
         self, extra: dict, payload: dict
     ) -> dict:
         """Render delivery_extra template values with payload data."""
-        rendered: Dict[str, Any] = {}
+        rendered: dict[str, Any] = {}
         for key, value in extra.items():
             if isinstance(value, str):
                 rendered[key] = self._render_prompt(value, payload, "", "")

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -110,7 +110,7 @@ def check_wecom_requirements() -> bool:
     return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
 
 
-def _coerce_list(value: Any) -> List[str]:
+def _coerce_list(value: Any) -> list[str]:
     """Coerce config values into a trimmed string list."""
     if value is None:
         return []
@@ -129,7 +129,7 @@ def _normalize_entry(raw: str) -> str:
     return value.strip()
 
 
-def _entry_matches(entries: List[str], target: str) -> bool:
+def _entry_matches(entries: list[str], target: str) -> bool:
     """Case-insensitive allowlist match with ``*`` support."""
     normalized_target = str(target).strip().lower()
     for entry in entries:
@@ -172,18 +172,18 @@ class WeComAdapter(BasePlatformAdapter):
         self._http_client: Optional["httpx.AsyncClient"] = None
         self._listen_task: Optional[asyncio.Task] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
-        self._pending_responses: Dict[str, asyncio.Future] = {}
+        self._pending_responses: dict[str, asyncio.Future] = {}
         self._dedup = MessageDeduplicator(max_size=DEDUP_MAX_SIZE)
-        self._reply_req_ids: Dict[str, str] = {}
+        self._reply_req_ids: dict[str, str] = {}
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
         self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
         self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
-        self._pending_text_batches: Dict[str, MessageEvent] = {}
-        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._pending_text_batches: dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex
-        self._last_chat_req_ids: Dict[str, str] = {}
+        self._last_chat_req_ids: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -299,7 +299,7 @@ class WeComAdapter(BasePlatformAdapter):
             errmsg = auth_payload.get("errmsg", "authentication failed")
             raise RuntimeError(f"{errmsg} (errcode={errcode})")
 
-    async def _wait_for_handshake(self, req_id: str) -> Dict[str, Any]:
+    async def _wait_for_handshake(self, req_id: str) -> dict[str, Any]:
         """Wait for the subscribe acknowledgement."""
         if not self._ws:
             raise RuntimeError("WebSocket not initialized")
@@ -384,7 +384,7 @@ class WeComAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             pass
 
-    async def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
+    async def _dispatch_payload(self, payload: dict[str, Any]) -> None:
         """Route inbound websocket payloads."""
         req_id = self._payload_req_id(payload)
         cmd = str(payload.get("cmd") or "")
@@ -410,13 +410,13 @@ class WeComAdapter(BasePlatformAdapter):
                 future.set_exception(exc)
             self._pending_responses.pop(req_id, None)
 
-    async def _send_json(self, payload: Dict[str, Any]) -> None:
+    async def _send_json(self, payload: dict[str, Any]) -> None:
         """Send a raw JSON frame over the active websocket."""
         if not self._ws or self._ws.closed:
             raise RuntimeError("WeCom websocket is not connected")
         await self._ws.send_json(payload)
 
-    async def _send_request(self, cmd: str, body: Dict[str, Any], timeout: float = REQUEST_TIMEOUT_SECONDS) -> Dict[str, Any]:
+    async def _send_request(self, cmd: str, body: dict[str, Any], timeout: float = REQUEST_TIMEOUT_SECONDS) -> dict[str, Any]:
         """Send a JSON request and await the correlated response."""
         if not self._ws or self._ws.closed:
             raise RuntimeError("WeCom websocket is not connected")
@@ -434,10 +434,10 @@ class WeComAdapter(BasePlatformAdapter):
     async def _send_reply_request(
         self,
         reply_req_id: str,
-        body: Dict[str, Any],
+        body: dict[str, Any],
         cmd: str = APP_CMD_RESPONSE,
         timeout: float = REQUEST_TIMEOUT_SECONDS,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Send a reply frame correlated to an inbound callback req_id."""
         if not self._ws or self._ws.closed:
             raise RuntimeError("WeCom websocket is not connected")
@@ -462,14 +462,14 @@ class WeComAdapter(BasePlatformAdapter):
         return f"{prefix}-{uuid.uuid4().hex}"
 
     @staticmethod
-    def _payload_req_id(payload: Dict[str, Any]) -> str:
+    def _payload_req_id(payload: dict[str, Any]) -> str:
         headers = payload.get("headers")
         if isinstance(headers, dict):
             return str(headers.get("req_id") or "")
         return ""
 
     @staticmethod
-    def _parse_json(raw: Any) -> Optional[Dict[str, Any]]:
+    def _parse_json(raw: Any) -> Optional[dict[str, Any]]:
         try:
             payload = json.loads(raw)
         except Exception:
@@ -481,7 +481,7 @@ class WeComAdapter(BasePlatformAdapter):
     # Inbound message parsing
     # ------------------------------------------------------------------
 
-    async def _on_message(self, payload: Dict[str, Any]) -> None:
+    async def _on_message(self, payload: dict[str, Any]) -> None:
         """Process an inbound WeCom message callback event."""
         body = payload.get("body")
         if not isinstance(body, dict):
@@ -641,9 +641,9 @@ class WeComAdapter(BasePlatformAdapter):
                 self._pending_text_batch_tasks.pop(key, None)
 
     @staticmethod
-    def _extract_text(body: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+    def _extract_text(body: dict[str, Any]) -> tuple[str, Optional[str]]:
         """Extract plain text and quoted text from a callback payload."""
-        text_parts: List[str] = []
+        text_parts: list[str] = []
         reply_text: Optional[str] = None
         msgtype = str(body.get("msgtype") or "").lower()
 
@@ -691,11 +691,11 @@ class WeComAdapter(BasePlatformAdapter):
 
         return "\n".join(part for part in text_parts if part).strip(), reply_text
 
-    async def _extract_media(self, body: Dict[str, Any]) -> Tuple[List[str], List[str]]:
+    async def _extract_media(self, body: dict[str, Any]) -> tuple[list[str], list[str]]:
         """Best-effort extraction of inbound media to local cache paths."""
-        media_paths: List[str] = []
-        media_types: List[str] = []
-        refs: List[Tuple[str, Dict[str, Any]]] = []
+        media_paths: list[str] = []
+        media_types: list[str] = []
+        refs: list[tuple[str, dict[str, Any]]] = []
         msgtype = str(body.get("msgtype") or "").lower()
 
         if msgtype == "mixed":
@@ -738,7 +738,7 @@ class WeComAdapter(BasePlatformAdapter):
 
         return media_paths, media_types
 
-    async def _cache_media(self, kind: str, media: Dict[str, Any]) -> Optional[Tuple[str, str]]:
+    async def _cache_media(self, kind: str, media: dict[str, Any]) -> Optional[tuple[str, str]]:
         """Cache an inbound image/file/media reference to local storage."""
         if "base64" in media and media.get("base64"):
             try:
@@ -833,7 +833,7 @@ class WeComAdapter(BasePlatformAdapter):
         return name
 
     @staticmethod
-    def _derive_message_type(body: Dict[str, Any], text: str, media_types: List[str]) -> MessageType:
+    def _derive_message_type(body: dict[str, Any], text: str, media_types: list[str]) -> MessageType:
         """Choose the normalized inbound message type."""
         if any(mtype.startswith(("application/", "text/")) for mtype in media_types):
             return MessageType.DOCUMENT
@@ -866,7 +866,7 @@ class WeComAdapter(BasePlatformAdapter):
             return _entry_matches(sender_allow, sender_id)
         return True
 
-    def _resolve_group_cfg(self, chat_id: str) -> Dict[str, Any]:
+    def _resolve_group_cfg(self, chat_id: str) -> dict[str, Any]:
         if not isinstance(self._groups, dict):
             return {}
         if chat_id in self._groups and isinstance(self._groups[chat_id], dict):
@@ -945,7 +945,7 @@ class WeComAdapter(BasePlatformAdapter):
         return "file"
 
     @staticmethod
-    def _apply_file_size_limits(file_size: int, detected_type: str, content_type: Optional[str] = None) -> Dict[str, Any]:
+    def _apply_file_size_limits(file_size: int, detected_type: str, content_type: Optional[str] = None) -> dict[str, Any]:
         file_size_mb = file_size / (1024 * 1024)
         normalized_type = str(detected_type or "file").lower()
         normalized_content_type = str(content_type or "").strip().lower()
@@ -1009,7 +1009,7 @@ class WeComAdapter(BasePlatformAdapter):
         }
 
     @staticmethod
-    def _response_error(response: Dict[str, Any]) -> Optional[str]:
+    def _response_error(response: dict[str, Any]) -> Optional[str]:
         errcode = response.get("errcode", 0)
         if errcode in {0, None}:
             return None
@@ -1017,7 +1017,7 @@ class WeComAdapter(BasePlatformAdapter):
         return f"WeCom errcode {errcode}: {errmsg}"
 
     @classmethod
-    def _raise_for_wecom_error(cls, response: Dict[str, Any], operation: str) -> None:
+    def _raise_for_wecom_error(cls, response: dict[str, Any], operation: str) -> None:
         error = cls._response_error(response)
         if error:
             raise RuntimeError(f"{operation} failed: {error}")
@@ -1056,7 +1056,7 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         url: str,
         max_bytes: int,
-    ) -> Tuple[bytes, Dict[str, str]]:
+    ) -> tuple[bytes, dict[str, str]]:
         from tools.url_safety import is_safe_url
         if not is_safe_url(url):
             raise ValueError(f"Blocked unsafe URL (SSRF protection): {url[:80]}")
@@ -1105,7 +1105,7 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         media_source: str,
         file_name: Optional[str] = None,
-    ) -> Tuple[bytes, str, str]:
+    ) -> tuple[bytes, str, str]:
         source = str(media_source or "").strip()
         if not source:
             raise ValueError("media source is required")
@@ -1140,7 +1140,7 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         media_source: str,
         file_name: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         data, content_type, resolved_name = await self._load_outbound_media(media_source, file_name=file_name)
         detected_type = self._detect_wecom_media_type(content_type)
         size_check = self._apply_file_size_limits(len(data), detected_type, content_type)
@@ -1152,7 +1152,7 @@ class WeComAdapter(BasePlatformAdapter):
             **size_check,
         }
 
-    async def _upload_media_bytes(self, data: bytes, media_type: str, filename: str) -> Dict[str, Any]:
+    async def _upload_media_bytes(self, data: bytes, media_type: str, filename: str) -> dict[str, Any]:
         if not data:
             raise ValueError("Cannot upload empty media")
 
@@ -1210,7 +1210,7 @@ class WeComAdapter(BasePlatformAdapter):
             "created_at": finish_body.get("created_at"),
         }
 
-    async def _send_media_message(self, chat_id: str, media_type: str, media_id: str) -> Dict[str, Any]:
+    async def _send_media_message(self, chat_id: str, media_type: str, media_id: str) -> dict[str, Any]:
         response = await self._send_request(
             APP_CMD_SEND,
             {
@@ -1222,7 +1222,7 @@ class WeComAdapter(BasePlatformAdapter):
         self._raise_for_wecom_error(response, "send media message")
         return response
 
-    async def _send_reply_markdown(self, reply_req_id: str, content: str) -> Dict[str, Any]:
+    async def _send_reply_markdown(self, reply_req_id: str, content: str) -> dict[str, Any]:
         response = await self._send_reply_request(
             reply_req_id,
             {
@@ -1238,7 +1238,7 @@ class WeComAdapter(BasePlatformAdapter):
         reply_req_id: str,
         media_type: str,
         media_id: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         response = await self._send_reply_request(
             reply_req_id,
             {
@@ -1350,7 +1350,7 @@ class WeComAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send markdown to a WeCom chat via proactive ``aibot_send_msg``."""
         del metadata
@@ -1397,7 +1397,7 @@ class WeComAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         del metadata
 
@@ -1484,7 +1484,7 @@ class WeComAdapter(BasePlatformAdapter):
         """WeCom does not expose typing indicators in this adapter."""
         del chat_id, metadata
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return minimal chat info."""
         return {
             "name": chat_id,
@@ -1506,7 +1506,7 @@ _QR_POLL_TIMEOUT = 300  # 5 minutes
 def qr_scan_for_bot_info(
     *,
     timeout_seconds: int = _QR_POLL_TIMEOUT,
-) -> Optional[Dict[str, str]]:
+) -> Optional[dict[str, str]]:
     """Run the WeCom QR scan flow to obtain bot_id and secret.
 
     Fetches a QR code from WeCom, renders it in the terminal, and polls

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -59,16 +59,16 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         self._host = str(extra.get("host") or DEFAULT_HOST)
         self._port = int(extra.get("port") or DEFAULT_PORT)
         self._path = str(extra.get("path") or DEFAULT_PATH)
-        self._apps: List[Dict[str, Any]] = self._normalize_apps(extra)
+        self._apps: list[dict[str, Any]] = self._normalize_apps(extra)
         self._runner: Optional[web.AppRunner] = None
         self._site: Optional[web.TCPSite] = None
         self._app: Optional[web.Application] = None
         self._http_client: Optional[httpx.AsyncClient] = None
         self._message_queue: asyncio.Queue[MessageEvent] = asyncio.Queue()
         self._poll_task: Optional[asyncio.Task] = None
-        self._seen_messages: Dict[str, float] = {}
-        self._user_app_map: Dict[str, str] = {}
-        self._access_tokens: Dict[str, Dict[str, Any]] = {}
+        self._seen_messages: dict[str, float] = {}
+        self._user_app_map: dict[str, str] = {}
+        self._access_tokens: dict[str, dict[str, Any]] = {}
 
     # ------------------------------------------------------------------
     # App normalisation
@@ -79,7 +79,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         return f"{corp_id}:{user_id}" if corp_id else user_id
 
     @staticmethod
-    def _normalize_apps(extra: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _normalize_apps(extra: dict[str, Any]) -> list[dict[str, Any]]:
         apps = extra.get("apps")
         if isinstance(apps, list) and apps:
             return [dict(app) for app in apps if isinstance(app, dict)]
@@ -182,7 +182,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         app = self._resolve_app_for_chat(chat_id)
         touser = chat_id.split(":", 1)[1] if ":" in chat_id else chat_id
@@ -222,7 +222,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
 
-    def _resolve_app_for_chat(self, chat_id: str) -> Dict[str, Any]:
+    def _resolve_app_for_chat(self, chat_id: str) -> dict[str, Any]:
         """Pick the app associated with *chat_id*, falling back sensibly."""
         app_name = self._user_app_map.get(chat_id)
         if not app_name and ":" not in chat_id:
@@ -233,7 +233,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         app = self._get_app_by_name(app_name) if app_name else None
         return app or self._apps[0]
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         return {"name": chat_id, "type": "dm"}
 
     # ------------------------------------------------------------------
@@ -319,7 +319,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _decrypt_request(
-        self, app: Dict[str, Any], body: str,
+        self, app: dict[str, Any], body: str,
         msg_signature: str, timestamp: str, nonce: str,
     ) -> str:
         root = ET.fromstring(body)
@@ -327,7 +327,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         crypt = self._crypt_for_app(app)
         return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")
 
-    def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
+    def _build_event(self, app: dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
         root = ET.fromstring(xml_text)
         msg_type = (root.findtext("MsgType") or "").lower()
         # Silently acknowledge lifecycle events.
@@ -363,14 +363,14 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             message_id=msg_id,
         )
 
-    def _crypt_for_app(self, app: Dict[str, Any]) -> WXBizMsgCrypt:
+    def _crypt_for_app(self, app: dict[str, Any]) -> WXBizMsgCrypt:
         return WXBizMsgCrypt(
             token=str(app.get("token") or ""),
             encoding_aes_key=str(app.get("encoding_aes_key") or ""),
             receive_id=str(app.get("corp_id") or ""),
         )
 
-    def _get_app_by_name(self, name: Optional[str]) -> Optional[Dict[str, Any]]:
+    def _get_app_by_name(self, name: Optional[str]) -> Optional[dict[str, Any]]:
         if not name:
             return None
         for app in self._apps:
@@ -382,14 +382,14 @@ class WecomCallbackAdapter(BasePlatformAdapter):
     # Access-token management
     # ------------------------------------------------------------------
 
-    async def _get_access_token(self, app: Dict[str, Any]) -> str:
+    async def _get_access_token(self, app: dict[str, Any]) -> str:
         cached = self._access_tokens.get(app["name"])
         now = time.time()
         if cached and cached.get("expires_at", 0) > now + 60:
             return cached["token"]
         return await self._refresh_access_token(app)
 
-    async def _refresh_access_token(self, app: Dict[str, Any]) -> str:
+    async def _refresh_access_token(self, app: dict[str, Any]) -> str:
         resp = await self._http_client.get(
             "https://qyapi.weixin.qq.com/cgi-bin/gettoken",
             params={

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -112,7 +112,7 @@ MEDIA_VIDEO = 2
 MEDIA_FILE = 3
 MEDIA_VOICE = 4
 
-_LIVE_ADAPTERS: Dict[str, Any] = {}
+_LIVE_ADAPTERS: dict[str, Any] = {}
 
 
 def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
@@ -167,7 +167,7 @@ def _safe_id(value: Optional[str], keep: int = 8) -> str:
     return raw[:keep]
 
 
-def _json_dumps(payload: Dict[str, Any]) -> str:
+def _json_dumps(payload: dict[str, Any]) -> str:
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
 
@@ -203,11 +203,11 @@ def _random_wechat_uin() -> str:
     return base64.b64encode(str(value).encode("utf-8")).decode("ascii")
 
 
-def _base_info() -> Dict[str, Any]:
+def _base_info() -> dict[str, Any]:
     return {"channel_version": CHANNEL_VERSION}
 
 
-def _headers(token: Optional[str], body: str) -> Dict[str, str]:
+def _headers(token: Optional[str], body: str) -> dict[str, str]:
     headers = {
         "Content-Type": "application/json",
         "AuthorizationType": "ilink_bot_token",
@@ -254,7 +254,7 @@ def save_weixin_account(
         pass
 
 
-def load_weixin_account(hermes_home: str, account_id: str) -> Optional[Dict[str, Any]]:
+def load_weixin_account(hermes_home: str, account_id: str) -> Optional[dict[str, Any]]:
     """Load persisted account credentials."""
     path = _account_file(hermes_home, account_id)
     if not path.exists():
@@ -270,7 +270,7 @@ class ContextTokenStore:
 
     def __init__(self, hermes_home: str):
         self._root = _account_dir(hermes_home)
-        self._cache: Dict[str, str] = {}
+        self._cache: dict[str, str] = {}
 
     def _path(self, account_id: str) -> Path:
         return self._root / f"{account_id}.context-tokens.json"
@@ -320,7 +320,7 @@ class TypingTicketCache:
 
     def __init__(self, ttl_seconds: float = 600.0):
         self._ttl_seconds = ttl_seconds
-        self._cache: Dict[str, Tuple[str, float]] = {}
+        self._cache: dict[str, tuple[str, float]] = {}
 
     def get(self, user_id: str) -> Optional[str]:
         entry = self._cache.get(user_id)
@@ -358,7 +358,7 @@ def _parse_aes_key(aes_key_b64: str) -> bytes:
     raise ValueError(f"unexpected aes_key format ({len(decoded)} decoded bytes)")
 
 
-def _guess_chat_type(message: Dict[str, Any], account_id: str) -> Tuple[str, str]:
+def _guess_chat_type(message: dict[str, Any], account_id: str) -> tuple[str, str]:
     room_id = str(message.get("room_id") or message.get("chat_room_id") or "").strip()
     to_user_id = str(message.get("to_user_id") or "").strip()
     is_group = bool(room_id) or (to_user_id and account_id and to_user_id != account_id and message.get("msg_type") == 1)
@@ -372,10 +372,10 @@ async def _api_post(
     *,
     base_url: str,
     endpoint: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
     token: Optional[str],
     timeout_ms: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     body = _json_dumps({**payload, "base_info": _base_info()})
     url = f"{base_url.rstrip('/')}/{endpoint}"
     timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
@@ -392,7 +392,7 @@ async def _api_get(
     base_url: str,
     endpoint: str,
     timeout_ms: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     url = f"{base_url.rstrip('/')}/{endpoint}"
     headers = {
         "iLink-App-Id": ILINK_APP_ID,
@@ -413,7 +413,7 @@ async def _get_updates(
     token: str,
     sync_buf: str,
     timeout_ms: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     try:
         return await _api_post(
             session,
@@ -436,7 +436,7 @@ async def _send_message(
     text: str,
     context_token: Optional[str],
     client_id: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Send a text message via iLink sendmessage API.
 
     Returns the raw API response dict (may contain error codes like
@@ -444,7 +444,7 @@ async def _send_message(
     """
     if not text or not text.strip():
         raise ValueError("_send_message: text must not be empty")
-    message: Dict[str, Any] = {
+    message: dict[str, Any] = {
         "from_user_id": "",
         "to_user_id": to,
         "client_id": client_id,
@@ -494,8 +494,8 @@ async def _get_config(
     token: str,
     user_id: str,
     context_token: Optional[str],
-) -> Dict[str, Any]:
-    payload: Dict[str, Any] = {"ilink_user_id": user_id}
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"ilink_user_id": user_id}
     if context_token:
         payload["context_token"] = context_token
     return await _api_post(
@@ -520,7 +520,7 @@ async def _get_upload_url(
     rawfilemd5: str,
     filesize: int,
     aeskey_hex: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     return await _api_post(
         session,
         base_url=base_url,
@@ -616,7 +616,7 @@ def _assert_weixin_cdn_url(url: str) -> None:
         )
 
 
-def _media_reference(item: Dict[str, Any], key: str) -> Dict[str, Any]:
+def _media_reference(item: dict[str, Any], key: str) -> dict[str, Any]:
     return (item.get(key) or {}).get("media") or {}
 
 
@@ -649,7 +649,7 @@ def _mime_from_filename(filename: str) -> str:
     return mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
 
-def _split_table_row(line: str) -> List[str]:
+def _split_table_row(line: str) -> list[str]:
     row = line.strip()
     if row.startswith("|"):
         row = row[1:]
@@ -669,7 +669,7 @@ def _rewrite_headers_for_weixin(line: str) -> str:
     return f"**{title}**"
 
 
-def _rewrite_table_block_for_weixin(lines: List[str]) -> str:
+def _rewrite_table_block_for_weixin(lines: list[str]) -> str:
     if len(lines) < 2:
         return "\n".join(lines)
     headers = _split_table_row(lines[0])
@@ -677,7 +677,7 @@ def _rewrite_table_block_for_weixin(lines: List[str]) -> str:
     if not headers or not body_rows:
         return "\n".join(lines)
 
-    formatted_rows: List[str] = []
+    formatted_rows: list[str] = []
     for row in body_rows:
         pairs = []
         for idx, header in enumerate(headers):
@@ -706,7 +706,7 @@ def _rewrite_table_block_for_weixin(lines: List[str]) -> str:
 
 def _normalize_markdown_blocks(content: str) -> str:
     lines = content.splitlines()
-    result: List[str] = []
+    result: list[str] = []
     in_code_block = False
     blank_run = 0
 
@@ -739,7 +739,7 @@ def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
     if not content:
         return content
 
-    wrapped: List[str] = []
+    wrapped: list[str] = []
     in_code_block = False
 
     for raw_line in content.splitlines():
@@ -774,13 +774,13 @@ def _wrap_copy_friendly_lines_for_weixin(content: str) -> str:
     return "\n".join(wrapped).strip()
 
 
-def _split_markdown_blocks(content: str) -> List[str]:
+def _split_markdown_blocks(content: str) -> list[str]:
     if not content:
         return []
 
-    blocks: List[str] = []
+    blocks: list[str] = []
     lines = content.splitlines()
-    current: List[str] = []
+    current: list[str] = []
     in_code_block = False
 
     for raw_line in lines:
@@ -812,7 +812,7 @@ def _split_markdown_blocks(content: str) -> List[str]:
     return [block for block in blocks if block]
 
 
-def _split_delivery_units_for_weixin(content: str) -> List[str]:
+def _split_delivery_units_for_weixin(content: str) -> list[str]:
     """Split formatted content into chat-friendly delivery units.
 
     Weixin can render Markdown, but chat readability is better when top-level
@@ -820,14 +820,14 @@ def _split_delivery_units_for_weixin(content: str) -> List[str]:
     attach indented continuation lines to the previous top-level line so nested
     list items do not get torn apart.
     """
-    units: List[str] = []
+    units: list[str] = []
 
     for block in _split_markdown_blocks(content):
         if _FENCE_RE.match(block.splitlines()[0].strip()):
             units.append(block)
             continue
 
-        current: List[str] = []
+        current: list[str] = []
         for raw_line in block.splitlines():
             line = raw_line.rstrip()
             if not line.strip():
@@ -891,11 +891,11 @@ def _should_split_short_chat_block_for_weixin(block: str) -> bool:
     return all(_looks_like_chatty_line_for_weixin(line) for line in lines)
 
 
-def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]:
+def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> list[str]:
     if len(content) <= max_length:
         return [content]
 
-    packed: List[str] = []
+    packed: list[str] = []
     current = ""
     for block in _split_markdown_blocks(content):
         candidate = block if not current else f"{current}\n\n{block}"
@@ -916,7 +916,7 @@ def _pack_markdown_blocks_for_weixin(content: str, max_length: int) -> List[str]
 
 def _split_text_for_weixin_delivery(
     content: str, max_length: int, split_per_line: bool = False,
-) -> List[str]:
+) -> list[str]:
     """Split content into sequential Weixin messages.
 
     *compact* (default): Keep everything in a single message whenever it fits
@@ -938,7 +938,7 @@ def _split_text_for_weixin_delivery(
         # Legacy: one message per top-level delivery unit.
         if len(content) <= max_length and "\n" not in content:
             return [content]
-        chunks: List[str] = []
+        chunks: list[str] = []
         for unit in _split_delivery_units_for_weixin(content):
             if len(unit) <= max_length:
                 chunks.append(unit)
@@ -976,7 +976,7 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return default
 
 
-def _extract_text(item_list: List[Dict[str, Any]]) -> str:
+def _extract_text(item_list: list[dict[str, Any]]) -> str:
     for item in item_list:
         if item.get("type") == ITEM_TEXT:
             text = str((item.get("text_item") or {}).get("text") or "")
@@ -988,7 +988,7 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
                 prefix = f"[引用媒体: {title}]\n" if title else "[引用媒体]\n"
                 return f"{prefix}{text}".strip()
             if ref_item:
-                parts: List[str] = []
+                parts: list[str] = []
                 if ref.get("title"):
                     parts.append(str(ref["title"]))
                 ref_text = _extract_text([ref_item])
@@ -1005,7 +1005,7 @@ def _extract_text(item_list: List[Dict[str, Any]]) -> str:
     return ""
 
 
-def _message_type_from_media(media_types: List[str], text: str) -> MessageType:
+def _message_type_from_media(media_types: list[str], text: str) -> MessageType:
     if any(m.startswith("image/") for m in media_types):
         return MessageType.PHOTO
     if any(m.startswith("video/") for m in media_types):
@@ -1043,7 +1043,7 @@ async def qr_login(
     *,
     bot_type: str = "3",
     timeout_seconds: int = 480,
-) -> Optional[Dict[str, str]]:
+) -> Optional[dict[str, str]]:
     """
     Run the interactive iLink QR login flow.
 
@@ -1233,7 +1233,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 self._base_url = str(persisted.get("base_url") or self._base_url).strip().rstrip("/")
 
     @staticmethod
-    def _coerce_list(value: Any) -> List[str]:
+    def _coerce_list(value: Any) -> list[str]:
         if value is None:
             return []
         if isinstance(value, str):
@@ -1370,13 +1370,13 @@ class WeixinAdapter(BasePlatformAdapter):
                 if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                     consecutive_failures = 0
 
-    async def _process_message_safe(self, message: Dict[str, Any]) -> None:
+    async def _process_message_safe(self, message: dict[str, Any]) -> None:
         try:
             await self._process_message(message)
         except Exception as exc:
             logger.error("[%s] unhandled inbound error from=%s: %s", self.name, _safe_id(message.get("from_user_id")), exc, exc_info=True)
 
-    async def _process_message(self, message: Dict[str, Any]) -> None:
+    async def _process_message(self, message: dict[str, Any]) -> None:
         assert self._poll_session is not None
         sender_id = str(message.get("from_user_id") or "").strip()
         if not sender_id:
@@ -1411,8 +1411,8 @@ class WeixinAdapter(BasePlatformAdapter):
             self._token_store.set(self._account_id, sender_id, context_token)
         asyncio.create_task(self._maybe_fetch_typing_ticket(sender_id, context_token or None))
 
-        media_paths: List[str] = []
-        media_types: List[str] = []
+        media_paths: list[str] = []
+        media_types: list[str] = []
 
         for item in item_list:
             await self._collect_media(item, media_paths, media_types)
@@ -1450,7 +1450,7 @@ class WeixinAdapter(BasePlatformAdapter):
             return sender_id in self._allow_from
         return True
 
-    async def _collect_media(self, item: Dict[str, Any], media_paths: List[str], media_types: List[str]) -> None:
+    async def _collect_media(self, item: dict[str, Any], media_paths: list[str], media_types: list[str]) -> None:
         item_type = item.get("type")
         if item_type == ITEM_IMAGE:
             path = await self._download_image(item)
@@ -1473,7 +1473,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 media_paths.append(voice_path)
                 media_types.append("audio/silk")
 
-    async def _download_image(self, item: Dict[str, Any]) -> Optional[str]:
+    async def _download_image(self, item: dict[str, Any]) -> Optional[str]:
         media = _media_reference(item, "image_item")
         try:
             data = await _download_and_decrypt_media(
@@ -1491,7 +1491,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] image download failed: %s", self.name, exc)
             return None
 
-    async def _download_video(self, item: Dict[str, Any]) -> Optional[str]:
+    async def _download_video(self, item: dict[str, Any]) -> Optional[str]:
         media = _media_reference(item, "video_item")
         try:
             data = await _download_and_decrypt_media(
@@ -1507,7 +1507,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] video download failed: %s", self.name, exc)
             return None
 
-    async def _download_file(self, item: Dict[str, Any]) -> Tuple[Optional[str], str]:
+    async def _download_file(self, item: dict[str, Any]) -> tuple[Optional[str], str]:
         file_item = item.get("file_item") or {}
         media = file_item.get("media") or {}
         filename = str(file_item.get("file_name") or "document.bin")
@@ -1526,7 +1526,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] file download failed: %s", self.name, exc)
             return None, mime
 
-    async def _download_voice(self, item: Dict[str, Any]) -> Optional[str]:
+    async def _download_voice(self, item: dict[str, Any]) -> Optional[str]:
         voice_item = item.get("voice_item") or {}
         media = voice_item.get("media") or {}
         if voice_item.get("text"):
@@ -1564,7 +1564,7 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[%s] getConfig failed for %s: %s", self.name, _safe_id(user_id), exc)
 
-    def _split_text(self, content: str) -> List[str]:
+    def _split_text(self, content: str) -> list[str]:
         return _split_text_for_weixin_delivery(
             content, self.MAX_MESSAGE_LENGTH, self._split_multiline_messages,
         )
@@ -1670,7 +1670,7 @@ class WeixinAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
@@ -1732,7 +1732,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)
             return SendResult(success=False, error=str(exc))
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Optional[dict[str, Any]] = None) -> None:
         if not self._send_session or not self._token:
             return
         typing_ticket = self._typing_cache.get(chat_id)
@@ -1774,7 +1774,7 @@ class WeixinAdapter(BasePlatformAdapter):
         image_url: str,
         caption: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         if image_url.startswith(("http://", "https://")):
             file_path = await self._download_remote_media(image_url)
@@ -1799,7 +1799,7 @@ class WeixinAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         del reply_to, kwargs
@@ -1817,7 +1817,7 @@ class WeixinAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         del file_name, reply_to, metadata, kwargs
@@ -1836,7 +1836,7 @@ class WeixinAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
@@ -1853,7 +1853,7 @@ class WeixinAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
@@ -2060,7 +2060,7 @@ class WeixinAdapter(BasePlatformAdapter):
             },
         }
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         chat_type = "group" if chat_id.endswith("@chatroom") else "dm"
         return {"name": chat_id, "type": chat_type, "chat_id": chat_id}
 
@@ -2072,12 +2072,12 @@ class WeixinAdapter(BasePlatformAdapter):
 
 async def send_weixin_direct(
     *,
-    extra: Dict[str, Any],
+    extra: dict[str, Any],
     token: Optional[str],
     chat_id: str,
     message: str,
-    media_files: Optional[List[Tuple[str, bool]]] = None,
-) -> Dict[str, Any]:
+    media_files: Optional[list[tuple[str, bool]]] = None,
+) -> dict[str, Any]:
     """
     One-shot send helper for ``send_message`` and cron delivery.
 

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -400,7 +400,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             normalized = normalized.replace(":", "@", 1)
         return normalized
 
-    def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
+    def _bot_ids_from_message(self, data: dict[str, Any]) -> set[str]:
         bot_ids = set()
         for candidate in data.get("botIds") or []:
             normalized = self._normalize_whatsapp_id(candidate)
@@ -408,13 +408,13 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 bot_ids.add(normalized)
         return bot_ids
 
-    def _message_is_reply_to_bot(self, data: Dict[str, Any]) -> bool:
+    def _message_is_reply_to_bot(self, data: dict[str, Any]) -> bool:
         quoted_participant = self._normalize_whatsapp_id(data.get("quotedParticipant"))
         if not quoted_participant:
             return False
         return quoted_participant in self._bot_ids_from_message(data)
 
-    def _message_mentions_bot(self, data: Dict[str, Any]) -> bool:
+    def _message_mentions_bot(self, data: dict[str, Any]) -> bool:
         bot_ids = self._bot_ids_from_message(data)
         if not bot_ids:
             return False
@@ -434,13 +434,13 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 return True
         return False
 
-    def _message_matches_mention_patterns(self, data: Dict[str, Any]) -> bool:
+    def _message_matches_mention_patterns(self, data: dict[str, Any]) -> bool:
         if not self._mention_patterns:
             return False
         body = str(data.get("body") or "")
         return any(pattern.search(body) for pattern in self._mention_patterns)
 
-    def _clean_bot_mention_text(self, text: str, data: Dict[str, Any]) -> str:
+    def _clean_bot_mention_text(self, text: str, data: dict[str, Any]) -> str:
         if not text:
             return text
         bot_ids = self._bot_ids_from_message(data)
@@ -451,7 +451,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 cleaned = re.sub(rf"@{re.escape(bare_id)}\b[,:\-]*\s*", "", cleaned)
         return cleaned.strip() or text
 
-    def _should_process_message(self, data: Dict[str, Any]) -> bool:
+    def _should_process_message(self, data: dict[str, Any]) -> bool:
         chat_id_raw = str(data.get("chatId") or "")
         # WhatsApp uses pseudo-chats for Status updates (Stories) and
         # Channel/Newsletter broadcasts. These are not real conversations
@@ -870,7 +870,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[dict[str, Any]] = None
     ) -> SendResult:
         """Send a message via the WhatsApp bridge.
 
@@ -895,7 +895,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
             last_message_id = None
             for chunk in chunks:
-                payload: Dict[str, Any] = {
+                payload: dict[str, Any] = {
                     "chatId": chat_id,
                     "message": chunk,
                 }
@@ -979,7 +979,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=f"File not found: {file_path}")
 
-            payload: Dict[str, Any] = {
+            payload: dict[str, Any] = {
                 "chatId": chat_id,
                 "filePath": file_path,
                 "mediaType": media_type,
@@ -1092,7 +1092,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         except Exception:
             pass  # Ignore typing indicator failures
     
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Get information about a WhatsApp chat."""
         if not self._running or not self._http_session:
             return {"name": "Unknown", "type": "dm"}
@@ -1152,7 +1152,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             
             await asyncio.sleep(1)  # Poll interval
     
-    async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
+    async def _build_message_event(self, data: dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
             if not self._should_process_message(data):

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -1775,13 +1775,13 @@ class ExtractContentMiddleware(InboundMiddleware):
         return text
 
     @staticmethod
-    def _extract_inbound_media_refs(msg_body: list) -> List[Dict[str, str]]:
+    def _extract_inbound_media_refs(msg_body: list) -> list[dict[str, str]]:
         """Extract inbound image/file references from TIM msg_body.
 
         Return example:
           [{"kind": "image", "url": "https://..."}, {"kind": "file", "url": "...", "name": "a.pdf"}]
         """
-        refs: List[Dict[str, str]] = []
+        refs: list[dict[str, str]] = []
         for elem in msg_body or []:
             if not isinstance(elem, dict):
                 continue
@@ -1813,7 +1813,7 @@ class ExtractContentMiddleware(InboundMiddleware):
                     or str(content.get("filename") or "").strip()
                 )
                 if file_url:
-                    ref: Dict[str, str] = {"kind": "file", "url": file_url}
+                    ref: dict[str, str] = {"kind": "file", "url": file_url}
                     if file_name:
                         ref["name"] = file_name
                     refs.append(ref)
@@ -1915,7 +1915,7 @@ class OwnerCommandMiddleware(InboundMiddleware):
         msg_body: list,
         chat_type: str,
         from_account: str,
-    ) -> Tuple[Optional[str], Optional[str], bool]:
+    ) -> tuple[Optional[str], Optional[str], bool]:
         """Identify allowlisted slash commands and determine sender identity.
 
         Returns (cmd, cmd_line, is_owner):
@@ -2178,7 +2178,7 @@ class QuoteContextMiddleware(InboundMiddleware):
     name = "quote-context"
 
     @staticmethod
-    def _extract_quote_context(cloud_custom_data: str) -> Tuple[Optional[str], Optional[str], list]:
+    def _extract_quote_context(cloud_custom_data: str) -> tuple[Optional[str], Optional[str], list]:
         """Extract quote context, mapping to MessageEvent.reply_to_*.
 
         Returns:
@@ -2327,7 +2327,7 @@ class MediaResolveMiddleware(InboundMiddleware):
     async def _download_and_cache(
         cls, adapter, *, fetch_url: str, kind: str,
         file_name: Optional[str] = None, log_tag: str = "",
-    ) -> Optional[Tuple[str, str]]:
+    ) -> Optional[tuple[str, str]]:
         """Download a Yuanbao resource and cache locally. Returns ``(local_path, mime)`` or ``None``."""
         try:
             file_bytes, content_type = await media_download_url(
@@ -2377,15 +2377,15 @@ class MediaResolveMiddleware(InboundMiddleware):
 
     @classmethod
     async def _resolve_media_urls(
-        cls, adapter, media_refs: List[Dict[str, str]]
-    ) -> Tuple[List[str], List[str]]:
+        cls, adapter, media_refs: list[dict[str, str]]
+    ) -> tuple[list[str], list[str]]:
         """Resolve inbound media refs: download to local cache, return (local_paths, mime_types).
 
         Yuanbao COS hostnames resolve to private IPs, tripping the SSRF guard
         in vision_tools. We download ourselves and return local cache paths.
         """
-        media_urls: List[str] = []
-        media_types: List[str] = []
+        media_urls: list[str] = []
+        media_types: list[str] = []
 
         for ref in media_refs:
             kind = str(ref.get("kind") or "").strip().lower()
@@ -2420,7 +2420,7 @@ class MediaResolveMiddleware(InboundMiddleware):
     @classmethod
     async def _collect_observed_media(
         cls, adapter, source,
-    ) -> Tuple[List[str], List[str]]:
+    ) -> tuple[list[str], list[str]]:
         """Resolve recent observed image/file anchors from transcript into ``(local_paths, mimes)``."""
         store = getattr(adapter, "_session_store", None)
         if not store:
@@ -2438,7 +2438,7 @@ class MediaResolveMiddleware(InboundMiddleware):
             return [], []
 
         start = max(0, len(history) - OBSERVED_MEDIA_BACKFILL_LOOKBACK)
-        order: List[Tuple[str, str, str]] = []  # (rid, kind, filename)
+        order: list[tuple[str, str, str]] = []  # (rid, kind, filename)
         seen: set = set()
         for msg in history[start:]:
             content = msg.get("content")
@@ -2463,8 +2463,8 @@ class MediaResolveMiddleware(InboundMiddleware):
         if not order:
             return [], []
 
-        media_paths: List[str] = []
-        mimes: List[str] = []
+        media_paths: list[str] = []
+        mimes: list[str] = []
         for rid, kind, filename in order:
             try:
                 fresh_url = await cls._resolve_by_resource_id(adapter, rid)
@@ -2573,8 +2573,8 @@ class DispatchMiddleware(InboundMiddleware):
                         media_types.append(mime)
             else:
                 # No quote — backfill observed media from recent transcript history
-                extra_img_urls: List[str] = []
-                extra_img_mimes: List[str] = []
+                extra_img_urls: list[str] = []
+                extra_img_mimes: list[str] = []
                 try:
                     extra_img_urls, extra_img_mimes = await MediaResolveMiddleware._collect_observed_media(
                         adapter, ctx.source,
@@ -2751,14 +2751,14 @@ class ConnectionManager:
         self._connect_id: Optional[str] = None
         self._heartbeat_task: Optional[asyncio.Task] = None
         self._recv_task: Optional[asyncio.Task] = None
-        self._pending_acks: Dict[str, asyncio.Future] = {}
+        self._pending_acks: dict[str, asyncio.Future] = {}
         self._pending_pong: Optional[asyncio.Future] = None
         self._consecutive_hb_timeouts: int = 0
         self._reconnect_attempts: int = 0
         self._reconnecting: bool = False
         # Debounce buffer for aggregating multi-part inbound messages
-        self._inbound_buffer: Dict[str, list] = {}  # key -> [raw_data_frames, ...]
-        self._inbound_timers: Dict[str, asyncio.TimerHandle] = {}  # key -> timer
+        self._inbound_buffer: dict[str, list] = {}  # key -> [raw_data_frames, ...]
+        self._inbound_timers: dict[str, asyncio.TimerHandle] = {}  # key -> timer
 
     # -- Properties --------------------------------------------------------
 
@@ -3406,7 +3406,7 @@ class MediaSendHandler(ABC):
     @abstractmethod
     async def acquire_file(
         self, adapter: "YuanbaoAdapter", **kwargs: Any,
-    ) -> Tuple[bytes, str, str]:
+    ) -> tuple[bytes, str, str]:
         """Return (file_bytes, filename, content_type).
 
         Raises:
@@ -3817,8 +3817,8 @@ class HeartbeatManager:
 
     def __init__(self, adapter: "YuanbaoAdapter") -> None:
         self._adapter = adapter
-        self._reply_heartbeat_tasks: Dict[str, asyncio.Task] = {}
-        self._reply_hb_last_active: Dict[str, float] = {}
+        self._reply_heartbeat_tasks: dict[str, asyncio.Task] = {}
+        self._reply_hb_last_active: dict[str, float] = {}
 
     async def send_heartbeat_once(self, chat_id: str, heartbeat_val: int) -> None:
         """Send a single heartbeat (RUNNING or FINISH), best effort."""
@@ -3939,7 +3939,7 @@ class SlowResponseNotifier:
     def __init__(self, adapter: "YuanbaoAdapter", sender: "MessageSender") -> None:
         self._adapter = adapter
         self._sender = sender
-        self._tasks: Dict[str, asyncio.Task] = {}
+        self._tasks: dict[str, asyncio.Task] = {}
 
     async def start(self, chat_id: str) -> None:
         """Start a delayed task that notifies the user when the agent is slow."""
@@ -4001,7 +4001,7 @@ class MessageSender:
         self._on_send_finish: Optional[Callable[[str], Any]] = None  # send FINISH heartbeat
 
         # Media send handlers (strategy pattern)
-        self._media_handlers: Dict[str, MediaSendHandler] = {
+        self._media_handlers: dict[str, MediaSendHandler] = {
             "image_url": ImageUrlHandler(),
             "image_file": ImageFileHandler(),
             "file_url": FileUrlHandler(),
@@ -4101,8 +4101,8 @@ class MessageSender:
         self,
         chat_id: str,
         message: str,
-        media_files: Optional[List[Tuple[str, bool]]] = None,
-    ) -> Dict[str, Any]:
+        media_files: Optional[list[tuple[str, bool]]] = None,
+    ) -> dict[str, Any]:
         """Send text + media via Yuanbao (used by the ``send_message`` tool).
 
         Unlike Weixin which creates a fresh adapter per call, Yuanbao reuses
@@ -4349,7 +4349,7 @@ class MessageSender:
         content: str,
         max_length: int = 4000,
         len_fn: Optional[Callable[[str], int]] = None,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Split a long message into chunks with table-awareness.
 
@@ -4455,8 +4455,8 @@ class OutboundManager:
 
     async def send_direct(
         self, chat_id: str, message: str,
-        media_files: Optional[List[Tuple[str, bool]]] = None,
-    ) -> Dict[str, Any]:
+        media_files: Optional[list[tuple[str, bool]]] = None,
+    ) -> dict[str, Any]:
         """Send text + media (used by send_message tool)."""
         return await self.sender.send_direct(chat_id, message, media_files)
 
@@ -4546,23 +4546,23 @@ class YuanbaoAdapter(BasePlatformAdapter):
         # Member cache: group_code -> (updated_ts, [{"user_id":..., "nickname":..., ...}, ...])
         # Populated by get_group_member_list(), used by @mention resolution.
         # Entries older than MEMBER_CACHE_TTL_S are treated as stale.
-        self._member_cache: Dict[str, Tuple[float, list]] = {}
+        self._member_cache: dict[str, tuple[float, list]] = {}
         self.MEMBER_CACHE_TTL_S: float = 300.0  # 5 minutes
 
         # Inbound message deduplication (WS reconnect / network jitter)
         self._dedup = MessageDeduplicator(ttl_seconds=300)
 
         # Group chat sequential dispatch queue (session_key → asyncio.Queue).
-        self._group_queues: Dict[str, asyncio.Queue] = {}
+        self._group_queues: dict[str, asyncio.Queue] = {}
 
         # Recall support: track which msg_id is being processed per session_key
         # so RecallGuardMiddleware can detect "currently processing" messages.
-        self._processing_msg_ids: Dict[str, str] = {}
-        self._processing_msg_texts: Dict[str, str] = {}
+        self._processing_msg_ids: dict[str, str] = {}
+        self._processing_msg_texts: dict[str, str] = {}
         # Bounded cache of msg_id → attributed content for recent messages.
         # Used by _patch_transcript as content-match fallback when transcript
         # entries lack a message_id field (agent-processed @bot messages).
-        self._msg_content_cache: Dict[str, str] = {}
+        self._msg_content_cache: dict[str, str] = {}
 
         # Reply-to dedup: inbound_msg_id -> expire_ts
         # ------------------------------------------------------------------
@@ -4664,13 +4664,13 @@ class YuanbaoAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         group_code: str = "",
     ) -> SendResult:
         """Send text message with auto-chunking. Delegates to OutboundManager."""
         return await self._outbound.send_text(chat_id, content, reply_to, group_code=group_code)
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic chat metadata derived from the chat_id prefix.
 
         chat_id conventions:
@@ -4868,7 +4868,7 @@ async def send_yuanbao_direct(
     adapter: "YuanbaoAdapter",
     chat_id: str,
     message: str,
-    media_files: Optional[List[Tuple[str, bool]]] = None,
-) -> Dict[str, Any]:
+    media_files: Optional[list[tuple[str, bool]]] = None,
+) -> dict[str, Any]:
     """Delegate to ``OutboundManager.send_direct``."""
     return await adapter._outbound.send_direct(chat_id, message, media_files)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -184,7 +184,7 @@ def _is_transient_network_error(exc: BaseException) -> bool:
 
 
 def _gateway_loop_exception_handler(
-    loop: "asyncio.AbstractEventLoop", context: Dict[str, Any]
+    loop: "asyncio.AbstractEventLoop", context: dict[str, Any]
 ) -> None:
     """Loop-level safety net for transient network errors.
 
@@ -507,7 +507,7 @@ _ASSISTANT_REPLAY_FIELDS: tuple[str, ...] = (
 )
 
 
-def _build_replay_entry(role: str, content: Any, msg: Dict[str, Any]) -> Dict[str, Any]:
+def _build_replay_entry(role: str, content: Any, msg: dict[str, Any]) -> dict[str, Any]:
     """Build a replay entry for a non-tool-calling message, preserving the
     assistant fields the agent's API builders rely on for multi-turn fidelity.
 
@@ -524,7 +524,7 @@ def _build_replay_entry(role: str, content: Any, msg: Dict[str, Any]) -> Dict[st
     all on the next turn, which can cause HTTP 400 from strict thinking
     providers.
     """
-    entry: Dict[str, Any] = {"role": role, "content": content}
+    entry: dict[str, Any] = {"role": role, "content": content}
     if role == "assistant":
         for _rkey in _ASSISTANT_REPLAY_FIELDS:
             if _rkey not in msg:
@@ -560,10 +560,10 @@ def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool
 
 
 def _build_gateway_agent_history(
-    history: List[Dict[str, Any]],
+    history: list[dict[str, Any]],
     *,
     channel_prompt: Optional[str] = None,
-) -> tuple[List[Dict[str, Any]], Optional[str]]:
+) -> tuple[list[dict[str, Any]], Optional[str]]:
     """Convert stored gateway transcript rows into agent replay messages.
 
     Observed Telegram group rows are returned as API-only context for the
@@ -573,8 +573,8 @@ def _build_gateway_agent_history(
     the current message behind ``history_offset`` during persistence.
     """
 
-    agent_history: List[Dict[str, Any]] = []
-    observed_group_context: List[str] = []
+    agent_history: list[dict[str, Any]] = []
+    observed_group_context: list[str] = []
     separate_observed_context = _uses_telegram_observed_group_context(channel_prompt)
 
     for msg in history or []:
@@ -643,7 +643,7 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
     return message
 
 
-def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
+def _last_transcript_timestamp(history: Optional[list[dict[str, Any]]]) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
     Skips metadata-only rows (``session_meta``, system injections) that are
@@ -1633,7 +1633,7 @@ class GatewayRunner:
 
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
-    _running_agents_ts: Dict[str, float] = {}
+    _running_agents_ts: dict[str, float] = {}
     _busy_input_mode: str = "interrupt"
     _busy_text_mode: str = "interrupt"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
@@ -1644,13 +1644,13 @@ class GatewayRunner:
     _restart_detached: bool = False
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
-    _session_model_overrides: Dict[str, Dict[str, str]] = {}
-    _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+    _session_model_overrides: dict[str, dict[str, str]] = {}
+    _session_reasoning_overrides: dict[str, dict[str, Any]] = {}
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
         self.config = config or load_gateway_config()
-        self.adapters: Dict[Platform, BasePlatformAdapter] = {}
+        self.adapters: dict[Platform, BasePlatformAdapter] = {}
         self._warn_if_docker_media_delivery_is_risky()
         _gateway_runner_ref = _weakref.ref(self)
 
@@ -1690,9 +1690,9 @@ class GatewayRunner:
         
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
-        self._running_agents: Dict[str, Any] = {}
-        self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
-        self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._running_agents: dict[str, Any] = {}
+        self._running_agents_ts: dict[str, float] = {}  # start timestamp per session
+        self._pending_messages: dict[str, str] = {}  # Queued messages during interrupt
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
         # "next-turn" follow-ups where repeated sends collapse into one
@@ -1702,10 +1702,10 @@ class GatewayRunner:
         # are promoted one-at-a-time after each run's drain.  Cleared on
         # /new and /reset.  /model and other mid-session operations
         # preserve the queue.
-        self._queued_events: Dict[str, List[MessageEvent]] = {}
-        self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
-        self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
-        self._session_run_generation: Dict[str, int] = {}
+        self._queued_events: dict[str, list[MessageEvent]] = {}
+        self._pending_native_image_paths_by_session: dict[str, list[str]] = {}
+        self._busy_ack_ts: dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
+        self._session_run_generation: dict[str, int] = {}
         # LRU cache of live SessionSources keyed by session_key. Used by
         # fallback routing paths (shutdown notifications, synthetic
         # background-process events) when the persisted origin is missing
@@ -1730,25 +1730,25 @@ class GatewayRunner:
 
         # Per-session model overrides from /model command.
         # Key: session_key, Value: dict with model/provider/api_key/base_url/api_mode
-        self._session_model_overrides: Dict[str, Dict[str, str]] = {}
+        self._session_model_overrides: dict[str, dict[str, str]] = {}
         # Per-session reasoning effort overrides from /reasoning.
         # Key: session_key, Value: parsed reasoning config dict.
-        self._session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+        self._session_reasoning_overrides: dict[str, dict[str, Any]] = {}
         self._kanban_notifier_profile = self._active_profile_name()
         # Teams meeting pipeline runtime (bound later when msgraph_webhook adapter exists).
         self._teams_pipeline_runtime = None
         self._teams_pipeline_runtime_error: Optional[str] = None
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
-        self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+        self._pending_approvals: dict[str, dict[str, Any]] = {}
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
-        self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
+        self._failed_platforms: dict[Platform, dict[str, Any]] = {}
 
         # Track pending /update prompt responses per session.
         # Key: session_key, Value: True when a prompt is waiting for user input.
-        self._update_prompt_pending: Dict[str, bool] = {}
+        self._update_prompt_pending: dict[str, bool] = {}
 
         # Slash-confirm state lives in tools.slash_confirm (module-level),
         # so platform adapters can resolve callbacks without a backref to
@@ -1831,11 +1831,11 @@ class GatewayRunner:
         self.hooks = HookRegistry()
 
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
-        self._voice_mode: Dict[str, str] = self._load_voice_modes()
+        self._voice_mode: dict[str, str] = self._load_voice_modes()
         # Recent voice transcripts per (guild,user) for duplicate suppression.
         # Protects against the same utterance being emitted twice by the voice
         # capture / STT pipeline, which otherwise produces a second delayed reply.
-        self._recent_voice_transcripts: Dict[tuple[int, int], List[tuple[float, str]]] = {}
+        self._recent_voice_transcripts: dict[tuple[int, int], list[tuple[float, str]]] = {}
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
@@ -1890,7 +1890,7 @@ class GatewayRunner:
             return
 
         raw_volumes = os.getenv("TERMINAL_DOCKER_VOLUMES", "").strip()
-        volumes: List[str] = []
+        volumes: list[str] = []
         if raw_volumes:
             try:
                 parsed = json.loads(raw_volumes)
@@ -1939,7 +1939,7 @@ class GatewayRunner:
         """Return a platform-namespaced key for voice mode state."""
         return f"{platform.value}:{chat_id}"
 
-    def _load_voice_modes(self) -> Dict[str, str]:
+    def _load_voice_modes(self) -> dict[str, str]:
         try:
             data = json.loads(self._VOICE_MODE_PATH.read_text())
         except (FileNotFoundError, json.JSONDecodeError, OSError):
@@ -2753,7 +2753,7 @@ class GatewayRunner:
         return True
 
     @staticmethod
-    def _load_prefill_messages() -> List[Dict[str, Any]]:
+    def _load_prefill_messages() -> list[dict[str, Any]]:
         """Load ephemeral prefill messages from config or env var.
         
         Checks HERMES_PREFILL_MESSAGES_FILE env var first, then falls back to
@@ -3006,7 +3006,7 @@ class GatewayRunner:
             pass
         return None
 
-    def _snapshot_running_agents(self) -> Dict[str, Any]:
+    def _snapshot_running_agents(self) -> dict[str, Any]:
         return {
             session_key: agent
             for session_key, agent in self._running_agents.items()
@@ -3229,7 +3229,7 @@ class GatewayRunner:
 
         return True
 
-    async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
+    async def _drain_active_agents(self, timeout: float) -> tuple[dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
         last_active_count = self._running_agent_count()
         last_status_at = 0.0
@@ -3416,7 +3416,7 @@ class GatewayRunner:
                     e,
                 )
 
-    def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
+    def _finalize_shutdown_agents(self, active_agents: dict[str, Any]) -> None:
         for agent in active_agents.values():
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
@@ -4351,7 +4351,7 @@ class GatewayRunner:
                 logger.debug("Handoff watcher tick error: %s", exc, exc_info=True)
             await asyncio.sleep(interval)
 
-    async def _process_handoff(self, row: Dict[str, Any]) -> None:
+    async def _process_handoff(self, row: dict[str, Any]) -> None:
         """Execute one handoff row. Raises on failure (caller marks failed)."""
         from gateway.config import Platform
         from gateway.session import SessionSource, build_session_key
@@ -4503,7 +4503,7 @@ class GatewayRunner:
         # Send the agent's reply to the destination. Route to the new
         # thread if we created one; otherwise the configured home channel
         # (which may itself carry a thread_id).
-        send_metadata: Dict[str, Any] = {}
+        send_metadata: dict[str, Any] = {}
         if effective_thread_id:
             send_metadata["thread_id"] = effective_thread_id
         try:
@@ -7729,7 +7729,7 @@ class GatewayRunner:
         *,
         event: MessageEvent,
         source: SessionSource,
-        history: List[Dict[str, Any]],
+        history: list[dict[str, Any]],
     ) -> Optional[str]:
         """Prepare inbound event text for the agent.
 
@@ -7961,7 +7961,7 @@ class GatewayRunner:
 
         return message_text
 
-    def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
+    def _consume_pending_native_image_paths(self, session_key: str) -> list[str]:
         pending_native = getattr(self, "_pending_native_image_paths_by_session", None)
         if not pending_native:
             return []
@@ -11305,7 +11305,7 @@ class GatewayRunner:
                     thread_meta["notify"] = True
                 else:
                     thread_meta = {"notify": True}
-                send_kwargs: Dict[str, Any] = {
+                send_kwargs: dict[str, Any] = {
                     "chat_id": event.source.chat_id,
                     "audio_path": actual_path,
                     "reply_to": reply_anchor,
@@ -11537,8 +11537,8 @@ class GatewayRunner:
         source: "SessionSource",
         task_id: str,
         event_message_id: Optional[str] = None,
-        media_urls: Optional[List[str]] = None,
-        media_types: Optional[List[str]] = None,
+        media_urls: Optional[list[str]] = None,
+        media_types: Optional[list[str]] = None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
@@ -13542,7 +13542,7 @@ class GatewayRunner:
         # Text fallback — return the prompt message as the direct reply.
         return message
 
-    def _read_user_config(self) -> Dict[str, Any]:
+    def _read_user_config(self) -> dict[str, Any]:
         """Read the user's raw config.yaml (cached) for gate lookups.
 
         Used by slash-confirm gates that must reflect on-disk state changes
@@ -13559,12 +13559,12 @@ class GatewayRunner:
         self,
         source,
         reply_to_message_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
         thread_id = getattr(source, "thread_id", None)
         if thread_id is None:
             return None
-        metadata: Dict[str, Any] = {"thread_id": thread_id}
+        metadata: dict[str, Any] = {"thread_id": thread_id}
         if (
             getattr(source, "platform", None) == Platform.TELEGRAM
             and getattr(source, "chat_type", None) == "dm"
@@ -14386,7 +14386,7 @@ class GatewayRunner:
     async def _enrich_message_with_vision(
         self,
         user_text: str,
-        image_paths: List[str],
+        image_paths: list[str],
     ) -> str:
         """
         Auto-analyze user-attached images with the vision tool and prepend
@@ -14455,7 +14455,7 @@ class GatewayRunner:
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
-        audio_paths: List[str],
+        audio_paths: list[str],
     ) -> str:
         """
         Auto-transcribe user voice/audio messages using the configured STT provider
@@ -14857,7 +14857,7 @@ class GatewayRunner:
         schemas at construction time, so a registry generation change must
         rebuild the agent before the next turn.
         """
-        out: Dict[str, Any] = {}
+        out: dict[str, Any] = {}
         cfg = user_config if isinstance(user_config, dict) else {}
         for section, key in cls._CACHE_BUSTING_CONFIG_KEYS:
             section_val = cfg.get(section)
@@ -15205,7 +15205,7 @@ class GatewayRunner:
         # temporarily over cap; it will re-check on the next insert,
         # after active turns have finished.
         excess = max(0, len(_cache) - _AGENT_CACHE_MAX_SIZE)
-        evict_plan: List[tuple] = []  # [(key, agent), ...]
+        evict_plan: list[tuple] = []  # [(key, agent), ...]
         if excess > 0:
             ordered_keys = list(_cache.keys())
             for key in ordered_keys[:excess]:
@@ -15255,7 +15255,7 @@ class GatewayRunner:
         if _cache is None or _lock is None:
             return 0
         now = time.time()
-        to_evict: List[tuple] = []
+        to_evict: list[tuple] = []
         running_ids = {
             id(a)
             for a in getattr(self, "_running_agents", {}).values()
@@ -15311,13 +15311,13 @@ class GatewayRunner:
         self,
         message: str,
         context_prompt: str,
-        history: List[Dict[str, Any]],
+        history: list[dict[str, Any]],
         source: "SessionSource",
         session_id: str,
         session_key: str = None,
         run_generation: Optional[int] = None,
         event_message_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
 
@@ -15367,7 +15367,7 @@ class GatewayRunner:
         # We always include the current message.  For history, send a
         # compact version (text-only user/assistant turns) — the remote
         # handles tool replay and system prompts.
-        api_messages: List[Dict[str, str]] = []
+        api_messages: list[dict[str, str]] = []
 
         if context_prompt:
             api_messages.append({"role": "system", "content": context_prompt})
@@ -15381,7 +15381,7 @@ class GatewayRunner:
         api_messages.append({"role": "user", "content": message})
 
         # HTTP headers ---------------------------------------------------
-        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        headers: dict[str, str] = {"Content-Type": "application/json"}
         if proxy_key:
             headers["Authorization"] = f"Bearer {proxy_key}"
         if session_id:
@@ -15412,7 +15412,7 @@ class GatewayRunner:
             else bool(_plat_streaming)
         )
 
-        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        _thread_metadata: Optional[dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
 
         if _streaming_enabled:
             try:
@@ -15597,7 +15597,7 @@ class GatewayRunner:
         self,
         message: str,
         context_prompt: str,
-        history: List[Dict[str, Any]],
+        history: list[dict[str, Any]],
         source: SessionSource,
         session_id: str,
         session_key: str = None,
@@ -15605,7 +15605,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Run the agent with the given message and context.
         
@@ -15724,7 +15724,7 @@ class GatewayRunner:
             # Adapter doesn't support deletion — silently disable.
             _cleanup_progress = False
             _cleanup_adapter = None
-        _cleanup_msg_ids: List[str] = []
+        _cleanup_msg_ids: list[str] = []
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]
@@ -16238,7 +16238,7 @@ class GatewayRunner:
             # sent via the reply API with reply_in_thread=true. Status/interim,
             # approval, and stream-consumer paths usually only receive metadata,
             # so carry the triggering message id as a Feishu-specific fallback.
-            _status_thread_metadata: Optional[Dict[str, Any]] = {
+            _status_thread_metadata: Optional[dict[str, Any]] = {
                 "thread_id": _progress_thread_id,
                 "reply_to_message_id": event_message_id,
             }

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -113,7 +113,7 @@ class SessionSource:
         
         return ", ".join(parts)
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = {
             "platform": self.platform.value,
             "chat_id": self.chat_id,
@@ -137,7 +137,7 @@ class SessionSource:
         return d
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SessionSource":
+    def from_dict(cls, data: dict[str, Any]) -> "SessionSource":
         return cls(
             platform=Platform(data["platform"]),
             chat_id=str(data["chat_id"]),
@@ -167,8 +167,8 @@ class SessionContext:
     - Where it can deliver scheduled task outputs
     """
     source: SessionSource
-    connected_platforms: List[Platform]
-    home_channels: Dict[Platform, HomeChannel]
+    connected_platforms: list[Platform]
+    home_channels: dict[Platform, HomeChannel]
     shared_multi_user_session: bool = False
     
     # Session metadata
@@ -177,7 +177,7 @@ class SessionContext:
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "source": self.source.to_dict(),
             "connected_platforms": [p.value for p in self.connected_platforms],
@@ -491,7 +491,7 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         result = {
             "session_key": self.session_key,
             "session_id": self.session_id,
@@ -527,7 +527,7 @@ class SessionEntry:
         return result
     
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SessionEntry":
+    def from_dict(cls, data: dict[str, Any]) -> "SessionEntry":
         origin = None
         if "origin" in data and data["origin"]:
             origin = SessionSource.from_dict(data["origin"])
@@ -677,7 +677,7 @@ class SessionStore:
                  has_active_processes_fn=None):
         self.sessions_dir = sessions_dir
         self.config = config
-        self._entries: Dict[str, SessionEntry] = {}
+        self._entries: dict[str, SessionEntry] = {}
         self._loaded = False
         self._lock = threading.Lock()
         self._has_active_processes_fn = has_active_processes_fn
@@ -1234,7 +1234,7 @@ class SessionStore:
 
         return new_entry
 
-    def list_sessions(self, active_minutes: Optional[int] = None) -> List[SessionEntry]:
+    def list_sessions(self, active_minutes: Optional[int] = None) -> list[SessionEntry]:
         """List all sessions, optionally filtered by activity."""
         with self._lock:
             self._ensure_loaded_locked()
@@ -1248,7 +1248,7 @@ class SessionStore:
 
         return entries
     
-    def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
+    def append_to_transcript(self, session_id: str, message: dict[str, Any], skip_db: bool = False) -> None:
         """Append a message to a session's transcript (SQLite).
 
         Args:
@@ -1282,7 +1282,7 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
     
-    def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+    def rewrite_transcript(self, session_id: str, messages: list[dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.
 
         Used by /retry, /undo, and /compress to persist modified conversation
@@ -1294,7 +1294,7 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
 
-    def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
+    def load_transcript(self, session_id: str) -> list[dict[str, Any]]:
         """Load all messages from a session's transcript.
 
         state.db is the canonical store. The legacy JSONL fallback was removed

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
-_SIGNAL_NAME_BY_NUM: Dict[int, str] = {}
+_SIGNAL_NAME_BY_NUM: dict[int, str] = {}
 for _name in ("SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT", "SIGUSR1", "SIGUSR2"):
     _val = getattr(signal, _name, None)
     if _val is not None:
@@ -70,12 +70,12 @@ def _read_proc_cmdline(pid: int) -> Optional[str]:
     return data.replace(b"\x00", b" ").decode("utf-8", errors="replace").strip()
 
 
-def _proc_summary(pid: int) -> Dict[str, Any]:
+def _proc_summary(pid: int) -> dict[str, Any]:
     """Compact /proc/<pid> snapshot: pid, ppid, state, uid, cmdline.
 
     Best-effort.  Missing fields are simply omitted rather than raising.
     """
-    summary: Dict[str, Any] = {"pid": pid}
+    summary: dict[str, Any] = {"pid": pid}
     if pid <= 0:
         return summary
     name = _read_proc_field(pid, "Name")
@@ -101,7 +101,7 @@ def _proc_summary(pid: int) -> Dict[str, Any]:
     return summary
 
 
-def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
+def snapshot_shutdown_context(received_signal: Any = None) -> dict[str, Any]:
     """Fast (<10ms) snapshot of who/what is asking us to shut down.
 
     Captures:
@@ -120,7 +120,7 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     pid = os.getpid()
     ppid = os.getppid()
 
-    ctx: Dict[str, Any] = {
+    ctx: dict[str, Any] = {
         "ts": now,
         "ts_monotonic": monotonic,
         "signal": _signal_name(received_signal),
@@ -278,7 +278,7 @@ def spawn_async_diagnostic(
     return proc.pid
 
 
-def format_context_for_log(ctx: Dict[str, Any]) -> str:
+def format_context_for_log(ctx: dict[str, Any]) -> str:
     """Render a shutdown context dict as a single, scannable log line."""
     sig = ctx.get("signal", "?")
     parent = ctx.get("parent") or {}
@@ -288,7 +288,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     under_systemd = "yes" if ctx.get("under_systemd") else "no"
     load = ctx.get("loadavg_1m")
     load_str = f"{load:.2f}" if isinstance(load, (int, float)) else "?"
-    extras: List[str] = []
+    extras: list[str] = []
     if ctx.get("takeover_marker") is not None:
         for_self = ctx.get("takeover_marker_for_self")
         extras.append(
@@ -311,7 +311,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     )
 
 
-def context_as_json(ctx: Dict[str, Any]) -> str:
+def context_as_json(ctx: dict[str, Any]) -> str:
     """JSON-serialise a context dict for structured ingestion.  Never raises."""
     try:
         return json.dumps(ctx, default=str, sort_keys=True)
@@ -319,7 +319,7 @@ def context_as_json(ctx: Dict[str, Any]) -> str:
         return "{}"
 
 
-def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, Any]]:
+def check_systemd_timing_alignment(drain_timeout: float) -> Optional[dict[str, Any]]:
     """At startup, sanity-check that systemd's TimeoutStopSec >= drain_timeout.
 
     When the gateway is run under a stale systemd unit file (e.g. the user

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -47,7 +47,7 @@ from typing import Any, FrozenSet, Iterable, Optional, Tuple
 # their own ``user_allowed_commands`` (this set is only the implicit
 # fallback floor — anything in ``user_allowed_commands`` overrides it
 # additively, never restrictively).
-_ALWAYS_ALLOWED_FOR_USERS: FrozenSet[str] = frozenset({
+_ALWAYS_ALLOWED_FOR_USERS: frozenset[str] = frozenset({
     "help",
     "whoami",
 })
@@ -63,8 +63,8 @@ class SlashAccessPolicy:
     """
 
     enabled: bool                      # gating active for this scope?
-    admin_user_ids: FrozenSet[str]
-    user_allowed_commands: FrozenSet[str]
+    admin_user_ids: frozenset[str]
+    user_allowed_commands: frozenset[str]
 
     def is_admin(self, user_id: Optional[str]) -> bool:
         if not self.enabled:
@@ -91,7 +91,7 @@ class SlashAccessPolicy:
 _DM_CHAT_TYPES = frozenset({"dm", "direct", "private", ""})
 
 
-def _coerce_id_list(raw: Any) -> FrozenSet[str]:
+def _coerce_id_list(raw: Any) -> frozenset[str]:
     """Normalize a YAML-loaded admin/user list into a frozenset of strings.
 
     Accepts ``None``, list, tuple, or comma-separated string. Stringifies
@@ -114,7 +114,7 @@ def _coerce_id_list(raw: Any) -> FrozenSet[str]:
     return frozenset(out)
 
 
-def _coerce_command_list(raw: Any) -> FrozenSet[str]:
+def _coerce_command_list(raw: Any) -> frozenset[str]:
     """Normalize a slash command allowlist.
 
     Strips leading slashes so YAML can read either ``["help", "status"]``
@@ -160,7 +160,7 @@ def _platform_extra(platform_config: Any) -> dict:
     return {}
 
 
-def _keys_for_scope(scope: str) -> Tuple[str, str]:
+def _keys_for_scope(scope: str) -> tuple[str, str]:
     """Return (admin_key, user_cmd_key) names for a scope."""
     if scope == "group":
         return ("group_allow_admin_from", "group_user_allowed_commands")

--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -67,7 +67,7 @@ def normalize_whatsapp_identifier(value: str) -> str:
     )
 
 
-def expand_whatsapp_aliases(identifier: str) -> Set[str]:
+def expand_whatsapp_aliases(identifier: str) -> set[str]:
     """Resolve WhatsApp phone/LID aliases via bridge session mapping files.
 
     Returns the set of all identifiers transitively reachable through the
@@ -83,7 +83,7 @@ def expand_whatsapp_aliases(identifier: str) -> Set[str]:
         return set()
 
     session_dir = get_hermes_home() / "whatsapp" / "session"
-    resolved: Set[str] = set()
+    resolved: set[str] = set()
     queue = [normalized]
 
     while queue:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -144,7 +144,7 @@ DEFAULT_SPOTIFY_SCOPE = " ".join((
     "user-library-read",
     "user-library-modify",
 ))
-SERVICE_PROVIDER_NAMES: Dict[str, str] = {
+SERVICE_PROVIDER_NAMES: dict[str, str] = {
     "spotify": "Spotify",
 }
 
@@ -173,14 +173,14 @@ class ProviderConfig:
     inference_base_url: str = ""
     client_id: str = ""
     scope: str = ""
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
     # For API-key providers: env vars to check (in priority order)
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
 
 
-PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
+PROVIDER_REGISTRY: dict[str, ProviderConfig] = {
     "nous": ProviderConfig(
         id="nous",
         name="Nous Portal",
@@ -636,7 +636,7 @@ ZAI_ENDPOINTS = [
 ]
 
 
-def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str, str]]:
+def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[dict[str, str]]:
     """Probe z.ai endpoints to find one that accepts this API key.
 
     Returns {"id": ..., "base_url": ..., "model": ..., "label": ...} for the
@@ -788,7 +788,7 @@ def _oauth_trace_enabled() -> bool:
 def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any) -> None:
     if not _oauth_trace_enabled():
         return
-    payload: Dict[str, Any] = {"event": event}
+    payload: dict[str, Any] = {"event": event}
     if sequence_id:
         payload["sequence_id"] = sequence_id
     payload.update(fields)
@@ -852,7 +852,7 @@ def _global_auth_file_path() -> Optional[Path]:
     return global_root / "auth.json"
 
 
-def _load_global_auth_store() -> Dict[str, Any]:
+def _load_global_auth_store() -> dict[str, Any]:
     """Load the global-root auth store (read-only fallback).
 
     Returns an empty dict when no global fallback exists (classic mode,
@@ -986,7 +986,7 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         yield
 
 
-def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
+def _load_auth_store(auth_file: Optional[Path] = None) -> dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
         return {"version": AUTH_STORE_VERSION, "providers": {}}
@@ -1026,7 +1026,7 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
 
-def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
+def _save_auth_store(auth_store: dict[str, Any]) -> Path:
     auth_file = _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
@@ -1075,7 +1075,7 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
     return auth_file
 
 
-def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Optional[Dict[str, Any]]:
+def _load_provider_state(auth_store: dict[str, Any], provider_id: str) -> Optional[dict[str, Any]]:
     providers = auth_store.get("providers")
     if not isinstance(providers, dict):
         return None
@@ -1083,7 +1083,7 @@ def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Option
     return dict(state) if isinstance(state, dict) else None
 
 
-def _save_provider_state(auth_store: Dict[str, Any], provider_id: str, state: Dict[str, Any]) -> None:
+def _save_provider_state(auth_store: dict[str, Any], provider_id: str, state: dict[str, Any]) -> None:
     providers = auth_store.setdefault("providers", {})
     if not isinstance(providers, dict):
         auth_store["providers"] = {}
@@ -1093,9 +1093,9 @@ def _save_provider_state(auth_store: Dict[str, Any], provider_id: str, state: Di
 
 
 def _store_provider_state(
-    auth_store: Dict[str, Any],
+    auth_store: dict[str, Any],
     provider_id: str,
-    state: Dict[str, Any],
+    state: dict[str, Any],
     *,
     set_active: bool = True,
 ) -> None:
@@ -1120,7 +1120,7 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def read_credential_pool(provider_id: Optional[str] = None) -> dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1141,7 +1141,7 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     if not isinstance(pool, dict):
         pool = {}
 
-    global_pool: Dict[str, Any] = {}
+    global_pool: dict[str, Any] = {}
     global_store = _load_global_auth_store()
     maybe_global_pool = global_store.get("credential_pool") if global_store else None
     if isinstance(maybe_global_pool, dict):
@@ -1167,7 +1167,7 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     return list(global_entries) if isinstance(global_entries, list) else []
 
 
-def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Path:
+def write_credential_pool(provider_id: str, entries: list[dict[str, Any]]) -> Path:
     """Persist one provider's credential pool under auth.json."""
     with _auth_store_lock():
         auth_store = _load_auth_store()
@@ -1222,7 +1222,7 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
         return True
 
 
-def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
+def get_provider_auth_state(provider_id: str) -> Optional[dict[str, Any]]:
     """Return persisted auth state for a provider, or None.
 
     In profile mode, falls back to the global-root ``auth.json`` when the
@@ -1569,7 +1569,7 @@ def _optional_base_url(value: Any) -> Optional[str]:
 # (NOUS_INFERENCE_BASE_URL) bypass validation — that's the documented
 # dev/staging escape hatch and the env source is already trusted (the
 # user set it themselves).
-_ALLOWED_NOUS_INFERENCE_HOSTS: FrozenSet[str] = frozenset({
+_ALLOWED_NOUS_INFERENCE_HOSTS: frozenset[str] = frozenset({
     "inference-api.nousresearch.com",
 })
 
@@ -1621,7 +1621,7 @@ def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[st
     return cleaned.rstrip("/")
 
 
-def _decode_jwt_claims(token: Any) -> Dict[str, Any]:
+def _decode_jwt_claims(token: Any) -> dict[str, Any]:
     if not isinstance(token, str) or token.count(".") != 2:
         return {}
     payload = token.split(".")[1]
@@ -1734,12 +1734,12 @@ def _nous_legacy_session_key_reason(
 
 
 def _choose_nous_inference_auth_path(
-    state: Dict[str, Any],
+    state: dict[str, Any],
     *,
     access_token: Any = None,
     min_key_ttl_seconds: int = DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
-) -> Tuple[str, Optional[str]]:
+) -> tuple[str, Optional[str]]:
     inference_auth_mode = _normalize_nous_inference_auth_mode(inference_auth_mode)
     token = state.get("access_token") if access_token is None else access_token
     if (
@@ -1814,7 +1814,7 @@ def _nous_jwt_expires_at(token: Any, fallback_expires_at: Any = None) -> Optiona
 
 
 def _set_nous_agent_key_from_invoke_jwt(
-    state: Dict[str, Any],
+    state: dict[str, Any],
     *,
     obtained_at: Optional[str] = None,
 ) -> None:
@@ -1852,7 +1852,7 @@ def _set_nous_agent_key_from_invoke_jwt(
 
 
 def _select_nous_invoke_jwt(
-    state: Dict[str, Any],
+    state: dict[str, Any],
     *,
     access_token: Any = None,
     sequence_id: Optional[str] = None,
@@ -1875,7 +1875,7 @@ _NOUS_EFFECTIVE_STATE_IGNORED_KEYS = frozenset({
 })
 
 
-def _nous_effective_provider_state(state: Dict[str, Any]) -> Dict[str, Any]:
+def _nous_effective_provider_state(state: dict[str, Any]) -> dict[str, Any]:
     return {
         key: value
         for key, value in state.items()
@@ -1895,7 +1895,7 @@ def _qwen_cli_auth_path() -> Path:
     return Path.home() / ".qwen" / "oauth_creds.json"
 
 
-def _read_qwen_cli_tokens() -> Dict[str, Any]:
+def _read_qwen_cli_tokens() -> dict[str, Any]:
     auth_path = _qwen_cli_auth_path()
     if not auth_path.exists():
         raise AuthError(
@@ -1920,7 +1920,7 @@ def _read_qwen_cli_tokens() -> Dict[str, Any]:
     return data
 
 
-def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
+def _save_qwen_cli_tokens(tokens: dict[str, Any]) -> Path:
     auth_path = _qwen_cli_auth_path()
     auth_path.parent.mkdir(parents=True, exist_ok=True)
     # secure_parent_dir refuses to chmod / or top-level dirs (#25821).
@@ -1959,7 +1959,7 @@ def _qwen_access_token_is_expiring(expiry_date_ms: Any, skew_seconds: int = QWEN
     return (time.time() + max(0, int(skew_seconds))) * 1000 >= expiry_ms
 
 
-def _refresh_qwen_cli_tokens(tokens: Dict[str, Any], timeout_seconds: float = 20.0) -> Dict[str, Any]:
+def _refresh_qwen_cli_tokens(tokens: dict[str, Any], timeout_seconds: float = 20.0) -> dict[str, Any]:
     refresh_token = str(tokens.get("refresh_token", "") or "").strip()
     if not refresh_token:
         raise AuthError(
@@ -2036,7 +2036,7 @@ def resolve_qwen_runtime_credentials(
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     tokens = _read_qwen_cli_tokens()
     access_token = str(tokens.get("access_token", "") or "").strip()
     should_refresh = bool(force_refresh)
@@ -2063,7 +2063,7 @@ def resolve_qwen_runtime_credentials(
     }
 
 
-def get_qwen_auth_status() -> Dict[str, Any]:
+def get_qwen_auth_status() -> dict[str, Any]:
     auth_path = _qwen_cli_auth_path()
     try:
         # Validate the runtime credentials, including refresh when the cached
@@ -2097,7 +2097,7 @@ def get_qwen_auth_status() -> Dict[str, Any]:
 def resolve_gemini_oauth_runtime_credentials(
     *,
     force_refresh: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Resolve runtime OAuth creds for google-gemini-cli."""
     try:
         from agent.google_oauth import (
@@ -2136,7 +2136,7 @@ def resolve_gemini_oauth_runtime_credentials(
     }
 
 
-def get_gemini_oauth_auth_status() -> Dict[str, Any]:
+def get_gemini_oauth_auth_status() -> dict[str, Any]:
     """Return a status dict for `hermes auth list` / `hermes status`."""
     try:
         from agent.google_oauth import _credentials_path, load_credentials
@@ -2163,11 +2163,11 @@ def get_gemini_oauth_auth_status() -> Dict[str, Any]:
 # =============================================================================
 
 
-def _spotify_scope_list(raw_scope: Optional[str] = None) -> List[str]:
+def _spotify_scope_list(raw_scope: Optional[str] = None) -> list[str]:
     scope_text = (raw_scope or DEFAULT_SPOTIFY_SCOPE).strip()
     scopes = [part for part in scope_text.split() if part]
     seen: set[str] = set()
-    ordered: List[str] = []
+    ordered: list[str] = []
     for scope in scopes:
         if scope not in seen:
             seen.add(scope)
@@ -2181,7 +2181,7 @@ def _spotify_scope_string(raw_scope: Optional[str] = None) -> str:
 
 def _spotify_client_id(
     explicit: Optional[str] = None,
-    state: Optional[Dict[str, Any]] = None,
+    state: Optional[dict[str, Any]] = None,
 ) -> str:
     from hermes_cli.config import get_env_value
 
@@ -2204,7 +2204,7 @@ def _spotify_client_id(
 
 def _spotify_redirect_uri(
     explicit: Optional[str] = None,
-    state: Optional[Dict[str, Any]] = None,
+    state: Optional[dict[str, Any]] = None,
 ) -> str:
     from hermes_cli.config import get_env_value
 
@@ -2222,7 +2222,7 @@ def _spotify_redirect_uri(
     return DEFAULT_SPOTIFY_REDIRECT_URI
 
 
-def _spotify_api_base_url(state: Optional[Dict[str, Any]] = None) -> str:
+def _spotify_api_base_url(state: Optional[dict[str, Any]] = None) -> str:
     from hermes_cli.config import get_env_value
 
     candidates = (
@@ -2237,7 +2237,7 @@ def _spotify_api_base_url(state: Optional[Dict[str, Any]] = None) -> str:
     return DEFAULT_SPOTIFY_API_BASE_URL
 
 
-def _spotify_accounts_base_url(state: Optional[Dict[str, Any]] = None) -> str:
+def _spotify_accounts_base_url(state: Optional[dict[str, Any]] = None) -> str:
     from hermes_cli.config import get_env_value
 
     candidates = (
@@ -2582,15 +2582,15 @@ def _xai_wait_for_callback(
 
 
 def _spotify_token_payload_to_state(
-    token_payload: Dict[str, Any],
+    token_payload: dict[str, Any],
     *,
     client_id: str,
     redirect_uri: str,
     requested_scope: str,
     accounts_base_url: str,
     api_base_url: str,
-    previous_state: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    previous_state: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     now = datetime.now(timezone.utc)
     expires_in = _coerce_ttl_seconds(token_payload.get("expires_in", 0))
     expires_at = datetime.fromtimestamp(now.timestamp() + expires_in, tz=timezone.utc)
@@ -2625,7 +2625,7 @@ def _spotify_exchange_code_for_tokens(
     code_verifier: str,
     accounts_base_url: str,
     timeout_seconds: float = 20.0,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     try:
         response = httpx.post(
             f"{accounts_base_url}/api/token",
@@ -2665,10 +2665,10 @@ def _spotify_exchange_code_for_tokens(
 
 
 def _refresh_spotify_oauth_state(
-    state: Dict[str, Any],
+    state: dict[str, Any],
     *,
     timeout_seconds: float = 20.0,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     refresh_token = str(state.get("refresh_token", "") or "").strip()
     if not refresh_token:
         raise AuthError(
@@ -2733,7 +2733,7 @@ def resolve_spotify_runtime_credentials(
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = SPOTIFY_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     with _auth_store_lock():
         auth_store = _load_auth_store()
         state = _load_provider_state(auth_store, "spotify")
@@ -2776,7 +2776,7 @@ def resolve_spotify_runtime_credentials(
     }
 
 
-def get_spotify_auth_status() -> Dict[str, Any]:
+def get_spotify_auth_status() -> dict[str, Any]:
     state = get_provider_auth_state("spotify")
     if not state:
         return {"logged_in": False}
@@ -3127,7 +3127,7 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
-def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+def _read_codex_tokens(*, _lock: bool = True) -> dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
     
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
@@ -3176,7 +3176,7 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     }
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
+def _save_codex_tokens(tokens: dict[str, str], last_refresh: str = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -3195,7 +3195,7 @@ def refresh_codex_oauth_pure(
     refresh_token: str,
     *,
     timeout_seconds: float = 20.0,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Refresh Codex OAuth tokens without mutating Hermes auth state."""
     del access_token  # Access token is only used by callers to decide whether to refresh.
     if not isinstance(refresh_token, str) or not refresh_token.strip():
@@ -3295,9 +3295,9 @@ def refresh_codex_oauth_pure(
 
 
 def _refresh_codex_auth_tokens(
-    tokens: Dict[str, str],
+    tokens: dict[str, str],
     timeout_seconds: float,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Refresh Codex access token using the refresh token.
     
     Saves the new tokens to Hermes auth store automatically.
@@ -3315,7 +3315,7 @@ def _refresh_codex_auth_tokens(
     return updated_tokens
 
 
-def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
+def _import_codex_cli_tokens() -> Optional[dict[str, str]]:
     """Try to read tokens from ~/.codex/auth.json (Codex CLI shared file).
     
     Returns tokens dict if valid and not expired, None otherwise.
@@ -3354,7 +3354,7 @@ def resolve_codex_runtime_credentials(
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Resolve runtime credentials from Hermes's own Codex token store."""
     data = _read_codex_tokens()
     tokens = dict(data["tokens"])
@@ -3398,7 +3398,7 @@ def resolve_codex_runtime_credentials(
 # xAI Grok OAuth — tokens stored in ~/.hermes/auth.json
 # =============================================================================
 
-def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+def _read_xai_oauth_tokens(*, _lock: bool = True) -> dict[str, Any]:
     if _lock:
         with _auth_store_lock():
             auth_store = _load_auth_store()
@@ -3445,9 +3445,9 @@ def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
 
 
 def _save_xai_oauth_tokens(
-    tokens: Dict[str, Any],
+    tokens: dict[str, Any],
     *,
-    discovery: Optional[Dict[str, Any]] = None,
+    discovery: Optional[dict[str, Any]] = None,
     redirect_uri: str = "",
     last_refresh: Optional[str] = None,
 ) -> None:
@@ -3582,7 +3582,7 @@ def _xai_validate_inference_base_url(value: str, *, fallback: str) -> str:
     return candidate
 
 
-def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:
+def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> dict[str, str]:
     try:
         response = httpx.get(
             XAI_OAUTH_DISCOVERY_URL,
@@ -3637,7 +3637,7 @@ def refresh_xai_oauth_pure(
     *,
     token_endpoint: str = "",
     timeout_seconds: float = 20.0,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     del access_token
     if not isinstance(refresh_token, str) or not refresh_token.strip():
         raise AuthError(
@@ -3730,12 +3730,12 @@ def refresh_xai_oauth_pure(
 
 
 def _refresh_xai_oauth_tokens(
-    tokens: Dict[str, Any],
+    tokens: dict[str, Any],
     *,
     token_endpoint: str,
     redirect_uri: str = "",
     timeout_seconds: float,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     refreshed = refresh_xai_oauth_pure(
         str(tokens.get("access_token", "") or ""),
         str(tokens.get("refresh_token", "") or ""),
@@ -3765,7 +3765,7 @@ def resolve_xai_oauth_runtime_credentials(
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: int = XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     data = _read_xai_oauth_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
@@ -3868,7 +3868,7 @@ def _resolve_verify(
     *,
     insecure: Optional[bool] = None,
     ca_bundle: Optional[str] = None,
-    auth_state: Optional[Dict[str, Any]] = None,
+    auth_state: Optional[dict[str, Any]] = None,
 ) -> bool | ssl.SSLContext:
     tls_state = auth_state.get("tls") if isinstance(auth_state, dict) else {}
     tls_state = tls_state if isinstance(tls_state, dict) else {}
@@ -3908,7 +3908,7 @@ def _request_device_code(
     portal_base_url: str,
     client_id: str,
     scope: Optional[str],
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """POST to the device code endpoint. Returns device_code, user_code, etc."""
     response = client.post(
         f"{portal_base_url}/api/oauth/device/code",
@@ -3962,7 +3962,7 @@ def _nous_device_scope_with_env_override(
     requested_scope: Optional[str],
     *,
     default_scope: str = DEFAULT_NOUS_SCOPE,
-) -> Tuple[str, bool]:
+) -> tuple[str, bool]:
     explicit_scope = requested_scope is not None
     scope = requested_scope or default_scope
     if _nous_legacy_session_keys_forced():
@@ -3977,7 +3977,7 @@ def _request_nous_device_code_with_scope_fallback(
     client_id: str,
     scope: str,
     allow_legacy_fallback: bool,
-) -> Tuple[Dict[str, Any], str]:
+) -> tuple[dict[str, Any], str]:
     try:
         return (
             _request_device_code(
@@ -4016,7 +4016,7 @@ def _poll_for_token(
     device_code: str,
     expires_in: int,
     poll_interval: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Poll the token endpoint until the user approves or the code expires."""
     deadline = time.monotonic() + max(1, expires_in)
     current_interval = max(1, min(poll_interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
@@ -4158,7 +4158,7 @@ def _nous_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         yield
 
 
-def _merge_shared_nous_oauth_state(state: Dict[str, Any]) -> bool:
+def _merge_shared_nous_oauth_state(state: dict[str, Any]) -> bool:
     """Copy fresher shared OAuth tokens into a profile-local Nous state."""
     shared = _read_shared_nous_state()
     if not shared:
@@ -4193,7 +4193,7 @@ def _merge_shared_nous_oauth_state(state: Dict[str, Any]) -> bool:
     return True
 
 
-def _write_shared_nous_state(state: Dict[str, Any]) -> None:
+def _write_shared_nous_state(state: dict[str, Any]) -> None:
     """Persist a minimal copy of the Nous OAuth state to the shared store.
 
     Best-effort: any failure is swallowed after logging. The shared store
@@ -4261,7 +4261,7 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
         logger.debug("Failed to write shared Nous auth store: %s", exc)
 
 
-def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
+def _read_shared_nous_state() -> Optional[dict[str, Any]]:
     """Return the shared Nous OAuth state if present and well-formed.
 
     Returns ``None`` when the file is missing, unreadable, malformed, or
@@ -4356,7 +4356,7 @@ def _is_terminal_codex_oauth_refresh_error(exc: Exception) -> bool:
 
 
 def _quarantine_nous_oauth_state(
-    state: Dict[str, Any],
+    state: dict[str, Any],
     error: AuthError,
     *,
     reason: str,
@@ -4389,7 +4389,7 @@ def _quarantine_nous_oauth_state(
 
 
 def _quarantine_nous_pool_entries(
-    auth_store: Dict[str, Any],
+    auth_store: dict[str, Any],
     error: AuthError,
     *,
     reason: str,
@@ -4425,7 +4425,7 @@ def _try_import_shared_nous_state(
     *,
     timeout_seconds: float = 15.0,
     min_key_ttl_seconds: int = 5 * 60,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     """Attempt to rehydrate Nous OAuth state from the shared store.
 
     Reads the shared file (if present), runs a forced refresh+mint using
@@ -4447,7 +4447,7 @@ def _try_import_shared_nous_state(
             # Build a full state dict so refresh_nous_oauth_from_state has every
             # field it needs. force_refresh=True gets us a fresh access_token
             # for this profile; fresh auth mode avoids stale cached legacy keys.
-            state: Dict[str, Any] = {
+            state: dict[str, Any] = {
                 "access_token": shared.get("access_token"),
                 "refresh_token": shared.get("refresh_token"),
                 "client_id": shared.get("client_id") or DEFAULT_NOUS_CLIENT_ID,
@@ -4462,7 +4462,7 @@ def _try_import_shared_nous_state(
                 "tls": {"insecure": False, "ca_bundle": None},
             }
 
-            def _persist_shared_refresh(updated_state: Dict[str, Any], _reason: str) -> None:
+            def _persist_shared_refresh(updated_state: dict[str, Any], _reason: str) -> None:
                 _write_shared_nous_state(updated_state)
 
             refreshed = refresh_nous_oauth_from_state(
@@ -4501,7 +4501,7 @@ def _refresh_access_token(
     portal_base_url: str,
     client_id: str,
     refresh_token: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     response = client.post(
         f"{portal_base_url}/api/oauth/token",
         headers={"x-nous-refresh-token": refresh_token},
@@ -4559,7 +4559,7 @@ def _mint_agent_key(
     portal_base_url: str,
     access_token: str,
     min_ttl_seconds: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Mint (or reuse) a short-lived inference API key."""
     response = client.post(
         f"{portal_base_url}/api/oauth/agent-key",
@@ -4592,7 +4592,7 @@ def fetch_nous_models(
     api_key: str,
     timeout_seconds: float = 15.0,
     verify: bool | str = True,
-) -> List[str]:
+) -> list[str]:
     """Fetch available model IDs from the Nous inference API."""
     timeout = httpx.Timeout(timeout_seconds)
     with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
@@ -4615,7 +4615,7 @@ def fetch_nous_models(
     if not isinstance(data, list):
         return []
 
-    model_ids: List[str] = []
+    model_ids: list[str] = []
     for item in data:
         if not isinstance(item, dict):
             continue
@@ -4643,7 +4643,7 @@ def fetch_nous_models(
     return list(dict.fromkeys(model_ids))
 
 
-def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
+def _agent_key_is_usable(state: dict[str, Any], min_ttl_seconds: int) -> bool:
     key = state.get("agent_key")
     if not isinstance(key, str) or not key.strip():
         return False
@@ -4782,8 +4782,8 @@ def refresh_nous_oauth_pure(
     ca_bundle: Optional[str] = None,
     force_refresh: bool = False,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
-    on_state_update: Optional[Callable[[Dict[str, Any], str], None]] = None,
-) -> Dict[str, Any]:
+    on_state_update: Optional[Callable[[dict[str, Any], str], None]] = None,
+) -> dict[str, Any]:
     """Refresh Nous OAuth state without mutating auth.json directly.
 
     ``on_state_update`` is called after a successful access-token refresh and
@@ -4791,7 +4791,7 @@ def refresh_nous_oauth_pure(
     use it to save the newly rotated refresh token before later work can fail.
     """
     inference_auth_mode = _normalize_nous_inference_auth_mode(inference_auth_mode)
-    state: Dict[str, Any] = {
+    state: dict[str, Any] = {
         "access_token": access_token,
         "refresh_token": refresh_token,
         "client_id": client_id or DEFAULT_NOUS_CLIENT_ID,
@@ -4885,14 +4885,14 @@ def refresh_nous_oauth_pure(
 
 
 def refresh_nous_oauth_from_state(
-    state: Dict[str, Any],
+    state: dict[str, Any],
     *,
     min_key_ttl_seconds: int = DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,
     timeout_seconds: float = 15.0,
     force_refresh: bool = False,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
-    on_state_update: Optional[Callable[[Dict[str, Any], str], None]] = None,
-) -> Dict[str, Any]:
+    on_state_update: Optional[Callable[[dict[str, Any], str], None]] = None,
+) -> dict[str, Any]:
     """Refresh Nous OAuth from a state dict. Thin wrapper around refresh_nous_oauth_pure."""
     tls = state.get("tls") or {}
     return refresh_nous_oauth_pure(
@@ -4918,7 +4918,7 @@ def refresh_nous_oauth_from_state(
 
 
 def persist_nous_credentials(
-    creds: Dict[str, Any],
+    creds: dict[str, Any],
     *,
     label: Optional[str] = None,
 ):
@@ -4993,7 +4993,7 @@ def resolve_nous_runtime_credentials(
     insecure: Optional[bool] = None,
     ca_bundle: Optional[str] = None,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Resolve Nous inference credentials for runtime use.
 
@@ -5179,7 +5179,7 @@ def resolve_nous_runtime_credentials(
             # path stores the NAS invoke JWT there; legacy path mints/reuses
             # the opaque session key.
             used_cached_key = False
-            mint_payload: Optional[Dict[str, Any]] = None
+            mint_payload: Optional[dict[str, Any]] = None
             selected_auth_path, fallback_reason = _choose_nous_inference_auth_path(
                 state,
                 access_token=access_token,
@@ -5374,7 +5374,7 @@ def resolve_nous_runtime_credentials(
 # Status helpers
 # =============================================================================
 
-def _empty_nous_auth_status() -> Dict[str, Any]:
+def _empty_nous_auth_status() -> dict[str, Any]:
     return {
         "logged_in": False,
         "portal_base_url": None,
@@ -5385,7 +5385,7 @@ def _empty_nous_auth_status() -> Dict[str, Any]:
     }
 
 
-def _snapshot_nous_pool_status() -> Dict[str, Any]:
+def _snapshot_nous_pool_status() -> dict[str, Any]:
     """Best-effort status from the credential pool.
 
     This is a fallback only. The auth-store provider state is the runtime source
@@ -5442,7 +5442,7 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # single-use refresh tokens. Cache the snapshot for a few seconds, keyed on the auth.json
 # mtime so that `hermes auth login/logout/add/remove` invalidate naturally on the next call.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
-_nous_auth_status_cache: Optional[Tuple[float, Optional[float], Dict[str, Any]]] = None
+_nous_auth_status_cache: Optional[tuple[float, Optional[float], dict[str, Any]]] = None
 
 
 def _auth_file_mtime() -> Optional[float]:
@@ -5466,7 +5466,7 @@ def invalidate_nous_auth_status_cache() -> None:
     _nous_auth_status_cache = None
 
 
-def get_nous_auth_status() -> Dict[str, Any]:
+def get_nous_auth_status() -> dict[str, Any]:
     """Status snapshot for Nous auth.
 
     Prefer the auth-store provider state, because that is the live source of
@@ -5498,7 +5498,7 @@ def get_nous_auth_status() -> Dict[str, Any]:
     return status
 
 
-def _compute_nous_auth_status() -> Dict[str, Any]:
+def _compute_nous_auth_status() -> dict[str, Any]:
     """Uncached implementation of get_nous_auth_status(). See that function."""
     state = get_provider_auth_state("nous")
     if state:
@@ -5544,7 +5544,7 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
     return _snapshot_nous_pool_status()
 
 
-def get_codex_auth_status() -> Dict[str, Any]:
+def get_codex_auth_status() -> dict[str, Any]:
     """Status snapshot for Codex auth.
     
     Checks the credential pool first (where `hermes auth` stores credentials),
@@ -5593,7 +5593,7 @@ def get_codex_auth_status() -> Dict[str, Any]:
         }
 
 
-def get_xai_oauth_auth_status() -> Dict[str, Any]:
+def get_xai_oauth_auth_status() -> dict[str, Any]:
     try:
         from agent.credential_pool import load_pool
 
@@ -5635,7 +5635,7 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
         }
 
 
-def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
+def get_api_key_provider_status(provider_id: str) -> dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "api_key":
@@ -5666,7 +5666,7 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
-def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
+def get_external_process_provider_status(provider_id: str) -> dict[str, Any]:
     """Status snapshot for providers that run a local subprocess."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
@@ -5696,7 +5696,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
-def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def get_auth_status(provider_id: Optional[str] = None) -> dict[str, Any]:
     """Generic auth status dispatcher."""
     target = (provider_id or get_active_provider() or "").strip().lower()
     if not target:
@@ -5733,7 +5733,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     return {"logged_in": False}
 
 
-def _get_azure_foundry_auth_status() -> Dict[str, Any]:
+def _get_azure_foundry_auth_status() -> dict[str, Any]:
     """Return structural auth status for Azure Foundry.
 
     ``logged_in`` is structural, matching other non-OAuth provider status
@@ -5748,7 +5748,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     Never invokes the Entra credential chain — keeps CLI startup latency
     flat regardless of token-service / az login state.
     """
-    info: Dict[str, Any] = {"provider": "azure-foundry"}
+    info: dict[str, Any] = {"provider": "azure-foundry"}
     try:
         from hermes_cli.config import load_config, get_env_value
         cfg = load_config()
@@ -5810,7 +5810,7 @@ def _get_azure_foundry_auth_status() -> Dict[str, Any]:
     return info
 
 
-def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
+def resolve_api_key_provider_credentials(provider_id: str) -> dict[str, Any]:
     """Resolve API key and base URL for an API-key provider.
 
     Returns dict with: provider, api_key, base_url, source.
@@ -5855,7 +5855,7 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     }
 
 
-def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str, Any]:
+def resolve_external_process_provider_credentials(provider_id: str) -> dict[str, Any]:
     """Resolve runtime details for local subprocess-backed providers."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
@@ -6033,10 +6033,10 @@ def _reset_config_provider() -> Path:
 
 
 def _prompt_model_selection(
-    model_ids: List[str],
+    model_ids: list[str],
     current_model: str = "",
-    pricing: Optional[Dict[str, Dict[str, str]]] = None,
-    unavailable_models: Optional[List[str]] = None,
+    pricing: Optional[dict[str, dict[str, str]]] = None,
+    unavailable_models: Optional[list[str]] = None,
     portal_url: str = "",
 ) -> Optional[str]:
     """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
@@ -6404,7 +6404,7 @@ def _xai_oauth_exchange_code_for_tokens(
     code_verifier: str,
     code_challenge: str,
     timeout_seconds: float = 20.0,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """POST the authorization code to xAI's token endpoint and return
     the parsed JSON payload.
 
@@ -6521,7 +6521,7 @@ def _xai_oauth_loopback_login(
     timeout_seconds: float = 20.0,
     open_browser: bool = True,
     manual_paste: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Run the xAI OAuth PKCE flow.
 
     When ``manual_paste=True`` the loopback HTTP listener is skipped
@@ -6678,7 +6678,7 @@ def _xai_oauth_loopback_login(
     }
 
 
-def _codex_device_code_login() -> Dict[str, Any]:
+def _codex_device_code_login() -> dict[str, Any]:
     """Run the OpenAI device code login flow and return credentials dict."""
     import time as _time
 
@@ -6839,7 +6839,7 @@ def _minimax_pkce_pair() -> tuple:
 def _minimax_request_user_code(
     client: httpx.Client, *, portal_base_url: str, client_id: str,
     code_challenge: str, state: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     response = client.post(
         f"{portal_base_url}/oauth/code",
         data={
@@ -6893,7 +6893,7 @@ def _minimax_resolve_token_expiry_unix(expired_in: int, *, now: datetime) -> flo
 def _minimax_poll_token(
     client: httpx.Client, *, portal_base_url: str, client_id: str,
     user_code: str, code_verifier: str, expired_in: int, interval_ms: Optional[int],
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     # OpenClaw treats expired_in as a unix-ms timestamp (Date.now() < expireTimeMs).
     # Defensive parsing: if it's small enough to be a duration, treat as seconds.
     import time as _time
@@ -6953,7 +6953,7 @@ def _minimax_poll_token(
     )
 
 
-def _minimax_save_auth_state(auth_state: Dict[str, Any]) -> None:
+def _minimax_save_auth_state(auth_state: dict[str, Any]) -> None:
     """Persist MiniMax OAuth state to Hermes auth store (~/.hermes/auth.json)."""
     with _auth_store_lock():
         auth_store = _load_auth_store()
@@ -6964,7 +6964,7 @@ def _minimax_save_auth_state(auth_state: Dict[str, Any]) -> None:
 def _minimax_oauth_login(
     *, region: str = "global", open_browser: bool = True,
     timeout_seconds: float = 15.0,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Run MiniMax OAuth flow, persist tokens, return auth state dict."""
     pconfig = PROVIDER_REGISTRY["minimax-oauth"]
     if region == "cn":
@@ -7045,9 +7045,9 @@ def _minimax_oauth_login(
 
 
 def _refresh_minimax_oauth_state(
-    state: Dict[str, Any], *, timeout_seconds: float = 15.0,
+    state: dict[str, Any], *, timeout_seconds: float = 15.0,
     force: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Refresh MiniMax OAuth access token if close to expiry (or forced)."""
     if not state.get("refresh_token"):
         raise AuthError(
@@ -7110,7 +7110,7 @@ def _refresh_minimax_oauth_state(
     return new_state
 
 
-def _minimax_oauth_quarantine_on_terminal_refresh(state: Dict[str, Any], exc: AuthError) -> None:
+def _minimax_oauth_quarantine_on_terminal_refresh(state: dict[str, Any], exc: AuthError) -> None:
     """Wipe dead tokens from auth.json after a terminal refresh failure.
 
     Shared by both the eager-resolve path and the lazy per-request token
@@ -7185,7 +7185,7 @@ def build_minimax_oauth_token_provider() -> Callable[[], str]:
 def resolve_minimax_oauth_runtime_credentials(
     *, min_token_ttl_seconds: int = MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
     as_token_provider: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Return {provider, api_key, base_url, source} for minimax-oauth.
 
     When ``as_token_provider`` is True, ``api_key`` is a zero-arg callable
@@ -7223,7 +7223,7 @@ def resolve_minimax_oauth_runtime_credentials(
     }
 
 
-def get_minimax_oauth_auth_status() -> Dict[str, Any]:
+def get_minimax_oauth_auth_status() -> dict[str, Any]:
     """Return auth status dict for MiniMax OAuth provider."""
     state = get_provider_auth_state("minimax-oauth")
     if not state or not state.get("access_token"):
@@ -7266,7 +7266,7 @@ def _nous_device_code_login(
     insecure: bool = False,
     ca_bundle: Optional[str] = None,
     min_key_ttl_seconds: int = 5 * 60,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Run the Nous device-code flow and return full OAuth state without persisting."""
     pconfig = PROVIDER_REGISTRY["nous"]
     portal_base_url = (

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -520,7 +520,7 @@ def create_quick_snapshot(
     snap_dir = root / snap_id
     snap_dir.mkdir(parents=True, exist_ok=True)
 
-    manifest: Dict[str, int] = {}  # rel_path -> file size
+    manifest: dict[str, int] = {}  # rel_path -> file size
 
     for rel in _QUICK_STATE_FILES:
         src = home / rel
@@ -586,7 +586,7 @@ def create_quick_snapshot(
 def list_quick_snapshots(
     limit: int = 20,
     hermes_home: Optional[Path] = None,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List existing quick state snapshots, most recent first."""
     root = _quick_snapshot_root(hermes_home)
     if not root.exists():

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -96,7 +96,7 @@ HERMES_CADUCEUS = """[#CD7F32]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⡀⠀⣀⣀�
 # Skills scanning
 # =========================================================================
 
-def get_available_skills() -> Dict[str, List[str]]:
+def get_available_skills() -> dict[str, list[str]]:
     """Return skills grouped by category, filtered by platform and disabled state.
 
     Delegates to ``_find_all_skills()`` from ``tools/skills_tool`` which already
@@ -109,7 +109,7 @@ def get_available_skills() -> Dict[str, List[str]]:
     except Exception:
         return {}
 
-    skills_by_category: Dict[str, List[str]] = {}
+    skills_by_category: dict[str, list[str]] = {}
     for skill in all_skills:
         category = skill.get("category") or "general"
         skills_by_category.setdefault(category, []).append(skill["name"])
@@ -448,8 +448,8 @@ def _display_toolset_name(toolset_name: str) -> str:
 
 
 def build_welcome_banner(console: Console, model: str, cwd: str,
-                         tools: List[dict] = None,
-                         enabled_toolsets: List[str] = None,
+                         tools: list[dict] = None,
+                         enabled_toolsets: list[str] = None,
                          session_id: str = None,
                          get_toolset_for_tool=None,
                          context_length: int = None):
@@ -522,7 +522,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     left_content = "\n".join(left_lines)
 
     right_lines = [f"[bold {accent}]Available Tools[/]"]
-    toolsets_dict: Dict[str, list] = {}
+    toolsets_dict: dict[str, list] = {}
 
     for tool in tools:
         tool_name = tool["function"]["name"]

--- a/hermes_cli/bundles.py
+++ b/hermes_cli/bundles.py
@@ -87,7 +87,7 @@ def _cmd_show(args) -> None:
 def _cmd_create(args) -> None:
     c = _console()
     name = args.name
-    skills: List[str] = list(args.skill or [])
+    skills: list[str] = list(args.skill or [])
     description = args.description or ""
     instruction = args.instruction or ""
     overwrite = bool(args.force)

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -11,7 +11,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CODEX_MODELS: List[str] = [
+DEFAULT_CODEX_MODELS: list[str] = [
     "gpt-5.5",
     "gpt-5.4-mini",
     "gpt-5.4",
@@ -34,7 +34,7 @@ DEFAULT_CODEX_MODELS: List[str] = [
     "gpt-5.1-codex-mini",
 ]
 
-_FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
+_FORWARD_COMPAT_TEMPLATE_MODELS: list[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.5", ("gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex")),
     ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
@@ -47,14 +47,14 @@ _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
 ]
 
 
-def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
+def _add_forward_compat_models(model_ids: list[str]) -> list[str]:
     """Add Clawdbot-style synthetic forward-compat Codex models.
 
     If a newer Codex slug isn't returned by live discovery, surface it when an
     older compatible template model is present. This mirrors Clawdbot's
     synthetic catalog / forward-compat behavior for GPT-5 Codex variants.
     """
-    ordered: List[str] = []
+    ordered: list[str] = []
     seen: set[str] = set()
     for model_id in model_ids:
         if model_id not in seen:
@@ -71,7 +71,7 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
     return ordered
 
 
-def _fetch_models_from_api(access_token: str) -> List[str]:
+def _fetch_models_from_api(access_token: str) -> list[str]:
     """Fetch available models from the Codex API. Returns visible models sorted by priority."""
     try:
         import httpx
@@ -129,7 +129,7 @@ def _read_default_model(codex_home: Path) -> Optional[str]:
     return None
 
 
-def _read_cache_models(codex_home: Path) -> List[str]:
+def _read_cache_models(codex_home: Path) -> list[str]:
     cache_path = codex_home / "models_cache.json"
     if not cache_path.exists():
         return []
@@ -159,14 +159,14 @@ def _read_cache_models(codex_home: Path) -> List[str]:
             sortable.append((rank, slug))
 
     sortable.sort(key=lambda item: (item[0], item[1]))
-    deduped: List[str] = []
+    deduped: list[str] = []
     for _, slug in sortable:
         if slug not in deduped:
             deduped.append(slug)
     return deduped
 
 
-def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
+def get_codex_model_ids(access_token: Optional[str] = None) -> list[str]:
     """Return available Codex model IDs, trying API first, then local sources.
     
     Resolution order: API (live, if token provided) > config.toml default >
@@ -174,7 +174,7 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     """
     codex_home_str = os.getenv("CODEX_HOME", "").strip() or str(Path.home() / ".codex")
     codex_home = Path(codex_home_str).expanduser()
-    ordered: List[str] = []
+    ordered: list[str] = []
 
     # Try live API if we have a token
     if access_token:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -72,7 +72,7 @@ def _warn_config_parse_failure(config_path: Path, exc: Exception) -> None:
 
 _IS_WINDOWS = platform.system() == "Windows"
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-_LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
+_LAST_EXPANDED_CONFIG_BY_PATH: dict[str, Any] = {}
 # (path, mtime_ns, size) -> cached expanded config dict.
 # load_config() returns a deepcopy of the cached value when the file
 # hasn't changed since the last load, skipping yaml.safe_load +
@@ -80,11 +80,11 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # save_config() + migrate_config() write via atomic_yaml_write which
 # produces a fresh inode, so stat() sees a new mtime_ns and the next
 # load repopulates automatically — no explicit invalidation hook.
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+_LOAD_CONFIG_CACHE: dict[str, tuple[int, int, dict[str, Any]]] = {}
 # (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
-_RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+_RAW_CONFIG_CACHE: dict[str, tuple[int, int, dict[str, Any]]] = {}
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit
@@ -1810,7 +1810,7 @@ DEFAULT_CONFIG = {
 
 # Track which env vars were introduced in each config version.
 # Migration only mentions vars new since the user's previous version.
-ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
+ENV_VARS_BY_VERSION: dict[int, list[str]] = {
     3: ["FIRECRAWL_API_KEY", "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID", "FAL_KEY"],
     4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
     5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
@@ -2892,7 +2892,7 @@ OPTIONAL_ENV_VARS = {
 # self-hosted / custom gateway setups regardless of subscription state.
 
 
-def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
+def get_missing_env_vars(required_only: bool = False) -> list[dict[str, Any]]:
     """
     Check which environment variables are missing.
     
@@ -2965,7 +2965,7 @@ def _set_nested(config, dotted_key: str, value):
         current[last] = value
 
 
-def get_missing_config_fields() -> List[Dict[str, Any]]:
+def get_missing_config_fields() -> list[dict[str, Any]]:
     """
     Check which config fields are missing or outdated (recursive).
     
@@ -2993,7 +2993,7 @@ def get_missing_config_fields() -> List[Dict[str, Any]]:
     return missing
 
 
-def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
+def get_missing_skill_config_vars() -> list[dict[str, Any]]:
     """Return skill-declared config vars that are missing or empty in config.yaml.
 
     Scans all enabled skills for ``metadata.hermes.config`` entries, then checks
@@ -3020,7 +3020,7 @@ def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
         return []
 
     config = load_config()
-    missing: List[Dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
     for var in all_vars:
         # Skill config is stored under skills.config.<logical_key>
         storage_key = f"{SKILL_CONFIG_PREFIX}.{var['key']}"
@@ -3044,13 +3044,13 @@ def _normalize_custom_provider_entry(
     entry: Any,
     *,
     provider_key: str = "",
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     """Return a runtime-compatible custom provider entry or ``None``."""
     if not isinstance(entry, dict):
         return None
 
     # Accept camelCase aliases commonly used in hand-written configs.
-    _CAMEL_ALIASES: Dict[str, str] = {
+    _CAMEL_ALIASES: dict[str, str] = {
         "apiKey": "api_key",
         "baseUrl": "base_url",
         "apiMode": "api_mode",
@@ -3116,7 +3116,7 @@ def _normalize_custom_provider_entry(
     if not name:
         return None
 
-    normalized: Dict[str, Any] = {
+    normalized: dict[str, Any] = {
         "name": name,
         "base_url": base_url,
     }
@@ -3172,12 +3172,12 @@ def _normalize_custom_provider_entry(
     return normalized
 
 
-def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, Any]]:
+def providers_dict_to_custom_providers(providers_dict: Any) -> list[dict[str, Any]]:
     """Normalize ``providers`` config entries into the legacy custom-provider shape."""
     if not isinstance(providers_dict, dict):
         return []
 
-    custom_providers: List[Dict[str, Any]] = []
+    custom_providers: list[dict[str, Any]] = []
     for key, entry in providers_dict.items():
         normalized = _normalize_custom_provider_entry(entry, provider_key=str(key))
         if normalized is not None:
@@ -3187,8 +3187,8 @@ def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, An
 
 
 def get_compatible_custom_providers(
-    config: Optional[Dict[str, Any]] = None,
-) -> List[Dict[str, Any]]:
+    config: Optional[dict[str, Any]] = None,
+) -> list[dict[str, Any]]:
     """Return a deduplicated custom-provider view across legacy and v12+ config.
 
     ``custom_providers`` remains the on-disk legacy format, while ``providers``
@@ -3199,11 +3199,11 @@ def get_compatible_custom_providers(
     if config is None:
         config = load_config()
 
-    compatible: List[Dict[str, Any]] = []
+    compatible: list[dict[str, Any]] = []
     seen_provider_keys: set = set()
     seen_name_url_pairs: set = set()
 
-    def _append_if_new(entry: Optional[Dict[str, Any]]) -> None:
+    def _append_if_new(entry: Optional[dict[str, Any]]) -> None:
         if entry is None:
             return
         provider_key = str(entry.get("provider_key", "") or "").strip().lower()
@@ -3239,8 +3239,8 @@ def get_compatible_custom_providers(
 def get_custom_provider_context_length(
     model: str,
     base_url: str,
-    custom_providers: Optional[List[Dict[str, Any]]] = None,
-    config: Optional[Dict[str, Any]] = None,
+    custom_providers: Optional[list[dict[str, Any]]] = None,
+    config: Optional[dict[str, Any]] = None,
 ) -> Optional[int]:
     """Look up a per-model ``context_length`` override from ``custom_providers``.
 
@@ -3301,7 +3301,7 @@ def get_custom_provider_context_length(
     return None
 
 
-def check_config_version() -> Tuple[int, int]:
+def check_config_version() -> tuple[int, int]:
     """
     Check config version.
     
@@ -3348,7 +3348,7 @@ class ConfigIssue:
     hint: str
 
 
-def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
+def validate_config_structure(config: Optional[dict[str, Any]] = None) -> list["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
     Catches common YAML formatting mistakes that produce confusing runtime
@@ -3362,7 +3362,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
         except Exception:
             return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
 
-    issues: List[ConfigIssue] = []
+    issues: list[ConfigIssue] = []
 
     # ── custom_providers must be a list, not a dict ──────────────────────
     cp = config.get("custom_providers")
@@ -3492,7 +3492,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     return issues
 
 
-def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
+def print_config_warnings(config: Optional[dict[str, Any]] = None) -> None:
     """Print config structure warnings to stderr at startup.
 
     Called early in CLI and gateway init so users see problems before
@@ -3514,7 +3514,7 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     sys.stderr.write("\n".join(lines) + "\n\n")
 
 
-def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
+def warn_deprecated_cwd_env_vars(config: Optional[dict[str, Any]] = None) -> None:
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
     These env vars are deprecated — the canonical setting is terminal.cwd
@@ -3559,7 +3559,7 @@ def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> Non
         sys.stderr.write("\n".join(lines) + "\n\n")
 
 
-def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
+def migrate_config(interactive: bool = True, quiet: bool = False) -> dict[str, Any]:
     """
     Migrate config to latest version, prompting for new required fields.
     
@@ -3860,7 +3860,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             disabled_set = set(disabled)
 
             # Scan ``$HERMES_HOME/plugins/`` for currently installed user plugins.
-            grandfathered: List[str] = []
+            grandfathered: list[str] = []
             try:
                 user_plugins_dir = get_hermes_home() / "plugins"
                 if user_plugins_dir.is_dir():
@@ -3936,7 +3936,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         raw_curator = config.get("curator")
         if not isinstance(raw_curator, dict):
             raw_curator = {}
-        added_curator: List[str] = []
+        added_curator: list[str] = []
         for k, v in _curator_defaults.items():
             if k not in raw_curator:
                 raw_curator[k] = copy.deepcopy(v)
@@ -3955,7 +3955,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         raw_aux_curator = raw_aux.get("curator")
         if not isinstance(raw_aux_curator, dict):
             raw_aux_curator = {}
-        added_aux: List[str] = []
+        added_aux: list[str] = []
         for k, v in _aux_curator_defaults.items():
             if k not in raw_aux_curator:
                 raw_aux_curator[k] = copy.deepcopy(v)
@@ -4257,7 +4257,7 @@ def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
     return current
 
 
-def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_root_model_keys(config: dict[str, Any]) -> dict[str, Any]:
     """Move stale root-level provider/base_url/context_length into model section.
 
     Some users (or older code) placed ``provider:``, ``base_url:``, or
@@ -4287,7 +4287,7 @@ def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
-def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_max_turns_config(config: dict[str, Any]) -> dict[str, Any]:
     """Normalize legacy root-level max_turns into agent.max_turns."""
     config = dict(config)
     agent_config = dict(config.get("agent") or {})
@@ -4303,7 +4303,7 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
-def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> Any:
+def cfg_get(cfg: Optional[dict[str, Any]], *keys: str, default: Any = None) -> Any:
     """Traverse nested dict keys safely, returning ``default`` on any miss.
 
     Canonical helper for the ``cfg.get("X", {}).get("Y", default)`` pattern
@@ -4350,7 +4350,7 @@ def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> A
 
 
 
-def read_raw_config() -> Dict[str, Any]:
+def read_raw_config() -> dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
 
     Returns the raw YAML dict, or ``{}`` if the file doesn't exist or can't
@@ -4388,7 +4388,7 @@ def read_raw_config() -> Dict[str, Any]:
         return data
 
 
-def load_config() -> Dict[str, Any]:
+def load_config() -> dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml.
 
     Cached on the config file's (mtime_ns, size). Returns a deepcopy of
@@ -4405,7 +4405,7 @@ def load_config() -> Dict[str, Any]:
     return _load_config_impl(want_deepcopy=True)
 
 
-def load_config_readonly() -> Dict[str, Any]:
+def load_config_readonly() -> dict[str, Any]:
     """Fast-path variant of ``load_config()`` for callers that ONLY READ.
 
     Returns the cached config dict directly without the defensive deepcopy
@@ -4428,7 +4428,7 @@ def load_config_readonly() -> Dict[str, Any]:
     return _load_config_impl(want_deepcopy=False)
 
 
-def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+def _load_config_impl(*, want_deepcopy: bool) -> dict[str, Any]:
     with _CONFIG_LOCK:
         ensure_hermes_home()
         config_path = get_config_path()
@@ -4436,7 +4436,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         try:
             st = config_path.stat()
-            cache_key: Optional[Tuple[int, int]] = (st.st_mtime_ns, st.st_size)
+            cache_key: Optional[tuple[int, int]] = (st.st_mtime_ns, st.st_size)
         except FileNotFoundError:
             cache_key = None
 
@@ -4562,7 +4562,7 @@ _COMMENTED_SECTIONS = """
 """
 
 
-def save_config(config: Dict[str, Any]):
+def save_config(config: dict[str, Any]):
     """Save configuration to ~/.hermes/config.yaml."""
     with _CONFIG_LOCK:
         if is_managed():
@@ -4606,7 +4606,7 @@ def save_config(config: Dict[str, Any]):
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 
-def load_env() -> Dict[str, str]:
+def load_env() -> dict[str, str]:
     """Load environment variables from ~/.hermes/.env.
 
     Sanitizes lines before parsing so that corrupted files (e.g.
@@ -4639,7 +4639,7 @@ def load_env() -> Dict[str, str]:
         if cached_key == cache_key:
             return dict(cached_vars)
 
-    env_vars: Dict[str, str] = {}
+    env_vars: dict[str, str] = {}
 
     if env_path.exists():
         # On Windows, open() defaults to the system locale (cp1252) which can
@@ -4668,7 +4668,7 @@ def load_env() -> Dict[str, str]:
 # is the explicit knob for writers that update .env via this module
 # (set_env_value, save_env, etc.) without relying on filesystem mtime
 # resolution.
-_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+_env_cache: Optional[tuple[tuple[str, Optional[float], Optional[int]], dict[str, str]]] = None
 
 
 def invalidate_env_cache() -> None:
@@ -4978,7 +4978,7 @@ def save_anthropic_api_key(value: str, save_fn=None):
     writer("ANTHROPIC_TOKEN", "")
 
 
-def save_env_value_secure(key: str, value: str) -> Dict[str, Any]:
+def save_env_value_secure(key: str, value: str) -> dict[str, Any]:
     save_env_value(key, value)
     return {
         "success": True,

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from hermes_cli.colors import Colors, color
 
 
-def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[List[str]]:
+def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[list[str]]:
     if skills is None:
         if single_skill is None:
             return None
@@ -24,7 +24,7 @@ def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None)
     else:
         raw_items = list(skills)
 
-    normalized: List[str] = []
+    normalized: list[str] = []
     for item in raw_items:
         text = str(item or "").strip()
         if text and text not in normalized:

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -34,12 +34,12 @@ def flush_stdin() -> None:
 
 def curses_checklist(
     title: str,
-    items: List[str],
-    selected: Set[int],
+    items: list[str],
+    selected: set[int],
     *,
-    cancel_returns: Set[int] | None = None,
-    status_fn: Optional[Callable[[Set[int]], str]] = None,
-) -> Set[int]:
+    cancel_returns: set[int] | None = None,
+    status_fn: Optional[Callable[[set[int]], str]] = None,
+) -> set[int]:
     """Curses multi-select checklist. Returns set of selected indices.
 
     Args:
@@ -164,7 +164,7 @@ def curses_checklist(
 
 def curses_radiolist(
     title: str,
-    items: List[str],
+    items: list[str],
     selected: int = 0,
     *,
     cancel_returns: int | None = None,
@@ -288,7 +288,7 @@ def curses_radiolist(
 
 def _radio_numbered_fallback(
     title: str,
-    items: List[str],
+    items: list[str],
     selected: int,
     cancel_returns: int,
 ) -> int:
@@ -314,7 +314,7 @@ def _radio_numbered_fallback(
 
 def curses_single_select(
     title: str,
-    items: List[str],
+    items: list[str],
     default_index: int = 0,
     *,
     cancel_label: str = "Cancel",
@@ -415,7 +415,7 @@ def curses_single_select(
 
 def _numbered_single_fallback(
     title: str,
-    items: List[str],
+    items: list[str],
     cancel_idx: int,
 ) -> int | None:
     """Text-based numbered fallback for single-select."""
@@ -439,11 +439,11 @@ def _numbered_single_fallback(
 
 def _numbered_fallback(
     title: str,
-    items: List[str],
-    selected: Set[int],
-    cancel_returns: Set[int],
-    status_fn: Optional[Callable[[Set[int]], str]] = None,
-) -> Set[int]:
+    items: list[str],
+    selected: set[int],
+    cancel_returns: set[int],
+    status_fn: Optional[Callable[[set[int]], str]] = None,
+) -> set[int]:
     """Text-based toggle fallback for terminals without curses."""
     chosen = set(selected)
     print(color(f"\n  {title}", Colors.YELLOW))

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -108,7 +108,7 @@ def wait_for_registration_success(
     interval: int = 3,
     expires_in: int = 7200,
     on_waiting: Optional[callable] = None,
-) -> Tuple[str, str]:
+) -> tuple[str, str]:
     """Block until the registration succeeds or times out.
 
     Returns (client_id, client_secret).
@@ -227,7 +227,7 @@ def render_qr_to_terminal(url: str) -> bool:
 
 # ── High-level entry point for the setup wizard ───────────────────────────
 
-def dingtalk_qr_auth() -> Optional[Tuple[str, str]]:
+def dingtalk_qr_auth() -> Optional[tuple[str, str]]:
     """Run the interactive QR-code device-flow authorization.
 
     Returns (client_id, client_secret) on success, or None if the user

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -28,7 +28,7 @@ from hermes_cli.fallback_config import get_fallback_chain
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _read_chain(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _read_chain(config: dict[str, Any]) -> list[dict[str, Any]]:
     """Return the normalized fallback chain as a list of dicts.
 
     Accepts both the new list format (``fallback_providers``) and the legacy
@@ -39,7 +39,7 @@ def _read_chain(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     return get_fallback_chain(config)
 
 
-def _write_chain(config: Dict[str, Any], chain: List[Dict[str, Any]]) -> None:
+def _write_chain(config: dict[str, Any], chain: list[dict[str, Any]]) -> None:
     """Persist the chain to ``fallback_providers`` and clear legacy key."""
     config["fallback_providers"] = chain
     # Drop the legacy single-dict key on write so there's only one source of truth.
@@ -47,7 +47,7 @@ def _write_chain(config: Dict[str, Any], chain: List[Dict[str, Any]]) -> None:
         config.pop("fallback_model", None)
 
 
-def _format_entry(entry: Dict[str, Any]) -> str:
+def _format_entry(entry: dict[str, Any]) -> str:
     """One-line human-readable rendering of a fallback entry."""
     provider = entry.get("provider", "?")
     model = entry.get("model", "?")
@@ -56,7 +56,7 @@ def _format_entry(entry: Dict[str, Any]) -> str:
     return f"{model}  (via {provider}){suffix}"
 
 
-def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]:
+def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[dict[str, Any]]:
     """Pull the ``{provider, model, base_url?, api_mode?}`` dict from a ``config["model"]`` snapshot."""
     if not isinstance(model_cfg, dict):
         return None
@@ -65,7 +65,7 @@ def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]
     model = (model_cfg.get("default") or model_cfg.get("model") or "").strip()
     if not provider or not model:
         return None
-    entry: Dict[str, Any] = {"provider": provider, "model": model}
+    entry: dict[str, Any] = {"provider": provider, "model": model}
     base_url = (model_cfg.get("base_url") or "").strip()
     if base_url:
         entry["base_url"] = base_url
@@ -132,7 +132,7 @@ def cmd_fallback_list(args) -> None:  # noqa: ARG001
     print()
 
 
-def _describe_primary(config: Dict[str, Any]) -> Optional[str]:
+def _describe_primary(config: dict[str, Any]) -> Optional[str]:
     """One-line description of the primary model for display purposes."""
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
@@ -311,7 +311,7 @@ def cmd_fallback_clear(args) -> None:  # noqa: ARG001
     print()
 
 
-def _numbered_pick(question: str, choices: List[str]) -> Optional[int]:
+def _numbered_pick(question: str, choices: list[str]) -> Optional[int]:
     """Fallback numbered-list picker when curses is unavailable."""
     print(question)
     for i, c in enumerate(choices, 1):

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -158,7 +158,7 @@ class GoalState:
     # include them so the agent works toward them and the judge factors
     # them into the verdict. Backwards-compatible: defaults to empty so
     # old state_meta rows load unchanged.
-    subgoals: List[str] = field(default_factory=list)
+    subgoals: list[str] = field(default_factory=list)
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), ensure_ascii=False)
@@ -167,7 +167,7 @@ class GoalState:
     def from_json(cls, raw: str) -> "GoalState":
         data = json.loads(raw)
         raw_subgoals = data.get("subgoals") or []
-        subgoals: List[str] = []
+        subgoals: list[str] = []
         if isinstance(raw_subgoals, list):
             subgoals = [str(s).strip() for s in raw_subgoals if str(s).strip()]
         return cls(
@@ -203,7 +203,7 @@ def _meta_key(session_id: str) -> str:
     return f"goal:{session_id}"
 
 
-_DB_CACHE: Dict[str, Any] = {}
+_DB_CACHE: dict[str, Any] = {}
 
 
 def _get_session_db() -> Optional[Any]:
@@ -319,7 +319,7 @@ def _goal_judge_max_tokens() -> int:
     return DEFAULT_JUDGE_MAX_TOKENS
 
 
-def _parse_judge_response(raw: str) -> Tuple[bool, str, bool]:
+def _parse_judge_response(raw: str) -> tuple[bool, str, bool]:
     """Parse the judge's reply. Fail-open to ``(False, "<reason>", parse_failed)``.
 
     Returns ``(done, reason, parse_failed)``. ``parse_failed`` is True when the
@@ -342,7 +342,7 @@ def _parse_judge_response(raw: str) -> Tuple[bool, str, bool]:
             text = text[nl + 1:]
 
     # First try: parse the whole blob.
-    data: Optional[Dict[str, Any]] = None
+    data: Optional[dict[str, Any]] = None
     try:
         data = json.loads(text)
     except Exception:
@@ -373,8 +373,8 @@ def judge_goal(
     last_response: str,
     *,
     timeout: float = DEFAULT_JUDGE_TIMEOUT,
-    subgoals: Optional[List[str]] = None,
-) -> Tuple[str, str, bool]:
+    subgoals: Optional[list[str]] = None,
+) -> tuple[str, str, bool]:
     """Ask the auxiliary model whether the goal is satisfied.
 
     Returns ``(verdict, reason, parse_failed)`` where verdict is ``"done"``,
@@ -622,7 +622,7 @@ class GoalManager:
         last_response: str,
         *,
         user_initiated: bool = True,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Run the judge and update state. Return a decision dict.
 
         ``user_initiated`` distinguishes a real user prompt (True) from a

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -61,7 +61,7 @@ def _cmd_list(_args) -> None:
         print("for the config schema and worked examples.")
         return
 
-    by_event: Dict[str, List] = {}
+    by_event: dict[str, list] = {}
     for spec in specs:
         by_event.setdefault(spec.event, []).append(spec)
 
@@ -238,7 +238,7 @@ def _cmd_test(args) -> None:
         print()
 
 
-def _print_run_result(result: Dict[str, Any]) -> None:
+def _print_run_result(result: dict[str, Any]) -> None:
     if result.get("error"):
         print(f"      ✗ error: {result['error']}")
         return

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-_MCP_PRESETS: Dict[str, Dict[str, Any]] = {
+_MCP_PRESETS: dict[str, dict[str, Any]] = {
     "codex": {
         "command": "codex",
         "args": ["mcp-server"],
@@ -74,7 +74,7 @@ def _prompt(question: str, *, password: bool = False, default: str = "") -> str:
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
-def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
+def _get_mcp_servers(config: Optional[dict] = None) -> dict[str, dict]:
     """Return the ``mcp_servers`` dict from config, or empty dict."""
     if config is None:
         config = load_config()
@@ -109,9 +109,9 @@ def _env_key_for_server(name: str) -> str:
     return f"MCP_{name.upper().replace('-', '_')}_API_KEY"
 
 
-def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
+def _parse_env_assignments(raw_env: Optional[list[str]]) -> dict[str, str]:
     """Parse ``KEY=VALUE`` strings from CLI args into an env dict."""
-    parsed: Dict[str, str] = {}
+    parsed: dict[str, str] = {}
     for item in raw_env or []:
         text = str(item or "").strip()
         if not text:
@@ -134,9 +134,9 @@ def _apply_mcp_preset(
     preset_name: Optional[str],
     url: Optional[str],
     command: Optional[str],
-    cmd_args: List[str],
-    server_config: Dict[str, Any],
-) -> tuple[Optional[str], Optional[str], List[str], bool]:
+    cmd_args: list[str],
+    server_config: dict[str, Any],
+) -> tuple[Optional[str], Optional[str], list[str], bool]:
     """Apply a known MCP preset when transport details were omitted."""
     if not preset_name:
         return url, command, cmd_args, False
@@ -166,7 +166,7 @@ def _apply_mcp_preset(
 
 def _probe_single_server(
     name: str, config: dict, connect_timeout: float = 30
-) -> List[Tuple[str, str]]:
+) -> list[tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
     Returns list of ``(tool_name, description)`` tuples.
@@ -181,7 +181,7 @@ def _probe_single_server(
 
     _ensure_mcp_loop()
 
-    tools_found: List[Tuple[str, str]] = []
+    tools_found: list[tuple[str, str]] = []
 
     async def _probe():
         server = await asyncio.wait_for(
@@ -236,7 +236,7 @@ def cmd_mcp_add(args):
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
 
-    server_config: Dict[str, Any] = {}
+    server_config: dict[str, Any] = {}
     try:
         explicit_env = _parse_env_assignments(raw_env)
         url, command, cmd_args, _preset_applied = _apply_mcp_preset(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1051,7 +1051,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
-) -> List[dict]:
+) -> list[dict]:
     """Detect which providers have credentials and list their curated models.
 
     Uses the curated model lists from hermes_cli/models.py (OPENROUTER_MODELS,
@@ -1082,7 +1082,7 @@ def list_authenticated_providers(
         get_curated_nous_model_ids,
     )
 
-    results: List[dict] = []
+    results: list[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
     seen_mdev_ids: set = set()  # prevent duplicate entries for aliases (e.g. kimi-coding + kimi-coding-cn)
     # Effective base URLs of every built-in row we emit (normalized lower+rstrip).
@@ -1746,7 +1746,7 @@ def list_picker_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
-) -> List[dict]:
+) -> list[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
     Post-processes the base list so the ``/model`` picker (Telegram/Discord
@@ -1777,7 +1777,7 @@ def list_picker_providers(
         current_model=current_model,
     )
 
-    filtered: List[dict] = []
+    filtered: list[dict] = []
     for p in providers:
         slug = str(p.get("slug", "")).lower()
         if slug == "openrouter":

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -52,7 +52,7 @@ class NousSubscriptionFeatures:
     subscribed: bool
     nous_auth_present: bool
     provider_is_nous: bool
-    features: Dict[str, NousFeatureState]
+    features: dict[str, NousFeatureState]
 
     @property
     def web(self) -> NousFeatureState:
@@ -80,7 +80,7 @@ class NousSubscriptionFeatures:
             yield self.features[key]
 
 
-def _model_config_dict(config: Dict[str, object]) -> Dict[str, object]:
+def _model_config_dict(config: dict[str, object]) -> dict[str, object]:
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
         return dict(model_cfg)
@@ -89,7 +89,7 @@ def _model_config_dict(config: Dict[str, object]) -> Dict[str, object]:
     return {}
 
 
-def _toolset_enabled(config: Dict[str, object], toolset_key: str) -> bool:
+def _toolset_enabled(config: dict[str, object], toolset_key: str) -> bool:
     from toolsets import resolve_toolset
 
     platform_toolsets = config.get("platform_toolsets")
@@ -111,7 +111,7 @@ def _toolset_enabled(config: Dict[str, object], toolset_key: str) -> bool:
             if default_toolset:
                 toolset_names = [default_toolset]
 
-        available_tools: Set[str] = set()
+        available_tools: set[str] = set()
         for toolset_name in toolset_names:
             if not isinstance(toolset_name, str) or not toolset_name:
                 continue
@@ -226,7 +226,7 @@ def _resolve_browser_feature_state(
 
 
 def get_nous_subscription_features(
-    config: Optional[Dict[str, object]] = None,
+    config: Optional[dict[str, object]] = None,
 ) -> NousSubscriptionFeatures:
     if config is None:
         config = load_config() or {}
@@ -490,7 +490,7 @@ def get_nous_subscription_features(
 
 
 def apply_nous_managed_defaults(
-    config: Dict[str, object],
+    config: dict[str, object],
     *,
     enabled_toolsets: Optional[Iterable[str]] = None,
 ) -> set[str]:
@@ -560,7 +560,7 @@ _GATEWAY_TOOL_LABELS = {
 }
 
 
-def _get_gateway_direct_credentials() -> Dict[str, bool]:
+def _get_gateway_direct_credentials() -> dict[str, bool]:
     """Return a dict of tool_key -> has_direct_credentials."""
     return {
         "web": bool(
@@ -593,7 +593,7 @@ _ALL_GATEWAY_KEYS = ("web", "image_gen", "tts", "browser")
 
 
 def get_gateway_eligible_tools(
-    config: Optional[Dict[str, object]] = None,
+    config: Optional[dict[str, object]] = None,
 ) -> tuple[list[str], list[str], list[str]]:
     """Return (unconfigured, has_direct, already_managed) tool key lists.
 
@@ -642,7 +642,7 @@ def get_gateway_eligible_tools(
 
 
 def apply_gateway_defaults(
-    config: Dict[str, object],
+    config: dict[str, object],
     tool_keys: list[str],
 ) -> set[str]:
     """Apply Tool Gateway config for the given tool keys.
@@ -695,7 +695,7 @@ def apply_gateway_defaults(
     return changed
 
 
-def prompt_enable_tool_gateway(config: Dict[str, object]) -> set[str]:
+def prompt_enable_tool_gateway(config: dict[str, object]) -> set[str]:
     """If eligible tools exist, prompt the user to enable the Tool Gateway.
 
     Uses prompt_choice() with a description parameter so the curses TUI

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -125,7 +125,7 @@ _install_plugin_debug_handler()
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_HOOKS: Set[str] = {
+VALID_HOOKS: set[str] = {
     "pre_tool_call",
     "post_tool_call",
     "transform_terminal_output",
@@ -227,7 +227,7 @@ def _get_enabled_plugins() -> Optional[set]:
 # Data classes
 # ---------------------------------------------------------------------------
 
-_VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
+_VALID_PLUGIN_KINDS: set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
 
 
 @dataclass
@@ -238,9 +238,9 @@ class PluginManifest:
     version: str = ""
     description: str = ""
     author: str = ""
-    requires_env: List[Union[str, Dict[str, Any]]] = field(default_factory=list)
-    provides_tools: List[str] = field(default_factory=list)
-    provides_hooks: List[str] = field(default_factory=list)
+    requires_env: list[Union[str, dict[str, Any]]] = field(default_factory=list)
+    provides_tools: list[str] = field(default_factory=list)
+    provides_hooks: list[str] = field(default_factory=list)
     source: str = ""        # "user", "project", or "entrypoint"
     path: Optional[str] = None
     # Plugin kind — see plugins.py module docstring for semantics.
@@ -273,9 +273,9 @@ class LoadedPlugin:
 
     manifest: PluginManifest
     module: Optional[types.ModuleType] = None
-    tools_registered: List[str] = field(default_factory=list)
-    hooks_registered: List[str] = field(default_factory=list)
-    commands_registered: List[str] = field(default_factory=list)
+    tools_registered: list[str] = field(default_factory=list)
+    hooks_registered: list[str] = field(default_factory=list)
+    commands_registered: list[str] = field(default_factory=list)
     enabled: bool = False
     error: Optional[str] = None
 
@@ -744,7 +744,7 @@ class PluginContext:
         *,
         display_name: str,
         description: str,
-        defaults: Optional[Dict[str, Any]] = None,
+        defaults: Optional[dict[str, Any]] = None,
     ) -> None:
         """Register a plugin-defined auxiliary LLM task.
 
@@ -823,7 +823,7 @@ class PluginContext:
 
         # Normalize defaults — plugin owns the schema, but we ensure routing
         # fields exist with sensible types so consumers don't crash.
-        merged_defaults: Dict[str, Any] = {
+        merged_defaults: dict[str, Any] = {
             "provider": "auto",
             "model": "",
             "base_url": "",
@@ -922,20 +922,20 @@ class PluginManager:
     """Central manager that discovers, loads, and invokes plugins."""
 
     def __init__(self) -> None:
-        self._plugins: Dict[str, LoadedPlugin] = {}
-        self._hooks: Dict[str, List[Callable]] = {}
-        self._plugin_tool_names: Set[str] = set()
-        self._plugin_platform_names: Set[str] = set()
-        self._cli_commands: Dict[str, dict] = {}
+        self._plugins: dict[str, LoadedPlugin] = {}
+        self._hooks: dict[str, list[Callable]] = {}
+        self._plugin_tool_names: set[str] = set()
+        self._plugin_platform_names: set[str] = set()
+        self._cli_commands: dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
-        self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
+        self._plugin_commands: dict[str, dict] = {}  # Slash commands registered by plugins
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
-        self._plugin_skills: Dict[str, Dict[str, Any]] = {}
+        self._plugin_skills: dict[str, dict[str, Any]] = {}
         # Plugin-registered auxiliary tasks: key → {key, display_name,
         # description, defaults, plugin}. See PluginContext.register_auxiliary_task.
-        self._aux_tasks: Dict[str, Dict[str, Any]] = {}
+        self._aux_tasks: dict[str, dict[str, Any]] = {}
 
     # -----------------------------------------------------------------------
     # Public
@@ -961,7 +961,7 @@ class PluginManager:
             self._context_engine = None
         self._discovered = True
 
-        manifests: List[PluginManifest] = []
+        manifests: list[PluginManifest] = []
 
         # 1. Bundled plugins (<repo>/plugins/<name>/)
         #
@@ -1024,7 +1024,7 @@ class PluginManager:
         # don't collide even when both manifests say ``name: openai``.
         disabled = _get_disabled_plugins()
         enabled = _get_enabled_plugins()  # None = opt-in default (nothing enabled)
-        winners: Dict[str, PluginManifest] = {}
+        winners: dict[str, PluginManifest] = {}
         for manifest in manifests:
             winners[manifest.key or manifest.name] = manifest
         for manifest in winners.values():
@@ -1117,8 +1117,8 @@ class PluginManager:
         self,
         path: Path,
         source: str,
-        skip_names: Optional[Set[str]] = None,
-    ) -> List[PluginManifest]:
+        skip_names: Optional[set[str]] = None,
+    ) -> list[PluginManifest]:
         """Read ``plugin.yaml`` manifests from subdirectories of *path*.
 
         Supports two layouts, mixed freely:
@@ -1143,17 +1143,17 @@ class PluginManager:
         path: Path,
         source: str,
         *,
-        skip_names: Optional[Set[str]],
+        skip_names: Optional[set[str]],
         prefix: str,
         depth: int,
-    ) -> List[PluginManifest]:
+    ) -> list[PluginManifest]:
         """Recursive implementation of :meth:`_scan_directory`.
 
         ``prefix`` is the category path already accumulated ("" at root,
         "image_gen" one level in). ``depth`` is the recursion depth; we
         cap at 2 so ``<root>/a/b/c/`` is ignored.
         """
-        manifests: List[PluginManifest] = []
+        manifests: list[PluginManifest] = []
         if not path.is_dir():
             return manifests
 
@@ -1289,9 +1289,9 @@ class PluginManager:
     # Entry-point scanning
     # -----------------------------------------------------------------------
 
-    def _scan_entry_points(self) -> List[PluginManifest]:
+    def _scan_entry_points(self) -> list[PluginManifest]:
         """Check ``importlib.metadata`` for pip-installed plugins."""
-        manifests: List[PluginManifest] = []
+        manifests: list[PluginManifest] = []
         try:
             eps = importlib.metadata.entry_points()
             # Python 3.12+ returns a SelectableGroups; earlier returns dict
@@ -1448,7 +1448,7 @@ class PluginManager:
     # Hook invocation
     # -----------------------------------------------------------------------
 
-    def invoke_hook(self, hook_name: str, **kwargs: Any) -> List[Any]:
+    def invoke_hook(self, hook_name: str, **kwargs: Any) -> list[Any]:
         """Call all registered callbacks for *hook_name*.
 
         Each callback is wrapped in its own try/except so a misbehaving
@@ -1469,7 +1469,7 @@ class PluginManager:
         persisted to session DB.
         """
         callbacks = self._hooks.get(hook_name, [])
-        results: List[Any] = []
+        results: list[Any] = []
         for cb in callbacks:
             try:
                 ret = cb(**kwargs)
@@ -1488,9 +1488,9 @@ class PluginManager:
     # Introspection
     # -----------------------------------------------------------------------
 
-    def list_plugins(self) -> List[Dict[str, Any]]:
+    def list_plugins(self) -> list[dict[str, Any]]:
         """Return a list of info dicts for all discovered plugins."""
-        result: List[Dict[str, Any]] = []
+        result: list[dict[str, Any]] = []
         for key, loaded in sorted(self._plugins.items()):
             result.append(
                 {
@@ -1518,7 +1518,7 @@ class PluginManager:
         entry = self._plugin_skills.get(qualified_name)
         return entry["path"] if entry else None
 
-    def list_plugin_skills(self, plugin_name: str) -> List[str]:
+    def list_plugin_skills(self, plugin_name: str) -> list[str]:
         """Return sorted bare names of all skills registered by *plugin_name*."""
         prefix = f"{plugin_name}:"
         return sorted(
@@ -1556,7 +1556,7 @@ def discover_plugins(force: bool = False) -> None:
     get_plugin_manager().discover_and_load(force=force)
 
 
-def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
+def invoke_hook(hook_name: str, **kwargs: Any) -> list[Any]:
     """Invoke a lifecycle hook on all loaded plugins.
 
     Returns a list of non-``None`` return values from plugin callbacks.
@@ -1569,7 +1569,7 @@ _thread_tool_whitelist = threading.local()
 
 
 def set_thread_tool_whitelist(
-    allowed: Optional[Set[str]],
+    allowed: Optional[set[str]],
     deny_msg_fmt: str = "Tool '{tool_name}' denied: not in this thread's tool whitelist",
 ) -> None:
     _thread_tool_whitelist.allowed = allowed
@@ -1582,7 +1582,7 @@ def clear_thread_tool_whitelist() -> None:
 
 def get_pre_tool_call_block_message(
     tool_name: str,
-    args: Optional[Dict[str, Any]],
+    args: Optional[dict[str, Any]],
     task_id: str = "",
     session_id: str = "",
     tool_call_id: str = "",
@@ -1666,8 +1666,8 @@ def resolve_plugin_command_result(result: Any) -> Any:
     except RuntimeError:
         return asyncio.run(result)
 
-    outcome: Dict[str, Any] = {}
-    failure: Dict[str, BaseException] = {}
+    outcome: dict[str, Any] = {}
+    failure: dict[str, BaseException] = {}
     done = threading.Event()
 
     def _runner() -> None:
@@ -1694,7 +1694,7 @@ def resolve_plugin_command_result(result: Any) -> Any:
     return outcome.get("value")
 
 
-def get_plugin_commands() -> Dict[str, dict]:
+def get_plugin_commands() -> dict[str, dict]:
     """Return the full plugin commands dict (name → {handler, description, plugin}).
 
     Triggers idempotent plugin discovery so callers can use plugin commands
@@ -1703,7 +1703,7 @@ def get_plugin_commands() -> Dict[str, dict]:
     return _ensure_plugins_discovered()._plugin_commands
 
 
-def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
+def get_plugin_auxiliary_tasks() -> list[dict[str, Any]]:
     """Return all plugin-registered auxiliary tasks as a stable-ordered list.
 
     Each entry is the registration dict from
@@ -1718,7 +1718,7 @@ def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:
     return [manager._aux_tasks[k] for k in sorted(manager._aux_tasks)]
 
 
-def get_plugin_toolsets() -> List[tuple]:
+def get_plugin_toolsets() -> list[tuple]:
     """Return plugin toolsets as ``(key, label, description)`` tuples.
 
     Used by the ``hermes tools`` TUI so plugin-provided toolsets appear
@@ -1734,8 +1734,8 @@ def get_plugin_toolsets() -> List[tuple]:
         return []
 
     # Group plugin tool names by their toolset
-    toolset_tools: Dict[str, List[str]] = {}
-    toolset_plugin: Dict[str, LoadedPlugin] = {}
+    toolset_tools: dict[str, list[str]] = {}
+    toolset_plugin: dict[str, LoadedPlugin] = {}
     for tool_name in manager._plugin_tool_names:
         entry = registry.get_entry(tool_name)
         if not entry:

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -84,7 +84,7 @@ ENV_EXAMPLE_FILENAME = ".env.EXAMPLE"
 # Default distribution-owned paths (relative to profile root).  Authors may
 # override via ``distribution_owned:`` in the manifest.  config.yaml is
 # distribution-owned but treated specially on update (see _is_config_like).
-DEFAULT_DIST_OWNED: Tuple[str, ...] = (
+DEFAULT_DIST_OWNED: tuple[str, ...] = (
     "SOUL.md",
     "config.yaml",
     "mcp.json",
@@ -156,8 +156,8 @@ class EnvRequirement:
             default=data.get("default"),
         )
 
-    def to_dict(self) -> Dict[str, Any]:
-        out: Dict[str, Any] = {"name": self.name, "description": self.description}
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"name": self.name, "description": self.description}
         if not self.required:
             out["required"] = False
         if self.default is not None:
@@ -173,8 +173,8 @@ class DistributionManifest:
     hermes_requires: str = ""
     author: str = ""
     license: str = ""
-    env_requires: List[EnvRequirement] = field(default_factory=list)
-    distribution_owned: List[str] = field(default_factory=list)
+    env_requires: list[EnvRequirement] = field(default_factory=list)
+    distribution_owned: list[str] = field(default_factory=list)
     # Tracked after install — where we pulled from, so ``update`` can re-pull.
     source: str = ""
     # ISO-8601 UTC timestamp written on install / update, so ``info`` and
@@ -212,8 +212,8 @@ class DistributionManifest:
             installed_at=str(data.get("installed_at") or ""),
         )
 
-    def to_dict(self) -> Dict[str, Any]:
-        out: Dict[str, Any] = {
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
             "name": self.name,
             "version": self.version,
         }
@@ -235,7 +235,7 @@ class DistributionManifest:
             out["installed_at"] = self.installed_at
         return out
 
-    def owned_paths(self) -> List[str]:
+    def owned_paths(self) -> list[str]:
         """Resolve which paths count as distribution-owned."""
         if self.distribution_owned:
             return list(self.distribution_owned)
@@ -282,7 +282,7 @@ def write_manifest(profile_dir: Path, manifest: DistributionManifest) -> Path:
 _VERSION_OP_RE = re.compile(r"^\s*(>=|<=|==|!=|>|<)\s*(.+?)\s*$")
 
 
-def _parse_semver(v: str) -> Tuple[int, int, int]:
+def _parse_semver(v: str) -> tuple[int, int, int]:
     """Very small semver parser — major.minor.patch only.  Extra labels stripped."""
     s = str(v).strip().lstrip("v")
     # Strip any pre-release / build metadata (e.g. "0.12.0-rc1+abc")
@@ -389,7 +389,7 @@ def _git_clone(url: str, dest: Path) -> None:
         raise DistributionError(f"git clone failed: {stderr.strip()}") from exc
 
 
-def _stage_source(source: str, workdir: Path) -> Tuple[Path, str]:
+def _stage_source(source: str, workdir: Path) -> tuple[Path, str]:
     """Resolve *source* to a local directory containing distribution.yaml.
 
     Returns ``(staged_dir, provenance)`` where ``provenance`` is stored in the
@@ -683,7 +683,7 @@ def update_distribution(
 # ---------------------------------------------------------------------------
 
 
-def describe_distribution(profile_name: str) -> Dict[str, Any]:
+def describe_distribution(profile_name: str) -> dict[str, Any]:
     """Return a structured view of a profile's distribution metadata.
 
     Returns an empty dict if the profile exists but has no manifest.

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -137,7 +137,7 @@ def _clone_all_copytree_ignore(source_dir: Path):
     source_resolved = source_dir.resolve()
     is_default_source = source_resolved == _get_default_hermes_home().resolve()
 
-    def _ignore(directory: str, names: List[str]) -> List[str]:
+    def _ignore(directory: str, names: list[str]) -> list[str]:
         ignored: list[str] = []
         for entry in names:
             # Universal exclusions at any depth.
@@ -573,7 +573,7 @@ def write_profile_meta(
 # CRUD operations
 # ---------------------------------------------------------------------------
 
-def list_profiles() -> List[ProfileInfo]:
+def list_profiles() -> list[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
     wrapper_dir = _get_wrapper_dir()
@@ -1288,7 +1288,7 @@ def export_profile(name: str, output_path: str) -> Path:
         return Path(result)
 
 
-def _normalize_profile_archive_parts(member_name: str) -> List[str]:
+def _normalize_profile_archive_parts(member_name: str) -> list[str]:
     """Return safe path parts for a profile archive member."""
     normalized_name = member_name.replace("\\", "/")
     posix_path = PurePosixPath(normalized_name)

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -38,12 +38,12 @@ class HermesOverlay:
     transport: str = "openai_chat"        # openai_chat | anthropic_messages | codex_responses
     is_aggregator: bool = False
     auth_type: str = "api_key"            # api_key | oauth_device_code | oauth_external | external_process
-    extra_env_vars: Tuple[str, ...] = ()  # env vars models.dev doesn't list
+    extra_env_vars: tuple[str, ...] = ()  # env vars models.dev doesn't list
     base_url_override: str = ""           # override if models.dev URL is wrong/missing
     base_url_env_var: str = ""            # env var for user-custom base URL
 
 
-HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
+HERMES_OVERLAYS: dict[str, HermesOverlay] = {
     "openrouter": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
@@ -224,7 +224,7 @@ class ProviderDef:
     id: str
     name: str
     transport: str                        # openai_chat | anthropic_messages | codex_responses
-    api_key_env_vars: Tuple[str, ...]     # all env vars to check for API key
+    api_key_env_vars: tuple[str, ...]     # all env vars to check for API key
     base_url: str = ""
     base_url_env_var: str = ""
     is_aggregator: bool = False
@@ -237,7 +237,7 @@ class ProviderDef:
 # Maps human-friendly / legacy names to canonical provider IDs.
 # Uses models.dev IDs where possible.
 
-ALIASES: Dict[str, str] = {
+ALIASES: dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
 
@@ -369,7 +369,7 @@ ALIASES: Dict[str, str] = {
 # Built dynamically from models.dev + overlays.  Fallback for providers
 # not in the catalog.
 
-_LABEL_OVERRIDES: Dict[str, str] = {
+_LABEL_OVERRIDES: dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
@@ -387,7 +387,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
 
 # -- Transport → API mode mapping ---------------------------------------------
 
-TRANSPORT_TO_API_MODE: Dict[str, str] = {
+TRANSPORT_TO_API_MODE: dict[str, str] = {
     "openai_chat": "chat_completions",
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
@@ -545,7 +545,7 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
 
 # -- Provider from user config ------------------------------------------------
 
-def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[ProviderDef]:
+def resolve_user_provider(name: str, user_config: dict[str, Any]) -> Optional[ProviderDef]:
     """Resolve a provider from the user's config.yaml ``providers:`` section.
 
     Args:
@@ -568,7 +568,7 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     key_env = entry.get("key_env", "") or ""
     transport = entry.get("transport", "openai_chat") or "openai_chat"
 
-    env_vars: List[str] = []
+    env_vars: list[str] = []
     if key_env:
         env_vars.append(key_env)
 
@@ -596,7 +596,7 @@ def custom_provider_slug(display_name: str) -> str:
 
 def resolve_custom_provider(
     name: str,
-    custom_providers: Optional[List[Dict[str, Any]]],
+    custom_providers: Optional[list[dict[str, Any]]],
 ) -> Optional[ProviderDef]:
     """Resolve a provider from the user's config.yaml ``custom_providers`` list."""
     if not custom_providers or not isinstance(custom_providers, list):
@@ -665,8 +665,8 @@ def resolve_custom_provider(
 
 def resolve_provider_full(
     name: str,
-    user_providers: Optional[Dict[str, Any]] = None,
-    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    user_providers: Optional[dict[str, Any]] = None,
+    custom_providers: Optional[list[dict[str, Any]]] = None,
 ) -> Optional[ProviderDef]:
     """Full resolution chain: built-in → models.dev → user config.
 

--- a/hermes_cli/proxy/adapters/__init__.py
+++ b/hermes_cli/proxy/adapters/__init__.py
@@ -13,7 +13,7 @@ from hermes_cli.proxy.adapters.xai import XAIGrokAdapter
 
 # Registry of available adapter classes keyed by provider name as used on
 # the ``hermes proxy start --provider <name>`` CLI flag.
-ADAPTERS: Dict[str, Type[UpstreamAdapter]] = {
+ADAPTERS: dict[str, type[UpstreamAdapter]] = {
     "nous": NousPortalAdapter,
     "xai": XAIGrokAdapter,
 }

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -50,7 +50,7 @@ class UpstreamAdapter(ABC):
 
     @property
     @abstractmethod
-    def allowed_paths(self) -> FrozenSet[str]:
+    def allowed_paths(self) -> frozenset[str]:
         """Set of relative request paths the upstream accepts.
 
         Paths are relative to the proxy's ``/v1`` mount point. For example,

--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 # Endpoints inference-api.nousresearch.com actually serves. Anything else
 # the proxy will reject with 404 — keeps stray clients from leaking weird
 # requests to the upstream.
-_ALLOWED_PATHS: FrozenSet[str] = frozenset(
+_ALLOWED_PATHS: frozenset[str] = frozenset(
     {
         "/chat/completions",
         "/completions",
@@ -65,7 +65,7 @@ class NousPortalAdapter(UpstreamAdapter):
         return "Nous Portal"
 
     @property
-    def allowed_paths(self) -> FrozenSet[str]:
+    def allowed_paths(self) -> frozenset[str]:
         return _ALLOWED_PATHS
 
     def is_authenticated(self) -> bool:
@@ -155,7 +155,7 @@ class NousPortalAdapter(UpstreamAdapter):
     # to hermes_cli.auth to avoid expanding that module's public surface.
     # ------------------------------------------------------------------
 
-    def _read_state(self) -> Optional[Dict[str, Any]]:
+    def _read_state(self) -> Optional[dict[str, Any]]:
         try:
             with _auth_store_lock():
                 store = _load_auth_store()
@@ -170,7 +170,7 @@ class NousPortalAdapter(UpstreamAdapter):
 
     def _save_state(
         self,
-        state: Dict[str, Any],
+        state: dict[str, Any],
         *,
         quarantine_error: Optional[AuthError] = None,
         quarantine_reason: Optional[str] = None,

--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -17,7 +17,7 @@ _POOL_PROVIDER = "xai-oauth"
 # xAI's public API is OpenAI-compatible for the endpoints Hermes commonly
 # uses. The Responses endpoint is included because Hermes' native xAI runtime
 # uses codex_responses mode.
-_ALLOWED_PATHS: FrozenSet[str] = frozenset(
+_ALLOWED_PATHS: frozenset[str] = frozenset(
     {
         "/responses",
         "/chat/completions",
@@ -46,7 +46,7 @@ class XAIGrokAdapter(UpstreamAdapter):
         return "xAI Grok OAuth"
 
     @property
-    def allowed_paths(self) -> FrozenSet[str]:
+    def allowed_paths(self) -> frozenset[str]:
         return _ALLOWED_PATHS
 
     def is_authenticated(self) -> bool:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -180,7 +180,7 @@ def _auto_detect_local_model(base_url: str) -> str:
     return ""
 
 
-def _get_model_config() -> Dict[str, Any]:
+def _get_model_config() -> dict[str, Any]:
     config = load_config()
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
@@ -219,7 +219,7 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(model_cfg: dict[str, Any], api_key: str) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
@@ -264,7 +264,7 @@ def _maybe_apply_codex_app_server_runtime(
     *,
     provider: str,
     api_mode: str,
-    model_cfg: Optional[Dict[str, Any]],
+    model_cfg: Optional[dict[str, Any]],
 ) -> str:
     """Optional opt-in: rewrite api_mode → "codex_app_server" for OpenAI/Codex
     providers when the user has explicitly enabled that runtime via
@@ -291,10 +291,10 @@ def _resolve_runtime_from_pool_entry(
     provider: str,
     entry: PooledCredential,
     requested_provider: str,
-    model_cfg: Optional[Dict[str, Any]] = None,
+    model_cfg: Optional[dict[str, Any]] = None,
     pool: Optional[CredentialPool] = None,
     target_model: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     model_cfg = model_cfg or _get_model_config()
     # When the caller is resolving for a specific target model (e.g. a /model
     # mid-session switch), prefer that over the persisted model.default. This
@@ -447,7 +447,7 @@ def _try_resolve_from_custom_pool(
     provider_label: str,
     api_mode_override: Optional[str] = None,
     provider_name: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
     if not pool_key:
@@ -474,7 +474,7 @@ def _try_resolve_from_custom_pool(
         return None
 
 
-def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
+def _get_named_custom_provider(requested_provider: str) -> Optional[dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm or requested_norm == "custom":
         return None
@@ -616,7 +616,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     return None
 
 
-def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[str, Any]:
+def _custom_provider_request_overrides(custom_provider: dict[str, Any]) -> dict[str, Any]:
     extra_body = custom_provider.get("extra_body")
     if not isinstance(extra_body, dict) or not extra_body:
         return {}
@@ -628,7 +628,7 @@ def _resolve_named_custom_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     # Bare `provider="custom"` with an explicit base_url (e.g. propagated
     # from a `model_aliases:` direct-alias resolution) — build a runtime
     # directly so the alias's base_url actually takes effect.
@@ -747,7 +747,7 @@ def _resolve_openrouter_runtime(
     requested_provider: str,
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     model_cfg = _get_model_config()
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
     cfg_provider = model_cfg.get("provider") if isinstance(model_cfg.get("provider"), str) else ""
@@ -885,11 +885,11 @@ def _resolve_openrouter_runtime(
 def _resolve_azure_foundry_runtime(
     *,
     requested_provider: str,
-    model_cfg: Dict[str, Any],
+    model_cfg: dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     target_model: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Resolve an Azure Foundry runtime entry.
 
     Reads ``model.base_url`` + ``model.api_mode`` from config.yaml (or
@@ -915,7 +915,7 @@ def _resolve_azure_foundry_runtime(
     cfg_base_url = ""
     cfg_api_mode = "chat_completions"
     cfg_auth_mode = "api_key"
-    cfg_entra: Dict[str, Any] = {}
+    cfg_entra: dict[str, Any] = {}
     if cfg_provider == "azure-foundry":
         cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
         cfg_api_mode = _parse_api_mode(model_cfg.get("api_mode")) or "chat_completions"
@@ -1055,10 +1055,10 @@ def _resolve_explicit_runtime(
     *,
     provider: str,
     requested_provider: str,
-    model_cfg: Dict[str, Any],
+    model_cfg: dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
     if not explicit_api_key and not explicit_base_url:
@@ -1203,7 +1203,7 @@ def resolve_runtime_provider(
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
     target_model: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Resolve runtime provider credentials for agent execution.
 
     target_model: Optional override for model_cfg.get("default") when

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -441,7 +441,7 @@ def _bws_version(binary: Path) -> str:
 
 def _list_projects(
     binary: Path, token: str, console: Console, *, server_url: str = ""
-) -> Optional[List[dict]]:
+) -> Optional[list[dict]]:
     """Call ``bws project list`` and return the parsed list, or None on failure."""
     env = os.environ.copy()
     env["BWS_ACCESS_TOKEN"] = token

--- a/hermes_cli/session_recap.py
+++ b/hermes_cli/session_recap.py
@@ -58,7 +58,7 @@ def _coerce_text(value: Any) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, list):
-        parts: List[str] = []
+        parts: list[str] = []
         for block in value:
             if isinstance(block, str):
                 parts.append(block)
@@ -71,7 +71,7 @@ def _coerce_text(value: Any) -> str:
     return str(value)
 
 
-def _tool_call_name_and_args(tool_call: Any) -> Tuple[str, Mapping[str, Any]]:
+def _tool_call_name_and_args(tool_call: Any) -> tuple[str, Mapping[str, Any]]:
     """Extract ``(name, arguments_dict)`` from a tool_call entry.
 
     ``arguments`` may be a JSON string or a dict depending on provider.
@@ -100,7 +100,7 @@ def _tool_call_name_and_args(tool_call: Any) -> Tuple[str, Mapping[str, Any]]:
 
 def _iter_assistant_tool_calls(
     messages: Sequence[Mapping[str, Any]],
-) -> Iterable[Tuple[str, Mapping[str, Any]]]:
+) -> Iterable[tuple[str, Mapping[str, Any]]]:
     for msg in messages:
         if not isinstance(msg, Mapping):
             continue
@@ -117,7 +117,7 @@ def _iter_assistant_tool_calls(
 
 def _count_visible_turns(
     messages: Sequence[Mapping[str, Any]],
-) -> Tuple[int, int, int]:
+) -> tuple[int, int, int]:
     """Return ``(user_turn_count, assistant_turn_count, tool_message_count)``."""
     users = assistants = tools = 0
     for msg in messages:
@@ -160,7 +160,7 @@ def _latest_assistant_text(
 
 def _recent_window(
     messages: Sequence[Mapping[str, Any]], window: int = _RECENT_TURN_WINDOW
-) -> List[Mapping[str, Any]]:
+) -> list[Mapping[str, Any]]:
     """Return the tail slice of ``messages`` covering at most ``window``
     user+assistant turns (tool messages ride along inside the window).
 
@@ -201,8 +201,8 @@ def _shortened_path(path: str) -> str:
 
 
 def _summarise_tool_activity(
-    tool_calls: Sequence[Tuple[str, Mapping[str, Any]]],
-) -> Tuple[List[Tuple[str, int]], List[str]]:
+    tool_calls: Sequence[tuple[str, Mapping[str, Any]]],
+) -> tuple[list[tuple[str, int]], list[str]]:
     """Return ``(tool_counts_sorted, recently_edited_files)``.
 
     ``tool_counts_sorted`` is descending by count, keeping the full list
@@ -210,7 +210,7 @@ def _summarise_tool_activity(
     distinct paths (most recent first) from file-editing tools.
     """
     counter: Counter[str] = Counter()
-    files_seen: List[str] = []
+    files_seen: list[str] = []
     files_set: set[str] = set()
     # Walk in reverse so "most recent first" drops out of order-preserved iteration.
     for name, args in reversed(list(tool_calls)):
@@ -257,9 +257,9 @@ def build_recap(
     (with 80-col wrapping) and a gateway message bubble.
     """
     _ = platform  # reserved for future use
-    lines: List[str] = []
+    lines: list[str] = []
 
-    header_bits: List[str] = ["Session recap"]
+    header_bits: list[str] = ["Session recap"]
     if session_title:
         header_bits.append(f"— {session_title}")
     elif session_id:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -34,7 +34,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 _DOCS_BASE = "https://hermes-agent.nousresearch.com/docs"
 
 
-def _model_config_dict(config: Dict[str, Any]) -> Dict[str, Any]:
+def _model_config_dict(config: dict[str, Any]) -> dict[str, Any]:
     current_model = config.get("model")
     if isinstance(current_model, dict):
         return dict(current_model)
@@ -43,12 +43,12 @@ def _model_config_dict(config: Dict[str, Any]) -> Dict[str, Any]:
     return {}
 
 
-def _get_credential_pool_strategies(config: Dict[str, Any]) -> Dict[str, str]:
+def _get_credential_pool_strategies(config: dict[str, Any]) -> dict[str, str]:
     strategies = config.get("credential_pool_strategies")
     return dict(strategies) if isinstance(strategies, dict) else {}
 
 
-def _set_credential_pool_strategy(config: Dict[str, Any], provider: str, strategy: str) -> None:
+def _set_credential_pool_strategy(config: dict[str, Any], provider: str, strategy: str) -> None:
     if not provider:
         return
     strategies = _get_credential_pool_strategies(config)
@@ -113,14 +113,14 @@ _DEFAULT_PROVIDER_MODELS = {
 }
 
 
-def _current_reasoning_effort(config: Dict[str, Any]) -> str:
+def _current_reasoning_effort(config: dict[str, Any]) -> str:
     agent_cfg = config.get("agent")
     if isinstance(agent_cfg, dict):
         return str(agent_cfg.get("reasoning_effort") or "").strip().lower()
     return ""
 
 
-def _set_reasoning_effort(config: Dict[str, Any], effort: str) -> None:
+def _set_reasoning_effort(config: dict[str, Any], effort: str) -> None:
     agent_cfg = config.get("agent")
     if not isinstance(agent_cfg, dict):
         agent_cfg = {}

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -24,7 +24,7 @@ PLATFORMS = {k: info.label for k, info in _PLATFORMS.items() if k != "api_server
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
-def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str]:
+def get_disabled_skills(config: dict, platform: Optional[str] = None) -> set[str]:
     """Return disabled skill names. Platform-specific list falls back to global."""
     skills_cfg = config.get("skills", {})
     global_disabled = set(skills_cfg.get("disabled", []))
@@ -36,7 +36,7 @@ def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str
     return set(platform_disabled)
 
 
-def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):
+def save_disabled_skills(config: dict, disabled: set[str], platform: Optional[str] = None):
     """Persist disabled skill names to config."""
     config.setdefault("skills", {})
     if platform is None:
@@ -49,7 +49,7 @@ def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[st
 
 # ─── Skill Discovery ─────────────────────────────────────────────────────────
 
-def _list_all_skills() -> List[dict]:
+def _list_all_skills() -> list[dict]:
     """Return all installed skills (ignoring disabled state)."""
     try:
         from tools.skills_tool import _find_all_skills
@@ -58,7 +58,7 @@ def _list_all_skills() -> List[dict]:
         return []
 
 
-def _get_categories(skills: List[dict]) -> List[str]:
+def _get_categories(skills: list[dict]) -> list[str]:
     """Return sorted unique category names (None -> 'uncategorized')."""
     return sorted({s["category"] or "uncategorized" for s in skills})
 
@@ -91,7 +91,7 @@ def _select_platform() -> Optional[str]:
 
 # ─── Category Toggle ─────────────────────────────────────────────────────────
 
-def _toggle_by_category(skills: List[dict], disabled: Set[str]) -> Set[str]:
+def _toggle_by_category(skills: list[dict], disabled: set[str]) -> set[str]:
     """Toggle all skills in a category at once."""
     from hermes_cli.curses_ui import curses_checklist
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -79,7 +79,7 @@ def _resolve_short_name(name: str, sources, console: Console) -> str:
     return ""
 
 
-def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
+def _format_extra_metadata_lines(extra: dict[str, Any]) -> list[str]:
     lines: list[str] = []
     if not extra:
         return lines
@@ -161,7 +161,7 @@ def _is_valid_installed_skill_name(name: str) -> bool:
     return bool(_VALID_NAME_RE.match(candidate))
 
 
-def _existing_categories() -> List[str]:
+def _existing_categories() -> list[str]:
     """Return sorted subdirectory names under ``~/.hermes/skills/`` that look
     like category buckets (contain at least one ``SKILL.md`` somewhere below).
 
@@ -169,7 +169,7 @@ def _existing_categories() -> List[str]:
     URL. Hidden dirs (``.hub``, ``.trash``) are skipped.
     """
     from tools.skills_hub import SKILLS_DIR
-    out: List[str] = []
+    out: list[str] = []
     try:
         for entry in SKILLS_DIR.iterdir():
             if not entry.is_dir() or entry.name.startswith("."):
@@ -218,7 +218,7 @@ def _prompt_for_skill_name(c: Console, url: str, default: str = "") -> Optional[
     return answer
 
 
-def _prompt_for_category(c: Console, existing: List[str]) -> str:
+def _prompt_for_category(c: Console, existing: list[str]) -> str:
     """Prompt interactively for a category. Empty/None input means flat install."""
     c.print()
     if existing:

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -131,11 +131,11 @@ class SkinConfig:
     """Complete skin configuration."""
     name: str
     description: str = ""
-    colors: Dict[str, str] = field(default_factory=dict)
-    spinner: Dict[str, Any] = field(default_factory=dict)
-    branding: Dict[str, str] = field(default_factory=dict)
+    colors: dict[str, str] = field(default_factory=dict)
+    spinner: dict[str, Any] = field(default_factory=dict)
+    branding: dict[str, str] = field(default_factory=dict)
     tool_prefix: str = "┊"
-    tool_emojis: Dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
+    tool_emojis: dict[str, str] = field(default_factory=dict)  # per-tool emoji overrides
     banner_logo: str = ""    # Rich-markup ASCII art logo (replaces HERMES_AGENT_LOGO)
     banner_hero: str = ""    # Rich-markup hero art (replaces HERMES_CADUCEUS)
 
@@ -143,7 +143,7 @@ class SkinConfig:
         """Get a color value with fallback."""
         return self.colors.get(key, fallback)
 
-    def get_spinner_wings(self) -> List[Tuple[str, str]]:
+    def get_spinner_wings(self) -> list[tuple[str, str]]:
         """Get spinner wing pairs, or empty list if none."""
         raw = self.spinner.get("wings", [])
         result = []
@@ -161,7 +161,7 @@ class SkinConfig:
 # Built-in skin definitions
 # =============================================================================
 
-_BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
+_BUILTIN_SKINS: dict[str, dict[str, Any]] = {
     "default": {
         "name": "default",
         "description": "Classic Hermes — gold and kawaii",
@@ -658,7 +658,7 @@ def _skins_dir() -> Path:
     return get_hermes_home() / "skins"
 
 
-def _load_skin_from_yaml(path: Path) -> Optional[Dict[str, Any]]:
+def _load_skin_from_yaml(path: Path) -> Optional[dict[str, Any]]:
     """Load a skin definition from a YAML file."""
     try:
         import yaml
@@ -671,7 +671,7 @@ def _load_skin_from_yaml(path: Path) -> Optional[Dict[str, Any]]:
     return None
 
 
-def _mapping_or_empty(value: Any, *, section: str, skin_name: str) -> Dict[str, Any]:
+def _mapping_or_empty(value: Any, *, section: str, skin_name: str) -> dict[str, Any]:
     """Return a mapping value or an empty dict when the section type is invalid."""
     if isinstance(value, dict):
         return value
@@ -686,7 +686,7 @@ def _mapping_or_empty(value: Any, *, section: str, skin_name: str) -> Dict[str, 
     return {}
 
 
-def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
+def _build_skin_config(data: dict[str, Any]) -> SkinConfig:
     """Build a SkinConfig from a raw dict (built-in or loaded from YAML)."""
     # Start with default values as base for missing keys
     default = _BUILTIN_SKINS["default"]
@@ -716,7 +716,7 @@ def _build_skin_config(data: Dict[str, Any]) -> SkinConfig:
     )
 
 
-def list_skins() -> List[Dict[str, str]]:
+def list_skins() -> list[dict[str, str]]:
     """List all available skins (built-in + user-installed).
 
     Returns list of {"name": ..., "description": ..., "source": "builtin"|"user"}.
@@ -843,7 +843,7 @@ def get_active_goodbye(fallback: str = "Goodbye! ⚕") -> str:
 
 
 
-def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
+def get_prompt_toolkit_style_overrides() -> dict[str, str]:
     """Return prompt_toolkit style overrides derived from the active skin.
 
     These are layered on top of the CLI's base TUI style so /skin can refresh

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -129,7 +129,7 @@ def _xai_credentials_present() -> bool:
 # Use this for tools whose APIs only make sense on one platform (Discord
 # server admin, Slack workspace admin, etc.).  Keeps every other platform's
 # checklist from filling up with irrelevant toggles.
-_TOOLSET_PLATFORM_RESTRICTIONS: Dict[str, Set[str]] = {
+_TOOLSET_PLATFORM_RESTRICTIONS: dict[str, set[str]] = {
     "discord": {"discord"},
     "discord_admin": {"discord"},
 }
@@ -489,7 +489,7 @@ def _cua_driver_cmd() -> str:
 
 
 def _pip_install(
-    args: List[str],
+    args: list[str],
     *,
     timeout: int = 300,
     capture_output: bool = True,
@@ -1062,7 +1062,7 @@ def _run_post_setup(post_setup_key: str):
 
 # ─── Platform / Toolset Helpers ───────────────────────────────────────────────
 
-def _get_enabled_platforms() -> List[str]:
+def _get_enabled_platforms() -> list[str]:
     """Return platform keys that are configured (have tokens or are CLI)."""
     enabled = ["cli"]
     if get_env_value("TELEGRAM_BOT_TOKEN"):
@@ -1078,7 +1078,7 @@ def _get_enabled_platforms() -> List[str]:
     return enabled
 
 
-def _platform_toolset_summary(config: dict, platforms: Optional[List[str]] = None) -> Dict[str, Set[str]]:
+def _platform_toolset_summary(config: dict, platforms: Optional[list[str]] = None) -> dict[str, set[str]]:
     """Return a summary of enabled toolsets per platform.
 
     When ``platforms`` is None, this uses ``_get_enabled_platforms`` to
@@ -1088,7 +1088,7 @@ def _platform_toolset_summary(config: dict, platforms: Optional[List[str]] = Non
     if platforms is None:
         platforms = _get_enabled_platforms()
 
-    summary: Dict[str, Set[str]] = {}
+    summary: dict[str, set[str]] = {}
     for pkey in platforms:
         summary[pkey] = _get_platform_tools(config, pkey)
     return summary
@@ -1116,7 +1116,7 @@ def _get_platform_tools(
     platform: str,
     *,
     include_default_mcp_servers: bool = True,
-) -> Set[str]:
+) -> set[str]:
     """Resolve which individual toolset names are enabled for a platform."""
     from toolsets import resolve_toolset, TOOLSETS
 
@@ -1343,7 +1343,7 @@ def _get_platform_tools(
     return enabled_toolsets
 
 
-def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[str]):
+def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: set[str]):
     """Save the selected toolset keys for a platform to config.
 
     Preserves any non-configurable toolset entries (like MCP server names)
@@ -1448,10 +1448,10 @@ def _prompt_choice(question: str, choices: list, default: int = 0) -> int:
 # ─── Token Estimation ────────────────────────────────────────────────────────
 
 # Module-level cache so discovery + tokenization runs at most once per process.
-_tool_token_cache: Optional[Dict[str, int]] = None
+_tool_token_cache: Optional[dict[str, int]] = None
 
 
-def _estimate_tool_tokens() -> Dict[str, int]:
+def _estimate_tool_tokens() -> dict[str, int]:
     """Return estimated token counts per individual tool name.
 
     Uses tiktoken (cl100k_base) to count tokens in the JSON-serialised
@@ -1481,7 +1481,7 @@ def _estimate_tool_tokens() -> Dict[str, int]:
         _tool_token_cache = {}
         return _tool_token_cache
 
-    counts: Dict[str, int] = {}
+    counts: dict[str, int] = {}
     for name in registry.get_all_tool_names():
         schema = registry.get_schema(name)
         if schema:
@@ -1493,7 +1493,7 @@ def _estimate_tool_tokens() -> Dict[str, int]:
     return _tool_token_cache
 
 
-def _prompt_toolset_checklist(platform_label: str, enabled: Set[str], platform: str = "cli") -> Set[str]:
+def _prompt_toolset_checklist(platform_label: str, enabled: set[str], platform: str = "cli") -> set[str]:
     """Multi-select checklist of toolsets. Returns set of selected toolset keys."""
     from hermes_cli.curses_ui import curses_checklist
     from toolsets import resolve_toolset
@@ -3164,7 +3164,7 @@ def _configure_mcp_tools_interactive(config: dict):
                 labels.append(tool_name)
 
         # Determine which tools are currently enabled
-        pre_selected: Set[int] = set()
+        pre_selected: set[int] = set()
         tool_names = [t[0] for t in tools]
         for i, tool_name in enumerate(tool_names):
             if include_list:
@@ -3224,7 +3224,7 @@ def _configure_mcp_tools_interactive(config: dict):
 # ─── Non-interactive disable/enable ──────────────────────────────────────────
 
 
-def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str], action: str):
+def _apply_toolset_change(config: dict, platform: str, toolset_names: list[str], action: str):
     """Add or remove built-in toolsets for a platform."""
     enabled = _get_platform_tools(config, platform, include_default_mcp_servers=False)
     if action == "disable":
@@ -3234,12 +3234,12 @@ def _apply_toolset_change(config: dict, platform: str, toolset_names: List[str],
     _save_platform_tools(config, platform, updated)
 
 
-def _apply_mcp_change(config: dict, targets: List[str], action: str) -> Set[str]:
+def _apply_mcp_change(config: dict, targets: list[str], action: str) -> set[str]:
     """Add or remove specific MCP tools from a server's exclude list.
 
     Returns the set of server names that were not found in config.
     """
-    failed_servers: Set[str] = set()
+    failed_servers: set[str] = set()
     mcp_servers = config.get("mcp_servers") or {}
 
     for target in targets:
@@ -3320,7 +3320,7 @@ def tools_disable_enable_command(args):
                           config.get("mcp_servers") or {}, platform)
         return
 
-    targets: List[str] = args.names
+    targets: list[str] = args.names
     toolset_targets = [t for t in targets if ":" not in t]
     mcp_targets = [t for t in targets if ":" in t]
 
@@ -3348,7 +3348,7 @@ def tools_disable_enable_command(args):
     if toolset_targets:
         _apply_toolset_change(config, platform, toolset_targets, action)
 
-    failed_servers: Set[str] = set()
+    failed_servers: set[str] = set()
     if mcp_targets:
         failed_servers = _apply_mcp_change(config, mcp_targets, action)
         for srv in failed_servers:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -93,7 +93,7 @@ _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 _DASHBOARD_EMBEDDED_CHAT_ENABLED = False
 
 # Simple rate limiter for the reveal endpoint
-_reveal_timestamps: List[float] = []
+_reveal_timestamps: list[float] = []
 _REVEAL_MAX_PER_WINDOW = 5
 _REVEAL_WINDOW_SECONDS = 30
 
@@ -252,7 +252,7 @@ async def auth_middleware(request: Request, call_next):
 # ---------------------------------------------------------------------------
 
 # Manual overrides for fields that need select options or custom types
-_SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
+_SCHEMA_OVERRIDES: dict[str, dict[str, Any]] = {
     "model": {
         "type": "string",
         "description": "Default model (e.g. anthropic/claude-sonnet-4.6)",
@@ -348,7 +348,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.
-_CATEGORY_MERGE: Dict[str, str] = {
+_CATEGORY_MERGE: dict[str, str] = {
     "privacy": "security",
     "context": "agent",
     "skills": "agent",
@@ -391,11 +391,11 @@ def _infer_type(value: Any) -> str:
 
 
 def _build_schema_from_config(
-    config: Dict[str, Any],
+    config: dict[str, Any],
     prefix: str = "",
-) -> Dict[str, Dict[str, Any]]:
+) -> dict[str, dict[str, Any]]:
     """Walk DEFAULT_CONFIG and produce a flat dot-path → field schema dict."""
-    schema: Dict[str, Dict[str, Any]] = {}
+    schema: dict[str, dict[str, Any]] = {}
     for key, value in config.items():
         full_key = f"{prefix}.{key}" if prefix else key
 
@@ -416,7 +416,7 @@ def _build_schema_from_config(
             # Recurse into nested dicts
             schema.update(_build_schema_from_config(value, full_key))
         else:
-            entry: Dict[str, Any] = {
+            entry: dict[str, Any] = {
                 "type": _infer_type(value),
                 "description": full_key.replace(".", " → ").replace("_", " ").title(),
                 "category": category,
@@ -436,7 +436,7 @@ CONFIG_SCHEMA = _build_schema_from_config(DEFAULT_CONFIG)
 # by the normalize/denormalize cycle.  Insert model_context_length right after
 # the "model" key so it renders adjacent in the frontend.
 _mcl_entry = _SCHEMA_OVERRIDES["model_context_length"]
-_ordered_schema: Dict[str, Dict[str, Any]] = {}
+_ordered_schema: dict[str, dict[str, Any]] = {}
 for _k, _v in CONFIG_SCHEMA.items():
     _ordered_schema[_k] = _v
     if _k == "model":
@@ -654,17 +654,17 @@ async def get_status():
 _ACTION_LOG_DIR: Path = get_hermes_home() / "logs"
 
 # Short ``name`` (from the URL) → absolute log file path.
-_ACTION_LOG_FILES: Dict[str, str] = {
+_ACTION_LOG_FILES: dict[str, str] = {
     "gateway-restart": "gateway-restart.log",
     "hermes-update": "hermes-update.log",
 }
 
 # ``name`` → most recently spawned Popen handle.  Used so ``status`` can
 # report liveness and exit code without shelling out to ``ps``.
-_ACTION_PROCS: Dict[str, subprocess.Popen] = {}
+_ACTION_PROCS: dict[str, subprocess.Popen] = {}
 
 
-def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
+def _spawn_hermes_action(subcommand: list[str], name: str) -> subprocess.Popen:
     """Spawn ``hermes <subcommand>`` detached and record the Popen handle.
 
     Uses the running interpreter's ``hermes_cli.main`` module so the action
@@ -680,7 +680,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
 
     cmd = [sys.executable, "-m", "hermes_cli.main", *subcommand]
 
-    popen_kwargs: Dict[str, Any] = {
+    popen_kwargs: dict[str, Any] = {
         "cwd": str(PROJECT_ROOT),
         "stdin": subprocess.DEVNULL,
         "stdout": log_file,
@@ -700,7 +700,7 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     return proc
 
 
-def _tail_lines(path: Path, n: int) -> List[str]:
+def _tail_lines(path: Path, n: int) -> list[str]:
     """Return the last ``n`` lines of ``path``.  Reads the whole file — fine
     for our small per-action logs.  Binary-decoded with ``errors='replace'``
     so log corruption doesn't 500 the endpoint."""
@@ -837,7 +837,7 @@ async def search_sessions(q: str = "", limit: int = 20):
         raise HTTPException(status_code=500, detail="Search failed")
 
 
-def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_config_for_web(config: dict[str, Any]) -> dict[str, Any]:
     """Normalize config for the web UI.
 
     Hermes supports ``model`` as either a bare string (``"anthropic/claude-sonnet-4"``)
@@ -972,7 +972,7 @@ def get_model_info():
 
 # Canonical auxiliary task slots. Keep in sync with DEFAULT_CONFIG["auxiliary"]
 # in hermes_cli/config.py — listed here for deterministic ordering in the UI.
-_AUX_TASK_SLOTS: Tuple[str, ...] = (
+_AUX_TASK_SLOTS: tuple[str, ...] = (
     "vision",
     "web_extract",
     "compression",
@@ -1137,7 +1137,7 @@ async def set_model_assignment(body: ModelAssignment):
 
 
 
-def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
+def _denormalize_config_from_web(config: dict[str, Any]) -> dict[str, Any]:
     """Reverse _normalize_config_for_web before saving.
 
     Reconstructs ``model`` as a dict by reading the current on-disk config
@@ -1309,7 +1309,7 @@ def _truncate_token(value: Optional[str], visible: int = 6) -> str:
     return f"…{s[-visible:]}"
 
 
-def _anthropic_oauth_status() -> Dict[str, Any]:
+def _anthropic_oauth_status() -> dict[str, Any]:
     """Combined status across the three Anthropic credential sources we read.
 
     Hermes resolves Anthropic creds in this order at runtime:
@@ -1374,7 +1374,7 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
     return {"logged_in": False, "source": None}
 
 
-def _claude_code_only_status() -> Dict[str, Any]:
+def _claude_code_only_status() -> dict[str, Any]:
     """Surface Claude Code CLI credentials as their own provider entry.
 
     Independent of the Anthropic entry above so users can see whether their
@@ -1405,7 +1405,7 @@ def _claude_code_only_status() -> Dict[str, Any]:
 # right UI: ``pkce`` = open URL + paste callback code, ``device_code`` =
 # show code + verification URL + poll, ``external`` = read-only (delegated
 # to a third-party CLI like Claude Code or Qwen).
-_OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
+_OAUTH_PROVIDER_CATALOG: tuple[dict[str, Any], ...] = (
     {
         "id": "anthropic",
         "name": "Anthropic (Claude API)",
@@ -1462,7 +1462,7 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
 )
 
 
-def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
+def _resolve_provider_status(provider_id: str, status_fn) -> dict[str, Any]:
     """Dispatch to the right status helper for an OAuth provider entry."""
     if status_fn is not None:
         try:
@@ -1629,7 +1629,7 @@ async def disconnect_oauth_provider(provider_id: str, request: Request):
 # expired sessions so the dict doesn't grow without bound.
 
 _OAUTH_SESSION_TTL_SECONDS = 15 * 60
-_oauth_sessions: Dict[str, Dict[str, Any]] = {}
+_oauth_sessions: dict[str, dict[str, Any]] = {}
 _oauth_sessions_lock = threading.Lock()
 
 # Import OAuth constants from canonical source instead of duplicating.
@@ -1658,7 +1658,7 @@ def _gc_oauth_sessions() -> None:
             _oauth_sessions.pop(sid, None)
 
 
-def _new_oauth_session(provider_id: str, flow: str) -> tuple[str, Dict[str, Any]]:
+def _new_oauth_session(provider_id: str, flow: str) -> tuple[str, dict[str, Any]]:
     """Create + register a new OAuth session, return (session_id, session_dict)."""
     sid = secrets.token_urlsafe(16)
     sess = {
@@ -1741,7 +1741,7 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
         _log.warning("anthropic pool add (dashboard) failed: %s", e)
 
 
-def _start_anthropic_pkce() -> Dict[str, Any]:
+def _start_anthropic_pkce() -> dict[str, Any]:
     """Begin PKCE flow. Returns the auth URL the UI should open."""
     if not _ANTHROPIC_OAUTH_AVAILABLE:
         raise HTTPException(status_code=501, detail="Anthropic OAuth not available (missing adapter)")
@@ -1768,7 +1768,7 @@ def _start_anthropic_pkce() -> Dict[str, Any]:
     }
 
 
-def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
+def _submit_anthropic_pkce(session_id: str, code_input: str) -> dict[str, Any]:
     """Exchange authorization code for tokens. Persists on success."""
     with _oauth_sessions_lock:
         sess = _oauth_sessions.get(session_id)
@@ -1834,7 +1834,7 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
     return {"ok": True, "status": "approved"}
 
 
-async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
+async def _start_device_code_flow(provider_id: str) -> dict[str, Any]:
     """Initiate a device-code flow (Nous, OpenAI Codex, or MiniMax).
 
     Calls the provider's device-auth endpoint via the existing CLI helpers,
@@ -2584,7 +2584,7 @@ class CronJobUpdate(BaseModel):
 _CRON_PROFILE_LOCK = threading.RLock()
 
 
-def _cron_profile_dicts() -> List[Dict[str, Any]]:
+def _cron_profile_dicts() -> list[dict[str, Any]]:
     """Return dashboard profile records, falling back to a directory scan."""
     from hermes_cli import profiles as profiles_mod
     try:
@@ -2594,7 +2594,7 @@ def _cron_profile_dicts() -> List[Dict[str, Any]]:
         return _fallback_profile_dicts(profiles_mod)
 
 
-def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
+def _cron_profile_home(profile: Optional[str]) -> tuple[str, Path]:
     """Resolve a profile query value to (profile_name, HERMES_HOME)."""
     from hermes_cli import profiles as profiles_mod
 
@@ -2609,7 +2609,7 @@ def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
     return canon, profiles_mod.get_profile_dir(canon)
 
 
-def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[str, Any]:
+def _annotate_cron_job(job: dict[str, Any], profile: str, home: Path) -> dict[str, Any]:
     annotated = dict(job)
     annotated["profile"] = profile
     annotated["profile_name"] = profile
@@ -2667,7 +2667,7 @@ async def list_cron_jobs(profile: str = "all"):
     if requested.lower() != "all":
         return _call_cron_for_profile(requested, "list_jobs", True)
 
-    jobs: List[Dict[str, Any]] = []
+    jobs: list[dict[str, Any]] = []
     for item in _cron_profile_dicts():
         name = str(item.get("name") or "")
         if not name:
@@ -2786,7 +2786,7 @@ def _profile_attr(info, name: str, default: Any = None) -> Any:
         return default
 
 
-def _profile_to_dict(info) -> Dict[str, Any]:
+def _profile_to_dict(info) -> dict[str, Any]:
     return {
         "name": _profile_attr(info, "name", ""),
         "path": str(_profile_attr(info, "path", "")),
@@ -2798,14 +2798,14 @@ def _profile_to_dict(info) -> Dict[str, Any]:
     }
 
 
-def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
+def _fallback_profile_dicts(profiles_mod) -> list[dict[str, Any]]:
     def _safe(callable_, default):
         try:
             return callable_()
         except Exception:
             return default
 
-    profiles: List[Dict[str, Any]] = []
+    profiles: list[dict[str, Any]] = []
     default_home = profiles_mod._get_default_hermes_home()
     if default_home.is_dir():
         model, provider = _safe(lambda: profiles_mod._read_config_model(default_home), (None, None))
@@ -3804,7 +3804,7 @@ _BUILTIN_DASHBOARD_THEMES = [
 ]
 
 
-def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0) -> Optional[Dict[str, Any]]:
+def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0) -> Optional[dict[str, Any]]:
     """Normalise a theme layer spec from YAML into `{hex, alpha}` form.
 
     Accepts shorthand (a bare hex string) or full dict form.  Returns
@@ -3828,7 +3828,7 @@ def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0)
     return None
 
 
-_THEME_DEFAULT_TYPOGRAPHY: Dict[str, str] = {
+_THEME_DEFAULT_TYPOGRAPHY: dict[str, str] = {
     "fontSans": 'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
     "fontMono": 'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace',
     "baseSize": "15px",
@@ -3836,7 +3836,7 @@ _THEME_DEFAULT_TYPOGRAPHY: Dict[str, str] = {
     "letterSpacing": "0",
 }
 
-_THEME_DEFAULT_LAYOUT: Dict[str, str] = {
+_THEME_DEFAULT_LAYOUT: dict[str, str] = {
     "radius": "0.5rem",
     "density": "comfortable",
 }
@@ -3873,7 +3873,7 @@ _THEME_LAYOUT_VARIANTS = {"standard", "cockpit", "tiled"}
 _THEME_CUSTOM_CSS_MAX = 32 * 1024
 
 
-def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _normalise_theme_definition(data: dict[str, Any]) -> Optional[dict[str, Any]]:
     """Normalise a user theme YAML into the wire format `ThemeProvider`
     expects.  Returns ``None`` if the theme is unusable.
 
@@ -3891,7 +3891,7 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
     # Allow top-level `colors.background` as a shorthand too.
     colors_src = data.get("colors", {}) if isinstance(data.get("colors"), dict) else {}
 
-    def _layer(key: str, default_hex: str, default_alpha: float = 1.0) -> Dict[str, Any]:
+    def _layer(key: str, default_hex: str, default_alpha: float = 1.0) -> dict[str, Any]:
         spec = palette_src.get(key, colors_src.get(key))
         parsed = _parse_theme_layer(spec, default_hex, default_alpha)
         return parsed if parsed is not None else {"hex": default_hex, "alpha": default_alpha}
@@ -3929,7 +3929,7 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
 
     # Color overrides — keep only valid keys with string values.
     overrides_src = data.get("colorOverrides", {})
-    color_overrides: Dict[str, str] = {}
+    color_overrides: dict[str, str] = {}
     if isinstance(overrides_src, dict):
         for key, val in overrides_src.items():
             if key in _THEME_OVERRIDE_KEYS and isinstance(val, str) and val.strip():
@@ -3940,7 +3940,7 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
     # We don't fetch remote assets here; the frontend just injects them as
     # CSS vars.  Empty values are dropped so a theme can explicitly clear a
     # slot by setting ``hero: ""``.
-    assets_out: Dict[str, Any] = {}
+    assets_out: dict[str, Any] = {}
     assets_src = data.get("assets", {}) if isinstance(data.get("assets"), dict) else {}
     for key in _THEME_NAMED_ASSET_KEYS:
         val = assets_src.get(key)
@@ -3948,7 +3948,7 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
             assets_out[key] = val
     custom_assets_src = assets_src.get("custom")
     if isinstance(custom_assets_src, dict):
-        custom_assets: Dict[str, str] = {}
+        custom_assets: dict[str, str] = {}
         for key, val in custom_assets_src.items():
             if (
                 isinstance(key, str)
@@ -3974,12 +3974,12 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
     # property -> CSS string.  The frontend converts these into CSS vars
     # that shell components (Card, App header, Backdrop) consume.
     component_styles_src = data.get("componentStyles", {})
-    component_styles: Dict[str, Dict[str, str]] = {}
+    component_styles: dict[str, dict[str, str]] = {}
     if isinstance(component_styles_src, dict):
         for bucket, props in component_styles_src.items():
             if bucket not in _THEME_COMPONENT_BUCKETS or not isinstance(props, dict):
                 continue
-            clean: Dict[str, str] = {}
+            clean: dict[str, str] = {}
             for prop, value in props.items():
                 if (
                     isinstance(prop, str)
@@ -3998,7 +3998,7 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
         else "standard"
     )
 
-    result: Dict[str, Any] = {
+    result: dict[str, Any] = {
         "name": name,
         "label": data.get("label") or name,
         "description": data.get("description", ""),
@@ -4190,7 +4190,7 @@ def _discover_dashboard_plugins() -> list:
                 # The frontend exposes ``registerSlot(pluginName, slotName, Component)``
                 # on window; plugins with non-empty slots call it from their JS bundle.
                 slots_src = data.get("slots")
-                slots: List[str] = []
+                slots: list[str] = []
                 if isinstance(slots_src, list):
                     slots = [s for s in slots_src if isinstance(s, str) and s]
                 # Validate ``api`` at discovery time so the value cached
@@ -4273,11 +4273,11 @@ class _AgentPluginInstallBody(BaseModel):
     enable: bool = True
 
 
-def _strip_dashboard_manifest(p: Dict[str, Any]) -> Dict[str, Any]:
+def _strip_dashboard_manifest(p: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in p.items() if not k.startswith("_")}
 
 
-def _merged_plugins_hub() -> Dict[str, Any]:
+def _merged_plugins_hub() -> dict[str, Any]:
     """Agent discovery + dashboard manifests + optional provider picker metadata."""
     from hermes_cli.plugins_cmd import (
         _discover_all_plugins,
@@ -4301,7 +4301,7 @@ def _merged_plugins_hub() -> Dict[str, Any]:
     hidden_plugins: list = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
 
     plugins_root_resolved = (get_hermes_home() / "plugins").resolve()
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
 
     for name, version, description, source, dir_str in _discover_all_plugins():
         if name in disabled_set:
@@ -4366,14 +4366,14 @@ def _merged_plugins_hub() -> Dict[str, Any]:
         if str(p["name"]) not in agent_names
     ]
 
-    memory_providers: List[Dict[str, str]] = []
+    memory_providers: list[dict[str, str]] = []
     try:
         for n, desc in _discover_memory_providers():
             memory_providers.append({"name": n, "description": desc})
     except Exception:
         memory_providers = []
 
-    context_engines: List[Dict[str, str]] = []
+    context_engines: list[dict[str, str]] = []
     try:
         for n, desc in _discover_context_engines():
             context_engines.append({"name": n, "description": desc})

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -37,7 +37,7 @@ def _subscriptions_path() -> Path:
     return _hermes_home() / _SUBSCRIPTIONS_FILENAME
 
 
-def _load_subscriptions() -> Dict[str, dict]:
+def _load_subscriptions() -> dict[str, dict]:
     path = _subscriptions_path()
     if not path.exists():
         return {}
@@ -48,7 +48,7 @@ def _load_subscriptions() -> Dict[str, dict]:
         return {}
 
 
-def _save_subscriptions(subs: Dict[str, dict]) -> None:
+def _save_subscriptions(subs: dict[str, dict]) -> None:
     path = _subscriptions_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     # webhook_subscriptions.json contains per-route HMAC secrets — write

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -20,7 +20,7 @@ RETIREMENT_DATE = "May 15, 2026"
 # Some entries set ``reasoning_effort`` because non-reasoning variants don't
 # have a one-to-one replacement: ``grok-4.3`` reasons by default, so emulating
 # ``*-non-reasoning`` behavior on it requires ``reasoning_effort="none"``.
-_RETIRED_MODELS: Dict[str, Dict[str, Optional[str]]] = {
+_RETIRED_MODELS: dict[str, dict[str, Optional[str]]] = {
     "grok-4-0709":                  {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
     "grok-4-fast-reasoning":        {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
     "grok-4-fast-non-reasoning":    {"replacement": "grok-4.3", "reasoning_effort": "none", "note": None},
@@ -59,7 +59,7 @@ def _looks_like_xai(model_id: Optional[str]) -> bool:
     return _normalize(model_id).startswith("grok-")
 
 
-def find_retired_xai_refs(config: Dict[str, Any]) -> List[RetirementIssue]:
+def find_retired_xai_refs(config: dict[str, Any]) -> list[RetirementIssue]:
     """Walk all model slots in a Hermes config and return retirement issues.
 
     Slots scanned:
@@ -69,7 +69,7 @@ def find_retired_xai_refs(config: Dict[str, Any]) -> List[RetirementIssue]:
       - ``tts.xai.model``
       - ``plugins.image_gen.xai.model``
     """
-    issues: List[RetirementIssue] = []
+    issues: list[RetirementIssue] = []
 
     def _check(path: str, model: Any) -> None:
         if not _looks_like_xai(model):
@@ -147,7 +147,7 @@ class ApplyResult:
 
     file_path: Path
     backup_path: Optional[Path]
-    issues_resolved: List[RetirementIssue]
+    issues_resolved: list[RetirementIssue]
     config_changed: bool
 
 
@@ -170,7 +170,7 @@ def _walk_to_parent(yaml_doc: Any, dotted_path: str) -> "tuple[Any, str]":
 
 def apply_migration(
     config_path: Path,
-    issues: List[RetirementIssue],
+    issues: list[RetirementIssue],
     backup: bool = True,
 ) -> ApplyResult:
     """Rewrite ``config_path`` in-place so each issue is resolved.
@@ -214,7 +214,7 @@ def apply_migration(
             config_changed=False,
         )
 
-    resolved: List[RetirementIssue] = []
+    resolved: list[RetirementIssue] = []
     for issue in issues:
         try:
             parent, leaf = _walk_to_parent(doc, issue.config_path)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -463,7 +463,7 @@ class SessionDB:
                 self._conn = None
 
     @staticmethod
-    def _parse_schema_columns(schema_sql: str) -> Dict[str, Dict[str, str]]:
+    def _parse_schema_columns(schema_sql: str) -> dict[str, dict[str, str]]:
         """Extract expected columns per table from SCHEMA_SQL.
 
         Uses an in-memory SQLite database to parse the SQL — SQLite itself
@@ -478,12 +478,12 @@ class SessionDB:
         ref = sqlite3.connect(":memory:")
         try:
             ref.executescript(schema_sql)
-            table_columns: Dict[str, Dict[str, str]] = {}
+            table_columns: dict[str, dict[str, str]] = {}
             for (tbl,) in ref.execute(
                 "SELECT name FROM sqlite_master "
                 "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
             ).fetchall():
-                cols: Dict[str, str] = {}
+                cols: dict[str, str] = {}
                 for row in ref.execute(
                     f'PRAGMA table_info("{tbl}")'
                 ).fetchall():
@@ -701,7 +701,7 @@ class SessionDB:
         session_id: str,
         source: str,
         model: str = None,
-        model_config: Dict[str, Any] = None,
+        model_config: dict[str, Any] = None,
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
@@ -944,7 +944,7 @@ class SessionDB:
 
         return self._execute_write(_do) or 0
 
-    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def get_session(self, session_id: str) -> Optional[dict[str, Any]]:
         """Get a session by ID."""
         with self._lock:
             cursor = self._conn.execute(
@@ -1065,7 +1065,7 @@ class SessionDB:
             row = cursor.fetchone()
         return row["title"] if row else None
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(self, title: str) -> Optional[dict[str, Any]]:
         """Look up a session by exact title. Returns session dict or None."""
         with self._lock:
             cursor = self._conn.execute(
@@ -1177,13 +1177,13 @@ class SessionDB:
     def list_sessions_rich(
         self,
         source: str = None,
-        exclude_sources: List[str] = None,
+        exclude_sources: list[str] = None,
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
         project_compression_tips: bool = True,
         order_by_last_active: bool = False,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
         Returns dicts with keys: id, source, model, title, started_at, ended_at,
@@ -1364,7 +1364,7 @@ class SessionDB:
 
         return sessions
 
-    def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def _get_session_rich_row(self, session_id: str) -> Optional[dict[str, Any]]:
         """Fetch a single session with the same enriched columns as
         ``list_sessions_rich`` (preview + last_active). Returns None if the
         session doesn't exist.
@@ -1542,7 +1542,7 @@ class SessionDB:
 
         return self._execute_write(_do)
 
-    def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+    def replace_messages(self, session_id: str, messages: list[dict[str, Any]]) -> None:
         """Atomically replace every message for a session.
 
         Used by transcript-rewrite flows such as /retry, /undo, and /compress.
@@ -1628,7 +1628,7 @@ class SessionDB:
 
         self._execute_write(_do)
 
-    def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
+    def get_messages(self, session_id: str) -> list[dict[str, Any]]:
         """Load all messages for a session, ordered by insertion order."""
         with self._lock:
             cursor = self._conn.execute(
@@ -1655,7 +1655,7 @@ class SessionDB:
         session_id: str,
         around_message_id: int,
         window: int = 5,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Load a window of messages anchored on a specific message id.
 
         Returns a dict with:
@@ -1734,8 +1734,8 @@ class SessionDB:
         around_message_id: int,
         window: int = 5,
         bookend: int = 3,
-        keep_roles: Optional[Tuple[str, ...]] = ("user", "assistant"),
-    ) -> Dict[str, Any]:
+        keep_roles: Optional[tuple[str, ...]] = ("user", "assistant"),
+    ) -> dict[str, Any]:
         """Return an anchored window plus session bookends.
 
         Built on top of ``get_messages_around``. Three slices:
@@ -1797,8 +1797,8 @@ class SessionDB:
         # by id range, role, and non-empty content — tool-call-only assistant
         # turns (content='' with tool_calls populated) are excluded so they
         # don't crowd out actual prose openings/closings.
-        bookend_start_rows: List[Any] = []
-        bookend_end_rows: List[Any] = []
+        bookend_start_rows: list[Any] = []
+        bookend_end_rows: list[Any] = []
         if bookend > 0:
             with self._lock:
                 role_clause = ""
@@ -1826,7 +1826,7 @@ class SessionDB:
                 # End rows came back DESC for the LIMIT cap; flip to ASC.
                 bookend_end_rows = list(reversed(bookend_end_rows))
 
-        def _hydrate(row) -> Dict[str, Any]:
+        def _hydrate(row) -> dict[str, Any]:
             msg = dict(row)
             if "content" in msg:
                 msg["content"] = self._decode_content(msg["content"])
@@ -1915,7 +1915,7 @@ class SessionDB:
 
     def get_messages_as_conversation(
         self, session_id: str, include_ancestors: bool = False
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Load messages in the OpenAI conversation format (role + content dicts).
         Used by the gateway to restore conversation history.
@@ -1992,7 +1992,7 @@ class SessionDB:
             messages.append(msg)
         return messages
 
-    def _session_lineage_root_to_tip(self, session_id: str) -> List[str]:
+    def _session_lineage_root_to_tip(self, session_id: str) -> list[str]:
         if not session_id:
             return [session_id]
 
@@ -2015,7 +2015,7 @@ class SessionDB:
         return list(reversed(chain)) or [session_id]
 
     @staticmethod
-    def _is_duplicate_replayed_user_message(messages: List[Dict[str, Any]], msg: Dict[str, Any]) -> bool:
+    def _is_duplicate_replayed_user_message(messages: list[dict[str, Any]], msg: dict[str, Any]) -> bool:
         if msg.get("role") != "user":
             return False
         content = msg.get("content")
@@ -2119,13 +2119,13 @@ class SessionDB:
     def search_messages(
         self,
         query: str,
-        source_filter: List[str] = None,
-        exclude_sources: List[str] = None,
-        role_filter: List[str] = None,
+        source_filter: list[str] = None,
+        exclude_sources: list[str] = None,
+        role_filter: list[str] = None,
         limit: int = 20,
         offset: int = 0,
         sort: str = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
 
@@ -2421,7 +2421,7 @@ class SessionDB:
         source: str = None,
         limit: int = 20,
         offset: int = 0,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """List sessions, optionally filtered by source.
 
         Returns rows enriched with a computed ``last_active`` column (latest
@@ -2482,7 +2482,7 @@ class SessionDB:
     # Export and cleanup
     # =========================================================================
 
-    def export_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def export_session(self, session_id: str) -> Optional[dict[str, Any]]:
         """Export a single session with all its messages as a dict."""
         session = self.get_session(session_id)
         if not session:
@@ -2490,7 +2490,7 @@ class SessionDB:
         messages = self.get_messages(session_id)
         return {**session, "messages": messages}
 
-    def export_all(self, source: str = None) -> List[Dict[str, Any]]:
+    def export_all(self, source: str = None) -> list[dict[str, Any]]:
         """
         Export all sessions (with messages) as a list of dicts.
         Suitable for writing to a JSONL file for backup/analysis.
@@ -2857,7 +2857,7 @@ class SessionDB:
         *,
         chat_id: str,
         thread_id: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         """Return the session binding for a Telegram DM topic, if present."""
         with self._lock:
             try:
@@ -2876,7 +2876,7 @@ class SessionDB:
         self,
         *,
         chat_id: str,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """All Telegram DM topic bindings for one chat, newest first.
 
         Read-only; returns [] if the bindings table doesn't exist yet
@@ -2897,7 +2897,7 @@ class SessionDB:
         self,
         *,
         session_id: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Optional[dict[str, Any]]:
         """Return the Telegram DM topic binding for a given session_id, if present.
 
         Uses the UNIQUE INDEX on telegram_dm_topic_bindings(session_id) for an
@@ -3009,7 +3009,7 @@ class SessionDB:
         chat_id: str,
         user_id: str,
         limit: int = 10,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """List previous Telegram sessions for this user that are not bound to a topic.
 
         Read-only: does NOT trigger the telegram-topic migration. If the
@@ -3071,7 +3071,7 @@ class SessionDB:
                     (str(user_id), int(limit)),
                 ).fetchall()
 
-        sessions: List[Dict[str, Any]] = []
+        sessions: list[dict[str, Any]] = []
         for row in rows:
             session = dict(row)
             raw = str(session.pop("_preview_raw", "") or "").strip()
@@ -3110,7 +3110,7 @@ class SessionDB:
         min_interval_hours: int = 24,
         vacuum: bool = True,
         sessions_dir: Optional[Path] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Idempotent auto-maintenance: prune old sessions + optional VACUUM.
 
         Records the last run timestamp in state_meta so subsequent calls
@@ -3130,7 +3130,7 @@ class SessionDB:
           - ``"vacuumed"`` (bool) — true if VACUUM ran
           - ``"error"`` (str, optional) — present only on failure
         """
-        result: Dict[str, Any] = {"skipped": False, "pruned": 0, "vacuumed": False}
+        result: dict[str, Any] = {"skipped": False, "pruned": 0, "vacuumed": False}
         try:
             # Skip if another process/call did maintenance recently.
             last_raw = self.get_meta("last_auto_prune")
@@ -3208,7 +3208,7 @@ class SessionDB:
             return cur.rowcount > 0
         return self._execute_write(_do)
 
-    def get_handoff_state(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def get_handoff_state(self, session_id: str) -> Optional[dict[str, Any]]:
         """Read the current handoff state for a session.
 
         Returns ``{"state", "platform", "error"}`` or None if the session has
@@ -3231,7 +3231,7 @@ class SessionDB:
         except Exception:
             return None
 
-    def list_pending_handoffs(self) -> List[Dict[str, Any]]:
+    def list_pending_handoffs(self) -> list[dict[str, Any]]:
         """Return all sessions in handoff_state='pending', oldest first.
 
         Used by the gateway's handoff watcher.

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -146,7 +146,7 @@ def _extract_message_content(msg: dict) -> str:
     return str(content) if content else ""
 
 
-def _extract_attachments(msg: dict) -> List[dict]:
+def _extract_attachments(msg: dict) -> list[dict]:
     """Extract non-text attachments from a message.
 
     Finds: multi-part image/file content blocks, MEDIA: tags in text,
@@ -210,15 +210,15 @@ class EventBridge:
     """
 
     def __init__(self):
-        self._queue: List[QueueEvent] = []
+        self._queue: list[QueueEvent] = []
         self._cursor = 0
         self._lock = threading.Lock()
         self._new_event = threading.Event()
         self._running = False
         self._thread: Optional[threading.Thread] = None
-        self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
+        self._last_poll_timestamps: dict[str, float] = {}  # session_key -> unix timestamp
         # In-memory approval tracking (populated from events)
-        self._pending_approvals: Dict[str, dict] = {}
+        self._pending_approvals: dict[str, dict] = {}
         # mtime cache — skip expensive work when files haven't changed
         self._sessions_json_mtime: float = 0.0
         self._state_db_mtime: float = 0.0
@@ -293,7 +293,7 @@ class EventBridge:
 
         return None
 
-    def list_pending_approvals(self) -> List[dict]:
+    def list_pending_approvals(self) -> list[dict]:
         """List approval requests observed during this bridge session."""
         with self._lock:
             return sorted(

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -264,7 +264,7 @@ class MiniSWERunner:
                 self.env.stop()
             self.env = None
     
-    def _execute_command(self, command: str, timeout: int = None) -> Dict[str, Any]:
+    def _execute_command(self, command: str, timeout: int = None) -> dict[str, Any]:
         """
         Execute a command in the environment.
         
@@ -307,10 +307,10 @@ class MiniSWERunner:
     
     def _convert_to_hermes_format(
         self,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         user_query: str,
         completed: bool
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Convert internal message format to Hermes trajectory format.
         
@@ -415,7 +415,7 @@ class MiniSWERunner:
         
         return trajectory
     
-    def run_task(self, task: str) -> Dict[str, Any]:
+    def run_task(self, task: str) -> dict[str, Any]:
         """
         Run a single task and return the result with trajectory.
         
@@ -582,9 +582,9 @@ Complete the user's task step by step."""
     
     def run_batch(
         self,
-        prompts: List[str],
+        prompts: list[str],
         output_file: str
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Run multiple tasks and save trajectories to a JSONL file.
         

--- a/model_tools.py
+++ b/model_tools.py
@@ -204,13 +204,13 @@ except Exception as e:
 # Backward-compat constants  (built once after discovery)
 # =============================================================================
 
-TOOL_TO_TOOLSET_MAP: Dict[str, str] = registry.get_tool_to_toolset_map()
+TOOL_TO_TOOLSET_MAP: dict[str, str] = registry.get_tool_to_toolset_map()
 
-TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
+TOOLSET_REQUIREMENTS: dict[str, dict] = registry.get_toolset_requirements()
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.
-_last_resolved_tool_names: List[str] = []
+_last_resolved_tool_names: list[str] = []
 
 
 # =============================================================================
@@ -251,7 +251,7 @@ _LEGACY_TOOLSET_MAP = {
 # which bumps on register() / deregister() / register_toolset_alias(). The
 # inner check_fn TTL cache in registry.py handles environment drift (Docker
 # daemon start/stop, env var changes, etc.) on a 30 s horizon.
-_tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_tool_defs_cache: dict[tuple, list[dict[str, Any]]] = {}
 
 
 def _clear_tool_defs_cache() -> None:
@@ -262,10 +262,10 @@ def _clear_tool_defs_cache() -> None:
 
 
 def get_tool_definitions(
-    enabled_toolsets: List[str] = None,
-    disabled_toolsets: List[str] = None,
+    enabled_toolsets: list[str] = None,
+    disabled_toolsets: list[str] = None,
     quiet_mode: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
 
@@ -327,10 +327,10 @@ def get_tool_definitions(
 
 
 def _compute_tool_definitions(
-    enabled_toolsets: List[str] = None,
-    disabled_toolsets: List[str] = None,
+    enabled_toolsets: list[str] = None,
+    disabled_toolsets: list[str] = None,
     quiet_mode: bool = False,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
     tools_to_include: set = set()
@@ -542,7 +542,7 @@ def _sanitize_tool_error(error_msg: str) -> str:
 # Tool argument type coercion
 # =========================================================================
 
-def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+def coerce_tool_args(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Coerce tool call arguments to match their JSON Schema types.
 
     LLMs frequently return numbers as strings (``"42"`` instead of ``42``)
@@ -740,12 +740,12 @@ def _coerce_boolean(value: str):
 
 def handle_function_call(
     function_name: str,
-    function_args: Dict[str, Any],
+    function_args: dict[str, Any],
     task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None,
     session_id: Optional[str] = None,
     user_task: Optional[str] = None,
-    enabled_tools: Optional[List[str]] = None,
+    enabled_tools: Optional[list[str]] = None,
     skip_pre_tool_call_hook: bool = False,
 ) -> str:
     """
@@ -898,7 +898,7 @@ def handle_function_call(
 # Backward-compat wrapper functions
 # =============================================================================
 
-def get_all_tool_names() -> List[str]:
+def get_all_tool_names() -> list[str]:
     """Return all registered tool names."""
     return registry.get_all_tool_names()
 
@@ -908,16 +908,16 @@ def get_toolset_for_tool(tool_name: str) -> Optional[str]:
     return registry.get_toolset_for_tool(tool_name)
 
 
-def get_available_toolsets() -> Dict[str, dict]:
+def get_available_toolsets() -> dict[str, dict]:
     """Return toolset availability info for UI display."""
     return registry.get_available_toolsets()
 
 
-def check_toolset_requirements() -> Dict[str, bool]:
+def check_toolset_requirements() -> dict[str, bool]:
     """Return {toolset: available_bool} for every registered toolset."""
     return registry.check_toolset_requirements()
 
 
-def check_tool_availability(quiet: bool = False) -> Tuple[List[str], List[dict]]:
+def check_tool_availability(quiet: bool = False) -> tuple[list[str], list[dict]]:
     """Return (available_toolsets, unavailable_info)."""
     return registry.check_tool_availability(quiet=quiet)

--- a/optional-skills/blockchain/evm/scripts/evm_client.py
+++ b/optional-skills/blockchain/evm/scripts/evm_client.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple
 # Chain registry
 # ---------------------------------------------------------------------------
 
-CHAINS: Dict[str, Dict[str, Any]] = {
+CHAINS: dict[str, dict[str, Any]] = {
     "ethereum": {
         "chain_id": 1,
         "rpc": "https://ethereum-rpc.publicnode.com",
@@ -90,7 +90,7 @@ DEFAULT_CHAIN = "ethereum"
 # Known ERC-20 token registry  {chain -> {symbol -> address}}
 # ---------------------------------------------------------------------------
 
-KNOWN_TOKENS: Dict[str, Dict[str, str]] = {
+KNOWN_TOKENS: dict[str, dict[str, str]] = {
     "ethereum": {
         "USDT":  "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         "USDC":  "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -190,7 +190,7 @@ GAS_ESTIMATES = {
 }
 
 # CoinGecko symbol -> id map for common tokens
-COINGECKO_IDS: Dict[str, str] = {
+COINGECKO_IDS: dict[str, str] = {
     "ETH":   "ethereum",
     "BTC":   "bitcoin",
     "BNB":   "binancecoin",
@@ -394,7 +394,7 @@ def get_rpc_url(chain: str) -> str:
         raise ValueError(f"Unknown chain '{chain}'. Available: {', '.join(CHAINS)}")
     return cfg["rpc"]
 
-def rpc_call(chain: str, method: str, params: List[Any], req_id: int = 1) -> Any:
+def rpc_call(chain: str, method: str, params: list[Any], req_id: int = 1) -> Any:
     url = get_rpc_url(chain)
     payload = {"jsonrpc": "2.0", "id": req_id, "method": method, "params": params}
     resp = _http_post(url, payload)
@@ -402,7 +402,7 @@ def rpc_call(chain: str, method: str, params: List[Any], req_id: int = 1) -> Any
         raise RuntimeError(f"RPC error: {resp['error']}")
     return resp.get("result")
 
-def rpc_batch(chain: str, calls: List[Tuple[str, List[Any]]], batch_limit: int = 10) -> List[Any]:
+def rpc_batch(chain: str, calls: list[tuple[str, list[Any]]], batch_limit: int = 10) -> list[Any]:
     """Send a batch of JSON-RPC calls; returns list of results in same order.
 
     Auto-chunks at `batch_limit` (default 10) so we stay under per-RPC limits.
@@ -417,7 +417,7 @@ def rpc_batch(chain: str, calls: List[Tuple[str, List[Any]]], batch_limit: int =
         for i, (m, p) in enumerate(calls)
     ]
 
-    out: List[Any] = [None] * len(items)
+    out: list[Any] = [None] * len(items)
     for start in range(0, len(items), batch_limit):
         chunk = items[start:start + batch_limit]
         resp = _http_post(url, chunk)
@@ -495,7 +495,7 @@ def _selector(sig: str) -> str:
     return "0x" + _keccak256(sig.encode()).hex()[:8]
 
 # Precomputed selectors for ERC-20 functions
-ERC20_SELECTORS: Dict[str, str] = {
+ERC20_SELECTORS: dict[str, str] = {
     "name()":                  "0x06fdde03",
     "symbol()":                "0x95d89b41",
     "decimals()":              "0x313ce567",
@@ -552,7 +552,7 @@ def cg_price_by_id(cg_id: str) -> Optional[float]:
     except Exception:
         return None
 
-def cg_price_by_ids(cg_ids: List[str]) -> Dict[str, float]:
+def cg_price_by_ids(cg_ids: list[str]) -> dict[str, float]:
     """Fetch multiple prices in one request."""
     if not cg_ids:
         return {}
@@ -840,7 +840,7 @@ def cmd_activity(args: argparse.Namespace) -> None:
     block_hex = rpc_call(chain, "eth_blockNumber", [])
     latest    = hex_to_int(block_hex or "0x0")
 
-    txs_out: List[Dict[str, Any]] = []
+    txs_out: list[dict[str, Any]] = []
     scan_range = min(200, latest)
     blocks_checked = 0
 
@@ -896,7 +896,7 @@ def cmd_gas(args: argparse.Namespace) -> None:
 
     native_price  = get_native_price(chain)
 
-    estimates: Dict[str, Any] = {}
+    estimates: dict[str, Any] = {}
     for op, gas_units in GAS_ESTIMATES.items():
         cost_wei   = gas_wei * gas_units
         cost_native = wei_to_native(cost_wei, cfg["decimals"])
@@ -955,7 +955,7 @@ def cmd_price(args: argparse.Namespace) -> None:
     })
 
 
-def _fetch_chain_stats(chain: str) -> Dict[str, Any]:
+def _fetch_chain_stats(chain: str) -> dict[str, Any]:
     """Fetch gas price + native price for a single chain (used in compare)."""
     try:
         gas_hex = rpc_call(chain, "eth_gasPrice", [])
@@ -987,8 +987,8 @@ def cmd_compare(_args: argparse.Namespace) -> None:
     """Compare gas prices and native token prices across all chains simultaneously."""
     import threading
 
-    results: Dict[str, Any] = {}
-    errors:  Dict[str, str] = {}
+    results: dict[str, Any] = {}
+    errors:  dict[str, str] = {}
     lock = threading.Lock()
 
     def fetch(chain: str) -> None:
@@ -1033,7 +1033,7 @@ def cmd_whale(args: argparse.Namespace) -> None:
     block_hex = rpc_call(chain, "eth_blockNumber", [])
     latest    = hex_to_int(block_hex or "0x0")
 
-    whales: List[Dict[str, Any]] = []
+    whales: list[dict[str, Any]] = []
     blocks_scanned = 0
 
     for bn in range(latest, max(0, latest - blocks), -1):
@@ -1088,7 +1088,7 @@ def cmd_multichain(args: argparse.Namespace) -> None:
     import threading
 
     address = require_address(args.address)
-    results: Dict[str, Any] = {}
+    results: dict[str, Any] = {}
     lock = threading.Lock()
 
     def scan_chain(chain: str) -> None:
@@ -1098,7 +1098,7 @@ def cmd_multichain(args: argparse.Namespace) -> None:
             native_bal = int(bal_hex, 16) / 1e18 if bal_hex else 0.0
             native_price = get_native_price(chain)
             native_usd = round(native_bal * native_price, 2) if native_price else None
-            entry: Dict[str, Any] = {
+            entry: dict[str, Any] = {
                 "native_symbol": cfg["native"],
                 "native_balance": round(native_bal, 8),
                 "native_price_usd": native_price,
@@ -1244,7 +1244,7 @@ def cmd_decode(args: argparse.Namespace) -> None:
         signatures = [r["text_signature"] for r in data["results"]]
 
     # Decode known transfer(address,uint256) manually as fallback
-    decoded_args: Optional[Dict] = None
+    decoded_args: Optional[dict] = None
     if signatures and len(input_data) >= 74:
         sig = signatures[0]
         if sig == "transfer(address,uint256)" and len(input_data) == 138:

--- a/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
+++ b/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
@@ -49,8 +49,8 @@ def _hermes_home() -> Path:
     return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
 
 
-def _dotenv_paths() -> List[Path]:
-    paths: List[Path] = []
+def _dotenv_paths() -> list[Path]:
+    paths: list[Path] = []
     project_env = Path.cwd() / ".env"
     if project_env.exists():
         paths.append(project_env)
@@ -62,8 +62,8 @@ def _dotenv_paths() -> List[Path]:
     return paths
 
 
-def _load_dotenv_values() -> Dict[str, str]:
-    values: Dict[str, str] = {}
+def _load_dotenv_values() -> dict[str, str]:
+    values: dict[str, str] = {}
     for env_path in _dotenv_paths():
         try:
             lines = env_path.read_text(encoding="utf-8").splitlines()
@@ -119,7 +119,7 @@ def _resolve_user(user: Optional[str]) -> str:
     )
 
 
-def _post_info(payload: Dict[str, Any], timeout: int = 20, retries: int = 2) -> Any:
+def _post_info(payload: dict[str, Any], timeout: int = 20, retries: int = 2) -> Any:
     data = json.dumps(payload).encode("utf-8")
     headers = {
         "Content-Type": "application/json",
@@ -155,7 +155,7 @@ def _safe_float(value: Any) -> Optional[float]:
         return None
 
 
-def _limit_items(items: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
+def _limit_items(items: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
     if limit <= 0:
         return items
     return items[:limit]
@@ -232,11 +232,11 @@ def _short_address(address: Any) -> str:
     return f"{address[:6]}...{address[-4:]}"
 
 
-def _render_table(headers: List[tuple[str, str]], rows: List[Dict[str, Any]]) -> str:
+def _render_table(headers: list[tuple[str, str]], rows: list[dict[str, Any]]) -> str:
     if not rows:
         return "(no data)"
 
-    prepared_rows: List[List[str]] = []
+    prepared_rows: list[list[str]] = []
     widths = [len(label) for label, _ in headers]
 
     for row in rows:
@@ -259,8 +259,8 @@ def _render_table(headers: List[tuple[str, str]], rows: List[Dict[str, Any]]) ->
     return "\n".join(lines)
 
 
-def _normalize_dexs(payload: Any) -> List[Dict[str, Any]]:
-    rows: List[Dict[str, Any]] = []
+def _normalize_dexs(payload: Any) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     if not isinstance(payload, list):
         return rows
 
@@ -295,7 +295,7 @@ def _normalize_dexs(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _normalize_perp_markets(payload: Any) -> List[Dict[str, Any]]:
+def _normalize_perp_markets(payload: Any) -> list[dict[str, Any]]:
     if not isinstance(payload, list) or len(payload) < 2:
         return []
 
@@ -305,7 +305,7 @@ def _normalize_perp_markets(payload: Any) -> List[Dict[str, Any]]:
     if not isinstance(universe, list):
         return []
 
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for index, spec in enumerate(universe):
         if not isinstance(spec, dict):
             continue
@@ -333,7 +333,7 @@ def _normalize_perp_markets(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _normalize_spot_markets(payload: Any) -> List[Dict[str, Any]]:
+def _normalize_spot_markets(payload: Any) -> list[dict[str, Any]]:
     if not isinstance(payload, list) or len(payload) < 2:
         return []
 
@@ -347,7 +347,7 @@ def _normalize_spot_markets(payload: Any) -> List[Dict[str, Any]]:
             if isinstance(token, dict) and "index" in token:
                 token_lookup[token["index"]] = token.get("name", str(token["index"]))
 
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     if not isinstance(pairs, list):
         return rows
 
@@ -378,8 +378,8 @@ def _normalize_spot_markets(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _normalize_candles(payload: Any) -> List[Dict[str, Any]]:
-    rows: List[Dict[str, Any]] = []
+def _normalize_candles(payload: Any) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     if not isinstance(payload, list):
         return rows
 
@@ -402,8 +402,8 @@ def _normalize_candles(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _normalize_funding_history(payload: Any) -> List[Dict[str, Any]]:
-    rows: List[Dict[str, Any]] = []
+def _normalize_funding_history(payload: Any) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     if not isinstance(payload, list):
         return rows
 
@@ -423,7 +423,7 @@ def _normalize_funding_history(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _normalize_book_levels(payload: Any) -> Dict[str, List[Dict[str, Any]]]:
+def _normalize_book_levels(payload: Any) -> dict[str, list[dict[str, Any]]]:
     if not isinstance(payload, dict):
         return {"bids": [], "asks": []}
 
@@ -431,7 +431,7 @@ def _normalize_book_levels(payload: Any) -> Dict[str, List[Dict[str, Any]]]:
     if not isinstance(levels, list) or len(levels) < 2:
         return {"bids": [], "asks": []}
 
-    def convert(side: Iterable[Any]) -> List[Dict[str, Any]]:
+    def convert(side: Iterable[Any]) -> list[dict[str, Any]]:
         converted = []
         for entry in side:
             if isinstance(entry, dict):
@@ -455,11 +455,11 @@ def _normalize_book_levels(payload: Any) -> Dict[str, List[Dict[str, Any]]]:
     return {"bids": convert(levels[0]), "asks": convert(levels[1])}
 
 
-def _normalize_positions(payload: Any) -> Dict[str, Any]:
+def _normalize_positions(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         return {"summary": {}, "positions": []}
 
-    positions: List[Dict[str, Any]] = []
+    positions: list[dict[str, Any]] = []
     for item in payload.get("assetPositions", []):
         if not isinstance(item, dict):
             continue
@@ -504,11 +504,11 @@ def _normalize_positions(payload: Any) -> Dict[str, Any]:
     }
 
 
-def _normalize_spot_balances(payload: Any) -> List[Dict[str, Any]]:
+def _normalize_spot_balances(payload: Any) -> list[dict[str, Any]]:
     if not isinstance(payload, dict):
         return []
 
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for item in payload.get("balances", []):
         if not isinstance(item, dict):
             continue
@@ -525,8 +525,8 @@ def _normalize_spot_balances(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _normalize_fills(payload: Any) -> List[Dict[str, Any]]:
-    rows: List[Dict[str, Any]] = []
+def _normalize_fills(payload: Any) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     if not isinstance(payload, list):
         return rows
 
@@ -555,8 +555,8 @@ def _normalize_fills(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
-def _normalize_orders(payload: Any) -> List[Dict[str, Any]]:
-    rows: List[Dict[str, Any]] = []
+def _normalize_orders(payload: Any) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     if not isinstance(payload, list):
         return rows
 
@@ -611,14 +611,14 @@ def _is_spot_coin(coin: str) -> bool:
     return "/" in coin or coin.startswith("@")
 
 
-def _safe_info_query(payload: Dict[str, Any]) -> Any:
+def _safe_info_query(payload: dict[str, Any]) -> Any:
     try:
         return _post_info(payload)
     except SystemExit:
         return None
 
 
-def _market_context_for_coin(coin: str, interval: str, start_ms: int, end_ms: int) -> Dict[str, Any]:
+def _market_context_for_coin(coin: str, interval: str, start_ms: int, end_ms: int) -> dict[str, Any]:
     candles = _normalize_candles(
         _safe_info_query(
             {
@@ -632,7 +632,7 @@ def _market_context_for_coin(coin: str, interval: str, start_ms: int, end_ms: in
             }
         )
     )
-    funding_history: List[Dict[str, Any]] = []
+    funding_history: list[dict[str, Any]] = []
     if not _is_spot_coin(coin):
         funding_history = _normalize_funding_history(
             _safe_info_query(
@@ -662,7 +662,7 @@ def _market_context_for_coin(coin: str, interval: str, start_ms: int, end_ms: in
     }
 
 
-def _build_coin_review(coin: str, fills: List[Dict[str, Any]], interval: str, start_ms: int, end_ms: int) -> Dict[str, Any]:
+def _build_coin_review(coin: str, fills: list[dict[str, Any]], interval: str, start_ms: int, end_ms: int) -> dict[str, Any]:
     pnl_values = [_safe_float(fill.get("closed_pnl")) for fill in fills]
     fee_values = [_safe_float(fill.get("fee")) for fill in fills]
     scored = [value for value in pnl_values if value is not None]
@@ -704,8 +704,8 @@ def _build_coin_review(coin: str, fills: List[Dict[str, Any]], interval: str, st
     }
 
 
-def _review_findings(summary: Dict[str, Any], coin_reviews: List[Dict[str, Any]]) -> List[str]:
-    findings: List[str] = []
+def _review_findings(summary: dict[str, Any], coin_reviews: list[dict[str, Any]]) -> list[str]:
+    findings: list[str] = []
 
     if summary["fill_count"] == 0:
         return ["No fills were found in the requested review window."]
@@ -756,14 +756,14 @@ def _review_findings(summary: Dict[str, Any], coin_reviews: List[Dict[str, Any]]
         elif market_change < -2 and item["open_long_count"] > item["open_short_count"]:
             findings.append(f"{item['coin']}: losses came while leaning long into a falling market window.")
 
-    deduped: List[str] = []
+    deduped: list[str] = []
     for finding in findings:
         if finding not in deduped:
             deduped.append(finding)
     return deduped[:6]
 
 
-def _recent_fill_rows(fills: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
+def _recent_fill_rows(fills: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
     rows = []
     for fill in _limit_items(fills, limit):
         rows.append(
@@ -794,12 +794,12 @@ def _default_export_path(coin: str, interval: str, hours: float) -> Path:
     return Path.cwd() / filename
 
 
-def _write_json_file(path: Path, payload: Dict[str, Any]) -> None:
+def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def _export_summary(candles: List[Dict[str, Any]], funding_history: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _export_summary(candles: list[dict[str, Any]], funding_history: list[dict[str, Any]]) -> dict[str, Any]:
     candle_change = None
     if candles:
         candle_change = _percent_change(candles[-1].get("close"), candles[0].get("open"))
@@ -813,14 +813,14 @@ def _export_summary(candles: List[Dict[str, Any]], funding_history: List[Dict[st
     }
 
 
-def run_dexs(_args: argparse.Namespace) -> Dict[str, Any]:
+def run_dexs(_args: argparse.Namespace) -> dict[str, Any]:
     payload = _post_info({"type": "perpDexs"})
     rows = _normalize_dexs(payload)
     return {"api_url": _info_url(), "count": len(rows), "dexs": rows}
 
 
-def run_markets(args: argparse.Namespace) -> Dict[str, Any]:
-    payload: Dict[str, Any] = {"type": "metaAndAssetCtxs"}
+def run_markets(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {"type": "metaAndAssetCtxs"}
     if args.dex:
         payload["dex"] = args.dex
     rows = _normalize_perp_markets(_post_info(payload))
@@ -844,7 +844,7 @@ def run_markets(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def run_spots(args: argparse.Namespace) -> Dict[str, Any]:
+def run_spots(args: argparse.Namespace) -> dict[str, Any]:
     rows = _normalize_spot_markets(_post_info({"type": "spotMetaAndAssetCtxs"}))
 
     if args.sort == "name":
@@ -857,7 +857,7 @@ def run_spots(args: argparse.Namespace) -> Dict[str, Any]:
     return {"count": len(rows), "sort": args.sort, "pairs": _limit_items(rows, args.limit)}
 
 
-def run_candles(args: argparse.Namespace) -> Dict[str, Any]:
+def run_candles(args: argparse.Namespace) -> dict[str, Any]:
     end_ms = int(time.time() * 1000)
     start_ms = _hours_ago_ms(args.hours, end_ms)
     payload = {
@@ -895,7 +895,7 @@ def run_candles(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def run_funding(args: argparse.Namespace) -> Dict[str, Any]:
+def run_funding(args: argparse.Namespace) -> dict[str, Any]:
     end_ms = int(time.time() * 1000)
     start_ms = _hours_ago_ms(args.hours, end_ms)
     payload = {"type": "fundingHistory", "coin": args.coin, "startTime": start_ms, "endTime": end_ms}
@@ -915,8 +915,8 @@ def run_funding(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def run_l2(args: argparse.Namespace) -> Dict[str, Any]:
-    payload: Dict[str, Any] = {"type": "l2Book", "coin": args.coin}
+def run_l2(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {"type": "l2Book", "coin": args.coin}
     if args.n_sig_figs is not None:
         payload["nSigFigs"] = args.n_sig_figs
     if args.mantissa is not None:
@@ -931,9 +931,9 @@ def run_l2(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def run_state(args: argparse.Namespace) -> Dict[str, Any]:
+def run_state(args: argparse.Namespace) -> dict[str, Any]:
     user = _resolve_user(args.user)
-    payload: Dict[str, Any] = {"type": "clearinghouseState", "user": user}
+    payload: dict[str, Any] = {"type": "clearinghouseState", "user": user}
     if args.dex:
         payload["dex"] = args.dex
     normalized = _normalize_positions(_post_info(payload))
@@ -945,16 +945,16 @@ def run_state(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def run_spot_balances(args: argparse.Namespace) -> Dict[str, Any]:
+def run_spot_balances(args: argparse.Namespace) -> dict[str, Any]:
     user = _resolve_user(args.user)
     payload = {"type": "spotClearinghouseState", "user": user}
     rows = _normalize_spot_balances(_post_info(payload))
     return {"user": user, "count": len(rows), "balances": _limit_items(rows, args.limit)}
 
 
-def run_fills(args: argparse.Namespace) -> Dict[str, Any]:
+def run_fills(args: argparse.Namespace) -> dict[str, Any]:
     user = _resolve_user(args.user)
-    payload: Dict[str, Any] = {"user": user}
+    payload: dict[str, Any] = {"user": user}
     if args.hours is not None:
         payload["type"] = "userFillsByTime"
         payload["startTime"] = _hours_ago_ms(args.hours)
@@ -972,18 +972,18 @@ def run_fills(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def run_orders(args: argparse.Namespace) -> Dict[str, Any]:
+def run_orders(args: argparse.Namespace) -> dict[str, Any]:
     user = _resolve_user(args.user)
     payload = {"type": "historicalOrders", "user": user}
     rows = _normalize_orders(_post_info(payload))
     return {"user": user, "count": len(rows), "orders": _limit_items(rows, args.limit)}
 
 
-def run_review(args: argparse.Namespace) -> Dict[str, Any]:
+def run_review(args: argparse.Namespace) -> dict[str, Any]:
     user = _resolve_user(args.user)
     end_ms = int(time.time() * 1000)
     start_ms = _hours_ago_ms(args.hours, end_ms)
-    payload: Dict[str, Any] = {"type": "userFillsByTime", "user": user, "startTime": start_ms}
+    payload: dict[str, Any] = {"type": "userFillsByTime", "user": user, "startTime": start_ms}
     if args.aggregate_by_time:
         payload["aggregateByTime"] = True
 
@@ -993,7 +993,7 @@ def run_review(args: argparse.Namespace) -> Dict[str, Any]:
         fills = [fill for fill in fills if str(fill.get("coin", "")).lower() == target]
     fills = _limit_items(fills, args.fills)
 
-    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    grouped: dict[str, list[dict[str, Any]]] = {}
     for fill in fills:
         grouped.setdefault(fill.get("coin", "-"), []).append(fill)
 
@@ -1042,7 +1042,7 @@ def run_review(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def run_export(args: argparse.Namespace) -> Dict[str, Any]:
+def run_export(args: argparse.Namespace) -> dict[str, Any]:
     end_ms = args.end_time_ms if args.end_time_ms is not None else int(time.time() * 1000)
     start_ms = _hours_ago_ms(args.hours, end_ms)
 
@@ -1057,7 +1057,7 @@ def run_export(args: argparse.Namespace) -> Dict[str, Any]:
     }
     candles = _normalize_candles(_post_info(candle_payload))
 
-    funding_history: List[Dict[str, Any]] = []
+    funding_history: list[dict[str, Any]] = []
     if not _is_spot_coin(args.coin):
         funding_history = _normalize_funding_history(
             _safe_info_query(
@@ -1099,7 +1099,7 @@ def run_export(args: argparse.Namespace) -> Dict[str, Any]:
     }
 
 
-def render_dexs(data: Dict[str, Any]) -> str:
+def render_dexs(data: dict[str, Any]) -> str:
     rows = [
         {
             "label": item["label"],
@@ -1127,7 +1127,7 @@ def render_dexs(data: Dict[str, Any]) -> str:
     )
 
 
-def render_markets(data: Dict[str, Any]) -> str:
+def render_markets(data: dict[str, Any]) -> str:
     rows = [
         {
             "coin": item["coin"],
@@ -1158,7 +1158,7 @@ def render_markets(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_spots(data: Dict[str, Any]) -> str:
+def render_spots(data: dict[str, Any]) -> str:
     rows = [
         {
             "pair": item["display_name"],
@@ -1185,7 +1185,7 @@ def render_spots(data: Dict[str, Any]) -> str:
     )
 
 
-def render_candles(data: Dict[str, Any]) -> str:
+def render_candles(data: dict[str, Any]) -> str:
     rows = [
         {
             "time": _format_timestamp_ms(item["time"]),
@@ -1231,7 +1231,7 @@ def render_candles(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_funding(data: Dict[str, Any]) -> str:
+def render_funding(data: dict[str, Any]) -> str:
     rows = [
         {
             "time": _format_timestamp_ms(item["time"]),
@@ -1260,7 +1260,7 @@ def render_funding(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_l2(data: Dict[str, Any]) -> str:
+def render_l2(data: dict[str, Any]) -> str:
     bid_rows = [
         {"px": _format_price(item["px"]), "sz": _compact_number(item["sz"]), "orders": item["orders"] or "-"}
         for item in data["bids"]
@@ -1282,7 +1282,7 @@ def render_l2(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_state(data: Dict[str, Any]) -> str:
+def render_state(data: dict[str, Any]) -> str:
     summary = data["summary"]
     position_rows = [
         {
@@ -1328,7 +1328,7 @@ def render_state(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_spot_balances(data: Dict[str, Any]) -> str:
+def render_spot_balances(data: dict[str, Any]) -> str:
     rows = [
         {
             "coin": item["coin"],
@@ -1356,7 +1356,7 @@ def render_spot_balances(data: Dict[str, Any]) -> str:
     )
 
 
-def render_fills(data: Dict[str, Any]) -> str:
+def render_fills(data: dict[str, Any]) -> str:
     rows = [
         {
             "time": _format_timestamp_ms(item["time"]),
@@ -1390,7 +1390,7 @@ def render_fills(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_orders(data: Dict[str, Any]) -> str:
+def render_orders(data: dict[str, Any]) -> str:
     rows = [
         {
             "time": _format_timestamp_ms(item["timestamp"]),
@@ -1424,7 +1424,7 @@ def render_orders(data: Dict[str, Any]) -> str:
     )
 
 
-def render_review(data: Dict[str, Any]) -> str:
+def render_review(data: dict[str, Any]) -> str:
     summary = data["summary"]
     coin_rows = [
         {
@@ -1511,7 +1511,7 @@ def render_review(data: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_export(data: Dict[str, Any]) -> str:
+def render_export(data: dict[str, Any]) -> str:
     summary = data["summary"]
     return "\n".join(
         [
@@ -1644,7 +1644,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def main(argv: Optional[list[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/optional-skills/blockchain/solana/scripts/solana_client.py
+++ b/optional-skills/blockchain/solana/scripts/solana_client.py
@@ -37,7 +37,7 @@ LAMPORTS_PER_SOL = 1_000_000_000
 
 # Well-known Solana token names — avoids API calls for common tokens.
 # Maps mint address → (symbol, name).
-KNOWN_TOKENS: Dict[str, tuple] = {
+KNOWN_TOKENS: dict[str, tuple] = {
     "So11111111111111111111111111111111111111112":  ("SOL",   "Solana"),
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v": ("USDC",  "USD Coin"),
     "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB":  ("USDT",  "Tether"),
@@ -172,14 +172,14 @@ def _short_mint(mint: str) -> str:
 # Price & token name helpers (CoinGecko — free, no API key)
 # ---------------------------------------------------------------------------
 
-def fetch_prices(mints: List[str], max_lookups: int = 20) -> Dict[str, float]:
+def fetch_prices(mints: list[str], max_lookups: int = 20) -> dict[str, float]:
     """Fetch USD prices for mint addresses via CoinGecko (one per request).
 
     CoinGecko free tier doesn't support batch Solana token lookups,
     so we do individual calls — capped at *max_lookups* to stay within
     rate limits. Returns {mint: usd_price}.
     """
-    prices: Dict[str, float] = {}
+    prices: dict[str, float] = {}
     for i, mint in enumerate(mints[:max_lookups]):
         url = (
             f"https://api.coingecko.com/api/v3/simple/token_price/solana"
@@ -207,7 +207,7 @@ def fetch_sol_price() -> Optional[float]:
     return None
 
 
-def resolve_token_name(mint: str) -> Optional[Dict[str, str]]:
+def resolve_token_name(mint: str) -> Optional[dict[str, str]]:
     """Look up token name and symbol from CoinGecko by mint address.
 
     Returns {"name": ..., "symbol": ...} or None.
@@ -317,7 +317,7 @@ def cmd_wallet(args):
 
     # Fetch prices for fungible tokens (cap lookups to avoid API abuse)
     sol_price = None
-    prices: Dict[str, float] = {}
+    prices: dict[str, float] = {}
     if not skip_prices and fungible:
         sol_price = fetch_sol_price()
         # Prioritize known tokens, then a small sample of unknowns.

--- a/optional-skills/devops/watchers/scripts/_watermark.py
+++ b/optional-skills/devops/watchers/scripts/_watermark.py
@@ -48,7 +48,7 @@ class Watermark:
         self.name = name
         self.max_seen = max_seen
         self._path = _state_dir() / f"{name}.json"
-        self._data: Dict[str, Any] = {"seen_ids": [], "first_run": True}
+        self._data: dict[str, Any] = {"seen_ids": [], "first_run": True}
 
     @classmethod
     def load(cls, name: str, *, max_seen: int = 500) -> "Watermark":
@@ -68,12 +68,12 @@ class Watermark:
         return bool(self._data.get("first_run", True))
 
     @property
-    def seen(self) -> List[str]:
+    def seen(self) -> list[str]:
         return list(self._data.get("seen_ids", []))
 
     def filter_new(
-        self, items: Iterable[Dict[str, Any]], *, id_key: str = "id"
-    ) -> List[Dict[str, Any]]:
+        self, items: Iterable[dict[str, Any]], *, id_key: str = "id"
+    ) -> list[dict[str, Any]]:
         """Return items whose id isn't in the stored set.
 
         Side effect: updates the in-memory seen set with every id in the
@@ -83,8 +83,8 @@ class Watermark:
         existing = set(str(x) for x in self._data.get("seen_ids", []))
         was_first_run = self.is_first_run
 
-        new_items: List[Dict[str, Any]] = []
-        batch_ids: List[str] = []
+        new_items: list[dict[str, Any]] = []
+        batch_ids: list[str] = []
         for item in items:
             ident = item.get(id_key)
             if ident is None:
@@ -115,7 +115,7 @@ class Watermark:
 
 
 def format_items_as_markdown(
-    items: List[Dict[str, Any]],
+    items: list[dict[str, Any]],
     *,
     title_key: str = "title",
     url_key: str = "url",
@@ -130,7 +130,7 @@ def format_items_as_markdown(
     """
     if not items:
         return ""
-    lines: List[str] = []
+    lines: list[str] = []
     for item in items:
         title = (item.get(title_key) or "(no title)").strip()
         url = (item.get(url_key) or "").strip()

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -42,7 +42,7 @@ SUPPORTED_SECRET_TARGETS={
     "VOICE_TOOLS_OPENAI_KEY",
 }
 WORKSPACE_INSTRUCTIONS_FILENAME = "AGENTS" + ".md"
-MIGRATION_OPTION_METADATA: Dict[str, Dict[str, str]] = {
+MIGRATION_OPTION_METADATA: dict[str, dict[str, str]] = {
     "soul": {
         "label": "SOUL.md",
         "description": "Import the OpenClaw persona file into Hermes.",
@@ -184,7 +184,7 @@ MIGRATION_OPTION_METADATA: Dict[str, Dict[str, str]] = {
         "description": "Archive OpenClaw logging and diagnostics configuration.",
     },
 }
-MIGRATION_PRESETS: Dict[str, set[str]] = {
+MIGRATION_PRESETS: dict[str, set[str]] = {
     "user-data": {
         "soul",
         "workspace-agents",
@@ -249,12 +249,12 @@ class ItemResult:
     destination: Optional[str]
     status: str
     reason: str = ""
-    details: Dict[str, Any] = field(default_factory=dict)
+    details: dict[str, Any] = field(default_factory=dict)
     sensitive: bool = False
 
 
-def parse_selection_values(values: Optional[Sequence[str]]) -> List[str]:
-    parsed: List[str] = []
+def parse_selection_values(values: Optional[Sequence[str]]) -> list[str]:
+    parsed: list[str] = []
     for value in values or ():
         for part in str(value).split(","):
             part = part.strip().lower()
@@ -323,7 +323,7 @@ def ensure_parent(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Optional[str]:
+def resolve_secret_input(value: Any, env: Optional[dict[str, str]] = None) -> Optional[str]:
     """Resolve an OpenClaw SecretInput value to a plain string.
 
     SecretInput can be:
@@ -346,14 +346,14 @@ def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Op
     return None
 
 
-def load_yaml_file(path: Path) -> Dict[str, Any]:
+def load_yaml_file(path: Path) -> dict[str, Any]:
     if yaml is None or not path.exists():
         return {}
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     return data if isinstance(data, dict) else {}
 
 
-def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
+def dump_yaml_file(path: Path, data: dict[str, Any]) -> None:
     if yaml is None:
         raise RuntimeError("PyYAML is required to update Hermes config.yaml")
     ensure_parent(path)
@@ -363,10 +363,10 @@ def dump_yaml_file(path: Path, data: Dict[str, Any]) -> None:
     )
 
 
-def parse_env_file(path: Path) -> Dict[str, str]:
+def parse_env_file(path: Path) -> dict[str, str]:
     if not path.exists():
         return {}
-    data: Dict[str, str] = {}
+    data: dict[str, str] = {}
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
@@ -376,7 +376,7 @@ def parse_env_file(path: Path) -> Dict[str, str]:
     return data
 
 
-def save_env_file(path: Path, data: Dict[str, str]) -> None:
+def save_env_file(path: Path, data: dict[str, str]) -> None:
     ensure_parent(path)
     lines = [f"{key}={value}" for key, value in data.items()]
     path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
@@ -403,7 +403,7 @@ def backup_existing(path: Path, backup_root: Path) -> Optional[Path]:
 # Case-preserving: ``OpenClaw`` → ``Hermes`` (prose), but lowercase matches
 # like ``openclaw`` → ``hermes`` (so filesystem paths like ``~/.openclaw``
 # become ``~/.hermes`` — the real Hermes home — not the broken ``~/.Hermes``).
-_REBRAND_PATTERNS: List[Tuple[re.Pattern, str]] = [
+_REBRAND_PATTERNS: list[tuple[re.Pattern, str]] = [
     (re.compile(r'\bOpen[\s-]?Claw\b', re.IGNORECASE), 'Hermes'),
     (re.compile(r'\bClawdBot\b', re.IGNORECASE), 'Hermes'),
     (re.compile(r'\bMoltBot\b', re.IGNORECASE), 'Hermes'),
@@ -438,7 +438,7 @@ def rebrand_text(text: str) -> str:
     return text
 
 
-def parse_existing_memory_entries(path: Path) -> List[str]:
+def parse_existing_memory_entries(path: Path) -> list[str]:
     if not path.exists():
         return []
     raw = read_text(path)
@@ -449,10 +449,10 @@ def parse_existing_memory_entries(path: Path) -> List[str]:
     return extract_markdown_entries(raw)
 
 
-def extract_markdown_entries(text: str) -> List[str]:
-    entries: List[str] = []
-    headings: List[str] = []
-    paragraph_lines: List[str] = []
+def extract_markdown_entries(text: str) -> list[str]:
+    entries: list[str] = []
+    headings: list[str] = []
+    paragraph_lines: list[str] = []
 
     def context_prefix() -> str:
         filtered = [h for h in headings if h and not re.search(r"\b(MEMORY|USER|SOUL|AGENTS|TOOLS|IDENTITY)\.md\b", h, re.I)]
@@ -514,7 +514,7 @@ def extract_markdown_entries(text: str) -> List[str]:
 
     flush_paragraph()
 
-    deduped: List[str] = []
+    deduped: list[str] = []
     seen = set()
     for entry in entries:
         normalized = normalize_text(entry)
@@ -529,11 +529,11 @@ def merge_entries(
     existing: Sequence[str],
     incoming: Sequence[str],
     limit: int,
-) -> Tuple[List[str], Dict[str, int], List[str]]:
+) -> tuple[list[str], dict[str, int], list[str]]:
     merged = list(existing)
     seen = {normalize_text(entry) for entry in existing if entry.strip()}
     stats = {"existing": len(existing), "added": 0, "duplicates": 0, "overflowed": 0}
-    overflowed: List[str] = []
+    overflowed: list[str] = []
 
     current_len = len(ENTRY_DELIMITER.join(merged)) if merged else 0
 
@@ -642,7 +642,7 @@ def _redact_internal(value: Any, seen: set) -> Any:
         if obj_id in seen:
             return REDACTED_MIGRATION_VALUE
         seen.add(obj_id)
-        out: Dict[str, Any] = {}
+        out: dict[str, Any] = {}
         for key, entry in value.items():
             if isinstance(key, str) and _is_secret_key(key):
                 out[key] = REDACTED_MIGRATION_VALUE
@@ -652,7 +652,7 @@ def _redact_internal(value: Any, seen: set) -> Any:
     return value
 
 
-def write_report(output_dir: Path, report: Dict[str, Any]) -> None:
+def write_report(output_dir: Path, report: dict[str, Any]) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     # Always redact before persisting.  Callers who need the raw object
     # (in-process) still get it back from build_report(); only the on-disk
@@ -663,7 +663,7 @@ def write_report(output_dir: Path, report: Dict[str, Any]) -> None:
         encoding="utf-8",
     )
 
-    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    grouped: dict[str, list[dict[str, Any]]] = {}
     for item in redacted["items"]:
         grouped.setdefault(item["status"], []).append(item)
 
@@ -738,7 +738,7 @@ class Migrator:
         self.archive_dir = self.output_dir / "archive" if self.output_dir else None
         self.backup_dir = self.output_dir / "backups" if self.output_dir else None
         self.overflow_dir = self.output_dir / "overflow" if self.output_dir else None
-        self.items: List[ItemResult] = []
+        self.items: list[ItemResult] = []
         # Once a config.yaml write hits conflict/error mid-run, later
         # config.yaml writes are deliberately short-circuited to avoid
         # leaving config in a partially-written state.  Modelled on
@@ -885,7 +885,7 @@ class Migrator:
             counter += 1
         return candidate
 
-    def migrate(self) -> Dict[str, Any]:
+    def migrate(self) -> dict[str, Any]:
         if not self.source_root.exists():
             self.record("source", self.source_root, None, "error", "OpenClaw directory does not exist")
             return self.build_report()
@@ -985,8 +985,8 @@ class Migrator:
             return
         func()
 
-    def build_report(self) -> Dict[str, Any]:
-        summary: Dict[str, int] = {
+    def build_report(self) -> dict[str, Any]:
+        summary: dict[str, int] = {
             "migrated": 0,
             "archived": 0,
             "skipped": 0,
@@ -1030,14 +1030,14 @@ class Migrator:
 
         return report
 
-    def _build_warnings(self, summary: Dict[str, int]) -> List[str]:
+    def _build_warnings(self, summary: dict[str, int]) -> list[str]:
         """Structured warnings surfaced on the report for downstream consumers.
 
         Modelled on OpenClaw's extensions/migrate-hermes/plan.ts warnings[].
         Keep the messages actionable — they show up in summary.md and the
         JSON report.
         """
-        warnings: List[str] = []
+        warnings: list[str] = []
         if summary.get("conflict", 0) > 0:
             warnings.append(
                 "Conflicts were found. Re-run with --overwrite to replace conflicting "
@@ -1066,7 +1066,7 @@ class Migrator:
             )
         return warnings
 
-    def _build_next_steps(self, summary: Dict[str, int]) -> List[str]:
+    def _build_next_steps(self, summary: dict[str, int]) -> list[str]:
         """Human-readable next-step guidance baked into the report."""
         if not self.execute:
             return [
@@ -1074,7 +1074,7 @@ class Migrator:
                 "Pass --overwrite to resolve conflicts, or --migrate-secrets to "
                 "include API keys.",
             ]
-        steps: List[str] = []
+        steps: list[str] = []
         if summary.get("migrated", 0) > 0:
             steps.append(
                 "Review the migration report at "
@@ -1213,7 +1213,7 @@ class Migrator:
             self.record("command-allowlist", source, destination, "error", f"Invalid JSON: {exc}")
             return
 
-        patterns: List[str] = []
+        patterns: list[str] = []
         agents = data.get("agents", {})
         if isinstance(agents, dict):
             for agent_data in agents.values():
@@ -1256,7 +1256,7 @@ class Migrator:
         else:
             self.record("command-allowlist", source, destination, "migrated", "Would merge patterns", added_patterns=added)
 
-    def load_openclaw_config(self) -> Dict[str, Any]:
+    def load_openclaw_config(self) -> dict[str, Any]:
         # Check current name and legacy config filenames
         for name in ("openclaw.json", "clawdbot.json", "moltbot.json"):
             config_path = self.source_root / name
@@ -1268,15 +1268,15 @@ class Migrator:
                     continue
         return {}
 
-    def load_openclaw_env(self) -> Dict[str, str]:
+    def load_openclaw_env(self) -> dict[str, str]:
         """Load the OpenClaw .env file for secrets that live there instead of config."""
         return parse_env_file(self.source_root / ".env")
 
-    def merge_env_values(self, additions: Dict[str, str], kind: str, source: Path) -> None:
+    def merge_env_values(self, additions: dict[str, str], kind: str, source: Path) -> None:
         destination = self.target_root / ".env"
         env_data = parse_env_file(destination)
-        added: Dict[str, str] = {}
-        conflicts: List[str] = []
+        added: dict[str, str] = {}
+        conflicts: list[str] = []
 
         for key, value in additions.items():
             current = env_data.get(key)
@@ -1318,9 +1318,9 @@ class Migrator:
                 conflicting_keys=conflicts,
             )
 
-    def migrate_messaging_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_messaging_settings(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
-        additions: Dict[str, str] = {}
+        additions: dict[str, str] = {}
 
         workspace = (
             config.get("agents", {})
@@ -1358,7 +1358,7 @@ class Migrator:
         else:
             self.record("messaging-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Hermes-compatible messaging settings found")
 
-    def handle_secret_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def handle_secret_settings(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         if self.migrate_secrets:
             self.migrate_secret_settings(config)
@@ -1384,8 +1384,8 @@ class Migrator:
                 supported_targets=sorted(SUPPORTED_SECRET_TARGETS),
             )
 
-    def migrate_secret_settings(self, config: Dict[str, Any]) -> None:
-        secret_additions: Dict[str, str] = {}
+    def migrate_secret_settings(self, config: dict[str, Any]) -> None:
+        secret_additions: dict[str, str] = {}
 
         tg_cfg = config.get("channels", {}).get("telegram", {})
         telegram_token = self._get_channel_field(tg_cfg, "botToken") if isinstance(tg_cfg, dict) else None
@@ -1409,7 +1409,7 @@ class Migrator:
         return resolve_secret_input(value, self.load_openclaw_env())
 
     @staticmethod
-    def _get_channel_field(ch_cfg: Dict[str, Any], field: str) -> Any:
+    def _get_channel_field(ch_cfg: dict[str, Any], field: str) -> Any:
         """Get a field from channel config, checking both flat and accounts.default layout."""
         val = ch_cfg.get(field)
         if val is not None:
@@ -1421,9 +1421,9 @@ class Migrator:
                 return default.get(field)
         return None
 
-    def migrate_discord_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_discord_settings(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
-        additions: Dict[str, str] = {}
+        additions: dict[str, str] = {}
         discord = config.get("channels", {}).get("discord", {})
         if isinstance(discord, dict):
             token = self._get_channel_field(discord, "token")
@@ -1439,9 +1439,9 @@ class Migrator:
         else:
             self.record("discord-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Discord settings found")
 
-    def migrate_slack_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_slack_settings(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
-        additions: Dict[str, str] = {}
+        additions: dict[str, str] = {}
         slack = config.get("channels", {}).get("slack", {})
         if isinstance(slack, dict):
             bot_token = self._get_channel_field(slack, "botToken")
@@ -1460,9 +1460,9 @@ class Migrator:
         else:
             self.record("slack-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Slack settings found")
 
-    def migrate_whatsapp_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_whatsapp_settings(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
-        additions: Dict[str, str] = {}
+        additions: dict[str, str] = {}
         whatsapp = config.get("channels", {}).get("whatsapp", {})
         if isinstance(whatsapp, dict):
             allow_from = self._get_channel_field(whatsapp, "allowFrom") or []
@@ -1475,9 +1475,9 @@ class Migrator:
         else:
             self.record("whatsapp-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No WhatsApp settings found")
 
-    def migrate_signal_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_signal_settings(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
-        additions: Dict[str, str] = {}
+        additions: dict[str, str] = {}
         signal = config.get("channels", {}).get("signal", {})
         if isinstance(signal, dict):
             account = self._get_channel_field(signal, "account")
@@ -1496,7 +1496,7 @@ class Migrator:
         else:
             self.record("signal-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Signal settings found")
 
-    def handle_provider_keys(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def handle_provider_keys(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         if not self.migrate_secrets:
             config_path = self.source_root / "openclaw.json"
@@ -1511,8 +1511,8 @@ class Migrator:
             return
         self.migrate_provider_keys(config)
 
-    def migrate_provider_keys(self, config: Dict[str, Any]) -> None:
-        secret_additions: Dict[str, str] = {}
+    def migrate_provider_keys(self, config: dict[str, Any]) -> None:
+        secret_additions: dict[str, str] = {}
 
         # Extract provider API keys from models.providers
         # Note: apiKey values can be strings, env templates, or SecretRef objects
@@ -1650,7 +1650,7 @@ class Migrator:
                 supported_targets=sorted(SUPPORTED_SECRET_TARGETS),
             )
 
-    def migrate_model_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_model_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         destination = self.target_root / "config.yaml"
         source_path = self.source_root / "openclaw.json"
@@ -1719,7 +1719,7 @@ class Migrator:
         else:
             self.record("model-config", source_path, destination, "migrated", "Would set model", model=model_str)
 
-    def migrate_tts_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_tts_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         destination = self.target_root / "config.yaml"
         source_path = self.source_root / "openclaw.json"
@@ -1733,7 +1733,7 @@ class Migrator:
             self.record("tts-config", source_path, destination, "error", "PyYAML is not available")
             return
 
-        tts_data: Dict[str, Any] = {}
+        tts_data: dict[str, Any] = {}
 
         provider = tts.get("provider")
         if isinstance(provider, str) and provider in {"elevenlabs", "openai", "edge", "microsoft"}:
@@ -1758,7 +1758,7 @@ class Migrator:
             (tts.get("elevenlabs") or {})
         )
         if isinstance(elevenlabs, dict):
-            el_settings: Dict[str, str] = {}
+            el_settings: dict[str, str] = {}
             voice_id = elevenlabs.get("voiceId") or talk_cfg.get("voiceId")
             if isinstance(voice_id, str) and voice_id.strip():
                 el_settings["voice_id"] = voice_id.strip()
@@ -1776,7 +1776,7 @@ class Migrator:
             (tts.get("openai") or {})
         )
         if isinstance(openai_tts, dict):
-            oai_settings: Dict[str, str] = {}
+            oai_settings: dict[str, str] = {}
             oai_model = openai_tts.get("model") or openai_tts.get("modelId")
             if isinstance(oai_model, str) and oai_model.strip():
                 oai_settings["model"] = oai_model.strip()
@@ -1862,7 +1862,7 @@ class Migrator:
                 if final_destination == destination and destination.exists():
                     shutil.rmtree(destination)
                 shutil.copytree(skill_dir, final_destination)
-                details: Dict[str, Any] = {"backup": str(backup_path) if backup_path else ""}
+                details: dict[str, Any] = {"backup": str(backup_path) if backup_path else ""}
                 if final_destination != destination:
                     details["renamed_from"] = str(destination)
                 self.record(kind_label, skill_dir, final_destination, "migrated", **details)
@@ -1899,7 +1899,7 @@ class Migrator:
             self.record("daily-memory", source_dir, destination, "skipped", "No .md files found in workspace/memory/")
             return
 
-        all_incoming: List[str] = []
+        all_incoming: list[str] = []
         for md_file in md_files:
             entries = extract_markdown_entries(read_text(md_file))
             all_incoming.extend(entries)
@@ -1972,7 +1972,7 @@ class Migrator:
                 if final_destination == destination and destination.exists():
                     shutil.rmtree(destination)
                 shutil.copytree(skill_dir, final_destination)
-                details: Dict[str, Any] = {"backup": str(backup_path) if backup_path else ""}
+                details: dict[str, Any] = {"backup": str(backup_path) if backup_path else ""}
                 if final_destination != destination:
                     details["renamed_from"] = str(destination)
                 self.record("skill", skill_dir, final_destination, "migrated", **details)
@@ -2100,7 +2100,7 @@ class Migrator:
             self.record("archive", source, destination, "archived", reason)
 
     # ── MCP servers ─────────────────────────────────────────────
-    def migrate_mcp_servers(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_mcp_servers(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         mcp_raw = (config.get("mcp") or {}).get("servers") or {}
         if not mcp_raw:
@@ -2120,7 +2120,7 @@ class Migrator:
                             "MCP server already exists in Hermes config")
                 continue
 
-            hermes_srv: Dict[str, Any] = {}
+            hermes_srv: dict[str, Any] = {}
             # STDIO transport
             if srv.get("command"):
                 hermes_srv["command"] = srv["command"]
@@ -2176,7 +2176,7 @@ class Migrator:
             dump_yaml_file(hermes_cfg_path, hermes_cfg)
 
     # ── Plugins ───────────────────────────────────────────────
-    def migrate_plugins_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_plugins_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         plugins = config.get("plugins") or {}
         if not plugins:
@@ -2214,7 +2214,7 @@ class Migrator:
                     self._set_env_var(env_key, api_key, f"plugins.entries.{plugin_name}.apiKey")
 
     # ── Cron jobs ─────────────────────────────────────────────
-    def migrate_cron_jobs(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_cron_jobs(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         cron = config.get("cron") or {}
         cron_store = self.source_root / "cron"
@@ -2246,7 +2246,7 @@ class Migrator:
             self.record("cron-jobs", None, None, "skipped", "No cron configuration found")
 
     # ── Hooks ─────────────────────────────────────────────────
-    def migrate_hooks_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_hooks_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         hooks = config.get("hooks") or {}
         if not hooks:
@@ -2276,7 +2276,7 @@ class Migrator:
                 break
 
     # ── Agent config ──────────────────────────────────────────
-    def migrate_agent_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_agent_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         agents = config.get("agents") or {}
         defaults = agents.get("defaults") or {}
@@ -2395,7 +2395,7 @@ class Migrator:
                         "archived", f"Agent routing bindings ({len(bindings)} rules) archived")
 
     # ── Gateway config ────────────────────────────────────────
-    def migrate_gateway_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_gateway_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         gateway = config.get("gateway") or {}
         if not gateway:
@@ -2416,7 +2416,7 @@ class Migrator:
             self._set_env_var("HERMES_GATEWAY_TOKEN", auth["token"], "gateway.auth.token")
 
     # ── Session config ────────────────────────────────────────
-    def migrate_session_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_session_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         session = config.get("session") or {}
         if not session:
@@ -2479,7 +2479,7 @@ class Migrator:
                         "Advanced session settings archived (identity links, thread bindings, etc.)")
 
     # ── Full model providers ──────────────────────────────────
-    def migrate_full_providers(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_full_providers(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         models = config.get("models") or {}
         providers = models.get("providers") or {}
@@ -2553,7 +2553,7 @@ class Migrator:
                         "archived", f"Model aliases/catalog ({len(model_aliases)} entries) archived")
 
     # ── Deep channel config ───────────────────────────────────
-    def migrate_deep_channels(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_deep_channels(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         channels = config.get("channels") or {}
         if not channels:
@@ -2641,7 +2641,7 @@ class Migrator:
                         f"Deep channel config for {len(complex_archive)} channels archived")
 
     # ── Browser config ────────────────────────────────────────
-    def migrate_browser_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_browser_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         browser = config.get("browser") or {}
         if not browser:
@@ -2681,7 +2681,7 @@ class Migrator:
                         "archive/browser-config.json", "archived")
 
     # ── Tools config ──────────────────────────────────────────
-    def migrate_tools_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_tools_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         tools = config.get("tools") or {}
         if not tools:
@@ -2725,7 +2725,7 @@ class Migrator:
                         "archived", "Full tools config archived for reference")
 
     # ── Approvals config ──────────────────────────────────────
-    def migrate_approvals_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_approvals_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         approvals = config.get("approvals") or {}
         if not approvals:
@@ -2758,7 +2758,7 @@ class Migrator:
                         "archive/approvals-config.json", "archived")
 
     # ── Memory backend ────────────────────────────────────────
-    def migrate_memory_backend(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_memory_backend(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         memory = config.get("memory") or {}
         if not memory:
@@ -2773,7 +2773,7 @@ class Migrator:
                     "archived", "Memory backend config (QMD, vector search, citations) archived for manual review")
 
     # ── Skills config ─────────────────────────────────────────
-    def migrate_skills_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_skills_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         skills = config.get("skills") or {}
         entries = skills.get("entries") or {}
@@ -2789,7 +2789,7 @@ class Migrator:
                     "archived", f"Skills registry config ({len(entries)} entries) archived")
 
     # ── UI / Identity ─────────────────────────────────────────
-    def migrate_ui_identity(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_ui_identity(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         ui = config.get("ui") or {}
         if not ui:
@@ -2804,7 +2804,7 @@ class Migrator:
                     "archived", "UI theme and identity settings archived")
 
     # ── Logging / Diagnostics ─────────────────────────────────
-    def migrate_logging_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_logging_config(self, config: Optional[dict[str, Any]] = None) -> None:
         config = config or self.load_openclaw_config()
         logging_cfg = config.get("logging") or {}
         diagnostics = config.get("diagnostics") or {}

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 # gateway returns 409 "already in progress" on retried POSTs; we forward the
 # original idempotency key so the gateway can deduplicate. Cleared on
 # success or terminal failure.
-_pending_create_keys: Dict[str, str] = {}
+_pending_create_keys: dict[str, str] = {}
 _pending_create_keys_lock = threading.Lock()
 
 _BASE_URL = "https://api.browser-use.com/api/v3"
@@ -125,7 +125,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
     # Config resolution (direct API key OR managed Nous gateway)
     # ------------------------------------------------------------------
 
-    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+    def _get_config_or_none(self) -> Optional[dict[str, Any]]:
         # Import here to avoid a hard dependency at module-import time —
         # managed_tool_gateway pulls in the Nous auth stack which can be
         # heavy and is not needed for direct-API-key users.
@@ -152,7 +152,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
             "managed_mode": True,
         }
 
-    def _get_config(self) -> Dict[str, Any]:
+    def _get_config(self) -> dict[str, Any]:
         from tools.tool_backend_helpers import managed_nous_tools_enabled
 
         config = self._get_config_or_none()
@@ -172,13 +172,13 @@ class BrowserUseBrowserProvider(BrowserProvider):
     # Session lifecycle
     # ------------------------------------------------------------------
 
-    def _headers(self, config: Dict[str, Any]) -> Dict[str, str]:
+    def _headers(self, config: dict[str, Any]) -> dict[str, str]:
         return {
             "Content-Type": "application/json",
             "X-Browser-Use-API-Key": config["api_key"],
         }
 
-    def create_session(self, task_id: str) -> Dict[str, object]:
+    def create_session(self, task_id: str) -> dict[str, object]:
         config = self._get_config()
         managed_mode = bool(config.get("managed_mode"))
 
@@ -294,7 +294,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
                 "Emergency cleanup failed for Browser Use session %s: %s", session_id, e
             )
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Browser Use",
             "badge": "paid",

--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -65,7 +65,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
     # Config resolution
     # ------------------------------------------------------------------
 
-    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+    def _get_config_or_none(self) -> Optional[dict[str, Any]]:
         api_key = os.environ.get("BROWSERBASE_API_KEY")
         project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
         if api_key and project_id:
@@ -78,7 +78,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
             }
         return None
 
-    def _get_config(self) -> Dict[str, Any]:
+    def _get_config(self) -> dict[str, Any]:
         config = self._get_config_or_none()
         if config is None:
             raise ValueError(
@@ -91,7 +91,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
     # Session lifecycle
     # ------------------------------------------------------------------
 
-    def create_session(self, task_id: str) -> Dict[str, object]:
+    def create_session(self, task_id: str) -> dict[str, object]:
         config = self._get_config()
 
         # Optional env-var knobs
@@ -112,7 +112,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
             "custom_timeout": False,
         }
 
-        session_config: Dict[str, object] = {"projectId": config["project_id"]}
+        session_config: dict[str, object] = {"projectId": config["project_id"]}
 
         if enable_keep_alive:
             session_config["keepAlive"] = True
@@ -277,7 +277,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
                 "Emergency cleanup failed for Browserbase session %s: %s", session_id, e
             )
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Browserbase",
             "badge": "paid",

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -65,7 +65,7 @@ class FirecrawlBrowserProvider(BrowserProvider):
     def _api_url(self) -> str:
         return os.environ.get("FIRECRAWL_API_URL", _BASE_URL)
 
-    def _headers(self) -> Dict[str, str]:
+    def _headers(self) -> dict[str, str]:
         api_key = os.environ.get("FIRECRAWL_API_KEY")
         if not api_key:
             raise ValueError(
@@ -77,10 +77,10 @@ class FirecrawlBrowserProvider(BrowserProvider):
             "Authorization": f"Bearer {api_key}",
         }
 
-    def create_session(self, task_id: str) -> Dict[str, object]:
+    def create_session(self, task_id: str) -> dict[str, object]:
         ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
 
-        body: Dict[str, object] = {"ttl": ttl}
+        body: dict[str, object] = {"ttl": ttl}
 
         try:
             response = requests.post(
@@ -152,7 +152,7 @@ class FirecrawlBrowserProvider(BrowserProvider):
                 "Emergency cleanup failed for Firecrawl session %s: %s", session_id, e
             )
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Firecrawl",
             "badge": "paid",

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 _CONTEXT_ENGINE_PLUGINS_DIR = Path(__file__).parent
 
 
-def discover_context_engines() -> List[Tuple[str, str, bool]]:
+def discover_context_engines() -> list[tuple[str, str, bool]]:
     """Scan plugins/context_engine/ for available engines.
 
     Returns list of (name, description, is_available) tuples.

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # (or session_id as fallback) so on_session_end can decide whether to run
 # cleanup.  Guarded by a lock — post_tool_call can fire concurrently on
 # parallel tool calls.
-_recent_test_tracks: Dict[str, Set[str]] = {}
+_recent_test_tracks: dict[str, set[str]] = {}
 _lock = threading.Lock()
 
 
@@ -62,7 +62,7 @@ def _record_track(task_id: str, session_id: str, path: Path, category: str) -> N
         _recent_test_tracks.setdefault(key, set()).add(str(path))
 
 
-def _drain(task_id: str, session_id: str) -> Set[str]:
+def _drain(task_id: str, session_id: str) -> set[str]:
     """Pop the set of test paths tracked during this turn."""
     key = _tracker_key(task_id, session_id)
     with _lock:
@@ -85,12 +85,12 @@ def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
         _record_track(task_id, session_id, p, category)
 
 
-def _extract_paths_from_write_file(args: Dict[str, Any]) -> Set[str]:
+def _extract_paths_from_write_file(args: dict[str, Any]) -> set[str]:
     path = args.get(_WRITE_FILE_PATH_KEY)
     return {path} if isinstance(path, str) and path else set()
 
 
-def _extract_paths_from_patch(args: Dict[str, Any]) -> Set[str]:
+def _extract_paths_from_patch(args: dict[str, Any]) -> set[str]:
     # The patch tool creates new files via the `mode="patch"` path too, but
     # most of its use is editing existing files — we only care about new
     # ephemeral creations, so treat patch conservatively and only pick up
@@ -100,11 +100,11 @@ def _extract_paths_from_patch(args: Dict[str, Any]) -> Set[str]:
     return {path} if isinstance(path, str) and path else set()
 
 
-def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
+def _extract_paths_from_terminal(args: dict[str, Any], result: str) -> set[str]:
     """Best-effort: pull candidate filesystem paths from a terminal command
     and its output, then let ``guess_category`` / ``is_safe_path`` filter.
     """
-    paths: Set[str] = set()
+    paths: set[str] = set()
     cmd = args.get("command") or ""
     if isinstance(cmd, str) and cmd:
         # Tokenise the command — catches `touch /tmp/hermes-x/test_foo.py`
@@ -127,7 +127,7 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
 
 def _on_post_tool_call(
     tool_name: str = "",
-    args: Optional[Dict[str, Any]] = None,
+    args: Optional[dict[str, Any]] = None,
     result: Any = None,
     task_id: str = "",
     session_id: str = "",
@@ -138,7 +138,7 @@ def _on_post_tool_call(
     if not isinstance(args, dict):
         return
 
-    candidates: Set[str] = set()
+    candidates: set[str] = set()
     if tool_name == "write_file":
         candidates = _extract_paths_from_write_file(args)
     elif tool_name == "patch":
@@ -210,7 +210,7 @@ Test files are auto-tracked on write_file / terminal and auto-cleaned at session
 """
 
 
-def _fmt_summary(summary: Dict[str, Any]) -> str:
+def _fmt_summary(summary: dict[str, Any]) -> str:
     base = (
         f"[disk-cleanup] Cleaned {summary['deleted']} files + "
         f"{summary['empty_dirs']} empty dirs, freed {dg.fmt_size(summary['freed'])}."

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -101,7 +101,7 @@ def _log(message: str) -> None:
 # tracked.json — atomic read/write, backup scoped to tracked.json only
 # ---------------------------------------------------------------------------
 
-def load_tracked() -> List[Dict[str, Any]]:
+def load_tracked() -> list[dict[str, Any]]:
     """Load tracked.json.  Restores from ``.bak`` on corruption."""
     tf = get_tracked_file()
     tf.parent.mkdir(parents=True, exist_ok=True)
@@ -124,7 +124,7 @@ def load_tracked() -> List[Dict[str, Any]]:
         return []
 
 
-def save_tracked(tracked: List[Dict[str, Any]]) -> None:
+def save_tracked(tracked: list[dict[str, Any]]) -> None:
     """Atomic write: ``.tmp`` → backup old → rename."""
     tf = get_tracked_file()
     tf.parent.mkdir(parents=True, exist_ok=True)
@@ -210,13 +210,13 @@ def forget(path_str: str) -> int:
 # Dry run
 # ---------------------------------------------------------------------------
 
-def dry_run() -> Tuple[List[Dict], List[Dict]]:
+def dry_run() -> tuple[list[dict], list[dict]]:
     """Return (auto_delete_list, needs_prompt_list) without touching files."""
     tracked = load_tracked()
     now = datetime.now(timezone.utc)
 
-    auto: List[Dict] = []
-    prompt: List[Dict] = []
+    auto: list[dict] = []
+    prompt: list[dict] = []
 
     for item in tracked:
         p = Path(item["path"])
@@ -246,7 +246,7 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
 # Quick cleanup
 # ---------------------------------------------------------------------------
 
-def quick() -> Dict[str, Any]:
+def quick() -> dict[str, Any]:
     """Safe deterministic cleanup — no prompts.
 
     Returns: ``{"deleted": N, "empty_dirs": N, "freed": bytes,
@@ -256,8 +256,8 @@ def quick() -> Dict[str, Any]:
     now = datetime.now(timezone.utc)
     deleted = 0
     freed = 0
-    new_tracked: List[Dict] = []
-    errors: List[str] = []
+    new_tracked: list[dict] = []
+    errors: list[str] = []
 
     for item in tracked:
         p = Path(item["path"])
@@ -341,7 +341,7 @@ def quick() -> Dict[str, Any]:
 
 def deep(
     confirm: Optional[callable] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Deep cleanup.
 
     Runs :func:`quick` first, then asks the *confirm* callable for each
@@ -378,7 +378,7 @@ def deep(
     old_research = research[10:]
 
     freed, count = 0, 0
-    to_remove: List[Dict] = []
+    to_remove: list[dict] = []
 
     for group in (old_research, chrome, large):
         for item in group:
@@ -410,10 +410,10 @@ def deep(
 # Status
 # ---------------------------------------------------------------------------
 
-def status() -> Dict[str, Any]:
+def status() -> dict[str, Any]:
     """Return per-category breakdown and top 10 largest tracked files."""
     tracked = load_tracked()
-    cats: Dict[str, Dict] = {}
+    cats: dict[str, dict] = {}
     for item in tracked:
         c = item["category"]
         cats.setdefault(c, {"count": 0, "size": 0})
@@ -433,7 +433,7 @@ def status() -> Dict[str, Any]:
     }
 
 
-def format_status(s: Dict[str, Any]) -> str:
+def format_status(s: dict[str, Any]) -> str:
     """Human-readable status string (for slash command output)."""
     lines = [f"{'Category':<20} {'Files':>6}  {'Size':>10}", "-" * 40]
     cats = s["categories"]

--- a/plugins/google_meet/node/client.py
+++ b/plugins/google_meet/node/client.py
@@ -30,7 +30,7 @@ class NodeClient:
 
     # ----- core RPC -----------------------------------------------------
 
-    def _rpc(self, type: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _rpc(self, type: str, payload: dict[str, Any]) -> dict[str, Any]:
         """Send one request, return the response payload dict.
 
         Raises RuntimeError when the server sends an ``error`` envelope
@@ -77,8 +77,8 @@ class NodeClient:
         duration: Optional[str] = None,
         headed: bool = False,
         mode: str = "transcribe",
-    ) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
             "url": url,
             "guest_name": guest_name,
             "headed": bool(headed),
@@ -88,20 +88,20 @@ class NodeClient:
             payload["duration"] = duration
         return self._rpc("start_bot", payload)
 
-    def stop(self) -> Dict[str, Any]:
+    def stop(self) -> dict[str, Any]:
         return self._rpc("stop", {})
 
-    def status(self) -> Dict[str, Any]:
+    def status(self) -> dict[str, Any]:
         return self._rpc("status", {})
 
-    def transcript(self, last: Optional[int] = None) -> Dict[str, Any]:
-        payload: Dict[str, Any] = {}
+    def transcript(self, last: Optional[int] = None) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
         if last is not None:
             payload["last"] = int(last)
         return self._rpc("transcript", payload)
 
-    def say(self, text: str) -> Dict[str, Any]:
+    def say(self, text: str) -> dict[str, Any]:
         return self._rpc("say", {"text": str(text)})
 
-    def ping(self) -> Dict[str, Any]:
+    def ping(self) -> dict[str, Any]:
         return self._rpc("ping", {})

--- a/plugins/google_meet/node/protocol.py
+++ b/plugins/google_meet/node/protocol.py
@@ -31,9 +31,9 @@ VALID_REQUEST_TYPES = frozenset({
 def make_request(
     type: str,
     token: str,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
     req_id: str | None = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Construct a request envelope.
 
     ``req_id`` is auto-generated (uuid4 hex) when not supplied so callers
@@ -55,7 +55,7 @@ def make_request(
     }
 
 
-def make_response(req_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+def make_response(req_id: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Build a success response. The caller supplies the *request* type;
     we suffix it with ``_res`` so clients can assert they got the right
     reply.
@@ -68,16 +68,16 @@ def make_response(req_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     return {"type": "response", "id": req_id, "payload": payload}
 
 
-def make_error(req_id: str, error: str) -> Dict[str, Any]:
+def make_error(req_id: str, error: str) -> dict[str, Any]:
     return {"type": "error", "id": req_id, "error": str(error)}
 
 
-def encode(msg: Dict[str, Any]) -> str:
+def encode(msg: dict[str, Any]) -> str:
     """Serialize a message envelope to a JSON string."""
     return json.dumps(msg, separators=(",", ":"), ensure_ascii=False)
 
 
-def decode(raw: str) -> Dict[str, Any]:
+def decode(raw: str) -> dict[str, Any]:
     """Parse a JSON envelope, raising ValueError on anything malformed.
 
     Minimal type validation: must be an object, must contain ``type`` and
@@ -97,7 +97,7 @@ def decode(raw: str) -> Dict[str, Any]:
     return obj
 
 
-def validate_request(msg: Dict[str, Any], expected_token: str) -> Tuple[bool, str]:
+def validate_request(msg: dict[str, Any], expected_token: str) -> tuple[bool, str]:
     """Check a decoded request against the server's shared token.
 
     Returns ``(True, "")`` when the envelope is acceptable or

--- a/plugins/google_meet/node/registry.py
+++ b/plugins/google_meet/node/registry.py
@@ -40,7 +40,7 @@ class NodeRegistry:
 
     # ----- storage ------------------------------------------------------
 
-    def _load(self) -> Dict[str, Any]:
+    def _load(self) -> dict[str, Any]:
         if not self.path.is_file():
             return {"nodes": {}}
         try:
@@ -51,7 +51,7 @@ class NodeRegistry:
             return {"nodes": {}}
         return data
 
-    def _save(self, data: Dict[str, Any]) -> None:
+    def _save(self, data: dict[str, Any]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self.path.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
@@ -59,7 +59,7 @@ class NodeRegistry:
 
     # ----- public API ---------------------------------------------------
 
-    def get(self, name: str) -> Optional[Dict[str, Any]]:
+    def get(self, name: str) -> Optional[dict[str, Any]]:
         data = self._load()
         entry = data["nodes"].get(name)
         if entry is None:
@@ -89,14 +89,14 @@ class NodeRegistry:
             return True
         return False
 
-    def list_all(self) -> List[Dict[str, Any]]:
+    def list_all(self) -> list[dict[str, Any]]:
         data = self._load()
-        out: List[Dict[str, Any]] = []
+        out: list[dict[str, Any]] = []
         for name, entry in sorted(data["nodes"].items()):
             out.append({"name": name, **entry})
         return out
 
-    def resolve(self, chrome_node: Optional[str]) -> Optional[Dict[str, Any]]:
+    def resolve(self, chrome_node: Optional[str]) -> Optional[dict[str, Any]]:
         """Resolve a node name to its entry.
 
         If ``chrome_node`` is provided, return that named node (or None).

--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -93,7 +93,7 @@ class NodeServer:
 
     # ----- dispatch -----------------------------------------------------
 
-    async def _handle_request(self, msg: Dict[str, Any]) -> Dict[str, Any]:
+    async def _handle_request(self, msg: dict[str, Any]) -> dict[str, Any]:
         """Validate + dispatch a single decoded request envelope.
 
         Always returns a response envelope (success or error); never

--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -44,7 +44,7 @@ def _active_file() -> Path:
     return _root() / ".active.json"
 
 
-def _read_active() -> Optional[Dict[str, Any]]:
+def _read_active() -> Optional[dict[str, Any]]:
     p = _active_file()
     if not p.is_file():
         return None
@@ -54,7 +54,7 @@ def _read_active() -> Optional[Dict[str, Any]]:
         return None
 
 
-def _write_active(data: Dict[str, Any]) -> None:
+def _write_active(data: dict[str, Any]) -> None:
     p = _active_file()
     p.parent.mkdir(parents=True, exist_ok=True)
     tmp = p.with_suffix(".json.tmp")
@@ -95,7 +95,7 @@ def start(
     realtime_voice: Optional[str] = None,
     realtime_instructions: Optional[str] = None,
     realtime_api_key: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Spawn the meet_bot subprocess for *url*.
 
     If a bot is already running for this hermes install, leave it first —
@@ -187,7 +187,7 @@ def start(
     return {"ok": True, **record}
 
 
-def status() -> Dict[str, Any]:
+def status() -> dict[str, Any]:
     """Return the current meeting state, or ``{"ok": False, "reason": ...}``."""
     active = _read_active()
     if not active:
@@ -197,7 +197,7 @@ def status() -> Dict[str, Any]:
     alive = _pid_alive(pid) if pid else False
 
     status_path = Path(active.get("out_dir", "")) / "status.json"
-    bot_status: Dict[str, Any] = {}
+    bot_status: dict[str, Any] = {}
     if status_path.is_file():
         try:
             bot_status = json.loads(status_path.read_text(encoding="utf-8"))
@@ -216,7 +216,7 @@ def status() -> Dict[str, Any]:
     }
 
 
-def transcript(last: Optional[int] = None) -> Dict[str, Any]:
+def transcript(last: Optional[int] = None) -> dict[str, Any]:
     """Read the current transcript file. Returns ok=False if none exists."""
     active = _read_active()
     if not active:
@@ -243,7 +243,7 @@ def transcript(last: Optional[int] = None) -> Dict[str, Any]:
     }
 
 
-def enqueue_say(text: str) -> Dict[str, Any]:
+def enqueue_say(text: str) -> dict[str, Any]:
     """Append a ``say`` request to the active bot's JSONL queue.
 
     Returns ``{"ok": False, "reason": ...}`` when no meeting is active or
@@ -285,7 +285,7 @@ def enqueue_say(text: str) -> Dict[str, Any]:
     }
 
 
-def stop(*, reason: str = "requested") -> Dict[str, Any]:
+def stop(*, reason: str = "requested") -> dict[str, Any]:
     """Signal the active bot to leave cleanly, then clear the active pointer.
 
     Sends SIGTERM and waits up to 10s for the bot to exit. Falls back to

--- a/plugins/google_meet/tools.py
+++ b/plugins/google_meet/tools.py
@@ -75,7 +75,7 @@ def _resolve_node_client(node: Optional[str]):
 # Schemas
 # ---------------------------------------------------------------------------
 
-MEET_JOIN_SCHEMA: Dict[str, Any] = {
+MEET_JOIN_SCHEMA: dict[str, Any] = {
     "name": "meet_join",
     "description": (
         "Join a Google Meet call and start scraping live captions into a "
@@ -142,7 +142,7 @@ MEET_JOIN_SCHEMA: Dict[str, Any] = {
     },
 }
 
-MEET_STATUS_SCHEMA: Dict[str, Any] = {
+MEET_STATUS_SCHEMA: dict[str, Any] = {
     "name": "meet_status",
     "description": (
         "Report the current Meet session state — whether the bot is alive, "
@@ -158,7 +158,7 @@ MEET_STATUS_SCHEMA: Dict[str, Any] = {
     },
 }
 
-MEET_TRANSCRIPT_SCHEMA: Dict[str, Any] = {
+MEET_TRANSCRIPT_SCHEMA: dict[str, Any] = {
     "name": "meet_transcript",
     "description": (
         "Read the scraped transcript for the active Meet session. Returns "
@@ -183,7 +183,7 @@ MEET_TRANSCRIPT_SCHEMA: Dict[str, Any] = {
     },
 }
 
-MEET_LEAVE_SCHEMA: Dict[str, Any] = {
+MEET_LEAVE_SCHEMA: dict[str, Any] = {
     "name": "meet_leave",
     "description": (
         "Leave the active Meet call cleanly, stop caption scraping, and "
@@ -199,7 +199,7 @@ MEET_LEAVE_SCHEMA: Dict[str, Any] = {
     },
 }
 
-MEET_SAY_SCHEMA: Dict[str, Any] = {
+MEET_SAY_SCHEMA: dict[str, Any] = {
     "name": "meet_say",
     "description": (
         "Speak text into the active Meet call. Requires the active meeting "
@@ -233,7 +233,7 @@ def _err(msg: str, **extra) -> str:
     return _json({"success": False, "error": msg, **extra})
 
 
-def handle_meet_join(args: Dict[str, Any], **_kw) -> str:
+def handle_meet_join(args: dict[str, Any], **_kw) -> str:
     url = (args.get("url") or "").strip()
     if not url:
         return _err("url is required")
@@ -278,7 +278,7 @@ def handle_meet_join(args: Dict[str, Any], **_kw) -> str:
     return _json({"success": bool(res.get("ok")), **res})
 
 
-def handle_meet_status(args: Dict[str, Any], **_kw) -> str:
+def handle_meet_status(args: dict[str, Any], **_kw) -> str:
     try:
         client, node_name = _resolve_node_client(args.get("node"))
     except RuntimeError as e:
@@ -293,7 +293,7 @@ def handle_meet_status(args: Dict[str, Any], **_kw) -> str:
     return _json({"success": bool(res.get("ok")), **res})
 
 
-def handle_meet_transcript(args: Dict[str, Any], **_kw) -> str:
+def handle_meet_transcript(args: dict[str, Any], **_kw) -> str:
     last = args.get("last")
     try:
         last_i = int(last) if last is not None else None
@@ -315,7 +315,7 @@ def handle_meet_transcript(args: Dict[str, Any], **_kw) -> str:
     return _json({"success": bool(res.get("ok")), **res})
 
 
-def handle_meet_leave(args: Dict[str, Any], **_kw) -> str:
+def handle_meet_leave(args: dict[str, Any], **_kw) -> str:
     try:
         client, node_name = _resolve_node_client(args.get("node"))
     except RuntimeError as e:
@@ -330,7 +330,7 @@ def handle_meet_leave(args: Dict[str, Any], **_kw) -> str:
     return _json({"success": bool(res.get("ok")), **res})
 
 
-def handle_meet_say(args: Dict[str, Any], **_kw) -> str:
+def handle_meet_say(args: dict[str, Any], **_kw) -> str:
     text = (args.get("text") or "").strip()
     if not text:
         return _err("text is required")

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -33,9 +33,9 @@ router = APIRouter()
 
 SNAPSHOT_TTL_SECONDS = 120
 _SCAN_LOCK = threading.Lock()
-_SNAPSHOT_CACHE: Optional[Dict[str, Any]] = None
+_SNAPSHOT_CACHE: Optional[dict[str, Any]] = None
 _SNAPSHOT_CACHE_AT = 0
-_SCAN_STATUS: Dict[str, Any] = {
+_SCAN_STATUS: dict[str, Any] = {
     "state": "idle",
     "started_at": None,
     "finished_at": None,
@@ -53,15 +53,15 @@ FILE_RE = re.compile(r"(?:/home/|~/?|\./|/mnt/)[\w./-]+\.(?:py|js|ts|tsx|jsx|css
 TIER_NAMES = ["Copper", "Silver", "Gold", "Diamond", "Olympian"]
 
 
-def tiers(values: List[int]) -> List[Dict[str, Any]]:
+def tiers(values: list[int]) -> list[dict[str, Any]]:
     return [{"name": name, "threshold": threshold} for name, threshold in zip(TIER_NAMES, values)]
 
 
-def req(metric: str, gte: int) -> Dict[str, Any]:
+def req(metric: str, gte: int) -> dict[str, Any]:
     return {"metric": metric, "gte": gte}
 
 
-ACHIEVEMENTS: List[Dict[str, Any]] = [
+ACHIEVEMENTS: list[dict[str, Any]] = [
     # Agent Autonomy — mostly best-session feats
     {"id": "let_him_cook", "name": "Let Him Cook", "description": "Let Hermes run a serious autonomous tool chain in one session.", "category": "Agent Autonomy", "kind": "best_session", "icon": "flame", "threshold_metric": "max_tool_calls_in_session", "tiers": tiers([200, 500, 1200, 3000, 8000])},
     {"id": "autonomous_avalanche", "name": "Autonomous Avalanche", "description": "Accumulate a lifetime avalanche of Hermes tool calls across sessions.", "category": "Agent Autonomy", "kind": "lifetime", "icon": "avalanche", "threshold_metric": "total_tool_calls", "tiers": tiers([1000, 3000, 8000, 20000, 50000])},
@@ -154,7 +154,7 @@ def checkpoint_path() -> Path:
     return get_hermes_home() / "plugins" / "hermes-achievements" / "scan_checkpoint.json"
 
 
-def load_state() -> Dict[str, Any]:
+def load_state() -> dict[str, Any]:
     path = state_path()
     if not path.exists():
         return {"unlocks": {}}
@@ -164,7 +164,7 @@ def load_state() -> Dict[str, Any]:
         return {"unlocks": {}}
 
 
-def save_state(state: Dict[str, Any]) -> None:
+def save_state(state: dict[str, Any]) -> None:
     path = state_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(state, indent=2, sort_keys=True))
@@ -180,7 +180,7 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
-def load_snapshot() -> Optional[Dict[str, Any]]:
+def load_snapshot() -> Optional[dict[str, Any]]:
     path = snapshot_path()
     if not path.exists():
         return None
@@ -193,13 +193,13 @@ def load_snapshot() -> Optional[Dict[str, Any]]:
     return None
 
 
-def save_snapshot(data: Dict[str, Any]) -> None:
+def save_snapshot(data: dict[str, Any]) -> None:
     path = snapshot_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True))
 
 
-def load_checkpoint() -> Dict[str, Any]:
+def load_checkpoint() -> dict[str, Any]:
     path = checkpoint_path()
     if not path.exists():
         return {"schema_version": 1, "generated_at": 0, "sessions": {}}
@@ -216,13 +216,13 @@ def load_checkpoint() -> Dict[str, Any]:
     return {"schema_version": 1, "generated_at": 0, "sessions": {}}
 
 
-def save_checkpoint(data: Dict[str, Any]) -> None:
+def save_checkpoint(data: dict[str, Any]) -> None:
     path = checkpoint_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True))
 
 
-def session_fingerprint(meta: Dict[str, Any]) -> Dict[str, Any]:
+def session_fingerprint(meta: dict[str, Any]) -> dict[str, Any]:
     return {
         "last_active": meta.get("last_active"),
         "started_at": meta.get("started_at"),
@@ -235,7 +235,7 @@ def _cache_is_fresh(now: int) -> bool:
     return _SNAPSHOT_CACHE is not None and (now - _SNAPSHOT_CACHE_AT) <= SNAPSHOT_TTL_SECONDS
 
 
-def _is_snapshot_stale(snapshot: Optional[Dict[str, Any]], now: Optional[int] = None) -> bool:
+def _is_snapshot_stale(snapshot: Optional[dict[str, Any]], now: Optional[int] = None) -> bool:
     if not isinstance(snapshot, dict):
         return True
     ts = int(snapshot.get("generated_at") or 0)
@@ -245,7 +245,7 @@ def _is_snapshot_stale(snapshot: Optional[Dict[str, Any]], now: Optional[int] = 
     return (current - ts) > SNAPSHOT_TTL_SECONDS
 
 
-def _scan_status_payload(now: Optional[int] = None) -> Dict[str, Any]:
+def _scan_status_payload(now: Optional[int] = None) -> dict[str, Any]:
     current = int(now or time.time())
     snap = _SNAPSHOT_CACHE if isinstance(_SNAPSHOT_CACHE, dict) else None
     generated_at = int((snap or {}).get("generated_at") or 0) if snap else 0
@@ -270,7 +270,7 @@ def _tool_name_from_call(call: Any) -> Optional[str]:
     return call.get("name") or fn.get("name")
 
 
-def _content(msg: Dict[str, Any]) -> str:
+def _content(msg: dict[str, Any]) -> str:
     content = msg.get("content")
     if content is None:
         return ""
@@ -282,7 +282,7 @@ def _content(msg: Dict[str, Any]) -> str:
         return str(content)
 
 
-def _count_tool(tool_names: List[str], *needles: str) -> int:
+def _count_tool(tool_names: list[str], *needles: str) -> int:
     lowered = [name.lower() for name in tool_names]
     return sum(1 for name in lowered if any(needle in name for needle in needles))
 
@@ -307,11 +307,11 @@ def is_local_model_name(model_name: str) -> bool:
     return any(marker in name for marker in local_markers)
 
 
-def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
-    tool_names: Set[str] = set()
-    tool_sequence: List[str] = []
-    files_touched: Set[str] = set()
-    full_text_parts: List[str] = []
+def analyze_messages(session_id: str, title: str, messages: list[dict[str, Any]]) -> dict[str, Any]:
+    tool_names: set[str] = set()
+    tool_sequence: list[str] = []
+    files_touched: set[str] = set()
+    full_text_parts: list[str] = []
     error_count = 0
 
     for msg in messages:
@@ -419,7 +419,7 @@ def analyze_messages(session_id: str, title: str, messages: List[Dict[str, Any]]
     }
 
 
-def evaluate_tiered(definition: Dict[str, Any], aggregate: Dict[str, Any]) -> Dict[str, Any]:
+def evaluate_tiered(definition: dict[str, Any], aggregate: dict[str, Any]) -> dict[str, Any]:
     metric = definition["threshold_metric"]
     progress = int(aggregate.get(metric, 0) or 0)
     tiers_list = sorted(definition.get("tiers", []), key=lambda t: t["threshold"])
@@ -437,7 +437,7 @@ def evaluate_tiered(definition: Dict[str, Any], aggregate: Dict[str, Any]) -> Di
     return {"unlocked": unlocked, "discovered": discovered or not definition.get("secret"), "state": state, "tier": tier, "progress": progress, "next_tier": next_tier, "next_threshold": next_threshold, "progress_pct": pct}
 
 
-def evaluate_requirements(definition: Dict[str, Any], aggregate: Dict[str, Any]) -> Dict[str, Any]:
+def evaluate_requirements(definition: dict[str, Any], aggregate: dict[str, Any]) -> dict[str, Any]:
     requirements = definition.get("requirements", [])
     if not requirements:
         return {"unlocked": False, "discovered": not definition.get("secret"), "state": "secret" if definition.get("secret") else "discovered", "tier": None, "progress": 0, "next_tier": None, "next_threshold": 1, "progress_pct": 0}
@@ -455,7 +455,7 @@ def evaluate_requirements(definition: Dict[str, Any], aggregate: Dict[str, Any])
     return {"unlocked": complete, "discovered": any_progress or not definition.get("secret"), "state": state, "tier": None, "progress": pct, "next_tier": None, "next_threshold": 100, "progress_pct": 100 if complete else min(99, pct)}
 
 
-def evaluate_boolean(definition: Dict[str, Any], aggregate: Dict[str, Any]) -> Dict[str, Any]:
+def evaluate_boolean(definition: dict[str, Any], aggregate: dict[str, Any]) -> dict[str, Any]:
     # Backward-compatible helper for old tests/definitions. New catalog avoids simple booleans.
     unlocked = bool(aggregate.get(definition["metric"]))
     return {"unlocked": unlocked, "discovered": True, "state": "unlocked" if unlocked else "discovered", "tier": None, "progress": 1 if unlocked else 0, "next_tier": None, "next_threshold": 1, "progress_pct": 100 if unlocked else 0}
@@ -531,7 +531,7 @@ def metric_label(metric: str) -> str:
     return METRIC_LABELS.get(metric, metric.replace("_", " "))
 
 
-def criteria_for(definition: Dict[str, Any]) -> str:
+def criteria_for(definition: dict[str, Any]) -> str:
     if definition.get("secret") and definition.get("state") == "secret":
         return "Secret: exact requirement hidden until Hermes sees the first matching signal. Keep using Hermes across debugging, tools, memory, skills, plugins, and model workflows to reveal it."
     secret_prefix = ""
@@ -549,7 +549,7 @@ def criteria_for(definition: Dict[str, Any]) -> str:
     return secret_prefix + "Requirement: complete the matching Hermes behavior."
 
 
-def display_achievement(item: Dict[str, Any]) -> Dict[str, Any]:
+def display_achievement(item: dict[str, Any]) -> dict[str, Any]:
     clean = dict(item)
     if clean.get("state") == "secret":
         return {**clean, "name": "???", "description": "Secret achievement: hidden until Hermes detects the first relevant behavior in your session history.", "criteria": criteria_for(clean), "icon": "secret"}
@@ -561,7 +561,7 @@ def scan_sessions(
     limit: Optional[int] = None,
     progress_callback: Optional[Any] = None,
     progress_every: int = 250,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Scan Hermes sessions and build per-session achievement stats.
 
     ``limit=None`` (the default) scans the ENTIRE session history. Prior
@@ -603,8 +603,8 @@ def scan_sessions(
     try:
         sessions_meta = db.list_sessions_rich(limit=db_limit, include_children=True, project_compression_tips=False)
         total_sessions = len(sessions_meta)
-        sessions: List[Dict[str, Any]] = []
-        checkpoint_sessions: Dict[str, Any] = {}
+        sessions: list[dict[str, Any]] = []
+        checkpoint_sessions: dict[str, Any] = {}
         for idx, meta in enumerate(sessions_meta, start=1):
             sid = meta.get("id")
             if not sid:
@@ -671,8 +671,8 @@ def scan_sessions(
     }
 
 
-def aggregate_stats(sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
-    agg: Dict[str, Any] = {
+def aggregate_stats(sessions: list[dict[str, Any]]) -> dict[str, Any]:
+    agg: dict[str, Any] = {
         "session_count": len(sessions),
         "max_tool_calls_in_session": 0,
         "max_distinct_tools_in_session": 0,
@@ -707,8 +707,8 @@ def aggregate_stats(sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
     for key in sum_keys:
         agg[key] = 0
 
-    model_names: Set[str] = set()
-    provider_names: Set[str] = set()
+    model_names: set[str] = set()
+    provider_names: set[str] = set()
     for s in sessions:
         agg["max_tool_calls_in_session"] = max(agg["max_tool_calls_in_session"], s.get("tool_call_count", 0))
         agg["max_distinct_tools_in_session"] = max(agg["max_distinct_tools_in_session"], s.get("distinct_tool_count", 0))
@@ -755,7 +755,7 @@ def aggregate_stats(sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
     return agg
 
 
-def evaluate_definition(definition: Dict[str, Any], aggregate: Dict[str, Any]) -> Dict[str, Any]:
+def evaluate_definition(definition: dict[str, Any], aggregate: dict[str, Any]) -> dict[str, Any]:
     if "threshold_metric" in definition:
         return evaluate_tiered(definition, aggregate)
     if "requirements" in definition:
@@ -763,7 +763,7 @@ def evaluate_definition(definition: Dict[str, Any], aggregate: Dict[str, Any]) -
     return evaluate_boolean(definition, aggregate)
 
 
-def evidence_for(definition: Dict[str, Any], sessions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def evidence_for(definition: dict[str, Any], sessions: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
     if not sessions:
         return None
     metric = definition.get("threshold_metric")
@@ -784,7 +784,7 @@ def evidence_for(definition: Dict[str, Any], sessions: List[Dict[str, Any]]) -> 
     return None
 
 
-def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dict[str, Any]:
+def _compute_from_scan(scan: dict[str, Any], *, is_partial: bool = False) -> dict[str, Any]:
     """Evaluate every achievement definition against a scan result.
 
     Used by ``compute_all`` for finished scans AND by the background
@@ -826,7 +826,7 @@ def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dic
     }
 
 
-def compute_all(progress_callback: Optional[Any] = None, progress_every: int = 250) -> Dict[str, Any]:
+def compute_all(progress_callback: Optional[Any] = None, progress_every: int = 250) -> dict[str, Any]:
     scan = scan_sessions(progress_callback=progress_callback, progress_every=progress_every)
     return _compute_from_scan(scan, is_partial=False)
 
@@ -835,7 +835,7 @@ _BACKGROUND_SCAN_THREAD: Optional[threading.Thread] = None
 _BACKGROUND_SCAN_LOCK = threading.Lock()
 
 
-def _build_pending_snapshot(now: int) -> Dict[str, Any]:
+def _build_pending_snapshot(now: int) -> dict[str, Any]:
     """Placeholder payload used while the first-ever scan is still running.
 
     Returns a structurally-complete response so the dashboard UI can render
@@ -941,7 +941,7 @@ def _start_background_scan() -> None:
         thread.start()
 
 
-def evaluate_all(force: bool = False) -> Dict[str, Any]:
+def evaluate_all(force: bool = False) -> dict[str, Any]:
     """Return the current achievements payload.
 
     Behavior matrix:

--- a/plugins/image_gen/fal/__init__.py
+++ b/plugins/image_gen/fal/__init__.py
@@ -66,7 +66,7 @@ class FalImageGenProvider(ImageGenProvider):
         except Exception:  # noqa: BLE001 — defensive; never break the picker
             return False
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         import tools.image_generation_tool as _it
         return [
             {
@@ -83,7 +83,7 @@ class FalImageGenProvider(ImageGenProvider):
         import tools.image_generation_tool as _it
         return _it.DEFAULT_MODEL
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "FAL.ai",
             "badge": "paid",
@@ -102,7 +102,7 @@ class FalImageGenProvider(ImageGenProvider):
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate an image via the legacy FAL pipeline.
 
         Forwards prompt + aspect_ratio (and any forward-compat extras

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 API_MODEL = "gpt-image-2"
 
-_MODELS: Dict[str, Dict[str, Any]] = {
+_MODELS: dict[str, dict[str, Any]] = {
     "gpt-image-2-low": {
         "display": "GPT Image 2 (Low)",
         "speed": "~15s",
@@ -85,7 +85,7 @@ _CODEX_INSTRUCTIONS = (
 # ---------------------------------------------------------------------------
 
 
-def _load_image_gen_config() -> Dict[str, Any]:
+def _load_image_gen_config() -> dict[str, Any]:
     """Read ``image_gen`` from config.yaml (returns {} on any failure)."""
     try:
         from hermes_cli.config import load_config
@@ -98,7 +98,7 @@ def _load_image_gen_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model() -> tuple[str, dict[str, Any]]:
     """Decide which tier to use and return ``(model_id, meta)``."""
     import os
 
@@ -239,7 +239,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             return False
         return True
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         return [
             {
                 "id": model_id,
@@ -254,7 +254,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
     def default_model(self) -> Optional[str]:
         return DEFAULT_MODEL
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "OpenAI (Codex auth)",
             "badge": "free",
@@ -271,7 +271,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         prompt = (prompt or "").strip()
         aspect = resolve_aspect_ratio(aspect_ratio)
 

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 
 API_MODEL = "gpt-image-2"
 
-_MODELS: Dict[str, Dict[str, Any]] = {
+_MODELS: dict[str, dict[str, Any]] = {
     "gpt-image-2-low": {
         "display": "GPT Image 2 (Low)",
         "speed": "~15s",
@@ -80,7 +80,7 @@ _SIZES = {
 }
 
 
-def _load_openai_config() -> Dict[str, Any]:
+def _load_openai_config() -> dict[str, Any]:
     """Read ``image_gen`` from config.yaml (returns {} on any failure)."""
     try:
         from hermes_cli.config import load_config
@@ -93,7 +93,7 @@ def _load_openai_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model() -> tuple[str, dict[str, Any]]:
     """Decide which tier to use and return ``(model_id, meta)``."""
     env_override = os.environ.get("OPENAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
@@ -142,7 +142,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
             return False
         return True
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         return [
             {
                 "id": model_id,
@@ -157,7 +157,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
     def default_model(self) -> Optional[str]:
         return DEFAULT_MODEL
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "OpenAI",
             "badge": "paid",
@@ -176,7 +176,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         prompt = (prompt or "").strip()
         aspect = resolve_aspect_ratio(aspect_ratio)
 
@@ -215,7 +215,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
 
         # gpt-image-2 returns b64_json unconditionally and REJECTS
         # ``response_format`` as an unknown parameter. Don't send it.
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "model": API_MODEL,
             "prompt": prompt,
             "size": size,
@@ -292,7 +292,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
+        extra: dict[str, Any] = {"size": size, "quality": meta["quality"]}
         if revised_prompt:
             extra["revised_prompt"] = revised_prompt
 

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 # Model catalog
 # ---------------------------------------------------------------------------
 
-_MODELS: Dict[str, Dict[str, Any]] = {
+_MODELS: dict[str, dict[str, Any]] = {
     "grok-imagine-image": {
         "display": "Grok Imagine Image",
         "speed": "~5-10s",
@@ -77,7 +77,7 @@ DEFAULT_RESOLUTION = "1k"
 # ---------------------------------------------------------------------------
 
 
-def _load_xai_config() -> Dict[str, Any]:
+def _load_xai_config() -> dict[str, Any]:
     """Read ``image_gen.xai`` from config.yaml."""
     try:
         from hermes_cli.config import load_config
@@ -91,7 +91,7 @@ def _load_xai_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model() -> tuple[str, dict[str, Any]]:
     """Decide which model to use and return ``(model_id, meta)``."""
     env_override = os.environ.get("XAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
@@ -134,7 +134,7 @@ class XAIImageGenProvider(ImageGenProvider):
         creds = resolve_xai_http_credentials()
         return bool(creds.get("api_key"))
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         return [
             {
                 "id": model_id,
@@ -145,7 +145,7 @@ class XAIImageGenProvider(ImageGenProvider):
             for model_id, meta in _MODELS.items()
         ]
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         # Auth resolution is delegated to the shared ``xai_grok`` post_setup
         # hook (``hermes_cli/tools_config.py``); identical to the TTS / video
         # gen entries so users see the same OAuth-or-API-key choice for every
@@ -163,7 +163,7 @@ class XAIImageGenProvider(ImageGenProvider):
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Generate an image using xAI's grok-imagine-image."""
         creds = resolve_xai_http_credentials()
         api_key = str(creds.get("api_key") or "").strip()
@@ -182,7 +182,7 @@ class XAIImageGenProvider(ImageGenProvider):
         resolution = _resolve_resolution()
         xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION
 
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "model": model_id,
             "prompt": prompt,
             "aspect_ratio": xai_ar,
@@ -310,7 +310,7 @@ class XAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        extra: Dict[str, Any] = {
+        extra: dict[str, Any] = {
             "resolution": xai_res,
         }
 

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -64,14 +64,14 @@ def _is_memory_provider_dir(path: Path) -> bool:
         return False
 
 
-def _iter_provider_dirs() -> List[Tuple[str, Path]]:
+def _iter_provider_dirs() -> list[tuple[str, Path]]:
     """Yield ``(name, path)`` for all discovered provider directories.
 
     Scans bundled first, then user-installed.  Bundled takes precedence
     on name collisions (first-seen wins via ``seen`` set).
     """
     seen: set = set()
-    dirs: List[Tuple[str, Path]] = []
+    dirs: list[tuple[str, Path]] = []
 
     # 1. Bundled providers (plugins/memory/<name>/)
     if _MEMORY_PLUGINS_DIR.is_dir():
@@ -120,7 +120,7 @@ def find_provider_dir(name: str) -> Optional[Path]:
 # Public API
 # ---------------------------------------------------------------------------
 
-def discover_memory_providers() -> List[Tuple[str, str, bool]]:
+def discover_memory_providers() -> list[tuple[str, str, bool]]:
     """Scan bundled and user-installed directories for available providers.
 
     Returns list of (name, description, is_available) tuples.
@@ -320,7 +320,7 @@ def _get_active_memory_provider() -> Optional[str]:
         return None
 
 
-def discover_plugin_cli_commands() -> List[dict]:
+def discover_plugin_cli_commands() -> list[dict]:
     """Return CLI commands for the **active** memory plugin only.
 
     Only one memory provider can be active at a time (set via
@@ -337,7 +337,7 @@ def discover_plugin_cli_commands() -> List[dict]:
     full plugin module.  Safe to call during argparse setup before
     any provider is loaded.
     """
-    results: List[dict] = []
+    results: list[dict] = []
     if not _MEMORY_PLUGINS_DIR.is_dir():
         return results
 

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -75,7 +75,7 @@ def _resolve_brv_path() -> Optional[str]:
     return found
 
 
-def _run_brv(args: List[str], timeout: int = _QUERY_TIMEOUT,
+def _run_brv(args: list[str], timeout: int = _QUERY_TIMEOUT,
              cwd: str = None) -> dict:
     """Run a brv CLI command. Returns {success, output, error}."""
     brv_path = _resolve_brv_path()
@@ -279,7 +279,7 @@ class ByteRoverMemoryProvider(MemoryProvider):
         t = threading.Thread(target=_write, daemon=True, name="brv-memwrite")
         t.start()
 
-    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+    def on_pre_compress(self, messages: list[dict[str, Any]]) -> str:
         """Extract insights before context compression discards turns."""
         if not messages:
             return ""
@@ -311,7 +311,7 @@ class ByteRoverMemoryProvider(MemoryProvider):
         t.start()
         return ""
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         return [QUERY_SCHEMA, CURATE_SCHEMA, STATUS_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -106,7 +106,7 @@ def _check_local_runtime() -> tuple[bool, str | None]:
 # Cache of API_URL -> bool (whether that API supports update_mode='append').
 # Probed once per URL per process — every provider talking to the same API
 # gets the same answer without re-hitting /version on each initialize().
-_append_capability_cache: Dict[str, bool] = {}
+_append_capability_cache: dict[str, bool] = {}
 _append_capability_lock = threading.Lock()
 
 
@@ -339,7 +339,7 @@ def _load_config() -> dict:
     }
 
 
-def _normalize_retain_tags(value: Any) -> List[str]:
+def _normalize_retain_tags(value: Any) -> list[str]:
     """Normalize tag config/tool values to a deduplicated list of strings."""
     if value is None:
         return []
@@ -528,7 +528,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._llm_base_url = ""
         self._memory_mode = "hybrid"  # "context", "tools", or "hybrid"
         self._prefetch_method = "recall"  # "recall" or "reflect"
-        self._retain_tags: List[str] = []
+        self._retain_tags: list[str] = []
         self._retain_source = ""
         self._retain_user_prefix = "User"
         self._retain_assistant_prefix = "Assistant"
@@ -1341,7 +1341,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
-    def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
+    def _build_turn_messages(self, user_content: str, assistant_content: str) -> list[dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
         return [
             {
@@ -1356,8 +1356,8 @@ class HindsightMemoryProvider(MemoryProvider):
             },
         ]
 
-    def _build_metadata(self, *, message_count: int, turn_index: int) -> Dict[str, str]:
-        metadata: Dict[str, str] = {
+    def _build_metadata(self, *, message_count: int, turn_index: int) -> dict[str, str]:
+        metadata: dict[str, str] = {
             "retained_at": _utc_timestamp(),
             "message_count": str(message_count),
             "turn_index": str(turn_index),
@@ -1390,11 +1390,11 @@ class HindsightMemoryProvider(MemoryProvider):
         *,
         context: str | None = None,
         document_id: str | None = None,
-        metadata: Dict[str, str] | None = None,
-        tags: List[str] | None = None,
+        metadata: dict[str, str] | None = None,
+        tags: list[str] | None = None,
         retain_async: bool | None = None,
-    ) -> Dict[str, Any]:
-        kwargs: Dict[str, Any] = {
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
             "bank_id": self._bank_id,
             "content": content,
             "metadata": metadata or self._build_metadata(message_count=1, turn_index=self._turn_index),
@@ -1490,7 +1490,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._register_atexit()
         self._retain_queue.put(_do_retain)
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         if self._memory_mode == "context":
             return []
         return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -224,17 +224,17 @@ class HolographicMemoryProvider(MemoryProvider):
         # The on_session_end hook handles auto-extraction if configured.
         pass
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         return [FACT_STORE_SCHEMA, FACT_FEEDBACK_SCHEMA]
 
-    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs) -> str:
         if tool_name == "fact_store":
             return self._handle_fact_store(args)
         elif tool_name == "fact_feedback":
             return self._handle_fact_feedback(args)
         return tool_error(f"Unknown tool: {tool_name}")
 
-    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
         if not self._config.get("auto_extract", False):
             return
         if not self._store or not messages:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1060,7 +1060,7 @@ class HonchoMemoryProvider(MemoryProvider):
 
         return chunks
 
-    def _empty_profile_hint(self, peer: str) -> Dict[str, Any]:
+    def _empty_profile_hint(self, peer: str) -> dict[str, Any]:
         """Build a diagnostic hint when honcho_profile returns an empty card.
 
         A literal "No profile facts available yet." tells the model nothing
@@ -1076,7 +1076,7 @@ class HonchoMemoryProvider(MemoryProvider):
              (honcho-ai server < 3.x)
         """
         cfg = self._config
-        reasons: List[str] = []
+        reasons: list[str] = []
 
         if cfg is not None:
             if peer == "user":
@@ -1155,7 +1155,7 @@ class HonchoMemoryProvider(MemoryProvider):
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Mirror built-in user profile writes as Honcho conclusions.
 
@@ -1180,7 +1180,7 @@ class HonchoMemoryProvider(MemoryProvider):
         t = threading.Thread(target=_write, daemon=True, name="honcho-memwrite")
         t.start()
 
-    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
         """Flush all pending messages to Honcho on session end."""
         if self._cron_skipped:
             return
@@ -1194,7 +1194,7 @@ class HonchoMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.debug("Honcho session-end flush failed: %s", e)
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         """Return tool schemas, respecting recall_mode.
 
         B1: context-only mode hides all tools.

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -209,11 +209,11 @@ class Mem0MemoryProvider(MemoryProvider):
         self._agent_id = self._config.get("agent_id", "hermes")
         self._rerank = self._config.get("rerank", True)
 
-    def _read_filters(self) -> Dict[str, Any]:
+    def _read_filters(self) -> dict[str, Any]:
         """Filters for search/get_all — scoped to user only for cross-session recall."""
         return {"user_id": self._user_id}
 
-    def _write_filters(self) -> Dict[str, Any]:
+    def _write_filters(self) -> dict[str, Any]:
         """Filters for add — scoped to user + agent for attribution."""
         return {"user_id": self._user_id, "agent_id": self._agent_id}
 
@@ -294,7 +294,7 @@ class Mem0MemoryProvider(MemoryProvider):
         self._sync_thread = threading.Thread(target=_sync, daemon=True, name="mem0-sync")
         self._sync_thread.start()
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         return [PROFILE_SCHEMA, SEARCH_SCHEMA, CONCLUDE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -602,7 +602,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         )
         self._sync_thread.start()
 
-    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
         """Commit the session to trigger memory extraction.
 
         OpenViking automatically extracts 6 categories of memories:
@@ -636,7 +636,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         """Mirror built-in memory writes to OpenViking via content/write."""
         if not self._client or action != "add" or not content:
@@ -662,7 +662,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
         t.start()
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         return [SEARCH_SCHEMA, READ_SCHEMA, BROWSE_SCHEMA, REMEMBER_SCHEMA, ADD_RESOURCE_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
@@ -741,7 +741,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not query:
             return tool_error("query is required")
 
-        payload: Dict[str, Any] = {"query": query}
+        payload: dict[str, Any] = {"query": query}
         mode = args.get("mode", "auto")
         if mode != "auto":
             payload["mode"] = mode
@@ -918,7 +918,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if args.get("to") and args.get("parent"):
             return tool_error("Cannot specify both 'to' and 'parent'")
 
-        payload: Dict[str, Any] = {}
+        payload: dict[str, Any] = {}
         for key in ("reason", "to", "parent", "instruction", "wait", "timeout"):
             if key in args and args[key] not in {None, ""}:
                 payload[key] = args[key]

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -477,7 +477,7 @@ class RetainDBMemoryProvider(MemoryProvider):
     def is_available(self) -> bool:
         return bool(os.environ.get("RETAINDB_API_KEY"))
 
-    def get_config_schema(self) -> List[Dict[str, Any]]:
+    def get_config_schema(self) -> list[dict[str, Any]]:
         return [
             {"key": "api_key", "description": "RetainDB API key", "secret": True, "required": True, "env_var": "RETAINDB_API_KEY", "url": "https://retaindb.com"},
             {"key": "base_url", "description": "API endpoint", "default": _DEFAULT_BASE_URL},
@@ -640,7 +640,7 @@ class RetainDBMemoryProvider(MemoryProvider):
 
     # ── Tools ──────────────────────────────────────────────────────────────
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         return [
             PROFILE_SCHEMA, SEARCH_SCHEMA, CONTEXT_SCHEMA,
             REMEMBER_SCHEMA, FORGET_SCHEMA,

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -443,9 +443,9 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._active = False
         # Multi-container support
         self._enable_custom_containers = False
-        self._custom_containers: List[str] = []
+        self._custom_containers: list[str] = []
         self._custom_container_instructions = ""
-        self._allowed_containers: List[str] = []
+        self._allowed_containers: list[str] = []
 
     @property
     def name(self) -> str:
@@ -592,7 +592,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._sync_thread = threading.Thread(target=_run, daemon=True, name="supermemory-sync")
         self._sync_thread.start()
 
-    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
         if not self._active or not self._write_enabled or not self._client or not self._session_id:
             return
         cleaned = []
@@ -663,7 +663,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
             )
         return sanitized
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         if not self._enable_custom_containers:
             return [STORE_SCHEMA, SEARCH_SCHEMA, FORGET_SCHEMA, PROFILE_SCHEMA]
 
@@ -773,7 +773,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         except Exception as exc:
             return tool_error(f"Profile failed: {exc}")
 
-    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+    def handle_tool_call(self, tool_name: str, args: dict[str, Any], **kwargs) -> str:
         if not self._active or not self._client:
             return tool_error("Supermemory is not configured")
         if tool_name == "supermemory_store":

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -45,15 +45,15 @@ class TraceState:
     trace_id: str
     root_ctx: Any
     root_span: Any
-    generations: Dict[str, Any] = field(default_factory=dict)
-    tools: Dict[str, Any] = field(default_factory=dict)
-    pending_tools_by_name: Dict[str, list] = field(default_factory=dict)
+    generations: dict[str, Any] = field(default_factory=dict)
+    tools: dict[str, Any] = field(default_factory=dict)
+    pending_tools_by_name: dict[str, list] = field(default_factory=dict)
     turn_tool_calls: list[dict[str, Any]] = field(default_factory=list)
     last_updated_at: float = field(default_factory=time.time)
 
 
 _STATE_LOCK = threading.Lock()
-_TRACE_STATE: Dict[str, TraceState] = {}
+_TRACE_STATE: dict[str, TraceState] = {}
 _LANGFUSE_CLIENT = None
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
@@ -65,7 +65,7 @@ _READ_FILE_TAIL_LINES = 15
 # leftover template value and would cause the SDK to silently accept the
 # credentials at construction time but drop every trace at flush time.
 # See #23823 — the silent-failure bug this guard fixes.
-_LANGFUSE_KEY_PREFIXES: Dict[str, str] = {
+_LANGFUSE_KEY_PREFIXES: dict[str, str] = {
     "HERMES_LANGFUSE_PUBLIC_KEY": "pk-lf-",
     "HERMES_LANGFUSE_SECRET_KEY": "sk-lf-",
 }
@@ -194,7 +194,7 @@ def _get_langfuse() -> Optional[Langfuse]:
     release = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
     sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")
 
-    kwargs: Dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "public_key": public_key,
         "secret_key": secret_key,
         "base_url": base_url,
@@ -478,8 +478,8 @@ def _serialize_assistant_message(message: Any) -> dict[str, Any]:
 
 
 def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, base_url: str) -> tuple[dict[str, int], dict[str, float]]:
-    usage_details: Dict[str, int] = {}
-    cost_details: Dict[str, float] = {}
+    usage_details: dict[str, int] = {}
+    cost_details: dict[str, float] = {}
     raw_usage = getattr(response, "usage", None)
     if not raw_usage:
         return usage_details, cost_details
@@ -553,7 +553,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
     }
 
     # session_id must be passed in trace_context for Langfuse session grouping.
-    trace_ctx: Dict[str, Any] = {"trace_id": trace_id}
+    trace_ctx: dict[str, Any] = {"trace_id": trace_id}
     if session_id:
         trace_ctx["session_id"] = session_id
 
@@ -621,7 +621,7 @@ def _end_observation(observation: Any, *, output: Any = None, metadata: Optional
     if observation is None:
         return
     try:
-        update_kwargs: Dict[str, Any] = {}
+        update_kwargs: dict[str, Any] = {}
         if output is not None:
             update_kwargs["output"] = output
         if metadata:
@@ -899,7 +899,7 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
         usage_details, cost_details = {}, {}
 
     tool_count = len(output.get("tool_calls", [])) or assistant_tool_call_count
-    gen_metadata: Dict[str, Any] = {"tool_call_count": tool_count}
+    gen_metadata: dict[str, Any] = {"tool_call_count": tool_count}
     if api_duration and api_duration > 0:
         gen_metadata["api_duration_s"] = round(api_duration, 3)
     if finish_reason:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -175,15 +175,15 @@ class VoiceReceiver:
         self._bot_ssrc: int = 0
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
-        self._ssrc_to_user: Dict[int, int] = {}
+        self._ssrc_to_user: dict[int, int] = {}
         self._lock = threading.Lock()
 
         # Per-user audio buffers
-        self._buffers: Dict[int, bytearray] = defaultdict(bytearray)
-        self._last_packet_time: Dict[int, float] = {}
+        self._buffers: dict[int, bytearray] = defaultdict(bytearray)
+        self._last_packet_time: dict[int, float] = {}
 
         # Opus decoder per SSRC (each user needs own decoder state)
-        self._decoders: Dict[int, object] = {}
+        self._decoders: dict[int, object] = {}
 
         # Pause flag: don't capture while bot is playing TTS
         self._paused = False
@@ -559,19 +559,19 @@ class DiscordAdapter(BasePlatformAdapter):
         self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
         self.gateway_runner = None  # Set by gateway/run.py for cross-platform delivery
         # Voice channel state (per-guild)
-        self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
-        self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
+        self._voice_clients: dict[int, Any] = {}  # guild_id -> VoiceClient
+        self._voice_locks: dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
         self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
         self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
-        self._pending_text_batches: Dict[str, MessageEvent] = {}
-        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
-        self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
-        self._voice_sources: Dict[int, Dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
-        self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
+        self._pending_text_batches: dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: dict[str, asyncio.Task] = {}
+        self._voice_text_channels: dict[int, int] = {}  # guild_id -> text_channel_id
+        self._voice_sources: dict[int, dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
+        self._voice_timeout_tasks: dict[int, asyncio.Task] = {}  # guild_id -> timeout task
         # Phase 2: voice listening
-        self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
-        self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
+        self._voice_receivers: dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
+        self._voice_listen_tasks: dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
         # Track threads where the bot has participated so follow-up messages
@@ -580,7 +580,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._threads = ThreadParticipationTracker("discord")
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
-        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._typing_tasks: dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
         # Dedup cache: prevents duplicate bot responses when Discord
@@ -593,7 +593,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # In-memory cache of the bot's last message ID per channel, used by
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
-        self._last_self_message_id: Dict[str, str] = {}
+        self._last_self_message_id: dict[str, str] = {}
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -1148,7 +1148,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         return "safe"
 
-    def _canonicalize_app_command_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _canonicalize_app_command_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Reduce command payloads to the semantic fields Hermes manages."""
         contexts = payload.get("contexts")
         integration_types = payload.get("integration_types")
@@ -1180,7 +1180,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return None
         return str(value)
 
-    def _existing_command_to_payload(self, command: Any) -> Dict[str, Any]:
+    def _existing_command_to_payload(self, command: Any) -> dict[str, Any]:
         """Build a canonical-ready dict from an AppCommand.
 
         discord.py's AppCommand.to_dict() does NOT include nsfw,
@@ -1203,7 +1203,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         return payload
 
-    def _canonicalize_app_command_option(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _canonicalize_app_command_option(self, payload: dict[str, Any]) -> dict[str, Any]:
         return {
             "type": int(payload.get("type", 0) or 0),
             "name": str(payload.get("name", "") or ""),
@@ -1230,7 +1230,7 @@ class DiscordAdapter(BasePlatformAdapter):
             ],
         }
 
-    def _patchable_app_command_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _patchable_app_command_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Fields supported by discord.py's edit_global_command route."""
         canonical = self._canonicalize_app_command_payload(payload)
         return {
@@ -1239,7 +1239,7 @@ class DiscordAdapter(BasePlatformAdapter):
             "options": canonical["options"],
         }
 
-    async def _safe_sync_slash_commands(self) -> Dict[str, int]:
+    async def _safe_sync_slash_commands(self) -> dict[str, int]:
         """Diff existing global commands and only mutate the commands that changed."""
         if not self._client:
             return {
@@ -1373,7 +1373,7 @@ class DiscordAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[dict[str, Any]] = None
     ) -> SendResult:
         """Send a message to a Discord channel or thread.
 
@@ -1526,7 +1526,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.warning("[%s] %s", self.name, warning)
                 warnings.append(warning)
 
-        raw_response: Dict[str, Any] = {"message_ids": message_ids, "thread_id": thread_id}
+        raw_response: dict[str, Any] = {"message_ids": message_ids, "thread_id": thread_id}
         if warnings:
             raw_response["warnings"] = warnings
 
@@ -1566,7 +1566,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     hint = getattr(files[0], "filename", "") or ""
             thread_name = _derive_forum_thread_name(hint) if hint.strip() else "New Post"
 
-        kwargs: Dict[str, Any] = {"name": thread_name}
+        kwargs: dict[str, Any] = {"name": thread_name}
         if content:
             kwargs["content"] = content
         if file is not None:
@@ -1657,8 +1657,8 @@ class DiscordAdapter(BasePlatformAdapter):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        images: list[tuple[str, str]],
+        metadata: Optional[dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single Discord message with multiple attachments.
@@ -1702,8 +1702,8 @@ class DiscordAdapter(BasePlatformAdapter):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
 
-            files: List[Any] = []
-            captions: List[str] = []
+            files: list[Any] = []
+            captions: list[str] = []
             aiohttp_session = None
             try:
                 for image_url, alt_text in chunk:
@@ -1806,7 +1806,7 @@ class DiscordAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
@@ -2039,7 +2039,7 @@ class DiscordAdapter(BasePlatformAdapter):
         vc = self._voice_clients.get(guild_id)
         return vc is not None and vc.is_connected()
 
-    def get_voice_channel_info(self, guild_id: int) -> Optional[Dict[str, Any]]:
+    def get_voice_channel_info(self, guild_id: int) -> Optional[dict[str, Any]]:
         """Return voice channel awareness info for the given guild.
 
         Returns None if the bot is not in a voice channel.  Otherwise
@@ -2293,7 +2293,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _evaluate_slash_authorization(
         self, interaction: "discord.Interaction",
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> tuple[bool, Optional[str]]:
         """Evaluate slash authorization without producing any response.
 
         Returns ``(allowed, reason)``. ``reason`` is populated only when
@@ -2509,7 +2509,7 @@ class DiscordAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
@@ -2526,7 +2526,7 @@ class DiscordAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively as a Discord file attachment."""
         if not self._client:
@@ -2605,7 +2605,7 @@ class DiscordAdapter(BasePlatformAdapter):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Discord file attachment."""
         if not self._client:
@@ -2674,7 +2674,7 @@ class DiscordAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
@@ -2692,7 +2692,7 @@ class DiscordAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
@@ -2767,7 +2767,7 @@ class DiscordAdapter(BasePlatformAdapter):
             except (asyncio.CancelledError, Exception):
                 pass
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Get information about a Discord channel."""
         if not self._client:
             return {"name": "Unknown", "type": "dm"}
@@ -3839,7 +3839,7 @@ class DiscordAdapter(BasePlatformAdapter):
         name: str,
         message: str = "",
         auto_archive_duration: int = 1440,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Create a thread in the current Discord channel.
 
         Tries ``parent_channel.create_thread()`` first.  If Discord rejects
@@ -4117,7 +4117,7 @@ class DiscordAdapter(BasePlatformAdapter):
         choices: Optional[list],
         clarify_id: str,
         session_key: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Render a clarify prompt with one Discord button per choice.
 
@@ -4191,7 +4191,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive button-based update prompt (Yes / No).
 
@@ -4230,7 +4230,7 @@ class DiscordAdapter(BasePlatformAdapter):
         current_provider: str,
         session_key: str,
         on_model_selected,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an interactive select-menu model picker.
 
@@ -5535,7 +5535,7 @@ def _define_discord_view_classes() -> None:
 
         def __init__(
             self,
-            choices: List[str],
+            choices: list[str],
             clarify_id: str,
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
@@ -5718,7 +5718,7 @@ if DISCORD_AVAILABLE:
 # Process-local cache for Discord channel-type probes.  Avoids re-probing the
 # same channel on every send when the directory cache has no entry (e.g. fresh
 # install, or channel created after the last directory build).
-_DISCORD_CHANNEL_TYPE_PROBE_CACHE: Dict[str, bool] = {}
+_DISCORD_CHANNEL_TYPE_PROBE_CACHE: dict[str, bool] = {}
 
 
 def _remember_channel_is_forum(chat_id: str, is_forum: bool) -> None:
@@ -5763,7 +5763,7 @@ async def _standalone_send(
     thread_id: Optional[str] = None,
     media_files: Optional[list] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Send via Discord REST API without a live gateway adapter.
 
     Used by ``tools/send_message_tool._send_via_adapter`` when the gateway

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -349,7 +349,7 @@ class _ThreadCountStore:
 
     def __init__(self, path: _Path):
         self._path = path
-        self._counts: Dict[str, Dict[str, int]] = {}
+        self._counts: dict[str, dict[str, int]] = {}
         self._loaded = False
 
     def load(self) -> None:
@@ -380,12 +380,12 @@ class _ThreadCountStore:
             self._counts = {}
             return
         # Validate shape — anything off-schema gets dropped silently.
-        clean: Dict[str, Dict[str, int]] = {}
+        clean: dict[str, dict[str, int]] = {}
         if isinstance(data, dict):
             for chat_id, threads in data.items():
                 if not isinstance(chat_id, str) or not isinstance(threads, dict):
                     continue
-                clean_threads: Dict[str, int] = {}
+                clean_threads: dict[str, int] = {}
                 for thread_name, count in threads.items():
                     if isinstance(thread_name, str) and isinstance(count, int):
                         clean_threads[thread_name] = count
@@ -485,14 +485,14 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self._user_chat_api: Optional[Any] = None
         self._user_credentials: Optional[Any] = None
         # Per-email caches. Populated lazily by ``_get_user_chat_for_chat``.
-        self._user_creds_by_email: Dict[str, Any] = {}
-        self._user_chat_api_by_email: Dict[str, Any] = {}
+        self._user_creds_by_email: dict[str, Any] = {}
+        self._user_chat_api_by_email: dict[str, Any] = {}
         # chat_id → most-recent inbound sender's email. Populated in
         # ``_build_message_event`` whenever the inbound event carries a
         # non-empty ``sender.email``. Drives the per-user token lookup
         # in ``_send_file`` so the bot uploads as the user who triggered
         # the request, not as some other authorized user.
-        self._last_sender_by_chat: Dict[str, str] = {}
+        self._last_sender_by_chat: dict[str, str] = {}
         self._credentials: Optional[Any] = None
         self._project_id: Optional[str] = None
         self._subscription_path: Optional[str] = None
@@ -501,9 +501,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._bot_user_id: Optional[str] = None  # users/{id}
         self._dedup = MessageDeduplicator()
-        self._typing_messages: Dict[str, str] = {}
+        self._typing_messages: dict[str, str] = {}
         self._shutting_down = False
-        self._rate_limit_hits: Dict[str, int] = {}
+        self._rate_limit_hits: dict[str, int] = {}
         # Last-seen inbound thread name per chat_id (space). Google Chat
         # DMs create a NEW thread per top-level user message but the user
         # views them as one logical conversation. We:
@@ -513,7 +513,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         #   (b) cache the most recent inbound thread name here so outbound
         #       replies still land in the right visual thread without
         #       re-coupling sessions to threads.
-        self._last_inbound_thread: Dict[str, str] = {}
+        self._last_inbound_thread: dict[str, str] = {}
         # Inbound message count per (chat_id, thread_name). Drives the
         # DM main-flow vs side-thread heuristic in _build_message_event
         # and the outbound thread routing in _resolve_thread_id.
@@ -533,12 +533,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # an Event here BEFORE starting the API call so concurrent calls
         # from base.py's _keep_typing wait instead of duplicating cards.
         # Cleared in the create_and_record finally.
-        self._typing_card_inflight: Dict[str, asyncio.Event] = {}
+        self._typing_card_inflight: dict[str, asyncio.Event] = {}
         # Orphaned typing cards (created by background tasks that lost a
         # race with send() / another concurrent create). Cleaned up at
         # end-of-turn by on_processing_complete via patch-to-empty so
         # they don't sit in the chat forever as "Hermes is thinking…".
-        self._orphan_typing_messages: Dict[str, List[str]] = {}
+        self._orphan_typing_messages: dict[str, list[str]] = {}
         # FlowControl knobs (env-configurable).
         self._max_messages = int(os.getenv("GOOGLE_CHAT_MAX_MESSAGES", "1"))
         self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
@@ -619,7 +619,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         )
         return credentials
 
-    def _validate_config(self) -> Tuple[str, str]:
+    def _validate_config(self) -> tuple[str, str]:
         """Return (project_id, subscription_path) after validation.
 
         Raises ValueError with a sanitized message on any config problem.
@@ -721,7 +721,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         filtering ``sender.type == 'BOT'`` (which is still safe but less
         precise — own messages and other bots look alike).
         """
-        candidate_spaces: List[str] = []
+        candidate_spaces: list[str] = []
         if self.config.home_channel and self.config.home_channel.chat_id:
             candidate_spaces.append(self.config.home_channel.chat_id)
         # Env-configured allowed spaces (comma-separated). Optional.
@@ -1017,8 +1017,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     @staticmethod
     def _extract_message_payload(
-        envelope: Dict[str, Any], ce_type: str = ""
-    ) -> Optional[Tuple[Dict[str, Any], Dict[str, Any], str]]:
+        envelope: dict[str, Any], ce_type: str = ""
+    ) -> Optional[tuple[dict[str, Any], dict[str, Any], str]]:
         """Detect Pub/Sub envelope format and return ``(message, space, format_name)``.
 
         Three known formats are accepted. Returns ``None`` when the envelope
@@ -1105,7 +1105,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             sender_type = str(sender_type_raw).strip().upper() or "HUMAN"
             if sender_type not in {"HUMAN", "BOT"}:
                 sender_type = "HUMAN"
-            msg: Dict[str, Any] = {
+            msg: dict[str, Any] = {
                 "name": envelope.get("message_name", "") or "",
                 "sender": {
                     "name": sender_name_surrogate,
@@ -1256,7 +1256,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-    async def _dispatch_message(self, msg: Dict[str, Any], envelope: Dict[str, Any]) -> None:
+    async def _dispatch_message(self, msg: dict[str, Any], envelope: dict[str, Any]) -> None:
         """Translate a Chat message payload to a MessageEvent and hand off.
 
         Intercepts the ``/setup-files`` admin command BEFORE the agent
@@ -1335,7 +1335,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         arg = parts[1].strip() if len(parts) > 1 else ""
 
         async def _reply(text: str) -> None:
-            body: Dict[str, Any] = {"text": text}
+            body: dict[str, Any] = {"text": text}
             if thread_id:
                 body["thread"] = {"name": thread_id}
             try:
@@ -1519,7 +1519,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         return True
 
     async def _build_message_event(
-        self, msg: Dict[str, Any], envelope: Dict[str, Any]
+        self, msg: dict[str, Any], envelope: dict[str, Any]
     ) -> Optional[MessageEvent]:
         """Parse a Chat API message into a hermes MessageEvent."""
         space = envelope.get("space") or msg.get("space") or {}
@@ -1552,8 +1552,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 text = f"/cmd_{command_id} {text}".strip()
 
         # Attachments: download and cache.
-        media_urls: List[str] = []
-        media_types: List[str] = []
+        media_urls: list[str] = []
+        media_types: list[str] = []
         message_type = MessageType.TEXT
         attachments = msg.get("attachment") or []
         for att in attachments:
@@ -1645,8 +1645,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         )
 
     async def _download_attachment(
-        self, attachment: Dict[str, Any]
-    ) -> Tuple[Optional[str], Optional[str]]:
+        self, attachment: dict[str, Any]
+    ) -> tuple[Optional[str], Optional[str]]:
         """Download an inbound attachment to the local cache; return (path, mime).
 
         Priority for bot Service Accounts:
@@ -1767,7 +1767,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a text message.
 
@@ -1806,7 +1806,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             patched_typing = False
 
             for idx, chunk in enumerate(chunks):
-                body: Dict[str, Any] = {"text": chunk}
+                body: dict[str, Any] = {"text": chunk}
                 # Only set thread on new-message create path. Patch inherits.
                 if thread_id and (idx > 0 or not typing_msg_name):
                     body["thread"] = {"name": thread_id}
@@ -1947,7 +1947,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             return False
 
     async def _patch_message(
-        self, message_name: str, body: Dict[str, Any]
+        self, message_name: str, body: dict[str, Any]
     ) -> SendResult:
         """Update a message's text (and optionally cards) in-place."""
         update_mask_fields = []
@@ -1960,7 +1960,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # Patch body cannot carry thread (immutable).
         patch_body = {k: v for k, v in body.items() if k not in {"thread",}}
 
-        def _do_patch() -> Dict[str, Any]:
+        def _do_patch() -> dict[str, Any]:
             return (
                 self._chat_api.spaces()
                 .messages()
@@ -1971,12 +1971,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
         resp = await asyncio.to_thread(_do_patch)
         return SendResult(success=True, message_id=resp.get("name", message_name))
 
-    def _chunk_text(self, text: str) -> List[str]:
+    def _chunk_text(self, text: str) -> list[str]:
         if not text:
             return []
         if len(text) <= _MAX_TEXT_LENGTH:
             return [text]
-        chunks: List[str] = []
+        chunks: list[str] = []
         remaining = text
         while remaining:
             if len(remaining) <= _MAX_TEXT_LENGTH:
@@ -2032,7 +2032,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             return content
 
         text = content
-        placeholders: Dict[str, str] = {}
+        placeholders: dict[str, str] = {}
         counter = [0]
 
         def _ph(value: str) -> str:
@@ -2094,7 +2094,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
     def _resolve_thread_id(
         self,
         reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
+        metadata: Optional[dict[str, Any]],
         chat_id: Optional[str] = None,
     ) -> Optional[str]:
         """Return the Google Chat thread resource name to reply under, or None.
@@ -2185,7 +2185,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         raise RuntimeError(f"{op_name}: retry loop exited without result")
 
     async def _create_message(
-        self, chat_id: str, body: Dict[str, Any]
+        self, chat_id: str, body: dict[str, Any]
     ) -> SendResult:
         """POST spaces/{space}/messages via REST, returning SendResult.
 
@@ -2199,7 +2199,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
         See https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages/create
         """
-        kwargs: Dict[str, Any] = {"parent": chat_id, "body": body}
+        kwargs: dict[str, Any] = {"parent": chat_id, "body": body}
         thread_meta = body.get("thread") or {}
         if thread_meta.get("name"):
             # FALLBACK_TO_NEW_THREAD: try the requested thread; if Chat
@@ -2209,7 +2209,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             # but possible.
             kwargs["messageReplyOption"] = "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
 
-        def _do_create() -> Dict[str, Any]:
+        def _do_create() -> dict[str, Any]:
             return (
                 self._chat_api.spaces()
                 .messages()
@@ -2290,7 +2290,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         thread_id = self._resolve_thread_id(
             reply_to=None, metadata=metadata, chat_id=chat_id,
         )
-        body: Dict[str, Any] = {"text": "Hermes is thinking…"}
+        body: dict[str, Any] = {"text": "Hermes is thinking…"}
         if thread_id:
             body["thread"] = {"name": thread_id}
 
@@ -2470,7 +2470,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an inline image via attachment URL (no upload).
 
@@ -2479,7 +2479,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         ``send()``. Otherwise create a new message.
         """
         thread_id = self._resolve_thread_id(reply_to, metadata, chat_id=chat_id)
-        text_parts: List[str] = []
+        text_parts: list[str] = []
         if caption:
             text_parts.append(caption)
         text_parts.append(image_url)
@@ -2489,7 +2489,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             patched = await self._consume_typing_card_with_text(chat_id, text)
             if patched is not None:
                 return patched
-            body: Dict[str, Any] = {"text": text}
+            body: dict[str, Any] = {"text": text}
             if thread_id:
                 body["thread"] = {"name": thread_id}
             return await self._create_message(chat_id, body)
@@ -2560,7 +2560,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         animation_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Google Chat has no native animation type; fall back to send_image."""
         return await self.send_image(
@@ -2654,7 +2654,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
     async def _acquire_user_chat_api(
         self, sender_email: Optional[str]
-    ) -> Tuple[Optional[Any], Optional[str]]:
+    ) -> tuple[Optional[Any], Optional[str]]:
         """Resolve the user-authed Chat client for an outbound attachment.
 
         Lookup order:
@@ -2775,7 +2775,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
 
-        def _upload() -> Dict[str, Any]:
+        def _upload() -> dict[str, Any]:
             media = MediaFileUpload(path, mimetype=mime, resumable=False)
             return (
                 chat_api.media()
@@ -2816,7 +2816,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 error="upload returned no attachmentDataRef",
             )
 
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "attachment": [{"attachmentDataRef": attachment_ref}],
         }
         if caption:
@@ -2829,13 +2829,13 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # uploading principal). messageReplyOption is required for the
         # thread.name in body to actually be honored — see
         # _create_message docstring for the API quirk.
-        create_kwargs: Dict[str, Any] = {"parent": chat_id, "body": body}
+        create_kwargs: dict[str, Any] = {"parent": chat_id, "body": body}
         if thread_id:
             create_kwargs["messageReplyOption"] = (
                 "REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD"
             )
 
-        def _create_with_attachment() -> Dict[str, Any]:
+        def _create_with_attachment() -> dict[str, Any]:
             return (
                 chat_api.spaces()
                 .messages()
@@ -2891,7 +2891,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             "**Para activarlo:** envía `/setup-files` y sigue las instrucciones.",
             f"Mientras tanto el archivo está en el host: `{path}`",
         ])
-        body: Dict[str, Any] = {"text": "\n".join(lines)}
+        body: dict[str, Any] = {"text": "\n".join(lines)}
         if thread_id:
             body["thread"] = {"name": thread_id}
         try:
@@ -2910,7 +2910,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Metadata
     # ------------------------------------------------------------------
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return {name, type, chat_id} for a space."""
         try:
             info = await asyncio.to_thread(
@@ -2979,7 +2979,7 @@ def _is_connected(config: PlatformConfig) -> bool:
     return bool(getattr(config, "enabled", False)) and _validate_config(config)
 
 
-def _env_enablement() -> Optional[Dict[str, Any]]:
+def _env_enablement() -> Optional[dict[str, Any]]:
     """Seed ``PlatformConfig.extra`` from env vars during
     ``_apply_env_overrides``.
 
@@ -3003,7 +3003,7 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
     )
     if not (project and subscription):
         return None
-    seed: Dict[str, Any] = {
+    seed: dict[str, Any] = {
         "project_id": project,
         "subscription_name": subscription,
     }
@@ -3127,9 +3127,9 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[list[str]] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """POST a single Google Chat message via the REST API without the SDK.
 
     Used by ``tools/send_message_tool._send_via_adapter`` when the gateway
@@ -3235,7 +3235,7 @@ async def _standalone_send(
     if not token:
         return {"error": "Google Chat standalone send: refreshed credentials have no token"}
 
-    body: Dict[str, Any] = {"text": message}
+    body: dict[str, Any] = {"text": message}
     if thread_id:
         body["thread"] = {"name": thread_id}
 

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -153,7 +153,7 @@ def _pending_auth_path(email: Optional[str] = None) -> Path:
 # `chat.messages.create` covers BOTH `media.upload` and the subsequent
 # `messages.create` that references the attachmentDataRef. We deliberately
 # do NOT request drive.file or other scopes — least privilege.
-SCOPES: List[str] = [
+SCOPES: list[str] = [
     "https://www.googleapis.com/auth/chat.messages.create",
 ]
 
@@ -280,7 +280,7 @@ def build_user_chat_service(creds: Any) -> Any:
     return build_service("chat", "v1", credentials=creds, cache_discovery=False)
 
 
-def list_authorized_emails() -> List[str]:
+def list_authorized_emails() -> list[str]:
     """Return the set of user emails that have stored per-user tokens.
 
     Lists files in the per-user tokens dir; does NOT include the legacy
@@ -291,7 +291,7 @@ def list_authorized_emails() -> List[str]:
     d = _user_tokens_dir()
     if not d.exists():
         return []
-    out: List[str] = []
+    out: list[str] = []
     for f in d.iterdir():
         if f.is_file() and f.suffix == ".json":
             out.append(f.stem)
@@ -471,7 +471,7 @@ def _load_pending_auth(email: Optional[str] = None) -> dict:
     return data
 
 
-def _extract_code_and_state(code_or_url: str) -> Tuple[str, Optional[str]]:
+def _extract_code_and_state(code_or_url: str) -> tuple[str, Optional[str]]:
     """Accept a raw auth code OR the full failed-redirect URL the user pastes."""
     if not code_or_url.startswith("http"):
         return code_or_url, None

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -258,7 +258,7 @@ class IRCAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ):
         if not self._writer or self._writer.is_closing():
             return SendResult(success=False, error="Not connected")
@@ -280,7 +280,7 @@ class IRCAdapter(BasePlatformAdapter):
         """IRC has no typing indicator — no-op."""
         pass
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         is_channel = chat_id.startswith("#") or chat_id.startswith("&")
         return {
             "name": chat_id,
@@ -289,7 +289,7 @@ class IRCAdapter(BasePlatformAdapter):
 
     # ── Message splitting ─────────────────────────────────────────────────
 
-    def _split_message(self, content: str, target: str) -> List[str]:
+    def _split_message(self, content: str, target: str) -> list[str]:
         """Split a long message into IRC-safe chunks.
 
         IRC has a ~512 byte line limit.  After accounting for protocol
@@ -302,7 +302,7 @@ class IRCAdapter(BasePlatformAdapter):
         max_bytes = 510 - overhead
         user_limit = self.max_message_length
 
-        lines: List[str] = []
+        lines: list[str] = []
         for paragraph in content.split("\n"):
             if not paragraph.strip():
                 continue
@@ -720,9 +720,9 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[list[str]] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Open an ephemeral IRC connection, send a PRIVMSG, and quit.
 
     Used by ``tools/send_message_tool._send_via_adapter`` when the gateway

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -195,7 +195,7 @@ def strip_markdown_preserving_urls(text: str) -> str:
     return text
 
 
-def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> List[str]:
+def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> list[str]:
     """Split ``text`` into LINE-sized bubbles, preferring paragraph/line breaks.
 
     Returns at most ``LINE_MAX_MESSAGES_PER_CALL`` chunks; longer text is
@@ -207,7 +207,7 @@ def split_for_line(text: str, max_chars: int = LINE_SAFE_BUBBLE_CHARS) -> List[s
     if len(text) <= max_chars:
         return [text]
 
-    chunks: List[str] = []
+    chunks: list[str] = []
     remaining = text
     while remaining and len(chunks) < LINE_MAX_MESSAGES_PER_CALL:
         if len(remaining) <= max_chars:
@@ -295,7 +295,7 @@ class RequestCache:
         ttl_seconds: int = 3600,
         pending_ttl_seconds: int = 86400,
     ) -> None:
-        self._entries: Dict[str, _CacheEntry] = {}
+        self._entries: dict[str, _CacheEntry] = {}
         self._ttl = ttl_seconds
         self._pending_ttl = pending_ttl_seconds
 
@@ -360,7 +360,7 @@ class _MessageDeduplicator:
     """Bounded LRU of LINE webhook event IDs to ignore at-least-once retries."""
 
     def __init__(self, max_size: int = 1000) -> None:
-        self._seen: Dict[str, float] = {}
+        self._seen: dict[str, float] = {}
         self._max = max_size
 
     def is_duplicate(self, event_id: str) -> bool:
@@ -380,7 +380,7 @@ class _MessageDeduplicator:
 # Source / chat-id resolution
 # ---------------------------------------------------------------------------
 
-def _resolve_chat(source: Dict[str, Any]) -> Tuple[str, str]:
+def _resolve_chat(source: dict[str, Any]) -> tuple[str, str]:
     """Return ``(chat_id, chat_type)`` from a LINE event ``source`` block.
 
     LINE sources are one of:
@@ -401,12 +401,12 @@ def _resolve_chat(source: Dict[str, Any]) -> Tuple[str, str]:
 
 
 def _allowed_for_source(
-    source: Dict[str, Any],
+    source: dict[str, Any],
     *,
     allow_all: bool,
-    user_ids: Set[str],
-    group_ids: Set[str],
-    room_ids: Set[str],
+    user_ids: set[str],
+    group_ids: set[str],
+    room_ids: set[str],
 ) -> bool:
     """Three-list gate — credit PR #18153."""
     if allow_all:
@@ -444,7 +444,7 @@ class _LineClient:
             "Content-Type": "application/json",
         }
 
-    async def reply(self, reply_token: str, messages: List[Dict[str, Any]]) -> None:
+    async def reply(self, reply_token: str, messages: list[dict[str, Any]]) -> None:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=self._timeout)
         async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
@@ -457,7 +457,7 @@ class _LineClient:
                     body = await resp.text()
                     raise RuntimeError(f"LINE reply {resp.status}: {body[:200]}")
 
-    async def push(self, chat_id: str, messages: List[Dict[str, Any]]) -> None:
+    async def push(self, chat_id: str, messages: list[dict[str, Any]]) -> None:
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=self._timeout)
         async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
@@ -518,14 +518,14 @@ class _LineClient:
 # Message builders
 # ---------------------------------------------------------------------------
 
-def _text_message(text: str) -> Dict[str, Any]:
+def _text_message(text: str) -> dict[str, Any]:
     """Build a LINE text message object, capped to per-bubble max."""
     if len(text) > LINE_PER_BUBBLE_CHARS:
         text = text[: LINE_PER_BUBBLE_CHARS - 1] + "…"
     return {"type": "text", "text": text}
 
 
-def _image_message(original_url: str, preview_url: Optional[str] = None) -> Dict[str, Any]:
+def _image_message(original_url: str, preview_url: Optional[str] = None) -> dict[str, Any]:
     return {
         "type": "image",
         "originalContentUrl": original_url,
@@ -533,7 +533,7 @@ def _image_message(original_url: str, preview_url: Optional[str] = None) -> Dict
     }
 
 
-def _audio_message(url: str, duration_ms: int = 1000) -> Dict[str, Any]:
+def _audio_message(url: str, duration_ms: int = 1000) -> dict[str, Any]:
     return {
         "type": "audio",
         "originalContentUrl": url,
@@ -541,7 +541,7 @@ def _audio_message(url: str, duration_ms: int = 1000) -> Dict[str, Any]:
     }
 
 
-def _video_message(url: str, preview_url: str) -> Dict[str, Any]:
+def _video_message(url: str, preview_url: str) -> dict[str, Any]:
     return {
         "type": "video",
         "originalContentUrl": url,
@@ -551,7 +551,7 @@ def _video_message(url: str, preview_url: str) -> Dict[str, Any]:
 
 def build_postback_button_message(
     text: str, button_label: str, request_id: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Template Buttons message — the slow-LLM postback bubble.
 
     From PR #18153 (leepoweii). Template Buttons stay tappable from chat
@@ -586,7 +586,7 @@ def build_postback_button_message(
 # steered). When the postback cache has a PENDING entry we *bypass* the
 # cache for these so they reach the user as visible bubbles instead of
 # being silently swallowed. From PR #18153.
-_SYSTEM_BYPASS_PREFIXES: Tuple[str, ...] = (
+_SYSTEM_BYPASS_PREFIXES: tuple[str, ...] = (
     "⚡ Interrupting",
     "⏳ Queued",
     "⏩ Steered",
@@ -604,7 +604,7 @@ def _is_system_bypass(content: str) -> bool:
 # Configuration helpers
 # ---------------------------------------------------------------------------
 
-def _csv_set(value: str) -> Set[str]:
+def _csv_set(value: str) -> set[str]:
     if not value:
         return set()
     return {x.strip() for x in value.split(",") if x.strip()}
@@ -707,20 +707,20 @@ class LineAdapter(BasePlatformAdapter):
         self._app = None  # aiohttp.web.Application
         self._runner = None  # aiohttp.web.AppRunner
         self._site = None  # aiohttp.web.TCPSite
-        self._reply_tokens: Dict[str, Tuple[str, float]] = {}  # chat_id → (token, expiry)
+        self._reply_tokens: dict[str, tuple[str, float]] = {}  # chat_id → (token, expiry)
         self._cache = RequestCache()
         self._dedup = _MessageDeduplicator()
         self._bot_user_id: Optional[str] = None
         self._lock_key: Optional[str] = None
 
         # Media state
-        self._media_tokens: Dict[str, Tuple[str, float]] = {}  # token → (path, expiry)
-        self._media_temp_paths: Set[str] = set()
+        self._media_tokens: dict[str, tuple[str, float]] = {}  # token → (path, expiry)
+        self._media_temp_paths: set[str] = set()
         self._media_ttl = MEDIA_TOKEN_TTL_SECONDS
 
         # Pending-button slot per chat — ensures one outstanding postback
         # button per chat at a time. Postback cache request_id keyed by chat_id.
-        self._pending_buttons: Dict[str, str] = {}
+        self._pending_buttons: dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -880,7 +880,7 @@ class LineAdapter(BasePlatformAdapter):
 
         return web.Response(status=200, text="ok")
 
-    async def _dispatch_event(self, event: Dict[str, Any]) -> None:
+    async def _dispatch_event(self, event: dict[str, Any]) -> None:
         event_type = event.get("type")
         source = event.get("source") or {}
         webhook_event_id = event.get("webhookEventId", "") or ""
@@ -915,7 +915,7 @@ class LineAdapter(BasePlatformAdapter):
         else:
             logger.debug("LINE: ignoring event type %r", event_type)
 
-    async def _handle_message_event(self, event: Dict[str, Any]) -> None:
+    async def _handle_message_event(self, event: dict[str, Any]) -> None:
         msg = event.get("message") or {}
         msg_type = msg.get("type", "")
         message_id = msg.get("id", "")
@@ -933,8 +933,8 @@ class LineAdapter(BasePlatformAdapter):
 
         # Handle media inbound — fetch the binary, cache it, and surface a
         # vision-tool-friendly local path on the MessageEvent.
-        media_urls: List[str] = []
-        media_types: List[str] = []
+        media_urls: list[str] = []
+        media_types: list[str] = []
         text = ""
 
         if msg_type == "text":
@@ -979,7 +979,7 @@ class LineAdapter(BasePlatformAdapter):
 
         await self.handle_message(event_obj)
 
-    async def _handle_postback_event(self, event: Dict[str, Any]) -> None:
+    async def _handle_postback_event(self, event: dict[str, Any]) -> None:
         """User tapped the slow-LLM postback button — deliver cached payload."""
         postback = event.get("postback") or {}
         data = postback.get("data", "") or ""
@@ -1067,7 +1067,7 @@ class LineAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         if not self._client:
             return SendResult(success=False, error="LINE adapter not connected")
@@ -1118,7 +1118,7 @@ class LineAdapter(BasePlatformAdapter):
             logger.error("LINE: push send failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
-    def _consume_reply_token(self, chat_id: str) -> Tuple[str, bool]:
+    def _consume_reply_token(self, chat_id: str) -> tuple[str, bool]:
         """Consume a stashed reply token if present and unexpired.
 
         Returns ``(token, used_reply)``.
@@ -1136,7 +1136,7 @@ class LineAdapter(BasePlatformAdapter):
         if self._client and chat_id:
             await self._client.loading(chat_id)
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Best-effort chat info derived from the chat_id prefix.
 
         LINE's chat-info APIs are limited and per-source-type — instead of
@@ -1308,7 +1308,7 @@ class LineAdapter(BasePlatformAdapter):
         chat_id: str,
         image_path: str,
         caption: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         path = Path(image_path)
         if not path.exists() or not path.is_file():
@@ -1328,7 +1328,7 @@ class LineAdapter(BasePlatformAdapter):
         url = self._media_url(token, path.name)
         if not url.lower().startswith("https://"):
             return SendResult(success=False, error=f"LINE image URL must be HTTPS: {url}")
-        msgs: List[Dict[str, Any]] = [_image_message(url)]
+        msgs: list[dict[str, Any]] = [_image_message(url)]
         if caption:
             msgs.append(_text_message(caption))
         return await self._send_messages(chat_id, msgs)
@@ -1338,7 +1338,7 @@ class LineAdapter(BasePlatformAdapter):
         chat_id: str,
         audio_path: str,
         duration_ms: int = 1000,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         path = Path(audio_path)
         if not path.exists() or not path.is_file():
@@ -1362,7 +1362,7 @@ class LineAdapter(BasePlatformAdapter):
         chat_id: str,
         video_path: str,
         preview_path: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         path = Path(video_path)
         if not path.exists() or not path.is_file():
@@ -1405,7 +1405,7 @@ class LineAdapter(BasePlatformAdapter):
     async def _send_messages(
         self,
         chat_id: str,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
     ) -> SendResult:
         """Send already-built message objects, batched at 5/call."""
         if not self._client:
@@ -1492,7 +1492,7 @@ def is_connected(config) -> bool:
     return validate_config(config)
 
 
-def _env_enablement() -> Optional[Dict[str, Any]]:
+def _env_enablement() -> Optional[dict[str, Any]]:
     """Auto-seed PlatformConfig.extra from env-only setups.
 
     Lets ``hermes status`` reflect a LINE configuration that lives entirely
@@ -1501,7 +1501,7 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
     """
     if not (os.getenv("LINE_CHANNEL_ACCESS_TOKEN") and os.getenv("LINE_CHANNEL_SECRET")):
         return None
-    seeded: Dict[str, Any] = {}
+    seeded: dict[str, Any] = {}
     if os.getenv("LINE_PORT"):
         try:
             seeded["port"] = int(os.environ["LINE_PORT"])
@@ -1522,9 +1522,9 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[list[str]] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Out-of-process push delivery for cron jobs running detached from the gateway.
 
     Without this hook ``deliver=line`` cron jobs fail with ``no live adapter``

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -103,13 +103,13 @@ class MattermostAdapter(BasePlatformAdapter):
     # HTTP helpers
     # ------------------------------------------------------------------
 
-    def _headers(self) -> Dict[str, str]:
+    def _headers(self) -> dict[str, str]:
         return {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
         }
 
-    async def _api_get(self, path: str) -> Dict[str, Any]:
+    async def _api_get(self, path: str) -> dict[str, Any]:
         """GET /api/v4/{path}."""
         import aiohttp
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
@@ -125,8 +125,8 @@ class MattermostAdapter(BasePlatformAdapter):
             return {}
 
     async def _api_post(
-        self, path: str, payload: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, path: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
         """POST /api/v4/{path} with JSON body."""
         import aiohttp
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
@@ -145,8 +145,8 @@ class MattermostAdapter(BasePlatformAdapter):
             return {}
 
     async def _api_put(
-        self, path: str, payload: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, path: str, payload: dict[str, Any]
+    ) -> dict[str, Any]:
         """PUT /api/v4/{path} with JSON body."""
         import aiohttp
         url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
@@ -271,7 +271,7 @@ class MattermostAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a message (or multiple chunks) to a channel."""
         if not content:
@@ -282,7 +282,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         last_id = None
         for chunk in chunks:
-            payload: Dict[str, Any] = {
+            payload: dict[str, Any] = {
                 "channel_id": chat_id,
                 "message": chunk,
             }
@@ -300,7 +300,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         return SendResult(success=True, message_id=last_id)
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return channel name and type."""
         data = await self._api_get(f"channels/{chat_id}")
         if not data:
@@ -315,7 +315,7 @@ class MattermostAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(
-        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+        self, chat_id: str, metadata: Optional[dict[str, Any]] = None
     ) -> None:
         """Send a typing indicator."""
         await self._api_post(
@@ -342,7 +342,7 @@ class MattermostAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
@@ -355,7 +355,7 @@ class MattermostAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
@@ -369,7 +369,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
@@ -382,7 +382,7 @@ class MattermostAdapter(BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
@@ -395,7 +395,7 @@ class MattermostAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
@@ -465,7 +465,7 @@ class MattermostAdapter(BasePlatformAdapter):
         if not file_id:
             return await self.send(chat_id, f"{caption or ''}\n{url}".strip(), reply_to)
 
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
@@ -504,7 +504,7 @@ class MattermostAdapter(BasePlatformAdapter):
         if not file_id:
             return SendResult(success=False, error="File upload failed")
 
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "channel_id": chat_id,
             "message": caption or "",
             "file_ids": [file_id],
@@ -520,8 +520,8 @@ class MattermostAdapter(BasePlatformAdapter):
     async def send_multiple_images(
         self,
         chat_id: str,
-        images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        images: list[tuple[str, str]],
+        metadata: Optional[dict[str, Any]] = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single Mattermost post with multiple attachments.
@@ -546,8 +546,8 @@ class MattermostAdapter(BasePlatformAdapter):
             if human_delay > 0 and chunk_idx > 0:
                 await asyncio.sleep(human_delay)
 
-            file_ids: List[str] = []
-            caption_parts: List[str] = []
+            file_ids: list[str] = []
+            caption_parts: list[str] = []
             try:
                 for image_url, alt_text in chunk:
                     if alt_text:
@@ -591,7 +591,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 if not file_ids:
                     continue
 
-                payload: Dict[str, Any] = {
+                payload: dict[str, Any] = {
                     "channel_id": chat_id,
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
@@ -688,7 +688,7 @@ class MattermostAdapter(BasePlatformAdapter):
                 logger.info("Mattermost: WebSocket closed (%s)", raw_msg.type)
                 break
 
-    async def _handle_ws_event(self, event: Dict[str, Any]) -> None:
+    async def _handle_ws_event(self, event: dict[str, Any]) -> None:
         """Process a single WebSocket event."""
         event_type = event.get("event")
         if event_type != "posted":
@@ -797,8 +797,8 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Download file attachments immediately (URLs require auth headers
         # that downstream tools won't have).
-        media_urls: List[str] = []
-        media_types: List[str] = []
+        media_urls: list[str] = []
+        media_types: list[str] = []
         for fid in file_ids:
             try:
                 file_info = await self._api_get(f"files/{fid}/info")
@@ -886,7 +886,7 @@ async def _standalone_send(
     thread_id: Optional[str] = None,
     media_files: Optional[list] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Send via the Mattermost v4 REST API without a live gateway adapter.
 
     Used by ``tools/send_message_tool._send_via_adapter`` when the gateway
@@ -944,7 +944,7 @@ async def _standalone_send(
             **_sess_kw,
         ) as session:
             # 1. Upload media (if any) and collect file_ids.
-            file_ids: List[str] = []
+            file_ids: list[str] = []
             for media in media_files:
                 file_path = media.get("path") if isinstance(media, dict) else media
                 if not file_path or not os.path.exists(file_path):
@@ -979,7 +979,7 @@ async def _standalone_send(
                             file_ids.append(info["id"])
 
             # 2. Post the message (with thread root + attached file_ids).
-            payload: Dict[str, Any] = {
+            payload: dict[str, Any] = {
                 "channel_id": chat_id,
                 "message": message,
             }

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -83,7 +83,7 @@ RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 STREAM_TIMEOUT_SECONDS = 90  # ntfy keepalive default is 55s; give margin
 
 
-def _build_auth_header(token: str) -> Dict[str, str]:
+def _build_auth_header(token: str) -> dict[str, str]:
     """Build an ``Authorization`` header from an ntfy token.
 
     Shared by :class:`NtfyAdapter._auth_headers` and :func:`_standalone_send`
@@ -178,7 +178,7 @@ class NtfyAdapter(BasePlatformAdapter):
         self._http_client: Optional["httpx.AsyncClient"] = None
 
         # Message deduplication: msg_id -> timestamp
-        self._seen_messages: Dict[str, float] = {}
+        self._seen_messages: dict[str, float] = {}
 
     # -- Connection lifecycle -----------------------------------------------
 
@@ -234,7 +234,7 @@ class NtfyAdapter(BasePlatformAdapter):
             await asyncio.sleep(delay)
             backoff_idx += 1
 
-    async def _consume_stream(self, url: str, headers: Dict[str, str]) -> None:
+    async def _consume_stream(self, url: str, headers: dict[str, str]) -> None:
         """Open an HTTP streaming connection and dispatch events."""
         # poll=false keeps a persistent streaming connection alive with keepalive events
         params = {"poll": "false"}
@@ -304,7 +304,7 @@ class NtfyAdapter(BasePlatformAdapter):
 
     # -- Inbound message processing -----------------------------------------
 
-    async def _on_message(self, event: Dict[str, Any]) -> None:
+    async def _on_message(self, event: dict[str, Any]) -> None:
         """Process an incoming ntfy message event."""
         msg_id = event.get("id") or uuid.uuid4().hex
         if self._is_duplicate(msg_id):
@@ -376,7 +376,7 @@ class NtfyAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Publish a message to the configured publish topic."""
         metadata = metadata or {}
@@ -422,13 +422,13 @@ class NtfyAdapter(BasePlatformAdapter):
         """ntfy does not support typing indicators."""
         pass
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic info about an ntfy topic."""
         return {"name": chat_id, "type": "dm"}
 
     # -- Helpers ------------------------------------------------------------
 
-    def _auth_headers(self) -> Dict[str, str]:
+    def _auth_headers(self) -> dict[str, str]:
         """Build Authorization header if a token is configured."""
         return _build_auth_header(self._token)
 
@@ -482,9 +482,9 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[list[str]] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Out-of-process publish for cron / send_message_tool fallbacks.
 
     Used by ``tools/send_message_tool._send_via_adapter`` and the cron

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -74,7 +74,7 @@ _CORR_PREFIX = "hermes-"
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _parse_comma_list(value: str) -> List[str]:
+def _parse_comma_list(value: str) -> list[str]:
     """Split a comma-separated string into a stripped list."""
     return [v.strip() for v in value.split(",") if v.strip()]
 
@@ -130,7 +130,7 @@ class SimplexAdapter(BasePlatformAdapter):
         self._ws = None  # websockets connection
         self._ws_task: Optional[asyncio.Task] = None
         self._health_task: Optional[asyncio.Task] = None
-        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._typing_tasks: dict[str, asyncio.Task] = {}
         self._running = False
         self._last_ws_activity = 0.0
 
@@ -371,8 +371,8 @@ class SimplexAdapter(BasePlatformAdapter):
         text = msg_content.get("text") or ""
 
         # Media attachments
-        media_urls: List[str] = []
-        media_types: List[str] = []
+        media_urls: list[str] = []
+        media_types: list[str] = []
         file_info = chat_item.get("file") or {}
         if file_info and file_info.get("fileStatus") not in {"cancelled", "error"}:
             file_id = file_info.get("fileId")
@@ -499,7 +499,7 @@ class SimplexAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send a text message to a contact or group."""
         corr_id = self._make_corr_id()
@@ -528,7 +528,7 @@ class SimplexAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image (URL) as a message with optional caption.
 
@@ -612,9 +612,9 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[list[str]] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Open an ephemeral WebSocket to the daemon, send, and close.
 
     Used by ``tools/send_message_tool._send_via_adapter`` when the gateway

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -501,7 +501,7 @@ async def _standalone_send(
     thread_id: Optional[str] = None,
     media_files: Optional[list] = None,
     force_document: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Acquire a Bot Framework bearer token and POST a single message activity.
 
     Used by ``tools/send_message_tool._send_via_adapter`` when the gateway
@@ -638,7 +638,7 @@ class TeamsAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator(max_size=1000)
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
-        self._conv_refs: Dict[str, Any] = {}
+        self._conv_refs: dict[str, Any] = {}
 
     async def connect(self) -> bool:
         if not TEAMS_SDK_AVAILABLE:
@@ -919,7 +919,7 @@ class TeamsAdapter(BasePlatformAdapter):
         command: str,
         session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         """Send an Adaptive Card approval prompt with Allow/Deny buttons."""
         if not self._app:
@@ -980,7 +980,7 @@ class TeamsAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")
@@ -1011,7 +1011,7 @@ class TeamsAdapter(BasePlatformAdapter):
 
         return SendResult(success=True, message_id=last_message_id)
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Optional[dict[str, Any]] = None) -> None:
         if not self._app:
             return
         try:
@@ -1025,7 +1025,7 @@ class TeamsAdapter(BasePlatformAdapter):
         image_url: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
     ) -> SendResult:
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")

--- a/plugins/spotify/client.py
+++ b/plugins/spotify/client.py
@@ -42,7 +42,7 @@ class SpotifyClient:
     def __init__(self) -> None:
         self._runtime = self._resolve_runtime(refresh_if_expiring=True)
 
-    def _resolve_runtime(self, *, force_refresh: bool = False, refresh_if_expiring: bool = True) -> Dict[str, Any]:
+    def _resolve_runtime(self, *, force_refresh: bool = False, refresh_if_expiring: bool = True) -> dict[str, Any]:
         try:
             return resolve_spotify_runtime_credentials(
                 force_refresh=force_refresh,
@@ -55,7 +55,7 @@ class SpotifyClient:
     def base_url(self) -> str:
         return str(self._runtime.get("base_url") or "").rstrip("/")
 
-    def _headers(self) -> Dict[str, str]:
+    def _headers(self) -> dict[str, str]:
         return {
             "Authorization": f"Bearer {self._runtime['access_token']}",
             "Content-Type": "application/json",
@@ -66,10 +66,10 @@ class SpotifyClient:
         method: str,
         path: str,
         *,
-        params: Optional[Dict[str, Any]] = None,
-        json_body: Optional[Dict[str, Any]] = None,
+        params: Optional[dict[str, Any]] = None,
+        json_body: Optional[dict[str, Any]] = None,
         allow_retry_on_401: bool = True,
-        empty_response: Optional[Dict[str, Any]] = None,
+        empty_response: Optional[dict[str, Any]] = None,
     ) -> Any:
         url = f"{self.base_url}{path}"
         response = httpx.request(
@@ -149,7 +149,7 @@ class SpotifyClient:
         device_id: Optional[str] = None,
         context_uri: Optional[str] = None,
         uris: Optional[list[str]] = None,
-        offset: Optional[Dict[str, Any]] = None,
+        offset: Optional[dict[str, Any]] = None,
         position_ms: Optional[int] = None,
     ) -> Any:
         return self.request(
@@ -376,7 +376,7 @@ def _friendly_spotify_error_message(
     return f"Spotify API request failed with status {status_code}."
 
 
-def _strip_none(payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _strip_none(payload: Optional[dict[str, Any]]) -> dict[str, Any]:
     if not payload:
         return {}
     return {key: value for key, value in payload.items() if value is not None}

--- a/plugins/spotify/tools.py
+++ b/plugins/spotify/tools.py
@@ -56,7 +56,7 @@ def _coerce_bool(raw: Any, default: bool = False) -> bool:
     return default
 
 
-def _as_list(raw: Any) -> List[str]:
+def _as_list(raw: Any) -> list[str]:
     if raw is None:
         return []
     if isinstance(raw, list):

--- a/plugins/teams_pipeline/store.py
+++ b/plugins/teams_pipeline/store.py
@@ -41,7 +41,7 @@ class TeamsPipelineStore:
     def __init__(self, path: str | Path):
         self.path = Path(path)
         self._lock = threading.RLock()
-        self._state: Dict[str, Dict[str, Any]] = {
+        self._state: dict[str, dict[str, Any]] = {
             "subscriptions": {},
             "notification_receipts": {},
             "event_timestamps": {},
@@ -76,16 +76,16 @@ class TeamsPipelineStore:
             tmp_path = Path(tmp.name)
         tmp_path.replace(self.path)
 
-    def list_subscriptions(self) -> Dict[str, Dict[str, Any]]:
+    def list_subscriptions(self) -> dict[str, dict[str, Any]]:
         with self._lock:
             return deepcopy(self._state["subscriptions"])
 
-    def get_subscription(self, subscription_id: str) -> Optional[Dict[str, Any]]:
+    def get_subscription(self, subscription_id: str) -> Optional[dict[str, Any]]:
         with self._lock:
             record = self._state["subscriptions"].get(subscription_id)
             return deepcopy(record) if isinstance(record, dict) else None
 
-    def upsert_subscription(self, subscription_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def upsert_subscription(self, subscription_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         with self._lock:
             existing = self._state["subscriptions"].get(subscription_id, {})
             merged = {**existing, **deepcopy(payload)}
@@ -105,7 +105,7 @@ class TeamsPipelineStore:
             return True
 
     @classmethod
-    def build_notification_receipt_key(cls, notification: Dict[str, Any]) -> str:
+    def build_notification_receipt_key(cls, notification: dict[str, Any]) -> str:
         explicit_id = notification.get("id")
         if explicit_id:
             return f"id:{explicit_id}"
@@ -120,7 +120,7 @@ class TeamsPipelineStore:
     def record_notification_receipt(
         self,
         receipt_key: str,
-        payload: Optional[Dict[str, Any]] = None,
+        payload: Optional[dict[str, Any]] = None,
         *,
         received_at: Optional[str] = None,
     ) -> bool:
@@ -146,7 +146,7 @@ class TeamsPipelineStore:
             value = self._state["event_timestamps"].get(event_key)
             return str(value) if value is not None else None
 
-    def stats(self) -> Dict[str, int]:
+    def stats(self) -> dict[str, int]:
         with self._lock:
             return {
                 "subscriptions": len(self._state["subscriptions"]),
@@ -156,7 +156,7 @@ class TeamsPipelineStore:
                 "sink_records": len(self._state["sink_records"]),
             }
 
-    def upsert_job(self, job_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def upsert_job(self, job_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         with self._lock:
             existing = self._state["jobs"].get(job_id, {})
             merged = {**existing, **deepcopy(payload)}
@@ -167,16 +167,16 @@ class TeamsPipelineStore:
             self._persist()
             return deepcopy(merged)
 
-    def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+    def get_job(self, job_id: str) -> Optional[dict[str, Any]]:
         with self._lock:
             record = self._state["jobs"].get(job_id)
             return deepcopy(record) if isinstance(record, dict) else None
 
-    def list_jobs(self) -> Dict[str, Dict[str, Any]]:
+    def list_jobs(self) -> dict[str, dict[str, Any]]:
         with self._lock:
             return deepcopy(self._state["jobs"])
 
-    def upsert_sink_record(self, sink_key: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def upsert_sink_record(self, sink_key: str, payload: dict[str, Any]) -> dict[str, Any]:
         with self._lock:
             existing = self._state["sink_records"].get(sink_key, {})
             merged = {**existing, **deepcopy(payload)}
@@ -187,7 +187,7 @@ class TeamsPipelineStore:
             self._persist()
             return deepcopy(merged)
 
-    def get_sink_record(self, sink_key: str) -> Optional[Dict[str, Any]]:
+    def get_sink_record(self, sink_key: str) -> Optional[dict[str, Any]]:
         with self._lock:
             record = self._state["sink_records"].get(sink_key)
             return deepcopy(record) if isinstance(record, dict) else None

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 #   audio          : True if generate_audio is supported
 #   negative       : True if negative_prompt is supported
 
-FAL_FAMILIES: Dict[str, Dict[str, Any]] = {
+FAL_FAMILIES: dict[str, dict[str, Any]] = {
     # ─── Cheap / fast tier ─────────────────────────────────────────────
     "ltx-2.3": {
         "display": "LTX 2.3 (22B)",
@@ -172,7 +172,7 @@ def _is_duration_range(durations: Any) -> bool:
     return durations[1] - durations[0] > 1
 
 
-def _clamp_duration(family: Dict[str, Any], duration: Optional[int]) -> Optional[int]:
+def _clamp_duration(family: dict[str, Any], duration: Optional[int]) -> Optional[int]:
     durations = family.get("durations")
     if not durations:
         return duration
@@ -192,7 +192,7 @@ def _clamp_duration(family: Dict[str, Any], duration: Optional[int]) -> Optional
 # ---------------------------------------------------------------------------
 
 
-def _load_video_gen_section() -> Dict[str, Any]:
+def _load_video_gen_section() -> dict[str, Any]:
     try:
         from hermes_cli.config import load_config
 
@@ -204,9 +204,9 @@ def _load_video_gen_section() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_family(explicit: Optional[str]) -> Tuple[str, Dict[str, Any]]:
+def _resolve_family(explicit: Optional[str]) -> tuple[str, dict[str, Any]]:
     """Decide which FAL family to use. Returns ``(family_id, meta)``."""
-    candidates: List[Optional[str]] = []
+    candidates: list[Optional[str]] = []
     candidates.append(explicit)
     candidates.append(os.environ.get("FAL_VIDEO_MODEL"))
 
@@ -232,7 +232,7 @@ def _resolve_family(explicit: Optional[str]) -> Tuple[str, Dict[str, Any]]:
 
 
 def _build_payload(
-    family: Dict[str, Any],
+    family: dict[str, Any],
     *,
     prompt: str,
     image_url: Optional[str],
@@ -242,9 +242,9 @@ def _build_payload(
     negative_prompt: Optional[str],
     audio: Optional[bool],
     seed: Optional[int],
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build a family-specific payload, dropping keys the family doesn't declare."""
-    payload: Dict[str, Any] = {}
+    payload: dict[str, Any] = {}
 
     if prompt:
         payload["prompt"] = prompt
@@ -331,10 +331,10 @@ class FALVideoGenProvider(VideoGenProvider):
             return False
         return True
 
-    def list_models(self) -> List[Dict[str, Any]]:
-        out: List[Dict[str, Any]] = []
+    def list_models(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
         for fid, meta in FAL_FAMILIES.items():
-            modalities: List[str] = []
+            modalities: list[str] = []
             if meta.get("text_endpoint"):
                 modalities.append("text")
             if meta.get("image_endpoint"):
@@ -353,7 +353,7 @@ class FALVideoGenProvider(VideoGenProvider):
     def default_model(self) -> Optional[str]:
         return DEFAULT_MODEL
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "FAL",
             "badge": "paid",
@@ -367,7 +367,7 @@ class FALVideoGenProvider(VideoGenProvider):
             ],
         }
 
-    def capabilities(self) -> Dict[str, Any]:
+    def capabilities(self) -> dict[str, Any]:
         return {
             "modalities": ["text", "image"],
             "aspect_ratios": ["16:9", "9:16", "1:1"],
@@ -385,7 +385,7 @@ class FALVideoGenProvider(VideoGenProvider):
         *,
         model: Optional[str] = None,
         image_url: Optional[str] = None,
-        reference_image_urls: Optional[List[str]] = None,
+        reference_image_urls: Optional[list[str]] = None,
         duration: Optional[int] = None,
         aspect_ratio: str = "16:9",
         resolution: str = "720p",
@@ -393,7 +393,7 @@ class FALVideoGenProvider(VideoGenProvider):
         audio: Optional[bool] = None,
         seed: Optional[int] = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         if not os.environ.get("FAL_KEY", "").strip():
             return error_response(
                 error=(
@@ -498,7 +498,7 @@ class FALVideoGenProvider(VideoGenProvider):
                 provider="fal", model=family_id, prompt=prompt,
             )
 
-        extra: Dict[str, Any] = {"endpoint": endpoint}
+        extra: dict[str, Any] = {"endpoint": endpoint}
         if isinstance(video, dict):
             if video.get("file_size"):
                 extra["file_size"] = video["file_size"]

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -54,7 +54,7 @@ VALID_RESOLUTIONS = {"480p", "720p"}
 MAX_REFERENCE_IMAGES = 7
 
 
-_MODELS: Dict[str, Dict[str, Any]] = {
+_MODELS: dict[str, dict[str, Any]] = {
     "grok-imagine-video": {
         "display": "Grok Imagine Video",
         "speed": "~60-240s",
@@ -70,7 +70,7 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 # ---------------------------------------------------------------------------
 
 
-def _resolve_xai_credentials() -> Tuple[str, str]:
+def _resolve_xai_credentials() -> tuple[str, str]:
     """Return ``(api_key, base_url)`` from the shared xAI credential resolver.
 
     Order: runtime provider (xai-oauth pool entry) → singleton ``auth.json``
@@ -103,7 +103,7 @@ def _xai_user_agent() -> str:
         return "hermes-agent/video_gen"
 
 
-def _xai_headers(api_key: str) -> Dict[str, str]:
+def _xai_headers(api_key: str) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
@@ -111,7 +111,7 @@ def _xai_headers(api_key: str) -> Dict[str, str]:
     }
 
 
-def _normalize_reference_images(reference_image_urls: Optional[List[str]]):
+def _normalize_reference_images(reference_image_urls: Optional[list[str]]):
     refs = []
     for url in reference_image_urls or []:
         normalized = (url or "").strip()
@@ -133,7 +133,7 @@ def _clamp_duration(duration: Optional[int], has_reference_images: bool) -> int:
 
 async def _submit(
     client: httpx.AsyncClient,
-    payload: Dict[str, Any],
+    payload: dict[str, Any],
     *,
     api_key: str,
     base_url: str,
@@ -162,7 +162,7 @@ async def _poll(
     base_url: str,
     timeout_seconds: int,
     poll_interval: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     elapsed = 0.0
     last_status = "queued"
     while elapsed < timeout_seconds:
@@ -206,13 +206,13 @@ class XAIVideoGenProvider(VideoGenProvider):
         api_key, _ = _resolve_xai_credentials()
         return bool(api_key)
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         return [{"id": mid, **meta} for mid, meta in _MODELS.items()]
 
     def default_model(self) -> Optional[str]:
         return DEFAULT_MODEL
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         # Auth resolution lives entirely in the shared ``xai_grok`` post_setup
         # hook (``hermes_cli/tools_config.py``) so the picker doesn't blindly
         # prompt for an API key when the user is already signed in via xAI
@@ -227,7 +227,7 @@ class XAIVideoGenProvider(VideoGenProvider):
             "post_setup": "xai_grok",
         }
 
-    def capabilities(self) -> Dict[str, Any]:
+    def capabilities(self) -> dict[str, Any]:
         return {
             "modalities": ["text", "image"],
             "aspect_ratios": sorted(VALID_ASPECT_RATIOS),
@@ -245,7 +245,7 @@ class XAIVideoGenProvider(VideoGenProvider):
         *,
         model: Optional[str] = None,
         image_url: Optional[str] = None,
-        reference_image_urls: Optional[List[str]] = None,
+        reference_image_urls: Optional[list[str]] = None,
         duration: Optional[int] = None,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         resolution: str = DEFAULT_RESOLUTION,
@@ -253,7 +253,7 @@ class XAIVideoGenProvider(VideoGenProvider):
         audio: Optional[bool] = None,
         seed: Optional[int] = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         try:
             loop = asyncio.new_event_loop()
             try:
@@ -285,11 +285,11 @@ class XAIVideoGenProvider(VideoGenProvider):
         prompt: str,
         model: Optional[str],
         image_url: Optional[str],
-        reference_image_urls: Optional[List[str]],
+        reference_image_urls: Optional[list[str]],
         duration: Optional[int],
         aspect_ratio: str,
         resolution: str,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         api_key, base_url = _resolve_xai_credentials()
         if not api_key:
             return error_response(
@@ -339,7 +339,7 @@ class XAIVideoGenProvider(VideoGenProvider):
         if normalized_resolution not in VALID_RESOLUTIONS:
             normalized_resolution = DEFAULT_RESOLUTION
 
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "model": model or DEFAULT_MODEL,
             "prompt": prompt,
             "duration": clamped_duration,
@@ -391,7 +391,7 @@ class XAIVideoGenProvider(VideoGenProvider):
                     model=body.get("model") or model or DEFAULT_MODEL,
                     prompt=prompt,
                 )
-            extra: Dict[str, Any] = {
+            extra: dict[str, Any] = {
                 "request_id": request_id,
                 "resolution": normalized_resolution,
             }

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -57,7 +57,7 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a search against the Brave Search API.
 
         Returns ``{"success": True, "data": {"web": [{"title", "url", "description", "position"}]}}``
@@ -122,7 +122,7 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
 
         return {"success": True, "data": {"web": web_results}}
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Brave Search (Free)",
             "badge": "free",

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -56,7 +56,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a DuckDuckGo search and return normalized results."""
         try:
             from ddgs import DDGS  # type: ignore
@@ -92,7 +92,7 @@ class DDGSWebSearchProvider(WebSearchProvider):
         logger.info("DDGS search '%s': %d results (limit %d)", query, len(web_results), limit)
         return {"success": True, "data": {"web": web_results}}
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "DuckDuckGo (ddgs)",
             "badge": "free · no key · search only",

--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -108,7 +108,7 @@ class ExaWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute an Exa search.
 
         Returns ``{"success": True, "data": {"web": [{...}, ...]}}`` on
@@ -150,7 +150,7 @@ class ExaWebSearchProvider(WebSearchProvider):
             logger.warning("Exa search error: %s", exc)
             return {"success": False, "error": f"Exa search failed: {exc}"}
 
-    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+    def extract(self, urls: list[str], **kwargs: Any) -> list[dict[str, Any]]:
         """Extract content from one or more URLs via Exa.
 
         Returns a list of result dicts shaped for the legacy LLM
@@ -168,7 +168,7 @@ class ExaWebSearchProvider(WebSearchProvider):
             logger.info("Exa extract: %d URL(s)", len(urls))
             response = _get_exa_client().get_contents(urls, text=True)
 
-            results: List[Dict[str, Any]] = []
+            results: list[dict[str, Any]] = []
             for result in response.results or []:
                 content = result.text or ""
                 url = result.url or ""
@@ -197,7 +197,7 @@ class ExaWebSearchProvider(WebSearchProvider):
                 for u in urls
             ]
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Exa",
             "badge": "paid",

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -127,7 +127,7 @@ def _get_direct_firecrawl_config() -> Optional[tuple]:
     if not api_key and not api_url:
         return None
 
-    kwargs: Dict[str, str] = {}
+    kwargs: dict[str, str] = {}
     if api_key:
         kwargs["api_key"] = api_key
     if api_url:
@@ -298,12 +298,12 @@ def _to_plain_object(value: Any) -> Any:
     return value
 
 
-def _normalize_result_list(values: Any) -> List[Dict[str, Any]]:
+def _normalize_result_list(values: Any) -> list[dict[str, Any]]:
     """Normalize mixed SDK/list payloads into a list of dicts."""
     if not isinstance(values, list):
         return []
 
-    normalized: List[Dict[str, Any]] = []
+    normalized: list[dict[str, Any]] = []
     for item in values:
         plain = _to_plain_object(item)
         if isinstance(plain, dict):
@@ -311,7 +311,7 @@ def _normalize_result_list(values: Any) -> List[Dict[str, Any]]:
     return normalized
 
 
-def _extract_web_search_results(response: Any) -> List[Dict[str, Any]]:
+def _extract_web_search_results(response: Any) -> list[dict[str, Any]]:
     """Extract Firecrawl search results across SDK/direct/gateway response shapes."""
     response_plain = _to_plain_object(response)
 
@@ -342,7 +342,7 @@ def _extract_web_search_results(response: Any) -> List[Dict[str, Any]]:
     return []
 
 
-def _extract_scrape_payload(scrape_result: Any) -> Dict[str, Any]:
+def _extract_scrape_payload(scrape_result: Any) -> dict[str, Any]:
     """Normalize Firecrawl scrape payload shape across SDK and gateway variants."""
     result_plain = _to_plain_object(scrape_result)
     if not isinstance(result_plain, dict):
@@ -384,7 +384,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
     def supports_crawl(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a Firecrawl search.
 
         Sync; matches the legacy ``_get_firecrawl_client().search(...)``
@@ -416,7 +416,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             logger.warning("Firecrawl search error: %s", exc)
             return {"success": False, "error": f"Firecrawl search failed: {exc}"}
 
-    async def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+    async def extract(self, urls: list[str], **kwargs: Any) -> list[dict[str, Any]]:
         """Extract content from one or more URLs via Firecrawl.
 
         Async; each URL is scraped in a background thread with a 60s
@@ -437,7 +437,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
 
         format = kwargs.get("format")
-        formats: List[str] = []
+        formats: list[str] = []
         if format == "markdown":
             formats = ["markdown"]
         elif format == "html":
@@ -449,7 +449,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         # module level (lazy-friendly because the website_policy import is
         # cheap) so monkeypatching it in tests works as expected.
 
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
 
         for url in urls:
             if _is_interrupted():
@@ -575,7 +575,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
 
         return results
 
-    async def crawl(self, url: str, **kwargs: Any) -> Dict[str, Any]:
+    async def crawl(self, url: str, **kwargs: Any) -> dict[str, Any]:
         """Crawl a seed URL via Firecrawl's ``/crawl`` endpoint.
 
         Sync SDK call wrapped in ``asyncio.to_thread`` because the dispatcher
@@ -634,7 +634,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
             )
 
             # CrawlJob normalization across SDK + direct + gateway shapes.
-            data_list: List[Any] = []
+            data_list: list[Any] = []
             if hasattr(crawl_result, "data"):
                 data_list = crawl_result.data if crawl_result.data else []
                 logger.info(
@@ -650,7 +650,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                     type(crawl_result).__name__,
                 )
 
-            pages: List[Dict[str, Any]] = []
+            pages: list[dict[str, Any]] = []
             for item in data_list:
                 # Pydantic model | typed object | dict — handle all shapes.
                 content_markdown = None
@@ -755,7 +755,7 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
                 ]
             }
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Firecrawl",
             "badge": "paid · optional gateway",

--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -161,7 +161,7 @@ class ParallelWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a Parallel search (sync).
 
         Uses the ``beta.search`` endpoint with the configured mode
@@ -210,8 +210,8 @@ class ParallelWebSearchProvider(WebSearchProvider):
             return {"success": False, "error": f"Parallel search failed: {exc}"}
 
     async def extract(
-        self, urls: List[str], **kwargs: Any
-    ) -> List[Dict[str, Any]]:
+        self, urls: list[str], **kwargs: Any
+    ) -> list[dict[str, Any]]:
         """Extract content from one or more URLs via the async SDK.
 
         Returns the legacy list-of-results shape that
@@ -233,7 +233,7 @@ class ParallelWebSearchProvider(WebSearchProvider):
                 full_content=True,
             )
 
-            results: List[Dict[str, Any]] = []
+            results: list[dict[str, Any]] = []
             for result in response.results or []:
                 content = result.full_content or ""
                 if not content:
@@ -276,7 +276,7 @@ class ParallelWebSearchProvider(WebSearchProvider):
                 for u in urls
             ]
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Parallel",
             "badge": "paid",

--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -52,7 +52,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
     def supports_extract(self) -> bool:
         return False
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a search against the configured SearXNG instance."""
         import httpx
 
@@ -60,7 +60,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
         if not base_url:
             return {"success": False, "error": "SEARXNG_URL is not set"}
 
-        params: Dict[str, Any] = {
+        params: dict[str, Any] = {
             "q": query,
             "format": "json",
             "pageno": 1,
@@ -125,7 +125,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
 
         return {"success": True, "data": {"web": web_results}}
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "SearXNG",
             "badge": "free · self-hosted",

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -41,7 +41,7 @@ from agent.web_search_provider import WebSearchProvider
 logger = logging.getLogger(__name__)
 
 
-def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+def _tavily_request(endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
     """POST to the Tavily API and return the parsed JSON response.
 
     Mirrors :func:`tools.web_tools._tavily_request`. Raises ``ValueError``
@@ -72,7 +72,7 @@ def _tavily_request(endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     return response.json()
 
 
-def _normalize_tavily_search_results(response: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_tavily_search_results(response: dict[str, Any]) -> dict[str, Any]:
     """Map Tavily ``/search`` response to ``{success, data: {web: [...]}}``."""
     web_results = []
     for i, result in enumerate(response.get("results", [])):
@@ -88,8 +88,8 @@ def _normalize_tavily_search_results(response: Dict[str, Any]) -> Dict[str, Any]
 
 
 def _normalize_tavily_documents(
-    response: Dict[str, Any], fallback_url: str = ""
-) -> List[Dict[str, Any]]:
+    response: dict[str, Any], fallback_url: str = ""
+) -> list[dict[str, Any]]:
     """Map Tavily ``/extract`` or ``/crawl`` response to standard documents.
 
     Documents follow the legacy LLM post-processing shape::
@@ -99,7 +99,7 @@ def _normalize_tavily_documents(
     Failures (``failed_results``, ``failed_urls``) become result entries
     with an ``error`` field rather than raising.
     """
-    documents: List[Dict[str, Any]] = []
+    documents: list[dict[str, Any]] = []
     for result in response.get("results", []):
         url = result.get("url", fallback_url)
         raw = result.get("raw_content", "") or result.get("content", "")
@@ -162,7 +162,7 @@ class TavilyWebSearchProvider(WebSearchProvider):
     def supports_crawl(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a Tavily search."""
         try:
             from tools.interrupt import is_interrupted
@@ -187,7 +187,7 @@ class TavilyWebSearchProvider(WebSearchProvider):
             logger.warning("Tavily search error: %s", exc)
             return {"success": False, "error": f"Tavily search failed: {exc}"}
 
-    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+    def extract(self, urls: list[str], **kwargs: Any) -> list[dict[str, Any]]:
         """Extract content from one or more URLs via Tavily.
 
         Sync — the underlying call is httpx.post(...). Returns the legacy
@@ -221,7 +221,7 @@ class TavilyWebSearchProvider(WebSearchProvider):
                 for u in urls
             ]
 
-    def crawl(self, url: str, **kwargs: Any) -> Dict[str, Any]:
+    def crawl(self, url: str, **kwargs: Any) -> dict[str, Any]:
         """Crawl a seed URL via Tavily's ``/crawl`` endpoint.
 
         Accepted kwargs (others ignored for forward compat):
@@ -243,7 +243,7 @@ class TavilyWebSearchProvider(WebSearchProvider):
             limit = kwargs.get("limit", 20)
 
             logger.info("Tavily crawl: %s (depth=%s, limit=%d)", url, depth, limit)
-            payload: Dict[str, Any] = {
+            payload: dict[str, Any] = {
                 "url": url,
                 "limit": limit,
                 "extract_depth": depth,
@@ -270,7 +270,7 @@ class TavilyWebSearchProvider(WebSearchProvider):
                 ]
             }
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         return {
             "name": "Tavily",
             "badge": "paid",

--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -61,7 +61,7 @@ _JSON_BLOCK_RE = re.compile(r"\{[\s\S]*\}", re.MULTILINE)
 # ---------------------------------------------------------------------------
 
 
-def _load_xai_web_config() -> Dict[str, Any]:
+def _load_xai_web_config() -> dict[str, Any]:
     """Read ``web.xai`` from config.yaml (returns {} on miss)."""
     try:
         from hermes_cli.config import load_config
@@ -75,11 +75,11 @@ def _load_xai_web_config() -> Dict[str, Any]:
         return {}
 
 
-def _coerce_domain_list(value: Any) -> List[str]:
+def _coerce_domain_list(value: Any) -> list[str]:
     """Coerce a config value to a clean list of <=5 domain strings."""
     if not isinstance(value, list):
         return []
-    cleaned: List[str] = []
+    cleaned: list[str] = []
     for item in value:
         if isinstance(item, str) and item.strip():
             cleaned.append(item.strip())
@@ -148,7 +148,7 @@ class XAIWebSearchProvider(WebSearchProvider):
 
     # -- Search -----------------------------------------------------------
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5) -> dict[str, Any]:
         """Execute a Grok-backed web search.
 
         Returns ``{"success": True, "data": {"web": [{title, url, description, position}, ...]}}``
@@ -206,7 +206,7 @@ class XAIWebSearchProvider(WebSearchProvider):
                 ),
             }
 
-        web_search_tool: Dict[str, Any] = {"type": "web_search"}
+        web_search_tool: dict[str, Any] = {"type": "web_search"}
         if allowed:
             web_search_tool["filters"] = {"allowed_domains": allowed}
         elif excluded:
@@ -214,7 +214,7 @@ class XAIWebSearchProvider(WebSearchProvider):
 
         prompt = self._build_prompt(query, limit)
 
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "model": model,
             "input": [{"role": "user", "content": prompt}],
             "tools": [web_search_tool],
@@ -363,10 +363,10 @@ class XAIWebSearchProvider(WebSearchProvider):
     @classmethod
     def _extract_results(
         cls,
-        response_data: Dict[str, Any],
+        response_data: dict[str, Any],
         *,
         limit: int,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Pull a ``[{title, url, description, position}, ...]`` list out of a
         Responses-API reply.
 
@@ -419,11 +419,11 @@ class XAIWebSearchProvider(WebSearchProvider):
 
     @staticmethod
     def _collect_output_text(
-        response_data: Dict[str, Any],
-    ) -> tuple[List[str], List[Dict[str, Any]]]:
+        response_data: dict[str, Any],
+    ) -> tuple[list[str], list[dict[str, Any]]]:
         """Return (text_blocks, annotations) extracted from ``response.output``."""
-        text_blocks: List[str] = []
-        annotations: List[Dict[str, Any]] = []
+        text_blocks: list[str] = []
+        annotations: list[dict[str, Any]] = []
         output = response_data.get("output")
         if not isinstance(output, list):
             return text_blocks, annotations
@@ -452,7 +452,7 @@ class XAIWebSearchProvider(WebSearchProvider):
         text: str,
         *,
         limit: int,
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> Optional[list[dict[str, Any]]]:
         """Parse a JSON object with a ``results`` array out of ``text``.
 
         Returns the normalized result list on success, ``None`` when the
@@ -476,7 +476,7 @@ class XAIWebSearchProvider(WebSearchProvider):
             results = parsed.get("results")
             if not isinstance(results, list):
                 continue
-            normalized: List[Dict[str, Any]] = []
+            normalized: list[dict[str, Any]] = []
             for row in results[:limit]:
                 if not isinstance(row, dict):
                     continue
@@ -500,11 +500,11 @@ class XAIWebSearchProvider(WebSearchProvider):
 
     @staticmethod
     def _results_from_annotations(
-        annotations: List[Dict[str, Any]],
+        annotations: list[dict[str, Any]],
         joined_text: str,
         *,
         limit: int,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Best-effort fallback when JSON parsing fails.
 
         Uses each ``url_citation`` annotation's ``url`` (the citation
@@ -512,7 +512,7 @@ class XAIWebSearchProvider(WebSearchProvider):
         slices ~200 characters of surrounding text as the description.
         """
         seen: set[str] = set()
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
         for ann in annotations:
             if ann.get("type") != "url_citation":
                 continue
@@ -544,7 +544,7 @@ class XAIWebSearchProvider(WebSearchProvider):
 
     # -- Setup picker -----------------------------------------------------
 
-    def get_setup_schema(self) -> Dict[str, Any]:
+    def get_setup_schema(self) -> dict[str, Any]:
         # Auth resolution is delegated to the shared ``xai_grok`` post_setup
         # hook (same one image_gen.xai and tts.xai use) so users see the
         # familiar OAuth-or-API-key prompt for every xAI service.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["UP006", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/run_agent.py
+++ b/run_agent.py
@@ -314,7 +314,7 @@ class _StreamErrorEvent(Exception):
         self.status_code = status_code
         # OpenAI SDK-shaped body so _extract_api_error_context /
         # _summarize_api_error / classify_api_error all pick it up.
-        self.body: Dict[str, Any] = {
+        self.body: dict[str, Any] = {
             "error": {
                 "message": message,
                 "code": code,
@@ -360,17 +360,17 @@ class AIAgent:
         model: str = "",
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
         tool_delay: float = 1.0,
-        enabled_toolsets: List[str] = None,
-        disabled_toolsets: List[str] = None,
+        enabled_toolsets: list[str] = None,
+        disabled_toolsets: list[str] = None,
         save_trajectories: bool = False,
         verbose_logging: bool = False,
         quiet_mode: bool = False,
         ephemeral_system_prompt: str = None,
         log_prefix_chars: int = 100,
         log_prefix: str = "",
-        providers_allowed: List[str] = None,
-        providers_ignored: List[str] = None,
-        providers_order: List[str] = None,
+        providers_allowed: list[str] = None,
+        providers_ignored: list[str] = None,
+        providers_order: list[str] = None,
         provider_sort: str = None,
         provider_require_parameters: bool = False,
         provider_data_collection: str = None,
@@ -388,10 +388,10 @@ class AIAgent:
         tool_gen_callback: callable = None,
         status_callback: callable = None,
         max_tokens: int = None,
-        reasoning_config: Dict[str, Any] = None,
+        reasoning_config: dict[str, Any] = None,
         service_tier: str = None,
-        request_overrides: Dict[str, Any] = None,
-        prefill_messages: List[Dict[str, Any]] = None,
+        request_overrides: dict[str, Any] = None,
+        prefill_messages: list[dict[str, Any]] = None,
         platform: str = None,
         user_id: str = None,
         user_name: str = None,
@@ -406,7 +406,7 @@ class AIAgent:
         session_db=None,
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
-        fallback_model: Dict[str, Any] = None,
+        fallback_model: dict[str, Any] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 20,
@@ -722,13 +722,13 @@ class AIAgent:
     from agent.stream_diag import STREAM_DIAG_HEADERS as _STREAM_DIAG_HEADERS  # noqa: E402
 
     @staticmethod
-    def _stream_diag_init() -> Dict[str, Any]:
+    def _stream_diag_init() -> dict[str, Any]:
         """Forwarder — see ``agent.stream_diag.stream_diag_init``."""
         from agent.stream_diag import stream_diag_init
         return stream_diag_init()
 
     def _stream_diag_capture_response(
-        self, diag: Dict[str, Any], http_response: Any
+        self, diag: dict[str, Any], http_response: Any
     ) -> None:
         """Forwarder — see ``agent.stream_diag.stream_diag_capture_response``."""
         from agent.stream_diag import stream_diag_capture_response
@@ -766,7 +766,7 @@ class AIAgent:
         attempt: int,
         max_attempts: int,
         mid_tool_call: bool,
-        diag: Optional[Dict[str, Any]] = None,
+        diag: Optional[dict[str, Any]] = None,
     ) -> None:
         """Forwarder — see ``agent.stream_diag.log_stream_retry``."""
         from agent.stream_diag import log_stream_retry
@@ -782,7 +782,7 @@ class AIAgent:
         attempt: int,
         max_attempts: int,
         mid_tool_call: bool,
-        diag: Optional[Dict[str, Any]] = None,
+        diag: Optional[dict[str, Any]] = None,
     ) -> None:
         """Forwarder — see ``agent.stream_diag.emit_stream_drop``."""
         from agent.stream_diag import emit_stream_drop
@@ -802,7 +802,7 @@ class AIAgent:
             detail = detail[:217].rstrip() + "..."
         self._emit_warning(f"⚠ Auxiliary {task} failed: {detail}")
 
-    def _current_main_runtime(self) -> Dict[str, str]:
+    def _current_main_runtime(self) -> dict[str, str]:
         """Return the live main runtime for session-scoped auxiliary routing."""
         return {
             "model": getattr(self, "model", "") or "",
@@ -1075,7 +1075,7 @@ class AIAgent:
         self,
         user_message: str,
         assistant_content: str,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
     ) -> bool:
         """Forwarder — see ``agent.agent_runtime_helpers.looks_like_codex_intermediate_ack``."""
         from agent.agent_runtime_helpers import looks_like_codex_intermediate_ack
@@ -1102,16 +1102,16 @@ class AIAgent:
 
     @staticmethod
     def _summarize_background_review_actions(
-        review_messages: List[Dict],
-        prior_snapshot: List[Dict],
-    ) -> List[str]:
+        review_messages: list[dict],
+        prior_snapshot: list[dict],
+    ) -> list[str]:
         """Forwarder — see ``agent.background_review.summarize_background_review_actions``."""
         from agent.background_review import summarize_background_review_actions
         return summarize_background_review_actions(review_messages, prior_snapshot)
 
     def _spawn_background_review(
         self,
-        messages_snapshot: List[Dict],
+        messages_snapshot: list[dict],
         review_memory: bool = False,
         review_skills: bool = False,
     ) -> None:
@@ -1140,7 +1140,7 @@ class AIAgent:
         execution_context: Optional[str] = None,
         task_id: Optional[str] = None,
         tool_call_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Forwarder — see ``agent.background_review.build_memory_write_metadata``."""
         from agent.background_review import build_memory_write_metadata
         return build_memory_write_metadata(
@@ -1151,7 +1151,7 @@ class AIAgent:
             tool_call_id=tool_call_id,
         )
 
-    def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
+    def _apply_persist_user_message_override(self, messages: list[dict]) -> None:
         """Rewrite the current-turn user message before persistence/return.
 
         Some call paths need an API-only user-message variant without letting
@@ -1169,7 +1169,7 @@ class AIAgent:
             if isinstance(msg, dict) and msg.get("role") == "user":
                 msg["content"] = override
 
-    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _persist_session(self, messages: list[dict], conversation_history: list[dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
@@ -1180,7 +1180,7 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
-    def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
+    def _drop_trailing_empty_response_scaffolding(self, messages: list[dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
 
         Also rewinds past any trailing tool-result / assistant(tool_calls) pair
@@ -1233,12 +1233,12 @@ class AIAgent:
         ):
             messages.pop()
 
-    def _repair_message_sequence(self, messages: List[Dict]) -> int:
+    def _repair_message_sequence(self, messages: list[dict]) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.repair_message_sequence``."""
         from agent.agent_runtime_helpers import repair_message_sequence
         return repair_message_sequence(self, messages)
 
-    def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _flush_messages_to_session_db(self, messages: list[dict], conversation_history: list[dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
 
         Uses _last_flushed_db_idx to track which messages have already been
@@ -1297,7 +1297,7 @@ class AIAgent:
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)
 
-    def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
+    def _get_messages_up_to_last_assistant(self, messages: list[dict]) -> list[dict]:
         """
         Get messages up to (but not including) the last assistant turn.
         
@@ -1333,12 +1333,12 @@ class AIAgent:
         from agent.system_prompt import format_tools_for_system_message
         return format_tools_for_system_message(self)
 
-    def _convert_to_trajectory_format(self, messages: List[Dict[str, Any]], user_query: str, completed: bool) -> List[Dict[str, Any]]:
+    def _convert_to_trajectory_format(self, messages: list[dict[str, Any]], user_query: str, completed: bool) -> list[dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.convert_to_trajectory_format``."""
         from agent.agent_runtime_helpers import convert_to_trajectory_format
         return convert_to_trajectory_format(self, messages, user_query, completed)
 
-    def _save_trajectory(self, messages: List[Dict[str, Any]], user_query: str, completed: bool):
+    def _save_trajectory(self, messages: list[dict[str, Any]], user_query: str, completed: bool):
         """
         Save conversation trajectory to JSONL file.
         
@@ -1355,7 +1355,7 @@ class AIAgent:
 
     @staticmethod
     def _is_entitlement_failure(
-        error_context: Optional[Dict[str, Any]],
+        error_context: Optional[dict[str, Any]],
         status_code: Optional[int],
     ) -> bool:
         """Detect subscription/entitlement 403s that masquerade as auth failures.
@@ -1505,12 +1505,12 @@ class AIAgent:
         return cleaned
 
     @staticmethod
-    def _extract_api_error_context(error: Exception) -> Dict[str, Any]:
+    def _extract_api_error_context(error: Exception) -> dict[str, Any]:
         """Forwarder — see ``agent.agent_runtime_helpers.extract_api_error_context``."""
         from agent.agent_runtime_helpers import extract_api_error_context
         return extract_api_error_context(error)
 
-    def _usage_summary_for_api_request_hook(self, response: Any) -> Optional[Dict[str, Any]]:
+    def _usage_summary_for_api_request_hook(self, response: Any) -> Optional[dict[str, Any]]:
         """Token buckets for ``post_api_request`` plugins (no raw ``response`` object)."""
         if response is None:
             return None
@@ -1528,7 +1528,7 @@ class AIAgent:
 
     def _dump_api_request_debug(
         self,
-        api_kwargs: Dict[str, Any],
+        api_kwargs: dict[str, Any],
         *,
         reason: str,
         error: Optional[Exception] = None,
@@ -1577,7 +1577,7 @@ class AIAgent:
             return redacted
         return content
 
-    def _save_session_log(self, messages: List[Dict[str, Any]] = None):
+    def _save_session_log(self, messages: list[dict[str, Any]] = None):
         """Optional per-session JSON snapshot writer.
 
         Gated by ``sessions.write_json_snapshots`` (default False).  state.db
@@ -1819,7 +1819,7 @@ class AIAgent:
     def _record_file_mutation_result(
         self,
         tool_name: str,
-        args: Dict[str, Any],
+        args: dict[str, Any],
         result: Any,
         is_error: bool,
     ) -> None:
@@ -1883,7 +1883,7 @@ class AIAgent:
         return True  # safe default: verifier on
 
     @staticmethod
-    def _format_file_mutation_failure_footer(failed: Dict[str, Dict[str, Any]]) -> str:
+    def _format_file_mutation_failure_footer(failed: dict[str, dict[str, Any]]) -> str:
         """Render the per-turn failed-mutation dict as a user-facing footer.
 
         Displays up to 10 paths with their first error preview, then a
@@ -2191,7 +2191,7 @@ class AIAgent:
         except Exception:
             pass
 
-    def _hydrate_todo_store(self, history: List[Dict[str, Any]]) -> None:
+    def _hydrate_todo_store(self, history: list[dict[str, Any]]) -> None:
         """
         Recover todo state from conversation history.
         
@@ -2237,7 +2237,7 @@ class AIAgent:
 
 
 
-    def _build_system_prompt_parts(self, system_message: str = None) -> Dict[str, str]:
+    def _build_system_prompt_parts(self, system_message: str = None) -> dict[str, str]:
         """Forwarder — see ``agent.system_prompt.build_system_prompt_parts``."""
         from agent.system_prompt import build_system_prompt_parts
         return build_system_prompt_parts(self, system_message=system_message)
@@ -2274,13 +2274,13 @@ class AIAgent:
     _VALID_API_ROLES = frozenset({"system", "user", "assistant", "tool", "function", "developer"})
 
     @staticmethod
-    def _sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _sanitize_api_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.sanitize_api_messages``."""
         from agent.agent_runtime_helpers import sanitize_api_messages
         return sanitize_api_messages(messages)
 
     @staticmethod
-    def _is_thinking_only_assistant(msg: Dict[str, Any]) -> bool:
+    def _is_thinking_only_assistant(msg: dict[str, Any]) -> bool:
         """Return True if ``msg`` is an assistant turn whose only payload is reasoning.
 
         "Thinking-only" means the model emitted reasoning (``reasoning`` or
@@ -2335,8 +2335,8 @@ class AIAgent:
 
     @staticmethod
     def _drop_thinking_only_and_merge_users(
-        messages: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
+        messages: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.drop_thinking_only_and_merge_users``."""
         from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
         return drop_thinking_only_and_merge_users(messages)
@@ -2957,7 +2957,7 @@ class AIAgent:
         status_code: Optional[int],
         has_retried_429: bool,
         classified_reason: Optional[FailoverReason] = None,
-        error_context: Optional[Dict[str, Any]] = None,
+        error_context: Optional[dict[str, Any]] = None,
     ) -> tuple[bool, bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.recover_with_credential_pool``."""
         from agent.agent_runtime_helpers import recover_with_credential_pool
@@ -3081,7 +3081,7 @@ class AIAgent:
         )
         return bool(streamed) and streamed == visible_content
 
-    def _emit_interim_assistant_message(self, assistant_msg: Dict[str, Any]) -> None:
+    def _emit_interim_assistant_message(self, assistant_msg: dict[str, Any]) -> None:
         """Surface a real mid-turn assistant commentary message to the UI layer."""
         cb = getattr(self, "interim_assistant_callback", None)
         if cb is None or not isinstance(assistant_msg, dict):
@@ -3324,8 +3324,8 @@ class AIAgent:
         if not self._content_has_image_parts(content):
             return content
 
-        text_parts: List[str] = []
-        image_notes: List[str] = []
+        text_parts: list[str] = []
+        image_notes: list[str] = []
         for part in content:
             if isinstance(part, str):
                 if part.strip():
@@ -3545,7 +3545,7 @@ class AIAgent:
                 continue
 
             # Salvage any text parts so the model still sees some signal.
-            text_parts: List[str] = []
+            text_parts: list[str] = []
             had_image = False
             for part in content:
                 if not isinstance(part, dict):
@@ -4093,11 +4093,11 @@ class AIAgent:
         self,
         user_message: str,
         system_message: str = None,
-        conversation_history: List[Dict[str, Any]] = None,
+        conversation_history: list[dict[str, Any]] = None,
         task_id: str = None,
         stream_callback: Optional[callable] = None,
         persist_user_message: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
         return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
@@ -4121,10 +4121,10 @@ class AIAgent:
         *,
         user_message: str,
         original_user_message: Any,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         effective_task_id: str,
         should_review_memory: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -84,7 +84,7 @@ _DURATIONS_FILE = "test_durations.json"
 
 
 def _count_tests(
-    files: List[Path], repo_root: Path, pytest_passthrough: List[str]
+    files: list[Path], repo_root: Path, pytest_passthrough: list[str]
 ) -> dict[Path, int]:
     """Run ``pytest --co -q`` once to count individual tests per file.
 
@@ -104,7 +104,7 @@ def _count_tests(
     # Build --ignore flags for skipped dirs so the --co collection
     # mirrors what we'll actually run (not what pytest might find via
     # conftest walking or directory traversal).
-    ignore_args: List[str] = []
+    ignore_args: list[str] = []
     for root in [repo_root / p for p in _DEFAULT_ROOTS]:
         for part in _SKIP_PARTS:
             d = root / part
@@ -141,7 +141,7 @@ def _count_tests(
     return counts
 
 
-def _discover_files(roots: List[Path]) -> List[Path]:
+def _discover_files(roots: list[Path]) -> list[Path]:
     """Return every ``test_*.py`` under the given roots (sorted).
 
     Roots may be directories (recursed for ``test_*.py``) or explicit
@@ -156,7 +156,7 @@ def _discover_files(roots: List[Path]) -> List[Path]:
     the sharded matrix from blowing up, not to block targeted runs.
     """
     seen: set[Path] = set()
-    out: List[Path] = []
+    out: list[Path] = []
     for root in roots:
         if not root.exists():
             continue
@@ -248,10 +248,10 @@ def _kill_tree(proc: "subprocess.Popen", pgid: int | None = None) -> None:
 
 def _run_one_file(
     file: Path,
-    pytest_args: List[str],
+    pytest_args: list[str],
     repo_root: Path,
     file_timeout: float,
-) -> Tuple[Path, int, str, dict[str, int], float]:
+) -> tuple[Path, int, str, dict[str, int], float]:
     """Run ``python -m pytest <file> <pytest_args>`` in a fresh subprocess.
 
     Returns (file, returncode, captured_combined_output, summary_counts, subprocess_wall_seconds).
@@ -467,7 +467,7 @@ def _print_progress(
 
 
 def _print_inline_failure(
-    file: Path, output: str, repo_root: Path, pytest_passthrough: List[str]
+    file: Path, output: str, repo_root: Path, pytest_passthrough: list[str]
 ) -> None:
     """Print a compact failure summary immediately when a file fails.
 
@@ -514,7 +514,7 @@ def _load_durations(repo_root: Path) -> dict[str, float]:
 
 
 def _save_durations(
-    file_times: List[Tuple[Path, float]],
+    file_times: list[tuple[Path, float]],
     repo_root: Path,
 ) -> None:
     """Write the duration cache so future ``--slice`` runs can use it.
@@ -533,12 +533,12 @@ def _save_durations(
 
 
 def _slice_files(
-    files: List[Path],
+    files: list[Path],
     slice_index: int,
     slice_count: int,
     durations: dict[str, float],
     repo_root: Path,
-) -> List[Path]:
+) -> list[Path]:
     """Return the subset of *files* belonging to slice *slice_index*.
 
     Uses **Longest Processing Time first** (LPT) distribution: sort files
@@ -565,7 +565,7 @@ def _slice_files(
 
     # Build (file, estimated_duration) pairs.
     default_dur = 2.0
-    file_durs: List[Tuple[Path, float]] = []
+    file_durs: list[tuple[Path, float]] = []
     for f in files:
         rel = _format_file(f, repo_root)
         dur = durations.get(rel, default_dur)
@@ -576,8 +576,8 @@ def _slice_files(
 
     # Greedy assignment: for each file, add it to the slice with the
     # smallest current total.
-    bucket_files: List[List[Path]] = [[] for _ in range(slice_count)]
-    bucket_totals: List[float] = [0.0] * slice_count
+    bucket_files: list[list[Path]] = [[] for _ in range(slice_count)]
+    bucket_totals: list[float] = [0.0] * slice_count
 
     for f, dur in file_durs:
         # Find the least-loaded bucket.
@@ -723,8 +723,8 @@ def main() -> int:
 
     # Capture and print on completion (out-of-order is fine — keeps the
     # terminal clean rather than interleaving N parallel pytest outputs).
-    failures: List[Tuple[Path, str, Dict[str, int]]] = []
-    file_times: List[Tuple[Path, float]] = []  # (file, subprocess_wall) for distribution
+    failures: list[tuple[Path, str, dict[str, int]]] = []
+    file_times: list[tuple[Path, float]] = []  # (file, subprocess_wall) for distribution
     started = time.monotonic()
     files_done = 0
     tests_done = 0
@@ -734,7 +734,7 @@ def main() -> int:
     tests_failed = 0
     lock = threading.Lock()
 
-    def _on_done(file: Path, started_at: float, fut: "Future[Tuple[Path, int, str, dict[str, int], float]]") -> None:
+    def _on_done(file: Path, started_at: float, fut: "Future[tuple[Path, int, str, dict[str, int], float]]") -> None:
         nonlocal files_done, tests_done, pass_count, fail_count, tests_passed, tests_failed
         n_tests = test_counts.get(file, 0)
         try:
@@ -777,7 +777,7 @@ def main() -> int:
                 _print_inline_failure(fpath, output, repo_root, pytest_passthrough)
 
     with ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        futures: List[Future] = []
+        futures: list[Future] = []
         for file in files:
             t0 = time.monotonic()
             fut = pool.submit(

--- a/scripts/sample_and_compress.py
+++ b/scripts/sample_and_compress.py
@@ -36,7 +36,7 @@ DEFAULT_DATASETS = [
 ]
 
 
-def load_dataset_from_hf(dataset_name: str) -> List[Dict[str, Any]]:
+def load_dataset_from_hf(dataset_name: str) -> list[dict[str, Any]]:
     """
     Load a dataset from HuggingFace.
     
@@ -85,7 +85,7 @@ def _init_tokenizer_worker(tokenizer_name: str):
     _TOKENIZER = AutoTokenizer.from_pretrained(tokenizer_name, trust_remote_code=True)
 
 
-def _count_tokens_for_entry(entry: Dict) -> Tuple[Dict, int]:
+def _count_tokens_for_entry(entry: dict) -> tuple[dict, int]:
     """
     Count tokens for a single entry (used in parallel processing).
     
@@ -115,13 +115,13 @@ def _count_tokens_for_entry(entry: Dict) -> Tuple[Dict, int]:
 
 
 def sample_from_datasets(
-    datasets: List[str],
+    datasets: list[str],
     total_samples: int,
     min_tokens: int = 16000,
     tokenizer_name: str = "moonshotai/Kimi-K2-Thinking",
     seed: int = 42,
     num_proc: int = 8
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """
     Load all datasets, filter by token count, then randomly sample from combined pool.
     
@@ -222,7 +222,7 @@ def sample_from_datasets(
 
 
 def save_samples_for_compression(
-    samples: List[Dict[str, Any]],
+    samples: list[dict[str, Any]],
     output_dir: Path,
     batch_size: int = 100
 ):

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -25,9 +25,9 @@ def _patch_oauth_flow(
     monkeypatch,
     *,
     callback_code: str,
-    token_response: Dict[str, Any] | None = None,
-    capture_token_request: Dict[str, Any] | None = None,
-    capture_auth_url: Dict[str, str] | None = None,
+    token_response: dict[str, Any] | None = None,
+    capture_token_request: dict[str, Any] | None = None,
+    capture_auth_url: dict[str, str] | None = None,
 ) -> None:
     """Wire up monkeypatches that let ``run_hermes_oauth_login_pure()`` run
     end-to-end without touching a real browser, stdin, or HTTP endpoint.
@@ -87,8 +87,8 @@ def test_authorization_url_state_is_not_pkce_verifier(monkeypatch, tmp_path):
     """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-    captured_url: Dict[str, str] = {}
-    captured_token: Dict[str, Any] = {}
+    captured_url: dict[str, str] = {}
+    captured_token: dict[str, Any] = {}
     _patch_oauth_flow(
         monkeypatch,
         # state echoed back unchanged so the CSRF guard passes
@@ -153,7 +153,7 @@ def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
     """
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
-    captured_token: Dict[str, Any] = {}
+    captured_token: dict[str, Any] = {}
     _patch_oauth_flow(
         monkeypatch,
         callback_code="attacker-code#attacker-state-does-not-match",

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -25,7 +25,7 @@ class StubEngine(ContextEngine):
     def name(self) -> str:
         return "stub"
 
-    def update_from_response(self, usage: Dict[str, Any]) -> None:
+    def update_from_response(self, usage: dict[str, Any]) -> None:
         self.last_prompt_tokens = usage.get("prompt_tokens", 0)
         self.last_completion_tokens = usage.get("completion_tokens", 0)
         self.last_total_tokens = usage.get("total_tokens", 0)
@@ -34,13 +34,13 @@ class StubEngine(ContextEngine):
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         return tokens >= self.threshold_tokens
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None) -> List[Dict[str, Any]]:
+    def compress(self, messages: list[dict[str, Any]], current_tokens: int = None) -> list[dict[str, Any]]:
         self._compress_called = True
         self.compression_count += 1
         # Trivial: just return as-is
         return messages
 
-    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
         return [
             {
                 "name": "stub_search",
@@ -49,7 +49,7 @@ class StubEngine(ContextEngine):
             }
         ]
 
-    def handle_tool_call(self, name: str, args: Dict[str, Any]) -> str:
+    def handle_tool_call(self, name: str, args: dict[str, Any]) -> str:
         self._tools_called.append(name)
         return json.dumps({"ok": True, "tool": name})
 

--- a/tests/fakes/fake_ha_server.py
+++ b/tests/fakes/fake_ha_server.py
@@ -28,7 +28,7 @@ from aiohttp.test_utils import TestServer
 
 # -- Sample entity data -------------------------------------------------------
 
-ENTITY_STATES: List[Dict[str, Any]] = [
+ENTITY_STATES: list[dict[str, Any]] = [
     {
         "entity_id": "light.bedroom",
         "state": "on",
@@ -87,11 +87,11 @@ class FakeHAServer:
         self.token = token
 
         # Observability -- tests inspect these after exercising the adapter.
-        self.received_service_calls: List[Dict[str, Any]] = []
-        self.received_notifications: List[Dict[str, Any]] = []
+        self.received_service_calls: list[dict[str, Any]] = []
+        self.received_notifications: list[dict[str, Any]] = []
 
         # Control -- tests push events, server forwards them over WS.
-        self._event_queue: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        self._event_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
         # Flag to simulate auth rejection.
         self.reject_auth = False
@@ -102,7 +102,7 @@ class FakeHAServer:
         # Internal bookkeeping.
         self._app: Optional[web.Application] = None
         self._server: Optional[TestServer] = None
-        self._ws_connections: List[web.WebSocketResponse] = []
+        self._ws_connections: list[web.WebSocketResponse] = []
 
     # -- Public helpers --------------------------------------------------------
 
@@ -114,7 +114,7 @@ class FakeHAServer:
         port = self._server.port
         return f"http://{host}:{port}"
 
-    async def push_event(self, event_data: Dict[str, Any]) -> None:
+    async def push_event(self, event_data: dict[str, Any]) -> None:
         """Enqueue a state_changed event for delivery over WebSocket."""
         await self._event_queue.put(event_data)
 

--- a/tests/gateway/test_compress_plugin_engine.py
+++ b/tests/gateway/test_compress_plugin_engine.py
@@ -38,7 +38,7 @@ class _FakePluginEngine(ContextEngine):
     def name(self) -> str:
         return "fake-plugin"
 
-    def update_from_response(self, usage: Dict[str, Any]) -> None:
+    def update_from_response(self, usage: dict[str, Any]) -> None:
         return None
 
     def should_compress(self, prompt_tokens: int = None) -> bool:
@@ -46,10 +46,10 @@ class _FakePluginEngine(ContextEngine):
 
     def compress(
         self,
-        messages: List[Dict[str, Any]],
+        messages: list[dict[str, Any]],
         current_tokens: int = None,
         focus_topic: str = None,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         # Pretend we dropped a middle turn.
         self.compression_count += 1
         if len(messages) >= 3:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3503,7 +3503,7 @@ class TestBotNameResolution(unittest.TestCase):
     """Tests for the bot branch of _resolve_sender_name_from_api (basic_batch API + shared cache)."""
 
     @staticmethod
-    def _batch_payload(bots: Dict[str, str]):
+    def _batch_payload(bots: dict[str, str]):
         import json as _json
         body = {
             oid: {"bot_id": oid, "name": name, "i18n_names": {"en_us": name}}
@@ -3511,7 +3511,7 @@ class TestBotNameResolution(unittest.TestCase):
         }
         return _json.dumps({"code": 0, "msg": "", "data": {"bots": body, "failed_bots": {}}}).encode()
 
-    def _build_adapter_with_bots(self, bots: Dict[str, str]):
+    def _build_adapter_with_bots(self, bots: dict[str, str]):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 

--- a/tests/hermes_cli/test_plugin_scanner_recursion.py
+++ b/tests/hermes_cli/test_plugin_scanner_recursion.py
@@ -24,7 +24,7 @@ def _write_plugin(
     root: Path,
     segments: list[str],
     *,
-    manifest_extra: Dict[str, Any] | None = None,
+    manifest_extra: dict[str, Any] | None = None,
     register_body: str = "pass",
 ) -> Path:
     """Create a plugin dir at ``root/<segments...>/`` with plugin.yaml + __init__.py.

--- a/tests/hermes_cli/test_plugins_tts_registration.py
+++ b/tests/hermes_cli/test_plugins_tts_registration.py
@@ -21,7 +21,7 @@ def _write_plugin(
     root: Path,
     name: str,
     *,
-    manifest_extra: Dict[str, Any] | None = None,
+    manifest_extra: dict[str, Any] | None = None,
     register_body: str = "pass",
 ) -> Path:
     plugin_dir = root / name

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -59,7 +59,7 @@ def test_get_adapter_unknown_provider_raises():
 # ---------------------------------------------------------------------------
 
 
-def _write_auth_store(hermes_home: Path, nous_state: Dict[str, Any]) -> Path:
+def _write_auth_store(hermes_home: Path, nous_state: dict[str, Any]) -> Path:
     """Write an auth.json with the given nous state into a hermetic HERMES_HOME."""
     auth_path = hermes_home / "auth.json"
     auth_path.write_text(json.dumps({
@@ -520,7 +520,7 @@ async def _start_runner(app: "web.Application"):
     return runner, f"http://127.0.0.1:{port}"
 
 
-def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
+def _build_fake_upstream(captured: dict[str, Any]) -> "web.Application":
     async def echo(request):
         body = await request.read()
         captured["requests"].append({
@@ -548,7 +548,7 @@ def _build_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
     return app
 
 
-def _build_retrying_fake_upstream(captured: Dict[str, Any]) -> "web.Application":
+def _build_retrying_fake_upstream(captured: dict[str, Any]) -> "web.Application":
     async def maybe_unauthorized(request):
         body = await request.read()
         auth = request.headers.get("Authorization")
@@ -569,7 +569,7 @@ def _build_retrying_fake_upstream(captured: Dict[str, Any]) -> "web.Application"
 
 def test_server_forwards_chat_completions():
     async def run():
-        captured: Dict[str, Any] = {"requests": []}
+        captured: dict[str, Any] = {"requests": []}
         upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
         adapter = FakeAdapter(f"{upstream_base}/v1", bearer="real-portal-key")
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))
@@ -599,7 +599,7 @@ def test_server_forwards_chat_completions():
 
 def test_server_retries_once_with_adapter_retry_credential_on_401():
     async def run():
-        captured: Dict[str, Any] = {"requests": []}
+        captured: dict[str, Any] = {"requests": []}
         upstream_runner, upstream_base = await _start_runner(
             _build_retrying_fake_upstream(captured)
         )
@@ -686,7 +686,7 @@ def test_server_health_endpoint():
 
 def test_server_streams_sse():
     async def run():
-        captured: Dict[str, Any] = {"requests": []}
+        captured: dict[str, Any] = {"requests": []}
         upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
         adapter = FakeAdapter(f"{upstream_base}/v1", allowed=["/sse"])
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))
@@ -710,7 +710,7 @@ def test_server_streams_sse():
 def test_server_strips_client_auth_header():
     """The client's Authorization header MUST NOT reach the upstream."""
     async def run():
-        captured: Dict[str, Any] = {"requests": []}
+        captured: dict[str, Any] = {"requests": []}
         upstream_runner, upstream_base = await _start_runner(_build_fake_upstream(captured))
         adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
         proxy_runner, proxy_base = await _start_runner(create_app(adapter))

--- a/tests/hermes_cli/test_video_gen_picker.py
+++ b/tests/hermes_cli/test_video_gen_picker.py
@@ -21,8 +21,8 @@ class _FakeVideoProvider(VideoGenProvider):
         self,
         name: str,
         available: bool = True,
-        schema: Optional[Dict[str, Any]] = None,
-        models: Optional[List[Dict[str, Any]]] = None,
+        schema: Optional[dict[str, Any]] = None,
+        models: Optional[list[dict[str, Any]]] = None,
     ):
         self._name = name
         self._available = available

--- a/tests/hermes_cli/test_xai_oauth_pkce_token_exchange.py
+++ b/tests/hermes_cli/test_xai_oauth_pkce_token_exchange.py
@@ -48,7 +48,7 @@ class _PostRecorder:
 
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
-        self.calls: List[Dict[str, Any]] = []
+        self.calls: list[dict[str, Any]] = []
 
     def __call__(self, url, *, headers=None, data=None, timeout=None, **kw):
         self.calls.append(
@@ -320,7 +320,7 @@ def test_wire_format_is_form_urlencoded_with_all_pkce_fields(monkeypatch):
     If anyone ever swaps ``data=`` for ``json=`` or refactors the dict,
     xAI will start rejecting again — this catches it locally."""
 
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     class _Transport(httpx.BaseTransport):
         def handle_request(self, request):

--- a/tests/integration/test_checkpoint_resumption.py
+++ b/tests/integration/test_checkpoint_resumption.py
@@ -53,7 +53,7 @@ def create_test_dataset(num_prompts: int = 20) -> Path:
     return dataset_file
 
 
-def monitor_checkpoint_during_run(checkpoint_file: Path, duration: int = 30) -> List[Dict[str, Any]]:
+def monitor_checkpoint_during_run(checkpoint_file: Path, duration: int = 30) -> list[dict[str, Any]]:
     """
     Monitor checkpoint file during a batch run to see when it gets updated.
     

--- a/tests/integration/test_web_tools.py
+++ b/tests/integration/test_web_tools.py
@@ -139,7 +139,7 @@ class WebToolsTester:
         
         return True
     
-    def test_web_search(self) -> List[str]:
+    def test_web_search(self) -> list[str]:
         """Test web search functionality"""
         print_section("Test 1: Web Search")
         
@@ -239,7 +239,7 @@ class WebToolsTester:
         
         return extracted_urls
     
-    async def test_web_extract(self, urls: List[str] = None):
+    async def test_web_extract(self, urls: list[str] = None):
         """Test web content extraction"""
         print_section("Test 2: Web Extract (without LLM)")
         
@@ -344,7 +344,7 @@ class WebToolsTester:
                     import traceback
                     print(f"    Traceback: {traceback.format_exc()}")
     
-    async def test_web_extract_with_llm(self, urls: List[str] = None):
+    async def test_web_extract_with_llm(self, urls: list[str] = None):
         """Test web extraction with LLM processing"""
         print_section("Test 3: Web Extract (with Gemini LLM)")
         

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -73,12 +73,12 @@ class _FakeSessionDB:
     def list_sessions_rich(
         self,
         source: Optional[str] = None,
-        exclude_sources: Optional[List[str]] = None,
+        exclude_sources: Optional[list[str]] = None,
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
         project_compression_tips: bool = True,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         if self.scan_delay:
             time.sleep(self.scan_delay)
         self.last_limit = limit
@@ -100,7 +100,7 @@ class _FakeSessionDB:
             for i in range(effective)
         ]
 
-    def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
+    def get_messages(self, session_id: str) -> list[dict[str, Any]]:
         self.messages_calls += 1
         return [
             {"role": "user", "content": f"ask {session_id}"},
@@ -312,7 +312,7 @@ def test_background_scan_publishes_partial_snapshots(plugin_api):
     _install_fake_session_db(plugin_api, fake_db)
 
     # Record every partial snapshot the scanner publishes.
-    partial_snapshots: List[Dict[str, Any]] = []
+    partial_snapshots: list[dict[str, Any]] = []
     original_compute_from_scan = plugin_api._compute_from_scan
 
     def recording_compute(scan, *, is_partial=False):

--- a/tests/plugins/video_gen/test_xai_plugin_integration.py
+++ b/tests/plugins/video_gen/test_xai_plugin_integration.py
@@ -24,7 +24,7 @@ def _reset_registry():
 
 
 class _FakeResponse:
-    def __init__(self, status: int = 200, payload: Optional[Dict[str, Any]] = None):
+    def __init__(self, status: int = 200, payload: Optional[dict[str, Any]] = None):
         self.status_code = status
         self._payload = payload or {}
         self.text = json.dumps(self._payload)
@@ -40,7 +40,7 @@ class _FakeResponse:
 
 class _FakeAsyncClient:
     def __init__(self):
-        self.posts: List[Dict[str, Any]] = []
+        self.posts: list[dict[str, Any]] = []
 
     async def __aenter__(self):
         return self
@@ -66,7 +66,7 @@ def xai_provider(monkeypatch):
 
     import plugins.video_gen.xai as xai_plugin
 
-    captured: Dict[str, _FakeAsyncClient] = {}
+    captured: dict[str, _FakeAsyncClient] = {}
 
     def _client_factory():
         captured["client"] = _FakeAsyncClient()
@@ -83,7 +83,7 @@ def xai_provider(monkeypatch):
     return provider, captured
 
 
-def _last_post(captured) -> Dict[str, Any]:
+def _last_post(captured) -> dict[str, Any]:
     return captured["client"].posts[-1]
 
 

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -34,8 +34,8 @@ class _CDPServer:
     """
 
     def __init__(self) -> None:
-        self._handlers: Dict[str, Any] = {}
-        self._responses: List[Dict[str, Any]] = []
+        self._handlers: dict[str, Any] = {}
+        self._responses: list[dict[str, Any]] = []
         self._loop: asyncio.AbstractEventLoop | None = None
         self._server: Any = None
         self._thread: threading.Thread | None = None
@@ -120,7 +120,7 @@ class _CDPServer:
         if self._thread:
             self._thread.join(timeout=3.0)
 
-    def received(self) -> List[Dict[str, Any]]:
+    def received(self) -> list[dict[str, Any]]:
         return list(self._responses)
 
 

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -18,7 +18,7 @@ class TestClarifyToolBasics:
 
     def test_simple_question_with_callback(self):
         """Should return user response for simple question."""
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             assert question == "What color?"
             assert choices is None
             return "blue"
@@ -30,7 +30,7 @@ class TestClarifyToolBasics:
 
     def test_question_with_choices(self):
         """Should pass choices to callback and return response."""
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             assert question == "Pick a number"
             assert choices == ["1", "2", "3"]
             return "2"
@@ -69,7 +69,7 @@ class TestClarifyToolChoicesValidation:
         """Should trim choices to MAX_CHOICES."""
         choices_passed = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             choices_passed.extend(choices or [])
             return "picked"
 
@@ -82,7 +82,7 @@ class TestClarifyToolChoicesValidation:
         """Empty choices list should become None (open-ended)."""
         choices_received = ["marker"]
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             choices_received.clear()
             if choices is not None:
                 choices_received.extend(choices)
@@ -95,7 +95,7 @@ class TestClarifyToolChoicesValidation:
         """Whitespace-only choices should be stripped out."""
         choices_received = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             choices_received.extend(choices or [])
             return "answer"
 
@@ -116,7 +116,7 @@ class TestClarifyToolChoicesValidation:
         """Non-string choices should be converted to strings."""
         choices_received = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             choices_received.extend(choices or [])
             return "answer"
 
@@ -129,7 +129,7 @@ class TestClarifyToolCallbackHandling:
 
     def test_callback_exception_returns_error(self):
         """Should return error if callback raises exception."""
-        def failing_callback(question: str, choices: Optional[List[str]]) -> str:
+        def failing_callback(question: str, choices: Optional[list[str]]) -> str:
             raise RuntimeError("User cancelled")
 
         result = json.loads(clarify_tool("Question?", callback=failing_callback))
@@ -141,7 +141,7 @@ class TestClarifyToolCallbackHandling:
         """Callback should receive trimmed question."""
         received_question = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             received_question.append(question)
             return "answer"
 
@@ -150,7 +150,7 @@ class TestClarifyToolCallbackHandling:
 
     def test_user_response_stripped(self):
         """User response should be stripped of whitespace."""
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: Optional[list[str]]) -> str:
             return "  response with spaces  \n"
 
         result = json.loads(clarify_tool("Q?", callback=mock_callback))

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -644,7 +644,7 @@ class TestAnthropicAdapterMultimodal:
 
         fake_png = "iVBORw0KGgo="
 
-        def _mm_tool(call_id: str) -> Dict[str, Any]:
+        def _mm_tool(call_id: str) -> dict[str, Any]:
             return {
                 "role": "tool",
                 "tool_call_id": call_id,
@@ -660,7 +660,7 @@ class TestAnthropicAdapterMultimodal:
             }
 
         # Build 5 screenshots interleaved with assistant messages.
-        messages: List[Dict[str, Any]] = [{"role": "user", "content": "start"}]
+        messages: list[dict[str, Any]] = [{"role": "user", "content": "start"}]
         for i in range(5):
             messages.append({
                 "role": "assistant", "content": "",
@@ -1188,7 +1188,7 @@ class TestCaptureAfterAppContext:
 #   matches nothing instead of silently picking the frontmost window.
 # ---------------------------------------------------------------------------
 
-def _make_cua_backend_with_windows(windows: List[Dict[str, Any]]):
+def _make_cua_backend_with_windows(windows: list[dict[str, Any]]):
     """Construct a CuaDriverBackend with a mocked MCP session that returns
     the supplied list_windows payload."""
     from tools.computer_use.cua_backend import CuaDriverBackend

--- a/tests/tools/test_video_generation_dispatch.py
+++ b/tests/tools/test_video_generation_dispatch.py
@@ -23,13 +23,13 @@ class _RecordingProvider(VideoGenProvider):
 
     def __init__(self, name: str = "fake"):
         self._name = name
-        self.last_kwargs: Dict[str, Any] = {}
+        self.last_kwargs: dict[str, Any] = {}
 
     @property
     def name(self) -> str:
         return self._name
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         return [{"id": "model-a"}]
 
     def default_model(self) -> Optional[str]:
@@ -60,7 +60,7 @@ class _RaisingProvider(VideoGenProvider):
 
 
 class TestUnifiedDispatch:
-    def _run(self, args: Dict[str, Any], *, configured: Optional[str] = None) -> Dict[str, Any]:
+    def _run(self, args: dict[str, Any], *, configured: Optional[str] = None) -> dict[str, Any]:
         from tools import video_generation_tool
         import hermes_cli.plugins as plugins_module
 

--- a/tests/tools/test_video_generation_dynamic_schema.py
+++ b/tests/tools/test_video_generation_dynamic_schema.py
@@ -38,13 +38,13 @@ class _BothModalitiesProvider(VideoGenProvider):
     def is_available(self) -> bool:
         return True
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         return [{"id": "family-a", "modalities": ["text", "image"]}]
 
     def default_model(self) -> Optional[str]:
         return "family-a"
 
-    def capabilities(self) -> Dict[str, Any]:
+    def capabilities(self) -> dict[str, Any]:
         return {
             "modalities": ["text", "image"],
             "aspect_ratios": ["16:9", "9:16"],
@@ -70,13 +70,13 @@ class _ImageOnlyProvider(VideoGenProvider):
     def is_available(self) -> bool:
         return True
 
-    def list_models(self) -> List[Dict[str, Any]]:
+    def list_models(self) -> list[dict[str, Any]]:
         return [{"id": "img-only-v1", "modalities": ["image"]}]
 
     def default_model(self) -> Optional[str]:
         return "img-only-v1"
 
-    def capabilities(self) -> Dict[str, Any]:
+    def capabilities(self) -> dict[str, Any]:
         return {"modalities": ["image"], "min_duration": 1, "max_duration": 10}
 
     def generate(self, prompt, **kwargs):

--- a/tests/tools/test_video_generation_tool_surface_matrix.py
+++ b/tests/tools/test_video_generation_tool_surface_matrix.py
@@ -37,8 +37,8 @@ def matrix_env(tmp_path, monkeypatch):
     monkeypatch.setenv("FAL_KEY", "test-key")
     monkeypatch.setenv("XAI_API_KEY", "test-key")
 
-    fal_calls: List[Dict[str, Any]] = []
-    xai_calls: List[Dict[str, Any]] = []
+    fal_calls: list[dict[str, Any]] = []
+    xai_calls: list[dict[str, Any]] = []
 
     # fal_client stub
     fake_fal = types.ModuleType("fal_client")

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -56,7 +56,7 @@ class TestWebProviderABCs:
             def supports_search(self) -> bool:
                 return True
 
-            def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+            def search(self, query: str, limit: int = 5) -> dict[str, Any]:
                 return {"success": True, "data": {"web": []}}
 
         d = Dummy()
@@ -92,13 +92,13 @@ class TestWebProviderABCs:
             def supports_crawl(self) -> bool:
                 return True
 
-            def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+            def search(self, query: str, limit: int = 5) -> dict[str, Any]:
                 return {"success": True, "data": {"web": []}}
 
-            def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+            def extract(self, urls: list[str], **kwargs: Any) -> list[dict[str, Any]]:
                 return [{"url": urls[0], "content": "x"}]
 
-            def crawl(self, url: str, **kwargs: Any) -> Dict[str, Any]:
+            def crawl(self, url: str, **kwargs: Any) -> dict[str, Any]:
                 return {"results": [{"url": url, "content": "x"}]}
 
         d = Dummy()
@@ -127,7 +127,7 @@ class TestWebProviderABCs:
             def supports_search(self) -> bool:
                 return True
 
-            def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+            def search(self, query: str, limit: int = 5) -> dict[str, Any]:
                 return {"success": True, "data": {"web": []}}
 
         # Should instantiate fine — extract/crawl have default

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -98,7 +98,7 @@ def get_vnc_url() -> Optional[str]:
     return _vnc_url
 
 
-def _get_camofox_config() -> Dict[str, Any]:
+def _get_camofox_config() -> dict[str, Any]:
     """Return the ``browser.camofox`` config block, or an empty dict."""
     try:
         camofox_cfg = load_config().get("browser", {}).get("camofox", {})
@@ -120,7 +120,7 @@ def _managed_persistence_enabled() -> bool:
     return bool(_get_camofox_config().get("managed_persistence"))
 
 
-def _camofox_identity_override(task_id: Optional[str], camofox_cfg: Dict[str, Any]) -> Optional[Dict[str, str]]:
+def _camofox_identity_override(task_id: Optional[str], camofox_cfg: dict[str, Any]) -> Optional[dict[str, str]]:
     """Return an externally configured Camofox identity, if one is set.
 
     Integrations that own the visible Camofox browser can set a shared user ID
@@ -151,7 +151,7 @@ def _env_flag(name: str) -> Optional[bool]:
     return None
 
 
-def _adopt_existing_tab_enabled(camofox_cfg: Dict[str, Any]) -> bool:
+def _adopt_existing_tab_enabled(camofox_cfg: dict[str, Any]) -> bool:
     """Return whether Hermes should recover an existing Camofox tab ID."""
     env_value = _env_flag("CAMOFOX_ADOPT_EXISTING_TAB")
     if env_value is not None:
@@ -163,11 +163,11 @@ def _adopt_existing_tab_enabled(camofox_cfg: Dict[str, Any]) -> bool:
 # Session management
 # ---------------------------------------------------------------------------
 # Maps task_id -> {"user_id": str, "tab_id": str|None}
-_sessions: Dict[str, Dict[str, Any]] = {}
+_sessions: dict[str, dict[str, Any]] = {}
 _sessions_lock = threading.Lock()
 
 
-def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
+def _adopt_existing_tab(session: dict[str, Any]) -> dict[str, Any]:
     """Attach process-local state to an already-open managed Camofox tab.
 
     Some integrations own the visible Camofox tab outside Hermes. Gateway
@@ -205,7 +205,7 @@ def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
     return session
 
 
-def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
+def _get_session(task_id: Optional[str]) -> dict[str, Any]:
     """Get or create a camofox session for the given task.
 
     When managed persistence is enabled, uses a deterministic userId
@@ -248,7 +248,7 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
         return _adopt_existing_tab(session)
 
 
-def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:
+def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> dict[str, Any]:
     """Ensure a tab exists for the session, creating one if needed."""
     session = _get_session(task_id)
     if session["tab_id"]:
@@ -269,7 +269,7 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     return session
 
 
-def _drop_session(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
+def _drop_session(task_id: Optional[str]) -> Optional[dict[str, Any]]:
     """Remove and return session info."""
     task_id = task_id or "default"
     with _sessions_lock:

--- a/tools/browser_camofox_state.py
+++ b/tools/browser_camofox_state.py
@@ -24,7 +24,7 @@ def get_camofox_state_dir() -> Path:
     return get_hermes_home() / CAMOFOX_STATE_DIR_NAME / CAMOFOX_STATE_SUBDIR
 
 
-def get_camofox_identity(task_id: Optional[str] = None) -> Dict[str, str]:
+def get_camofox_identity(task_id: Optional[str] = None) -> dict[str, str]:
     """Return the stable Hermes-managed Camofox identity for this profile.
 
     The user identity is profile-scoped (same Hermes profile = same userId).

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -94,10 +94,10 @@ def _resolve_cdp_endpoint() -> str:
 async def _cdp_call(
     ws_url: str,
     method: str,
-    params: Dict[str, Any],
+    params: dict[str, Any],
     target_id: Optional[str],
     timeout: float,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Make a single CDP call, optionally attaching to a target first.
 
     When ``target_id`` is provided, we call ``Target.attachToTarget`` with
@@ -157,7 +157,7 @@ async def _cdp_call(
         # --- Step 2: dispatch the real method ---
         call_id = next_id
         next_id += 1
-        req: Dict[str, Any] = {
+        req: dict[str, Any] = {
             "id": call_id,
             "method": method,
             "params": params or {},
@@ -191,7 +191,7 @@ def _browser_cdp_via_supervisor(
     task_id: str,
     frame_id: str,
     method: str,
-    params: Optional[Dict[str, Any]],
+    params: Optional[dict[str, Any]],
     timeout: float,
 ) -> str:
     """Route a CDP call through the live supervisor session for an OOPIF frame.
@@ -222,7 +222,7 @@ def _browser_cdp_via_supervisor(
     snap = supervisor.snapshot()
     # Search both the top frame and the children for the requested id.
     top = snap.frame_tree.get("top")
-    frame_info: Optional[Dict[str, Any]] = None
+    frame_info: Optional[dict[str, Any]] = None
     if top and top.get("frame_id") == frame_id:
         frame_info = top
     else:
@@ -288,7 +288,7 @@ def _browser_cdp_via_supervisor(
             cdp_docs=CDP_DOCS_URL,
         )
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "success": True,
         "method": method,
         "frame_id": frame_id,
@@ -300,7 +300,7 @@ def _browser_cdp_via_supervisor(
 
 def browser_cdp(
     method: str,
-    params: Optional[Dict[str, Any]] = None,
+    params: Optional[dict[str, Any]] = None,
     target_id: Optional[str] = None,
     frame_id: Optional[str] = None,
     timeout: float = 30.0,
@@ -372,7 +372,7 @@ def browser_cdp(
             "browser is actually listening on the debug port."
         )
 
-    call_params: Dict[str, Any] = params or {}
+    call_params: dict[str, Any] = params or {}
     if not isinstance(call_params, dict):
         return tool_error(
             f"'params' must be an object/dict, got {type(call_params).__name__}"
@@ -410,7 +410,7 @@ def browser_cdp(
             method=method,
         )
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "success": True,
         "method": method,
         "result": result,
@@ -425,7 +425,7 @@ def browser_cdp(
 # ---------------------------------------------------------------------------
 
 
-BROWSER_CDP_SCHEMA: Dict[str, Any] = {
+BROWSER_CDP_SCHEMA: dict[str, Any] = {
     "name": "browser_cdp",
     "description": (
         "Send a raw Chrome DevTools Protocol (CDP) command. Escape hatch for "

--- a/tools/browser_dialog_tool.py
+++ b/tools/browser_dialog_tool.py
@@ -25,7 +25,7 @@ from tools.registry import registry
 logger = logging.getLogger(__name__)
 
 
-BROWSER_DIALOG_SCHEMA: Dict[str, Any] = {
+BROWSER_DIALOG_SCHEMA: dict[str, Any] = {
     "name": "browser_dialog",
     "description": (
         "Respond to a native JavaScript dialog (alert / confirm / prompt / "

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -143,7 +143,7 @@ class PendingDialog:
     # Page.handleJavaScriptDialog — the native dialog never fired.
     bridge_request_id: Optional[str] = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "type": self.type,
@@ -171,7 +171,7 @@ class DialogRecord:
     closed_by: str  # "agent" | "auto_policy" | "remote" | "watchdog"
     frame_id: Optional[str] = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "type": self.type,
@@ -200,7 +200,7 @@ class FrameInfo:
     cdp_session_id: Optional[str] = None
     name: str = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = {
             "frame_id": self.frame_id,
             "url": self.url,
@@ -234,17 +234,17 @@ class SupervisorSnapshot:
     worrying about mutation under their feet.
     """
 
-    pending_dialogs: Tuple[PendingDialog, ...]
-    recent_dialogs: Tuple[DialogRecord, ...]
-    frame_tree: Dict[str, Any]
-    console_errors: Tuple[ConsoleEvent, ...]
+    pending_dialogs: tuple[PendingDialog, ...]
+    recent_dialogs: tuple[DialogRecord, ...]
+    frame_tree: dict[str, Any]
+    console_errors: tuple[ConsoleEvent, ...]
     active: bool  # False if supervisor is detached/stopped
     cdp_url: str
     task_id: str
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize for inclusion in ``browser_snapshot`` output."""
-        out: Dict[str, Any] = {
+        out: dict[str, Any] = {
             "pending_dialogs": [d.to_dict() for d in self.pending_dialogs],
             "frame_tree": self.frame_tree,
         }
@@ -293,10 +293,10 @@ class CDPSupervisor:
 
         # State protected by ``_state_lock`` for cross-thread reads.
         self._state_lock = threading.Lock()
-        self._pending_dialogs: Dict[str, PendingDialog] = {}
-        self._recent_dialogs: List[DialogRecord] = []
-        self._frames: Dict[str, FrameInfo] = {}
-        self._console_events: List[ConsoleEvent] = []
+        self._pending_dialogs: dict[str, PendingDialog] = {}
+        self._recent_dialogs: list[DialogRecord] = []
+        self._frames: dict[str, FrameInfo] = {}
+        self._console_events: list[ConsoleEvent] = []
         self._active = False
 
         # Supervisor loop machinery — populated in start().
@@ -308,13 +308,13 @@ class CDPSupervisor:
 
         # CDP call tracking (runs on supervisor loop only).
         self._next_call_id = 1
-        self._pending_calls: Dict[int, asyncio.Future] = {}
+        self._pending_calls: dict[int, asyncio.Future] = {}
         self._ws: Optional[ClientConnection] = None
         self._page_session_id: Optional[str] = None
-        self._child_sessions: Dict[str, Dict[str, Any]] = {}  # session_id -> info
+        self._child_sessions: dict[str, dict[str, Any]] = {}  # session_id -> info
 
         # Dialog auto-dismiss watchdog handles (per dialog id).
-        self._dialog_watchdogs: Dict[str, asyncio.TimerHandle] = {}
+        self._dialog_watchdogs: dict[str, asyncio.TimerHandle] = {}
         # Monotonic id generator for dialogs (human-readable in snapshots).
         self._dialog_seq = 0
 
@@ -407,7 +407,7 @@ class CDPSupervisor:
         prompt_text: Optional[str] = None,
         dialog_id: Optional[str] = None,
         timeout: float = 10.0,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Accept/dismiss a pending dialog. Sync bridge onto the supervisor loop.
 
         Returns ``{"ok": True, "dialog": {...}}`` on success,
@@ -469,7 +469,7 @@ class CDPSupervisor:
         return_by_value: bool = True,
         await_promise: bool = True,
         timeout: float = 10.0,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Evaluate ``expression`` in the page's Runtime context over the live WS.
 
         Reuses the supervisor's already-connected WebSocket — zero subprocess
@@ -496,7 +496,7 @@ class CDPSupervisor:
         if not session_id:
             return {"ok": False, "error": "supervisor has no attached page session"}
 
-        async def _do_eval() -> Dict[str, Any]:
+        async def _do_eval() -> dict[str, Any]:
             return await self._cdp(
                 "Runtime.evaluate",
                 {
@@ -767,17 +767,17 @@ class CDPSupervisor:
     async def _cdp(
         self,
         method: str,
-        params: Optional[Dict[str, Any]] = None,
+        params: Optional[dict[str, Any]] = None,
         *,
         session_id: Optional[str] = None,
         timeout: float = 10.0,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Send a CDP command and await its response."""
         if self._ws is None:
             raise RuntimeError("supervisor WebSocket is not connected")
         call_id = self._next_call_id
         self._next_call_id += 1
-        payload: Dict[str, Any] = {"id": call_id, "method": method}
+        payload: dict[str, Any] = {"id": call_id, "method": method}
         if params:
             payload["params"] = params
         if session_id:
@@ -819,7 +819,7 @@ class CDPSupervisor:
     # ── Event dispatch ──────────────────────────────────────────────────────
 
     async def _on_event(
-        self, method: str, params: Dict[str, Any], session_id: Optional[str]
+        self, method: str, params: dict[str, Any], session_id: Optional[str]
     ) -> None:
         if method == "Page.javascriptDialogOpening":
             await self._on_dialog_opening(params, session_id)
@@ -843,7 +843,7 @@ class CDPSupervisor:
             self._on_console(params, level_from="exception")
 
     async def _on_dialog_opening(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: dict[str, Any], session_id: Optional[str]
     ) -> None:
         self._dialog_seq += 1
         dialog = PendingDialog(
@@ -892,7 +892,7 @@ class CDPSupervisor:
         Dialog has already been archived by the caller (``_on_dialog_opening``);
         this just fires the CDP call so the page unblocks.
         """
-        params: Dict[str, Any] = {"accept": accept}
+        params: dict[str, Any] = {"accept": accept}
         if dialog.type == "prompt":
             params["promptText"] = prompt_text
         try:
@@ -975,7 +975,7 @@ class CDPSupervisor:
                     handle.cancel()
             return
 
-        params: Dict[str, Any] = {"accept": accept}
+        params: dict[str, Any] = {"accept": accept}
         if dialog.type == "prompt":
             params["promptText"] = prompt_text
         try:
@@ -997,7 +997,7 @@ class CDPSupervisor:
                 handle.cancel()
 
     async def _on_dialog_closed(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: dict[str, Any], session_id: Optional[str]
     ) -> None:
         # ``Page.javascriptDialogClosed`` spec has only ``result`` (bool) and
         # ``userInput`` (string), not the original ``message``.  Match by
@@ -1026,7 +1026,7 @@ class CDPSupervisor:
                     handle.cancel()
 
     async def _on_fetch_paused(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: dict[str, Any], session_id: Optional[str]
     ) -> None:
         """Bridge XHR captured mid-flight — materialize as a pending dialog.
 
@@ -1138,7 +1138,7 @@ class CDPSupervisor:
     # ── Frame / target tracking ─────────────────────────────────────────────
 
     def _on_frame_attached(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: dict[str, Any], session_id: Optional[str]
     ) -> None:
         frame_id = params.get("frameId")
         if not frame_id:
@@ -1154,7 +1154,7 @@ class CDPSupervisor:
             )
 
     def _on_frame_navigated(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: dict[str, Any], session_id: Optional[str]
     ) -> None:
         frame = params.get("frame") or {}
         frame_id = frame.get("id")
@@ -1174,7 +1174,7 @@ class CDPSupervisor:
             self._frames[frame_id] = info
 
     def _on_frame_detached(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: dict[str, Any], session_id: Optional[str]
     ) -> None:
         """Remove a frame from our state only when it's truly gone.
 
@@ -1210,7 +1210,7 @@ class CDPSupervisor:
                 return
             self._frames.pop(frame_id, None)
 
-    async def _on_target_attached(self, params: Dict[str, Any]) -> None:
+    async def _on_target_attached(self, params: dict[str, Any]) -> None:
         info = params.get("targetInfo") or {}
         sid = params.get("sessionId")
         target_type = info.get("type")
@@ -1258,7 +1258,7 @@ class CDPSupervisor:
         # Install the dialog bridge on the child so iframe dialogs are captured.
         await self._install_dialog_bridge(sid)
 
-    def _on_target_detached(self, params: Dict[str, Any]) -> None:
+    def _on_target_detached(self, params: dict[str, Any]) -> None:
         """Handle a child CDP session detaching.
 
         We deliberately DO NOT drop frames from ``_frames`` here — Browserbase
@@ -1290,7 +1290,7 @@ class CDPSupervisor:
 
     # ── Console / exception ring buffer ─────────────────────────────────────
 
-    def _on_console(self, params: Dict[str, Any], *, level_from: str) -> None:
+    def _on_console(self, params: dict[str, Any], *, level_from: str) -> None:
         if level_from == "exception":
             details = params.get("exceptionDetails") or {}
             text = str(details.get("text") or "")
@@ -1302,7 +1302,7 @@ class CDPSupervisor:
                 "warning" if raw_level == "warning" else "log"
             )
             args = params.get("args") or []
-            parts: List[str] = []
+            parts: list[str] = []
             for a in args[:4]:
                 if isinstance(a, dict):
                     parts.append(str(a.get("value") or a.get("description") or ""))
@@ -1315,7 +1315,7 @@ class CDPSupervisor:
 
     # ── Frame tree building (bounded) ───────────────────────────────────────
 
-    def _build_frame_tree_locked(self) -> Dict[str, Any]:
+    def _build_frame_tree_locked(self) -> dict[str, Any]:
         """Build the capped frame_tree payload. Must be called under state lock."""
         frames = self._frames
         if not frames:
@@ -1327,12 +1327,12 @@ class CDPSupervisor:
 
         # BFS from top, capped by FRAME_TREE_MAX_ENTRIES and
         # FRAME_TREE_MAX_OOPIF_DEPTH for OOPIF branches.
-        children: List[Dict[str, Any]] = []
+        children: list[dict[str, Any]] = []
         truncated = False
         if top is None:
             return {"top": None, "children": [], "truncated": False}
 
-        queue: List[Tuple[FrameInfo, int]] = [
+        queue: list[tuple[FrameInfo, int]] = [
             (f, 1) for f in frames.values() if f.parent_frame_id == top.frame_id
         ]
         visited: set[str] = {top.frame_id}
@@ -1370,7 +1370,7 @@ class _SupervisorRegistry:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._by_task: Dict[str, CDPSupervisor] = {}
+        self._by_task: dict[str, CDPSupervisor] = {}
 
     def get(self, task_id: str) -> Optional[CDPSupervisor]:
         """Return the supervisor for ``task_id`` if running, else ``None``."""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -308,7 +308,7 @@ def _get_cdp_override() -> str:
     return ""
 
 
-def _get_dialog_policy_config() -> Tuple[str, float]:
+def _get_dialog_policy_config() -> tuple[str, float]:
     """Read ``browser.dialog_policy`` + ``browser.dialog_timeout_s`` from config.
 
     Returns a ``(policy, timeout_s)`` tuple, falling back to the supervisor's
@@ -419,7 +419,7 @@ def _stop_cdp_supervisor(task_id: str) -> None:
 # wins. This keeps the test surface stable while letting third-party
 # plugins drop in under ``~/.hermes/plugins/browser/<vendor>/``.
 
-_PROVIDER_REGISTRY: Dict[str, type] = {
+_PROVIDER_REGISTRY: dict[str, type] = {
     "browserbase": BrowserbaseProvider,
     "browser-use": BrowserUseProvider,
     "firecrawl": FirecrawlProvider,
@@ -427,7 +427,7 @@ _PROVIDER_REGISTRY: Dict[str, type] = {
 # Frozen copy of the import-time _PROVIDER_REGISTRY, used by
 # ``_is_legacy_provider_registry_overridden`` to detect test-time
 # monkeypatching. NEVER mutate this dict.
-_DEFAULT_PROVIDER_REGISTRY: Dict[str, type] = dict(_PROVIDER_REGISTRY)
+_DEFAULT_PROVIDER_REGISTRY: dict[str, type] = dict(_PROVIDER_REGISTRY)
 
 _cached_cloud_provider: Optional[CloudBrowserProvider] = None
 _cloud_provider_resolved = False
@@ -700,7 +700,7 @@ def _using_lightpanda_engine() -> bool:
     return _get_browser_engine() == "lightpanda"
 
 
-def _lightpanda_fallback_reason(engine: str, command: str, result: Dict[str, Any]) -> Optional[str]:
+def _lightpanda_fallback_reason(engine: str, command: str, result: dict[str, Any]) -> Optional[str]:
     """Return the user-visible reason a Lightpanda result needs Chrome fallback.
 
     ``None`` means no fallback should run.  The returned string is copied into
@@ -752,12 +752,12 @@ def _lightpanda_fallback_reason(engine: str, command: str, result: Dict[str, Any
     return None
 
 
-def _needs_lightpanda_fallback(engine: str, command: str, result: Dict[str, Any]) -> bool:
+def _needs_lightpanda_fallback(engine: str, command: str, result: dict[str, Any]) -> bool:
     """Check if a Lightpanda result should trigger an automatic Chrome fallback."""
     return _lightpanda_fallback_reason(engine, command, result) is not None
 
 
-def _annotate_lightpanda_fallback(result: Dict[str, Any], reason: str) -> Dict[str, Any]:
+def _annotate_lightpanda_fallback(result: dict[str, Any], reason: str) -> dict[str, Any]:
     """Add a user-visible Chrome fallback warning to a browser command result."""
     warning = (
         "⚠ Lightpanda fallback: Chrome was used for this browser action. "
@@ -784,7 +784,7 @@ def _annotate_lightpanda_fallback(result: Dict[str, Any], reason: str) -> Dict[s
     return annotated
 
 
-def _copy_fallback_warning(target: Dict[str, Any], result: Dict[str, Any]) -> Dict[str, Any]:
+def _copy_fallback_warning(target: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
     """Copy browser fallback metadata from an internal result into a tool response."""
     if result.get("fallback_warning"):
         target["fallback_warning"] = result["fallback_warning"]
@@ -796,9 +796,9 @@ def _copy_fallback_warning(target: Dict[str, Any], result: Dict[str, Any]) -> Di
 def _run_chrome_fallback_command(
     task_id: str,
     command: str,
-    args: List[str],
+    args: list[str],
     timeout: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Run a browser command in a temporary Chrome session at the current URL.
 
     agent-browser locks the engine when a named daemon starts. Passing
@@ -864,7 +864,7 @@ def _run_chrome_fallback_command(
     if "AGENT_BROWSER_IDLE_TIMEOUT_MS" not in browser_env:
         browser_env["AGENT_BROWSER_IDLE_TIMEOUT_MS"] = str(BROWSER_SESSION_INACTIVITY_TIMEOUT * 1000)
 
-    def _run_tmp(cmd: str, cmd_args: List[str]) -> Dict[str, Any]:
+    def _run_tmp(cmd: str, cmd_args: list[str]) -> dict[str, Any]:
         full = base_args + [cmd] + cmd_args
         # Use temp-file stdout/stderr pattern (same as _run_browser_command)
         # to avoid pipe hang from agent-browser daemon inheriting fds.
@@ -960,9 +960,9 @@ def _run_chrome_fallback_command(
 
 def _chrome_fallback_screenshot(
     task_id: str,
-    args: List[str],
+    args: list[str],
     timeout: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Take a screenshot using a temporary Chrome session."""
     return _run_chrome_fallback_command(task_id, "screenshot", args, timeout)
 
@@ -1158,7 +1158,7 @@ def _socket_safe_tmpdir() -> str:
 # cleanup_browser code paths — the key is opaque to those internals.
 #
 # Stores: session_name (always), bb_session_id + cdp_url (cloud mode only)
-_active_sessions: Dict[str, Dict[str, str]] = {}  # session_key -> {session_name, ...}
+_active_sessions: dict[str, dict[str, str]] = {}  # session_key -> {session_name, ...}
 _recording_sessions: set = set()  # session_keys with active recordings
 
 # Tracks the most recent session_key used per task_id. Set by browser_navigate()
@@ -1166,7 +1166,7 @@ _recording_sessions: set = set()  # session_keys with active recordings
 # (snapshot/click/fill/eval/...) so they target the session that served the last
 # navigation.  Without this, a task that navigated to localhost on the local
 # sidecar would fall back to the cloud session on its next snapshot call.
-_last_active_session_key: Dict[str, str] = {}  # task_id -> session_key
+_last_active_session_key: dict[str, str] = {}  # task_id -> session_key
 _LOCAL_SUFFIX = "::local"
 
 # Flag to track if cleanup has been done
@@ -1182,7 +1182,7 @@ _cleanup_done = False
 BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
 
 # Track last activity time per session
-_session_last_activity: Dict[str, float] = {}
+_session_last_activity: dict[str, float] = {}
 
 # Background cleanup thread state
 _cleanup_thread = None
@@ -1622,7 +1622,7 @@ BROWSER_TOOL_SCHEMAS = [
 # Utility Functions
 # ============================================================================
 
-def _create_local_session(task_id: str) -> Dict[str, str]:
+def _create_local_session(task_id: str) -> dict[str, str]:
     import uuid
     session_name = f"h_{uuid.uuid4().hex[:10]}"
     logger.info("Created local browser session %s for task %s",
@@ -1635,7 +1635,7 @@ def _create_local_session(task_id: str) -> Dict[str, str]:
     }
 
 
-def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
+def _create_cdp_session(task_id: str, cdp_url: str) -> dict[str, str]:
     """Create a session that connects to a user-supplied CDP endpoint."""
     import uuid
     session_name = f"cdp_{uuid.uuid4().hex[:10]}"
@@ -1649,7 +1649,7 @@ def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
     }
 
 
-def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
+def _get_session_info(task_id: Optional[str] = None) -> dict[str, str]:
     """
     Get or create session info for the given session key.
 
@@ -1876,10 +1876,10 @@ def _extract_screenshot_path_from_text(text: str) -> Optional[str]:
 def _run_browser_command(
     task_id: str,
     command: str,
-    args: List[str] = None,
+    args: list[str] = None,
     timeout: Optional[int] = None,
     _engine_override: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Run an agent-browser CLI command using our pre-created Browserbase session.
 
@@ -3493,7 +3493,7 @@ def cleanup_all_browsers() -> None:
 _cached_chromium_installed: Optional[bool] = None
 
 
-def _chromium_search_roots() -> List[str]:
+def _chromium_search_roots() -> list[str]:
     """Directories to scan for a Chromium / headless-shell build.
 
     Order mirrors what agent-browser and Playwright actually probe:
@@ -3505,7 +3505,7 @@ def _chromium_search_roots() -> List[str]:
     4. ``%USERPROFILE%\\AppData\\Local\\ms-playwright`` — Playwright's default
        on Windows.
     """
-    roots: List[str] = []
+    roots: list[str] = []
     env_path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
     if env_path and env_path != "0":
         roots.append(env_path)

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 # Tools whose thresholds must never be overridden.
 # read_file=inf prevents infinite persist->read->persist loops.
-PINNED_THRESHOLDS: Dict[str, float] = {
+PINNED_THRESHOLDS: dict[str, float] = {
     "read_file": float("inf"),
 }
 
@@ -32,7 +32,7 @@ class BudgetConfig:
     default_result_size: int = DEFAULT_RESULT_SIZE_CHARS
     turn_budget: int = DEFAULT_TURN_BUDGET_CHARS
     preview_size: int = DEFAULT_PREVIEW_SIZE_CHARS
-    tool_overrides: Dict[str, int] = field(default_factory=dict)
+    tool_overrides: dict[str, int] = field(default_factory=dict)
 
     def resolve_threshold(self, tool_name: str) -> int | float:
         """Resolve the persistence threshold for a tool.

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -271,13 +271,13 @@ def _git_env(
 
 
 def _run_git(
-    args: List[str],
+    args: list[str],
     store: Path,
     working_dir: str,
     timeout: int = _GIT_TIMEOUT,
-    allowed_returncodes: Optional[Set[int]] = None,
+    allowed_returncodes: Optional[set[int]] = None,
     index_file: Optional[Path] = None,
-) -> Tuple[bool, str, str]:
+) -> tuple[bool, str, str]:
     """Run a git command against the shared store.  Returns (ok, stdout, stderr).
 
     ``allowed_returncodes`` suppresses error logging for known/expected non-zero
@@ -455,7 +455,7 @@ def _register_project(store: Path, working_dir: str) -> None:
     dir_hash = _project_hash(working_dir)
     meta_path = _project_meta_path(store, dir_hash)
     now = time.time()
-    meta: Dict = {"workdir": str(_normalize_path(working_dir)),
+    meta: dict = {"workdir": str(_normalize_path(working_dir)),
                   "created_at": now, "last_touch": now}
     if meta_path.exists():
         try:
@@ -493,12 +493,12 @@ def _touch_project(store: Path, working_dir: str) -> None:
         logger.debug("Could not update project metadata %s: %s", meta_path, exc)
 
 
-def _list_projects(store: Path) -> List[Dict]:
+def _list_projects(store: Path) -> list[dict]:
     """Return all registered projects under the store."""
     projects_dir = store / _PROJECTS_DIRNAME
     if not projects_dir.exists():
         return []
-    out: List[Dict] = []
+    out: list[dict] = []
     for meta_path in projects_dir.glob("*.json"):
         dir_hash = meta_path.stem
         try:
@@ -605,7 +605,7 @@ class CheckpointManager:
         self.max_snapshots = max(1, int(max_snapshots))
         self.max_total_size_mb = max(0, int(max_total_size_mb))
         self.max_file_size_mb = max(0, int(max_file_size_mb))
-        self._checkpointed_dirs: Set[str] = set()
+        self._checkpointed_dirs: set[str] = set()
         self._git_available: Optional[bool] = None  # lazy probe
 
     # ------------------------------------------------------------------
@@ -654,7 +654,7 @@ class CheckpointManager:
             logger.debug("Checkpoint failed (non-fatal): %s", e)
             return False
 
-    def list_checkpoints(self, working_dir: str) -> List[Dict]:
+    def list_checkpoints(self, working_dir: str) -> list[dict]:
         """List available checkpoints for a directory (most recent first)."""
         abs_dir = str(_normalize_path(working_dir))
         store = _store_path(CHECKPOINT_BASE)
@@ -672,7 +672,7 @@ class CheckpointManager:
         if not ok or not stdout:
             return []
 
-        results: List[Dict] = []
+        results: list[dict] = []
         for line in stdout.splitlines():
             parts = line.split("|", 3)
             if len(parts) == 4:
@@ -696,7 +696,7 @@ class CheckpointManager:
         return results
 
     @staticmethod
-    def _parse_shortstat(stat_line: str, entry: Dict) -> None:
+    def _parse_shortstat(stat_line: str, entry: dict) -> None:
         """Parse git --shortstat output into entry dict."""
         m = re.search(r'(\d+) file', stat_line)
         if m:
@@ -708,7 +708,7 @@ class CheckpointManager:
         if m:
             entry["deletions"] = int(m.group(1))
 
-    def diff(self, working_dir: str, commit_hash: str) -> Dict:
+    def diff(self, working_dir: str, commit_hash: str) -> dict:
         """Show diff between a checkpoint and the current working tree."""
         hash_err = _validate_commit_hash(commit_hash)
         if hash_err:
@@ -758,7 +758,7 @@ class CheckpointManager:
             "diff": diff_out if ok_diff else "",
         }
 
-    def restore(self, working_dir: str, commit_hash: str, file_path: str = None) -> Dict:
+    def restore(self, working_dir: str, commit_hash: str, file_path: str = None) -> dict:
         """Restore files to a checkpoint state."""
         hash_err = _validate_commit_hash(commit_hash)
         if hash_err:
@@ -992,7 +992,7 @@ class CheckpointManager:
         # whitespace but that leaves NULs alone; rebuild list.
         paths = [p for p in stdout.split("\x00") if p]
         abs_workdir = _normalize_path(working_dir)
-        oversize: List[str] = []
+        oversize: list[str] = []
         for rel in paths:
             try:
                 size = (abs_workdir / rel).stat().st_size
@@ -1171,7 +1171,7 @@ class CheckpointManager:
         )
 
 
-def format_checkpoint_list(checkpoints: List[Dict], directory: str) -> str:
+def format_checkpoint_list(checkpoints: list[dict], directory: str) -> str:
     """Format checkpoint list for display to user."""
     if not checkpoints:
         return f"No checkpoints found for {directory}"
@@ -1225,7 +1225,7 @@ def prune_checkpoints(
     delete_orphans: bool = True,
     checkpoint_base: Optional[Path] = None,
     max_total_size_mb: int = 0,
-) -> Dict[str, int]:
+) -> dict[str, int]:
     """Delete stale/orphan checkpoints and reclaim store space.
 
     A project entry is deleted when either:
@@ -1465,7 +1465,7 @@ def maybe_auto_prune_checkpoints(
     delete_orphans: bool = True,
     checkpoint_base: Optional[Path] = None,
     max_total_size_mb: int = 0,
-) -> Dict[str, object]:
+) -> dict[str, object]:
     """Idempotent wrapper around ``prune_checkpoints`` for startup hooks.
 
     Writes ``CHECKPOINT_BASE/.last_prune`` on completion so subsequent
@@ -1475,7 +1475,7 @@ def maybe_auto_prune_checkpoints(
     "error": optional str}``.
     """
     base = checkpoint_base or CHECKPOINT_BASE
-    out: Dict[str, object] = {"skipped": False}
+    out: dict[str, object] = {"skipped": False}
 
     try:
         if not base.exists():
@@ -1530,7 +1530,7 @@ def maybe_auto_prune_checkpoints(
 # Public helpers for `hermes checkpoints` CLI
 # ---------------------------------------------------------------------------
 
-def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
+def store_status(checkpoint_base: Optional[Path] = None) -> dict:
     """Return a summary of the shadow store.
 
     ``{"base": path, "store_size_bytes": N, "legacy_size_bytes": N,
@@ -1538,7 +1538,7 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
        "legacy_archives": [...]}``
     """
     base = checkpoint_base or CHECKPOINT_BASE
-    out: Dict = {
+    out: dict = {
         "base": str(base),
         "store_size_bytes": 0,
         "legacy_size_bytes": 0,
@@ -1597,7 +1597,7 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
     return out
 
 
-def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
+def clear_all(checkpoint_base: Optional[Path] = None) -> dict[str, int]:
     """Nuke the entire checkpoint base (store + legacy).  Irreversible.
 
     Returns ``{"bytes_freed": N, "deleted": bool}``.
@@ -1616,7 +1616,7 @@ def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
     return out
 
 
-def clear_legacy(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
+def clear_legacy(checkpoint_base: Optional[Path] = None) -> dict[str, int]:
     """Delete all ``legacy-*`` archive directories.
 
     Returns ``{"bytes_freed": N, "deleted": count}``.

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -50,12 +50,12 @@ class _ClarifyEntry:
     clarify_id: str
     session_key: str
     question: str
-    choices: Optional[List[str]]
+    choices: Optional[list[str]]
     event: threading.Event = field(default_factory=threading.Event)
     response: Optional[str] = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
 
-    def signature(self) -> Dict[str, object]:
+    def signature(self) -> dict[str, object]:
         return {
             "clarify_id": self.clarify_id,
             "session_key": self.session_key,
@@ -66,9 +66,9 @@ class _ClarifyEntry:
 
 _lock = threading.RLock()
 # clarify_id → _ClarifyEntry  (primary lookup for button callbacks)
-_entries: Dict[str, _ClarifyEntry] = {}
+_entries: dict[str, _ClarifyEntry] = {}
 # session_key → list[clarify_id]  (FIFO; for text-fallback intercept and session cleanup)
-_session_index: Dict[str, List[str]] = {}
+_session_index: dict[str, list[str]] = {}
 
 
 # =========================================================================
@@ -79,7 +79,7 @@ def register(
     clarify_id: str,
     session_key: str,
     question: str,
-    choices: Optional[List[str]],
+    choices: Optional[list[str]],
 ) -> _ClarifyEntry:
     """Register a pending clarify request and return the entry.
 
@@ -255,7 +255,7 @@ def get_clarify_timeout() -> int:
 # callback bridges sync→async (runs on the agent thread; schedules the
 # adapter ``send_clarify`` call on the event loop).
 
-_notify_cbs: Dict[str, Callable[[_ClarifyEntry], None]] = {}
+_notify_cbs: dict[str, Callable[[_ClarifyEntry], None]] = {}
 
 
 def register_notify(session_key: str, cb: Callable[[_ClarifyEntry], None]) -> None:

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -22,7 +22,7 @@ MAX_CHOICES = 4
 
 def clarify_tool(
     question: str,
-    choices: Optional[List[str]] = None,
+    choices: Optional[list[str]] = None,
     callback: Optional[Callable] = None,
 ) -> str:
     """

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -227,7 +227,7 @@ _TOOL_STUBS = {
 }
 
 
-def generate_hermes_tools_module(enabled_tools: List[str],
+def generate_hermes_tools_module(enabled_tools: list[str],
                                  transport: str = "uds") -> str:
     """
     Build the source code for the hermes_tools.py stub module.
@@ -841,7 +841,7 @@ def _rpc_poll_loop(
 def _execute_remote(
     code: str,
     task_id: Optional[str],
-    enabled_tools: Optional[List[str]],
+    enabled_tools: Optional[list[str]],
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -998,7 +998,7 @@ def _execute_remote(
     stdout_text = redact_sensitive_text(stdout_text)
 
     # Build response
-    result: Dict[str, Any] = {
+    result: dict[str, Any] = {
         "status": status,
         "output": stdout_text,
         "tool_calls_made": tool_call_counter[0],
@@ -1036,7 +1036,7 @@ def _execute_remote(
 def execute_code(
     code: str,
     task_id: Optional[str] = None,
-    enabled_tools: Optional[List[str]] = None,
+    enabled_tools: Optional[list[str]] = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -1382,7 +1382,7 @@ def execute_code(
         stderr_text = redact_sensitive_text(stderr_text)
 
         # Build response
-        result: Dict[str, Any] = {
+        result: dict[str, Any] = {
             "status": status,
             "output": stdout_text,
             "tool_calls_made": tool_call_counter[0],

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -19,13 +19,13 @@ class UIElement:
     index: int                       # 1-based SOM index
     role: str                        # AX role (AXButton, AXTextField, ...)
     label: str = ""                  # AXTitle / AXDescription / AXValue snippet
-    bounds: Tuple[int, int, int, int] = (0, 0, 0, 0)  # x, y, w, h (logical px)
+    bounds: tuple[int, int, int, int] = (0, 0, 0, 0)  # x, y, w, h (logical px)
     app: str = ""                    # owning bundle ID or app name
     pid: int = 0                     # owning process PID
     window_id: int = 0               # SkyLight / CG window ID
-    attributes: Dict[str, Any] = field(default_factory=dict)
+    attributes: dict[str, Any] = field(default_factory=dict)
 
-    def center(self) -> Tuple[int, int]:
+    def center(self) -> tuple[int, int]:
         x, y, w, h = self.bounds
         return x + w // 2, y + h // 2
 
@@ -46,7 +46,7 @@ class CaptureResult:
     width: int                      # screenshot width (logical px, pre-Anthropic-scale)
     height: int
     png_b64: Optional[str] = None
-    elements: List[UIElement] = field(default_factory=list)
+    elements: list[UIElement] = field(default_factory=list)
     # Optional: the target app/window the elements were captured for.
     app: str = ""
     window_title: str = ""
@@ -65,7 +65,7 @@ class ActionResult:
     # post-action capture or the backend always returns one.
     capture: Optional[CaptureResult] = None
     # Arbitrary extra fields for debugging / telemetry.
-    meta: Dict[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
 
 
 class ComputerUseBackend(ABC):
@@ -98,7 +98,7 @@ class ComputerUseBackend(ABC):
         y: Optional[int] = None,
         button: str = "left",           # left | right | middle
         click_count: int = 1,
-        modifiers: Optional[List[str]] = None,
+        modifiers: Optional[list[str]] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -107,10 +107,10 @@ class ComputerUseBackend(ABC):
         *,
         from_element: Optional[int] = None,
         to_element: Optional[int] = None,
-        from_xy: Optional[Tuple[int, int]] = None,
-        to_xy: Optional[Tuple[int, int]] = None,
+        from_xy: Optional[tuple[int, int]] = None,
+        to_xy: Optional[tuple[int, int]] = None,
         button: str = "left",
-        modifiers: Optional[List[str]] = None,
+        modifiers: Optional[list[str]] = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -122,7 +122,7 @@ class ComputerUseBackend(ABC):
         element: Optional[int] = None,
         x: Optional[int] = None,
         y: Optional[int] = None,
-        modifiers: Optional[List[str]] = None,
+        modifiers: Optional[list[str]] = None,
     ) -> ActionResult: ...
 
     # ── Keyboard ────────────────────────────────────────────────────
@@ -135,7 +135,7 @@ class ComputerUseBackend(ABC):
 
     # ── Introspection ───────────────────────────────────────────────
     @abstractmethod
-    def list_apps(self) -> List[Dict[str, Any]]:
+    def list_apps(self) -> list[dict[str, Any]]:
         """Return running apps with bundle IDs, PIDs, window counts."""
 
     @abstractmethod

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -101,7 +101,7 @@ def cua_driver_install_hint() -> str:
     )
 
 
-def _parse_windows_from_text(text: str) -> List[Dict[str, Any]]:
+def _parse_windows_from_text(text: str) -> list[dict[str, Any]]:
     """Parse window records from list_windows text output."""
     windows = []
     for m in _WINDOW_LINE_RE.finditer(text):
@@ -114,7 +114,7 @@ def _parse_windows_from_text(text: str) -> List[Dict[str, Any]]:
     return windows
 
 
-def _parse_elements_from_tree(markdown: str) -> List[UIElement]:
+def _parse_elements_from_tree(markdown: str) -> list[UIElement]:
     """Parse UIElement list from get_window_state AX tree markdown.
 
     Handles both the classic ``"label"``-quoted format and the newer
@@ -133,7 +133,7 @@ def _parse_elements_from_tree(markdown: str) -> List[UIElement]:
     return elements
 
 
-def _split_tree_text(full_text: str) -> Tuple[str, str]:
+def _split_tree_text(full_text: str) -> tuple[str, str]:
     """Split get_window_state text into (summary_line, tree_markdown)."""
     lines = full_text.split("\n", 1)
     summary = lines[0]
@@ -141,7 +141,7 @@ def _split_tree_text(full_text: str) -> Tuple[str, str]:
     return summary, tree
 
 
-def _parse_key_combo(keys: str) -> Tuple[Optional[str], List[str]]:
+def _parse_key_combo(keys: str) -> tuple[Optional[str], list[str]]:
     """Parse a key string like 'cmd+s' into (key, modifiers).
 
     Returns (key, modifiers) where key is the non-modifier key and modifiers
@@ -280,16 +280,16 @@ class _CuaDriverSession:
             finally:
                 self._started = False
 
-    async def _call_tool_async(self, name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+    async def _call_tool_async(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
         result = await self._session.call_tool(name, args)
         return _extract_tool_result(result)
 
-    def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
+    def call_tool(self, name: str, args: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
         self._require_started()
         return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
 
 
-def _extract_tool_result(mcp_result: Any) -> Dict[str, Any]:
+def _extract_tool_result(mcp_result: Any) -> dict[str, Any]:
     """Convert an mcp CallToolResult into a plain dict.
 
     cua-driver returns a mix of text parts, image parts, and structuredContent.
@@ -305,10 +305,10 @@ def _extract_tool_result(mcp_result: Any) -> Dict[str, Any]:
     list_windows window arrays.
     """
     data: Any = None
-    images: List[str] = []
+    images: list[str] = []
     is_error = bool(getattr(mcp_result, "isError", False))
-    structured: Optional[Dict] = getattr(mcp_result, "structuredContent", None) or None
-    text_chunks: List[str] = []
+    structured: Optional[dict] = getattr(mcp_result, "structuredContent", None) or None
+    text_chunks: list[str] = []
     for part in getattr(mcp_result, "content", []) or []:
         ptype = getattr(part, "type", None)
         if ptype == "text":
@@ -427,7 +427,7 @@ class CuaDriverBackend(ComputerUseBackend):
 
         # Step 2: capture.
         png_b64: Optional[str] = None
-        elements: List[UIElement] = []
+        elements: list[UIElement] = []
         width = height = 0
         window_title = ""
 
@@ -489,7 +489,7 @@ class CuaDriverBackend(ComputerUseBackend):
         y: Optional[int] = None,
         button: str = "left",
         click_count: int = 1,
-        modifiers: Optional[List[str]] = None,
+        modifiers: Optional[list[str]] = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
@@ -504,7 +504,7 @@ class CuaDriverBackend(ComputerUseBackend):
         else:
             tool = "click"
 
-        args: Dict[str, Any] = {"pid": pid}
+        args: dict[str, Any] = {"pid": pid}
         if element is not None:
             if self._active_window_id is None:
                 return ActionResult(ok=False, action=tool,
@@ -527,16 +527,16 @@ class CuaDriverBackend(ComputerUseBackend):
         *,
         from_element: Optional[int] = None,
         to_element: Optional[int] = None,
-        from_xy: Optional[Tuple[int, int]] = None,
-        to_xy: Optional[Tuple[int, int]] = None,
+        from_xy: Optional[tuple[int, int]] = None,
+        to_xy: Optional[tuple[int, int]] = None,
         button: str = "left",
-        modifiers: Optional[List[str]] = None,
+        modifiers: Optional[list[str]] = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="drag",
                                 message="No active window — call capture() first.")
-        args: Dict[str, Any] = {"pid": pid}
+        args: dict[str, Any] = {"pid": pid}
         if from_element is not None and to_element is not None:
             if self._active_window_id is None:
                 return ActionResult(ok=False, action="drag",
@@ -560,13 +560,13 @@ class CuaDriverBackend(ComputerUseBackend):
         element: Optional[int] = None,
         x: Optional[int] = None,
         y: Optional[int] = None,
-        modifiers: Optional[List[str]] = None,
+        modifiers: Optional[list[str]] = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
             return ActionResult(ok=False, action="scroll",
                                 message="No active window — call capture() first.")
-        args: Dict[str, Any] = {
+        args: dict[str, Any] = {
             "pid": pid,
             "direction": direction,
             "amount": max(1, min(50, amount)),
@@ -615,7 +615,7 @@ class CuaDriverBackend(ComputerUseBackend):
         if element is None:
             return ActionResult(ok=False, action="set_value",
                                 message="set_value requires element= (element index).")
-        args: Dict[str, Any] = {
+        args: dict[str, Any] = {
             "pid": pid,
             "window_id": window_id,
             "element_index": element,
@@ -624,7 +624,7 @@ class CuaDriverBackend(ComputerUseBackend):
         return self._action("set_value", args)
 
     # ── Introspection ──────────────────────────────────────────────
-    def list_apps(self) -> List[Dict[str, Any]]:
+    def list_apps(self) -> list[dict[str, Any]]:
         out = self._session.call_tool("list_apps", {})
         data = out["data"]
         if isinstance(data, list):
@@ -692,7 +692,7 @@ class CuaDriverBackend(ComputerUseBackend):
                             message=f"No on-screen window found for app '{app}'.")
 
     # ── Internal ───────────────────────────────────────────────────
-    def _action(self, name: str, args: Dict[str, Any]) -> ActionResult:
+    def _action(self, name: str, args: dict[str, Any]) -> ActionResult:
         try:
             out = self._session.call_tool(name, args)
         except Exception as e:
@@ -709,7 +709,7 @@ class CuaDriverBackend(ComputerUseBackend):
                             meta=data if isinstance(data, dict) else {})
 
 
-def _parse_element(d: Dict[str, Any]) -> UIElement:
+def _parse_element(d: dict[str, Any]) -> UIElement:
     bounds = d.get("bounds") or (0, 0, 0, 0)
     if isinstance(bounds, dict):
         bounds = (

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -13,7 +13,7 @@ from typing import Any, Dict
 
 # One consolidated tool with an `action` discriminator. Keeps the schema
 # compact and the per-turn token cost low.
-COMPUTER_USE_SCHEMA: Dict[str, Any] = {
+COMPUTER_USE_SCHEMA: dict[str, Any] = {
     "name": "computer_use",
     "description": (
         "Drive the macOS desktop in the background — screenshots, mouse, "
@@ -208,6 +208,6 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
 }
 
 
-def get_computer_use_schema() -> Dict[str, Any]:
+def get_computer_use_schema() -> dict[str, Any]:
     """Return the generic OpenAI function-calling schema."""
     return COMPUTER_USE_SCHEMA

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -160,7 +160,7 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
     """Test/CI stub. Records calls; returns trivial results."""
 
     def __init__(self) -> None:
-        self.calls: List[Tuple[str, Dict[str, Any]]] = []
+        self.calls: list[tuple[str, dict[str, Any]]] = []
         self._started = False
 
     def start(self) -> None: self._started = True
@@ -192,7 +192,7 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("key", {"keys": keys}))
         return ActionResult(ok=True, action="key")
 
-    def list_apps(self) -> List[Dict[str, Any]]:
+    def list_apps(self) -> list[dict[str, Any]]:
         self.calls.append(("list_apps", {}))
         return []
 
@@ -209,7 +209,7 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
 # Dispatch
 # ---------------------------------------------------------------------------
 
-def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
+def handle_computer_use(args: dict[str, Any], **kwargs) -> Any:
     """Main entry point — dispatched by tools.registry.
 
     Returns either a JSON string (text-only) or a dict marked `_multimodal`
@@ -261,7 +261,7 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         return json.dumps({"error": f"{action} failed: {e}"})
 
 
-def _request_approval(action: str, args: Dict[str, Any]) -> Optional[str]:
+def _request_approval(action: str, args: dict[str, Any]) -> Optional[str]:
     """Return None if approved, or a JSON error string if denied."""
     global _session_auto_approve, _always_allow
     if _session_auto_approve:
@@ -289,7 +289,7 @@ def _request_approval(action: str, args: Dict[str, Any]) -> Optional[str]:
     return json.dumps({"error": "denied by user", "action": action})
 
 
-def _summarize_action(action: str, args: Dict[str, Any]) -> str:
+def _summarize_action(action: str, args: dict[str, Any]) -> str:
     if action in {"click", "double_click", "right_click", "middle_click"}:
         if args.get("element") is not None:
             return f"{action} element #{args['element']}"
@@ -313,7 +313,7 @@ def _summarize_action(action: str, args: Dict[str, Any]) -> str:
     return action
 
 
-def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) -> Any:
+def _dispatch(backend: ComputerUseBackend, action: str, args: dict[str, Any]) -> Any:
     capture_after = bool(args.get("capture_after"))
 
     if action == "capture":
@@ -412,7 +412,7 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
 # ---------------------------------------------------------------------------
 
 def _text_response(res: ActionResult) -> str:
-    payload: Dict[str, Any] = {"ok": res.ok, "action": res.action}
+    payload: dict[str, Any] = {"ok": res.ok, "action": res.action}
     if res.message:
         payload["message"] = res.message
     if res.meta:
@@ -521,7 +521,7 @@ def _capture_response(cap: CaptureResult, max_elements: int = _DEFAULT_MAX_ELEME
             f"raise max_elements or pass app= to narrow)"
         )
     summary = "\n".join(summary_lines)
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "mode": cap.mode,
         "width": cap.width,
         "height": cap.height,
@@ -708,8 +708,8 @@ def _maybe_follow_capture(
     return json.dumps(data)
 
 
-def _format_elements(elements: List[UIElement], max_lines: int = 40) -> List[str]:
-    out: List[str] = []
+def _format_elements(elements: list[UIElement], max_lines: int = 40) -> list[str]:
+    out: list[str] = []
     for e in elements[:max_lines]:
         label = e.label.replace("\n", " ")[:60]
         out.append(f"  #{e.index} {e.role} {label!r} @ {e.bounds}"
@@ -719,7 +719,7 @@ def _format_elements(elements: List[UIElement], max_lines: int = 40) -> List[str
     return out
 
 
-def _element_to_dict(e: UIElement) -> Dict[str, Any]:
+def _element_to_dict(e: UIElement) -> dict[str, Any]:
     return {
         "index": e.index,
         "role": e.role,
@@ -744,6 +744,6 @@ def check_computer_use_requirements() -> bool:
     return cua_driver_binary_available()
 
 
-def get_computer_use_schema() -> Dict[str, Any]:
+def get_computer_use_schema() -> dict[str, Any]:
     from tools.computer_use.schema import COMPUTER_USE_SCHEMA
     return COMPUTER_USE_SCHEMA

--- a/tools/computer_use/vision_routing.py
+++ b/tools/computer_use/vision_routing.py
@@ -49,7 +49,7 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 
-def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
+def _explicit_aux_vision_override(cfg: Optional[dict[str, Any]]) -> bool:
     """True when ``auxiliary.vision`` carries a non-default user override.
 
     Mirrors ``agent.image_routing._explicit_aux_vision_override`` so the
@@ -118,7 +118,7 @@ def _provider_accepts_multimodal_tool_result(provider: str, model: str) -> Optio
 def should_route_capture_to_aux_vision(
     provider: str,
     model: str,
-    cfg: Optional[Dict[str, Any]],
+    cfg: Optional[dict[str, Any]],
 ) -> bool:
     """Return True iff the captured screenshot should be pre-analysed via aux vision.
 

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -31,21 +31,21 @@ logger = logging.getLogger(__name__)
 
 # Session-scoped list of credential files to mount.
 # Backed by ContextVar to prevent cross-session data bleed in the gateway pipeline.
-_registered_files_var: ContextVar[Dict[str, str]] = ContextVar("_registered_files")
+_registered_files_var: ContextVar[dict[str, str]] = ContextVar("_registered_files")
 
 
-def _get_registered() -> Dict[str, str]:
+def _get_registered() -> dict[str, str]:
     """Get or create the registered credential files dict for the current context/session."""
     try:
         return _registered_files_var.get()
     except LookupError:
-        val: Dict[str, str] = {}
+        val: dict[str, str] = {}
         _registered_files_var.set(val)
         return val
 
 
 # Cache for config-based file list (loaded once per process).
-_config_files: List[Dict[str, str]] | None = None
+_config_files: list[dict[str, str]] | None = None
 
 
 def _resolve_hermes_home() -> Path:
@@ -106,7 +106,7 @@ def register_credential_file(
 def register_credential_files(
     entries: list,
     container_base: str = "/root/.hermes",
-) -> List[str]:
+) -> list[str]:
     """Register multiple credential files from skill frontmatter entries.
 
     Each entry is either a string (relative path) or a dict with a ``path``
@@ -128,13 +128,13 @@ def register_credential_files(
     return missing
 
 
-def _load_config_files() -> List[Dict[str, str]]:
+def _load_config_files() -> list[dict[str, str]]:
     """Load ``terminal.credential_files`` from config.yaml (cached)."""
     global _config_files
     if _config_files is not None:
         return _config_files
 
-    result: List[Dict[str, str]] = []
+    result: list[dict[str, str]] = []
     try:
         from hermes_cli.config import read_raw_config
         hermes_home = _resolve_hermes_home()
@@ -173,13 +173,13 @@ def _load_config_files() -> List[Dict[str, str]]:
     return _config_files
 
 
-def get_credential_file_mounts() -> List[Dict[str, str]]:
+def get_credential_file_mounts() -> list[dict[str, str]]:
     """Return all credential files that should be mounted into remote sandboxes.
 
     Each item has ``host_path`` and ``container_path`` keys.
     Combines skill-registered files and user config.
     """
-    mounts: Dict[str, str] = {}
+    mounts: dict[str, str] = {}
 
     # Skill-registered files
     for container_path, host_path in _get_registered().items():
@@ -201,7 +201,7 @@ def get_credential_file_mounts() -> List[Dict[str, str]]:
 
 def get_skills_directory_mount(
     container_base: str = "/root/.hermes",
-) -> list[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Return mount info for all skill directories (local + external).
 
     Skills may include ``scripts/``, ``templates/``, and ``references/``
@@ -292,7 +292,7 @@ def _safe_skills_path(skills_dir: Path) -> str:
 
 def iter_skills_files(
     container_base: str = "/root/.hermes",
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Yield individual (host_path, container_path) entries for skills files.
 
     Includes both the local skills dir and any external dirs configured via
@@ -300,7 +300,7 @@ def iter_skills_files(
     that upload files individually (Daytona, Modal) rather than mounting a
     directory.
     """
-    result: List[Dict[str, str]] = []
+    result: list[dict[str, str]] = []
 
     hermes_home = _resolve_hermes_home()
     skills_dir = hermes_home / "skills"
@@ -352,7 +352,7 @@ _CACHE_DIRS: list[tuple[str, str]] = [
 
 def get_cache_directory_mounts(
     container_base: str = "/root/.hermes",
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Return mount entries for each cache directory that exists on disk.
 
     Used by Docker to create bind mounts.  Each entry has ``host_path`` and
@@ -361,7 +361,7 @@ def get_cache_directory_mounts(
     """
     from hermes_constants import get_hermes_dir
 
-    mounts: List[Dict[str, str]] = []
+    mounts: list[dict[str, str]] = []
     for new_subpath, old_name in _CACHE_DIRS:
         host_dir = get_hermes_dir(new_subpath, old_name)
         if host_dir.is_dir():
@@ -404,7 +404,7 @@ def to_agent_visible_cache_path(
 
 def iter_cache_files(
     container_base: str = "/root/.hermes",
-) -> List[Dict[str, str]]:
+) -> list[dict[str, str]]:
     """Return individual (host_path, container_path) entries for cache files.
 
     Used by Modal to upload files individually and resync before each command.
@@ -412,7 +412,7 @@ def iter_cache_files(
     """
     from hermes_constants import get_hermes_dir
 
-    result: List[Dict[str, str]] = []
+    result: list[dict[str, str]] = []
     for new_subpath, old_name in _CACHE_DIRS:
         host_dir = get_hermes_dir(new_subpath, old_name)
         if not host_dir.is_dir():

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -140,7 +140,7 @@ def _scan_cron_prompt(prompt: str) -> str:
     return ""
 
 
-def _origin_from_env() -> Optional[Dict[str, str]]:
+def _origin_from_env() -> Optional[dict[str, str]]:
     from gateway.session_context import get_session_env
     origin_platform = get_session_env("HERMES_SESSION_PLATFORM")
     origin_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
@@ -160,7 +160,7 @@ def _origin_from_env() -> Optional[Dict[str, str]]:
     return None
 
 
-def _repeat_display(job: Dict[str, Any]) -> str:
+def _repeat_display(job: dict[str, Any]) -> str:
     times = (job.get("repeat") or {}).get("times")
     completed = (job.get("repeat") or {}).get("completed", 0)
     if times is None:
@@ -170,7 +170,7 @@ def _repeat_display(job: Dict[str, Any]) -> str:
     return f"{completed}/{times}" if completed else f"{times} times"
 
 
-def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
+def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None) -> list[str]:
     if skills is None:
         raw_items = [skill] if skill else []
     elif isinstance(skills, str):
@@ -178,7 +178,7 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
     else:
         raw_items = list(skills)
 
-    normalized: List[str] = []
+    normalized: list[str] = []
     for item in raw_items:
         text = str(item or "").strip()
         if text and text not in normalized:
@@ -188,7 +188,7 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
 
 
 
-def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
+def _resolve_model_override(model_obj: Optional[dict[str, Any]]) -> tuple:
     """Resolve a model override object into (provider, model) for job storage.
 
     If provider is omitted, pins the current main provider from config so the
@@ -291,7 +291,7 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     return None
 
 
-def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
+def _format_job(job: dict[str, Any]) -> dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
@@ -340,14 +340,14 @@ def cronjob(
     deliver: Optional[str] = None,
     include_disabled: bool = False,
     skill: Optional[str] = None,
-    skills: Optional[List[str]] = None,
+    skills: Optional[list[str]] = None,
     model: Optional[str] = None,
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
-    context_from: Optional[Union[str, List[str]]] = None,
-    enabled_toolsets: Optional[List[str]] = None,
+    context_from: Optional[Union[str, list[str]]] = None,
+    enabled_toolsets: Optional[list[str]] = None,
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
@@ -500,7 +500,7 @@ def cronjob(
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "update":
-            updates: Dict[str, Any] = {}
+            updates: dict[str, Any] = {}
             if prompt is not None:
                 scan_error = _scan_cron_prompt(prompt)
                 if scan_error:

--- a/tools/debug_helpers.py
+++ b/tools/debug_helpers.py
@@ -45,7 +45,7 @@ class DebugSession:
         self.enabled = os.getenv(env_var, "false").lower() == "true"
         self.session_id = str(uuid.uuid4()) if self.enabled else ""
         self.log_dir = get_hermes_home() / "logs"
-        self._calls: list[Dict[str, Any]] = []
+        self._calls: list[dict[str, Any]] = []
         self._start_time = datetime.datetime.now().isoformat() if self.enabled else ""
 
         if self.enabled:
@@ -57,7 +57,7 @@ class DebugSession:
     def active(self) -> bool:
         return self.enabled
 
-    def log_call(self, call_name: str, call_data: Dict[str, Any]) -> None:
+    def log_call(self, call_name: str, call_data: dict[str, Any]) -> None:
         """Append a tool-call entry to the in-memory log."""
         if not self.enabled:
             return
@@ -88,7 +88,7 @@ class DebugSession:
         except Exception as e:
             logger.error("Error saving %s debug log: %s", self.tool_name, e)
 
-    def get_session_info(self) -> Dict[str, Any]:
+    def get_session_info(self) -> dict[str, Any]:
         """Return a summary dict suitable for returning from get_debug_session_info()."""
         if not self.enabled:
             return {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -152,7 +152,7 @@ _spawn_paused: bool = False
 _active_subagents_lock = threading.Lock()
 # subagent_id -> mutable record tracking the live child agent.  Stays only
 # for the lifetime of the run; _run_single_child is the owner.
-_active_subagents: Dict[str, Dict[str, Any]] = {}
+_active_subagents: dict[str, dict[str, Any]] = {}
 
 
 def set_spawn_paused(paused: bool) -> bool:
@@ -172,7 +172,7 @@ def is_spawn_paused() -> bool:
         return _spawn_paused
 
 
-def _register_subagent(record: Dict[str, Any]) -> None:
+def _register_subagent(record: dict[str, Any]) -> None:
     sid = record.get("subagent_id")
     if not sid:
         return
@@ -208,7 +208,7 @@ def interrupt_subagent(subagent_id: str) -> bool:
     return True
 
 
-def list_active_subagents() -> List[Dict[str, Any]]:
+def list_active_subagents() -> list[dict[str, Any]]:
     """Snapshot of the currently running subagent tree.
 
     Each record: {subagent_id, parent_id, depth, goal, model, started_at,
@@ -222,11 +222,11 @@ def list_active_subagents() -> List[Dict[str, Any]]:
 
 
 def _extract_output_tail(
-    result: Dict[str, Any],
+    result: dict[str, Any],
     *,
     max_entries: int = 12,
     max_chars: int = 8000,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Pull the last N tool-call results from a child's conversation.
 
     Powers the overlay's "Output" section — the cc-swarm-parity feature.
@@ -239,8 +239,8 @@ def _extract_output_tail(
         return []
 
     # Walk in reverse to build a tail; stop when we have enough.
-    tail: List[Dict[str, Any]] = []
-    pending_call_by_id: Dict[str, str] = {}
+    tail: list[dict[str, Any]] = []
+    pending_call_by_id: dict[str, str] = {}
 
     # First pass (forward): build tool_call_id -> tool_name map
     for msg in messages:
@@ -499,8 +499,8 @@ def _expand_parent_toolsets(parent_toolsets: set) -> set:
 
 
 def _preserve_parent_mcp_toolsets(
-    child_toolsets: List[str], parent_toolsets: set[str]
-) -> List[str]:
+    child_toolsets: list[str], parent_toolsets: set[str]
+) -> list[str]:
     """Append any parent MCP toolsets that are missing from a narrowed child."""
     preserved = list(child_toolsets)
     for toolset_name in sorted(parent_toolsets):
@@ -552,7 +552,7 @@ class DelegateEvent(str, enum.Enum):
 
 # Legacy event strings → DelegateEvent mapping.
 # Incoming child-agent events use the old names; the callback normalises them.
-_LEGACY_EVENT_MAP: Dict[str, DelegateEvent] = {
+_LEGACY_EVENT_MAP: dict[str, DelegateEvent] = {
     "_thinking": DelegateEvent.TASK_THINKING,
     "reasoning.available": DelegateEvent.TASK_THINKING,
     "tool.started": DelegateEvent.TASK_TOOL_STARTED,
@@ -669,7 +669,7 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     return None
 
 
-def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
+def _strip_blocked_tools(toolsets: list[str]) -> list[str]:
     """Remove toolsets that contain only blocked tools."""
     blocked_toolset_names = {
         "delegation",
@@ -690,7 +690,7 @@ def _build_child_progress_callback(
     parent_id: Optional[str] = None,
     depth: Optional[int] = None,
     model: Optional[str] = None,
-    toolsets: Optional[List[str]] = None,
+    toolsets: Optional[list[str]] = None,
 ) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -719,11 +719,11 @@ def _build_child_progress_callback(
 
     # Gateway: batch tool names, flush periodically
     _BATCH_SIZE = 5
-    _batch: List[str] = []
+    _batch: list[str] = []
     _tool_count = [0]  # per-subagent running counter (list for closure mutation)
 
-    def _identity_kwargs() -> Dict[str, Any]:
-        kw: Dict[str, Any] = {
+    def _identity_kwargs() -> dict[str, Any]:
+        kw: dict[str, Any] = {
             "task_index": task_index,
             "task_count": task_count,
             "goal": goal_label,
@@ -871,7 +871,7 @@ def _build_child_agent(
     task_index: int,
     goal: str,
     context: Optional[str],
-    toolsets: Optional[List[str]],
+    toolsets: Optional[list[str]],
     model: Optional[str],
     max_iterations: int,
     task_count: int,
@@ -883,7 +883,7 @@ def _build_child_agent(
     override_api_mode: Optional[str] = None,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
-    override_acp_args: Optional[List[str]] = None,
+    override_acp_args: Optional[list[str]] = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1211,7 +1211,7 @@ def _dump_subagent_timeout_diagnostic(
         ts = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
         dump_path = logs_dir / f"subagent-timeout-{subagent_id}-{ts}.log"
 
-        lines: List[str] = []
+        lines: list[str] = []
         def _w(line: str = "") -> None:
             lines.append(line)
 
@@ -1324,7 +1324,7 @@ def _run_single_child(
     child=None,
     parent_agent=None,
     **_kwargs,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Run a pre-built child agent. Called from within a thread.
     Returns a structured result dict.
@@ -1500,7 +1500,7 @@ def _run_single_child(
         )
         # Capture the worker thread so the timeout diagnostic can dump its
         # Python stack (see #14726 — 0-API-call hangs are opaque without it).
-        _worker_thread_holder: Dict[str, Optional[threading.Thread]] = {"t": None}
+        _worker_thread_holder: dict[str, Optional[threading.Thread]] = {"t": None}
 
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
@@ -1634,8 +1634,8 @@ def _run_single_child(
 
         # Build tool trace from conversation messages (already in memory).
         # Uses tool_call_id to correctly pair parallel tool calls with results.
-        tool_trace: list[Dict[str, Any]] = []
-        trace_by_id: Dict[str, Dict[str, Any]] = {}
+        tool_trace: list[dict[str, Any]] = []
+        trace_by_id: dict[str, dict[str, Any]] = {}
         messages = result.get("messages") or []
         if isinstance(messages, list):
             for msg in messages:
@@ -1681,7 +1681,7 @@ def _run_single_child(
         _output_tokens = getattr(child, "session_completion_tokens", 0)
         _model = getattr(child, "model", None)
 
-        entry: Dict[str, Any] = {
+        entry: dict[str, Any] = {
             "task_index": task_index,
             "status": status,
             "summary": summary,
@@ -1780,7 +1780,7 @@ def _run_single_child(
 
         _output_tail = _extract_output_tail(result, max_entries=8, max_chars=600)
 
-        complete_kwargs: Dict[str, Any] = {
+        complete_kwargs: dict[str, Any] = {
             "preview": summary[:160] if summary else entry.get("error", ""),
             "status": status,
             "duration_seconds": duration,
@@ -1894,7 +1894,7 @@ def _run_single_child(
 
 def _recover_tasks_from_json_string(
     tasks: Any,
-) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+) -> tuple[Optional[list[dict[str, Any]]], Optional[str]]:
     if not isinstance(tasks, str):
         return None, None
     raw = tasks.strip()
@@ -1918,11 +1918,11 @@ def _recover_tasks_from_json_string(
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
-    toolsets: Optional[List[str]] = None,
-    tasks: Optional[List[Dict[str, Any]]] = None,
+    toolsets: Optional[list[str]] = None,
+    tasks: Optional[list[dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
-    acp_args: Optional[List[str]] = None,
+    acp_args: Optional[list[str]] = None,
     role: Optional[str] = None,
     parent_agent=None,
 ) -> str:

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -59,8 +59,8 @@ def _discord_request(
     method: str,
     path: str,
     token: str,
-    params: Optional[Dict[str, str]] = None,
-    body: Optional[Dict[str, Any]] = None,
+    params: Optional[dict[str, str]] = None,
+    body: Optional[dict[str, Any]] = None,
     timeout: int = 15,
 ) -> Any:
     """Make a request to the Discord REST API."""
@@ -132,10 +132,10 @@ def _channel_type_name(type_id: int) -> str:
 # ---------------------------------------------------------------------------
 
 # Module-level cache so the app/me endpoint is hit at most once per process.
-_capability_cache: Dict[str, Dict[str, Any]] = {}
+_capability_cache: dict[str, dict[str, Any]] = {}
 
 
-def _detect_capabilities(token: str, *, force: bool = False) -> Dict[str, Any]:
+def _detect_capabilities(token: str, *, force: bool = False) -> dict[str, Any]:
     """Detect the bot's app-wide capabilities via GET /applications/@me.
 
     Returns a dict with keys:
@@ -151,7 +151,7 @@ def _detect_capabilities(token: str, *, force: bool = False) -> Dict[str, Any]:
     if token in _capability_cache and not force:
         return _capability_cache[token]
 
-    caps: Dict[str, Any] = {
+    caps: dict[str, Any] = {
         "has_members_intent": True,
         "has_message_content": True,
         "detected": False,
@@ -224,8 +224,8 @@ def _list_channels(token: str, guild_id: str, **_kwargs: Any) -> str:
     channels = _discord_request("GET", f"/guilds/{guild_id}/channels", token)
 
     # Organize: categories first, then channels under each
-    categories: Dict[Optional[str], Dict[str, Any]] = {}
-    uncategorized: List[Dict[str, Any]] = []
+    categories: dict[Optional[str], dict[str, Any]] = {}
+    uncategorized: list[dict[str, Any]] = []
 
     # First pass: collect categories
     for ch in channels:
@@ -261,7 +261,7 @@ def _list_channels(token: str, guild_id: str, **_kwargs: Any) -> str:
         cat["channels"].sort(key=lambda c: c["position"])
     uncategorized.sort(key=lambda c: c["position"])
 
-    result: List[Dict[str, Any]] = []
+    result: list[dict[str, Any]] = []
     if uncategorized:
         result.append({"category": None, "channels": uncategorized})
     for cat in sorted_cats:
@@ -358,7 +358,7 @@ def _fetch_messages(
         limit = int(limit)
     except (TypeError, ValueError):
         limit = 50
-    params: Dict[str, str] = {"limit": str(min(limit, 100))}
+    params: dict[str, str] = {"limit": str(min(limit, 100))}
     if before:
         params["before"] = before
     if after:
@@ -434,7 +434,7 @@ def _create_thread(
     if message_id:
         # Create thread from an existing message
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
-        body: Dict[str, Any] = {
+        body: dict[str, Any] = {
             "name": name,
             "auto_archive_duration": auto_archive_duration,
         }
@@ -497,7 +497,7 @@ _ADMIN_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _ADMIN_ACTION_NAMES}
 # Single-source-of-truth manifest: action → (signature, one-line description).
 # Consumed by :func:`_build_schema` so the schema's top-level description
 # always matches the registered action set.
-_ACTION_MANIFEST: List[Tuple[str, str, str]] = [
+_ACTION_MANIFEST: list[tuple[str, str, str]] = [
     ("list_guilds", "()", "list servers the bot is in"),
     ("server_info", "(guild_id)", "server details + member counts"),
     ("list_channels", "(guild_id)", "all channels grouped by category"),
@@ -519,7 +519,7 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
 _INTENT_GATED_MEMBERS = frozenset({"member_info", "search_members"})
 
 # Per-action required params for runtime validation.
-_REQUIRED_PARAMS: Dict[str, List[str]] = {
+_REQUIRED_PARAMS: dict[str, list[str]] = {
     "server_info": ["guild_id"],
     "list_channels": ["guild_id"],
     "list_roles": ["guild_id"],
@@ -541,7 +541,7 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
 # Config-based action allowlist
 # ---------------------------------------------------------------------------
 
-def _load_allowed_actions_config() -> Optional[List[str]]:
+def _load_allowed_actions_config() -> Optional[list[str]]:
     """Read ``discord.server_actions`` from user config.
 
     Returns a list of allowed action names, or ``None`` if the user
@@ -583,14 +583,14 @@ def _load_allowed_actions_config() -> Optional[List[str]]:
 
 
 def _available_actions(
-    caps: Dict[str, Any],
-    allowlist: Optional[List[str]],
-) -> List[str]:
+    caps: dict[str, Any],
+    allowlist: Optional[list[str]],
+) -> list[str]:
     """Compute the visible action list from intents + config allowlist.
 
     Preserves the canonical order from :data:`_ACTIONS`.
     """
-    actions: List[str] = []
+    actions: list[str] = []
     for name in _ACTIONS:
         # Intent filter
         if not caps.get("has_members_intent", True) and name in _INTENT_GATED_MEMBERS:
@@ -607,10 +607,10 @@ def _available_actions(
 # ---------------------------------------------------------------------------
 
 def _build_schema(
-    actions: List[str],
-    caps: Optional[Dict[str, Any]] = None,
+    actions: list[str],
+    caps: Optional[dict[str, Any]] = None,
     tool_name: str = "discord",
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     """Build the tool schema for the given filtered action list.
 
     Returns ``None`` when *actions* is empty — callers should drop the
@@ -660,7 +660,7 @@ def _build_schema(
             f"{content_note}"
         )
 
-    properties: Dict[str, Any] = {
+    properties: dict[str, Any] = {
         "action": {
             "type": "string",
             "enum": actions,
@@ -726,9 +726,9 @@ def _build_schema(
 
 
 def _get_dynamic_schema(
-    action_subset: Dict[str, Any],
+    action_subset: dict[str, Any],
     tool_name: str,
-) -> Optional[Dict[str, Any]]:
+) -> Optional[dict[str, Any]]:
     """Build a dynamic schema for *action_subset* filtered by intents + config."""
     token = _get_bot_token()
     if not token:
@@ -741,15 +741,15 @@ def _get_dynamic_schema(
     return _build_schema(actions, caps, tool_name=tool_name)
 
 
-def get_dynamic_schema_core() -> Optional[Dict[str, Any]]:
+def get_dynamic_schema_core() -> Optional[dict[str, Any]]:
     return _get_dynamic_schema(_CORE_ACTIONS, "discord")
 
 
-def get_dynamic_schema_admin() -> Optional[Dict[str, Any]]:
+def get_dynamic_schema_admin() -> Optional[dict[str, Any]]:
     return _get_dynamic_schema(_ADMIN_ACTIONS, "discord_admin")
 
 
-def get_dynamic_schema() -> Optional[Dict[str, Any]]:
+def get_dynamic_schema() -> Optional[dict[str, Any]]:
     """Backward-compat wrapper — returns core schema."""
     return get_dynamic_schema_core()
 
@@ -826,7 +826,7 @@ def check_discord_tool_requirements() -> bool:
 
 def _run_discord_action(
     action: str,
-    valid_actions: Dict[str, Any],
+    valid_actions: dict[str, Any],
     tool_label: str,
     guild_id: str = "",
     channel_id: str = "",

--- a/tools/environments/managed_modal.py
+++ b/tools/environments/managed_modal.py
@@ -48,7 +48,7 @@ class ManagedModalEnvironment(BaseModalExecutionEnvironment):
         image: str,
         cwd: str = "/root",
         timeout: int = 60,
-        modal_sandbox_kwargs: Optional[Dict[str, Any]] = None,
+        modal_sandbox_kwargs: Optional[dict[str, Any]] = None,
         persistent_filesystem: bool = True,
         task_id: str = "default",
     ):
@@ -71,7 +71,7 @@ class ManagedModalEnvironment(BaseModalExecutionEnvironment):
 
     def _start_modal_exec(self, prepared: PreparedModalExec) -> ModalExecStart:
         exec_id = str(uuid.uuid4())
-        payload: Dict[str, Any] = {
+        payload: dict[str, Any] = {
             "execId": exec_id,
             "command": prepared.command,
             "cwd": prepared.cwd,
@@ -227,9 +227,9 @@ class ManagedModalEnvironment(BaseModalExecutionEnvironment):
             )
 
     def _request(self, method: str, path: str, *,
-                 json: Dict[str, Any] | None = None,
+                 json: dict[str, Any] | None = None,
                  timeout: int = 30,
-                 extra_headers: Dict[str, str] | None = None) -> requests.Response:
+                 extra_headers: dict[str, str] | None = None) -> requests.Response:
         headers = {
             "Authorization": f"Bearer {self._nous_user_token}",
             "Content-Type": "application/json",

--- a/tools/fal_common.py
+++ b/tools/fal_common.py
@@ -116,13 +116,13 @@ class _ManagedFalSyncClient:
     def submit(
         self,
         application: str,
-        arguments: Dict[str, Any],
+        arguments: dict[str, Any],
         *,
         path: str = "",
         hint: Optional[str] = None,
         webhook_url: Optional[str] = None,
         priority: Any = None,
-        headers: Optional[Dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
         start_timeout: Optional[Union[int, float]] = None,
     ):
         url = self._queue_url_format + application

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -62,7 +62,7 @@ def _strip_terminal_fence_leaks(text: str) -> str:
     if not text:
         return text
 
-    cleaned_lines: List[str] = []
+    cleaned_lines: list[str] = []
     for line in text.splitlines(keepends=True):
         had_terminal_wrapper = "__HERMES_FENCE_" in line or "\x1b]" in line
         cleaned = _OSC_SEQUENCE_RE.sub("", line)
@@ -108,7 +108,7 @@ class ReadResult:
     mime_type: Optional[str] = None
     dimensions: Optional[str] = None  # For images: "WIDTHxHEIGHT"
     error: Optional[str] = None
-    similar_files: List[str] = field(default_factory=list)
+    similar_files: list[str] = field(default_factory=list)
     
     def to_dict(self) -> dict:
         return {k: v for k, v in self.__dict__.items() if v is not None and v != []}
@@ -119,7 +119,7 @@ class WriteResult:
     """Result from writing a file."""
     bytes_written: int = 0
     dirs_created: bool = False
-    lint: Optional[Dict[str, Any]] = None
+    lint: Optional[dict[str, Any]] = None
     # Semantic diagnostics from the LSP layer, when applicable.  Kept in
     # its own field (not folded into ``lint``) so the model and any
     # downstream parsers can read syntax errors and semantic errors as
@@ -139,10 +139,10 @@ class PatchResult:
     """Result from patching a file."""
     success: bool = False
     diff: str = ""
-    files_modified: List[str] = field(default_factory=list)
-    files_created: List[str] = field(default_factory=list)
-    files_deleted: List[str] = field(default_factory=list)
-    lint: Optional[Dict[str, Any]] = None
+    files_modified: list[str] = field(default_factory=list)
+    files_created: list[str] = field(default_factory=list)
+    files_deleted: list[str] = field(default_factory=list)
+    lint: Optional[dict[str, Any]] = None
     # See :class:`WriteResult.lsp_diagnostics`.
     lsp_diagnostics: Optional[str] = None
     error: Optional[str] = None
@@ -178,9 +178,9 @@ class SearchMatch:
 @dataclass
 class SearchResult:
     """Result from searching."""
-    matches: List[SearchMatch] = field(default_factory=list)
-    files: List[str] = field(default_factory=list)
-    counts: Dict[str, int] = field(default_factory=dict)
+    matches: list[SearchMatch] = field(default_factory=list)
+    files: list[str] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
     total_count: int = 0
     truncated: bool = False
     error: Optional[str] = None
@@ -579,7 +579,7 @@ class ShellFileOperations(FileOperations):
                    getattr(getattr(terminal_env, 'config', None), 'cwd', None) or "/"
 
         # Cache for command availability checks
-        self._command_cache: Dict[str, bool] = {}
+        self._command_cache: dict[str, bool] = {}
     
     def _exec(self, command: str, cwd: str = None, timeout: int = None,
               stdin_data: str = None) -> ExecuteResult:

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -45,7 +45,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 # (mtime, read_ts, partial).  partial=True when read_file returned a
 # windowed view (offset > 1 or limit < total_lines) — writes that happen
 # after a partial read should still warn so the model re-reads in full.
-ReadStamp = Tuple[float, float, bool]
+ReadStamp = tuple[float, float, bool]
 
 # Number of resolved-path entries retained per agent.  Bounded to keep
 # long sessions from accumulating unbounded state.  On overflow we drop
@@ -60,9 +60,9 @@ class FileStateRegistry:
     """Process-wide coordinator for cross-agent file edits."""
 
     def __init__(self) -> None:
-        self._reads: Dict[str, Dict[str, ReadStamp]] = defaultdict(dict)
-        self._last_writer: Dict[str, Tuple[str, float]] = {}
-        self._path_locks: Dict[str, threading.Lock] = {}
+        self._reads: dict[str, dict[str, ReadStamp]] = defaultdict(dict)
+        self._last_writer: dict[str, tuple[str, float]] = {}
+        self._path_locks: dict[str, threading.Lock] = {}
         self._meta_lock = threading.Lock()  # guards _path_locks
         self._state_lock = threading.Lock()  # guards _reads + _last_writer
 
@@ -220,7 +220,7 @@ class FileStateRegistry:
         exclude_task_id: str,
         since_ts: float,
         paths: Iterable[str],
-    ) -> Dict[str, List[str]]:
+    ) -> dict[str, list[str]]:
         """Return ``{writer_task_id: [paths]}`` for writes done after
         ``since_ts`` by agents OTHER than ``exclude_task_id``.
 
@@ -230,7 +230,7 @@ class FileStateRegistry:
         if _disabled():
             return {}
         paths_set = set(paths)
-        out: Dict[str, List[str]] = defaultdict(list)
+        out: dict[str, list[str]] = defaultdict(list)
         with self._state_lock:
             for p, (writer_tid, ts) in self._last_writer.items():
                 if writer_tid == exclude_task_id:
@@ -241,7 +241,7 @@ class FileStateRegistry:
                     out[writer_tid].append(p)
         return dict(out)
 
-    def known_reads(self, task_id: str) -> List[str]:
+    def known_reads(self, task_id: str) -> list[str]:
         """Return the list of resolved paths this agent has read."""
         if _disabled():
             return []
@@ -312,11 +312,11 @@ def writes_since(
     exclude_task_id: str,
     since_ts: float,
     paths: Iterable[str | Path],
-) -> Dict[str, List[str]]:
+) -> dict[str, list[str]]:
     return _registry.writes_since(exclude_task_id, since_ts, [str(p) for p in paths])
 
 
-def known_reads(task_id: str) -> List[str]:
+def known_reads(task_id: str) -> list[str]:
     return _registry.known_reads(task_id)
 
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -48,7 +48,7 @@ def _unicode_normalize(text: str) -> str:
 
 
 def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
-                            replace_all: bool = False) -> Tuple[str, int, Optional[str], Optional[str]]:
+                            replace_all: bool = False) -> tuple[str, int, Optional[str], Optional[str]]:
     """
     Find and replace text using a chain of increasingly fuzzy matching strategies.
 
@@ -70,7 +70,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
         return content, 0, None, "old_string and new_string are identical"
 
     # Try each matching strategy in order
-    strategies: List[Tuple[str, Callable]] = [
+    strategies: list[tuple[str, Callable]] = [
         ("exact", _strategy_exact),
         ("line_trimmed", _strategy_line_trimmed),
         ("whitespace_normalized", _strategy_whitespace_normalized),
@@ -116,7 +116,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
     return content, 0, None, "Could not find a match for old_string in the file"
 
 
-def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
+def _detect_escape_drift(content: str, matches: list[tuple[int, int]],
                          old_string: str, new_string: str) -> Optional[str]:
     """Detect tool-call escape-drift artifacts in new_string.
 
@@ -156,7 +156,7 @@ def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
     return None
 
 
-def _apply_replacements(content: str, matches: List[Tuple[int, int]], new_string: str) -> str:
+def _apply_replacements(content: str, matches: list[tuple[int, int]], new_string: str) -> str:
     """
     Apply replacements at the given positions.
     
@@ -183,7 +183,7 @@ def _apply_replacements(content: str, matches: List[Tuple[int, int]], new_string
 # Matching Strategies
 # =============================================================================
 
-def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_exact(content: str, pattern: str) -> list[tuple[int, int]]:
     """Strategy 1: Exact string match."""
     matches = []
     start = 0
@@ -196,7 +196,7 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
     return matches
 
 
-def _strategy_line_trimmed(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_line_trimmed(content: str, pattern: str) -> list[tuple[int, int]]:
     """
     Strategy 2: Match with line-by-line whitespace trimming.
     
@@ -216,7 +216,7 @@ def _strategy_line_trimmed(content: str, pattern: str) -> List[Tuple[int, int]]:
     )
 
 
-def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_whitespace_normalized(content: str, pattern: str) -> list[tuple[int, int]]:
     """
     Strategy 3: Collapse multiple whitespace to single space.
     """
@@ -237,7 +237,7 @@ def _strategy_whitespace_normalized(content: str, pattern: str) -> List[Tuple[in
     return _map_normalized_positions(content, content_normalized, matches_in_normalized)
 
 
-def _strategy_indentation_flexible(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_indentation_flexible(content: str, pattern: str) -> list[tuple[int, int]]:
     """
     Strategy 4: Ignore indentation differences entirely.
     
@@ -253,7 +253,7 @@ def _strategy_indentation_flexible(content: str, pattern: str) -> List[Tuple[int
     )
 
 
-def _strategy_escape_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_escape_normalized(content: str, pattern: str) -> list[tuple[int, int]]:
     """
     Strategy 5: Convert escape sequences to actual characters.
     
@@ -272,7 +272,7 @@ def _strategy_escape_normalized(content: str, pattern: str) -> List[Tuple[int, i
     return _strategy_exact(content, pattern_unescaped)
 
 
-def _strategy_trimmed_boundary(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_trimmed_boundary(content: str, pattern: str) -> list[tuple[int, int]]:
     """
     Strategy 6: Trim whitespace from first and last lines only.
     
@@ -314,7 +314,7 @@ def _strategy_trimmed_boundary(content: str, pattern: str) -> List[Tuple[int, in
     return matches
 
 
-def _build_orig_to_norm_map(original: str) -> List[int]:
+def _build_orig_to_norm_map(original: str) -> list[int]:
     """Build a list mapping each original character index to its normalized index.
 
     Because UNICODE_MAP replacements may expand characters (e.g. em-dash → '--',
@@ -325,7 +325,7 @@ def _build_orig_to_norm_map(original: str) -> List[int]:
     Returns a list of length ``len(original) + 1``; entry ``i`` is the
     normalised index that character ``i`` maps to.
     """
-    result: List[int] = []
+    result: list[int] = []
     norm_pos = 0
     for char in original:
         result.append(norm_pos)
@@ -336,9 +336,9 @@ def _build_orig_to_norm_map(original: str) -> List[int]:
 
 
 def _map_positions_norm_to_orig(
-    orig_to_norm: List[int],
-    norm_matches: List[Tuple[int, int]],
-) -> List[Tuple[int, int]]:
+    orig_to_norm: list[int],
+    norm_matches: list[tuple[int, int]],
+) -> list[tuple[int, int]]:
     """Convert (start, end) positions in the normalised string to original positions."""
     # Invert the map: norm_pos -> first original position with that norm_pos
     norm_to_orig_start: dict[int, int] = {}
@@ -346,7 +346,7 @@ def _map_positions_norm_to_orig(
         if norm_pos not in norm_to_orig_start:
             norm_to_orig_start[norm_pos] = orig_pos
 
-    results: List[Tuple[int, int]] = []
+    results: list[tuple[int, int]] = []
     orig_len = len(orig_to_norm) - 1  # number of original characters
 
     for norm_start, norm_end in norm_matches:
@@ -364,7 +364,7 @@ def _map_positions_norm_to_orig(
     return results
 
 
-def _strategy_unicode_normalized(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_unicode_normalized(content: str, pattern: str) -> list[tuple[int, int]]:
     """Strategy 7: Unicode normalisation.
 
     Normalises smart quotes, em/en-dashes, ellipsis, and non-breaking spaces
@@ -395,7 +395,7 @@ def _strategy_unicode_normalized(content: str, pattern: str) -> List[Tuple[int, 
     return _map_positions_norm_to_orig(orig_to_norm, norm_matches)
 
 
-def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_block_anchor(content: str, pattern: str) -> list[tuple[int, int]]:
     """
     Strategy 8: Match by anchoring on first and last lines.
     Adjusted with permissive thresholds and unicode normalization.
@@ -451,7 +451,7 @@ def _strategy_block_anchor(content: str, pattern: str) -> List[Tuple[int, int]]:
     return matches
 
 
-def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]:
+def _strategy_context_aware(content: str, pattern: str) -> list[tuple[int, int]]:
     """
     Strategy 9: Line-by-line similarity with 50% threshold.
     
@@ -490,8 +490,8 @@ def _strategy_context_aware(content: str, pattern: str) -> List[Tuple[int, int]]
 # Helper Functions
 # =============================================================================
 
-def _calculate_line_positions(content_lines: List[str], start_line: int,
-                              end_line: int, content_length: int) -> Tuple[int, int]:
+def _calculate_line_positions(content_lines: list[str], start_line: int,
+                              end_line: int, content_length: int) -> tuple[int, int]:
     """Calculate start and end character positions from line indices.
 
     Args:
@@ -509,9 +509,9 @@ def _calculate_line_positions(content_lines: List[str], start_line: int,
     return start_pos, end_pos
 
 
-def _find_normalized_matches(content: str, content_lines: List[str],
-                              content_normalized_lines: List[str],
-                              pattern: str, pattern_normalized: str) -> List[Tuple[int, int]]:
+def _find_normalized_matches(content: str, content_lines: list[str],
+                              content_normalized_lines: list[str],
+                              pattern: str, pattern_normalized: str) -> list[tuple[int, int]]:
     """
     Find matches in normalized content and map back to original positions.
     
@@ -545,7 +545,7 @@ def _find_normalized_matches(content: str, content_lines: List[str],
 
 
 def _map_normalized_positions(original: str, normalized: str,
-                               normalized_matches: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
+                               normalized_matches: list[tuple[int, int]]) -> list[tuple[int, int]]:
     """
     Map positions from normalized string back to original.
     

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -60,7 +60,7 @@ _BLOCKED_DOMAINS = frozenset({
 })
 
 
-def _get_headers(token: str = "") -> Dict[str, str]:
+def _get_headers(token: str = "") -> dict[str, str]:
     """Return authorization headers for HA REST API."""
     if not token:
         _, token = _get_config()
@@ -78,7 +78,7 @@ def _filter_and_summarize(
     states: list,
     domain: Optional[str] = None,
     area: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Filter raw HA states by domain/area and return a compact summary."""
     if domain:
         states = [s for s in states if s.get("entity_id", "").startswith(f"{domain}.")]
@@ -105,7 +105,7 @@ def _filter_and_summarize(
 async def _async_list_entities(
     domain: Optional[str] = None,
     area: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Fetch entity states from HA and optionally filter by domain/area."""
     import aiohttp
 
@@ -119,7 +119,7 @@ async def _async_list_entities(
     return _filter_and_summarize(states, domain, area)
 
 
-async def _async_get_state(entity_id: str) -> Dict[str, Any]:
+async def _async_get_state(entity_id: str) -> dict[str, Any]:
     """Fetch detailed state of a single entity."""
     import aiohttp
 
@@ -141,10 +141,10 @@ async def _async_get_state(entity_id: str) -> Dict[str, Any]:
 
 def _build_service_payload(
     entity_id: Optional[str] = None,
-    data: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    data: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """Build the JSON payload for a HA service call."""
-    payload: Dict[str, Any] = {}
+    payload: dict[str, Any] = {}
     if data:
         payload.update(data)
     # entity_id parameter takes precedence over data["entity_id"]
@@ -157,7 +157,7 @@ def _parse_service_response(
     domain: str,
     service: str,
     result: Any,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Parse HA service call response into a structured result."""
     affected = []
     if isinstance(result, list):
@@ -178,8 +178,8 @@ async def _async_call_service(
     domain: str,
     service: str,
     entity_id: Optional[str] = None,
-    data: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    data: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """Call a Home Assistant service."""
     import aiohttp
 
@@ -292,7 +292,7 @@ def _handle_call_service(args: dict, **kw) -> str:
 # List services
 # ---------------------------------------------------------------------------
 
-async def _async_list_services(domain: Optional[str] = None) -> Dict[str, Any]:
+async def _async_list_services(domain: Optional[str] = None) -> dict[str, Any]:
     """Fetch available services from HA and optionally filter by domain."""
     import aiohttp
 
@@ -313,7 +313,7 @@ async def _async_list_services(domain: Optional[str] = None) -> Dict[str, Any]:
         d = svc_domain.get("domain", "")
         domain_services = {}
         for svc_name, svc_info in svc_domain.get("services", {}).items():
-            svc_entry: Dict[str, Any] = {"description": svc_info.get("description", "")}
+            svc_entry: dict[str, Any] = {"description": svc_info.get("description", "")}
             fields = svc_info.get("fields", {})
             if fields:
                 svc_entry["fields"] = {

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -93,7 +93,7 @@ logger = logging.getLogger(__name__)
 #
 # ``upscale`` controls whether to chain Clarity Upscaler after generation.
 
-FAL_MODELS: Dict[str, Dict[str, Any]] = {
+FAL_MODELS: dict[str, dict[str, Any]] = {
     "fal-ai/flux-2/klein/9b": {
         "display": "FLUX 2 Klein 9B",
         "speed": "<1s",
@@ -381,7 +381,7 @@ def _get_managed_fal_client(managed_gateway):
         return _managed_fal_client
 
 
-def _submit_fal_request(model: str, arguments: Dict[str, Any]):
+def _submit_fal_request(model: str, arguments: dict[str, Any]):
     """Submit a FAL request using direct credentials or the managed queue gateway."""
     # Trigger the lazy import on first call. Idempotent.
     _load_fal_client()
@@ -457,8 +457,8 @@ def _build_fal_payload(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
     seed: Optional[int] = None,
-    overrides: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    overrides: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """Build a FAL request payload for `model_id` from unified inputs.
 
     Translates aspect_ratio into the model's native size spec (preset enum,
@@ -473,7 +473,7 @@ def _build_fal_payload(
     if aspect not in sizes:
         aspect = DEFAULT_ASPECT_RATIO
 
-    payload: Dict[str, Any] = dict(meta.get("defaults", {}))
+    payload: dict[str, Any] = dict(meta.get("defaults", {}))
     payload["prompt"] = (prompt or "").strip()
 
     if size_style in {"image_size_preset", "gpt_literal"}:
@@ -498,7 +498,7 @@ def _build_fal_payload(
 # ---------------------------------------------------------------------------
 # Upscaler
 # ---------------------------------------------------------------------------
-def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, Any]]:
+def _upscale_image(image_url: str, original_prompt: str) -> Optional[dict[str, Any]]:
     """Upscale an image using FAL.ai's Clarity Upscaler.
 
     Returns upscaled image dict, or None on failure (caller falls back to
@@ -602,7 +602,7 @@ def image_generate_tool(
             )
             aspect_lc = DEFAULT_ASPECT_RATIO
 
-        overrides: Dict[str, Any] = {}
+        overrides: dict[str, Any] = {}
         if num_inference_steps is not None:
             overrides["num_inference_steps"] = num_inference_steps
         if guidance_scale is not None:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -364,7 +364,7 @@ _MCP_INJECTION_PATTERNS = [
 ]
 
 
-def _scan_mcp_description(server_name: str, tool_name: str, description: str) -> List[str]:
+def _scan_mcp_description(server_name: str, tool_name: str, description: str) -> list[str]:
     """Scan an MCP tool description for prompt injection patterns.
 
     Returns a list of finding strings (empty = clean).
@@ -584,10 +584,10 @@ def _format_connect_error(exc: BaseException) -> str:
                     return missing
         return None
 
-    def _flatten_messages(current: BaseException) -> List[str]:
+    def _flatten_messages(current: BaseException) -> list[str]:
         nested = getattr(current, "exceptions", None)
         if nested:
-            flattened: List[str] = []
+            flattened: list[str] = []
             for child in nested:
                 flattened.extend(_flatten_messages(child))
             return flattened
@@ -612,7 +612,7 @@ def _format_connect_error(exc: BaseException) -> str:
             )
         return _sanitize_error(message)
 
-    deduped: List[str] = []
+    deduped: list[str] = []
     for item in _flatten_messages(exc):
         if item not in deduped:
             deduped.append(item)
@@ -670,7 +670,7 @@ class SamplingHandler:
         )
 
         # Per-instance state
-        self._rate_timestamps: List[float] = []
+        self._rate_timestamps: list[float] = []
         self._tool_loop_count = 0
         self.metrics = {"requests": 0, "errors": 0, "tokens_used": 0, "tool_use_count": 0}
 
@@ -708,7 +708,7 @@ class SamplingHandler:
         items = block.content if isinstance(block.content, list) else [block.content]
         return "\n".join(item.text for item in items if hasattr(item, "text"))
 
-    def _convert_messages(self, params) -> List[dict]:
+    def _convert_messages(self, params) -> list[dict]:
         """Convert MCP SamplingMessages to OpenAI format.
 
         Uses ``msg.content_as_list`` (SDK helper) so single-block and
@@ -716,7 +716,7 @@ class SamplingHandler:
         with ``isinstance`` on real SDK types when available, falling back
         to duck-typing via ``hasattr`` for compatibility.
         """
-        messages: List[dict] = []
+        messages: list[dict] = []
         for msg in params.messages:
             blocks = msg.content_as_list if hasattr(msg, "content_as_list") else (
                 msg.content if isinstance(msg.content, list) else [msg.content]
@@ -1715,7 +1715,7 @@ class MCPServerTask:
 # Module-level state
 # ---------------------------------------------------------------------------
 
-_servers: Dict[str, MCPServerTask] = {}
+_servers: dict[str, MCPServerTask] = {}
 
 # Circuit breaker: consecutive error counts per server.  After
 # _CIRCUIT_BREAKER_THRESHOLD consecutive failures, the handler returns
@@ -1734,8 +1734,8 @@ _servers: Dict[str, MCPServerTask] = {}
 # the breaker most recently transitioned into the open state. Use the
 # ``_bump_server_error`` / ``_reset_server_error`` helpers to mutate
 # this state — they keep the count and timestamp in sync.
-_server_error_counts: Dict[str, int] = {}
-_server_breaker_opened_at: Dict[str, float] = {}
+_server_error_counts: dict[str, int] = {}
+_server_breaker_opened_at: dict[str, float] = {}
 _CIRCUIT_BREAKER_THRESHOLD = 3
 _CIRCUIT_BREAKER_COOLDOWN_SEC = 60.0
 
@@ -2083,7 +2083,7 @@ _parallel_safe_servers: set = set()
 # ``b_tool`` or server ``a_b`` + tool ``tool``). Keep the server component
 # captured at registration time so parallel safety never relies on prefix
 # guessing.
-_mcp_tool_server_names: Dict[str, str] = {}
+_mcp_tool_server_names: dict[str, str] = {}
 
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -2097,7 +2097,7 @@ _lock = threading.Lock()
 # them on shutdown if the graceful cleanup (SDK context-manager teardown)
 # fails or times out.  PIDs are added after connection and removed on
 # normal server shutdown.
-_stdio_pids: Dict[int, str] = {}  # pid -> server_name
+_stdio_pids: dict[int, str] = {}  # pid -> server_name
 
 # PIDs that survived their session context exit (SDK teardown failed to
 # terminate them).  These are detected in _run_stdio's finally block and
@@ -2243,7 +2243,7 @@ def _interpolate_env_vars(value):
     return value
 
 
-def _load_mcp_config() -> Dict[str, dict]:
+def _load_mcp_config() -> dict[str, dict]:
     """Read ``mcp_servers`` from the Hermes config file.
 
     Returns a dict of ``{server_name: server_config}`` or empty dict.
@@ -2364,7 +2364,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # both too stale to cherry-pick. #10848's approach (integrate with
             # Hermes' MEDIA tag + cache_image_from_bytes) was the cleaner of
             # the two — plugs into existing infrastructure.
-            parts: List[str] = []
+            parts: list[str] = []
             for block in (result.content or []):
                 if hasattr(block, "text") and block.text:
                     parts.append(block.text)
@@ -2519,7 +2519,7 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
             async with server._rpc_lock:
                 result = await server.session.read_resource(uri)
             # read_resource returns ReadResourceResult with .contents list
-            parts: List[str] = []
+            parts: list[str] = []
             contents = result.contents if hasattr(result, "contents") else []
             for block in contents:
                 if hasattr(block, "text"):
@@ -2847,7 +2847,7 @@ def _convert_mcp_schema(server_name: str, mcp_tool) -> dict:
     }
 
 
-def _build_utility_schemas(server_name: str) -> List[dict]:
+def _build_utility_schemas(server_name: str) -> list[dict]:
     """Build schemas for the MCP utility tools (resources & prompts).
 
     Returns a list of (schema, handler_factory_name) tuples encoded as dicts
@@ -2986,7 +2986,7 @@ def _forget_mcp_tool_server(tool_name: str) -> None:
         _mcp_tool_server_names.pop(tool_name, None)
 
 
-def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> List[dict]:
+def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dict) -> list[dict]:
     """Select utility schemas based on config and server capabilities."""
     tools_filter = config.get("tools") or {}
     resources_enabled = _parse_boolish(tools_filter.get("resources"), default=True)
@@ -3002,7 +3002,7 @@ def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dic
     if init_result is not None:
         advertised_caps = getattr(init_result, "capabilities", None)
 
-    selected: List[dict] = []
+    selected: list[dict] = []
     for entry in _build_utility_schemas(server_name):
         handler_key = entry["handler_key"]
         if handler_key in {"list_resources", "read_resource"} and not resources_enabled:
@@ -3043,9 +3043,9 @@ def _select_utility_schemas(server_name: str, server: MCPServerTask, config: dic
     return selected
 
 
-def _existing_tool_names() -> List[str]:
+def _existing_tool_names() -> list[str]:
     """Return tool names for all currently connected servers."""
-    names: List[str] = []
+    names: list[str] = []
     for _sname, server in _servers.items():
         if hasattr(server, "_registered_tool_names"):
             names.extend(server._registered_tool_names)
@@ -3056,7 +3056,7 @@ def _existing_tool_names() -> List[str]:
     return names
 
 
-def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> List[str]:
+def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> list[str]:
     """Register tools from an already-connected server into the registry.
 
     Handles include/exclude filtering and utility tools. Toolset resolution
@@ -3070,7 +3070,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     """
     from tools.registry import registry
 
-    registered_names: List[str] = []
+    registered_names: list[str] = []
     toolset_name = f"mcp-{name}"
 
     # Selective tool loading: honour include/exclude lists from config.
@@ -3166,7 +3166,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     return registered_names
 
 
-async def _discover_and_register_server(name: str, config: dict) -> List[str]:
+async def _discover_and_register_server(name: str, config: dict) -> list[str]:
     """Connect to a single MCP server, discover tools, and register them.
 
     Returns list of registered tool names.
@@ -3195,7 +3195,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
 # Public API
 # ---------------------------------------------------------------------------
 
-def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
+def register_mcp_servers(servers: dict[str, dict]) -> list[str]:
     """Connect to explicit MCP servers and register their tools.
 
     Idempotent for already-connected server names. Servers with
@@ -3236,7 +3236,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     # Start the background event loop for MCP connections
     _ensure_mcp_loop()
 
-    async def _discover_one(name: str, cfg: dict) -> List[str]:
+    async def _discover_one(name: str, cfg: dict) -> list[str]:
         """Connect to a single server and return its registered tool names."""
         return await _discover_and_register_server(name, cfg)
 
@@ -3290,7 +3290,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
     return _existing_tool_names()
 
 
-def discover_mcp_tools() -> List[str]:
+def discover_mcp_tools() -> list[str]:
     """Entry point: load config, connect to MCP servers, register tools.
 
     Called from ``model_tools`` after ``discover_builtin_tools()``. Safe to call even when
@@ -3357,13 +3357,13 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return bool(server_name and server_name in _parallel_safe_servers)
 
 
-def get_mcp_status() -> List[dict]:
+def get_mcp_status() -> list[dict]:
     """Return status of all configured MCP servers for banner display.
 
     Returns a list of dicts with keys: name, transport, tools, connected.
     Includes both successfully connected servers and configured-but-failed ones.
     """
-    result: List[dict] = []
+    result: list[dict] = []
 
     # Get configured servers from config
     configured = _load_mcp_config()
@@ -3397,7 +3397,7 @@ def get_mcp_status() -> List[dict]:
     return result
 
 
-def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
+def probe_mcp_server_tools() -> dict[str, list[tuple]]:
     """Temporarily connect to configured MCP servers and list their tools.
 
     Designed for ``hermes tools`` interactive configuration — connects to each
@@ -3424,8 +3424,8 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
 
     _ensure_mcp_loop()
 
-    result: Dict[str, List[tuple]] = {}
-    probed_servers: List[MCPServerTask] = []
+    result: dict[str, list[tuple]] = {}
+    probed_servers: list[MCPServerTask] = []
 
     async def _probe_all():
         names = list(enabled.keys())
@@ -3529,7 +3529,7 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
     import signal as _signal
 
     with _lock:
-        pids: Dict[int, str] = {}
+        pids: dict[int, str] = {}
         for opid in _orphan_stdio_pids:
             pids[opid] = "orphan"
         _orphan_stdio_pids.clear()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -105,7 +105,7 @@ def _scan_memory_content(content: str) -> Optional[str]:
     return None
 
 
-def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
+def _drift_error(path: "Path", bak_path: str) -> dict[str, Any]:
     """Build the error dict returned when external drift is detected.
 
     The on-disk memory file contains content that wouldn't round-trip
@@ -147,12 +147,12 @@ class MemoryStore:
     """
 
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
-        self.memory_entries: List[str] = []
-        self.user_entries: List[str] = []
+        self.memory_entries: list[str] = []
+        self.user_entries: list[str] = []
         self.memory_char_limit = memory_char_limit
         self.user_char_limit = user_char_limit
         # Frozen snapshot for system prompt -- set once at load_from_disk()
-        self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
+        self._system_prompt_snapshot: dict[str, str] = {"memory": "", "user": ""}
 
     def load_from_disk(self):
         """Load entries from MEMORY.md and USER.md, capture system prompt snapshot."""
@@ -239,12 +239,12 @@ class MemoryStore:
         get_memory_dir().mkdir(parents=True, exist_ok=True)
         self._write_file(self._path_for(target), self._entries_for(target))
 
-    def _entries_for(self, target: str) -> List[str]:
+    def _entries_for(self, target: str) -> list[str]:
         if target == "user":
             return self.user_entries
         return self.memory_entries
 
-    def _set_entries(self, target: str, entries: List[str]):
+    def _set_entries(self, target: str, entries: list[str]):
         if target == "user":
             self.user_entries = entries
         else:
@@ -261,7 +261,7 @@ class MemoryStore:
             return self.user_char_limit
         return self.memory_char_limit
 
-    def add(self, target: str, content: str) -> Dict[str, Any]:
+    def add(self, target: str, content: str) -> dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
         if not content:
@@ -311,7 +311,7 @@ class MemoryStore:
 
         return self._success_response(target, "Entry added.")
 
-    def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
+    def replace(self, target: str, old_text: str, new_content: str) -> dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
         old_text = old_text.strip()
         new_content = new_content.strip()
@@ -371,7 +371,7 @@ class MemoryStore:
 
         return self._success_response(target, "Entry replaced.")
 
-    def remove(self, target: str, old_text: str) -> Dict[str, Any]:
+    def remove(self, target: str, old_text: str) -> dict[str, Any]:
         """Remove the entry containing old_text substring."""
         old_text = old_text.strip()
         if not old_text:
@@ -422,7 +422,7 @@ class MemoryStore:
 
     # -- Internal helpers --
 
-    def _success_response(self, target: str, message: str = None) -> Dict[str, Any]:
+    def _success_response(self, target: str, message: str = None) -> dict[str, Any]:
         entries = self._entries_for(target)
         current = self._char_count(target)
         limit = self._char_limit(target)
@@ -439,7 +439,7 @@ class MemoryStore:
             resp["message"] = message
         return resp
 
-    def _render_block(self, target: str, entries: List[str]) -> str:
+    def _render_block(self, target: str, entries: list[str]) -> str:
         """Render a system prompt block with header and usage indicator."""
         if not entries:
             return ""
@@ -458,7 +458,7 @@ class MemoryStore:
         return f"{separator}\n{header}\n{separator}\n{content}"
 
     @staticmethod
-    def _read_file(path: Path) -> List[str]:
+    def _read_file(path: Path) -> list[str]:
         """Read a memory file and split into entries.
 
         No file locking needed: _write_file uses atomic rename, so readers
@@ -535,7 +535,7 @@ class MemoryStore:
         return str(bak_path)
 
     @staticmethod
-    def _write_file(path: Path, entries: List[str]):
+    def _write_file(path: Path, entries: list[str]):
         """Write entries to a memory file using atomic temp-file + rename.
 
         Previous implementation used open("w") + flock, but "w" truncates the

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -87,7 +87,7 @@ Responses from models:"""
 _debug = DebugSession("moa_tools", env_var="MOA_TOOLS_DEBUG")
 
 
-def _construct_aggregator_prompt(system_prompt: str, responses: List[str]) -> str:
+def _construct_aggregator_prompt(system_prompt: str, responses: list[str]) -> str:
     """
     Construct the final system prompt for the aggregator including all model responses.
     
@@ -235,7 +235,7 @@ async def _run_aggregator_model(
 
 async def mixture_of_agents_tool(
     user_prompt: str,
-    reference_models: Optional[List[str]] = None,
+    reference_models: Optional[list[str]] = None,
     aggregator_model: Optional[str] = None
 ) -> str:
     """
@@ -420,7 +420,7 @@ def check_moa_requirements() -> bool:
 
 
 
-def get_moa_configuration() -> Dict[str, Any]:
+def get_moa_configuration() -> dict[str, Any]:
     """
     Get the current MoA configuration settings.
     

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -74,7 +74,7 @@ def _infer_ecosystem(command: str) -> Optional[str]:
 
 def _parse_package_from_args(
     args: list, ecosystem: str
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str]]:
     """Extract package name and optional version from command args.
 
     Returns (package_name, version) or (None, None) if not parseable.
@@ -102,7 +102,7 @@ def _parse_package_from_args(
     return package_token, None
 
 
-def _parse_npm_package(token: str) -> Tuple[Optional[str], Optional[str]]:
+def _parse_npm_package(token: str) -> tuple[Optional[str], Optional[str]]:
     """Parse npm package: @scope/name@version or name@version."""
     if token.startswith("@"):
         # Scoped: @scope/name@version
@@ -119,7 +119,7 @@ def _parse_npm_package(token: str) -> Tuple[Optional[str], Optional[str]]:
     return token, None
 
 
-def _parse_pypi_package(token: str) -> Tuple[Optional[str], Optional[str]]:
+def _parse_pypi_package(token: str) -> tuple[Optional[str], Optional[str]]:
     """Parse PyPI package: name==version or name[extras]==version."""
     # Strip extras: name[extra1,extra2]==version
     match = re.match(r"^([a-zA-Z0-9._-]+)(?:\[[^\]]*\])?(?:==(.+))?$", token)

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -53,7 +53,7 @@ class HunkLine:
 class Hunk:
     """A group of changes within a file."""
     context_hint: Optional[str] = None
-    lines: List[HunkLine] = field(default_factory=list)
+    lines: list[HunkLine] = field(default_factory=list)
 
 
 @dataclass
@@ -62,11 +62,11 @@ class PatchOperation:
     operation: OperationType
     file_path: str
     new_path: Optional[str] = None  # For move operations
-    hunks: List[Hunk] = field(default_factory=list)
+    hunks: list[Hunk] = field(default_factory=list)
     content: Optional[str] = None  # For add file operations
 
 
-def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[str]]:
+def parse_v4a_patch(patch_content: str) -> tuple[list[PatchOperation], Optional[str]]:
     """
     Parse a V4A format patch.
     
@@ -79,7 +79,7 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
         - If failed: ([], error_description)
     """
     lines = patch_content.split('\n')
-    operations: List[PatchOperation] = []
+    operations: list[PatchOperation] = []
     
     # Find patch boundaries
     start_idx = None
@@ -209,7 +209,7 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
         # Empty patch is not an error — callers get [] and can decide
         return operations, None
 
-    parse_errors: List[str] = []
+    parse_errors: list[str] = []
     for op in operations:
         if not op.file_path:
             parse_errors.append("Operation with empty file path")
@@ -238,9 +238,9 @@ def _count_occurrences(text: str, pattern: str) -> int:
 
 
 def _validate_operations(
-    operations: List[PatchOperation],
+    operations: list[PatchOperation],
     file_ops: Any,
-) -> List[str]:
+) -> list[str]:
     """Validate all operations without writing any files.
 
     Returns a list of error strings; an empty list means all operations
@@ -252,7 +252,7 @@ def _validate_operations(
     # Deferred import: breaks the patch_parser ↔ fuzzy_match circular dependency
     from tools.fuzzy_match import fuzzy_find_and_replace
 
-    errors: List[str] = []
+    errors: list[str] = []
 
     for op in operations:
         if op.operation == OperationType.UPDATE:
@@ -328,7 +328,7 @@ def _validate_operations(
     return errors
 
 
-def apply_v4a_operations(operations: List[PatchOperation],
+def apply_v4a_operations(operations: list[PatchOperation],
                           file_ops: Any) -> 'PatchResult':
     """Apply V4A patch operations using a file operations interface.
 
@@ -368,7 +368,7 @@ def apply_v4a_operations(operations: List[PatchOperation],
     # write_file and patch_replace use, so without explicit propagation
     # the LSP tier's output gets silently dropped — see
     # ``PatchResult.lsp_diagnostics`` aggregation below.
-    lsp_blocks: List[str] = []
+    lsp_blocks: list[str] = []
     errors = []
 
     for op in operations:
@@ -452,7 +452,7 @@ def apply_v4a_operations(operations: List[PatchOperation],
     )
 
 
-def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optional[str]]:
+def _apply_add(op: PatchOperation, file_ops: Any) -> tuple[bool, str, Optional[str]]:
     """Apply an add file operation.
 
     Returns ``(success, diff_or_error, lsp_diagnostics)``.  The third
@@ -480,7 +480,7 @@ def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optional[s
     return True, diff, getattr(result, "lsp_diagnostics", None)
 
 
-def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
+def _apply_delete(op: PatchOperation, file_ops: Any) -> tuple[bool, str]:
     """Apply a delete file operation."""
     # Read before deleting so we can produce a real unified diff.
     # Validation already confirmed existence; this guards against races.
@@ -501,7 +501,7 @@ def _apply_delete(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     return True, diff or f"# Deleted: {op.file_path}"
 
 
-def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
+def _apply_move(op: PatchOperation, file_ops: Any) -> tuple[bool, str]:
     """Apply a move file operation."""
     result = file_ops.move_file(op.file_path, op.new_path)
     if result.error:
@@ -511,7 +511,7 @@ def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     return True, diff
 
 
-def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optional[str]]:
+def _apply_update(op: PatchOperation, file_ops: Any) -> tuple[bool, str, Optional[str]]:
     """Apply an update file operation.
 
     Returns ``(success, diff_or_error, lsp_diagnostics)`` — see

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -114,7 +114,7 @@ class ProcessSession:
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
     # Watch patterns — trigger agent notification when output matches any pattern
-    watch_patterns: List[str] = field(default_factory=list)
+    watch_patterns: list[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
     _watch_suppressed: int = field(default=0, repr=False)    # matches dropped by rate limit
     _watch_disabled: bool = field(default=False, repr=False) # permanently killed after strike limit
@@ -153,12 +153,12 @@ class ProcessRegistry:
     )
 
     def __init__(self):
-        self._running: Dict[str, ProcessSession] = {}
-        self._finished: Dict[str, ProcessSession] = {}
+        self._running: dict[str, ProcessSession] = {}
+        self._finished: dict[str, ProcessSession] = {}
         self._lock = threading.Lock()
 
         # Side-channel for check_interval watchers (gateway reads after agent run)
-        self.pending_watchers: List[Dict[str, Any]] = []
+        self.pending_watchers: list[dict[str, Any]] = []
 
         # Notification queue — unified queue for all background process events.
         # Completion notifications (notify_on_complete) and watch pattern matches

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -54,7 +54,7 @@ def _module_registers_tools(module_path: Path) -> bool:
     return any(_is_registry_register_call(stmt) for stmt in tree.body)
 
 
-def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
+def discover_builtin_tools(tools_dir: Optional[Path] = None) -> list[str]:
     """Import built-in self-registering tool modules and return their module names."""
     tools_path = Path(tools_dir) if tools_dir is not None else Path(__file__).resolve().parent
     module_names = [
@@ -64,7 +64,7 @@ def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
         and _module_registers_tools(path)
     ]
 
-    imported: List[str] = []
+    imported: list[str] = []
     for mod_name in module_names:
         try:
             importlib.import_module(mod_name)
@@ -119,7 +119,7 @@ class ToolEntry:
 # ---------------------------------------------------------------------------
 
 _CHECK_FN_TTL_SECONDS = 30.0
-_check_fn_cache: Dict[Callable, tuple[float, bool]] = {}
+_check_fn_cache: dict[Callable, tuple[float, bool]] = {}
 _check_fn_cache_lock = threading.Lock()
 
 
@@ -152,9 +152,9 @@ class ToolRegistry:
     """Singleton registry that collects tool schemas + handlers from tool files."""
 
     def __init__(self):
-        self._tools: Dict[str, ToolEntry] = {}
-        self._toolset_checks: Dict[str, Callable] = {}
-        self._toolset_aliases: Dict[str, str] = {}
+        self._tools: dict[str, ToolEntry] = {}
+        self._toolset_checks: dict[str, Callable] = {}
+        self._toolset_aliases: dict[str, str] = {}
         # MCP dynamic refresh can mutate the registry while other threads are
         # reading tool metadata, so keep mutations serialized and readers on
         # stable snapshots.
@@ -166,16 +166,16 @@ class ToolRegistry:
         # long as the generation hasn't changed.
         self._generation: int = 0
 
-    def _snapshot_state(self) -> tuple[List[ToolEntry], Dict[str, Callable]]:
+    def _snapshot_state(self) -> tuple[list[ToolEntry], dict[str, Callable]]:
         """Return a coherent snapshot of registry entries and toolset checks."""
         with self._lock:
             return list(self._tools.values()), dict(self._toolset_checks)
 
-    def _snapshot_entries(self) -> List[ToolEntry]:
+    def _snapshot_entries(self) -> list[ToolEntry]:
         """Return a stable snapshot of registered tool entries."""
         return self._snapshot_state()[0]
 
-    def _snapshot_toolset_checks(self) -> Dict[str, Callable]:
+    def _snapshot_toolset_checks(self) -> dict[str, Callable]:
         """Return a stable snapshot of toolset availability checks."""
         return self._snapshot_state()[1]
 
@@ -194,11 +194,11 @@ class ToolRegistry:
         with self._lock:
             return self._tools.get(name)
 
-    def get_registered_toolset_names(self) -> List[str]:
+    def get_registered_toolset_names(self) -> list[str]:
         """Return sorted unique toolset names present in the registry."""
         return sorted({entry.toolset for entry in self._snapshot_entries()})
 
-    def get_tool_names_for_toolset(self, toolset: str) -> List[str]:
+    def get_tool_names_for_toolset(self, toolset: str) -> list[str]:
         """Return sorted tool names registered under a given toolset."""
         return sorted(
             entry.name for entry in self._snapshot_entries()
@@ -217,7 +217,7 @@ class ToolRegistry:
             self._toolset_aliases[alias] = toolset
             self._generation += 1
 
-    def get_registered_toolset_aliases(self) -> Dict[str, str]:
+    def get_registered_toolset_aliases(self) -> dict[str, str]:
         """Return a snapshot of ``{alias: canonical_toolset}`` mappings."""
         with self._lock:
             return dict(self._toolset_aliases)
@@ -334,7 +334,7 @@ class ToolRegistry:
     # Schema retrieval
     # ------------------------------------------------------------------
 
-    def get_definitions(self, tool_names: Set[str], quiet: bool = False) -> List[dict]:
+    def get_definitions(self, tool_names: set[str], quiet: bool = False) -> list[dict]:
         """Return OpenAI-format tool schemas for the requested tool names.
 
         Only tools whose ``check_fn()`` returns True (or have no check_fn)
@@ -349,7 +349,7 @@ class ToolRegistry:
         # Per-call cache on top of the 30 s TTL — handles repeat probes of the
         # same check_fn within one definitions pass without re-reading the
         # TTL clock.
-        check_results: Dict[Callable, bool] = {}
+        check_results: dict[Callable, bool] = {}
         entries_by_name = {entry.name: entry for entry in self._snapshot_entries()}
         for name in sorted(tool_names):
             entry = entries_by_name.get(name)
@@ -429,7 +429,7 @@ class ToolRegistry:
         from tools.budget_config import DEFAULT_RESULT_SIZE_CHARS
         return DEFAULT_RESULT_SIZE_CHARS
 
-    def get_all_tool_names(self) -> List[str]:
+    def get_all_tool_names(self) -> list[str]:
         """Return sorted list of all registered tool names."""
         return sorted(entry.name for entry in self._snapshot_entries())
 
@@ -452,7 +452,7 @@ class ToolRegistry:
         entry = self.get_entry(name)
         return (entry.emoji if entry and entry.emoji else default)
 
-    def get_tool_to_toolset_map(self) -> Dict[str, str]:
+    def get_tool_to_toolset_map(self) -> dict[str, str]:
         """Return ``{tool_name: toolset_name}`` for every registered tool."""
         return {entry.name: entry.toolset for entry in self._snapshot_entries()}
 
@@ -466,7 +466,7 @@ class ToolRegistry:
             check = self._toolset_checks.get(toolset)
         return self._evaluate_toolset_check(toolset, check)
 
-    def check_toolset_requirements(self) -> Dict[str, bool]:
+    def check_toolset_requirements(self) -> dict[str, bool]:
         """Return ``{toolset: available_bool}`` for every toolset."""
         entries, toolset_checks = self._snapshot_state()
         toolsets = sorted({entry.toolset for entry in entries})
@@ -475,9 +475,9 @@ class ToolRegistry:
             for toolset in toolsets
         }
 
-    def get_available_toolsets(self) -> Dict[str, dict]:
+    def get_available_toolsets(self) -> dict[str, dict]:
         """Return toolset metadata for UI display."""
-        toolsets: Dict[str, dict] = {}
+        toolsets: dict[str, dict] = {}
         entries, toolset_checks = self._snapshot_state()
         for entry in entries:
             ts = entry.toolset
@@ -497,9 +497,9 @@ class ToolRegistry:
                         toolsets[ts]["requirements"].append(env)
         return toolsets
 
-    def get_toolset_requirements(self) -> Dict[str, dict]:
+    def get_toolset_requirements(self) -> dict[str, dict]:
         """Build a TOOLSET_REQUIREMENTS-compatible dict for backward compat."""
-        result: Dict[str, dict] = {}
+        result: dict[str, dict] = {}
         entries, toolset_checks = self._snapshot_state()
         for entry in entries:
             ts = entry.toolset

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -86,7 +86,7 @@ def _resolve_to_parent(db, session_id: str) -> str:
     return cur
 
 
-def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[str, Any]:
+def _shape_message(m: dict[str, Any], anchor_id: Optional[int] = None) -> dict[str, Any]:
     """Slim a message row for the tool response. Keeps content even if empty."""
     entry = {
         "id": m.get("id"),
@@ -277,7 +277,7 @@ def _scroll(
 def _discover(
     db,
     query: str,
-    role_filter: Optional[List[str]],
+    role_filter: Optional[list[str]],
     limit: int,
     sort: Optional[str],
     current_session_id: str = None,
@@ -429,7 +429,7 @@ def session_search(
         return _list_recent_sessions(db, limit, current_session_id)
 
     # Parse role_filter
-    role_list: Optional[List[str]] = None
+    role_list: Optional[list[str]] = None
     if isinstance(role_filter, str) and role_filter.strip():
         role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -275,7 +275,7 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
     return SKILLS_DIR / name
 
 
-def _find_skill(name: str) -> Optional[Dict[str, Any]]:
+def _find_skill(name: str) -> Optional[dict[str, Any]]:
     """
     Find a skill by name across all skill directories.
 
@@ -295,7 +295,7 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     return None
 
 
-def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
+def _find_skill_in_other_profiles(name: str) -> list[tuple[str, Path]]:
     """Look for ``name`` under SKILL.md across OTHER Hermes profiles.
 
     Returns a list of ``(profile_name, skill_dir)`` pairs. Used to make
@@ -304,7 +304,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     when profile discovery fails — fail-quiet, the caller falls back to
     the plain "not found" error).
     """
-    matches: List[Tuple[str, Path]] = []
+    matches: list[tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
         from agent.skill_utils import is_excluded_skill_path
@@ -319,7 +319,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     # Collect (profile_name, skills_dir) for every profile EXCEPT the
     # one whose SKILLS_DIR we already searched in _find_skill().
     active_dir = SKILLS_DIR.resolve() if SKILLS_DIR.exists() else SKILLS_DIR
-    candidates: List[Tuple[str, Path]] = []
+    candidates: list[tuple[str, Path]] = []
 
     # Default profile (~/.hermes/skills) — only consider when active is non-default.
     default_skills = root / "skills"
@@ -426,7 +426,7 @@ def _validate_file_path(file_path: str) -> Optional[str]:
     return None
 
 
-def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Path], Optional[str]]:
+def _resolve_skill_target(skill_dir: Path, file_path: str) -> tuple[Optional[Path], Optional[str]]:
     """Resolve a supporting-file path and ensure it stays within the skill directory."""
     from tools.path_security import validate_within_dir
 
@@ -473,7 +473,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
 # Core actions
 # =============================================================================
 
-def _create_skill(name: str, content: str, category: str = None) -> Dict[str, Any]:
+def _create_skill(name: str, content: str, category: str = None) -> dict[str, Any]:
     """Create a new user skill with SKILL.md content."""
     # Validate name
     err = _validate_name(name)
@@ -530,7 +530,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     return result
 
 
-def _edit_skill(name: str, content: str) -> Dict[str, Any]:
+def _edit_skill(name: str, content: str) -> dict[str, Any]:
     """Replace the SKILL.md of any existing skill (full rewrite)."""
     err = _validate_frontmatter(content)
     if err:
@@ -569,7 +569,7 @@ def _patch_skill(
     new_string: str,
     file_path: str = None,
     replace_all: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Targeted find-and-replace within a skill file.
 
     Defaults to SKILL.md. Use file_path to patch a supporting file instead.
@@ -657,7 +657,7 @@ def _patch_skill(
     }
 
 
-def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
+def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> dict[str, Any]:
     """Delete a skill.
 
     ``absorbed_into`` declares intent:
@@ -714,7 +714,7 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     }
 
 
-def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
+def _write_file(name: str, file_path: str, file_content: str) -> dict[str, Any]:
     """Add or overwrite a supporting file within any skill directory."""
     err = _validate_file_path(file_path)
     if err:
@@ -766,7 +766,7 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     }
 
 
-def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
+def _remove_file(name: str, file_path: str) -> dict[str, Any]:
     """Remove a supporting file from any skill directory."""
     err = _validate_file_path(file_path)
     if err:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -121,7 +121,7 @@ def _parse_iso_timestamp(value: Any) -> Optional[datetime]:
     return parsed
 
 
-def latest_activity_at(record: Dict[str, Any]) -> Optional[str]:
+def latest_activity_at(record: dict[str, Any]) -> Optional[str]:
     """Return the newest actual activity timestamp for a usage record.
 
     "Activity" means a skill was used, viewed, or patched. Creation time is
@@ -141,7 +141,7 @@ def latest_activity_at(record: Dict[str, Any]) -> Optional[str]:
     return latest_raw
 
 
-def activity_count(record: Dict[str, Any]) -> int:
+def activity_count(record: dict[str, Any]) -> int:
     """Return the total observed activity count across use/view/patch events."""
     total = 0
     for key in ("use_count", "view_count", "patch_count"):
@@ -156,7 +156,7 @@ def activity_count(record: Dict[str, Any]) -> int:
 # Provenance — which skills are agent-created (and thus eligible for curation)
 # ---------------------------------------------------------------------------
 
-def _read_bundled_manifest_names() -> Set[str]:
+def _read_bundled_manifest_names() -> set[str]:
     """Return the set of skill names that were seeded from the bundled repo.
 
     Reads ~/.hermes/skills/.bundled_manifest (format: "name:hash" per line).
@@ -165,7 +165,7 @@ def _read_bundled_manifest_names() -> Set[str]:
     manifest = _skills_dir() / ".bundled_manifest"
     if not manifest.exists():
         return set()
-    names: Set[str] = set()
+    names: set[str] = set()
     try:
         for line in manifest.read_text(encoding="utf-8").splitlines():
             line = line.strip()
@@ -179,7 +179,7 @@ def _read_bundled_manifest_names() -> Set[str]:
     return names
 
 
-def _read_hub_installed_names() -> Set[str]:
+def _read_hub_installed_names() -> set[str]:
     """Return the set of skill names installed via the Skills Hub.
 
     Reads ~/.hermes/skills/.hub/lock.json (see tools/skills_hub.py :: HubLockFile).
@@ -217,7 +217,7 @@ def _read_hub_installed_names() -> Set[str]:
     return set()
 
 
-def list_agent_created_skill_names() -> List[str]:
+def list_agent_created_skill_names() -> list[str]:
     """Enumerate skills explicitly authored by the agent.
 
     The curator operates exclusively on this set. Skills are only eligible
@@ -234,7 +234,7 @@ def list_agent_created_skill_names() -> List[str]:
     off_limits = bundled | hub
     usage = load_usage()
 
-    names: List[str] = []
+    names: list[str] = []
     # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
     for skill_md in base.rglob("SKILL.md"):
         # Skip Hermes metadata, VCS, virtualenv/dependency, and cache dirs
@@ -253,7 +253,7 @@ def list_agent_created_skill_names() -> List[str]:
     return sorted(set(names))
 
 
-def list_archived_skill_names() -> List[str]:
+def list_archived_skill_names() -> list[str]:
     """Enumerate skills in ``~/.hermes/skills/.archive/``.
 
     Archive layout is flat (``.archive/<skill>/``) as set by ``archive_skill``,
@@ -304,7 +304,7 @@ def _is_curator_managed_record(record: Any) -> bool:
 # Sidecar I/O
 # ---------------------------------------------------------------------------
 
-def _empty_record() -> Dict[str, Any]:
+def _empty_record() -> dict[str, Any]:
     return {
         "created_by": None,
         "use_count": 0,
@@ -320,7 +320,7 @@ def _empty_record() -> Dict[str, Any]:
     }
 
 
-def load_usage() -> Dict[str, Dict[str, Any]]:
+def load_usage() -> dict[str, dict[str, Any]]:
     """Read the entire .usage.json map. Returns empty dict on missing/corrupt."""
     path = _usage_file()
     if not path.exists():
@@ -333,14 +333,14 @@ def load_usage() -> Dict[str, Dict[str, Any]]:
     if not isinstance(data, dict):
         return {}
     # Defensive: coerce any non-dict values to a fresh empty record
-    clean: Dict[str, Dict[str, Any]] = {}
+    clean: dict[str, dict[str, Any]] = {}
     for k, v in data.items():
         if isinstance(v, dict):
             clean[str(k)] = v
     return clean
 
 
-def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
+def save_usage(data: dict[str, dict[str, Any]]) -> None:
     """Write the usage map atomically. Best-effort — errors are logged, not raised."""
     path = _usage_file()
     try:
@@ -364,7 +364,7 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
         logger.debug("Failed to write %s: %s", path, e, exc_info=True)
 
 
-def get_record(skill_name: str) -> Dict[str, Any]:
+def get_record(skill_name: str) -> dict[str, Any]:
     """Return the record for *skill_name*, creating a fresh one if missing."""
     data = load_usage()
     rec = data.get(skill_name)
@@ -407,7 +407,7 @@ def _mutate(skill_name: str, mutator) -> None:
 
 def bump_view(skill_name: str) -> None:
     """Bump view_count and last_viewed_at. Called from skill_view()."""
-    def _apply(rec: Dict[str, Any]) -> None:
+    def _apply(rec: dict[str, Any]) -> None:
         rec["view_count"] = int(rec.get("view_count") or 0) + 1
         rec["last_viewed_at"] = _now_iso()
     _mutate(skill_name, _apply)
@@ -416,7 +416,7 @@ def bump_view(skill_name: str) -> None:
 def bump_use(skill_name: str) -> None:
     """Bump use_count and last_used_at. Called when a skill is actively used
     (e.g. loaded into the prompt path or referenced from an assistant turn)."""
-    def _apply(rec: Dict[str, Any]) -> None:
+    def _apply(rec: dict[str, Any]) -> None:
         rec["use_count"] = int(rec.get("use_count") or 0) + 1
         rec["last_used_at"] = _now_iso()
     _mutate(skill_name, _apply)
@@ -424,7 +424,7 @@ def bump_use(skill_name: str) -> None:
 
 def bump_patch(skill_name: str) -> None:
     """Bump patch_count and last_patched_at. Called from skill_manage (patch/edit)."""
-    def _apply(rec: Dict[str, Any]) -> None:
+    def _apply(rec: dict[str, Any]) -> None:
         rec["patch_count"] = int(rec.get("patch_count") or 0) + 1
         rec["last_patched_at"] = _now_iso()
     _mutate(skill_name, _apply)
@@ -436,7 +436,7 @@ def mark_agent_created(skill_name: str) -> None:
     Viewing or invoking a manually authored skill may still create telemetry,
     but only this explicit marker makes it eligible for automatic curation.
     """
-    def _apply(rec: Dict[str, Any]) -> None:
+    def _apply(rec: dict[str, Any]) -> None:
         rec["created_by"] = "agent"
     _mutate(skill_name, _apply)
 
@@ -446,7 +446,7 @@ def set_state(skill_name: str, state: str) -> None:
     if state not in _VALID_STATES:
         logger.debug("set_state: invalid state %r for %s", state, skill_name)
         return
-    def _apply(rec: Dict[str, Any]) -> None:
+    def _apply(rec: dict[str, Any]) -> None:
         rec["state"] = state
         if state == STATE_ARCHIVED:
             rec["archived_at"] = _now_iso()
@@ -456,7 +456,7 @@ def set_state(skill_name: str, state: str) -> None:
 
 
 def set_pinned(skill_name: str, pinned: bool) -> None:
-    def _apply(rec: Dict[str, Any]) -> None:
+    def _apply(rec: dict[str, Any]) -> None:
         rec["pinned"] = bool(pinned)
     _mutate(skill_name, _apply)
 
@@ -479,7 +479,7 @@ def forget(skill_name: str) -> None:
 # Archive / restore
 # ---------------------------------------------------------------------------
 
-def archive_skill(skill_name: str) -> Tuple[bool, str]:
+def archive_skill(skill_name: str) -> tuple[bool, str]:
     """Move an agent-created skill directory to ~/.hermes/skills/.archive/.
 
     Returns (ok, message). Never archives bundled or hub skills — callers are
@@ -518,7 +518,7 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
     return True, f"archived to {dest}"
 
 
-def restore_skill(skill_name: str) -> Tuple[bool, str]:
+def restore_skill(skill_name: str) -> tuple[bool, str]:
     """Move an archived skill back to ~/.hermes/skills/. Restores to the flat
     top-level layout; original category nesting is NOT reconstructed.
 
@@ -588,12 +588,12 @@ def _find_skill_dir(skill_name: str) -> Optional[Path]:
 # Reporting — for the curator CLI / slash command
 # ---------------------------------------------------------------------------
 
-def agent_created_report() -> List[Dict[str, Any]]:
+def agent_created_report() -> list[dict[str, Any]]:
     """Return a list of {name, state, pinned, last_activity_at, ...}
     records for every agent-created skill. Missing usage records are backfilled
     with defaults so callers can always index fields."""
     data = load_usage()
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for name in list_agent_created_skill_names():
         rec = data.get(name)
         if not isinstance(rec, dict):

--- a/tools/skills_ast_audit.py
+++ b/tools/skills_ast_audit.py
@@ -17,18 +17,18 @@ from pathlib import Path
 from typing import List, Tuple
 
 # (file, line, pattern_id, description)
-Finding = Tuple[str, int, str, str]
+Finding = tuple[str, int, str, str]
 
 _IGNORED_DIRS = {"__pycache__", ".venv", "venv", "node_modules"}
 
 
-def _scan_source(content: str, rel_path: str) -> List[Finding]:
+def _scan_source(content: str, rel_path: str) -> list[Finding]:
     try:
         tree = ast.parse(content)
     except (SyntaxError, ValueError, RecursionError):
         return []
 
-    findings: List[Finding] = []
+    findings: list[Finding] = []
 
     class V(ast.NodeVisitor):
         def visit_Call(self, node):
@@ -81,7 +81,7 @@ def _scan_source(content: str, rel_path: str) -> List[Finding]:
     return findings
 
 
-def ast_scan_path(path: Path) -> List[Finding]:
+def ast_scan_path(path: Path) -> list[Finding]:
     """Scan a single .py file or recursively scan all .py under a directory.
 
     Returns a list of (file, line, pattern_id, description) tuples. Empty for
@@ -99,7 +99,7 @@ def ast_scan_path(path: Path) -> List[Finding]:
     if not path.is_dir():
         return []
 
-    out: List[Finding] = []
+    out: list[Finding] = []
     for py in sorted(path.rglob("*.py")):
         if set(py.parent.parts) & _IGNORED_DIRS:
             continue
@@ -115,7 +115,7 @@ def ast_scan_path(path: Path) -> List[Finding]:
     return out
 
 
-def format_ast_report(findings: List[Finding], skill_name: str = "") -> str:
+def format_ast_report(findings: list[Finding], skill_name: str = "") -> str:
     """Plain-text report (Rich-markup-free) grouped by file."""
     header = f"AST deep scan: {skill_name}" if skill_name else "AST deep scan"
     if not findings:

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -74,7 +74,7 @@ class ScanResult:
     source: str
     trust_level: str    # "builtin" | "trusted" | "community"
     verdict: str        # "safe" | "caution" | "dangerous"
-    findings: List[Finding] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
     scanned_at: str = ""
     summary: str = ""
 
@@ -531,7 +531,7 @@ INVISIBLE_CHARS = {
 # Scanning functions
 # ---------------------------------------------------------------------------
 
-def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
+def scan_file(file_path: Path, rel_path: str = "") -> list[Finding]:
     """
     Scan a single file for threat patterns and invisible unicode characters.
 
@@ -615,7 +615,7 @@ def scan_skill(skill_path: Path, source: str = "community") -> ScanResult:
     skill_name = skill_path.name
     trust_level = _resolve_trust_level(source)
 
-    all_findings: List[Finding] = []
+    all_findings: list[Finding] = []
 
     if skill_path.is_dir():
         # Structural checks first
@@ -643,7 +643,7 @@ def scan_skill(skill_path: Path, source: str = "community") -> ScanResult:
     )
 
 
-def should_allow_install(result: ScanResult, force: bool = False) -> Tuple[bool, str]:
+def should_allow_install(result: ScanResult, force: bool = False) -> tuple[bool, str]:
     """
     Determine whether a skill should be installed based on scan result and trust.
 
@@ -754,7 +754,7 @@ def content_hash(skill_path: Path) -> str:
 # Structural checks
 # ---------------------------------------------------------------------------
 
-def _check_structure(skill_dir: Path) -> List[Finding]:
+def _check_structure(skill_dir: Path) -> list[Finding]:
     """
     Check the skill directory for structural anomalies:
     - Too many files
@@ -927,7 +927,7 @@ def _resolve_trust_level(source: str) -> str:
     return "community"
 
 
-def _determine_verdict(findings: List[Finding]) -> str:
+def _determine_verdict(findings: list[Finding]) -> str:
     """Determine the overall verdict from a list of findings."""
     if not findings:
         return "safe"
@@ -943,7 +943,7 @@ def _determine_verdict(findings: List[Finding]) -> str:
     return "safe"
 
 
-def _build_summary(name: str, source: str, trust: str, verdict: str, findings: List[Finding]) -> str:
+def _build_summary(name: str, source: str, trust: str, verdict: str, findings: list[Finding]) -> str:
     """Build a one-line summary of the scan result."""
     if not findings:
         return f"{name}: clean scan, no threats detected"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -76,19 +76,19 @@ class SkillMeta:
     trust_level: str      # "builtin" | "trusted" | "community"
     repo: Optional[str] = None
     path: Optional[str] = None
-    tags: List[str] = field(default_factory=list)
-    extra: Dict[str, Any] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
 class SkillBundle:
     """A downloaded skill ready for quarantine/scanning/installation."""
     name: str
-    files: Dict[str, Union[str, bytes]]   # relative_path -> file content
+    files: dict[str, Union[str, bytes]]   # relative_path -> file content
     source: str
     identifier: str
     trust_level: str
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 def _normalize_bundle_path(path_value: str, *, field_name: str, allow_nested: bool) -> str:
@@ -183,7 +183,7 @@ class GitHubAuth:
         self._cached_method: Optional[str] = None
         self._app_token_expiry: float = 0
 
-    def get_headers(self) -> Dict[str, str]:
+    def get_headers(self) -> dict[str, str]:
         """Return authorization headers for GitHub API requests."""
         token = self._resolve_token()
         headers = {"Accept": "application/vnd.github.v3+json"}
@@ -296,7 +296,7 @@ class SkillSource(ABC):
     """Abstract base for all skill registry adapters."""
 
     @abstractmethod
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         """Search for skills matching a query string."""
         ...
 
@@ -336,14 +336,14 @@ class GitHubSource(SkillSource):
         {"repo": "MiniMax-AI/cli", "path": "skill/"},
     ]
 
-    def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):
+    def __init__(self, auth: GitHubAuth, extra_taps: Optional[list[dict]] = None):
         self.auth = auth
         self.taps = list(self.DEFAULT_TAPS)
         if extra_taps:
             self.taps.extend(extra_taps)
         # Per-instance cache: repo -> (default_branch, tree_entries)
         # Survives within a single search/install flow, avoiding redundant API calls.
-        self._tree_cache: Dict[str, Tuple[str, List[dict]]] = {}
+        self._tree_cache: dict[str, tuple[str, list[dict]]] = {}
         # Set when GitHub returns 403 with rate limit exhausted
         self._rate_limited: bool = False
 
@@ -364,9 +364,9 @@ class GitHubSource(SkillSource):
                 return "trusted"
         return "community"
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         """Search all taps for skills matching the query."""
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
         query_lower = query.lower()
 
         for tap in self.taps:
@@ -462,7 +462,7 @@ class GitHubSource(SkillSource):
 
     # -- Internal helpers --
 
-    def _list_skills_in_repo(self, repo: str, path: str) -> List[SkillMeta]:
+    def _list_skills_in_repo(self, repo: str, path: str) -> list[SkillMeta]:
         """List skill directories in a GitHub repo path, using cached index."""
         cache_key = f"{repo}_{path}".replace("/", "_").replace(" ", "_")
         cached = self._read_cache(cache_key)
@@ -481,7 +481,7 @@ class GitHubSource(SkillSource):
         if not isinstance(entries, list):
             return []
 
-        skills: List[SkillMeta] = []
+        skills: list[SkillMeta] = []
         for entry in entries:
             if entry.get("type") != "dir":
                 continue
@@ -502,7 +502,7 @@ class GitHubSource(SkillSource):
 
     # -- Repo tree cache (avoids redundant API calls) --
 
-    def _get_repo_tree(self, repo: str) -> Optional[Tuple[str, List[dict]]]:
+    def _get_repo_tree(self, repo: str) -> Optional[tuple[str, list[dict]]]:
         """Get cached or fresh repo tree.
 
         Returns ``(default_branch, tree_entries)`` or ``None``.
@@ -563,7 +563,7 @@ class GitHubSource(SkillSource):
                     "Set GITHUB_TOKEN or install the gh CLI to raise the limit to 5,000/hr."
                 )
 
-    def _download_directory(self, repo: str, path: str) -> Dict[str, str]:
+    def _download_directory(self, repo: str, path: str) -> dict[str, str]:
         """Recursively download all text files from a GitHub directory.
 
         Uses the Git Trees API first (single call for the entire tree) to
@@ -577,7 +577,7 @@ class GitHubSource(SkillSource):
         logger.debug("Tree API unavailable for %s/%s, falling back to Contents API", repo, path)
         return self._download_directory_recursive(repo, path)
 
-    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, str]]:
+    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[dict[str, str]]:
         """Download an entire directory using the Git Trees API (single request).
 
         Returns:
@@ -604,7 +604,7 @@ class GitHubSource(SkillSource):
             return {}
 
         # Filter to blobs under our target path and fetch content
-        files: Dict[str, str] = {}
+        files: dict[str, str] = {}
         for item in tree_entries:
             if item.get("type") != "blob":
                 continue
@@ -620,7 +620,7 @@ class GitHubSource(SkillSource):
 
         return files if files else None
 
-    def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, str]:
+    def _download_directory_recursive(self, repo: str, path: str) -> dict[str, str]:
         """Recursively download via Contents API (fallback)."""
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
         try:
@@ -635,7 +635,7 @@ class GitHubSource(SkillSource):
         if not isinstance(entries, list):
             return {}
 
-        files: Dict[str, str] = {}
+        files: dict[str, str] = {}
         for entry in entries:
             name = entry.get("name", "")
             entry_type = entry.get("type", "")
@@ -762,7 +762,7 @@ class WellKnownSkillSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return "community"
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         index_url = self._query_to_index_url(query)
         if not index_url:
             return []
@@ -771,7 +771,7 @@ class WellKnownSkillSource(SkillSource):
         if not parsed:
             return []
 
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
         for entry in parsed["skills"][:limit]:
             name = entry.get("name")
             if not isinstance(name, str) or not name:
@@ -843,7 +843,7 @@ class WellKnownSkillSource(SkillSource):
         if not isinstance(files, list) or not files:
             files = ["SKILL.md"]
 
-        downloaded: Dict[str, str] = {}
+        downloaded: dict[str, str] = {}
         for rel_path in files:
             if not isinstance(rel_path, str) or not rel_path:
                 continue
@@ -998,7 +998,7 @@ class UrlSource(SkillSource):
         return "community"
 
     # Search is meaningless for a direct URL — skip (return empty).
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         return []
 
     def _matches(self, identifier: str) -> bool:
@@ -1034,7 +1034,7 @@ class UrlSource(SkillSource):
         fm = GitHubSource._parse_frontmatter_quick(text)
         name = self._resolve_skill_name(fm, url)
         description = str(fm.get("description") or "")
-        tags: List[str] = []
+        tags: list[str] = []
         metadata = fm.get("metadata", {})
         if isinstance(metadata, dict):
             hermes_meta = metadata.get("hermes", {})
@@ -1176,7 +1176,7 @@ class SkillsShSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return self.github.trust_level_for(self._normalize_identifier(identifier))
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         if not query.strip():
             return self._featured_skills(limit)
 
@@ -1201,7 +1201,7 @@ class SkillsShSource(SkillSource):
         if not isinstance(items, list):
             return []
 
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
         for item in items[:limit]:
             meta = self._meta_from_search_item(item)
             if meta:
@@ -1239,7 +1239,7 @@ class SkillsShSource(SkillSource):
             return self._finalize_inspect_meta(meta, canonical, detail)
         return None
 
-    def _featured_skills(self, limit: int) -> List[SkillMeta]:
+    def _featured_skills(self, limit: int) -> list[SkillMeta]:
         cache_key = "skills_sh_featured"
         cached = _read_index_cache(cache_key)
         if cached is not None:
@@ -1253,7 +1253,7 @@ class SkillsShSource(SkillSource):
             return []
 
         seen: set[str] = set()
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
         for match in self._SKILL_LINK_RE.finditer(resp.text):
             canonical = match.group("id")
             if canonical in seen:
@@ -1468,7 +1468,7 @@ class SkillsShSource(SkillSource):
         return meta
 
     @classmethod
-    def _matches_skill_tokens(cls, meta: SkillMeta, skill_tokens: List[str]) -> bool:
+    def _matches_skill_tokens(cls, meta: SkillMeta, skill_tokens: list[str]) -> bool:
         candidates = set()
         candidates.update(cls._token_variants(meta.name))
         candidates.update(cls._token_variants(meta.path))
@@ -1532,7 +1532,7 @@ class SkillsShSource(SkillSource):
             return None
         return SkillsShSource._strip_html(value).strip() or None
 
-    def _detail_to_metadata(self, canonical: str, detail: Optional[dict]) -> Dict[str, Any]:
+    def _detail_to_metadata(self, canonical: str, detail: Optional[dict]) -> dict[str, Any]:
         parts = canonical.split("/", 2)
         repo = f"{parts[0]}/{parts[1]}" if len(parts) >= 2 else ""
         metadata = {
@@ -1555,8 +1555,8 @@ class SkillsShSource(SkillSource):
         return match.group("count")
 
     @staticmethod
-    def _extract_security_audits(html: str, identifier: str) -> Dict[str, str]:
-        audits: Dict[str, str] = {}
+    def _extract_security_audits(html: str, identifier: str) -> dict[str, str]:
+        audits: dict[str, str] = {}
         for audit in ("agent-trust-hub", "socket", "snyk"):
             idx = html.find(f"/security/{audit}")
             if idx == -1:
@@ -1585,7 +1585,7 @@ class SkillsShSource(SkillSource):
         return identifier
 
     @staticmethod
-    def _candidate_identifiers(identifier: str) -> List[str]:
+    def _candidate_identifiers(identifier: str) -> list[str]:
         parts = identifier.split("/", 2)
         if len(parts) < 3:
             return [identifier]
@@ -1600,7 +1600,7 @@ class SkillsShSource(SkillSource):
         ]
 
         seen = set()
-        deduped: List[str] = []
+        deduped: list[str] = []
         for candidate in candidates:
             if candidate not in seen:
                 seen.add(candidate)
@@ -1632,7 +1632,7 @@ class ClawHubSource(SkillSource):
         return "community"
 
     @staticmethod
-    def _normalize_tags(tags: Any) -> List[str]:
+    def _normalize_tags(tags: Any) -> list[str]:
         if isinstance(tags, list):
             return [str(t) for t in tags]
         if isinstance(tags, dict):
@@ -1640,7 +1640,7 @@ class ClawHubSource(SkillSource):
         return []
 
     @staticmethod
-    def _coerce_skill_payload(data: Any) -> Optional[Dict[str, Any]]:
+    def _coerce_skill_payload(data: Any) -> Optional[dict[str, Any]]:
         if not isinstance(data, dict):
             return None
         nested = data.get("skill")
@@ -1653,7 +1653,7 @@ class ClawHubSource(SkillSource):
         return data
 
     @staticmethod
-    def _query_terms(query: str) -> List[str]:
+    def _query_terms(query: str) -> list[str]:
         return [term for term in re.split(r"[^a-z0-9]+", query.lower()) if term]
 
     @classmethod
@@ -1706,9 +1706,9 @@ class ClawHubSource(SkillSource):
         return score
 
     @staticmethod
-    def _dedupe_results(results: List[SkillMeta]) -> List[SkillMeta]:
+    def _dedupe_results(results: list[SkillMeta]) -> list[SkillMeta]:
         seen: set[str] = set()
-        deduped: List[SkillMeta] = []
+        deduped: list[SkillMeta] = []
         for result in results:
             key = (result.identifier or result.name).lower()
             if key in seen:
@@ -1720,7 +1720,7 @@ class ClawHubSource(SkillSource):
     def _exact_slug_meta(self, query: str) -> Optional[SkillMeta]:
         slug = query.strip().split("/")[-1]
         query_terms = self._query_terms(query)
-        candidates: List[str] = []
+        candidates: list[str] = []
 
         if slug and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", slug):
             candidates.append(slug)
@@ -1750,7 +1750,7 @@ class ClawHubSource(SkillSource):
 
         return None
 
-    def _finalize_search_results(self, query: str, results: List[SkillMeta], limit: int) -> List[SkillMeta]:
+    def _finalize_search_results(self, query: str, results: list[SkillMeta], limit: int) -> list[SkillMeta]:
         query_norm = query.strip()
         if not query_norm:
             return self._dedupe_results(results)[:limit]
@@ -1778,7 +1778,7 @@ class ClawHubSource(SkillSource):
 
         return self._dedupe_results(results)[:limit]
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         query = query.strip()
 
         if query:
@@ -1898,7 +1898,7 @@ class ClawHubSource(SkillSource):
             tags=tags,
         )
 
-    def _search_catalog(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def _search_catalog(self, query: str, limit: int = 10) -> list[SkillMeta]:
         cache_key = f"clawhub_search_catalog_v1_{hashlib.md5(f'{query}|{limit}'.encode()).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if cached is not None:
@@ -1912,19 +1912,19 @@ class ClawHubSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(s) for s in results])
         return results
 
-    def _load_catalog_index(self) -> List[SkillMeta]:
+    def _load_catalog_index(self) -> list[SkillMeta]:
         cache_key = "clawhub_catalog_v1"
         cached = _read_index_cache(cache_key)
         if cached is not None:
             return [SkillMeta(**s) for s in cached]
 
         cursor: Optional[str] = None
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
         seen: set[str] = set()
         max_pages = 50
 
         for _ in range(max_pages):
-            params: Dict[str, Any] = {"limit": 200}
+            params: dict[str, Any] = {"limit": 200}
             if cursor:
                 params["cursor"] = cursor
 
@@ -1973,7 +1973,7 @@ class ClawHubSource(SkillSource):
         except (httpx.HTTPError, json.JSONDecodeError):
             return None
 
-    def _resolve_latest_version(self, slug: str, skill_data: Dict[str, Any]) -> Optional[str]:
+    def _resolve_latest_version(self, slug: str, skill_data: dict[str, Any]) -> Optional[str]:
         latest = skill_data.get("latestVersion")
         if isinstance(latest, dict):
             version = latest.get("version")
@@ -1995,8 +1995,8 @@ class ClawHubSource(SkillSource):
                     return version
         return None
 
-    def _extract_files(self, version_data: Dict[str, Any]) -> Dict[str, str]:
-        files: Dict[str, str] = {}
+    def _extract_files(self, version_data: dict[str, Any]) -> dict[str, str]:
+        files: dict[str, str] = {}
         file_list = version_data.get("files")
 
         if isinstance(file_list, dict):
@@ -2026,12 +2026,12 @@ class ClawHubSource(SkillSource):
 
         return files
 
-    def _download_zip(self, slug: str, version: str) -> Dict[str, str]:
+    def _download_zip(self, slug: str, version: str) -> dict[str, str]:
         """Download skill as a ZIP bundle from the /download endpoint and extract text files."""
         import io
         import zipfile
 
-        files: Dict[str, str] = {}
+        files: dict[str, str] = {}
         max_retries = 3
         for attempt in range(max_retries):
             try:
@@ -2125,8 +2125,8 @@ class ClaudeMarketplaceSource(SkillSource):
                 return "trusted"
         return "community"
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        results: List[SkillMeta] = []
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
+        results: list[SkillMeta] = []
         query_lower = query.lower()
 
         for marketplace_repo in self.KNOWN_MARKETPLACES:
@@ -2169,7 +2169,7 @@ class ClaudeMarketplaceSource(SkillSource):
             meta.trust_level = self.trust_level_for(identifier)
         return meta
 
-    def _fetch_marketplace_index(self, repo: str) -> List[dict]:
+    def _fetch_marketplace_index(self, repo: str) -> list[dict]:
         """Fetch and parse .claude-plugin/marketplace.json from a repo."""
         cache_key = f"claude_marketplace_{repo.replace('/', '_')}"
         cached = _read_index_cache(cache_key)
@@ -2213,13 +2213,13 @@ class LobeHubSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return "community"
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         index = self._fetch_index()
         if not index:
             return []
 
         query_lower = query.lower()
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
 
         agents = index.get("agents", index) if isinstance(index, dict) else index
         if not isinstance(agents, list):
@@ -2380,7 +2380,7 @@ class BrowseShSource(SkillSource):
     def trust_level_for(self, identifier: str) -> str:
         return "community"
 
-    def _fetch_catalog(self) -> List[Dict]:
+    def _fetch_catalog(self) -> list[dict]:
         cached = _read_index_cache(self._CACHE_KEY)
         if cached is not None:
             return cached
@@ -2396,7 +2396,7 @@ class BrowseShSource(SkillSource):
             _write_index_cache(self._CACHE_KEY, skills)
         return skills if isinstance(skills, list) else []
 
-    def _item_to_meta(self, item: Dict) -> Optional[SkillMeta]:
+    def _item_to_meta(self, item: dict) -> Optional[SkillMeta]:
         slug = item.get("slug", "")
         name = item.get("name", "")
         title = item.get("title", name)
@@ -2423,7 +2423,7 @@ class BrowseShSource(SkillSource):
             },
         )
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         catalog = self._fetch_catalog()
         query_lower = query.lower()
         results = []
@@ -2494,7 +2494,7 @@ class BrowseShSource(SkillSource):
             },
         )
 
-    def _resolve_skill_md_url(self, slug: str, item: Dict) -> Optional[str]:
+    def _resolve_skill_md_url(self, slug: str, item: dict) -> Optional[str]:
         """Resolve the SKILL.md content URL for a slug.
 
         Primary path: hit ``/api/skills/{slug}`` and read ``skillMdUrl``.
@@ -2557,8 +2557,8 @@ class OptionalSkillSource(SkillSource):
 
     # -- search -----------------------------------------------------------
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        results: List[SkillMeta] = []
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
+        results: list[SkillMeta] = []
         query_lower = query.lower()
 
         for meta in self._scan_all():
@@ -2594,7 +2594,7 @@ class OptionalSkillSource(SkillSource):
         else:
             skill_dir = resolved
 
-        files: Dict[str, Union[str, bytes]] = {}
+        files: dict[str, Union[str, bytes]] = {}
         for f in skill_dir.rglob("*"):
             if (
                 f.is_file()
@@ -2646,12 +2646,12 @@ class OptionalSkillSource(SkillSource):
                 return skill_md.parent
         return None
 
-    def _scan_all(self) -> List[SkillMeta]:
+    def _scan_all(self) -> list[SkillMeta]:
         """Enumerate all optional skills with metadata."""
         if not self._optional_dir.is_dir():
             return []
 
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
         for skill_md in sorted(self._optional_dir.rglob("SKILL.md")):
             if is_excluded_skill_path(skill_md):
                 continue
@@ -2785,8 +2785,8 @@ class HubLockFile:
         scan_verdict: str,
         skill_hash: str,
         install_path: str,
-        files: List[str],
-        metadata: Optional[Dict[str, Any]] = None,
+        files: list[str],
+        metadata: Optional[dict[str, Any]] = None,
     ) -> None:
         data = self.load()
         data["installed"][name] = {
@@ -2812,7 +2812,7 @@ class HubLockFile:
         data = self.load()
         return data["installed"].get(name)
 
-    def list_installed(self) -> List[dict]:
+    def list_installed(self) -> list[dict]:
         data = self.load()
         result = []
         for name, entry in data["installed"].items():
@@ -2830,7 +2830,7 @@ class TapsManager:
     def __init__(self, path: Path = TAPS_FILE):
         self.path = path
 
-    def load(self) -> List[dict]:
+    def load(self) -> list[dict]:
         if not self.path.exists():
             return []
         try:
@@ -2839,7 +2839,7 @@ class TapsManager:
         except (json.JSONDecodeError, OSError):
             return []
 
-    def save(self, taps: List[dict]) -> None:
+    def save(self, taps: list[dict]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
 
@@ -2861,7 +2861,7 @@ class TapsManager:
         self.save(new_taps)
         return True
 
-    def list_taps(self) -> List[dict]:
+    def list_taps(self) -> list[dict]:
         return self.load()
 
 
@@ -2906,7 +2906,7 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
     """Write a skill bundle to the quarantine directory for scanning."""
     ensure_hub_dirs()
     skill_name = _validate_skill_name(bundle.name)
-    validated_files: List[Tuple[str, Union[str, bytes]]] = []
+    validated_files: list[tuple[str, Union[str, bytes]]] = []
     for rel_path, file_content in bundle.files.items():
         safe_rel_path = _validate_bundle_rel_path(rel_path)
         validated_files.append((safe_rel_path, file_content))
@@ -2992,7 +2992,7 @@ def install_from_quarantine(
     return install_dir
 
 
-def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
+def uninstall_skill(skill_name: str) -> tuple[bool, str]:
     """Remove a hub-installed skill. Refuses to remove builtins."""
     lock = HubLockFile()
     entry = lock.get_installed(skill_name)
@@ -3044,9 +3044,9 @@ def check_for_skill_updates(
     name: Optional[str] = None,
     *,
     lock: Optional[HubLockFile] = None,
-    sources: Optional[List[SkillSource]] = None,
+    sources: Optional[list[SkillSource]] = None,
     auth: Optional[GitHubAuth] = None,
-) -> List[dict]:
+) -> list[dict]:
     """Check installed hub skills for upstream changes."""
     lock = lock or HubLockFile()
     installed = lock.list_installed()
@@ -3056,7 +3056,7 @@ def check_for_skill_updates(
     if sources is None:
         sources = create_source_router(auth=auth)
 
-    results: List[dict] = []
+    results: list[dict] = []
     for entry in installed:
         identifier = entry.get("identifier", "")
         source_name = entry.get("source", "")
@@ -3203,7 +3203,7 @@ class HermesIndexSource(SkillSource):
                 return skill.get("trust_level", "community")
         return "community"
 
-    def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
+    def search(self, query: str, limit: int = 10) -> list[SkillMeta]:
         """Search the cached index.  Zero API calls."""
         index = self._ensure_loaded()
         skills = index.get("skills", [])
@@ -3215,7 +3215,7 @@ class HermesIndexSource(SkillSource):
             return [self._to_meta(s) for s in skills[:limit]]
 
         query_lower = query.lower()
-        results: List[SkillMeta] = []
+        results: list[SkillMeta] = []
         for s in skills:
             searchable = f"{s.get('name', '')} {s.get('description', '')} {' '.join(s.get('tags', []))}".lower()
             if query_lower in searchable:
@@ -3312,7 +3312,7 @@ class HermesIndexSource(SkillSource):
         )
 
 
-def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]:
+def create_source_router(auth: Optional[GitHubAuth] = None) -> list[SkillSource]:
     """
     Create all configured source adapters.
     Returns a list of active sources for search/fetch operations.
@@ -3323,7 +3323,7 @@ def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]
     taps_mgr = TapsManager()
     extra_taps = taps_mgr.list_taps()
 
-    sources: List[SkillSource] = [
+    sources: list[SkillSource] = [
         OptionalSkillSource(),        # Official optional skills (highest priority)
         HermesIndexSource(auth=auth), # Centralized index (search + resolved install paths)
         SkillsShSource(auth=auth),
@@ -3341,7 +3341,7 @@ def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]
 
 def _search_one_source(
     src: SkillSource, query: str, limit: int
-) -> Tuple[str, List[SkillMeta]]:
+) -> tuple[str, list[SkillMeta]]:
     """Search a single source.  Runs in a thread for parallelism."""
     try:
         return src.source_id(), src.search(query, limit=limit)
@@ -3351,13 +3351,13 @@ def _search_one_source(
 
 
 def parallel_search_sources(
-    sources: List[SkillSource],
+    sources: list[SkillSource],
     query: str = "",
-    per_source_limits: Optional[Dict[str, int]] = None,
+    per_source_limits: Optional[dict[str, int]] = None,
     source_filter: str = "all",
     overall_timeout: float = 30,
     on_source_done: Optional[Any] = None,
-) -> Tuple[List[SkillMeta], Dict[str, int], List[str]]:
+) -> tuple[list[SkillMeta], dict[str, int], list[str]]:
     """Search all sources in parallel with per-source timeout.
 
     Returns ``(all_results, source_counts, timed_out_ids)``.
@@ -3369,7 +3369,7 @@ def parallel_search_sources(
 
     per_source_limits = per_source_limits or {}
 
-    active: List[SkillSource] = []
+    active: list[SkillSource] = []
     # When the centralized index is available and the user hasn't filtered
     # to a specific source, skip external API sources (github, skills-sh,
     # clawhub, etc.) — the index already has their data.  This avoids
@@ -3393,9 +3393,9 @@ def parallel_search_sources(
             continue
         active.append(src)
 
-    all_results: List[SkillMeta] = []
-    source_counts: Dict[str, int] = {}
-    timed_out_ids: List[str] = []
+    all_results: list[SkillMeta] = []
+    source_counts: dict[str, int] = {}
+    timed_out_ids: list[str] = []
 
     if not active:
         return all_results, source_counts, timed_out_ids
@@ -3430,8 +3430,8 @@ def parallel_search_sources(
     return all_results, source_counts, timed_out_ids
 
 
-def unified_search(query: str, sources: List[SkillSource],
-                   source_filter: str = "all", limit: int = 10) -> List[SkillMeta]:
+def unified_search(query: str, sources: list[SkillSource],
+                   source_filter: str = "all", limit: int = 10) -> list[SkillMeta]:
     """Search all sources (in parallel) and merge results."""
     all_results, _, _ = parallel_search_sources(
         sources,
@@ -3445,7 +3445,7 @@ def unified_search(query: str, sources: List[SkillSource],
     # Using name would incorrectly collapse browse-sh skills from different sites that share
     # the same task name (e.g. "search-listings" from Airbnb and Booking.com).
     _TRUST_RANK = {"builtin": 2, "trusted": 1, "community": 0}
-    seen: Dict[str, SkillMeta] = {}
+    seen: dict[str, SkillMeta] = {}
     for r in all_results:
         if r.identifier not in seen:
             seen[r.identifier] = r

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -49,7 +49,7 @@ def _get_bundled_dir() -> Path:
     return get_bundled_skills_dir(Path(__file__).parent.parent / "skills")
 
 
-def _read_manifest() -> Dict[str, str]:
+def _read_manifest() -> dict[str, str]:
     """
     Read the manifest as a dict of {skill_name: origin_hash}.
 
@@ -76,7 +76,7 @@ def _read_manifest() -> Dict[str, str]:
         return {}
 
 
-def _write_manifest(entries: Dict[str, str]):
+def _write_manifest(entries: dict[str, str]):
     """Write the manifest file atomically in v2 format (name:hash).
 
     Uses a temp file + os.replace() to avoid corruption if the process
@@ -130,7 +130,7 @@ def _read_skill_name(skill_md: Path, fallback: str) -> str:
     return fallback
 
 
-def _discover_bundled_skills(bundled_dir: Path) -> List[Tuple[str, Path]]:
+def _discover_bundled_skills(bundled_dir: Path) -> list[tuple[str, Path]]:
     """
     Find all SKILL.md files in the bundled directory.
     Returns list of (skill_name, skill_directory_path) tuples.

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -108,10 +108,10 @@ _REMOTE_ENV_BACKENDS = frozenset(
 _secret_capture_callback = None
 
 
-def load_env() -> Dict[str, str]:
+def load_env() -> dict[str, str]:
     """Load profile-scoped environment variables from HERMES_HOME/.env."""
     env_path = get_hermes_home() / ".env"
-    env_vars: Dict[str, str] = {}
+    env_vars: dict[str, str] = {}
     if not env_path.exists():
         return env_vars
 
@@ -149,7 +149,7 @@ def set_secret_capture_callback(callback) -> None:
     _secret_capture_callback = callback
 
 
-def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
+def skill_matches_platform(frontmatter: dict[str, Any]) -> bool:
     """Check if a skill is compatible with the current OS platform.
 
     Delegates to ``agent.skill_utils.skill_matches_platform`` — kept here
@@ -159,7 +159,7 @@ def skill_matches_platform(frontmatter: Dict[str, Any]) -> bool:
     return _impl(frontmatter)
 
 
-def _normalize_prerequisite_values(value: Any) -> List[str]:
+def _normalize_prerequisite_values(value: Any) -> list[str]:
     if not value:
         return []
     if isinstance(value, str):
@@ -168,8 +168,8 @@ def _normalize_prerequisite_values(value: Any) -> List[str]:
 
 
 def _collect_prerequisite_values(
-    frontmatter: Dict[str, Any],
-) -> Tuple[List[str], List[str]]:
+    frontmatter: dict[str, Any],
+) -> tuple[list[str], list[str]]:
     prereqs = frontmatter.get("prerequisites")
     if not prereqs or not isinstance(prereqs, dict):
         return [], []
@@ -179,7 +179,7 @@ def _collect_prerequisite_values(
     )
 
 
-def _normalize_setup_metadata(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
+def _normalize_setup_metadata(frontmatter: dict[str, Any]) -> dict[str, Any]:
     setup = frontmatter.get("setup")
     if not isinstance(setup, dict):
         return {"help": None, "collect_secrets": []}
@@ -197,7 +197,7 @@ def _normalize_setup_metadata(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(collect_secrets_raw, list):
         collect_secrets_raw = []
 
-    collect_secrets: List[Dict[str, Any]] = []
+    collect_secrets: list[dict[str, Any]] = []
     for item in collect_secrets_raw:
         if not isinstance(item, dict):
             continue
@@ -209,7 +209,7 @@ def _normalize_setup_metadata(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
         prompt = str(item.get("prompt") or f"Enter value for {env_var}").strip()
         provider_url = str(item.get("provider_url") or item.get("url") or "").strip()
 
-        entry: Dict[str, Any] = {
+        entry: dict[str, Any] = {
             "env_var": env_var,
             "prompt": prompt,
             "secret": bool(item.get("secret", True)),
@@ -225,9 +225,9 @@ def _normalize_setup_metadata(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _get_required_environment_variables(
-    frontmatter: Dict[str, Any],
-    legacy_env_vars: List[str] | None = None,
-) -> List[Dict[str, Any]]:
+    frontmatter: dict[str, Any],
+    legacy_env_vars: list[str] | None = None,
+) -> list[dict[str, Any]]:
     setup = _normalize_setup_metadata(frontmatter)
     required_raw = frontmatter.get("required_environment_variables")
     if isinstance(required_raw, dict):
@@ -235,17 +235,17 @@ def _get_required_environment_variables(
     if not isinstance(required_raw, list):
         required_raw = []
 
-    required: List[Dict[str, Any]] = []
+    required: list[dict[str, Any]] = []
     seen: set[str] = set()
 
-    def _append_required(entry: Dict[str, Any]) -> None:
+    def _append_required(entry: dict[str, Any]) -> None:
         env_name = str(entry.get("name") or entry.get("env_var") or "").strip()
         if not env_name or env_name in seen:
             return
         if not _ENV_VAR_NAME_RE.match(env_name):
             return
 
-        normalized: Dict[str, Any] = {
+        normalized: dict[str, Any] = {
             "name": env_name,
             "prompt": str(entry.get("prompt") or f"Enter value for {env_name}").strip(),
         }
@@ -295,8 +295,8 @@ def _get_required_environment_variables(
 
 def _capture_required_environment_variables(
     skill_name: str,
-    missing_entries: List[Dict[str, Any]],
-) -> Dict[str, Any]:
+    missing_entries: list[dict[str, Any]],
+) -> dict[str, Any]:
     if not missing_entries:
         return {
             "missing_names": [],
@@ -320,7 +320,7 @@ def _capture_required_environment_variables(
         }
 
     setup_skipped = False
-    remaining_names: List[str] = []
+    remaining_names: list[str] = []
 
     for entry in missing_entries:
         metadata = {"skill_name": skill_name}
@@ -377,7 +377,7 @@ def _get_terminal_backend_name() -> str:
 
 
 def _is_env_var_persisted(
-    var_name: str, env_snapshot: Dict[str, str] | None = None
+    var_name: str, env_snapshot: dict[str, str] | None = None
 ) -> bool:
     if env_snapshot is None:
         env_snapshot = load_env()
@@ -387,11 +387,11 @@ def _is_env_var_persisted(
 
 
 def _remaining_required_environment_names(
-    required_env_vars: List[Dict[str, Any]],
-    capture_result: Dict[str, Any],
+    required_env_vars: list[dict[str, Any]],
+    capture_result: dict[str, Any],
     *,
-    env_snapshot: Dict[str, str] | None = None,
-) -> List[str]:
+    env_snapshot: dict[str, str] | None = None,
+) -> list[str]:
     missing_names = set(capture_result["missing_names"])
 
     if env_snapshot is None:
@@ -417,7 +417,7 @@ def _gateway_setup_hint() -> str:
 
 def _build_setup_note(
     readiness_status: SkillReadinessStatus,
-    missing: List[str],
+    missing: list[str],
     setup_help: str | None = None,
 ) -> str | None:
     if readiness_status == SkillReadinessStatus.SETUP_NEEDED:
@@ -434,7 +434,7 @@ def check_skills_requirements() -> bool:
     return True
 
 
-def _parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
+def _parse_frontmatter(content: str) -> tuple[dict[str, Any], str]:
     """Parse YAML frontmatter from markdown content.
 
     Delegates to ``agent.skill_utils.parse_frontmatter`` — kept here
@@ -470,7 +470,7 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     return None
 
 
-def _parse_tags(tags_value) -> List[str]:
+def _parse_tags(tags_value) -> list[str]:
     """
     Parse tags from frontmatter value.
 
@@ -501,7 +501,7 @@ def _parse_tags(tags_value) -> List[str]:
 
 
 
-def _get_disabled_skill_names() -> Set[str]:
+def _get_disabled_skill_names() -> set[str]:
     """Load disabled skill names from config.
 
     Delegates to ``agent.skill_utils.get_disabled_skill_names`` — kept here
@@ -547,7 +547,7 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
-def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
+def _find_all_skills(*, skip_disabled: bool = False) -> list[dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
     Args:
@@ -624,7 +624,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     return skills
 
 
-def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _sort_skills(skills: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Keep every skill listing path ordered the same way."""
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
@@ -774,7 +774,7 @@ def _serve_plugin_skill(
             ensure_ascii=False,
         )
 
-    parsed_frontmatter: Dict[str, Any] = {}
+    parsed_frontmatter: dict[str, Any] = {}
     try:
         parsed_frontmatter, _ = _parse_frontmatter(content)
     except Exception:
@@ -965,7 +965,7 @@ def skill_view(
         # loaded the other) so we surface it loudly instead of guessing.
         from agent.skill_utils import iter_skill_index_files
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
+        candidates: list[tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
         seen_md: set = set()
 
         def _record(sd: Optional[Path], smd: Path) -> None:
@@ -1088,7 +1088,7 @@ def skill_view(
                 _warnings.append("skill content contains patterns that may indicate prompt injection")
             logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
 
-        parsed_frontmatter: Dict[str, Any] = {}
+        parsed_frontmatter: dict[str, Any] = {}
         try:
             parsed_frontmatter, _ = _parse_frontmatter(content)
         except Exception:

--- a/tools/slash_confirm.py
+++ b/tools/slash_confirm.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 #       "handler":    Callable[[str], Awaitable[Optional[str]]],
 #       "created_at": float,                     # time.time()
 #   }
-_pending: Dict[str, Dict[str, Any]] = {}
+_pending: dict[str, dict[str, Any]] = {}
 _lock = threading.RLock()
 
 # Default timeout — a pending confirm older than this is discarded when
@@ -68,7 +68,7 @@ def register(
         }
 
 
-def get_pending(session_key: str) -> Optional[Dict[str, Any]]:
+def get_pending(session_key: str) -> Optional[dict[str, Any]]:
     """Return the pending confirm dict for a session, or None."""
     with _lock:
         entry = _pending.get(session_key)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -917,10 +917,10 @@ Do NOT use vim/nano/interactive tools without pty=true — they hang without a p
 """
 
 # Global state for environment lifecycle management
-_active_environments: Dict[str, Any] = {}
-_last_activity: Dict[str, float] = {}
+_active_environments: dict[str, Any] = {}
+_last_activity: dict[str, float] = {}
 _env_lock = threading.Lock()
-_creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
+_creation_locks: dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
@@ -933,10 +933,10 @@ _cleanup_running = False
 #
 # This is never exposed to the model -- only infrastructure code calls it.
 # Thread-safe because each task_id is unique per rollout.
-_task_env_overrides: Dict[str, Dict[str, Any]] = {}
+_task_env_overrides: dict[str, dict[str, Any]] = {}
 
 
-def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
+def register_task_env_overrides(task_id: str, overrides: dict[str, Any]):
     """
     Register environment overrides for a specific task/rollout.
 
@@ -1006,7 +1006,7 @@ def _parse_env_var(name: str, default: str, converter=int, type_label: str = "in
         )
 
 
-def _get_env_config() -> Dict[str, Any]:
+def _get_env_config() -> dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
@@ -1094,7 +1094,7 @@ def _get_env_config() -> Dict[str, Any]:
     }
 
 
-def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
+def _get_modal_backend_state(modal_mode: object | None) -> dict[str, Any]:
     """Resolve direct vs managed Modal backend selection."""
     return resolve_modal_backend_state(
         modal_mode,
@@ -1665,7 +1665,7 @@ def terminal_tool(
     workdir: Optional[str] = None,
     pty: bool = False,
     notify_on_complete: bool = False,
-    watch_patterns: Optional[List[str]] = None,
+    watch_patterns: Optional[list[str]] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -33,9 +33,9 @@ class TodoStore:
     """
 
     def __init__(self):
-        self._items: List[Dict[str, str]] = []
+        self._items: list[dict[str, str]] = []
 
-    def write(self, todos: List[Dict[str, Any]], merge: bool = False) -> List[Dict[str, str]]:
+    def write(self, todos: list[dict[str, Any]], merge: bool = False) -> list[dict[str, str]]:
         """
         Write todos. Returns the full current list after writing.
 
@@ -79,7 +79,7 @@ class TodoStore:
             self._items = rebuilt
         return self.read()
 
-    def read(self) -> List[Dict[str, str]]:
+    def read(self) -> list[dict[str, str]]:
         """Return a copy of the current list."""
         return [item.copy() for item in self._items]
 
@@ -122,7 +122,7 @@ class TodoStore:
         return "\n".join(lines)
 
     @staticmethod
-    def _validate(item: Dict[str, Any]) -> Dict[str, str]:
+    def _validate(item: dict[str, Any]) -> dict[str, str]:
         """
         Validate and normalize a todo item.
 
@@ -144,9 +144,9 @@ class TodoStore:
         return {"id": item_id, "content": content, "status": status}
 
     @staticmethod
-    def _dedupe_by_id(todos: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _dedupe_by_id(todos: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Collapse duplicate ids, keeping the last occurrence in its position."""
-        last_index: Dict[str, int] = {}
+        last_index: dict[str, int] = {}
         for i, item in enumerate(todos):
             item_id = str(item.get("id", "")).strip() or "?"
             last_index[item_id] = i
@@ -154,7 +154,7 @@ class TodoStore:
 
 
 def todo_tool(
-    todos: Optional[List[Dict[str, Any]]] = None,
+    todos: Optional[list[dict[str, Any]]] = None,
     merge: bool = False,
     store: Optional[TodoStore] = None,
 ) -> str:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -69,7 +69,7 @@ def resolve_modal_backend_state(
     *,
     has_direct: bool,
     managed_ready: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Resolve direct vs managed Modal backend selection.
 
     Semantics:

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -52,7 +52,7 @@ def _coerce_positive_int(value: Any, default: int) -> int:
     return iv
 
 
-def get_tool_output_limits() -> Dict[str, int]:
+def get_tool_output_limits() -> dict[str, int]:
     """Return resolved tool-output limits, reading ``tool_output`` from config.
 
     Keys: ``max_bytes``, ``max_lines``, ``max_line_length``. Missing or

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -332,7 +332,7 @@ def _get_provider(stt_config: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
+def _validate_audio_file(file_path: str) -> Optional[dict[str, Any]]:
     """Validate the audio file.  Returns an error dict or None if OK."""
     audio_path = Path(file_path)
 
@@ -424,7 +424,7 @@ def _load_local_whisper_model(model_name: str):
         return WhisperModel(model_name, device="cpu", compute_type="int8")
 
 
-def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_local(file_path: str, model_name: str) -> dict[str, Any]:
     """Transcribe using faster-whisper (local, free)."""
     global _local_model, _local_model_name
 
@@ -507,7 +507,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
         return None, f"Failed to convert audio for local STT: {details}"
 
 
-def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_local_command(file_path: str, model_name: str) -> dict[str, Any]:
     """Run the configured local STT command template and read back a .txt transcript."""
     command_template = _get_local_command_template()
     if not command_template:
@@ -583,7 +583,7 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_groq(file_path: str, model_name: str) -> dict[str, Any]:
     """Transcribe using Groq Whisper API (free tier available)."""
     api_key = get_env_value("GROQ_API_KEY")
     if not api_key:
@@ -635,7 +635,7 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_openai(file_path: str, model_name: str) -> dict[str, Any]:
     """Transcribe using OpenAI Whisper API (paid)."""
     try:
         api_key, base_url = _resolve_openai_audio_client_config()
@@ -692,7 +692,7 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_mistral(file_path: str, model_name: str) -> dict[str, Any]:
     """Transcribe using Mistral Voxtral Transcribe API.
 
     Uses the ``mistralai`` Python SDK to call ``/v1/audio/transcriptions``.
@@ -731,7 +731,7 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_xai(file_path: str, model_name: str) -> dict[str, Any]:
     """Transcribe using xAI Grok STT API.
 
     Uses the ``POST /v1/stt`` REST endpoint with multipart/form-data.
@@ -771,7 +771,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
         import requests
         from tools.xai_http import hermes_xai_user_agent
 
-        data: Dict[str, str] = {}
+        data: dict[str, str] = {}
         if language:
             data["language"] = language
         if use_format:
@@ -838,7 +838,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def transcribe_audio(file_path: str, model: Optional[str] = None) -> dict[str, Any]:
     """
     Transcribe an audio file using the configured STT provider.
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -190,7 +190,7 @@ DEFAULT_OUTPUT_DIR = _get_default_output_dir()
 # input tokens.  Users can override any of these via
 # ``tts.<provider>.max_text_length`` in config.yaml.
 # ---------------------------------------------------------------------------
-PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
+PROVIDER_MAX_TEXT_LENGTH: dict[str, int] = {
     "edge": 5000,         # edge-tts practical sync limit
     "openai": 4096,       # https://platform.openai.com/docs/guides/text-to-speech
     "xai": 15000,         # https://docs.x.ai/developers/model-capabilities/audio/text-to-speech
@@ -204,7 +204,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
-ELEVENLABS_MODEL_MAX_TEXT_LENGTH: Dict[str, int] = {
+ELEVENLABS_MODEL_MAX_TEXT_LENGTH: dict[str, int] = {
     "eleven_v3": 5000,
     "eleven_ttv_v3": 5000,
     "eleven_multilingual_v2": 10000,
@@ -224,7 +224,7 @@ MAX_TEXT_LENGTH = FALLBACK_MAX_TEXT_LENGTH
 
 def _resolve_max_text_length(
     provider: Optional[str],
-    tts_config: Optional[Dict[str, Any]] = None,
+    tts_config: Optional[dict[str, Any]] = None,
 ) -> int:
     """Return the input-character cap for *provider*.
 
@@ -281,7 +281,7 @@ def _resolve_max_text_length(
 # ===========================================================================
 # Config loader -- reads tts: section from ~/.hermes/config.yaml
 # ===========================================================================
-def _load_tts_config() -> Dict[str, Any]:
+def _load_tts_config() -> dict[str, Any]:
     """
     Load TTS configuration from ~/.hermes/config.yaml.
 
@@ -300,7 +300,7 @@ def _load_tts_config() -> Dict[str, Any]:
         return {}
 
 
-def _get_provider(tts_config: Dict[str, Any]) -> str:
+def _get_provider(tts_config: dict[str, Any]) -> str:
     """Get the configured TTS provider name."""
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
 
@@ -355,7 +355,7 @@ COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 
 
-def _get_provider_section(tts_config: Dict[str, Any], name: str) -> Dict[str, Any]:
+def _get_provider_section(tts_config: dict[str, Any], name: str) -> dict[str, Any]:
     """Return a provider config block if it's a dict, else an empty dict."""
     if not isinstance(tts_config, dict):
         return {}
@@ -364,9 +364,9 @@ def _get_provider_section(tts_config: Dict[str, Any], name: str) -> Dict[str, An
 
 
 def _get_named_provider_config(
-    tts_config: Dict[str, Any],
+    tts_config: dict[str, Any],
     name: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Return the config dict for a user-declared provider.
 
     Looks up ``tts.providers.<name>`` first (the canonical location), and
@@ -387,7 +387,7 @@ def _get_named_provider_config(
     return {}
 
 
-def _is_command_provider_config(config: Dict[str, Any]) -> bool:
+def _is_command_provider_config(config: dict[str, Any]) -> bool:
     """Return True when *config* declares a command-type provider."""
     if not isinstance(config, dict):
         return False
@@ -400,8 +400,8 @@ def _is_command_provider_config(config: Dict[str, Any]) -> bool:
 
 def _resolve_command_provider_config(
     provider: str,
-    tts_config: Dict[str, Any],
-) -> Optional[Dict[str, Any]]:
+    tts_config: dict[str, Any],
+) -> Optional[dict[str, Any]]:
     """Return the provider config if *provider* resolves to a command type.
 
     Built-in provider names are rejected (they have native handlers).
@@ -423,7 +423,7 @@ def _dispatch_to_plugin_provider(
     text: str,
     output_path: str,
     provider: str,
-    tts_config: Dict[str, Any],
+    tts_config: dict[str, Any],
 ) -> Optional[str]:
     """Route the call to a plugin-registered TTS provider, or return None.
 
@@ -536,7 +536,7 @@ def _plugin_provider_is_voice_compatible(provider: str) -> bool:
         return False
 
 
-def _iter_command_providers(tts_config: Dict[str, Any]):
+def _iter_command_providers(tts_config: dict[str, Any]):
     """Yield (name, config) pairs for every declared command-type provider."""
     if not isinstance(tts_config, dict):
         return
@@ -547,7 +547,7 @@ def _iter_command_providers(tts_config: Dict[str, Any]):
                 yield name, cfg
 
 
-def _get_command_tts_timeout(config: Dict[str, Any]) -> float:
+def _get_command_tts_timeout(config: dict[str, Any]) -> float:
     """Return timeout in seconds, falling back when invalid."""
     raw = config.get("timeout", config.get("timeout_seconds", DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS))
     try:
@@ -560,7 +560,7 @@ def _get_command_tts_timeout(config: Dict[str, Any]) -> float:
 
 
 def _get_command_tts_output_format(
-    config: Dict[str, Any],
+    config: dict[str, Any],
     output_path: Optional[str] = None,
 ) -> str:
     """Return the validated output format (mp3/wav/ogg/flac)."""
@@ -577,7 +577,7 @@ def _get_command_tts_output_format(
     return fmt if fmt in COMMAND_TTS_OUTPUT_FORMATS else DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
 
-def _is_command_tts_voice_compatible(config: Dict[str, Any]) -> bool:
+def _is_command_tts_voice_compatible(config: dict[str, Any]) -> bool:
     """Return True only when the user explicitly opted in to voice delivery."""
     value = config.get("voice_compatible", False)
     if isinstance(value, str):
@@ -635,7 +635,7 @@ def _quote_command_tts_placeholder(value: str, quote_context: Optional[str]) -> 
 
 def _render_command_tts_template(
     command_template: str,
-    placeholders: Dict[str, str],
+    placeholders: dict[str, str],
 ) -> str:
     """Replace supported placeholders while preserving ``{{`` / ``}}``."""
     names = "|".join(re.escape(name) for name in placeholders)
@@ -716,7 +716,7 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
 
 def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProcess:
     """Run a command-provider shell command with process-tree timeout cleanup."""
-    popen_kwargs: Dict[str, Any] = {
+    popen_kwargs: dict[str, Any] = {
         "shell": True,
         "stdout": subprocess.PIPE,
         "stderr": subprocess.PIPE,
@@ -754,7 +754,7 @@ def _run_command_tts(command: str, timeout: float) -> subprocess.CompletedProces
     return subprocess.CompletedProcess(command, proc.returncode, stdout, stderr)
 
 
-def _configured_command_tts_output_path(path: Path, config: Dict[str, Any]) -> Path:
+def _configured_command_tts_output_path(path: Path, config: dict[str, Any]) -> Path:
     """Return an output path whose extension matches the provider's output_format."""
     fmt = _get_command_tts_output_format(config)
     return path.with_suffix(f".{fmt}")
@@ -764,8 +764,8 @@ def _generate_command_tts(
     text: str,
     output_path: str,
     provider_name: str,
-    config: Dict[str, Any],
-    tts_config: Dict[str, Any],
+    config: dict[str, Any],
+    tts_config: dict[str, Any],
 ) -> str:
     """Generate speech by running a user-configured shell command.
 
@@ -828,7 +828,7 @@ def _generate_command_tts(
     return str(output)
 
 
-def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+def _has_any_command_tts_provider(tts_config: Optional[dict[str, Any]] = None) -> bool:
     """Return True when any command-type TTS provider is configured."""
     if tts_config is None:
         tts_config = _load_tts_config()
@@ -883,7 +883,7 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
 # ===========================================================================
 # Provider: Edge TTS (free)
 # ===========================================================================
-async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+async def _generate_edge_tts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """
     Generate audio using Edge TTS.
 
@@ -913,7 +913,7 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
 # ===========================================================================
 # Provider: ElevenLabs (premium)
 # ===========================================================================
-def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_elevenlabs(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """
     Generate audio using ElevenLabs.
 
@@ -959,7 +959,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
 # ===========================================================================
 # Provider: OpenAI TTS
 # ===========================================================================
-def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_openai_tts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """
     Generate audio using OpenAI TTS.
 
@@ -1083,7 +1083,7 @@ def _apply_xai_auto_speech_tags(text: str) -> str:
     return clean
 
 
-def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_xai_tts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """
     Generate audio using xAI TTS.
 
@@ -1120,7 +1120,7 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
     # Match the documented minimal POST /v1/tts shape by default. Only send
     # output_format when Hermes actually needs a non-default format/override.
     codec = "wav" if output_path.endswith(".wav") else "mp3"
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "text": text,
         "voice_id": voice_id,
         "language": language,
@@ -1130,7 +1130,7 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         or sample_rate != DEFAULT_XAI_SAMPLE_RATE
         or (codec == "mp3" and bit_rate != DEFAULT_XAI_BIT_RATE)
     ):
-        output_format: Dict[str, Any] = {"codec": codec}
+        output_format: dict[str, Any] = {"codec": codec}
         if sample_rate:
             output_format["sample_rate"] = sample_rate
         if codec == "mp3" and bit_rate:
@@ -1158,7 +1158,7 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
 # ===========================================================================
 # Provider: MiniMax TTS
 # ===========================================================================
-def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_minimax_tts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """
     Generate audio using MiniMax TTS API.
 
@@ -1289,7 +1289,7 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
 # ===========================================================================
 # Provider: Mistral (Voxtral TTS)
 # ===========================================================================
-def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_mistral_tts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """Generate audio using Mistral Voxtral TTS API.
 
     The API returns base64-encoded audio; this function decodes it
@@ -1372,7 +1372,7 @@ def _wrap_pcm_as_wav(
     return riff_header + fmt_chunk + data_chunk_header + pcm_bytes
 
 
-def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_gemini_tts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """Generate audio using Google Gemini TTS.
 
     Gemini's generateContent endpoint with responseModalities=["AUDIO"] returns
@@ -1406,7 +1406,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         or DEFAULT_GEMINI_TTS_BASE_URL
     ).strip().rstrip("/")
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "contents": [{"parts": [{"text": text}]}],
         "generationConfig": {
             "responseModalities": ["AUDIO"],
@@ -1535,7 +1535,7 @@ def _default_neutts_ref_text() -> str:
     return str(Path(__file__).parent / "neutts_samples" / "jo.txt")
 
 
-def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_neutts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """Generate speech using the local NeuTTS engine.
 
     Runs synthesis in a subprocess via tools/neutts_synth.py to keep the
@@ -1595,7 +1595,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 # Module-level cache for Piper voice instances. Voices are keyed on their
 # absolute .onnx model path so switching voices doesn't invalidate older
 # cached voices.
-_piper_voice_cache: Dict[str, Any] = {}
+_piper_voice_cache: dict[str, Any] = {}
 
 
 def _check_piper_available() -> bool:
@@ -1671,7 +1671,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
     return str(cached)
 
 
-def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_piper_tts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """Generate speech using the local Piper engine.
 
     Loads the voice model once per process (cached by absolute path) and
@@ -1754,10 +1754,10 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 
 # Module-level cache for KittenTTS model instance
-_kittentts_model_cache: Dict[str, Any] = {}
+_kittentts_model_cache: dict[str, Any] = {}
 
 
-def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+def _generate_kittentts(text: str, output_path: str, tts_config: dict[str, Any]) -> str:
     """Generate speech using KittenTTS local ONNX model.
 
     KittenTTS is a lightweight TTS engine (25-80MB models) that runs

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -58,7 +58,7 @@ from tools.registry import registry, tool_error
 logger = logging.getLogger(__name__)
 
 
-VIDEO_GENERATE_SCHEMA: Dict[str, Any] = {
+VIDEO_GENERATE_SCHEMA: dict[str, Any] = {
     "name": "video_generate",
     # Placeholder — the real description is built dynamically at
     # get_tool_definitions() time so it reflects the active backend's
@@ -165,7 +165,7 @@ VIDEO_GENERATE_SCHEMA: Dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 
-def _read_video_gen_section() -> Dict[str, Any]:
+def _read_video_gen_section() -> dict[str, Any]:
     try:
         from hermes_cli.config import load_config
 
@@ -293,21 +293,21 @@ def _coerce_bool(value: Any) -> Optional[bool]:
     return None
 
 
-def _normalize_reference_images(value: Any) -> Optional[List[str]]:
+def _normalize_reference_images(value: Any) -> Optional[list[str]]:
     if value is None:
         return None
     if isinstance(value, str):
         value = [value]
     if not isinstance(value, (list, tuple)):
         return None
-    out: List[str] = []
+    out: list[str] = []
     for item in value:
         if isinstance(item, str) and item.strip():
             out.append(item.strip())
     return out or None
 
 
-def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
+def _handle_video_generate(args: dict[str, Any], **_kw: Any) -> str:
     prompt = (args.get("prompt") or "").strip()
     image_url = (args.get("image_url") or "").strip() or None
     reference_image_urls = _normalize_reference_images(args.get("reference_image_urls"))
@@ -334,7 +334,7 @@ def _handle_video_generate(args: Dict[str, Any], **_kw: Any) -> str:
     # Resolve model: explicit arg wins, then config, then provider default.
     model = model_override or _read_configured_video_model() or provider.default_model()
 
-    kwargs: Dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "model": model,
         "image_url": image_url,
         "reference_image_urls": reference_image_urls,
@@ -425,15 +425,15 @@ _GENERIC_DESCRIPTION = (
 
 
 def _format_model_caveats(
-    model_meta: Dict[str, Any],
-    backend_caps: Dict[str, Any],
-) -> List[str]:
+    model_meta: dict[str, Any],
+    backend_caps: dict[str, Any],
+) -> list[str]:
     """Pull human-readable caveats out of one model's catalog metadata.
 
     Only surfaces things that meaningfully differ from the backend's
     overall capabilities — repeating defaults is noise.
     """
-    caveats: List[str] = []
+    caveats: list[str] = []
 
     modalities = set(model_meta.get("modalities") or [])
     modality = model_meta.get("modality")  # FAL's plugin uses this key for single-modality entries
@@ -453,7 +453,7 @@ def _format_model_caveats(
     return caveats
 
 
-def _build_dynamic_video_schema() -> Dict[str, Any]:
+def _build_dynamic_video_schema() -> dict[str, Any]:
     """Build a description that reflects the active backend's actual surface.
 
     Cheap: reads config (already memoized by the caller), asks the active
@@ -461,7 +461,7 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
     and formats a few lines of prose. Falls back to the generic
     description when no provider is configured or registered.
     """
-    parts: List[str] = [_GENERIC_DESCRIPTION]
+    parts: list[str] = [_GENERIC_DESCRIPTION]
 
     configured = _read_configured_video_provider()
     configured_model = _read_configured_video_model()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -481,7 +481,7 @@ def _build_native_vision_tool_result(
     question: str,
     image_data_url: str,
     image_size_bytes: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build the multimodal tool-result envelope returned by the fast path.
 
     Shape:
@@ -1026,7 +1026,7 @@ VISION_ANALYZE_SCHEMA = {
 }
 
 
-def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
+def _handle_vision_analyze(args: dict[str, Any], **kw: Any) -> Awaitable[str]:
     image_url = args.get("image_url", "")
     question = args.get("question", "")
 
@@ -1413,7 +1413,7 @@ VIDEO_ANALYZE_SCHEMA = {
 }
 
 
-def _handle_video_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
+def _handle_video_analyze(args: dict[str, Any], **kw: Any) -> Awaitable[str]:
     video_url = args.get("video_url", "")
     question = args.get("question", "")
     full_prompt = (

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -393,7 +393,7 @@ class AudioRecorder:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._stream: Any = None
-        self._frames: List[Any] = []
+        self._frames: list[Any] = []
         self._recording = False
         self._start_time: float = 0.0
         # Silence detection state
@@ -787,7 +787,7 @@ def is_whisper_hallucination(transcript: str) -> bool:
 # ============================================================================
 # STT dispatch
 # ============================================================================
-def transcribe_recording(wav_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def transcribe_recording(wav_path: str, model: Optional[str] = None) -> dict[str, Any]:
     """Transcribe a WAV recording using the existing Whisper pipeline.
 
     Delegates to ``tools.transcription_tools.transcribe_audio()``.
@@ -830,12 +830,12 @@ def _transcribe_wav_in_chunks(
     *,
     model: Optional[str],
     max_file_size: int,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Split an oversized WAV into provider-sized chunks and join transcripts."""
     from tools.transcription_tools import transcribe_audio
 
-    chunk_paths: List[str] = []
-    transcripts: List[str] = []
+    chunk_paths: list[str] = []
+    transcripts: list[str] = []
 
     try:
         chunk_paths = _split_wav_for_transcription(wav_path, max_file_size=max_file_size)
@@ -875,10 +875,10 @@ def _transcribe_wav_in_chunks(
                 pass
 
 
-def _split_wav_for_transcription(wav_path: str, *, max_file_size: int) -> List[str]:
+def _split_wav_for_transcription(wav_path: str, *, max_file_size: int) -> list[str]:
     """Write WAV chunks small enough to pass the shared STT file-size gate."""
     os.makedirs(_TEMP_DIR, exist_ok=True)
-    chunk_paths: List[str] = []
+    chunk_paths: list[str] = []
     header_reserve = 64 * 1024
 
     with wave.open(wav_path, "rb") as source:
@@ -1033,7 +1033,7 @@ def play_audio_file(file_path: str) -> bool:
 # ============================================================================
 # Requirements check
 # ============================================================================
-def check_voice_requirements() -> Dict[str, Any]:
+def check_voice_requirements() -> dict[str, Any]:
     """Check if all voice mode requirements are met.
 
     Returns:
@@ -1047,7 +1047,7 @@ def check_voice_requirements() -> Dict[str, Any]:
     stt_provider = _get_provider(stt_config)
     stt_available = stt_enabled and stt_provider != "none"
 
-    missing: List[str] = []
+    missing: list[str] = []
     termux_capture = _termux_voice_capture_available()
     has_audio = _audio_available() or termux_capture
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -304,13 +304,13 @@ def _is_nous_auxiliary_client(client: Any) -> bool:
     return host == "nousresearch.com" or host.endswith(".nousresearch.com")
 
 
-def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optional[Any], Optional[str], Dict[str, Any]]:
+def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optional[Any], Optional[str], dict[str, Any]]:
     """Resolve the current web-extract auxiliary client, model, and extra body."""
     client, default_model = get_async_text_auxiliary_client("web_extract")
     configured_model = os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip()
     effective_model = model or configured_model or default_model
 
-    extra_body: Dict[str, Any] = {}
+    extra_body: dict[str, Any] = {}
     if client is not None and _is_nous_auxiliary_client(client):
         from agent.auxiliary_client import get_auxiliary_extra_body
         from agent.portal_tags import nous_portal_tags
@@ -850,7 +850,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
 
 
 async def web_extract_tool(
-    urls: List[str],
+    urls: list[str],
     format: str = None,
     use_llm_processing: bool = True,
     model: Optional[str] = None,
@@ -912,7 +912,7 @@ async def web_extract_tool(
 
         # ── SSRF protection — filter out private/internal URLs before any backend ──
         safe_urls = []
-        ssrf_blocked: List[Dict[str, Any]] = []
+        ssrf_blocked: list[dict[str, Any]] = []
         for url in urls:
             if not is_safe_url(url):
                 ssrf_blocked.append({

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -32,7 +32,7 @@ _DEFAULT_WEBSITE_BLOCKLIST = {
 # URL check (a web_crawl with 50 pages would otherwise mean 51 YAML parses).
 _CACHE_TTL_SECONDS = 30.0
 _cache_lock = threading.Lock()
-_cached_policy: Optional[Dict[str, Any]] = None
+_cached_policy: Optional[dict[str, Any]] = None
 _cached_policy_path: Optional[str] = None
 _cached_policy_time: float = 0.0
 
@@ -64,7 +64,7 @@ def _normalize_rule(rule: Any) -> Optional[str]:
     return value or None
 
 
-def _iter_blocklist_file_rules(path: Path) -> List[str]:
+def _iter_blocklist_file_rules(path: Path) -> list[str]:
     """Load rules from a shared blocklist file.
 
     Missing or unreadable files log a warning and return an empty list
@@ -79,7 +79,7 @@ def _iter_blocklist_file_rules(path: Path) -> List[str]:
         logger.warning("Failed to read shared blocklist file %s (skipping): %s", path, exc)
         return []
 
-    rules: List[str] = []
+    rules: list[str] = []
     for line in raw.splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
@@ -90,7 +90,7 @@ def _iter_blocklist_file_rules(path: Path) -> List[str]:
     return rules
 
 
-def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
+def _load_policy_config(config_path: Optional[Path] = None) -> dict[str, Any]:
     config_path = config_path or _get_default_config_path()
     if not config_path.exists():
         return dict(_DEFAULT_WEBSITE_BLOCKLIST)
@@ -128,7 +128,7 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     return policy
 
 
-def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]:
+def load_website_blocklist(config_path: Optional[Path] = None) -> dict[str, Any]:
     """Load and return the parsed website blocklist policy.
 
     Results are cached for ``_CACHE_TTL_SECONDS`` to avoid re-reading
@@ -165,8 +165,8 @@ def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]
     if not isinstance(enabled, bool):
         raise WebsitePolicyError("security.website_blocklist.enabled must be a boolean")
 
-    rules: List[Dict[str, str]] = []
-    seen: set[Tuple[str, str]] = set()
+    rules: list[dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
 
     for raw_rule in raw_domains:
         normalized = _normalize_rule(raw_rule)
@@ -229,7 +229,7 @@ def _extract_host_from_urlish(url: str) -> str:
     return ""
 
 
-def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[Dict[str, str]]:
+def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[dict[str, str]]:
     """Check whether a URL is allowed by the website blocklist policy.
 
     Returns ``None`` if access is allowed, or a dict with block metadata

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -67,7 +67,7 @@ MAX_HANDLES = 10
 # Config
 # ---------------------------------------------------------------------------
 
-def _load_x_search_config() -> Dict[str, Any]:
+def _load_x_search_config() -> dict[str, Any]:
     try:
         from hermes_cli.config import load_config
 
@@ -103,7 +103,7 @@ def _get_x_search_retries() -> int:
 # Credential resolution
 # ---------------------------------------------------------------------------
 
-def _resolve_xai_bearer() -> Tuple[str, str, str]:
+def _resolve_xai_bearer() -> tuple[str, str, str]:
     """Return ``(api_key, base_url, source)``.
 
     ``source`` is one of ``"xai-oauth"`` or ``"xai"`` so callers (and tests)
@@ -144,8 +144,8 @@ def check_x_search_requirements() -> bool:
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _normalize_handles(handles: Optional[List[str]], field_name: str) -> List[str]:
-    cleaned: List[str] = []
+def _normalize_handles(handles: Optional[list[str]], field_name: str) -> list[str]:
+    cleaned: list[str] = []
     for handle in handles or []:
         normalized = str(handle or "").strip().lstrip("@")
         if normalized:
@@ -206,12 +206,12 @@ def _validate_date_range(from_date: str, to_date: str) -> None:
             )
 
 
-def _extract_response_text(payload: Dict[str, Any]) -> str:
+def _extract_response_text(payload: dict[str, Any]) -> str:
     output_text = str(payload.get("output_text") or "").strip()
     if output_text:
         return output_text
 
-    parts: List[str] = []
+    parts: list[str] = []
     for item in payload.get("output", []) or []:
         if item.get("type") != "message":
             continue
@@ -224,8 +224,8 @@ def _extract_response_text(payload: Dict[str, Any]) -> str:
     return "\n\n".join(parts).strip()
 
 
-def _extract_inline_citations(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
-    citations: List[Dict[str, Any]] = []
+def _extract_inline_citations(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    citations: list[dict[str, Any]] = []
     for item in payload.get("output", []) or []:
         if item.get("type") != "message":
             continue
@@ -274,8 +274,8 @@ def _http_error_message(exc: requests.HTTPError) -> str:
 
 def x_search_tool(
     query: str,
-    allowed_x_handles: Optional[List[str]] = None,
-    excluded_x_handles: Optional[List[str]] = None,
+    allowed_x_handles: Optional[list[str]] = None,
+    excluded_x_handles: Optional[list[str]] = None,
     from_date: str = "",
     to_date: str = "",
     enable_image_understanding: bool = False,
@@ -300,7 +300,7 @@ def x_search_tool(
         except ValueError as exc:
             return tool_error(str(exc))
 
-        tool_def: Dict[str, Any] = {"type": "x_search"}
+        tool_def: dict[str, Any] = {"type": "x_search"}
         if allowed:
             tool_def["allowed_x_handles"] = allowed
         if excluded:
@@ -383,7 +383,7 @@ def x_search_tool(
         # any narrowing filter is active AND both citation channels came back
         # empty, mark the response as degraded so callers can decide to
         # broaden filters, retry, or fall back to a different source.
-        active_filters: List[str] = []
+        active_filters: list[str] = []
         if allowed:
             active_filters.append("allowed_x_handles")
         if excluded:

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -72,7 +72,7 @@ def hermes_xai_user_agent() -> str:
     return f"Hermes-Agent/{__version__}"
 
 
-def resolve_xai_http_credentials(*, force_refresh: bool = False) -> Dict[str, str]:
+def resolve_xai_http_credentials(*, force_refresh: bool = False) -> dict[str, str]:
     """Resolve bearer credentials for direct xAI HTTP endpoints.
 
     Prefers Hermes-managed xAI OAuth credentials when available, then falls back

--- a/tools/yuanbao_tools.py
+++ b/tools/yuanbao_tools.py
@@ -292,7 +292,7 @@ async def send_dm(
     name: str,
     message: str,
     user_id: str = "",
-    media_files: Optional[List[Tuple[str, bool]]] = None,
+    media_files: Optional[list[tuple[str, bool]]] = None,
 ) -> dict:
     """
     Send a DM (private chat message) to a group member, with optional media.

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[dict[str, any]]:
     """
     Get a toolset distribution by name.
     
@@ -234,7 +234,7 @@ def get_distribution(name: str) -> Optional[Dict[str, any]]:
     return DISTRIBUTIONS.get(name)
 
 
-def list_distributions() -> Dict[str, Dict]:
+def list_distributions() -> dict[str, dict]:
     """
     List all available distributions.
     
@@ -244,7 +244,7 @@ def list_distributions() -> Dict[str, Dict]:
     return DISTRIBUTIONS.copy()
 
 
-def sample_toolsets_from_distribution(distribution_name: str) -> List[str]:
+def sample_toolsets_from_distribution(distribution_name: str) -> list[str]:
     """
     Sample toolsets based on a distribution's probabilities.
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -546,7 +546,7 @@ TOOLSETS = {
 
 
 
-def get_toolset(name: str) -> Optional[Dict[str, Any]]:
+def get_toolset(name: str) -> Optional[dict[str, Any]]:
     """
     Get a toolset definition by name.
     
@@ -597,7 +597,7 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
     }
 
 
-def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
+def resolve_toolset(name: str, visited: set[str] = None) -> list[str]:
     """
     Recursively resolve a toolset to get all tool names.
     
@@ -617,7 +617,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     # Special aliases that represent all tools across every toolset
     # This ensures future toolsets are automatically included without changes.
     if name in {"all", "*"}:
-        all_tools: Set[str] = set()
+        all_tools: set[str] = set()
         for toolset_name in get_toolset_names():
             # Use a fresh visited set per branch to avoid cross-branch contamination
             resolved = resolve_toolset(toolset_name, visited.copy())
@@ -671,7 +671,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     return sorted(tools)
 
 
-def resolve_multiple_toolsets(toolset_names: List[str]) -> List[str]:
+def resolve_multiple_toolsets(toolset_names: list[str]) -> list[str]:
     """
     Resolve multiple toolsets and combine their tools.
     
@@ -690,7 +690,7 @@ def resolve_multiple_toolsets(toolset_names: List[str]) -> List[str]:
     return sorted(all_tools)
 
 
-def _get_plugin_toolset_names() -> Set[str]:
+def _get_plugin_toolset_names() -> set[str]:
     """Return toolset names registered by plugins (from the tool registry).
 
     These are toolsets that exist in the registry but not in the static
@@ -707,7 +707,7 @@ def _get_plugin_toolset_names() -> Set[str]:
         return set()
 
 
-def _get_registry_toolset_aliases() -> Dict[str, str]:
+def _get_registry_toolset_aliases() -> dict[str, str]:
     """Return explicit toolset aliases registered in the live registry."""
     try:
         from tools.registry import registry
@@ -716,7 +716,7 @@ def _get_registry_toolset_aliases() -> Dict[str, str]:
         return {}
 
 
-def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
+def get_all_toolsets() -> dict[str, dict[str, Any]]:
     """
     Get all available toolsets with their definitions.
 
@@ -741,7 +741,7 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     return result
 
 
-def get_toolset_names() -> List[str]:
+def get_toolset_names() -> list[str]:
     """
     Get names of all available toolsets (excluding aliases).
 
@@ -787,8 +787,8 @@ def validate_toolset(name: str) -> bool:
 def create_custom_toolset(
     name: str,
     description: str,
-    tools: List[str] = None,
-    includes: List[str] = None
+    tools: list[str] = None,
+    includes: list[str] = None
 ) -> None:
     """
     Create a custom toolset at runtime.
@@ -808,7 +808,7 @@ def create_custom_toolset(
 
 
 
-def get_toolset_info(name: str) -> Dict[str, Any]:
+def get_toolset_info(name: str) -> dict[str, Any]:
     """
     Get detailed information about a toolset including resolved tools.
     

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -202,7 +202,7 @@ class TrajectoryMetrics:
     summarization_api_calls: int = 0
     summarization_errors: int = 0
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "original_tokens": self.original_tokens,
             "compressed_tokens": self.compressed_tokens,
@@ -245,9 +245,9 @@ class AggregateMetrics:
     total_summarization_errors: int = 0
     
     # Distribution stats
-    compression_ratios: List[float] = field(default_factory=list)
-    tokens_saved_list: List[int] = field(default_factory=list)
-    turns_removed_list: List[int] = field(default_factory=list)
+    compression_ratios: list[float] = field(default_factory=list)
+    tokens_saved_list: list[int] = field(default_factory=list)
+    turns_removed_list: list[int] = field(default_factory=list)
     
     processing_start_time: str = ""
     processing_end_time: str = ""
@@ -277,7 +277,7 @@ class AggregateMetrics:
         if metrics.still_over_limit:
             self.trajectories_still_over_limit += 1
     
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         avg_compression_ratio = (
             sum(self.compression_ratios) / len(self.compression_ratios) 
             if self.compression_ratios else 1.0
@@ -471,15 +471,15 @@ class TrajectoryCompressor:
             # Fallback to character estimate
             return len(text) // 4
     
-    def count_trajectory_tokens(self, trajectory: List[Dict[str, str]]) -> int:
+    def count_trajectory_tokens(self, trajectory: list[dict[str, str]]) -> int:
         """Count total tokens in a trajectory."""
         return sum(self.count_tokens(turn.get("value", "")) for turn in trajectory)
     
-    def count_turn_tokens(self, trajectory: List[Dict[str, str]]) -> List[int]:
+    def count_turn_tokens(self, trajectory: list[dict[str, str]]) -> list[int]:
         """Count tokens for each turn in a trajectory."""
         return [self.count_tokens(turn.get("value", "")) for turn in trajectory]
     
-    def _find_protected_indices(self, trajectory: List[Dict[str, str]]) -> Tuple[set, int, int]:
+    def _find_protected_indices(self, trajectory: list[dict[str, str]]) -> tuple[set, int, int]:
         """
         Find indices of protected turns.
         
@@ -527,7 +527,7 @@ class TrajectoryCompressor:
         
         return protected, compressible_start, compressible_end
     
-    def _extract_turn_content_for_summary(self, trajectory: List[Dict[str, str]], start: int, end: int) -> str:
+    def _extract_turn_content_for_summary(self, trajectory: list[dict[str, str]], start: int, end: int) -> str:
         """
         Extract content from turns to be summarized.
         
@@ -708,8 +708,8 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
     
     def compress_trajectory(
         self,
-        trajectory: List[Dict[str, str]]
-    ) -> Tuple[List[Dict[str, str]], TrajectoryMetrics]:
+        trajectory: list[dict[str, str]]
+    ) -> tuple[list[dict[str, str]], TrajectoryMetrics]:
         """
         Compress a single trajectory to fit within target token budget.
         
@@ -828,8 +828,8 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
     
     async def compress_trajectory_async(
         self,
-        trajectory: List[Dict[str, str]]
-    ) -> Tuple[List[Dict[str, str]], TrajectoryMetrics]:
+        trajectory: list[dict[str, str]]
+    ) -> tuple[list[dict[str, str]], TrajectoryMetrics]:
         """
         Compress a single trajectory to fit within target token budget (async version).
         
@@ -924,7 +924,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         
         return compressed, metrics
     
-    async def process_entry_async(self, entry: Dict[str, Any]) -> Tuple[Dict[str, Any], TrajectoryMetrics]:
+    async def process_entry_async(self, entry: dict[str, Any]) -> tuple[dict[str, Any], TrajectoryMetrics]:
         """
         Process a single JSONL entry (async version).
         """
@@ -945,7 +945,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         
         return result, metrics
     
-    def process_entry(self, entry: Dict[str, Any]) -> Tuple[Dict[str, Any], TrajectoryMetrics]:
+    def process_entry(self, entry: dict[str, Any]) -> tuple[dict[str, Any], TrajectoryMetrics]:
         """
         Process a single JSONL entry.
         
@@ -1043,7 +1043,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         # Track timeouts separately
         timeout_count = 0
         
-        async def process_single(file_path: Path, entry_idx: int, entry: Dict, 
+        async def process_single(file_path: Path, entry_idx: int, entry: dict, 
                                   progress, main_task, status_task):
             """Process a single entry with semaphore rate limiting and timeout."""
             nonlocal compressed_count, skipped_count, api_calls, in_flight, timeout_count


### PR DESCRIPTION
## What does this PR do?

Adds the `UP006` rule to pyproject.toml and applies auto-fix across 294 files.

Converts PEP 585-deprecated type annotations — `List[str]` → `list[str]`, `Dict[str, int]` → `dict[str, int]`, `Tuple[int, ...]` → `tuple[int, ...]`, `Set[str]` → `set[str]`, `Type[X]` → `type[X]`. Requires Python ≥ 3.9 (project target: 3.11).

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds the `UP006` rule to pyproject.toml and applies auto-fix across 294 files.

Converts PEP 585-deprecated type annotations — `List[str]` → `list[str]`, `Dict[str, int]` → `dict[str, int]`, `Tuple[int, ...]` → `tuple[int, ...]`, `Set[str]` → `set[str]`, `Type[X]` → `type[X]`. Requires Python ≥ 3.9 (project target: 3.11).

## What Changed

- `pyproject.toml`: added `UP006` to `[tool.ruff.lint] select`
- **294 files** changed: **+3792/-3792** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `UP006` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_