### PR TITLE
fix(gateway): show Telegram context usage footer

### DIFF
--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -30,6 +30,11 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
+    # Telegram users do not have the CLI status bar, so give them a tiny
+    # built-in footer that exposes the same core context-usage signal.
+    "telegram": {"enabled": True, "fields": ["context_usage"]},
+}
 _SEP = " · "
 
 
@@ -54,6 +59,23 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def _format_token_count(tokens: int) -> str:
+    """Format token counts compactly (e.g. 11800 -> '11.8K')."""
+    if tokens >= 1_000_000:
+        val = tokens / 1_000_000
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}M"
+        return f"{val:.1f}M"
+    if tokens >= 1_000:
+        val = tokens / 1_000
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}K"
+        return f"{val:.1f}K"
+    return str(tokens)
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -62,8 +84,9 @@ def resolve_footer_config(
 
     Merge order (later wins):
         1. Built-in defaults (enabled=False)
-        2. ``display.runtime_footer``
-        3. ``display.platforms.<platform_key>.runtime_footer``
+        2. Built-in per-platform defaults
+        3. ``display.runtime_footer``
+        4. ``display.platforms.<platform_key>.runtime_footer``
     """
     resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
     cfg = (user_config or {}).get("display") or {}
@@ -85,6 +108,22 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+
+    has_user_global = isinstance(global_cfg, dict)
+    has_user_platform = False
+    if platform_key:
+        platforms = cfg.get("platforms") or {}
+        plat_cfg = platforms.get(platform_key)
+        if isinstance(plat_cfg, dict):
+            has_user_platform = isinstance(plat_cfg.get("runtime_footer"), dict)
+
+    if not has_user_global and not has_user_platform:
+        plat_default = _PLATFORM_DEFAULTS.get(platform_key or "")
+        if isinstance(plat_default, dict):
+            if "enabled" in plat_default:
+                resolved["enabled"] = bool(plat_default.get("enabled"))
+            if isinstance(plat_default.get("fields"), list) and plat_default["fields"]:
+                resolved["fields"] = [str(f) for f in plat_default["fields"]]
 
     return resolved
 
@@ -108,6 +147,12 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "context_usage":
+            if context_length and context_length > 0 and context_tokens >= 0:
+                parts.append(
+                    f"{_format_token_count(context_tokens)}/"
+                    f"{_format_token_count(context_length)}"
+                )
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1074,10 +1074,11 @@ DEFAULT_CONFIG = {
         # (disabled) preserves prior behavior.
         "ephemeral_system_ttl": 0,
         "platforms": {},  # Per-platform display overrides: {"telegram": {"tool_progress": "all"}, "slack": {"tool_progress": "off"}}
-        # Gateway runtime-metadata footer appended to the FINAL message of a turn
-        # (disabled by default to keep replies minimal). When enabled, renders
-        # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under
-        # display.platforms.<platform>.runtime_footer.
+        # Gateway runtime-metadata footer appended to the FINAL message of a turn.
+        # Global default stays off to keep replies minimal, but Telegram gets a
+        # built-in per-platform `context_usage` footer unless the user overrides it.
+        # When enabled, renders e.g. `model · 68% · ~/projects/hermes`. Per-platform
+        # overrides go under display.platforms.<platform>.runtime_footer.
         "runtime_footer": {
             "enabled": False,
             "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -8,6 +8,7 @@ import os
 import pytest
 
 from gateway.runtime_footer import (
+    _format_token_count,
     _home_relative_cwd,
     _model_short,
     build_footer_line,
@@ -17,7 +18,7 @@ from gateway.runtime_footer import (
 
 
 # ---------------------------------------------------------------------------
-# _model_short + _home_relative_cwd
+# _model_short + _home_relative_cwd + _format_token_count
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize(
@@ -50,6 +51,19 @@ def test_home_relative_cwd_leaves_abs_path_alone(tmp_path, monkeypatch):
 
 def test_home_relative_cwd_empty_returns_empty():
     assert _home_relative_cwd("") == ""
+
+
+@pytest.mark.parametrize(
+    "tokens,expected",
+    [
+        (999, "999"),
+        (11_800, "11.8K"),
+        (204_800, "204.8K"),
+        (1_050_000, "1.1M"),
+    ],
+)
+def test_format_token_count(tokens, expected):
+    assert _format_token_count(tokens) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +107,17 @@ def test_format_footer_context_pct_clamped_to_100():
         fields=("context_pct",),
     )
     assert out == "100%"
+
+
+def test_format_footer_context_usage():
+    out = format_runtime_footer(
+        model="m",
+        context_tokens=11_800,
+        context_length=204_800,
+        cwd="",
+        fields=("context_usage",),
+    )
+    assert out == "11.8K/204.8K"
 
 
 def test_format_footer_context_pct_never_negative():
@@ -152,14 +177,26 @@ def test_format_footer_unknown_field_silently_ignored():
 # ---------------------------------------------------------------------------
 
 def test_resolve_defaults_off_empty_config():
-    cfg = resolve_footer_config({}, "telegram")
+    cfg = resolve_footer_config({}, "discord")
     assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"]}
+
+
+def test_resolve_telegram_platform_default_enabled():
+    cfg = resolve_footer_config({}, "telegram")
+    assert cfg == {"enabled": True, "fields": ["context_usage"]}
 
 
 def test_resolve_global_enable():
     user = {"display": {"runtime_footer": {"enabled": True}}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is True
+    assert cfg["fields"] == ["model", "context_pct", "cwd"]
+
+
+def test_resolve_global_disable_can_override_telegram_default():
+    user = {"display": {"runtime_footer": {"enabled": False}}}
+    cfg = resolve_footer_config(user, "telegram")
+    assert cfg["enabled"] is False
     assert cfg["fields"] == ["model", "context_pct", "cwd"]
 
 
@@ -198,7 +235,7 @@ def test_resolve_platform_can_add_fields_only():
 def test_resolve_ignores_malformed_config():
     # Non-dict runtime_footer shouldn't crash
     user = {"display": {"runtime_footer": "on"}}
-    cfg = resolve_footer_config(user, "telegram")
+    cfg = resolve_footer_config(user, "discord")
     assert cfg["enabled"] is False
 
 
@@ -209,12 +246,24 @@ def test_resolve_ignores_malformed_config():
 def test_build_footer_empty_when_disabled():
     out = build_footer_line(
         user_config={},
-        platform_key="telegram",
+        platform_key="discord",
         model="openai/gpt-5.4",
         context_tokens=10, context_length=100,
         cwd="/tmp",
     )
     assert out == ""
+
+
+def test_build_footer_telegram_uses_platform_default():
+    out = build_footer_line(
+        user_config={},
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_tokens=11_800,
+        context_length=204_800,
+        cwd="/tmp",
+    )
+    assert out == "11.8K/204.8K"
 
 
 def test_build_footer_returns_rendered_when_enabled(monkeypatch, tmp_path):


### PR DESCRIPTION
Fixes #3953.

## Summary
- add a compact `context_usage` runtime-footer field for gateway replies
- enable a minimal Telegram-only footer by default when the user has not configured `display.runtime_footer`
- keep explicit global/per-platform runtime_footer config authoritative over the built-in Telegram default

## Proof
- `pytest -o addopts='' tests/gateway/test_runtime_footer.py -q`
- `uv run --frozen ruff check gateway/runtime_footer.py tests/gateway/test_runtime_footer.py hermes_cli/config.py`
- `python3 -m py_compile gateway/runtime_footer.py tests/gateway/test_runtime_footer.py hermes_cli/config.py`
- `git diff --check`
