### PR TITLE
feat(gateway): inject voice-aware context when reply will be spoken

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2149,9 +2149,32 @@ class BasePlatformAdapter(ABC):
     def prepare_tts_text(self, text: str) -> str:
         """Prepare text for TTS. Override to filter tool output, code, etc.
 
-        Default strips markdown formatting and truncates to 4000 chars.
+        Default strips markdown-like characters that would otherwise be read
+        literally (``*``, ``_``, `` ` ``, ``#``, ``[``, ``]``, ``(``, ``)``)
+        and truncates to 4000 chars.
+
+        Square brackets are preserved when the active TTS provider is Inworld
+        TTS-2, which treats ``[directive]`` as performance steering — both
+        instruction tags (``[say excitedly]``) and non-verbal tags
+        (``[laugh]``, ``[sigh]``). Stripping them would surface the directive
+        prose as literal speech (e.g. ``"say excitedly Oh you want me to..."``).
+        Other providers render bracket contents literally, so the default
+        remains to strip.
         """
-        return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
+        strip_chars = r'[*_`#\[\]()]'
+        try:
+            from tools.tts_tool import _load_tts_config, _get_provider
+            _tts_cfg = _load_tts_config() or {}
+            _provider = (_get_provider(_tts_cfg) or "").strip().lower()
+            if _provider == "inworld":
+                _model_id = str(
+                    (_tts_cfg.get("inworld") or {}).get("model_id") or ""
+                ).strip().lower()
+                if _model_id == "inworld-tts-2":
+                    strip_chars = r'[*_`#()]'
+        except Exception:
+            pass
+        return re.sub(strip_chars, '', text)[:4000].strip()
 
     async def play_tts(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1636,6 +1636,31 @@ DEFAULT_SPOKEN_REPLY_ADDENDUM = (
 )
 
 
+# Additional rules appended when the active TTS provider is Inworld and the
+# model is ``inworld-tts-2``, which honors rich performance directives
+# (instruction tags, non-verbal tags, CAPS emphasis) that other models would
+# render as literal text.  Users can override via ``voice.inworld_tts2_prompt``
+# in ``config.yaml``.
+DEFAULT_INWORLD_TTS2_RULES = (
+    "[Inworld TTS-2 speech rules] Your reply will be spoken by Inworld TTS-2, "
+    "which honors rich performance directives. Use these sparingly, only when "
+    "they genuinely improve the delivery.\n"
+    "- Instruction tags: open a sentence with a bracketed directive combining "
+    "mood, pitch, pace, and manner. Examples: [say excitedly with a high pitch "
+    "and fast pace], [sound concerned with a measured pace and low tone], "
+    "[quietly with a warm and gentle tone]. Place the tag at the start of the "
+    "sentence it applies to.\n"
+    "- Non-verbal tags: insert [laugh], [sigh], or [breathe] where organic.\n"
+    "- Emphasis: capitalize full words for stress (\"I told you NOT to do "
+    "that\") or syllables for nuance (\"absoLUTEly\"). Use rarely.\n"
+    "- Naturalness: include occasional filler words (uh, um, well, you know) "
+    "and use contractions (don't, can't, I'm). Vary sentence length.\n"
+    "- Spoken form: write numbers and dates as words (\"twenty-three\" not "
+    "\"23\", \"march fifteenth\" not \"3/15\"). Plain spoken sentences only — "
+    "no markdown, no bullets, no emoji."
+)
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -2039,6 +2064,51 @@ class GatewayRunner:
         except Exception as exc:
             logger.debug(
                 "Voice-aware context injection skipped (non-fatal): %s", exc
+            )
+            return context_prompt
+
+    def _apply_inworld_tts2_rules(self, source, event, context_prompt: str) -> str:
+        """Append Inworld TTS-2 performance-directive rules to ``context_prompt``
+        when the turn will be spoken AND the active TTS provider is Inworld
+        with model ``inworld-tts-2``.
+
+        Inworld TTS-2 uses bracketed instruction tags (``[say excitedly...]``),
+        non-verbal tags (``[laugh]``, ``[sigh]``), and CAPS emphasis to drive
+        delivery. Other models render those as literal text, so the rules are
+        gated on the provider+model combination. Configurable via
+        ``voice.inworld_tts2_prompt``; falls back to
+        :data:`DEFAULT_INWORLD_TTS2_RULES`.
+
+        Best-effort — any failure leaves ``context_prompt`` unchanged so a bad
+        config or future TTS-tool refactor can never break a turn.
+        """
+        try:
+            if not self._turn_will_be_spoken(source, event):
+                return context_prompt
+            from tools.tts_tool import _load_tts_config, _get_provider
+            tts_cfg = _load_tts_config()
+            if _get_provider(tts_cfg) != "inworld":
+                return context_prompt
+            inworld_cfg = tts_cfg.get("inworld") or {}
+            model_id = str(inworld_cfg.get("model_id") or "").strip().lower()
+            if model_id != "inworld-tts-2":
+                return context_prompt
+            vcfg = (_load_gateway_config().get("voice") or {})
+            override = vcfg.get("inworld_tts2_prompt")
+            # Distinguish "not configured" (use default) from "configured to
+            # empty string" (explicitly disable the rules).
+            if override is None:
+                rules = DEFAULT_INWORLD_TTS2_RULES.strip()
+            else:
+                rules = str(override).strip()
+            if not rules:
+                return context_prompt
+            if context_prompt:
+                return (context_prompt + "\n\n" + rules).strip()
+            return rules
+        except Exception as exc:
+            logger.debug(
+                "Inworld TTS-2 rule injection skipped (non-fatal): %s", exc
             )
             return context_prompt
 
@@ -8239,6 +8309,14 @@ class GatewayRunner:
         # speakable output (no markdown / code blocks / lists / headers) for
         # both the text and the spoken delivery.
         context_prompt = self._apply_voice_aware_addendum(
+            source, event, context_prompt
+        )
+        # If the active TTS provider is Inworld and the model is
+        # ``inworld-tts-2``, append rules covering its expressive directives
+        # (instruction tags, non-verbal tags, CAPS emphasis, spoken-form
+        # numbers). Gated on the provider+model combo so other backends don't
+        # see them rendered as literal text.
+        context_prompt = self._apply_inworld_tts2_rules(
             source, event, context_prompt
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1623,6 +1623,19 @@ def _preserve_queued_followup_history_offset(
     return merged
 
 
+# Default context note appended to the system prompt when the agent's reply
+# will be spoken aloud via TTS this turn.  Users can override the wording via
+# ``voice.spoken_reply_prompt`` in ``config.yaml``.
+DEFAULT_SPOKEN_REPLY_ADDENDUM = (
+    "[Voice reply mode] Your next reply will be read aloud via "
+    "text-to-speech AND shown as a text message. Keep it short "
+    "(1-3 sentences when possible), conversational, and speakable: "
+    "no markdown formatting, no code blocks, no bullet lists, "
+    "no headers, no emoji. Spell out symbols only when they would "
+    "be unclear when read."
+)
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -1973,6 +1986,61 @@ class GatewayRunner:
             )
         except OSError as e:
             logger.warning("Failed to save voice modes: %s", e)
+
+    def _turn_will_be_spoken(self, source, event) -> bool:
+        """Return True if the agent's reply on this turn will be sent via TTS.
+
+        Mirrors the per-chat gating used by the response path: voice mode
+        ``"all"`` always speaks; ``"voice_only"`` speaks only when the inbound
+        message was a voice note.  Best-effort — any lookup error returns
+        ``False`` so callers degrade to text-only behavior.
+        """
+        try:
+            mode = self._voice_mode.get(
+                self._voice_key(source.platform, source.chat_id), "off"
+            )
+        except Exception:
+            return False
+        if mode == "all":
+            return True
+        if mode == "voice_only":
+            return getattr(event, "message_type", None) == MessageType.VOICE
+        return False
+
+    def _apply_voice_aware_addendum(self, source, event, context_prompt: str) -> str:
+        """Append a voice-aware system note to ``context_prompt`` when this
+        turn's reply will be spoken aloud.
+
+        Lets the model produce speakable output (short, plain prose, no
+        markdown / code blocks / lists / headers / emoji) instead of generating
+        a long markdown reply that gets read literally by TTS.  The addendum
+        text is configurable via ``voice.spoken_reply_prompt`` in
+        ``config.yaml``; falls back to :data:`DEFAULT_SPOKEN_REPLY_ADDENDUM`.
+
+        Best-effort — any failure leaves ``context_prompt`` unchanged so a
+        bad addendum can never break a turn.
+        """
+        try:
+            if not self._turn_will_be_spoken(source, event):
+                return context_prompt
+            vcfg = (_load_gateway_config().get("voice") or {})
+            override = vcfg.get("spoken_reply_prompt")
+            # Distinguish "not configured" (use default) from "configured to
+            # empty string" (explicitly disable the addendum).
+            if override is None:
+                addendum = DEFAULT_SPOKEN_REPLY_ADDENDUM.strip()
+            else:
+                addendum = str(override).strip()
+            if not addendum:
+                return context_prompt
+            if context_prompt:
+                return (context_prompt + "\n\n" + addendum).strip()
+            return addendum
+        except Exception as exc:
+            logger.debug(
+                "Voice-aware context injection skipped (non-fatal): %s", exc
+            )
+            return context_prompt
 
     def _set_adapter_auto_tts_disabled(self, adapter, chat_id: str, disabled: bool) -> None:
         """Update an adapter's in-memory auto-TTS suppression set if present."""
@@ -8165,6 +8233,14 @@ class GatewayRunner:
 
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
+
+        # Voice-aware system context: if the agent's reply on this turn will
+        # be spoken via TTS, append a brief instruction so the model produces
+        # speakable output (no markdown / code blocks / lists / headers) for
+        # both the text and the spoken delivery.
+        context_prompt = self._apply_voice_aware_addendum(
+            source, event, context_prompt
+        )
 
         # Auto-load skill(s) for topic/channel bindings (Telegram DM Topics,
         # Discord channel_skill_bindings).  Supports a single name or ordered list.

--- a/tests/gateway/platforms/test_prepare_tts_text.py
+++ b/tests/gateway/platforms/test_prepare_tts_text.py
@@ -1,0 +1,131 @@
+"""Tests for ``BasePlatformAdapter.prepare_tts_text`` — the per-platform
+text-cleanup that runs immediately before handing a reply to the TTS tool.
+
+The default strips markdown-like characters that would otherwise be read
+literally (``*_`#()[]``). Square brackets are intentionally **preserved**
+when the active TTS provider is Inworld TTS-2 because that backend treats
+``[directive]`` as performance steering (instruction tags like
+``[say excitedly]``, non-verbal tags like ``[laugh]``). Stripping the
+brackets would turn the directive prose into literal speech — the bug this
+gating exists to prevent.
+"""
+from __future__ import annotations
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+# ``BasePlatformAdapter`` is ABC; ``prepare_tts_text`` only touches its
+# ``text`` argument, so we exercise it as an unbound function.
+prepare = BasePlatformAdapter.prepare_tts_text
+
+
+def _patch_tts(monkeypatch, provider: str, model_id: str = "") -> None:
+    """Mirror the patch helper from ``TestInworldTts2Rules`` so test setup
+    reads the same across the two TTS-2 gating call sites."""
+    cfg = {"provider": provider, "inworld": {"model_id": model_id}}
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: cfg)
+    monkeypatch.setattr("tools.tts_tool._get_provider", lambda _cfg: provider)
+
+
+# -- default behavior: brackets stripped for non-TTS-2 providers ------------
+
+def test_default_strips_brackets_when_provider_unknown(monkeypatch):
+    """Config-load failure (or no provider configured) must fall back to the
+    strip-all default — readers of bare ``[label]`` would otherwise hear the
+    label spoken aloud."""
+    def _boom():
+        raise RuntimeError("config unreadable")
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", _boom)
+    out = prepare(None, "[say excitedly] hello (aside) **bold**")
+    assert out == "say excitedly hello aside bold"
+
+
+def test_elevenlabs_strips_brackets(monkeypatch):
+    _patch_tts(monkeypatch, "elevenlabs")
+    out = prepare(None, "[say excitedly] hello")
+    assert out == "say excitedly hello"
+
+
+def test_openai_strips_brackets(monkeypatch):
+    _patch_tts(monkeypatch, "openai")
+    out = prepare(None, "[laugh] ok")
+    assert out == "laugh ok"
+
+
+def test_inworld_old_model_strips_brackets(monkeypatch):
+    """Inworld TTS 1.x does not honor bracket directives — keep stripping."""
+    _patch_tts(monkeypatch, "inworld", "inworld-tts-1.5-max")
+    out = prepare(None, "[say excitedly] hello")
+    assert out == "say excitedly hello"
+
+
+# -- bracket preservation: only for Inworld + inworld-tts-2 -----------------
+
+def test_inworld_tts2_preserves_brackets(monkeypatch):
+    _patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+    text = "[say excitedly with a high pitch and fast pace] Oh you want me to show off the voice tags?"
+    out = prepare(None, text)
+    assert out == text
+
+
+def test_inworld_tts2_preserves_non_verbal_tags(monkeypatch):
+    _patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+    text = "[laugh] okay here's one with a sigh. [sigh] long night coding huh?"
+    out = prepare(None, text)
+    assert out == text
+
+
+def test_inworld_tts2_preserves_multiple_directives(monkeypatch):
+    """The reported repro: multi-paragraph reply with several directives.
+    Pre-fix this came out with every bracket character deleted, which fed
+    the directive prose into Inworld as literal speech."""
+    _patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+    text = (
+        "[say excitedly with a high pitch and fast pace] One.\n\n"
+        "[sound concerned with a measured pace and low tone] Two.\n\n"
+        "[laugh] Three. [sigh] Four."
+    )
+    out = prepare(None, text)
+    assert out == text
+
+
+def test_inworld_tts2_model_id_case_insensitive(monkeypatch):
+    """Mirrors ``TestInworldTts2Rules.test_model_id_is_case_insensitive`` —
+    config keys are user-edited and people will capitalise the model id."""
+    _patch_tts(monkeypatch, "inworld", "Inworld-TTS-2")
+    out = prepare(None, "[laugh] ok")
+    assert out == "[laugh] ok"
+
+
+def test_inworld_tts2_provider_case_insensitive(monkeypatch):
+    _patch_tts(monkeypatch, "Inworld", "inworld-tts-2")
+    out = prepare(None, "[laugh] ok")
+    assert out == "[laugh] ok"
+
+
+# -- other markdown still stripped under TTS-2 ------------------------------
+
+def test_inworld_tts2_still_strips_non_bracket_markdown(monkeypatch):
+    """Only the bracket characters get reprieved — asterisks, backticks,
+    parens, hashes, and underscores remain markdown noise even with TTS-2.
+    TTS-2's emphasis convention is CAPS, not asterisks."""
+    _patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+    out = prepare(None, "[say excitedly] **bold** `code` (aside) # header _underscore_")
+    assert out == "[say excitedly] bold code aside  header underscore"
+
+
+# -- truncation and whitespace ----------------------------------------------
+
+def test_truncates_to_4000_chars(monkeypatch):
+    _patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+    long_text = "[laugh] " + ("a" * 5000)
+    out = prepare(None, long_text)
+    assert len(out) == 4000
+
+
+def test_strips_surrounding_whitespace(monkeypatch):
+    _patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+    out = prepare(None, "   [laugh] hello   \n")
+    assert out == "[laugh] hello"

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -404,6 +404,150 @@ class TestAutoVoiceReply:
 
 
 # =====================================================================
+# Voice-aware system context addendum
+# =====================================================================
+
+class TestVoiceAwareAddendum:
+    """Tests for ``_apply_voice_aware_addendum`` — the gating that injects a
+    'reply will be spoken' note into the per-turn system context.
+
+    Without this, the model produces long markdown replies that TTS reads
+    literally, including bullets and asterisks.  The addendum should fire
+    only when the reply will actually be spoken aloud this turn.
+    """
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        return _make_runner(tmp_path)
+
+    def _setup(self, runner, voice_mode):
+        chat_id = "123"
+        key = "telegram:" + chat_id
+        if voice_mode == "off":
+            runner._voice_mode.pop(key, None)
+        else:
+            runner._voice_mode[key] = voice_mode
+        return chat_id
+
+    # -- gating: when the addendum should NOT fire --------------------------
+
+    def test_mode_off_returns_unchanged(self, runner):
+        self._setup(runner, "off")
+        event = _make_event(message_type=MessageType.TEXT)
+        result = runner._apply_voice_aware_addendum(
+            event.source, event, "base context"
+        )
+        assert result == "base context"
+
+    def test_voice_only_with_text_input_returns_unchanged(self, runner):
+        """voice_only mode only speaks for voice input, so TEXT skips addendum."""
+        self._setup(runner, "voice_only")
+        event = _make_event(message_type=MessageType.TEXT)
+        result = runner._apply_voice_aware_addendum(
+            event.source, event, "base context"
+        )
+        assert result == "base context"
+
+    # -- gating: when the addendum SHOULD fire ------------------------------
+
+    def test_voice_only_with_voice_input_appends_addendum(self, runner):
+        self._setup(runner, "voice_only")
+        event = _make_event(message_type=MessageType.VOICE)
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert result.startswith("base context\n\n")
+        assert "[Voice reply mode]" in result
+
+    def test_all_mode_with_text_input_appends_addendum(self, runner):
+        """all-mode speaks every reply regardless of input type."""
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert "[Voice reply mode]" in result
+
+    def test_all_mode_with_voice_input_appends_addendum(self, runner):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.VOICE)
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert "[Voice reply mode]" in result
+
+    # -- config override behavior ------------------------------------------
+
+    def test_custom_addendum_from_config(self, runner):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        cfg = {"voice": {"spoken_reply_prompt": "BE BRIEF NELLIE"}}
+        with patch("gateway.run._load_gateway_config", return_value=cfg):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert result.endswith("BE BRIEF NELLIE")
+        assert "[Voice reply mode]" not in result
+
+    def test_explicit_empty_string_disables_addendum(self, runner):
+        """spoken_reply_prompt='' is explicit opt-out, not a 'use default'."""
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        cfg = {"voice": {"spoken_reply_prompt": ""}}
+        with patch("gateway.run._load_gateway_config", return_value=cfg):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert result == "base context"
+
+    def test_whitespace_only_override_disables_addendum(self, runner):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        cfg = {"voice": {"spoken_reply_prompt": "   \n  "}}
+        with patch("gateway.run._load_gateway_config", return_value=cfg):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert result == "base context"
+
+    def test_missing_voice_key_uses_default(self, runner):
+        """No ``voice:`` block in config → default addendum is used."""
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert "[Voice reply mode]" in result
+
+    # -- edge cases --------------------------------------------------------
+
+    def test_empty_context_prompt_returns_just_addendum(self, runner):
+        """No leading newlines when there's no prior context."""
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, ""
+            )
+        assert result.startswith("[Voice reply mode]")
+        assert not result.startswith("\n")
+
+    def test_lookup_exception_is_swallowed(self, runner):
+        """Best-effort: any exception leaves context_prompt unchanged."""
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        with patch("gateway.run._load_gateway_config", side_effect=RuntimeError("boom")):
+            result = runner._apply_voice_aware_addendum(
+                event.source, event, "base context"
+            )
+        assert result == "base context"
+
+
+# =====================================================================
 # _send_voice_reply
 # =====================================================================
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -548,6 +548,165 @@ class TestVoiceAwareAddendum:
 
 
 # =====================================================================
