### PR TITLE
fix(memory): surface gateway write failures + auto-truncate + capacity warning (salvage of #2774 + #2777, fixes #2771)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -835,9 +835,14 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         return False, ""
 
     # Memory: distinguish "store full" from real errors.
+    # Match both the legacy "exceed the limit" wording and any newer variant
+    # that includes the literal word "full" (e.g. "memory store is full",
+    # "MemoryFullError"), case-insensitively. Keeps fixtures backward-compatible.
     if tool_name == "memory":
-        if isinstance(data, dict):
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+        if isinstance(data, dict) and data.get("success") is False:
+            err_msg = data.get("error", "") or ""
+            err_lower = err_msg.lower()
+            if "exceed the limit" in err_lower or "full" in err_lower:
                 return True, " [full]"
 
     # Structured error in JSON result (any tool that surfaces {"error": ...}).

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -733,6 +733,47 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 old_text=function_args.get("old_text"),
                 store=agent._memory_store,
             )
+            # Surface memory write outcomes to gateway/IM users via the
+            # existing _emit_warning plumbing (#2771). Three cases:
+            #   1. success=False                — surface the underlying error
+            #   2. success=True + truncated     — tell user content was cut
+            #   3. success=True + usage >= 80%  — proactive capacity warning
+            # Wrapped in a broad try/except so a malformed result can never
+            # break the tool path.
+            try:
+                _mem_data = (
+                    json.loads(function_result)
+                    if isinstance(function_result, str)
+                    else None
+                )
+                if isinstance(_mem_data, dict):
+                    if _mem_data.get("success") is False:
+                        _err = str(_mem_data.get("error", "unknown error"))[:200]
+                        agent._emit_warning(
+                            f"Memory write failed ({target}): {_err}"
+                        )
+                    elif _mem_data.get("success") is True:
+                        if _mem_data.get("truncated"):
+                            _orig = _mem_data.get("original_length", 0)
+                            _saved = _mem_data.get("saved_length", 0)
+                            agent._emit_warning(
+                                f"Memory entry truncated to fit: kept "
+                                f"{_saved}/{_orig} chars in {target}."
+                            )
+                        _usage = _mem_data.get("usage", "")
+                        if isinstance(_usage, str) and "%" in _usage:
+                            try:
+                                _pct = int(_usage.split("%", 1)[0].strip())
+                                if _pct >= 80:
+                                    agent._emit_warning(
+                                        f"Memory store '{target}' at "
+                                        f"{_pct}% capacity. Consider "
+                                        f"/compress or pruning entries soon."
+                                    )
+                            except (ValueError, IndexError):
+                                pass
+            except (ValueError, TypeError):
+                pass  # JSON parse failed -- silently skip warning
             # Bridge: notify external memory provider of built-in memory writes
             if agent._memory_manager and function_args.get("action") in {"add", "replace"}:
                 try:

--- a/tests/agent/test_display_tool_failure.py
+++ b/tests/agent/test_display_tool_failure.py
@@ -85,6 +85,19 @@ class TestDetectToolFailureMemory:
         result = json.dumps({"success": False, "error": "would exceed the limit"})
         assert _detect_tool_failure("memory", result) == (True, " [full]")
 
+    def test_memory_full_keyword_returns_full_suffix(self):
+        # Broadened detection: any error message containing 'full' should
+        # collapse to ' [full]' too — covers MemoryFullError, 'store is
+        # full', etc. without needing the exact 'exceed the limit' phrase.
+        result = json.dumps({"success": False, "error": "memory store is full"})
+        assert _detect_tool_failure("memory", result) == (True, " [full]")
+
+    def test_memory_full_case_insensitive(self):
+        # Matching is case-insensitive so future LLM-formatted errors with
+        # different capitalisation also collapse cleanly.
+        result = json.dumps({"success": False, "error": "MEMORY STORE IS FULL"})
+        assert _detect_tool_failure("memory", result) == (True, " [full]")
+
     def test_memory_other_error_returns_specific_message(self):
         # An error that's NOT a "full" overflow falls through to the
         # structured-error path and surfaces the actual message.

