### PR TITLE
fix(gateway): surface rejected media paths instead of dropping silently

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -578,7 +578,17 @@ def _send_media_via_adapter(
 
     from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_files, _rejected = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    # Normally empty here — _deliver_result already filtered. Defensive: if a
+    # caller passes raw paths, surface the rejection instead of dropping it.
+    if _rejected:
+        notice = BasePlatformAdapter.format_media_rejection_notice(_rejected)
+        try:
+            from agent.async_utils import safe_schedule_threadsafe
+            coro = adapter.send(chat_id=chat_id, content=notice.lstrip(), metadata=metadata)
+            safe_schedule_threadsafe(coro, loop)
+        except Exception as exc:
+            logger.warning("Job '%s': failed to send rejection notice: %s", job.get("id", "?"), exc)
 
     for media_path, _is_voice in media_files:
         try:
@@ -663,7 +673,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_files, _rejected_media = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    cleaned_delivery_content = (
+        cleaned_delivery_content
+        + BasePlatformAdapter.format_media_rejection_notice(_rejected_media)
+    )
 
     try:
         config = load_gateway_config()

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2350,28 +2350,59 @@ class BasePlatformAdapter(ABC):
         return validate_media_delivery_path(path)
 
     @staticmethod
-    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
-        """Drop unsafe MEDIA paths and normalize accepted paths."""
+    def filter_media_delivery_paths(
+        media_files,
+    ) -> Tuple[List[Tuple[str, bool]], List[str]]:
+        """Drop unsafe MEDIA paths and normalize accepted paths.
+
+        Returns ``(accepted, rejected_basenames)``. ``rejected_basenames`` lets
+        callers surface a user-visible notice when paths are dropped — without
+        it, a model that emits ``MEDIA:/tmp/foo.png`` (outside the allowed
+        roots) gets silent failure: the text streams, the attachment vanishes,
+        and the only trace is a WARNING in the gateway log.
+        """
         safe_media: List[Tuple[str, bool]] = []
+        rejected: List[str] = []
         for media_path, is_voice in media_files or []:
-            safe_path = validate_media_delivery_path(str(media_path))
+            raw = str(media_path)
+            safe_path = validate_media_delivery_path(raw)
             if safe_path:
                 safe_media.append((safe_path, bool(is_voice)))
             else:
                 logger.warning("Skipping unsafe MEDIA directive path outside allowed roots")
-        return safe_media
+                rejected.append(os.path.basename(raw.strip().strip("`\"'")) or raw)
+        return safe_media, rejected
 
     @staticmethod
-    def filter_local_delivery_paths(file_paths) -> List[str]:
-        """Drop unsafe bare local file paths and normalize accepted paths."""
+    def filter_local_delivery_paths(file_paths) -> Tuple[List[str], List[str]]:
+        """Drop unsafe bare local file paths and normalize accepted paths.
+
+        Returns ``(accepted, rejected_basenames)``; see
+        :meth:`filter_media_delivery_paths` for why the rejected list exists.
+        """
         safe_paths: List[str] = []
+        rejected: List[str] = []
         for file_path in file_paths or []:
-            safe_path = validate_media_delivery_path(str(file_path))
+            raw = str(file_path)
+            safe_path = validate_media_delivery_path(raw)
             if safe_path:
                 safe_paths.append(safe_path)
             else:
                 logger.warning("Skipping unsafe local file path outside allowed roots")
-        return safe_paths
+                rejected.append(os.path.basename(raw.strip().strip("`\"'")) or raw)
+        return safe_paths, rejected
+
+    @staticmethod
+    def format_media_rejection_notice(rejected_basenames: List[str]) -> str:
+        """Build the user-visible notice for paths the allowlist dropped.
+
+        Returns ``""`` when nothing was rejected so callers can unconditionally
+        concatenate the result onto outgoing text.
+        """
+        if not rejected_basenames:
+            return ""
+        names = ", ".join(rejected_basenames)
+        return f"\n\n⚠️ Couldn't attach: {names} (path outside allowed roots)"
 
     @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
@@ -3581,7 +3612,7 @@ class BasePlatformAdapter(ABC):
 
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
-                media_files = self.filter_media_delivery_paths(media_files)
+                media_files, _rejected_media = self.filter_media_delivery_paths(media_files)
 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
@@ -3595,7 +3626,15 @@ class BasePlatformAdapter(ABC):
                 # Auto-detect bare local file paths for native media delivery
                 # (helps small models that don't use MEDIA: syntax)
                 local_files, text_content = self.extract_local_files(text_content)
-                local_files = self.filter_local_delivery_paths(local_files)
+                local_files, _rejected_local = self.filter_local_delivery_paths(local_files)
+
+                # Append a notice for any paths the allowlist dropped so the
+                # user knows a file didn't make it instead of silently missing.
+                _rejection_notice = self.format_media_rejection_notice(
+                    _rejected_media + _rejected_local
+                )
+                if _rejection_notice:
+                    text_content = (text_content + _rejection_notice).strip()
                 if local_files:
                     logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
                 

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1679,10 +1679,15 @@ class WeixinAdapter(BasePlatformAdapter):
 
         # Extract MEDIA: tags and bare local file paths before text delivery.
         media_files, cleaned_content = self.extract_media(content)
-        media_files = self.filter_media_delivery_paths(media_files)
+        media_files, _rejected_media = self.filter_media_delivery_paths(media_files)
         _, image_cleaned = self.extract_images(cleaned_content)
         local_files, final_content = self.extract_local_files(image_cleaned)
-        local_files = self.filter_local_delivery_paths(local_files)
+        local_files, _rejected_local = self.filter_local_delivery_paths(local_files)
+        _rejection_notice = self.format_media_rejection_notice(
+            _rejected_media + _rejected_local
+        )
+        if _rejection_notice:
+            final_content = (final_content + _rejection_notice).strip()
 
         _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5258,7 +5258,13 @@ class GatewayRunner:
             return
 
         from gateway.platforms.base import BasePlatformAdapter
-        candidates = BasePlatformAdapter.filter_local_delivery_paths(candidates)
+        candidates, rejected = BasePlatformAdapter.filter_local_delivery_paths(candidates)
+        if rejected:
+            notice = BasePlatformAdapter.format_media_rejection_notice(rejected)
+            try:
+                await adapter.send(chat_id=chat_id, content=notice.lstrip(), metadata=metadata)
+            except Exception as exc:
+                logger.warning("kanban notifier: failed to send rejection notice: %s", exc)
         if not candidates:
             return
 
@@ -11543,12 +11549,27 @@ class GatewayRunner:
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
             media_files, _ = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            media_files, _rejected_media = BasePlatformAdapter.filter_media_delivery_paths(media_files)
             _, cleaned = adapter.extract_images(response)
             local_files, _ = adapter.extract_local_files(cleaned)
-            local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
+            local_files, _rejected_local = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
             _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+
+            # Text was already streamed by the time we get here, so a rejection
+            # notice has to ship as its own follow-up send.
+            _rejection_notice = BasePlatformAdapter.format_media_rejection_notice(
+                _rejected_media + _rejected_local
+            )
+            if _rejection_notice:
+                try:
+                    await adapter.send(
+                        chat_id=event.source.chat_id,
+                        content=_rejection_notice.lstrip(),
+                        metadata=_thread_meta,
+                    )
+                except Exception as e:
+                    logger.warning("[%s] Post-stream rejection notice failed: %s", adapter.name, e)
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -11843,22 +11864,29 @@ class GatewayRunner:
             if response:
                 media_files, response = adapter.extract_media(response)
                 from gateway.platforms.base import BasePlatformAdapter
-                media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+                media_files, _rejected_media = BasePlatformAdapter.filter_media_delivery_paths(media_files)
                 images, text_content = adapter.extract_images(response)
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
+                _rejection_notice = BasePlatformAdapter.format_media_rejection_notice(_rejected_media)
 
                 if text_content:
                     await adapter.send(
                         chat_id=source.chat_id,
-                        content=header + text_content,
+                        content=header + text_content + _rejection_notice,
                         metadata=_thread_metadata,
                     )
                 elif not images and not media_files:
                     await adapter.send(
                         chat_id=source.chat_id,
-                        content=header + "(No response generated)",
+                        content=header + "(No response generated)" + _rejection_notice,
+                        metadata=_thread_metadata,
+                    )
+                elif _rejection_notice:
+                    await adapter.send(
+                        chat_id=source.chat_id,
+                        content=header.rstrip() + _rejection_notice,
                         metadata=_thread_metadata,
                     )
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -414,12 +414,54 @@ class TestMediaDeliveryPathValidation:
         unsafe.write_bytes(b"OggS")
         self._patch_roots(monkeypatch, root)
 
-        filtered = BasePlatformAdapter.filter_media_delivery_paths([
+        accepted, rejected = BasePlatformAdapter.filter_media_delivery_paths([
             (str(unsafe), False),
             (str(safe), True),
         ])
 
-        assert filtered == [(str(safe.resolve()), True)]
+        assert accepted == [(str(safe.resolve()), True)]
+        assert rejected == ["outside.ogg"]
+
+    def test_filter_media_rejected_basename_strips_quotes(self, tmp_path, monkeypatch):
+        """Quoted paths emitted by some models should report a clean basename."""
+        root = tmp_path / "media-cache"
+        root.mkdir()
+        self._patch_roots(monkeypatch, root)
+
+        _, rejected = BasePlatformAdapter.filter_media_delivery_paths([
+            ("'/tmp/quoted.png'", False),
+        ])
+
+        assert rejected == ["quoted.png"]
+
+    def test_filter_local_returns_rejected_basenames(self, tmp_path, monkeypatch):
+        root = tmp_path / "media-cache"
+        safe = root / "doc.pdf"
+        unsafe = tmp_path / "secret.pdf"
+        safe.parent.mkdir(parents=True)
+        safe.write_bytes(b"%PDF-1.4")
+        unsafe.write_bytes(b"%PDF-1.4")
+        self._patch_roots(monkeypatch, root)
+
+        accepted, rejected = BasePlatformAdapter.filter_local_delivery_paths([
+            str(safe), str(unsafe),
+        ])
+
+        assert accepted == [str(safe.resolve())]
+        assert rejected == ["secret.pdf"]
+
+    def test_filter_empty_input_returns_empty_pair(self):
+        assert BasePlatformAdapter.filter_media_delivery_paths(None) == ([], [])
+        assert BasePlatformAdapter.filter_local_delivery_paths([]) == ([], [])
+
+    def test_rejection_notice_empty_when_nothing_rejected(self):
+        assert BasePlatformAdapter.format_media_rejection_notice([]) == ""
+
+    def test_rejection_notice_lists_basenames(self):
+        notice = BasePlatformAdapter.format_media_rejection_notice(["a.png", "b.pdf"])
+        assert "a.png" in notice
+        assert "b.pdf" in notice
+        assert "outside allowed roots" in notice
 
     def test_allows_operator_configured_extra_root(self, tmp_path, monkeypatch):
         extra_root = tmp_path / "operator-media"
@@ -430,6 +472,23 @@ class TestMediaDeliveryPathValidation:
         monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(extra_root))
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(media_file)) == str(media_file.resolve())
+
+    def test_extract_filter_notice_composition(self, tmp_path, monkeypatch):
+        """End-to-end: model emits a MEDIA tag outside roots → the user sees
+        a rejection notice instead of silently losing the attachment."""
+        root = tmp_path / "cache"
+        root.mkdir()
+        self._patch_roots(monkeypatch, root)
+
+        response = "Here is your file: MEDIA:/tmp/bad.png"
+        media, cleaned = BasePlatformAdapter.extract_media(response)
+        accepted, rejected = BasePlatformAdapter.filter_media_delivery_paths(media)
+        final_text = cleaned + BasePlatformAdapter.format_media_rejection_notice(rejected)
+
+        assert accepted == []
+        assert "Here is your file" in final_text
+        assert "bad.png" in final_text
+        assert "outside allowed roots" in final_text
 
     def test_recency_trust_allows_freshly_produced_file(self, tmp_path, monkeypatch):
         """A PDF the agent just wrote to /tmp should be deliverable.
@@ -532,8 +591,9 @@ class TestMediaDeliveryPathValidation:
         fresh = tmp_path / "report.pdf"
         fresh.write_bytes(b"%PDF-1.4")
 
-        out = BasePlatformAdapter.filter_local_delivery_paths([str(fresh)])
-        assert out == [str(fresh.resolve())]
+        accepted, rejected = BasePlatformAdapter.filter_local_delivery_paths([str(fresh)])
+        assert accepted == [str(fresh.resolve())]
+        assert rejected == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -378,6 +378,8 @@ class TestSendMessageTool:
         )
 
     def test_media_tag_outside_allowed_roots_is_not_sent(self, tmp_path, monkeypatch):
+        """The unsafe MEDIA path is dropped (no attachment), and the user gets
+        a visible rejection notice appended to the outgoing text."""
         # This test exercises the strict-allowlist path; disable recency trust
         # so the freshly-written tmp_path file is not auto-accepted by the
         # trust window. (Recency trust is covered in test_platform_base.py.)
@@ -402,15 +404,18 @@ class TestSendMessageTool:
             )
 
         assert result["success"] is True
-        send_mock.assert_awaited_once_with(
-            Platform.TELEGRAM,
-            telegram_cfg,
-            "12345",
-            "hello",
-            thread_id=None,
-            media_files=[],
-            force_document=False,
-        )
+        send_mock.assert_awaited_once()
+        sent_args, sent_kwargs = send_mock.await_args
+        assert sent_args[:3] == (Platform.TELEGRAM, telegram_cfg, "12345")
+        sent_message = sent_args[3]
+        assert sent_message.startswith("hello")
+        assert "secret.pdf" in sent_message
+        assert "outside allowed roots" in sent_message
+        assert sent_kwargs == {
+            "thread_id": None,
+            "media_files": [],
+            "force_document": False,
+        }
 
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -251,7 +251,8 @@ def _handle_send(args):
     force_document_attachments = "[[as_document]]" in message
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_files, _rejected_media = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    cleaned_message = cleaned_message + BasePlatformAdapter.format_media_rejection_notice(_rejected_media)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False

--- a/tools/yuanbao_tools.py
+++ b/tools/yuanbao_tools.py
@@ -472,7 +472,8 @@ async def _handle_yb_send_dm(args, **kw):
     embedded_media, message = BasePlatformAdapter.extract_media(message)
     if embedded_media:
         media_files.extend(embedded_media)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_files, _rejected_media = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    message = (message + BasePlatformAdapter.format_media_rejection_notice(_rejected_media))
 
     return tool_result(await send_dm(
         group_code=group_code,        name=args.get("name", ""),


### PR DESCRIPTION
 ## What does this PR do?

  When a model emits `MEDIA:/path` or a bare local path that falls outside the allowed roots (`image_cache`, `audio_cache`, `document_cache`, etc., or operator-configured `HERMES_MEDIA_ALLOW_DIRS`), `filter_media_delivery_paths` and `filter_local_delivery_paths` previously logged a `WARNING` and returned only the surviving paths — the rejection vanished. The user saw text without the promised attachment and nothing in the response indicated why; the only trace was a gateway log line.

  This change:

  - Changes both filter functions to return `(accepted, rejected_basenames)` so callers can react. Basenames (not full paths) are surfaced to avoid leaking filesystem layout into chat output.
  - Adds `BasePlatformAdapter.format_media_rejection_notice()` so the user-visible string lives in one place.
  - Updates every call site (13 total across `base.py`, `weixin.py`, `run.py`, `scheduler.py`, `send_message_tool.py`, `yuanbao_tools.py`) to unpack the new tuple and either append the notice to outgoing text or send it as a follow-up message when text has already streamed.

  **Breaking change** to the `filter_media_delivery_paths` / `filter_local_delivery_paths` signatures. Both are part of `BasePlatformAdapter`'s static-method surface; third-party platform plugins that call them will need a one-line unpack update. Happy to split into deprecated wrappers + new variants if maintainers prefer.

  ## Related Issue

  No related issue — surfaced while testing media delivery on a personal Discord deployment.

  Fixes #

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️  Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  > Note: this is a behavior-visible bug fix but the static-method signatures change. Marked as bug fix because the user-facing observable change is purely "silent failure → visible notice."

  ## Changes Made

  - `gateway/platforms/base.py`
    - `filter_media_delivery_paths` returns `(accepted, rejected_basenames)`
    - `filter_local_delivery_paths` returns `(accepted, rejected_basenames)`
    - New `format_media_rejection_notice(rejected_basenames) -> str` helper
    - `_process_message_background` unpacks new tuples and appends notice to `text_content`
  - `gateway/platforms/weixin.py` — same pattern; appends notice to `final_content`
  - `gateway/run.py`
    - Kanban notifier (`:5154`) — sends notice as standalone message (no surrounding text)
    - `_deliver_media_from_response` (`:11355/11358`) — sends notice as follow-up (text already streamed)
    - Background task delivery (`:11669`) — appends notice to header+text payload
  - `cron/scheduler.py`
    - `_send_media_via_adapter` — defensive notice send (normally a no-op; `_deliver_result` already filters)
    - `_deliver_result` — appends notice to `cleaned_delivery_content`
  - `tools/send_message_tool.py` — appends notice to `cleaned_message`
  - `tools/yuanbao_tools.py` — appends notice to `message`
  - `tests/gateway/test_platform_base.py`
    - Updated `test_filter_keeps_safe_media_and_drops_unsafe` to assert new tuple shape
    - New: `test_filter_media_rejected_basename_strips_quotes`
    - New: `test_filter_local_returns_rejected_basenames`
    - New: `test_filter_empty_input_returns_empty_pair`
    - New: `test_rejection_notice_empty_when_nothing_rejected`
    - New: `test_rejection_notice_lists_basenames`
    - New: `test_extract_filter_notice_composition` (end-to-end)
  - `tests/tools/test_send_message_tool.py`
    - Updated `test_media_tag_outside_allowed_roots_is_not_sent` to assert the new visible-notice behavior (was asserting the silent-failure behavior this PR fixes)

  ## How to Test

  1. **Automated**: `scripts/run_tests.sh tests/gateway/test_platform_base.py tests/tools/test_send_message_tool.py` — all relevant tests pass (350/350 across the changed paths and their adjacent
  suites).
  2. **Manual reproduction of the bug (without this fix)**: with a running gateway, ask the bot on any chat platform (Discord/Telegram/etc.) to deliver a file outside the safe roots: *"Save a small test
  file to `/tmp/test.txt` and upload it here."* You'll see the bot's reply text but no attachment, and `grep "Skipping unsafe" ~/.hermes/logs/gateway.log` is the only trace.
  3. **With this fix**: same prompt now also surfaces `⚠️  Couldn't attach: test.txt (path outside allowed roots)` in the reply.
  4. **Regression check (success path unchanged)**: write a file into `~/.hermes/document_cache/` instead and ask the bot to deliver it. Should still arrive as an attachment, no notice (existing
  behavior).

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): …`)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix (no unrelated commits)
  - [x] I've run `pytest tests/ -q` and all tests pass — *all tests related to the changed code paths pass (350/350 across `tests/gateway/`, `tests/tools/test_send_message_tool.py`,
  `tests/hermes_cli/test_kanban_notify.py`, `tests/test_yuanbao_pipeline.py`). The full `scripts/run_tests.sh tests/` run surfaces ~45 pre-existing failures in unrelated areas (process management, MCP
  stability, voice/TTS, plugin scanner) that reproduce on clean `upstream/main` without these changes applied; none touch media filtering.*
  - [x] I've added tests for my changes (6 new tests + 2 updated)
  - [x] I've tested on my platform: Ubuntu (Linux), Python 3.11

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on both filter functions updated to describe the new return shape and the rationale
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys added)
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact — `scripts/check-windows-footguns.py --diff upstream/main` returned clean; change uses only `os.path.basename` + string ops, no platform-specific syscalls
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schemas changed; `send_message` and `yuanbao_tools` internal handlers updated but visible tool schemas unchanged)

  ## Screenshots / Logs

  **Before the fix** (gateway log shows the silent rejection):

  2026-05-23 22:41:54,978 WARNING gateway.platforms.base: Skipping unsafe local file path outside allowed roots
  2026-05-23 22:41:54,979 INFO gateway.platforms.base: [Discord] Sending response (737 chars) to

  …and the user's chat shows the bot's text reply with no attachment and no explanation.

  **After the fix** (verified live on Discord):

  ⚠️  Couldn't attach: gibberish.txt (path outside allowed roots)

  …appended to the same reply, telling the user exactly what failed and which file.
