### PR TITLE
fix(web): honor plugin-registered search providers in availability gate

### DIFF
--- a/tests/tools/test_web_api_key_plugin_providers.py
+++ b/tests/tools/test_web_api_key_plugin_providers.py
@@ -1,0 +1,66 @@
+"""Regression tests for check_web_api_key() plugin-provider awareness (#31873).
+
+Third-party web search plugins register a WebSearchProvider via
+PluginContext.register_web_search_provider(). Previously check_web_api_key()
+only knew the hardcoded built-in backends, so the web_search/web_extract tools
+were gated off whenever ONLY a plugin provider (e.g. Kagi on KAGI_API_KEY) was
+configured. The check now also consults agent.web_search_registry.
+"""
+from unittest.mock import MagicMock, patch
+
+import tools.web_tools as wt
+
+
+def _no_builtins():
+    """All built-in backends unavailable; no backend configured."""
+    return (
+        patch.object(wt, "_load_web_config", return_value={}),
+        patch.object(wt, "_is_backend_available", return_value=False),
+    )
+
+
+def test_available_plugin_provider_enables_web_tools():
+    cfg, avail = _no_builtins()
+    provider = MagicMock()
+    provider.is_available.return_value = True
+    with cfg, avail, patch(
+        "agent.web_search_registry.get_active_search_provider",
+        return_value=provider,
+    ):
+        assert wt.check_web_api_key() is True
+
+
+def test_no_builtin_and_no_plugin_returns_false():
+    cfg, avail = _no_builtins()
+    with cfg, avail, patch(
+        "agent.web_search_registry.get_active_search_provider",
+        return_value=None,
+    ):
+        assert wt.check_web_api_key() is False
+
+
+def test_plugin_present_but_unavailable_returns_false():
+    cfg, avail = _no_builtins()
+    provider = MagicMock()
+    provider.is_available.return_value = False
+    with cfg, avail, patch(
+        "agent.web_search_registry.get_active_search_provider",
+        return_value=provider,
+    ):
+        assert wt.check_web_api_key() is False
+
+
+def test_registry_failure_does_not_crash_the_gate():
+    cfg, avail = _no_builtins()
+    with cfg, avail, patch(
+        "agent.web_search_registry.get_active_search_provider",
+        side_effect=RuntimeError("registry boom"),
+    ):
+        assert wt.check_web_api_key() is False
+
+
+def test_builtin_backend_still_wins_without_touching_registry():
+    """An available built-in backend short-circuits to True as before."""
+    with patch.object(wt, "_load_web_config", return_value={"backend": "exa"}), \
+         patch.object(wt, "_is_backend_available", return_value=True):
+        assert wt.check_web_api_key() is True

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1366,13 +1366,27 @@ async def web_crawl_tool(
 # Convenience function to check Firecrawl credentials
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
+    _BUILTIN_BACKENDS = ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
-        return _is_backend_available(configured)
-    return any(
-        _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
-    )
+    if configured in set(_BUILTIN_BACKENDS):
+        if _is_backend_available(configured):
+            return True
+    elif any(_is_backend_available(backend) for backend in _BUILTIN_BACKENDS):
+        return True
+    # Built-in backends are not the only source: third-party plugins register
+    # their own WebSearchProvider via PluginContext.register_web_search_provider
+    # (e.g. a Kagi provider keyed on KAGI_API_KEY). Consult the registry so the
+    # web_search / web_extract tools are not gated off when only a plugin
+    # provider is configured and available (#31873).
+    try:
+        from agent.web_search_registry import get_active_search_provider
+
+        provider = get_active_search_provider()
+        if provider is not None and provider.is_available():
+            return True
+    except Exception as exc:  # registry must never hard-fail the availability gate
+        logger.debug("web_search_registry availability check failed: %s", exc)
+    return False
 
 
 def check_auxiliary_model() -> bool:


### PR DESCRIPTION
Fixes #31873.

## Summary
`check_web_api_key()` only knew the hardcoded built-in backends, so a third-party web search plugin — registered via `PluginContext.register_web_search_provider()` (e.g. a Kagi provider keyed on `KAGI_API_KEY`) — was silently disabled: `web_search`/`web_extract` were filtered out of the tool registry because the availability gate returned `False`, even though the plugin registered successfully and its `is_available()` returns `True`.

After the built-in checks, this now consults `agent.web_search_registry.get_active_search_provider()` and returns `True` when a registered provider is available. The registry already backs the actual `web_search` dispatch in this module (it's imported at `tools/web_tools.py:806`), so the gate now matches real runtime availability.

## Pre-implement audit
- **Existing-helper check**: reused `agent.web_search_registry.get_active_search_provider` (already imported elsewhere in `web_tools.py` for dispatch) — no new registry/lookup logic.
- **Shared-helper caller check**: `check_web_api_key` is a tool-availability `check_fn`; the change only widens `False → True` when a provider is genuinely available, so no caller is regressed. Built-in path unchanged.
- **Broader-fix rival scan**: no competing PR for #31873.
- Registry import/availability failures are caught and logged at debug so the gate can never hard-fail.

## Real-behavior proof
```
$ python -c "<backend=kagi plugin, no built-in keys>"
backend=kagi (plugin), no builtin keys -> check_web_api_key(): True
PROOF: third-party web plugin no longer gated off
nothing available -> False
```

## Test plan
```
uv sync --extra dev
.venv/bin/python -m pytest tests/tools/test_web_api_key_plugin_providers.py tests/tools/test_web_tools_config.py -q
# 54 passed
```
New `tests/tools/test_web_api_key_plugin_providers.py`: available plugin → True; no plugin → False; plugin present but unavailable → False; registry exception → False (no crash); built-in backend still short-circuits to True.