--- a/tests/agent/test_tool_executor_memory_warnings.py
+++ b/tests/agent/test_tool_executor_memory_warnings.py
@@ -1,0 +1,234 @@
+"""Tests for memory-tool result -> _emit_warning surfacing (#2771).
+
+The built-in `memory` tool is executed inline by
+``execute_tool_calls_sequential`` in ``agent/tool_executor.py``. Prior to
+the salvage fix for #2771, capacity overflows / write failures were
+JSON-encoded into the tool result string and silently flowed back to the
+model — gateway/IM users never saw them. The fix parses the result and
+fans the three interesting cases out through the existing
+``Agent._emit_warning`` plumbing.
+
+These tests verify:
+  - ``success: False``                          -> warning containing 'failed'
+  - ``success: True`` + ``usage`` >= 80%%         -> capacity warning
+  - ``success: True`` + ``truncated: True``       -> truncation warning
+  - normal success (usage < 80%%, no truncate)   -> NO warning emitted
+
+We construct a real ``AIAgent`` (cheap thanks to ``skip_memory=True``)
+and monkey-patch ``tools.memory_tool.memory_tool`` to return a chosen
+JSON string. We then capture ``_emit_warning`` calls and assert on them.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_tool_call(name="memory", arguments="{}", call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _make_agent() -> AIAgent:
+    """Build a minimal AIAgent that can run the sequential tool dispatcher."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("memory")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            max_iterations=3,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    # Capture warnings for assertion. _emit_warning is the user-visible
+    # channel we are validating.
+    agent._captured_warnings = []
+    original = agent._emit_warning
+
+    def _capture(msg):
+        agent._captured_warnings.append(msg)
+        # Don't call original — it tries to vprint which is fine but
+        # noisy; we just need the list of messages.
+        return original(msg) if False else None
+
+    agent._emit_warning = _capture  # type: ignore[assignment]
+    return agent
+
+
+def _run_memory_tool(agent: AIAgent, memory_result: dict, args: dict | None = None) -> list:
+    """Drive a single memory tool call through the sequential dispatcher.
+
+    Returns the list of warning messages captured during the run.
+    """
+    args = args or {"action": "add", "target": "memory", "content": "hello"}
+    tc = _mock_tool_call("memory", json.dumps(args), "c-mem")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages: list = []
+    # Patch the symbol where it is imported inside the dispatcher branch.
+    with patch(
+        "tools.memory_tool.memory_tool",
+        return_value=json.dumps(memory_result),
+    ):
+        agent._execute_tool_calls_sequential(msg, messages, "task-mem")
+    return list(agent._captured_warnings)
+
+
+# =========================================================================
+# Failure path: success=False -> warning containing 'failed'
+# =========================================================================
+
+
+def test_failure_emits_warning():
+    agent = _make_agent()
+    warnings = _run_memory_tool(
+        agent,
+        {
+            "success": False,
+            "error": "Memory at 480/500 chars. Adding this entry (200 chars) would exceed the limit.",
+        },
+    )
+    assert any("failed" in w.lower() for w in warnings), warnings
+    assert any("memory" in w.lower() for w in warnings), warnings
+
+
+def test_failure_warning_truncates_long_error():
+    # Defensive: a runaway error string must not flood the warning channel.
+    agent = _make_agent()
+    long_err = "boom " * 200  # 1000 chars
+    warnings = _run_memory_tool(
+        agent,
+        {"success": False, "error": long_err},
+    )
+    assert warnings, "expected at least one warning"
+    # The warning includes a prefix; the embedded error portion should
+    # be capped at ~200 chars per the spec.
+    bodies = [w for w in warnings if "failed" in w.lower()]
+    assert bodies
+    # The whole warning is "Memory write failed (target): <err[:200]>";
+    # check the err substring is truncated.
+    assert len(bodies[0]) < 400
+
+
+# =========================================================================
+# Capacity warning: usage >= 80%% -> capacity message
+# =========================================================================
+
+
+def test_full_capacity_emits_warning():
+    agent = _make_agent()
+    warnings = _run_memory_tool(
+        agent,
+        {
+            "success": True,
+            "target": "memory",
+            "entries": ["fact"],
+            "usage": "85% — 1,700/2,000 chars",
+            "entry_count": 1,
+        },
+    )
+    assert any("85%" in w and "capacity" in w.lower() for w in warnings), warnings
+
+
+def test_capacity_warning_at_exactly_80():
+    agent = _make_agent()
+    warnings = _run_memory_tool(
+        agent,
+        {
+            "success": True,
+            "target": "memory",
+            "entries": ["fact"],
+            "usage": "80% — 1,600/2,000 chars",
+            "entry_count": 1,
+        },
+    )
+    assert any("capacity" in w.lower() for w in warnings), warnings
+
+
+# =========================================================================
+# Truncation warning: truncated=True -> kept N/M chars message
+# =========================================================================
+
+
+def test_truncated_emits_warning():
+    agent = _make_agent()
+    warnings = _run_memory_tool(
+        agent,
+        {
+            "success": True,
+            "target": "memory",
+            "entries": ["x"],
+            "usage": "60% — 1,200/2,000 chars",
+            "entry_count": 1,
+            "truncated": True,
+            "original_length": 1000,
+            "saved_length": 600,
+        },
+    )
+    assert any("truncated" in w.lower() for w in warnings), warnings
+    # Should mention the byte counts.
+    truncation_msgs = [w for w in warnings if "truncated" in w.lower()]
+    assert any("600" in w and "1000" in w for w in truncation_msgs), truncation_msgs
+
+
+# =========================================================================
+# Normal success: no warning at all
+# =========================================================================
+
+
+def test_normal_success_no_warning():
+    agent = _make_agent()
+    warnings = _run_memory_tool(
+        agent,
+        {
+            "success": True,
+            "target": "memory",
+            "entries": ["fact"],
+            "usage": "30% — 600/2,000 chars",
+            "entry_count": 1,
+        },
+    )
+    assert warnings == [], warnings
+
+
+def test_malformed_result_does_not_break_path():
+    # Guarantee robustness: a non-JSON result must not raise. Use a string
+    # that isn't valid JSON via a patch that returns garbage.
+    agent = _make_agent()
+    tc = _mock_tool_call("memory", json.dumps({"action": "add", "content": "x"}), "c-mem")
+    msg = SimpleNamespace(content="", tool_calls=[tc])
+    messages: list = []
+    with patch("tools.memory_tool.memory_tool", return_value="not valid json!!"):
+        # Should not raise.
+        agent._execute_tool_calls_sequential(msg, messages, "task-mem")
+    # And no warnings synthesised from garbage.
+    assert agent._captured_warnings == []

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -636,3 +636,82 @@ class TestLoadTimeSnapshotSanitization:
         # Block marker appears exactly once, not nested
         assert snapshot.count("[BLOCKED:") == 1
         assert "Clean fact" in snapshot
