### PR TITLE
feat(image-gen): add Azure AI Foundry (gpt-image-2) as image generation provider

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -120,6 +120,23 @@ class ImageGenProvider(abc.ABC):
             "env_vars": [],
         }
 
+    def setup_interactive(self, config: dict) -> bool:
+        """Run an interactive setup wizard for this provider.
+
+        Called by ``hermes tools`` when the user selects this provider.
+        Return ``True`` when setup completed successfully so the caller
+        skips the generic env-var-prompt flow.  Return ``False`` (default)
+        to fall back to that flow.
+
+        ``config`` is the live in-memory config dict; the caller persists
+        it to disk after this method returns.
+
+        Override this when your provider needs more than a list of env-var
+        prompts — for example when it must ask for a URL, choose an auth
+        mode, or run a credential preflight before persisting anything.
+        """
+        return False
+
     def default_model(self) -> Optional[str]:
         """Return the default model id, or None if not applicable."""
         models = self.list_models()

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2230,7 +2230,25 @@ def _configure_imagegen_model_for_plugin(plugin_name: str, config: dict) -> None
 
 
 def _select_plugin_image_gen_provider(plugin_name: str, config: dict) -> None:
-    """Persist a plugin-backed image generation provider selection."""
+    """Persist a plugin-backed image generation provider selection.
+
+    If the registered provider implements :meth:`ImageGenProvider.setup_interactive`,
+    that wizard runs and the generic env-var flow is skipped.  Any provider
+    that needs more than a simple list of env-var prompts (e.g. endpoint URL,
+    auth-mode choice, credential preflight) should override that method.
+    """
+    # Ask the provider whether it wants to run its own interactive wizard.
+    _provider = None
+    try:
+        from agent.image_gen_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+        _ensure_plugins_discovered()
+        _provider = get_provider(plugin_name)
+    except Exception:
+        pass
+    if _provider is not None and _provider.setup_interactive(config):
+        return
+
     img_cfg = config.setdefault("image_gen", {})
     if not isinstance(img_cfg, dict):
         img_cfg = {}

--- a/plugins/image_gen/azure-foundry/__init__.py
+++ b/plugins/image_gen/azure-foundry/__init__.py
@@ -17,8 +17,9 @@ Resolution order (first hit wins):
 
        AZURE_FOUNDRY_IMAGE_ENDPOINT   — Azure resource endpoint
                                         e.g. https://my-resource.openai.azure.com
-       AZURE_FOUNDRY_IMAGE_KEY        — API key
+       AZURE_FOUNDRY_IMAGE_KEY        — API key (not needed for Entra ID)
        AZURE_FOUNDRY_IMAGE_DEPLOYMENT — deployment name (default: gpt-image-2)
+       AZURE_FOUNDRY_IMAGE_AUTH_MODE  — ``api_key`` (default) or ``entra_id``
        AZURE_FOUNDRY_IMAGE_QUALITY    — quality tier: low / medium / high (default: medium)
 
 2. ``image_gen.azure_foundry`` section in ``config.yaml``::
@@ -27,11 +28,19 @@ Resolution order (first hit wins):
          provider: azure_foundry
          azure_foundry:
            endpoint: "https://my-resource.openai.azure.com"
-           api_key_env: "AZURE_FOUNDRY_IMAGE_KEY"   # env var name, not the key itself
            deployment_name: "gpt-image-2"
+           auth_mode: "api_key"         # or "entra_id" for keyless auth
 
-3. Global ``AZURE_OPENAI_*`` fallback env vars
-   (``AZURE_OPENAI_API_KEY`` + ``AZURE_OPENAI_ENDPOINT``).
+Authentication
+--------------
+**API key** (default): set ``AZURE_FOUNDRY_IMAGE_KEY`` in ``.env``.
+
+**Microsoft Entra ID**: keyless RBAC auth via ``azure-identity``'s
+``DefaultAzureCredential`` chain (az login, managed identity, workload
+identity, service principal env vars). Set
+``image_gen.azure_foundry.auth_mode: entra_id`` in ``config.yaml``
+or ``AZURE_FOUNDRY_IMAGE_AUTH_MODE=entra_id``. No API key needed;
+requires the ``Azure AI User`` role on the Foundry resource.
 
 Quality
 -------
@@ -121,37 +130,32 @@ def _load_azure_foundry_config() -> Dict[str, Any]:
 
 
 def _resolve_credentials() -> Dict[str, Any]:
-    """Resolve endpoint, API key, and deployment name.
+    """Resolve endpoint, API key, deployment name, and auth mode.
 
-    Returns a dict with keys: ``endpoint``, ``api_key``, ``deployment``.
-    Empty string means not configured.
+    Returns a dict with keys: ``endpoint``, ``api_key``, ``deployment``,
+    ``auth_mode``. ``api_key`` is empty string when ``auth_mode`` is
+    ``"entra_id"``.
     """
     # 1. Dedicated env vars
     endpoint = os.environ.get("AZURE_FOUNDRY_IMAGE_ENDPOINT", "").strip()
     api_key = os.environ.get("AZURE_FOUNDRY_IMAGE_KEY", "").strip()
     deployment = os.environ.get("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "").strip()
+    auth_mode = os.environ.get("AZURE_FOUNDRY_IMAGE_AUTH_MODE", "").strip().lower()
 
     # 2. config.yaml fills gaps
     cfg = _load_azure_foundry_config()
     if not endpoint:
         endpoint = str(cfg.get("endpoint") or "").strip()
-    if not api_key:
-        key_env = str(cfg.get("api_key_env") or "").strip()
-        if key_env:
-            api_key = os.environ.get(key_env, "").strip()
     if not deployment:
         deployment = str(cfg.get("deployment_name") or "").strip()
-
-    # 3. Global Azure OpenAI fallback (endpoint + key only)
-    if not endpoint:
-        endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
-    if not api_key:
-        api_key = os.environ.get("AZURE_OPENAI_API_KEY", "").strip()
+    if not auth_mode:
+        auth_mode = str(cfg.get("auth_mode") or "").strip().lower()
 
     return {
         "endpoint": endpoint,
         "api_key": api_key,
         "deployment": deployment or DEFAULT_DEPLOYMENT,
+        "auth_mode": auth_mode or "api_key",
     }
 
 
@@ -164,6 +168,7 @@ class AzureFoundryImageGenProvider(ImageGenProvider):
     """Azure AI Foundry gpt-image-2 image generation backend.
 
     Uses ``openai.OpenAI`` with Azure OpenAI v1 ``base_url``.
