### PR TITLE
fix(cron): bound oversized delivery output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -14,6 +14,7 @@ import contextvars
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -153,6 +154,7 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+_DEFAULT_DELIVERY_MAX_CHARS = 3500
 
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
@@ -168,6 +170,61 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+def _resolve_delivery_max_chars(cron_cfg: dict | None = None) -> int:
+    """Resolve the max inline cron delivery size before using file fallback."""
+    env_value = os.getenv("HERMES_CRON_DELIVERY_MAX_CHARS", "").strip()
+    raw_value = env_value or (cron_cfg or {}).get("delivery_max_chars")
+    if raw_value is not None:
+        try:
+            value = int(float(raw_value))
+            if value > 0:
+                return max(value, 100)
+        except Exception:
+            logger.warning("Invalid cron delivery_max_chars=%r; using default", raw_value)
+    return _DEFAULT_DELIVERY_MAX_CHARS
+
+
+def _safe_delivery_attachment_name(job: dict) -> str:
+    raw_id = str(job.get("id") or "cron-job")
+    safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw_id).strip("-._") or "cron-job"
+    timestamp = _hermes_now().strftime("%Y%m%d-%H%M%S")
+    return f"cron-{safe_id}-{timestamp}-{os.getpid()}.txt"
+
+
+def _write_delivery_attachment(job: dict, content: str) -> Path:
+    """Persist full cron output under a Hermes-managed document cache."""
+    output_dir = _get_hermes_home() / "document_cache" / "cron-deliveries"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / _safe_delivery_attachment_name(job)
+    output_path.write_text(content, encoding="utf-8")
+    return output_path
+
+
+def _with_large_delivery_fallback(job: dict, delivery_content: str, max_chars: int) -> str:
+    """Replace oversized inline cron delivery text with a small summary + MEDIA file."""
+    if len(delivery_content) <= max_chars:
+        return delivery_content
+
+    attachment = _write_delivery_attachment(job, delivery_content)
+    prefix_budget = max(0, max_chars - 160)
+    preview = delivery_content[:prefix_budget].rstrip()
+    if prefix_budget and len(delivery_content) > prefix_budget:
+        preview += "\n..."
+
+    summary = (
+        "Cron output was too large for safe inline delivery.\n"
+        f"Full output attached: {attachment.name}\n"
+        f"Inline characters: {len(delivery_content)}; limit: {max_chars}."
+    )
+    if preview:
+        summary = f"{summary}\n\nPreview:\n{preview}"
+
+    # The MEDIA tag is stripped before text send and delivered separately by the
+    # existing attachment pipeline.  Keeping it on a separate final line makes
+    # extraction deterministic even when the summary is truncated aggressively.
+    return f"{summary[:max_chars].rstrip()}\nMEDIA:{attachment}"
 
 
 @contextmanager
@@ -641,11 +698,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    delivery_max_chars = _DEFAULT_DELIVERY_MAX_CHARS
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {}) if isinstance(user_cfg, dict) else {}
+        wrap_response = cron_cfg.get("wrap_response", True)
+        delivery_max_chars = _resolve_delivery_max_chars(cron_cfg)
     except Exception:
-        pass
+        delivery_max_chars = _resolve_delivery_max_chars({})
 
     if wrap_response:
         task_name = job.get("name", job["id"])
@@ -660,10 +720,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
+    # Extract user/model MEDIA tags before applying the large-text fallback so
+    # original attachments are not lost when their tag appears beyond the
+    # truncated preview.  The fallback can add one more MEDIA tag for the full
+    # text attachment, so extract that second pass too.
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    original_media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
+    fallback_content = _with_large_delivery_fallback(job, cleaned_delivery_content, delivery_max_chars)
+    fallback_media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(fallback_content)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(original_media_files + fallback_media_files)
 
     try:
         config = load_gateway_config()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -575,6 +575,128 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
 
