### PR TITLE
fix(gateway): bound Telegram proxy httpx pools to stop fd leak

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -193,6 +193,38 @@ def _strip_mdv2(text: str) -> str:
     return cleaned
 
 
+def _proxy_http_limits() -> Any:
+    """Bounded httpx connection limits for the Telegram pools when a proxy is set.
+
+    Through a tunneling proxy, httpcore does not reliably release the underlying
+    socket on ConnectError, so half-closed connections accumulate in the pool
+    over long flaky-proxy runs and eventually exhaust the process fd limit (see
+    #31599). Capping the pool and setting a finite ``keepalive_expiry`` lets
+    httpx evict idle/dead connections during pool maintenance instead of leaving
+    them pinned for the process lifetime. All three knobs are env-tunable so an
+    operator can widen them for high-throughput proxied deployments.
+    """
+    import httpx
+
+    def _env_int(name: str, default: int) -> int:
+        try:
+            return int(os.getenv(name, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    def _env_float(name: str, default: float) -> float:
+        try:
+            return float(os.getenv(name, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    return httpx.Limits(
+        max_connections=_env_int("HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS", 20),
+        max_keepalive_connections=_env_int("HERMES_TELEGRAM_PROXY_MAX_KEEPALIVE", 10),
+        keepalive_expiry=_env_float("HERMES_TELEGRAM_PROXY_KEEPALIVE_EXPIRY", 30.0),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Markdown table → Telegram-friendly row groups
 # ---------------------------------------------------------------------------
@@ -1430,8 +1462,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                # Bound the proxied pools and set a keepalive expiry so half-closed
+                # connections leaked by httpcore's tunnel-proxy path on ConnectError
+                # are evicted instead of accumulating until fd exhaustion (#31599).
+                proxy_kwargs = {**request_kwargs, "httpx_kwargs": {"limits": _proxy_http_limits()}}
+                request = HTTPXRequest(**proxy_kwargs, proxy=proxy_url)
+                get_updates_request = HTTPXRequest(**proxy_kwargs, proxy=proxy_url)
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)

--- a/tests/gateway/test_telegram_proxy_limits.py
+++ b/tests/gateway/test_telegram_proxy_limits.py
@@ -1,0 +1,44 @@
+"""Regression tests for the bounded proxy connection limits (#31599).
+
+Through a tunneling proxy, httpcore does not reliably release the underlying
+socket on ConnectError, so half-closed connections accumulate in the Telegram
+adapter's general-request pool and eventually exhaust the process fd limit.
+The gateway now caps the proxied pools and sets a finite ``keepalive_expiry``
+so idle/dead connections are evicted instead of pinned for the process
+lifetime. These tests pin the defaults and the env-override knobs.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from gateway.platforms.telegram import _proxy_http_limits
+
+
+def test_proxy_http_limits_defaults():
+    limits = _proxy_http_limits()
+    assert isinstance(limits, httpx.Limits)
+    assert limits.max_connections == 20
+    assert limits.max_keepalive_connections == 10
+    # A finite expiry is the actual leak mitigation: dead keepalive connections
+    # get evicted during pool maintenance rather than living forever.
+    assert limits.keepalive_expiry == 30.0
+
+
+def test_proxy_http_limits_env_overrides(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS", "64")
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_MAX_KEEPALIVE", "32")
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_KEEPALIVE_EXPIRY", "5")
+    limits = _proxy_http_limits()
+    assert limits.max_connections == 64
+    assert limits.max_keepalive_connections == 32
+    assert limits.keepalive_expiry == 5.0
+
+
+def test_proxy_http_limits_ignores_garbage_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS", "not-an-int")
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_KEEPALIVE_EXPIRY", "")
+    limits = _proxy_http_limits()
+    assert limits.max_connections == 20
+    assert limits.keepalive_expiry == 30.0


### PR DESCRIPTION
## What does this PR do?

The Telegram adapter accumulates half-closed sockets in its httpx **general-request** pool when running behind a tunneling proxy. As the reporter documents in #31599, httpcore does not reliably release the underlying socket on `ConnectError`, so over long flaky-proxy runs `CLOSED` connections pile up (lsof showed 280/287 fds terminating at the local proxy port) until the process fd limit is hit and every `bot.send_message()` / `set_my_commands()` fails with `httpx.ConnectError: All connection attempts failed`.

The existing `_drain_polling_connections` only resets the polling pool (`_request[0]`) and deliberately leaves the general pool (`_request[1]`) untouched, so that leak vector was unbounded.

This applies the reporter's prioritized suggestion (#1): when a proxy is configured, construct both proxied `HTTPXRequest` pools with bounded `httpx.Limits` and a finite `keepalive_expiry`. The cap stops unbounded growth, and the keepalive expiry lets httpx evict idle/dead connections during pool maintenance instead of pinning them for the process lifetime. All three knobs are env-tunable so high-throughput proxied deployments can widen them.

This is a bounded mitigation of the leak, not a full cure of the upstream httpcore socket-release behavior — hence `Refs` rather than `Fixes`. The reporter's deeper options (periodic general-pool drain, send-path heartbeat for observability) are left for maintainer direction.

## Related Issue

Refs #31599

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: add module-level `_proxy_http_limits()` helper that builds bounded `httpx.Limits` (defaults: `max_connections=20`, `max_keepalive_connections=10`, `keepalive_expiry=30.0s`), each overridable via `HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS` / `HERMES_TELEGRAM_PROXY_MAX_KEEPALIVE` / `HERMES_TELEGRAM_PROXY_KEEPALIVE_EXPIRY`. Pass these limits through `httpx_kwargs` when constructing the proxied request and get-updates pools. Non-proxy and fallback-IP paths are unchanged.
- `tests/gateway/test_telegram_proxy_limits.py`: unit tests for the helper — defaults, env overrides, and garbage-env fallback.

## How to Test

1. `pytest tests/gateway/test_telegram_proxy_limits.py -q` — verifies the limits defaults and env overrides.
2. `pytest tests/tools/test_send_message_telegram_proxy.py tests/gateway/test_proxy_mode.py -q` — confirms the proxy send/construction paths still pass (27 passed locally).
3. Functional: with `TELEGRAM_PROXY` set, start the gateway and confirm `lsof -p <pid> | wc -l` stabilizes under flaky-proxy reconnect cycles instead of climbing past the fd limit; the proxied pools are now capped at `max_connections` (20 by default) rather than 512.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant `pytest` suites and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env-only knobs)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure httpx limits config, no platform-specific calls)

<!-- autocontrib:worker-id=issue-new-d38f36f9 kind=pr-open -->