### PR TITLE
fix(auth): validate Gemini OAuth status via runtime credentials check

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2139,25 +2139,28 @@ def resolve_gemini_oauth_runtime_credentials(
 def get_gemini_oauth_auth_status() -> Dict[str, Any]:
     """Return a status dict for `hermes auth list` / `hermes status`."""
     try:
-        from agent.google_oauth import _credentials_path, load_credentials
+        from agent.google_oauth import _credentials_path
     except ImportError:
         return {"logged_in": False, "error": "agent.google_oauth unavailable"}
     auth_path = _credentials_path()
-    creds = load_credentials()
-    if creds is None or not creds.access_token:
+    try:
+        # Validate runtime credentials so expired tokens trigger refresh or
+        # surface a re-login requirement instead of looking "logged in".
+        creds = resolve_gemini_oauth_runtime_credentials(force_refresh=False)
+    except AuthError as exc:
         return {
             "logged_in": False,
             "auth_file": str(auth_path),
-            "error": "not logged in",
+            "error": str(exc),
         }
     return {
         "logged_in": True,
         "auth_file": str(auth_path),
-        "source": "google-oauth",
-        "api_key": creds.access_token,
-        "expires_at_ms": creds.expires_ms,
-        "email": creds.email,
-        "project_id": creds.project_id,
+        "source": creds.get("source", "google-oauth"),
+        "api_key": creds.get("api_key"),
+        "expires_at_ms": creds.get("expires_at_ms"),
+        "email": creds.get("email", ""),
+        "project_id": creds.get("project_id", ""),
     }
 # Spotify auth — PKCE tokens stored in ~/.hermes/auth.json
 # =============================================================================

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -1182,6 +1182,45 @@ class TestAuthStatus:
         s = get_auth_status("google-gemini-cli")
         assert s["logged_in"] is False
 
+    def test_expired_unrefreshable_token_is_not_logged_in(self):
+        from agent.google_oauth import GoogleCredentials, save_credentials
+        from hermes_cli.auth import get_auth_status
+
+        save_credentials(GoogleCredentials(
+            access_token="expired-at",
+            refresh_token="",
+            expires_ms=int((time.time() - 3600) * 1000),
+            email="tek@nous.ai",
+            project_id="tek-proj",
+        ))
+
+        s = get_auth_status("google-gemini-cli")
+        assert s["logged_in"] is False
+        assert "Re-run OAuth login" in s["error"]
+
+    def test_expired_token_refreshes_before_reporting_logged_in(self, monkeypatch):
+        from agent import google_oauth
+        from agent.google_oauth import GoogleCredentials, save_credentials
+        from hermes_cli.auth import get_auth_status
+
+        save_credentials(GoogleCredentials(
+            access_token="expired-at",
+            refresh_token="rt",
+            expires_ms=int((time.time() - 3600) * 1000),
+            email="tek@nous.ai",
+            project_id="tek-proj",
+        ))
+
+        monkeypatch.setattr(
+            google_oauth,
+            "_post_form",
+            lambda *args, **kwargs: {"access_token": "refreshed-at", "expires_in": 3600},
+        )
+
+        s = get_auth_status("google-gemini-cli")
+        assert s["logged_in"] is True
+        assert s["api_key"] == "refreshed-at"
+
     def test_logged_in_reports_email_and_project(self):
         from agent.google_oauth import GoogleCredentials, save_credentials
         from hermes_cli.auth import get_auth_status
@@ -1197,6 +1236,45 @@ class TestAuthStatus:
         assert s["logged_in"] is True
         assert s["email"] == "tek@nous.ai"
         assert s["project_id"] == "tek-proj"
+
+
+class TestGeminiModelFlow:
+    def test_stale_token_triggers_relogin_before_model_selection(self, monkeypatch, capsys):
+        from agent.google_oauth import GoogleCredentials, save_credentials
+        from hermes_cli.main import _model_flow_google_gemini_cli
+
+        save_credentials(GoogleCredentials(
+            access_token="expired-at",
+            refresh_token="",
+            expires_ms=int((time.time() - 3600) * 1000),
+            email="tek@nous.ai",
+            project_id="old-proj",
+        ))
+
+        relogin = {"called": False}
+
+        def fake_start_oauth_flow(*, force_relogin=False, project_id=""):
+            relogin["called"] = True
+            assert force_relogin is True
+            save_credentials(GoogleCredentials(
+                access_token="fresh-at",
+                refresh_token="fresh-rt",
+                expires_ms=int((time.time() + 3600) * 1000),
+                email="tek@nous.ai",
+                project_id=project_id or "fresh-proj",
+            ))
+
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        monkeypatch.setattr("agent.google_oauth.resolve_project_id_from_env", lambda: "fresh-proj")
+        monkeypatch.setattr("agent.google_oauth.start_oauth_flow", fake_start_oauth_flow)
+        monkeypatch.setattr("hermes_cli.auth._prompt_model_selection", lambda *args, **kwargs: None)
+
+        _model_flow_google_gemini_cli({}, current_model="gemini-2.5-pro")
+
+        out = capsys.readouterr().out
+        assert relogin["called"] is True
+        assert "Using GCP project: fresh-proj" in out
+        assert "Failed to resolve Gemini credentials" not in out
 
 
 class TestGquotaCommand:


### PR DESCRIPTION
## What does this PR do?

Fixes a stale-auth bug in the Gemini OAuth provider status path.

Before this change, `get_gemini_oauth_auth_status()` only checked whether a cached access token existed on disk. That let expired Gemini OAuth credentials show up as `logged_in=True`, so `hermes model` could skip the re-login path and then fail later when runtime credential resolution correctly detected the token was stale.

This PR aligns Gemini OAuth status reporting with the runtime credential path by validating credentials through `resolve_gemini_oauth_runtime_credentials()`. That makes auth state expiry-aware, allows refresh when possible, and correctly reports `logged_in=False` when re-login is required.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/auth.py` so `get_gemini_oauth_auth_status()` validates Gemini OAuth state through `resolve_gemini_oauth_runtime_credentials()` instead of only checking for a cached token on disk.
- Preserved the existing status response shape while making it expiry/refresh aware.
- Added regression tests in `tests/agent/test_gemini_cloudcode.py` for:
  - `TestAuthStatus::test_expired_unrefreshable_token_is_not_logged_in`
  - `TestAuthStatus::test_expired_token_refreshes_before_reporting_logged_in`
  - `TestGeminiModelFlow::test_stale_token_triggers_relogin_before_model_selection`

## How to Test

1. Reproduce the old failure with expired Gemini OAuth credentials:
   - store a stale `~/.hermes/auth/google_oauth.json`
   - run `hermes model` and select `google-gemini-cli`
   - before this fix, the flow can skip re-login and later fail during credential resolution
2. Run:
   - `tests/agent/test_gemini_cloudcode.py::TestAuthStatus::test_expired_unrefreshable_token_is_not_logged_in`
   - `tests/agent/test_gemini_cloudcode.py::TestAuthStatus::test_expired_token_refreshes_before_reporting_logged_in`
   - `tests/agent/test_gemini_cloudcode.py::TestGeminiModelFlow::test_stale_token_triggers_relogin_before_model_selection`
3. Confirm the targeted tests pass and that stale credentials now trigger re-auth instead of surfacing as logged in.

Additional validation run:
- `tests/agent/test_gemini_cloudcode.py`

Result:
- targeted regression tests passed
- full file result: `90 passed, 1 failed`

Known unrelated failure on Windows:
- `tests/agent/test_gemini_cloudcode.py::TestCredentialIo::test_save_uses_0600_permissions`
- this is a Windows file-mode assertion issue and not caused by this auth-status fix

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression tests passed:
- `tests/agent/test_gemini_cloudcode.py::TestAuthStatus::test_expired_unrefreshable_token_is_not_logged_in`
- `tests/agent/test_gemini_cloudcode.py::TestAuthStatus::test_expired_token_refreshes_before_reporting_logged_in`
- `tests/agent/test_gemini_cloudcode.py::TestGeminiModelFlow::test_stale_token_triggers_relogin_before_model_selection`

Full validation run:
- `tests/agent/test_gemini_cloudcode.py`

Unrelated Windows-only failure:
- `tests/agent/test_gemini_cloudcode.py::TestCredentialIo::test_save_uses_0600_permissions`