### PR TITLE
feat(kanban): auto-subscribe, review-required promotion, unblock dispatch, rerun, parent workspace

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -550,6 +550,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_unblock = sub.add_parser("unblock", help="Return one or more blocked/scheduled tasks to ready")
     p_unblock.add_argument("task_ids", nargs="+")
 
+    p_rerun = sub.add_parser("rerun", help="Reset a completed/blocked task for another attempt")
+    p_rerun.add_argument("task_id")
+    p_rerun.add_argument("--reason", default=None,
+                         help="Optional reason recorded on the rerun event")
+    p_rerun.add_argument("--reassign-to", dest="new_assignee", default=None,
+                         help="Optional assignee profile to use for the rerun")
+
     p_promote = sub.add_parser(
         "promote",
         help="Manually move one or more todo/blocked tasks to ready (recovery path)",
@@ -932,6 +939,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "block":    _cmd_block,
         "schedule": _cmd_schedule,
         "unblock":  _cmd_unblock,
+        "rerun":    _cmd_rerun,
         "promote":  _cmd_promote,
         "archive":  _cmd_archive,
         "tail":     _cmd_tail,
@@ -1297,6 +1305,26 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
     return 0
 
 
+def _build_subscribe_from_args(args: argparse.Namespace) -> Optional[dict]:
+    """Build a ``subscribe`` dict from env vars for CLI create.
+
+    Reads HERMES_NOTIFY_PLATFORM and HERMES_NOTIFY_CHAT_ID from the
+    environment. Returns None when neither is set."""
+    import os
+    platform = os.environ.get("HERMES_NOTIFY_PLATFORM", "").strip()
+    chat_id = os.environ.get("HERMES_NOTIFY_CHAT_ID", "").strip()
+    if not platform or not chat_id:
+        return None
+    sub: dict = {"platform": platform, "chat_id": chat_id}
+    thread_id = os.environ.get("HERMES_NOTIFY_THREAD_ID", "").strip()
+    if thread_id:
+        sub["thread_id"] = thread_id
+    user_id = os.environ.get("HERMES_NOTIFY_USER_ID", "").strip()
+    if user_id:
+        sub["user_id"] = user_id
+    return sub
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
         ws_kind, ws_path = _parse_workspace_flag(args.workspace)
@@ -1339,6 +1367,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
             initial_status=getattr(args, "initial_status", "running"),
+            subscribe=_build_subscribe_from_args(args),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):
@@ -1986,7 +2015,30 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
                 print(f"Unblocked {tid}")
+        # Auto-dispatch after unblock if any task moved to ready.
+        if not failed:
+            kb.dispatch_once(conn, max_spawn=1)
     return 0 if not failed else 1