+    def test_large_delivery_writes_full_output_to_attachment_and_sends_bounded_text(self, tmp_path, monkeypatch):
+        """Oversized cron output should not be sent inline where platforms can abort it."""
+        from gateway.config import Platform
+
+        hermes_home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(hermes_home / "document_cache"))
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        large_output = "0123456789" * 80
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "delivery_max_chars": 200}}):
+            job = {
+                "id": "large-job",
+                "name": "large cron",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, large_output)
+
+        send_mock.assert_called_once()
+        args, kwargs = send_mock.call_args
+        sent_content = args[3]
+        assert len(sent_content) <= 200
+        assert "Cron output was too large" in sent_content
+        assert "Full output attached" in sent_content
+        assert large_output not in sent_content
+        assert kwargs["media_files"]
+        attachment_path, is_voice = kwargs["media_files"][0]
+        assert is_voice is False
+        assert attachment_path.endswith(".txt")
+        assert os.path.exists(attachment_path)
+        assert large_output in open(attachment_path, encoding="utf-8").read()
+
+    def test_live_adapter_large_delivery_sends_document_attachment(self, tmp_path, monkeypatch):
+        """Live cron delivery should route oversized full output as a native document."""
+        from concurrent.futures import Future
+        from gateway.config import Platform
+
+        hermes_home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(hermes_home / "document_cache"))
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+        adapter.send_document.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        large_output = "abcdef" * 100
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "delivery_max_chars": 180}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            _deliver_result(
+                {
+                    "id": "large-live",
+                    "name": "large live",
+                    "deliver": "origin",
+                    "origin": {"platform": "telegram", "chat_id": "123"},
+                },
+                large_output,
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        adapter.send.assert_called_once()
+        text_sent = adapter.send.call_args[0][1]
+        assert len(text_sent) <= 180
+        assert large_output not in text_sent
+        adapter.send_document.assert_called_once()
+        attachment_path = adapter.send_document.call_args[1]["file_path"]
+        assert attachment_path.endswith(".txt")
+        assert large_output in open(attachment_path, encoding="utf-8").read()
+
+    def test_large_delivery_preserves_original_media_tags_after_preview_cutoff(self, tmp_path, monkeypatch):
+        """Large-output fallback must not drop original MEDIA attachments outside preview."""
+        from gateway.config import Platform
+
+        hermes_home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(hermes_home / "document_cache"))
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "late-chart.png")
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        large_prefix = "x" * 500
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "delivery_max_chars": 200}}):
+            _deliver_result(
+                {
+                    "id": "late-media",
+                    "deliver": "origin",
+                    "origin": {"platform": "telegram", "chat_id": "123"},
+                },
+                f"{large_prefix}\nMEDIA:{media_path}",
+            )
+
+        media_files = send_mock.call_args.kwargs["media_files"]
+        assert (str(media_path), False) in media_files
+        assert any(path.endswith(".txt") for path, _ in media_files)
+
     def test_delivery_extracts_media_tags_before_send(self, tmp_path, monkeypatch):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
         from gateway.config import Platform


### PR DESCRIPTION
## Summary
- Add a bounded cron delivery fallback for oversized text output before live-adapter and standalone sends.
- Preserve original `MEDIA:` attachment extraction while attaching the full oversized cron output as a `.txt` document.
- Keep `[SILENT]` / empty-output behavior unchanged.

## Links
- Linear: N/A
- Kanban: N/A
- brain-sync: `projects/mina-operating-system/runs/repo-promotion-choice-packet-2026-05-25.md`
- Source packet: `projects/mina-operating-system/runs/repo-promotion-3898-3902-cron-delivery-abort-2026-05-24.md`

## Scope boundary
In scope:
- `cron/scheduler.py` delivery-size normalization
- focused cron scheduler regression tests
- safe document attachment fallback for large cron output

Out of scope:
- live gateway/scheduler restart
- merge / auto-merge
- Telegram noisy live smoke
- broad product-policy changes beyond the size guard
- Linear/Kanban/runtime/cron config mutation

## Verification
- [x] `uv run --with pytest --with pytest-timeout pytest tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_large_delivery_writes_full_output_to_attachment_and_sends_bounded_text tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_live_adapter_large_delivery_sends_document_attachment tests/cron/test_scheduler.py::TestDeliverResultWrapping::test_large_delivery_preserves_original_media_tags_after_preview_cutoff tests/cron/test_scheduler.py::TestSilentDelivery -q` → `10 passed`
- [x] `uv run --with pytest --with pytest-timeout pytest tests/cron/test_scheduler.py tests/cron/test_cron_script.py -q` → `167 passed`
- [x] `git diff --check origin/main...HEAD` → no output

## Reviewer gate
- Round 1: pending
- Final: pending `must_fixes=0`, `should_fixes=0`

## Merge boundary
This is a draft PR. Merge, auto-merge, and live runtime restart remain explicit approval boundaries.
