### PR TITLE
feat: add MCP registry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Hermes Agent ☤
 
+<!-- mcp-name: io.github.nousresearch/hermes-agent -->
+
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
@@ -134,13 +136,24 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |
 | [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) | Persistent memory, user profiles, best practices |
-| [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities |
+| [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities; expose Hermes itself with `hermes mcp serve` |
 | [Cron Scheduling](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) | Scheduled tasks with platform delivery |
 | [Context Files](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) | Project context that shapes every conversation |
 | [Architecture](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) | Project structure, agent loop, key classes |
 | [Contributing](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) | Development setup, PR process, code style |
 | [CLI Reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) | All commands and flags |
 | [Environment Variables](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) | Complete env var reference |
+
+### MCP registry metadata
+
+Hermes can run as an MCP server for other clients:
+
+```bash
+pip install "hermes-agent[mcp]"
+hermes mcp serve
+```
+
+This repository includes `server.json` metadata for MCP registries. Clients that cannot parse PyPI extras should install `hermes-agent[mcp]` first, then launch the registered package with the fixed arguments `mcp serve`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "mcp_serve", "utils"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nousresearch/hermes-agent",
+  "title": "Hermes Agent",
+  "description": "Expose Hermes Agent sessions, conversations, messages, and attachments to MCP-compatible clients.",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github",
+    "id": "1024554267"
+  },
+  "version": "0.14.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "hermes-agent",
+      "version": "0.14.0",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.nousresearch/hermes-agent": {
+        "installExtra": "mcp",
+        "recommendedInstall": "pip install \"hermes-agent[mcp]\"",
+        "launchCommand": "hermes mcp serve",
+        "docs": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp"
+      }
+    }
+  }
+}

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -11,11 +11,15 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
-def _load_package_data():
+def _load_setuptools_config():
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject_path.open("rb") as handle:
         tool = tomllib.load(handle)["tool"]
-    return tool["setuptools"]["package-data"]
+    return tool["setuptools"]
+
+
+def _load_package_data():
+    return _load_setuptools_config()["package-data"]
 
 
 def test_matrix_extra_not_in_all():
@@ -110,6 +114,13 @@ def test_feishu_extra_includes_qrcode_for_qr_login():
 
     feishu_extra = optional_dependencies["feishu"]
     assert any(dep.startswith("qrcode") for dep in feishu_extra)
+
+
+def test_mcp_server_module_is_packaged_for_cli_entrypoint():
+    """`hermes mcp serve` imports top-level mcp_serve from wheel installs."""
+    setuptools_config = _load_setuptools_config()
+
+    assert "mcp_serve" in setuptools_config["py-modules"]
 
 
 def test_dashboard_plugin_manifests_and_assets_are_packaged():


### PR DESCRIPTION
## Summary
- add root `server.json` metadata for publishing Hermes Agent's MCP server (`hermes mcp serve`) to MCP registries
- add the PyPI README ownership marker required by the official MCP Registry
- document the `hermes-agent[mcp]` install extra fallback for clients that cannot infer PyPI extras
- package `mcp_serve.py` in wheels and add a regression test so `hermes mcp serve` works from PyPI installs

## Test Plan
- `scripts/run_tests.sh tests/test_project_metadata.py`
- validate `server.json` against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` with `jsonschema.Draft7Validator`
- `uv build --wheel --out-dir /tmp/hermes-wheel-check-new` and inspect the wheel for `mcp_serve.py`

## Notes
This prepares the repo for official MCP Registry / directory submissions; actual registry publishing should happen after this lands and a package version containing `mcp_serve.py` is released.