+
+
+def _cmd_rerun(args: argparse.Namespace) -> int:
+    with kb.connect() as conn:
+        ok = kb.rerun_task(
+            conn,
+            args.task_id,
+            reason=getattr(args, "reason", None),
+            new_assignee=getattr(args, "new_assignee", None),
+        )
+        if not ok:
+            print(
+                f"cannot rerun {args.task_id} (not completed/blocked/archived?)",
+                file=sys.stderr,
+            )
+            return 1
+        task = kb.get_task(conn, args.task_id)
+    status = task.status if task else "?"
+    print(f"Rerun {args.task_id} ({status})")
+    return 0
 
 
 def _cmd_promote(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1545,13 +1545,18 @@ def create_task(
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
+    subscribe: Optional[dict] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
+
+    ``subscribe`` optionally creates a notification subscription in the
+    ``kanban_notify_subs`` table so completion/status-change events are
+    delivered to the specified chat (platform + chat_id required).
 
     Returns the new task id.  Status is ``ready`` when there are no
     parents (or all parents already ``done``), otherwise ``todo``.
     If ``triage=True``, status is forced to ``triage`` regardless of
-    parents — a specifier/triager is expected to promote the task to
+    parents -- a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
 
     If ``idempotency_key`` is provided and a non-archived task with the
@@ -1570,6 +1575,22 @@ def create_task(
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
     """
+    # Resolve notification subscription.
+    resolved_subscribe: Optional[dict[str, str]] = None
+    if isinstance(subscribe, dict):
+        platform = str(subscribe.get("platform", "")).strip()
+        chat_id = str(subscribe.get("chat_id", "")).strip()
+        if platform and chat_id:
+            resolved_subscribe = {"platform": platform, "chat_id": chat_id}
+            thread_id = str(subscribe.get("thread_id", "")).strip()
+            if thread_id:
+                resolved_subscribe["thread_id"] = thread_id
+            user_id = str(subscribe.get("user_id", "")).strip()
+            if user_id:
+                resolved_subscribe["user_id"] = user_id
+            notifier_profile = str(subscribe.get("notifier_profile", "")).strip()
+            if notifier_profile:
+                resolved_subscribe["notifier_profile"] = notifier_profile
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
         raise ValueError("title is required")
@@ -1666,6 +1687,28 @@ def create_task(
         if board_default:
             workspace_path = str(board_default)
 
+    # Inherit workspace_path from parent tasks when the caller did not
+    # specify one. Parent workspaces carry the project checkout the child
+    # should operate in — without this, children of a `dir` parent created
+    # via ``kanban_create`` land in a scratch tmpdir with no project files.
+    if workspace_path is None and parents:
+        placeholders = ",".join("?" * len(parents))
+        parent_rows = conn.execute(
+            f"SELECT workspace_path, workspace_kind FROM tasks "
+            f"WHERE id IN ({placeholders}) "
+            f"AND workspace_path IS NOT NULL "
+            f"ORDER BY created_at ASC",
+            parents,
+        ).fetchall()
+        if parent_rows:
+            workspace_path = parent_rows[0]["workspace_path"]
+            # Mirror the parent's workspace kind so the dispatcher doesn't
+            # treat it like a scratch that gets auto-deleted.  Only upgrade
+            # "scratch" → something persistent; never downgrade.
+            parent_kind = parent_rows[0]["workspace_kind"]
+            if workspace_kind == "scratch" and parent_kind in {"dir", "worktree"}:
+                workspace_kind = parent_kind
+
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
         task_id = _new_task_id()
@@ -1750,6 +1793,19 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+            if resolved_subscribe:
+                try:
+                    add_notify_sub(
+                        conn,
+                        task_id=task_id,
+                        platform=resolved_subscribe["platform"],
+                        chat_id=resolved_subscribe["chat_id"],
+                        thread_id=resolved_subscribe.get("thread_id"),
+                        user_id=resolved_subscribe.get("user_id"),
+                        notifier_profile=resolved_subscribe.get("notifier_profile"),
+                    )
+                except Exception:
+                    pass  # subscription is best-effort; never fail task creation
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -2268,7 +2324,7 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(p["status"] in ("done", "archived", "review-required") for p in parents):
                 # Blocked tasks also get their failure counters reset —
                 # this is effectively an auto-unblock (circuit-breaker
                 # recovery; worker-initiated blocks are skipped above).
@@ -2320,7 +2376,7 @@ def claim_task(
         undone = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived', 'review-required') LIMIT 1",
             (task_id,),
         ).fetchone()
         if undone:
@@ -3521,6 +3577,126 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         _append_event(
             conn, task_id, "unblocked",
             {"status": new_status} if new_status != "ready" else None,
+        )
+        return True
+
+
+def _parent_counts_as_done_for_rerun(
+    conn: sqlite3.Connection,
+    parent_id: str,
+) -> bool:
+    """Return True when ``parent_id`` should satisfy rerun parent gates."""
+    row = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?",
+        (parent_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    status = row["status"]
+    if status in ("done", "archived"):
+        return True
+    if status != "blocked":
+        return False
+    event = conn.execute(
+        "SELECT kind, payload FROM task_events "
+        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
+        "ORDER BY id DESC LIMIT 1",
+        (parent_id,),
+    ).fetchone()
+    if not event or event["kind"] != "blocked" or not event["payload"]:
+        return False
+    try:
+        payload = json.loads(event["payload"])
+    except Exception:
+        payload = None
+    reason = payload.get("reason") if isinstance(payload, dict) else None
+    return isinstance(reason, str) and reason.startswith("review-required")
+
+
+def rerun_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+    new_assignee: Optional[str] = None,
+) -> bool:
+    """Reset a completed/blocked task to ready for another attempt.
+
+    Clears claim state, the active run pointer, and the failure counter.
+    Parent gates are re-evaluated: undone parents send the task to
+    ``todo``; ``review-required`` blocked parents count as satisfied for
+    this rerun decision.
+
+    Returns True when the task was reset, False when the task is not in
+    a rerunnable state.
+    """
+    with write_txn(conn):
+        task = get_task(conn, task_id)
+        if not task:
+            return False
+        if task.status not in ("done", "blocked", "archived", "gave_up"):
+            return False
+
+        parent_rows = conn.execute(
+            "SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id",
+            (task_id,),
+        ).fetchall()
+        new_status = "ready"
+        for row in parent_rows:
+            if not _parent_counts_as_done_for_rerun(conn, row["parent_id"]):
+                new_status = "todo"
+                break
+
+        # Defensive invariant recovery: terminal tasks should not carry
+        # an open run pointer, but clear it safely if some external path
+        # leaked one.
+        if task.current_run_id is not None:
+            _end_run(
+                conn,
+                task_id,
+                outcome="reclaimed",
+                status="reclaimed",
+                summary="invariant recovery on rerun",
+            )
+
+        assignee = _canonical_assignee(new_assignee) if new_assignee is not None else task.assignee
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET assignee             = ?,
+                   status               = ?,
+                   started_at           = NULL,
+                   completed_at         = NULL,
+                   claim_lock           = NULL,
+                   claim_expires        = NULL,
+                   worker_pid           = NULL,
+                   last_heartbeat_at    = NULL,
+                   consecutive_failures = 0,
+                   last_failure_error   = NULL,
+                   current_run_id       = NULL
+             WHERE id = ?
+            """,
+            (assignee, new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn,
+            task_id,
+            "rerun",
+            {
+                "reason": reason,
+                "status": new_status,
+                "assignee": assignee,
+            },
+        )
+        max_event_id = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) AS max_id FROM task_events WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()["max_id"]
+        conn.execute(
+            "UPDATE kanban_notify_subs SET last_event_id = ? WHERE task_id = ?",
+            (int(max_event_id), task_id),
         )
         return True
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -636,6 +636,20 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _agent_subscribe_from_env() -> Optional[dict]:
+    """Build subscribe dict from env vars for agent kanban_create tool."""
+    platform = os.environ.get("HERMES_NOTIFY_PLATFORM", "").strip()
+    chat_id = os.environ.get("HERMES_NOTIFY_CHAT_ID", "").strip()
+    if not platform or not chat_id:
+        return None
+    sub = {"platform": platform, "chat_id": chat_id}
+    for key in ("HERMES_NOTIFY_THREAD_ID", "HERMES_NOTIFY_USER_ID"):
+        val = os.environ.get(key, "").strip()
+        if val:
+            sub[key.replace("HERMES_NOTIFY_", "").lower()] = val
+    return sub
+
+
 def _handle_create(args: dict, **kw) -> str:
     """Create a child task. Orchestrator workers use this to fan out.
 
@@ -705,6 +719,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                subscribe=_agent_subscribe_from_env(),
             )
             new_task = kb.get_task(conn, new_tid)
             return _ok(


### PR DESCRIPTION
## Summary

Six kanban fixes built and tested after rebasing to latest upstream/main (commit `7e165e843`, 2026-05-25).

### Changes

**P1/P7: Auto-subscribe on kanban_create**
- Both CLI and agent tool paths now auto-subscribe the calling conversation to task notifications by reading `HERMES_NOTIFY_*` env vars
- Completion/status-change events push to the origin chat without manual subscription

**P2: Review-required as promoteable parent status**
- `recompute_ready` and `claim_task` now treat `review-required` same as `done`/`archived` for child promotion
- Children of workers that requested human review can proceed without waiting for unblock

**P3: Auto-dispatch after unblock**
- `kanban unblock` calls `dispatch_once(max_spawn=1)` after successful unblock so newly-ready tasks don't sit idle

**P5: Rerun command**
- `kanban rerun` resets completed/blocked/archived tasks to ready/todo
- Clears claim state, failure counters, optionally reassigns (`--reassign-to`)
- `--reason` flag for audit trails

**P6: Parent workspace inheritance**
- Child tasks without explicit `workspace_path` inherit from first parent with one
- `workspace_kind` upgraded (scratch→dir/worktree) so children operate in project checkout

### Files Changed
- `hermes_cli/kanban_db.py` — +182 lines (P1 subscribe, P2 promotion, P5 rerun, P6 workspace)
- `hermes_cli/kanban.py` — +52 lines (P3 dispatch, P5 rerun CLI)
- `tools/kanban_tools.py` — +15 lines (P1/P7 agent tool subscribe)
- **Total: 3 files, +246 lines**

### Verification
- Each fix tested independently via Python direct API and CLI
- `kanban.db` integrity check passes
- Deployed and tested on crayfish-ai fork server for 3+ days

### History
- Replaces closed PR #28331 (same feature set, now rebased to latest main)
- See [comment](https://github.com/NousResearch/hermes-agent/pull/31883#issuecomment-4531804225) for relationship analysis with other open kanban PRs (#29984, #30848, #28728, etc.)