+
+
+# =========================================================================
+# Auto-truncation on capacity overflow (#2771)
+#
+# When an add() would push the store past its char_limit, the store now
+# attempts one retry with the new entry shrunk to ~60%% of its original
+# length (capped by the actual available budget, word-boundary preserved).
+# If even the salvageable budget is too small to be meaningful (<50 chars)
+# the original overflow error is returned unchanged.
+# =========================================================================
+
+
+class TestAutoTruncation:
+    """add() salvages over-budget entries instead of failing outright."""
+
+    def test_add_truncates_when_over_limit(self, store):
+        # Fixture limit is 500 chars. Pre-fill so only ~100 chars remain,
+        # then try to add a 400-char entry. The retry should shrink it to
+        # ~60%% (=240 chars) and then cap to the actual available budget.
+        store.add("memory", "x" * 380)
+        oversized = "the quick brown fox " * 30  # ~600 chars
+        before_len = len(oversized.strip())
+
+        result = store.add("memory", oversized)
+
+        assert result["success"] is True
+        assert result.get("truncated") is True
+        assert result["original_length"] == before_len
+        assert result["saved_length"] <= int(before_len * 0.6) + 1
+        assert result["saved_length"] < before_len
+        # And the stored entry actually fits the limit.
+        from tools.memory_tool import ENTRY_DELIMITER
+        total = len(ENTRY_DELIMITER.join(store.memory_entries))
+        assert total <= 500
+
+    def test_add_no_truncation_when_within_limit(self, store):
+        # Normal add path: truncated flag must be absent.
+        result = store.add("memory", "Plain entry that fits easily.")
+        assert result["success"] is True
+        assert "truncated" not in result
+        assert "original_length" not in result
+        assert "saved_length" not in result
+
+    def test_truncation_preserves_word_boundary(self, store):
+        # Stuff the store so the budget is small but >50 chars; truncated
+        # entry must NOT end mid-word (i.e. last char shouldn't be a
+        # letter followed by a chopped-off remainder).
+        store.add("memory", "x" * 300)
+        sentence = "alpha bravo charlie delta echo foxtrot golf hotel " * 10
+        result = store.add("memory", sentence)
+        assert result["success"] is True
+        assert result.get("truncated") is True
+        saved = store.memory_entries[-1]
+        # The original sentence is built from whole space-separated words.
+        # If the truncated string was cut mid-word, its final whitespace-
+        # separated token would not appear in the original word list.
+        words = sentence.split()
+        last_token = saved.split()[-1]
+        assert last_token in words, (
+            f"truncated entry ends mid-word: ...{saved[-30:]!r}"
+        )
+
+    def test_truncation_skipped_when_too_small_budget(self, tmp_path, monkeypatch):
+        # Use a very small char_limit so 60%% of the new entry would be
+        # below the 50-char floor. Must return the original overflow
+        # error, not save a useless stub.
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        tiny_store = MemoryStore(memory_char_limit=60, user_char_limit=60)
+        tiny_store.load_from_disk()
+        tiny_store.add("memory", "x" * 50)  # near-full
+
+        result = tiny_store.add("memory", "another fact that will not fit")
+
+        assert result["success"] is False
+        assert "exceed" in result["error"].lower()
+        assert "truncated" not in result
+        # Store is unchanged (only the original 50-char entry).
+        assert len(tiny_store.memory_entries) == 1

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -327,7 +327,7 @@ class MemoryStore:
 
             if new_total > limit:
                 current = self._char_count(target)
