### PR TITLE
fix(file-tools): reject empty read_file path

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -13,10 +13,31 @@ from tools.file_tools import (
     WRITE_FILE_SCHEMA,
     PATCH_SCHEMA,
     SEARCH_FILES_SCHEMA,
+    _handle_read_file,
 )
 
 
 class TestReadFileHandler:
+    def test_schema_path_rejects_empty_string(self):
+        path_schema = READ_FILE_SCHEMA["parameters"]["properties"]["path"]
+        assert path_schema["type"] == "string"
+        assert path_schema["minLength"] == 1
+
+    def test_missing_path_key_returns_error(self):
+        result = json.loads(_handle_read_file({}))
+        assert "error" in result
+        assert "missing required field 'path'" in result["error"]
+
+    def test_empty_path_returns_error(self):
+        result = json.loads(_handle_read_file({"path": ""}))
+        assert "error" in result
+        assert "missing required field 'path'" in result["error"]
+
+    def test_non_string_path_returns_error(self):
+        result = json.loads(_handle_read_file({"path": ["not", "a", "string"]}))
+        assert "error" in result
+        assert "missing required field 'path'" in result["error"]
+
     @patch("tools.file_tools._get_file_ops")
     def test_returns_file_content(self, mock_get):
         mock_ops = MagicMock()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1089,7 +1089,7 @@ READ_FILE_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
+            "path": {"type": "string", "minLength": 1, "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
             "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
         },
@@ -1188,7 +1188,12 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    if not args.get("path") or not isinstance(args.get("path"), str):
+        return tool_error(
+            "read_file: missing required field 'path'. Re-emit the tool call with "
+            "a valid file path (absolute, relative, or ~/path)."
+        )
+    return read_file_tool(path=args["path"], offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## Summary
- reject `read_file` tool calls that omit `path`, pass an empty string, or pass a non-string value before they reach the file-read pipeline
- add `minLength: 1` to the `read_file` schema so empty-string arguments are rejected earlier by schema-aware callers
- add focused regression tests for the new handler guard and schema contract

## Test Plan
- [x] `scripts/run_tests.sh tests/tools/test_file_tools.py`
- [x] `python scripts/check-windows-footguns.py --all`
- [x] independent delegated code review passed

Closes #31791