+    Supports API key and Microsoft Entra ID (keyless) authentication.
     Quality (low / medium / high) is resolved from config, not from the caller.
     """
 
@@ -177,7 +182,11 @@ class AzureFoundryImageGenProvider(ImageGenProvider):
 
     def is_available(self) -> bool:
         creds = _resolve_credentials()
-        return bool(creds.get("endpoint") and creds.get("api_key"))
+        if not creds.get("endpoint"):
+            return False
+        if creds.get("auth_mode") == "entra_id":
+            return True
+        return bool(creds.get("api_key"))
 
     def list_models(self) -> List[Dict[str, Any]]:
         """Return one entry for the configured deployment."""
@@ -196,6 +205,159 @@ class AzureFoundryImageGenProvider(ImageGenProvider):
     def default_model(self) -> Optional[str]:
         return _resolve_credentials()["deployment"]
 
+    def setup_interactive(self, config: dict) -> bool:
+        """Interactive setup wizard for hermes tools.
+
+        Prompts for endpoint URL, deployment name, and auth mode (API key
+        or Microsoft Entra ID).  Saves endpoint/deployment/auth_mode to
+        ``image_gen.azure_foundry`` in config and (for API key mode) the
+        key to ``AZURE_FOUNDRY_IMAGE_KEY`` in .env.
+        """
+        import getpass
+        from hermes_cli.config import get_env_value, save_env_value
+        from hermes_cli.cli_output import print_success
+
+        # Load existing values so the wizard can show defaults.
+        _img = config.get("image_gen") or {}
+        _az = _img.get("azure_foundry") if isinstance(_img, dict) else None
+        cur: dict = _az if isinstance(_az, dict) else {}
+        current_endpoint = str(cur.get("endpoint") or "").strip()
+        current_deployment = str(cur.get("deployment_name") or "").strip()
+        current_auth_mode = str(cur.get("auth_mode") or "api_key").strip().lower()
+        current_key = get_env_value("AZURE_FOUNDRY_IMAGE_KEY") or ""
+
+        print()
+        print("  Azure AI Foundry \u2014 Image Generation Setup")
+        print("  " + "\u2500" * 46)
+        print()
+
+        # ── Step 1: Endpoint URL ──────────────────────────────────────
+        _ep_placeholder = current_endpoint or "https://<resource>.openai.azure.com"
+        try:
+            endpoint_input = input(f"  Endpoint URL [{_ep_placeholder}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\n  Cancelled.")
+            return False
+        effective_endpoint = endpoint_input or current_endpoint
+        if not effective_endpoint:
+            print("  No endpoint provided. Cancelled.")
+            return False
+        if not effective_endpoint.startswith(("http://", "https://")):
+            print(f"  Invalid URL: {effective_endpoint!r} (must start with https://)")
+            return False
+
+        # ── Step 2: Deployment name ───────────────────────────────────
+        _dep_default = current_deployment or DEFAULT_DEPLOYMENT
+        try:
+            dep_input = input(f"  Deployment name [{_dep_default}]: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\n  Cancelled.")
+            return False
+        effective_deployment = dep_input or _dep_default
+
+        # ── Step 3: Auth mode ─────────────────────────────────────────
+        print()
+        print("  Authentication:")
+        print("    1. API key          (saved to AZURE_FOUNDRY_IMAGE_KEY in .env)")
+        print("    2. Microsoft Entra ID  (keyless \u2014 az login / managed identity / workload identity)")
+        print("       Requires the 'Azure AI User' role on the Foundry resource.")
+        try:
+            _auth_default = "2" if current_auth_mode == "entra_id" else "1"
+            auth_input = (
+                input(f"  Auth mode [1/2] ({_auth_default}): ").strip() or _auth_default
+            )
+        except (KeyboardInterrupt, EOFError):
+            print("\n  Cancelled.")
+            return False
+        use_entra = auth_input == "2"
+        auth_mode_label = "entra_id" if use_entra else "api_key"
+
+        # ── Step 4: Credentials ───────────────────────────────────────
+        effective_key = ""
+
+        if use_entra:
+            try:
+                from agent.azure_identity_adapter import (
+                    EntraIdentityConfig,
+                    describe_active_credential,
+                    has_azure_identity_installed,
+                )
+            except ImportError as exc:
+                print(f"\n  \u26a0 Could not import azure-identity adapter: {exc}")
+                print("  Falling back to API key auth.")
+                use_entra = False
+                auth_mode_label = "api_key"
+
+        if use_entra:
+            print()
+            if not has_azure_identity_installed():
+                print("  azure-identity is not installed.")
+                print("  It will be auto-installed on first use, or run: pip install azure-identity")
+            else:
+                print("  \u25d0 Probing Microsoft Entra ID credential chain (up to 10 s)...")
+                _entra_cfg = EntraIdentityConfig()
+                info = describe_active_credential(config=_entra_cfg, timeout_seconds=10.0)
+                if info.get("ok"):
+                    _sources = info.get("env_sources") or []
+                    _tag = ", ".join(_sources) if _sources else "default chain"
+                    print(f"  \u2713 Entra ID token acquired ({_tag})")
+                else:
+                    _err = info.get("error") or "credential chain exhausted"
+                    _hint = info.get("hint") or (
+                        "Run `az login`, attach a managed identity, or set "
+                        "AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET."
+                    )
+                    print(f"  \u26a0 {_err}")
+                    print(f"    Hint: {_hint}")
+                    try:
+                        _ans = input("  Save Entra config anyway and validate later? [Y/n]: ").strip().lower()
+                    except (KeyboardInterrupt, EOFError):
+                        print("\n  Cancelled.")
+                        return False
+                    if _ans and _ans not in ("y", "yes"):
+                        print("  Cancelled.")
+                        return False
+        else:
+            print()
+            try:
+                _key_hint = current_key[:8] + "..." if current_key else "required"
+                key_input = getpass.getpass(f"  API key [{_key_hint}]: ").strip()
+            except (KeyboardInterrupt, EOFError):
+                print("\n  Cancelled.")
+                return False
+            effective_key = key_input or current_key
+            if not effective_key:
+                print("  No API key provided. Cancelled.")
+                return False
+
+        # ── Persist ───────────────────────────────────────────────────
+        if not use_entra:
+            save_env_value("AZURE_FOUNDRY_IMAGE_KEY", effective_key)
+
+        img_section = config.setdefault("image_gen", {})
+        if not isinstance(img_section, dict):
+            img_section = {}
+            config["image_gen"] = img_section
+
+        az_section = img_section.setdefault("azure_foundry", {})
+        if not isinstance(az_section, dict):
+            az_section = {}
+            img_section["azure_foundry"] = az_section
+
+        az_section["endpoint"] = effective_endpoint
+        az_section["deployment_name"] = effective_deployment
+        az_section["auth_mode"] = auth_mode_label
+
+        img_section["provider"] = self.name
+        img_section["use_gateway"] = False
+
+        _auth_label = "Microsoft Entra ID (keyless)" if use_entra else "API key"
+        print_success(f"  Azure AI Foundry image gen configured:")
+        print_success(f"    Endpoint:   {effective_endpoint}")
+        print_success(f"    Deployment: {effective_deployment}")
+        print_success(f"    Auth:       {_auth_label}")
+        return True
+
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "Azure AI Foundry",
@@ -205,29 +367,6 @@ class AzureFoundryImageGenProvider(ImageGenProvider):
                 "resource with an image generation deployment."
             ),
             "env_vars": [
-                {
-                    "key": "AZURE_FOUNDRY_IMAGE_ENDPOINT",
-                    "prompt": "Azure resource endpoint (e.g. https://my-resource.openai.azure.com)",
-                    "url": "https://portal.azure.com",
-                    "secret": False,
-                },
-                {
-                    "key": "AZURE_FOUNDRY_IMAGE_KEY",
-                    "prompt": "Azure API key",
-                    "url": "https://portal.azure.com",
-                },
-                {
-                    "key": "AZURE_FOUNDRY_IMAGE_DEPLOYMENT",
-                    "prompt": f"Deployment name (default: {DEFAULT_DEPLOYMENT})",
-                    "url": "https://ai.azure.com",
-                    "secret": False,
-                },
-                {
-                    "key": "AZURE_FOUNDRY_IMAGE_QUALITY",
-                    "prompt": f"Image quality — low / medium / high (default: {DEFAULT_QUALITY})",
-                    "url": "https://learn.microsoft.com/azure/ai-services/openai/concepts/models",
-                    "secret": False,
-                },
             ],
         }
 
@@ -270,13 +409,26 @@ class AzureFoundryImageGenProvider(ImageGenProvider):
         creds = _resolve_credentials()
         endpoint = creds.get("endpoint", "")
         api_key = creds.get("api_key", "")
+        auth_mode = creds.get("auth_mode", "api_key")
 
-        if not endpoint or not api_key:
+        if not endpoint:
             return error_response(
                 error=(
-                    "Azure AI Foundry credentials not configured. "
-                    "Set AZURE_FOUNDRY_IMAGE_ENDPOINT and AZURE_FOUNDRY_IMAGE_KEY, "
-                    "or configure image_gen.azure_foundry in config.yaml."
+                    "Azure AI Foundry endpoint not configured. "
+                    "Set AZURE_FOUNDRY_IMAGE_ENDPOINT or configure "
+                    "image_gen.azure_foundry.endpoint in config.yaml."
+                ),
+                error_type="auth_required",
+                provider=self.name,
+                aspect_ratio=aspect,
+            )
+
+        if auth_mode != "entra_id" and not api_key:
+            return error_response(
+                error=(
+                    "Azure AI Foundry API key not configured. "
+                    "Set AZURE_FOUNDRY_IMAGE_KEY in .env, or set "
+                    "image_gen.azure_foundry.auth_mode: entra_id for keyless auth."
                 ),
                 error_type="auth_required",
                 provider=self.name,
@@ -298,10 +450,32 @@ class AzureFoundryImageGenProvider(ImageGenProvider):
         base_url = endpoint.rstrip("/") + "/openai/v1/"
         size = _SIZES.get(aspect, _SIZES["square"])
 
+        # --- build auth (API key or Entra ID token provider) ---
+        if auth_mode == "entra_id":
+            try:
+                from agent.azure_identity_adapter import (
+                    EntraIdentityConfig,
+                    build_token_provider,
+                )
+                _entra_cfg = EntraIdentityConfig()
+                effective_api_key: Any = build_token_provider(config=_entra_cfg)
+            except ImportError as exc:
+                return error_response(
+                    error=(
+                        "Microsoft Entra ID auth requires azure-identity: "
+                        f"pip install azure-identity ({exc})"
+                    ),
+                    error_type="missing_dependency",
+                    provider=self.name,
+                    aspect_ratio=aspect,
+                )
+        else:
+            effective_api_key = api_key
+
         # --- API call (Azure OpenAI v1) ---
         try:
             client = openai.OpenAI(
-                api_key=api_key,
+                api_key=effective_api_key,
                 base_url=base_url,
             )
             response = client.images.generate(

--- a/plugins/image_gen/azure-foundry/__init__.py
+++ b/plugins/image_gen/azure-foundry/__init__.py
@@ -1,0 +1,388 @@
+"""Azure AI Foundry image generation backend.
+
+Exposes Azure AI Foundry's gpt-image-2 as an :class:`ImageGenProvider`
+implementation using the Azure OpenAI v1 API (``openai.OpenAI`` with
+``base_url`` pointing to ``/openai/v1/``).
+
+The user configures one deployment (e.g. ``gpt-image-2``). Quality is
+configured globally (``"low"`` / ``"medium"`` / ``"high"``) via the
+``AZURE_FOUNDRY_IMAGE_QUALITY`` env var or ``image_gen.azure_foundry.quality``
+in ``config.yaml``, defaulting to ``"medium"``.
+
+Configuration
+-------------
+Resolution order (first hit wins):
+
+1. Environment variables::
+
+       AZURE_FOUNDRY_IMAGE_ENDPOINT   — Azure resource endpoint
+                                        e.g. https://my-resource.openai.azure.com
+       AZURE_FOUNDRY_IMAGE_KEY        — API key
+       AZURE_FOUNDRY_IMAGE_DEPLOYMENT — deployment name (default: gpt-image-2)
+       AZURE_FOUNDRY_IMAGE_QUALITY    — quality tier: low / medium / high (default: medium)
+
+2. ``image_gen.azure_foundry`` section in ``config.yaml``::
+
+       image_gen:
+         provider: azure_foundry
+         azure_foundry:
+           endpoint: "https://my-resource.openai.azure.com"
+           api_key_env: "AZURE_FOUNDRY_IMAGE_KEY"   # env var name, not the key itself
+           deployment_name: "gpt-image-2"
+
+3. Global ``AZURE_OPENAI_*`` fallback env vars
+   (``AZURE_OPENAI_API_KEY`` + ``AZURE_OPENAI_ENDPOINT``).
+
+Quality
+-------
+Set quality via ``AZURE_FOUNDRY_IMAGE_QUALITY`` env var or
+``image_gen.azure_foundry.quality`` in ``config.yaml``.
+Valid values: ``"low"``, ``"medium"``, ``"high"``. Default: ``"medium"``.
+
+Sizes
+-----
+``1024x1024`` (square), ``1536x1024`` (landscape), ``1024x1536`` (portrait).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_DEPLOYMENT = "gpt-image-2"
+
+VALID_QUALITY_VALUES = {"low", "medium", "high"}
+DEFAULT_QUALITY = "medium"
+
+
+def _resolve_quality() -> str:
+    """Resolve quality setting from env var or config.yaml.
+
+    Precedence:
+    1. ``AZURE_FOUNDRY_IMAGE_QUALITY`` env var
+    2. ``image_gen.azure_foundry.quality`` in config.yaml
+    3. :data:`DEFAULT_QUALITY` (``"medium"``)
+
+    Unknown values are silently ignored and fall back to the default.
+    """
+    env_val = os.environ.get("AZURE_FOUNDRY_IMAGE_QUALITY", "").strip().lower()
+    if env_val:
+        return env_val if env_val in VALID_QUALITY_VALUES else DEFAULT_QUALITY
+
+    cfg = _load_azure_foundry_config()
+    cfg_val = str(cfg.get("quality") or "").strip().lower()
+    if cfg_val and cfg_val in VALID_QUALITY_VALUES:
+        return cfg_val
+
+    return DEFAULT_QUALITY
+
+_SIZES: Dict[str, str] = {
+    "landscape": "1536x1024",
+    "square": "1024x1024",
+    "portrait": "1024x1536",
+}
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_azure_foundry_config() -> Dict[str, Any]:
+    """Read ``image_gen.azure_foundry`` from config.yaml (returns {} on failure)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        img_cfg = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        if not isinstance(img_cfg, dict):
+            return {}
+        section = img_cfg.get("azure_foundry")
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen.azure_foundry config: %s", exc)
+        return {}
+
+
+def _resolve_credentials() -> Dict[str, Any]:
+    """Resolve endpoint, API key, and deployment name.
+
+    Returns a dict with keys: ``endpoint``, ``api_key``, ``deployment``.
+    Empty string means not configured.
+    """
+    # 1. Dedicated env vars
+    endpoint = os.environ.get("AZURE_FOUNDRY_IMAGE_ENDPOINT", "").strip()
+    api_key = os.environ.get("AZURE_FOUNDRY_IMAGE_KEY", "").strip()
+    deployment = os.environ.get("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "").strip()
+
+    # 2. config.yaml fills gaps
+    cfg = _load_azure_foundry_config()
+    if not endpoint:
+        endpoint = str(cfg.get("endpoint") or "").strip()
+    if not api_key:
+        key_env = str(cfg.get("api_key_env") or "").strip()
+        if key_env:
+            api_key = os.environ.get(key_env, "").strip()
+    if not deployment:
+        deployment = str(cfg.get("deployment_name") or "").strip()
+
+    # 3. Global Azure OpenAI fallback (endpoint + key only)
+    if not endpoint:
+        endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip()
+    if not api_key:
+        api_key = os.environ.get("AZURE_OPENAI_API_KEY", "").strip()
+
+    return {
+        "endpoint": endpoint,
+        "api_key": api_key,
+        "deployment": deployment or DEFAULT_DEPLOYMENT,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class AzureFoundryImageGenProvider(ImageGenProvider):
+    """Azure AI Foundry gpt-image-2 image generation backend.
+
+    Uses ``openai.OpenAI`` with Azure OpenAI v1 ``base_url``.
+    Quality (low / medium / high) is resolved from config, not from the caller.
+    """
+
+    @property
+    def name(self) -> str:
+        return "azure-foundry"
+
+    @property
+    def display_name(self) -> str:
+        return "Azure AI Foundry"
+
+    def is_available(self) -> bool:
+        creds = _resolve_credentials()
+        return bool(creds.get("endpoint") and creds.get("api_key"))
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        """Return one entry for the configured deployment."""
+        creds = _resolve_credentials()
+        deployment = creds["deployment"]
+        return [
+            {
+                "id": deployment,
+                "display": f"Azure AI Foundry — {deployment}",
+                "speed": "varies by quality",
+                "strengths": "Quality configured globally: low / medium / high",
+                "price": "varies",
+            }
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return _resolve_credentials()["deployment"]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Azure AI Foundry",
+            "badge": "paid",
+            "tag": (
+                "gpt-image-2 via Azure AI Foundry — requires an Azure "
+                "resource with an image generation deployment."
+            ),
+            "env_vars": [
+                {
+                    "key": "AZURE_FOUNDRY_IMAGE_ENDPOINT",
+                    "prompt": "Azure resource endpoint (e.g. https://my-resource.openai.azure.com)",
+                    "url": "https://portal.azure.com",
+                    "secret": False,
+                },
+                {
+                    "key": "AZURE_FOUNDRY_IMAGE_KEY",
+                    "prompt": "Azure API key",
+                    "url": "https://portal.azure.com",
+                },
+                {
+                    "key": "AZURE_FOUNDRY_IMAGE_DEPLOYMENT",
+                    "prompt": f"Deployment name (default: {DEFAULT_DEPLOYMENT})",
+                    "url": "https://ai.azure.com",
+                    "secret": False,
+                },
+                {
+                    "key": "AZURE_FOUNDRY_IMAGE_QUALITY",
+                    "prompt": f"Image quality — low / medium / high (default: {DEFAULT_QUALITY})",
+                    "url": "https://learn.microsoft.com/azure/ai-services/openai/concepts/models",
+                    "secret": False,
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate an image using Azure AI Foundry.
+
+        Quality is resolved from configuration (``AZURE_FOUNDRY_IMAGE_QUALITY``
+        env var or ``image_gen.azure_foundry.quality`` in config.yaml).
+        It is not a per-call parameter.
+
+        Args:
+            prompt:       Text description of the image to generate.
+            aspect_ratio: ``"landscape"``, ``"square"``, or ``"portrait"``.
+            **kwargs:     Ignored (forward-compat).
+
+        Returns:
+            A dict from :func:`success_response` or :func:`error_response`.
+        """
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        # --- quality from config ---
+        resolved_quality = _resolve_quality()
+
+        # --- input validation ---
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string.",
+                error_type="invalid_argument",
+                provider=self.name,
+                aspect_ratio=aspect,
+            )
+
+        # --- credentials ---
+        creds = _resolve_credentials()
+        endpoint = creds.get("endpoint", "")
+        api_key = creds.get("api_key", "")
+
+        if not endpoint or not api_key:
+            return error_response(
+                error=(
+                    "Azure AI Foundry credentials not configured. "
+                    "Set AZURE_FOUNDRY_IMAGE_ENDPOINT and AZURE_FOUNDRY_IMAGE_KEY, "
+                    "or configure image_gen.azure_foundry in config.yaml."
+                ),
+                error_type="auth_required",
+                provider=self.name,
+                aspect_ratio=aspect,
+            )
+
+        # --- openai SDK ---
+        try:
+            import openai
+        except ImportError:
+            return error_response(
+                error="openai Python package not installed (pip install openai)",
+                error_type="missing_dependency",
+                provider=self.name,
+                aspect_ratio=aspect,
+            )
+
+        deployment = creds["deployment"]
+        base_url = endpoint.rstrip("/") + "/openai/v1/"
+        size = _SIZES.get(aspect, _SIZES["square"])
+
+        # --- API call (Azure OpenAI v1) ---
+        try:
+            client = openai.OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+            )
+            response = client.images.generate(
+                model=deployment,
+                prompt=prompt,
+                size=size,  # type: ignore[arg-type]
+                n=1,
+                quality=resolved_quality,  # type: ignore[arg-type]
+            )
+        except Exception as exc:
+            logger.debug("Azure Foundry image generation failed", exc_info=True)
+            return error_response(
+                error=f"Azure Foundry image generation failed: {exc}",
+                error_type="api_error",
+                provider=self.name,
+                model=deployment,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # --- response parsing ---
+        data = getattr(response, "data", None) or []
+        if not data:
+            return error_response(
+                error="Azure Foundry returned no image data.",
+                error_type="empty_response",
+                provider=self.name,
+                model=deployment,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        first = data[0]
+        b64 = getattr(first, "b64_json", None)
+        url = getattr(first, "url", None)
+        revised_prompt = getattr(first, "revised_prompt", None)
+
+        if b64:
+            try:
+                saved_path = save_b64_image(b64, prefix=f"azure_foundry_{deployment}")
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save image to cache: {exc}",
+                    error_type="io_error",
+                    provider=self.name,
+                    model=deployment,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            image_ref = str(saved_path)
+        elif url:
+            image_ref = url
+        else:
+            return error_response(
+                error="Azure Foundry response contained neither b64_json nor URL.",
+                error_type="empty_response",
+                provider=self.name,
+                model=deployment,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {"size": size, "quality": resolved_quality}
+        if revised_prompt:
+            extra["revised_prompt"] = revised_prompt
+
+        return success_response(
+            image=image_ref,
+            model=deployment,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider=self.name,
+            extra=extra,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point — register AzureFoundryImageGenProvider."""
+    ctx.register_image_gen_provider(AzureFoundryImageGenProvider())

--- a/plugins/image_gen/azure-foundry/plugin.yaml
+++ b/plugins/image_gen/azure-foundry/plugin.yaml
@@ -1,0 +1,5 @@
+name: azure-foundry
+version: 1.0.0
+description: "Azure AI Foundry image generation backend (DALL-E-3 via AzureOpenAI). Saves generated images to $HERMES_HOME/cache/images/."
+author: NousResearch
+kind: backend

--- a/plugins/image_gen/azure-foundry/plugin.yaml
+++ b/plugins/image_gen/azure-foundry/plugin.yaml
@@ -1,5 +1,5 @@
 name: azure-foundry
 version: 1.0.0
-description: "Azure AI Foundry image generation backend (DALL-E-3 via AzureOpenAI). Saves generated images to $HERMES_HOME/cache/images/."
+description: "Azure AI Foundry image generation backend (gpt-image-2). Saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend

--- a/tests/tools/test_image_gen_azure_foundry.py
+++ b/tests/tools/test_image_gen_azure_foundry.py
@@ -94,9 +94,6 @@ class TestConstants:
     def test_default_deployment(self, plugin):
         assert plugin.DEFAULT_DEPLOYMENT == "gpt-image-2"
 
-    def test_default_api_version_preview(self, plugin):
-        assert "preview" in plugin.DEFAULT_API_VERSION
-
     def test_valid_quality_values(self, plugin):
         assert plugin.VALID_QUALITY_VALUES == {"low", "medium", "high"}
 
@@ -169,7 +166,7 @@ class TestGenerateQualityFromConfig:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text("image_gen: {}\n")
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a fox")
         assert result["success"] is True
         assert fake_client.images.generate.call_args.kwargs["quality"] == "medium"
@@ -179,7 +176,7 @@ class TestGenerateQualityFromConfig:
         monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "low")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a fox")
         assert result["success"] is True
         assert fake_client.images.generate.call_args.kwargs["quality"] == "low"
@@ -192,7 +189,7 @@ class TestGenerateQualityFromConfig:
             "image_gen:\n  azure_foundry:\n    quality: high\n"
         )
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a fox")
         assert result["success"] is True
         assert fake_client.images.generate.call_args.kwargs["quality"] == "high"
@@ -202,7 +199,7 @@ class TestGenerateQualityFromConfig:
         monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "high")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a fox")
         assert result.get("quality") == "high"
 
@@ -223,7 +220,7 @@ class TestGenerateDeployment:
         monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "my-deploy")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             provider.generate("a fox")
         assert fake_client.images.generate.call_args.kwargs["model"] == "my-deploy"
 
@@ -233,7 +230,7 @@ class TestGenerateDeployment:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text("image_gen: {}\n")
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             provider.generate("a fox")
         assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2"
 
@@ -242,7 +239,7 @@ class TestGenerateDeployment:
         monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "my-deploy")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a fox")
         assert result["model"] == "my-deploy"
 
@@ -256,7 +253,7 @@ class TestGenerateHappyPath:
         _set_creds(monkeypatch)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = _fake_url_client("https://cdn.example.com/out.png")
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a cat")
         assert result["success"] is True
         assert result["image"] == "https://cdn.example.com/out.png"
@@ -273,7 +270,7 @@ class TestGenerateHappyPath:
         fake_resp.data = [fake_item]
         fake_client = MagicMock()
         fake_client.images.generate.return_value = fake_resp
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a dog")
         assert result["success"] is True
         assert result["image"].endswith(".png")
@@ -289,7 +286,7 @@ class TestGenerateHappyPath:
         fake_resp.data = [fake_item]
         fake_client = MagicMock()
         fake_client.images.generate.return_value = fake_resp
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a fox")
         assert result.get("revised_prompt") == "a swift arctic fox"
 
@@ -297,7 +294,7 @@ class TestGenerateHappyPath:
         _set_creds(monkeypatch)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             provider.generate("a fox", aspect_ratio="landscape")
         assert fake_client.images.generate.call_args.kwargs["size"] == "1536x1024"
 
@@ -305,7 +302,7 @@ class TestGenerateHappyPath:
         _set_creds(monkeypatch)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = _fake_url_client()
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             provider.generate("a fox", aspect_ratio="portrait")
         assert fake_client.images.generate.call_args.kwargs["size"] == "1024x1536"
 
@@ -322,8 +319,7 @@ class TestGenerateErrors:
         assert result["error_type"] == "invalid_argument"
 
     def test_missing_credentials_returns_auth_error(self, provider, monkeypatch, tmp_path):
-        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT",
-                  "AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"):
+        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT"):
             monkeypatch.delenv(k, raising=False)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text("image_gen: {}\n")
@@ -343,7 +339,7 @@ class TestGenerateErrors:
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         fake_client = MagicMock()
         fake_client.images.generate.side_effect = RuntimeError("quota exceeded")
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a cat")
         assert result["success"] is False
         assert result["error_type"] == "api_error"
@@ -356,7 +352,7 @@ class TestGenerateErrors:
         fake_resp.data = []
         fake_client = MagicMock()
         fake_client.images.generate.return_value = fake_resp
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a cat")
         assert result["success"] is False
         assert result["error_type"] == "empty_response"
@@ -371,7 +367,7 @@ class TestGenerateErrors:
         fake_resp.data = [fake_item]
         fake_client = MagicMock()
         fake_client.images.generate.return_value = fake_resp
-        with patch("openai.AzureOpenAI", return_value=fake_client):
+        with patch("openai.OpenAI", return_value=fake_client):
             result = provider.generate("a cat")
         assert result["success"] is False
         assert result["error_type"] == "empty_response"
@@ -383,8 +379,7 @@ class TestGenerateErrors:
 
 class TestIsAvailable:
     def test_false_when_no_env(self, provider, monkeypatch, tmp_path):
-        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT",
-                  "AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"):
+        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT"):
             monkeypatch.delenv(k, raising=False)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text("image_gen: {}\n")
@@ -392,15 +387,13 @@ class TestIsAvailable:
 
     def test_false_when_only_key(self, provider, monkeypatch, tmp_path):
         monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_KEY", "sk-test")
-        for k in ("AZURE_FOUNDRY_IMAGE_ENDPOINT", "AZURE_OPENAI_ENDPOINT"):
-            monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_ENDPOINT", raising=False)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text("image_gen: {}\n")
         assert not provider.is_available()
 
     def test_false_when_only_endpoint(self, provider, monkeypatch, tmp_path):
-        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_OPENAI_API_KEY"):
-            monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_KEY", raising=False)
         monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_ENDPOINT", "https://my.openai.azure.com")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text("image_gen: {}\n")
@@ -447,7 +440,8 @@ class TestSetupSchema:
         assert "name" in provider.get_setup_schema()
 
     def test_has_env_vars(self, provider):
-        assert len(provider.get_setup_schema()["env_vars"]) > 0
+        # env_vars may be empty when setup_interactive() handles setup
+        assert isinstance(provider.get_setup_schema()["env_vars"], list)
 
     def test_has_badge(self, provider):
         assert "badge" in provider.get_setup_schema()
@@ -502,19 +496,18 @@ class TestConfigResolution:
         assert creds["endpoint"] == "https://env.openai.azure.com"
         assert creds["deployment"] == "my-deploy"
 
-    def test_resolve_credentials_from_config(self, plugin, monkeypatch, tmp_path):
-        monkeypatch.setenv("MY_KEY", "config-key")
-        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT"):
+    def test_resolve_credentials_from_config_endpoint(self, plugin, monkeypatch, tmp_path):
+        """Endpoint and deployment resolve from config.yaml when env vars absent."""
+        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT",
+                  "AZURE_FOUNDRY_IMAGE_DEPLOYMENT"):
             monkeypatch.delenv(k, raising=False)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "config.yaml").write_text(
             "image_gen:\n"
             "  azure_foundry:\n"
             "    endpoint: \"https://cfg.openai.azure.com\"\n"
-            "    api_key_env: MY_KEY\n"
             "    deployment_name: cfg-deploy\n"
         )
         creds = plugin._resolve_credentials()
-        assert creds["api_key"] == "config-key"
         assert creds["endpoint"] == "https://cfg.openai.azure.com"
         assert creds["deployment"] == "cfg-deploy"

--- a/tests/tools/test_image_gen_azure_foundry.py
+++ b/tests/tools/test_image_gen_azure_foundry.py
@@ -1,0 +1,520 @@
+"""Tests for plugins/image_gen/azure-foundry — Azure AI Foundry image generation.
+
+Covers:
+- Provider metadata (name, display_name)
+- is_available() credential checks
+- generate() happy path: quality resolved from config/env and sent to API
+- generate() error paths: no credentials, missing openai, API error, empty response
+- list_models() — one entry per configured deployment
+- get_setup_schema() shape validation
+- Plugin register() entry point
+- Credential / config resolution (including quality)
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_plugin():
+    spec_path = (
+        Path(__file__).parent.parent.parent
+        / "plugins" / "image_gen" / "azure-foundry" / "__init__.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "plugins.image_gen.azure_foundry", spec_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fake_url_client(url: str = "https://example.com/img.png"):
+    fake_item = MagicMock()
+    fake_item.b64_json = None
+    fake_item.url = url
+    fake_item.revised_prompt = None
+    fake_resp = MagicMock()
+    fake_resp.data = [fake_item]
+    fake_client = MagicMock()
+    fake_client.images.generate.return_value = fake_resp
+    return fake_client
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def plugin():
+    return _load_plugin()
+
+
+@pytest.fixture
+def provider(plugin):
+    return plugin.AzureFoundryImageGenProvider()
+
+
+def _set_creds(monkeypatch):
+    monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_KEY", "sk-test")
+    monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_ENDPOINT", "https://my.openai.azure.com")
+
+
+# ---------------------------------------------------------------------------
+# Provider metadata
+# ---------------------------------------------------------------------------
+
+class TestProviderMetadata:
+    def test_name(self, provider):
+        assert provider.name == "azure-foundry"
+
+    def test_display_name_contains_azure(self, provider):
+        assert "Azure" in provider.display_name
+
+    def test_is_image_gen_provider(self, provider):
+        from agent.image_gen_provider import ImageGenProvider
+        assert isinstance(provider, ImageGenProvider)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+class TestConstants:
+    def test_default_deployment(self, plugin):
+        assert plugin.DEFAULT_DEPLOYMENT == "gpt-image-2"
+
+    def test_default_api_version_preview(self, plugin):
+        assert "preview" in plugin.DEFAULT_API_VERSION
+
+    def test_valid_quality_values(self, plugin):
+        assert plugin.VALID_QUALITY_VALUES == {"low", "medium", "high"}
+
+    def test_default_quality_is_medium(self, plugin):
+        assert plugin.DEFAULT_QUALITY == "medium"
+
+    def test_default_quality_in_valid_values(self, plugin):
+        assert plugin.DEFAULT_QUALITY in plugin.VALID_QUALITY_VALUES
+
+    def test_sizes_landscape(self, plugin):
+        assert plugin._SIZES["landscape"] == "1536x1024"
+
+    def test_sizes_portrait(self, plugin):
+        assert plugin._SIZES["portrait"] == "1024x1536"
+
+    def test_sizes_square(self, plugin):
+        assert plugin._SIZES["square"] == "1024x1024"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_quality() — reads from config/env, not from generate() call
+# ---------------------------------------------------------------------------
+
+class TestResolveQuality:
+    def test_default_when_nothing_set(self, plugin, monkeypatch, tmp_path):
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_QUALITY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        assert plugin._resolve_quality() == "medium"
+
+    def test_env_var_sets_quality_low(self, plugin, monkeypatch):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "low")
+        assert plugin._resolve_quality() == "low"
+
+    def test_env_var_sets_quality_high(self, plugin, monkeypatch):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "high")
+        assert plugin._resolve_quality() == "high"
+
+    def test_env_var_unknown_falls_back_to_default(self, plugin, monkeypatch, tmp_path):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "ultra")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        assert plugin._resolve_quality() == "medium"
+
+    def test_config_yaml_sets_quality(self, plugin, monkeypatch, tmp_path):
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_QUALITY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  azure_foundry:\n    quality: high\n"
+        )
+        assert plugin._resolve_quality() == "high"
+
+    def test_env_var_wins_over_config(self, plugin, monkeypatch, tmp_path):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "low")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  azure_foundry:\n    quality: high\n"
+        )
+        assert plugin._resolve_quality() == "low"
+
+
+# ---------------------------------------------------------------------------
+# generate() — quality comes from config, not from caller
+# ---------------------------------------------------------------------------
+
+class TestGenerateQualityFromConfig:
+    def test_default_quality_medium_sent_to_api(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_QUALITY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a fox")
+        assert result["success"] is True
+        assert fake_client.images.generate.call_args.kwargs["quality"] == "medium"
+
+    def test_quality_low_from_env(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "low")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a fox")
+        assert result["success"] is True
+        assert fake_client.images.generate.call_args.kwargs["quality"] == "low"
+
+    def test_quality_high_from_config_yaml(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_QUALITY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  azure_foundry:\n    quality: high\n"
+        )
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a fox")
+        assert result["success"] is True
+        assert fake_client.images.generate.call_args.kwargs["quality"] == "high"
+
+    def test_quality_echoed_in_response(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_QUALITY", "high")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a fox")
+        assert result.get("quality") == "high"
+
+    def test_generate_has_no_quality_parameter(self, provider):
+        """generate() must not accept a quality kwarg — quality is config-only."""
+        import inspect
+        sig = inspect.signature(provider.generate)
+        assert "quality" not in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# generate() — deployment used as API model param
+# ---------------------------------------------------------------------------
+
+class TestGenerateDeployment:
+    def test_deployment_sent_as_model_param(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "my-deploy")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            provider.generate("a fox")
+        assert fake_client.images.generate.call_args.kwargs["model"] == "my-deploy"
+
+    def test_default_deployment_when_not_set(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            provider.generate("a fox")
+        assert fake_client.images.generate.call_args.kwargs["model"] == "gpt-image-2"
+
+    def test_response_model_is_deployment_name(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "my-deploy")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a fox")
+        assert result["model"] == "my-deploy"
+
+
+# ---------------------------------------------------------------------------
+# generate() — happy path
+# ---------------------------------------------------------------------------
+
+class TestGenerateHappyPath:
+    def test_url_response_returned_directly(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = _fake_url_client("https://cdn.example.com/out.png")
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a cat")
+        assert result["success"] is True
+        assert result["image"] == "https://cdn.example.com/out.png"
+
+    def test_b64_response_saves_file(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        import base64
+        fake_item = MagicMock()
+        fake_item.b64_json = base64.b64encode(b"PNG").decode()
+        fake_item.url = None
+        fake_item.revised_prompt = None
+        fake_resp = MagicMock()
+        fake_resp.data = [fake_item]
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = fake_resp
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a dog")
+        assert result["success"] is True
+        assert result["image"].endswith(".png")
+
+    def test_revised_prompt_in_response(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_item = MagicMock()
+        fake_item.b64_json = None
+        fake_item.url = "https://cdn.example.com/out.png"
+        fake_item.revised_prompt = "a swift arctic fox"
+        fake_resp = MagicMock()
+        fake_resp.data = [fake_item]
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = fake_resp
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a fox")
+        assert result.get("revised_prompt") == "a swift arctic fox"
+
+    def test_landscape_size(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            provider.generate("a fox", aspect_ratio="landscape")
+        assert fake_client.images.generate.call_args.kwargs["size"] == "1536x1024"
+
+    def test_portrait_size(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = _fake_url_client()
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            provider.generate("a fox", aspect_ratio="portrait")
+        assert fake_client.images.generate.call_args.kwargs["size"] == "1024x1536"
+
+
+# ---------------------------------------------------------------------------
+# generate() — error paths
+# ---------------------------------------------------------------------------
+
+class TestGenerateErrors:
+    def test_empty_prompt_returns_error(self, provider, monkeypatch):
+        _set_creds(monkeypatch)
+        result = provider.generate("")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_missing_credentials_returns_auth_error(self, provider, monkeypatch, tmp_path):
+        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT",
+                  "AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+    def test_missing_openai_package_returns_error(self, provider, monkeypatch):
+        _set_creds(monkeypatch)
+        with patch.dict(sys.modules, {"openai": None}):
+            result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "missing_dependency"
+
+    def test_api_error_returns_api_error(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_client = MagicMock()
+        fake_client.images.generate.side_effect = RuntimeError("quota exceeded")
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "quota exceeded" in result["error"]
+
+    def test_empty_response_returns_error(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_resp = MagicMock()
+        fake_resp.data = []
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = fake_resp
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_no_b64_or_url_returns_error(self, provider, monkeypatch, tmp_path):
+        _set_creds(monkeypatch)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        fake_item = MagicMock()
+        fake_item.b64_json = None
+        fake_item.url = None
+        fake_resp = MagicMock()
+        fake_resp.data = [fake_item]
+        fake_client = MagicMock()
+        fake_client.images.generate.return_value = fake_resp
+        with patch("openai.AzureOpenAI", return_value=fake_client):
+            result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+
+# ---------------------------------------------------------------------------
+# is_available()
+# ---------------------------------------------------------------------------
+
+class TestIsAvailable:
+    def test_false_when_no_env(self, provider, monkeypatch, tmp_path):
+        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT",
+                  "AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        assert not provider.is_available()
+
+    def test_false_when_only_key(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_KEY", "sk-test")
+        for k in ("AZURE_FOUNDRY_IMAGE_ENDPOINT", "AZURE_OPENAI_ENDPOINT"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        assert not provider.is_available()
+
+    def test_false_when_only_endpoint(self, provider, monkeypatch, tmp_path):
+        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_OPENAI_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_ENDPOINT", "https://my.openai.azure.com")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        assert not provider.is_available()
+
+    def test_true_when_both_set(self, provider, monkeypatch):
+        _set_creds(monkeypatch)
+        assert provider.is_available()
+
+
+# ---------------------------------------------------------------------------
+# list_models()
+# ---------------------------------------------------------------------------
+
+class TestListModels:
+    def test_returns_list(self, provider):
+        assert isinstance(provider.list_models(), list)
+
+    def test_includes_default_deployment(self, provider, monkeypatch, tmp_path):
+        monkeypatch.delenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        ids = [m["id"] for m in provider.list_models()]
+        assert "gpt-image-2" in ids
+
+    def test_custom_deployment_shown(self, provider, monkeypatch):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "my-custom-deploy")
+        ids = [m["id"] for m in provider.list_models()]
+        assert "my-custom-deploy" in ids
+
+    def test_no_dalle(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        ids = [m["id"] for m in provider.list_models()]
+        assert not any("dall-e" in mid for mid in ids)
+
+
+# ---------------------------------------------------------------------------
+# get_setup_schema()
+# ---------------------------------------------------------------------------
+
+class TestSetupSchema:
+    def test_has_name(self, provider):
+        assert "name" in provider.get_setup_schema()
+
+    def test_has_env_vars(self, provider):
+        assert len(provider.get_setup_schema()["env_vars"]) > 0
+
+    def test_has_badge(self, provider):
+        assert "badge" in provider.get_setup_schema()
+
+
+# ---------------------------------------------------------------------------
+# Plugin register()
+# ---------------------------------------------------------------------------
+
+class TestRegister:
+    def test_register_calls_ctx(self, plugin):
+        ctx = MagicMock()
+        plugin.register(ctx)
+        ctx.register_image_gen_provider.assert_called_once()
+
+    def test_registered_provider_name(self, plugin):
+        captured = []
+        ctx = MagicMock()
+        ctx.register_image_gen_provider.side_effect = lambda p: captured.append(p)
+        plugin.register(ctx)
+        assert captured[0].name == "azure-foundry"
+
+
+# ---------------------------------------------------------------------------
+# Credential / config resolution
+# ---------------------------------------------------------------------------
+
+class TestConfigResolution:
+    def test_load_config_from_yaml(self, plugin, monkeypatch, tmp_path):
+        monkeypatch.setenv("MY_AZURE_KEY", "key-from-env")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n"
+            "  azure_foundry:\n"
+            "    endpoint: \"https://my.openai.azure.com\"\n"
+            "    api_key_env: MY_AZURE_KEY\n"
+            "    deployment_name: gpt-image-2\n"
+            "    api_version: \"2025-04-01-preview\"\n"
+        )
+        cfg = plugin._load_azure_foundry_config()
+        assert cfg.get("endpoint") == "https://my.openai.azure.com"
+        assert cfg.get("deployment_name") == "gpt-image-2"
+
+    def test_resolve_credentials_from_env(self, plugin, monkeypatch, tmp_path):
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_KEY", "sk-test")
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_ENDPOINT", "https://env.openai.azure.com")
+        monkeypatch.setenv("AZURE_FOUNDRY_IMAGE_DEPLOYMENT", "my-deploy")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen: {}\n")
+        creds = plugin._resolve_credentials()
+        assert creds["api_key"] == "sk-test"
+        assert creds["endpoint"] == "https://env.openai.azure.com"
+        assert creds["deployment"] == "my-deploy"
+
+    def test_resolve_credentials_from_config(self, plugin, monkeypatch, tmp_path):
+        monkeypatch.setenv("MY_KEY", "config-key")
+        for k in ("AZURE_FOUNDRY_IMAGE_KEY", "AZURE_FOUNDRY_IMAGE_ENDPOINT"):
+            monkeypatch.delenv(k, raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n"
+            "  azure_foundry:\n"
+            "    endpoint: \"https://cfg.openai.azure.com\"\n"
+            "    api_key_env: MY_KEY\n"
+            "    deployment_name: cfg-deploy\n"
+        )
+        creds = plugin._resolve_credentials()
+        assert creds["api_key"] == "config-key"
+        assert creds["endpoint"] == "https://cfg.openai.azure.com"
+        assert creds["deployment"] == "cfg-deploy"


### PR DESCRIPTION
## What does this PR do?

Adds **Azure AI Foundry** as a new image generation provider backed by the `gpt-image-2` model. This allows users with Azure OpenAI resources to generate images through Hermes without needing a FAL.ai or OpenAI API key.

The provider follows the existing plugin architecture (`ImageGenProvider` subclass + `plugin.yaml`). It implements a custom `setup_interactive()` wizard that handles the full configuration flow — endpoint URL, deployment name, auth mode selection, and credential validation — replacing the generic env-var prompt loop for a smoother UX.

Two auth modes are supported:
- **API key** — saved to `AZURE_FOUNDRY_IMAGE_KEY` in `.env`
- **Microsoft Entra ID (keyless)** — via `azure-identity`'s `DefaultAzureCredential` chain (az login, managed identity, workload identity, service principal env vars)

Quality (`low` / `medium` / `high`) is configured globally — not per call — which matches Azure's deployment model where one deployment serves all quality tiers.

The provider uses `openai.OpenAI` with `base_url` pointing to `<endpoint>/openai/v1/` (Azure OpenAI v1 API), rather than the `AzureOpenAI` SDK client.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/image_gen/azure-foundry/__init__.py` — New `AzureFoundryImageGenProvider` implementing `ImageGenProvider`
  - Uses `openai.OpenAI` with `base_url=<endpoint>/openai/v1/` (Azure OpenAI v1 API)
  - Supports API key auth and Microsoft Entra ID (keyless) via `azure-identity` `DefaultAzureCredential`
  - Quality configured globally via `AZURE_FOUNDRY_IMAGE_QUALITY` env var or `image_gen.azure_foundry.quality` in config.yaml (values: `low` / `medium` / `high`, default: `medium`)
  - Sizes: `1536x1024` (landscape), `1024x1024` (square), `1024x1536` (portrait)
  - Implements `setup_interactive()` — a full guided wizard (endpoint → deployment → auth mode → credentials → Entra ID preflight); `get_setup_schema()` returns empty `env_vars` since the wizard handles everything
- `plugins/image_gen/azure-foundry/plugin.yaml` — Plugin metadata (`provider_name: azure_foundry`, `kind: backend`)
- `agent/image_gen_provider.py` — Adds `setup_interactive(config: dict) -> bool` hook to the `ImageGenProvider` base class. Returns `False` by default (no-op); providers override it to run a custom wizard and skip the generic env-var prompt flow
- `hermes_cli/tools_config.py` — Updates `_select_plugin_image_gen_provider()` to call `provider.setup_interactive(config)` before the generic env-var flow; if it returns `True`, the generic flow is skipped
- `tests/tools/test_image_gen_azure_foundry.py` — 52 new tests

## How to Test

**Via `hermes tools` setup wizard:**
1. Run `hermes tools` and navigate to image generation
2. Select "Azure AI Foundry" — the interactive wizard will prompt for endpoint, deployment name, and auth mode
3. After setup, ask Hermes to generate an image: `generate an image of a mountain at sunset`

**Manual config:**
1. Add to `~/.hermes/.env`:
   ```
   AZURE_FOUNDRY_IMAGE_ENDPOINT=https://your-resource.openai.azure.com
   AZURE_FOUNDRY_IMAGE_KEY=your-api-key
   ```
2. Add to `~/.hermes/config.yaml`:
   ```yaml
   image_gen:
     provider: azure_foundry
     azure_foundry:
       deployment_name: gpt-image-2
       quality: medium
   ```
3. Generate an image via Hermes

**Run tests:**
```bash
pytest tests/tools/test_image_gen_azure_foundry.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_image_gen_azure_foundry.py -q
....................................................  [100%]
52 passed in 1.69s
```

Example successful generation response:
```json
{
  "success": true,
  "provider": "azure-foundry",
  "model": "gpt-image-2",
  "size": "1536x1024",
  "quality": "medium",
  "aspect_ratio": "landscape"
}
```
<img width="1739" height="989" alt="image" src="https://github.com/user-attachments/assets/65395ac1-fd50-45af-b8e7-d8183e971eaf" />