-                return {
+                overflow_error = {
                     "success": False,
                     "error": (
                         f"Memory at {current:,}/{limit:,} chars. "
@@ -337,6 +337,49 @@ class MemoryStore:
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 }
+
+                # Attempt ONE auto-truncation retry: shrink the new entry to
+                # ~60% of its original length and cap it at the actual
+                # available budget. Preserve word boundaries by trimming at
+                # the last whitespace within the budget. If the salvaged
+                # entry would be too small to be useful (<50 chars), give up
+                # and surface the original overflow error.
+                delimiter_overhead = len(ENTRY_DELIMITER) if entries else 0
+                available = limit - current - delimiter_overhead
+                target_len = min(int(len(content) * 0.6), available)
+                if target_len < 50:
+                    return overflow_error
+
+                candidate = content[:target_len]
+                # Trim at last whitespace to keep word boundaries when
+                # possible; fall back to a hard cut if there is no space.
+                if " " in candidate:
+                    candidate = candidate.rsplit(" ", 1)[0]
+                truncated = candidate.rstrip()
+                if not truncated or len(truncated) < 50:
+                    return overflow_error
+
+                # Re-verify the truncated entry fits (paranoia: word-boundary
+                # trim should only ever shrink, never grow, the budget).
+                trial_entries = entries + [truncated]
+                if len(ENTRY_DELIMITER.join(trial_entries)) > limit:
+                    return overflow_error
+
+                entries.append(truncated)
+                self._set_entries(target, entries)
+                self.save_to_disk(target)
+
+                resp = self._success_response(
+                    target,
+                    (
+                        f"Entry was truncated from {len(content)} to "
+                        f"{len(truncated)} chars to fit available space."
+                    ),
+                )
+                resp["truncated"] = True
+                resp["original_length"] = len(content)
+                resp["saved_length"] = len(truncated)
+                return resp
 
             entries.append(content)
             self._set_entries(target, entries)


### PR DESCRIPTION
Salvage PR for #2771 (silent memory write failures invisible to gateway/IM users). Combines the cleaner core of #2774 (Mibayy) with the richer feature set of #2777 (ygd58), wires both through the existing `Agent._emit_warning` plumbing instead of adding a new callback path, and ships with tests neither prior PR had end-to-end.

## What changed — 4 layers

- **Layer 1 — broaden `[full]` detector** (`agent/display.py`, +7/-2). The memory failure detector now matches any case-insensitive occurrence of `full` in the error string in addition to the legacy `exceed the limit` phrase. Covers `MemoryFullError`, `"store is full"`, etc., without breaking existing fixtures.
- **Layer 2 — auto-truncation in `MemoryStore.add()`** (`tools/memory_tool.py`, +44/-1). On capacity overflow, attempt one retry with the new entry shrunk to roughly 60% of original length, capped by the actual available budget, with the trim point snapped to the last whitespace so word boundaries are preserved. A salvaged save returns success plus `truncated: True`, `original_length`, `saved_length`, and a human-readable `message`. If the budget is too small to be useful (<50 chars) the original overflow error is returned unchanged — no garbage stubs. `replace()` and `remove()` are deliberately left strict.
- **Layer 3 — surface results via existing `_emit_warning`** (`agent/tool_executor.py`, +41/-0). After the memory tool returns, the executor parses the JSON result and routes three previously-silent conditions through `Agent._emit_warning` (which already fans out to both CLI `_vprint` and gateway `status_callback("warn", ...)`):
  - `success: False` → trimmed (≤200 char) error
  - `success: True` + `truncated: True` → "kept N/M chars" notice
  - `usage >= 80%` → proactive capacity warning suggesting `/compress` or pruning
  Wrapped in try/except so a malformed result can never break the tool path.
- **Layer 4 — tests** (3 files, +326): two new cases in `test_display_tool_failure.py`, a new `TestAutoTruncation` class with 4 cases in `test_memory_tool.py`, and a new `test_tool_executor_memory_warnings.py` (7 cases) that drives a real `AIAgent.execute_tool_calls_sequential` with a patched `memory_tool` to assert on captured warning messages.

## Improvements over #2774 / #2777

- **Simpler plumbing than either**: reuses `Agent._emit_warning` instead of introducing a new failure-callback parameter or a separate status pipeline. Zero new gateway surface area; warnings already flow to IM via existing `status_callback("warn", ...)`.
- **Broader `[full]` detection**: both prior PRs only handled the exact `exceed the limit` phrase. This one matches any `full` keyword (case-insensitive), covering future error variants and `MemoryFullError`-style class names.
- **Word-boundary-preserving truncation**: #2777's variant cut mid-word. Here the trim point is snapped to the last whitespace within the budget, with a hard fallback if no space exists.
- **Comprehensive test coverage**: 11 new test cases covering all three behaviors end-to-end, including a defensive case for malformed tool results. Neither prior PR had executor-level tests.

## Tests

- `tests/agent/test_display_tool_failure.py` — 2 new cases (broadened detector).
- `tests/tools/test_memory_tool.py` — `TestAutoTruncation` with 4 cases (truncates when over limit; no truncation flag on normal add; word boundary preserved; skipped when budget < 50 chars).
- `tests/agent/test_tool_executor_memory_warnings.py` — 7 cases (failure → warning; long-error truncation; capacity >= 80%; exactly 80% threshold; truncated → warning with counts; normal success → no warning; malformed JSON does not raise).

## Validation

```
python -m pytest tests/agent/test_display_tool_failure.py tests/agent/test_tool_executor_memory_warnings.py "tests/tools/test_memory_tool.py::TestAutoTruncation" -q
→ 37 passed in 74.03s

python -m ruff check tools/memory_tool.py agent/display.py agent/tool_executor.py tests/agent/test_display_tool_failure.py tests/tools/test_memory_tool.py tests/agent/test_tool_executor_memory_warnings.py
→ All checks passed!

python -m py_compile tools/memory_tool.py agent/display.py agent/tool_executor.py
→ OK
```

(Full-file run shows 76 passed, 1 failed in `TestMemoryStorePersistence::test_deduplication_on_load` — this is a pre-existing Windows UTF-8 encoding bug unrelated to this PR, verified to fail identically on `main`.)

## Why salvage

@alt-glitch (COLLABORATOR) flagged #2774 and #2777 as "competing implementations for #2771" on 2026-04-29 and both have been stale since. This salvage pattern matches @teknium1's recent merge cadence (e.g. `salvage of #31712`, `salvage of #30553+#11004` merged 2026-05-24/25). Both original authors get credit; the bug gets fixed.

Fixes #2771
Closes #2774
Closes #2777