+# Inworld TTS-2 speech-rule addendum
+# =====================================================================
+
+class TestInworldTts2Rules:
+    """Tests for ``_apply_inworld_tts2_rules`` — the gating that injects
+    Inworld-TTS-2-specific performance directives (instruction tags,
+    non-verbal tags, CAPS emphasis) into the per-turn system context.
+
+    The rules are gated on (a) the turn will be spoken and (b) the active TTS
+    provider is Inworld AND the configured model is ``inworld-tts-2``. Other
+    backends would render the bracketed tags as literal text.
+    """
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        return _make_runner(tmp_path)
+
+    def _setup(self, runner, voice_mode):
+        chat_id = "123"
+        key = "telegram:" + chat_id
+        if voice_mode == "off":
+            runner._voice_mode.pop(key, None)
+        else:
+            runner._voice_mode[key] = voice_mode
+        return chat_id
+
+    @staticmethod
+    def _patch_tts(monkeypatch, provider: str, model_id: str = "") -> None:
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: {"provider": provider, "inworld": {"model_id": model_id}},
+        )
+        monkeypatch.setattr("tools.tts_tool._get_provider", lambda _cfg: provider)
+
+    # -- gating: when the rules should NOT fire ----------------------------
+
+    def test_mode_off_returns_unchanged(self, runner, monkeypatch):
+        self._setup(runner, "off")
+        event = _make_event(message_type=MessageType.VOICE)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+        result = runner._apply_inworld_tts2_rules(
+            event.source, event, "base context"
+        )
+        assert result == "base context"
+
+    def test_voice_only_with_text_input_returns_unchanged(self, runner, monkeypatch):
+        self._setup(runner, "voice_only")
+        event = _make_event(message_type=MessageType.TEXT)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+        result = runner._apply_inworld_tts2_rules(
+            event.source, event, "base context"
+        )
+        assert result == "base context"
+
+    def test_non_inworld_provider_returns_unchanged(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        self._patch_tts(monkeypatch, "elevenlabs", "")
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, "base context"
+            )
+        assert result == "base context"
+
+    def test_inworld_but_old_model_returns_unchanged(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-1.5-max")
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, "base context"
+            )
+        assert result == "base context"
+
+    # -- gating: when the rules SHOULD fire --------------------------------
+
+    def test_inworld_tts2_with_voice_input_appends_rules(self, runner, monkeypatch):
+        self._setup(runner, "voice_only")
+        event = _make_event(message_type=MessageType.VOICE)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, "base context"
+            )
+        assert result.startswith("base context\n\n")
+        assert "[Inworld TTS-2 speech rules]" in result
+
+    def test_inworld_tts2_all_mode_with_text_appends_rules(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.TEXT)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, "base context"
+            )
+        assert "[Inworld TTS-2 speech rules]" in result
+
+    def test_model_id_is_case_insensitive(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.VOICE)
+        self._patch_tts(monkeypatch, "inworld", "Inworld-TTS-2")
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, "base context"
+            )
+        assert "[Inworld TTS-2 speech rules]" in result
+
+    # -- config override behavior ------------------------------------------
+
+    def test_custom_rules_from_config(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.VOICE)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+        cfg = {"voice": {"inworld_tts2_prompt": "BE EXPRESSIVE NELLIE"}}
+        with patch("gateway.run._load_gateway_config", return_value=cfg):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, "base context"
+            )
+        assert result.endswith("BE EXPRESSIVE NELLIE")
+        assert "[Inworld TTS-2 speech rules]" not in result
+
+    def test_explicit_empty_string_disables_rules(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.VOICE)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+        cfg = {"voice": {"inworld_tts2_prompt": ""}}
+        with patch("gateway.run._load_gateway_config", return_value=cfg):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, "base context"
+            )
+        assert result == "base context"
+
+    # -- edge cases --------------------------------------------------------
+
+    def test_empty_context_prompt_returns_just_rules(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.VOICE)
+        self._patch_tts(monkeypatch, "inworld", "inworld-tts-2")
+        with patch("gateway.run._load_gateway_config", return_value={}):
+            result = runner._apply_inworld_tts2_rules(
+                event.source, event, ""
+            )
+        assert result.startswith("[Inworld TTS-2 speech rules]")
+        assert not result.startswith("\n")
+
+    def test_lookup_exception_is_swallowed(self, runner, monkeypatch):
+        self._setup(runner, "all")
+        event = _make_event(message_type=MessageType.VOICE)
+        monkeypatch.setattr(
+            "tools.tts_tool._load_tts_config",
+            lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        result = runner._apply_inworld_tts2_rules(
+            event.source, event, "base context"
+        )
+        assert result == "base context"
+
+
+# =====================================================================
 # _send_voice_reply
 # =====================================================================
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1330,9 +1330,13 @@ voice:
   beep_enabled: true            # Play record start/stop beeps in CLI voice mode
   silence_threshold: 200        # RMS threshold for speech detection
   silence_duration: 3.0         # Seconds of silence before auto-stop
+  # spoken_reply_prompt: ""     # Optional override for the voice-mode system note
+                                # (empty string disables; omit to use the built-in default)
 ```
 
 Use `/voice on` in the CLI to enable microphone mode, `record_key` to start/stop recording, and `/voice tts` to toggle spoken replies. See [Voice Mode](/docs/user-guide/features/voice-mode) for end-to-end setup and platform-specific behavior.
+
+When voice replies are enabled on a messaging platform (`/voice on` for voice-input-only, `/voice tts` for every reply), Hermes appends a brief system note to the per-turn context telling the model its reply will be read aloud, so it produces short conversational prose instead of long markdown that TTS would read literally. Override the wording with `voice.spoken_reply_prompt`, or set it to an empty string to suppress the note entirely.
 
 ## Streaming
 


### PR DESCRIPTION
## What does this PR do?

When a chat has `/voice on` (voice-input-only) or `/voice tts` (always speak), Hermes sends both a text reply AND runs TTS on it. The model has no signal that its reply is about to be read aloud, so it produces long markdown-heavy replies — bullets, headers, asterisks — which TTS reads literally word-for-word and which also spam the text channel.

This PR appends a small per-turn context note to the system prompt when the reply will be spoken this turn, telling the model to keep the reply short and speakable (no markdown, no bullets, no code blocks, no emoji). The note fires using the same gating already used by the response path:

| Voice mode | Inbound message | Addendum injected? |
|---|---|---|
| `off` | any | No |
| `voice_only` | TEXT | No |
| `voice_only` | VOICE | **Yes** |
| `all` | any | **Yes** |

Users can override the wording with `voice.spoken_reply_prompt` in `config.yaml`, or set it to an empty string to suppress the note entirely. Behavior is best-effort — any exception in the addendum path leaves `context_prompt` unchanged so a bad config can never break a turn.

The reporter's use case: Nellie (their assistant persona) was responding to Tagalog voice notes on Telegram with multi-paragraph markdown replies that were being read aloud literally. With this change, the model produces a couple of conversational sentences appropriate for both reading on the screen and hearing through speakers.

## Related Issue

N/A — discovered while configuring voice mode on Telegram.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/run.py`
  - New module-level constant `DEFAULT_SPOKEN_REPLY_ADDENDUM` with the default note text.
  - New method `GatewayRunner._turn_will_be_spoken(source, event)` — mirrors per-chat TTS gating so the addendum only fires when TTS will actually run.
  - New method `GatewayRunner._apply_voice_aware_addendum(source, event, context_prompt)` — appends the addendum (default or `voice.spoken_reply_prompt` override) to `context_prompt`. Best-effort; swallows exceptions to logger.debug.
  - Call site in `_handle_message_with_agent`: one line, immediately after the auto-reset notification block and before agent invocation.
- `tests/gateway/test_voice_command.py`
  - New `TestVoiceAwareAddendum` class — 11 tests covering the full mode × input-type matrix, the default-text path, custom-text override, explicit empty-string opt-out, whitespace-only opt-out, missing `voice:` config block, empty `context_prompt` edge case, and best-effort exception swallowing.
- `website/docs/user-guide/configuration.md`
  - Documents `voice.spoken_reply_prompt` in the Voice Mode (CLI) section and explains the new behavior on messaging platforms.

## How to Test

1. From a fresh clone of this branch, run the targeted tests:
   ```
   pytest tests/gateway/test_voice_command.py::TestVoiceAwareAddendum -v
   ```
   All 11 should pass.
2. To verify behavior end-to-end on a live Telegram bot:
   - Configure TTS + STT (e.g. ElevenLabs + OpenAI whisper-1).
   - `hermes gateway start`
   - In a Telegram chat with your bot, `/voice tts`
   - Ask "What's the weather like?"
   - **Before this PR:** model produces a multi-paragraph reply with headers/bullets; TTS reads it all literally.
   - **After this PR:** model produces a brief conversational reply suitable for speaking.
3. To verify the override:
   - Add `voice: { spoken_reply_prompt: "Be brief." }` (or your own text) to `~/.hermes/config.yaml`, restart the gateway. The custom note is used in place of the default.
4. To verify opt-out:
   - Set `spoken_reply_prompt: ""`. The note is suppressed even when voice mode is on.

Sanity-ran the full `tests/gateway/test_voice_command.py` and `tests/gateway/test_telegram_audio_vs_voice.py` suites after the change — 197 passed, no regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_voice_command.py tests/gateway/test_telegram_audio_vs_voice.py -q` and all tests pass (197 passed)
- [x] I've added tests for my changes (11 new tests covering the full gating matrix and override semantics)
- [x] I've tested on my platform: Ubuntu 26.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/configuration.md`)
- [x] `cli-config.yaml.example` doesn't currently have a `voice:` section, so nothing to add there — N/A
- [x] No architecture or workflow change — `CONTRIBUTING.md` / `AGENTS.md` N/A
- [x] No platform-specific concerns — change is pure Python, no new system deps
- [x] No tool description/schema change — N/A