### PR TITLE
fix(dashboard): stop ChatPage from clearing all pages' header action buttons

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -217,14 +217,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   useEffect(() => {
     // When hidden (non-chat tab) we must not register the header button —
     // another page owns the header's end slot at that point.
-    if (!isActive) {
-      setEnd(null);
-      return;
-    }
-    if (!narrow) {
-      setEnd(null);
-      return;
-    }
+    if (!isActive || !narrow) return;
     setEnd(
       <Button
         ghost


### PR DESCRIPTION
Fixes #31862

## Problem

When the dashboard is started with embedded TUI chat enabled (`hermes dashboard --tui`), navigating to **any** non-chat page causes the page-specific header action buttons to disappear after a few seconds.

This affects at least:
- **Cron** page — the "CREATE" button disappears
- **Models** page — the "7D / 30D / 90D" filter buttons disappear
- **Sessions** page — the search box disappears

## Screenshots

### Cron page — normal vs buggy
 Normal
<img width="1667" height="60" alt="cron" src="https://github.com/user-attachments/assets/5f8e8bd4-2788-4740-bf1c-2a43a855d2a3" />

Buggy 
<img width="1672" height="98" alt="cron_issue" src="https://github.com/user-attachments/assets/4bc7ace7-cacb-44c3-b38d-19f6d40886ea" />


### Models page — normal vs buggy
Normal 
<img width="1673" height="58" alt="models" src="https://github.com/user-attachments/assets/914a4ec4-928c-4f3c-a7c8-217b726fc5df" />

Buggy 
<img width="1657" height="48" alt="models_issue" src="https://github.com/user-attachments/assets/a085d016-f2a7-423d-ae8a-cac24f3eca5f" />

## Root Cause

`ChatPage` is mounted **persistently** outside `<Routes>` (so the PTY / WebSocket survive tab switches). Even when the user is on `/cron`, `/models`, or `/sessions`, `ChatPage` is still in the React tree with `isActive=false`.

Its `useEffect` for the header button actively calls `setEnd(null)` on every render when `!isActive`, clobbering the action buttons that the current page had just placed in the same slot.

The trigger for the ~3–4 second timing is the **plugin load delay**: `usePlugins()` fetches manifests asynchronously; once the promise settles, the entire tree re-renders, ChatPage's effect fires, and the header slot is wiped.

## Fix

Change the effect to **only register when Chat should own the slot**, and let cleanup run only when it actually did:

```tsx
// Before (buggy): actively clears other pages' content
useEffect(() => {
  if (!isActive) {
    setEnd(null);  // ← clears Cron CREATE button!
    return;
  }
  if (!narrow) {
    setEnd(null);  // ← also clears!
    return;
  }
  setEnd(<Button ... />);
  return () => setEnd(null);
}, [...]);

// After (fixed): only cleanup on unmount / when Chat owned the slot
useEffect(() => {
  if (!isActive || !narrow) return;  // just don't register
  setEnd(<Button ... />);
  return () => setEnd(null);  // cleanup only when Chat owned the slot
}, [...]);
```

`PageHeaderProvider` already clears all slots on `pathname` change via `useLayoutEffect`, so ChatPage's active clearing is redundant and harmful.

## Safety Analysis

| Scenario | Before | After |
|----------|--------|-------|
| Direct load /cron | Slots cleared by pathname effect, then set by CronPage | Same |
| Navigate /cron → /chat (wide) | ChatPage clears, pathname effect clears (redundant) | pathname effect clears, ChatPage doesn't set → Same result |
| Navigate /cron → /chat (narrow) | ChatPage clears, then sets button | pathname effect clears, ChatPage sets button → Same result |
| Resize /chat wide → narrow | ChatPage clears, then sets button | ChatPage sets button → Same result |
| Plugin delay causes re-render on /cron | ChatPage clears Cron's CREATE button | ChatPage does nothing; button stays → **Fixed** |

No behavior change for Chat itself; only stops the erroneous clearing of other pages' header content.

## Verification

- Reproduced on clean community `main`: Cron CREATE button and Models filter buttons disappear after plugin 404 delay (~3–4 s)
- Fix applied: all action buttons persist correctly across navigation and plugin delays

🤖 Generated with [Claude Code](https://claude.com/claude-code)