### PR TITLE
fix(skills): resolve inspect against installed local skills before hub

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12389,9 +12389,14 @@ Examples:
     )
 
     skills_inspect = skills_subparsers.add_parser(
-        "inspect", help="Preview a skill without installing"
+        "inspect",
+        help="Preview an installed local skill or a hub skill without installing",
     )
-    skills_inspect.add_argument("identifier", help="Skill identifier")
+    skills_inspect.add_argument(
+        "identifier",
+        help="Skill name (resolved against installed local skills first, then "
+             "hub registries) or a full source/path identifier",
+    )
 
     skills_list = skills_subparsers.add_parser("list", help="List installed skills")
     skills_list.add_argument(

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -630,11 +630,117 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print("[dim]Use /reset to start a new session now, or --now to activate immediately (invalidates prompt cache).[/]\n")
 
 
+def _inspect_local_skill(name: str, console: Console) -> bool:
+    """Display an installed builtin/local skill by bare name, reading from disk.
+
+    `inspect` historically queried only hub registries, so a skill that is
+    installed on disk — and shows up in `hermes skills list` — returned a
+    misleading "not found in any source" error (#25087). We look on disk first
+    and, on a match, print the same panel the hub path would. Returns True when
+    a local skill was found and displayed (so the caller skips the hub lookup).
+    """
+    from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, MAX_NAME_LENGTH
+    from tools.skills_sync import _read_manifest
+    from agent.skill_utils import (
+        get_disabled_skill_names,
+        get_external_skills_dirs,
+        iter_skill_index_files,
+    )
+
+    c = console or _console
+
+    dirs_to_scan = []
+    if SKILLS_DIR.exists():
+        dirs_to_scan.append(SKILLS_DIR)
+    dirs_to_scan.extend(get_external_skills_dirs())
+
+    # (skill_name, skill_md_path, frontmatter, content)
+    matches: list = []
+    seen: set = set()
+    for scan_dir in dirs_to_scan:
+        for skill_md in iter_skill_index_files(scan_dir, "SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            try:
+                key = skill_md.resolve()
+            except OSError:
+                key = skill_md
+            if key in seen:
+                continue
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, PermissionError, OSError):
+                continue
+            try:
+                frontmatter, _ = _parse_frontmatter(content)
+            except Exception:
+                frontmatter = {}
+            skill_name = (frontmatter.get("name") or skill_md.parent.name)[:MAX_NAME_LENGTH]
+            # Match the canonical (frontmatter) name or the on-disk directory
+            # name — the same identity `hermes skills list` shows.
+            if name.lower() not in (skill_name.lower(), skill_md.parent.name.lower()):
+                continue
+            seen.add(key)
+            matches.append((skill_name, skill_md, frontmatter, content))
+
+    if not matches:
+        return False
+
+    if len(matches) > 1:
+        c.print(f"\n[yellow]Multiple local skills match '{name}':[/]")
+        for sname, smd, _, _ in matches:
+            c.print(f"  [cyan]{sname}[/] — {smd}")
+        c.print("[bold]Pass the full categorized path to disambiguate.[/]\n")
+        return True
+
+    skill_name, skill_md, frontmatter, content = matches[0]
+    builtin_names = set(_read_manifest())
+    disabled = get_disabled_skill_names()
+    source = "builtin" if skill_name in builtin_names else "local"
+    trust_style = "bright_cyan" if source == "builtin" else "dim"
+    status = "[dim red]disabled[/]" if skill_name in disabled else "[bold green]enabled[/]"
+
+    description = frontmatter.get("description", "")
+    tags = (((frontmatter.get("metadata") or {}).get("hermes") or {}).get("tags")
+            if isinstance(frontmatter.get("metadata"), dict) else None)
+
+    c.print()
+    info_lines = [
+        f"[bold]Name:[/] {skill_name}",
+        f"[bold]Description:[/] {description}",
+        f"[bold]Source:[/] {source}",
+        f"[bold]Trust:[/] [{trust_style}]{source}[/]",
+        f"[bold]Status:[/] {status}",
+        f"[bold]Path:[/] {skill_md}",
+    ]
+    if tags:
+        info_lines.append(f"[bold]Tags:[/] {', '.join(str(t) for t in tags)}")
+    c.print(Panel("\n".join(info_lines), title=f"Skill: {skill_name}"))
+
+    lines = content.split("\n")
+    preview = "\n".join(lines[:50])
+    if len(lines) > 50:
+        preview += f"\n\n... ({len(lines) - 50} more lines)"
+    c.print(Panel(preview, title="SKILL.md Preview",
+                  subtitle="installed locally — loaded by the runtime resolver"))
+    c.print()
+    return True
+
+
 def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
-    """Preview a skill's SKILL.md content without installing."""
+    """Preview a skill's SKILL.md content without installing.
+
+    Bare names are resolved against installed builtin/local skills first, then
+    fall back to hub registries; pass a full ``source/path`` identifier to force
+    a hub lookup.
+    """
     from tools.skills_hub import GitHubAuth, create_source_router
 
     c = console or _console
+
+    if "/" not in identifier and _inspect_local_skill(identifier, c):
+        return
+
     auth = GitHubAuth()
     sources = create_source_router(auth)
 
@@ -1602,7 +1708,7 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]browse[/] [--source official]   Browse all available skills (paginated)\n"
         "  [cyan]search[/] <query>              Search registries for skills\n"
         "  [cyan]install[/] <identifier>        Install a skill (with security scan)\n"
-        "  [cyan]inspect[/] <identifier>        Preview a skill without installing\n"
+        "  [cyan]inspect[/] <identifier>        Preview an installed local skill or a hub skill\n"
         "  [cyan]list[/] [--source hub|builtin|local] [--enabled-only]\n"
         "       List installed skills; --enabled-only filters to the active profile's live set\n"
         "  [cyan]check[/] [name]                Check hub skills for upstream updates\n"

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -565,3 +565,98 @@ def test_browse_skills_dedup_uses_identifier_not_name(monkeypatch):
         "browse_skills() must not deduplicate browse-sh skills with the same name "
         "but different identifiers"
     )
+
+
+# ---------------------------------------------------------------------------
+# inspect: bare names resolve to installed local/builtin skills first (#25087)
+# ---------------------------------------------------------------------------
+
+
+def _write_local_skill(skills_dir, name, description="A local skill", body="# Body\nstuff"):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    return skill_dir / "SKILL.md"
+
+
+@pytest.fixture()
+def local_skill_env(monkeypatch, tmp_path):
+    """Point the on-disk skill scan at an isolated tmp dir with no externals."""
+    import tools.skills_tool as skills_tool
+    import tools.skills_sync as skills_sync
+    import agent.skill_utils as skill_utils
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    monkeypatch.setattr(skill_utils, "get_disabled_skill_names", lambda *a, **k: set())
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {})
+    return skills_dir
+
+
+def _capture_inspect(identifier: str) -> str:
+    from hermes_cli.skills_hub import do_inspect
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=200)
+    do_inspect(identifier, console=console)
+    return sink.getvalue()
+
+
+def test_inspect_finds_installed_local_skill(local_skill_env):
+    _write_local_skill(local_skill_env, "dogfood", description="Eat our own food")
+
+    out = _capture_inspect("dogfood")
+
+    assert "dogfood" in out
+    assert "Eat our own food" in out
+    assert "local" in out
+    assert "enabled" in out
+    # The misleading hub-only errors must not appear for an installed skill.
+    assert "any source" not in out
+    assert "Did you mean" not in out
+
+
+def test_inspect_labels_builtin_skill(local_skill_env, monkeypatch):
+    import tools.skills_sync as skills_sync
+
+    _write_local_skill(local_skill_env, "gifs")
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: {"gifs": "deadbeef"})
+
+    out = _capture_inspect("gifs")
+
+    assert "gifs" in out
+    assert "builtin" in out
+
+
+def test_inspect_marks_disabled_local_skill(local_skill_env, monkeypatch):
+    import agent.skill_utils as skill_utils
+
+    _write_local_skill(local_skill_env, "findmy")
+    monkeypatch.setattr(skill_utils, "get_disabled_skill_names", lambda *a, **k: {"findmy"})
+
+    out = _capture_inspect("findmy")
+
+    assert "findmy" in out
+    assert "disabled" in out
+
+
+def test_inspect_falls_back_to_hub_when_no_local_match(local_skill_env, monkeypatch):
+    import hermes_cli.skills_hub as cli_hub
+
+    called = {}
+
+    def _fake_resolve(name, sources, console):
+        called["name"] = name
+        return ""  # mimic "no hub match" so do_inspect returns cleanly
+
+    monkeypatch.setattr(cli_hub, "_resolve_short_name", _fake_resolve)
+    with patch("tools.skills_hub.create_source_router", return_value=[]), \
+         patch("tools.skills_hub.GitHubAuth"):
+        _capture_inspect("not-installed-anywhere")
+
+    assert called.get("name") == "not-installed-anywhere"


### PR DESCRIPTION
## What does this PR do?

`hermes skills inspect <name>` queried only hub/registry sources, so a skill that is installed on disk — and shows up in `hermes skills list` as enabled — returned a misleading `No skill named X found in any source` (or a confusing fuzzy "did you mean" list). This misleads users and agent-driven setup flows told to "verify your skill with `hermes skills inspect <name>`".

This implements **option A** from the issue: `do_inspect` now resolves a bare name against installed local/builtin skills first, printing the same panel (name, description, source, status, on-disk path, SKILL.md preview), and only falls back to hub registries when there is no local match. A full `source/path` identifier still forces a hub lookup, so nothing regresses for hub skills.

## Related Issue

Fixes #25087

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_hub.py`: add `_inspect_local_skill()` which scans `~/.hermes/skills/` and configured external dirs for a bare name (matching the canonical frontmatter name or directory name, same identity `skills list` uses), then renders the skill panel + preview; classifies the source as `builtin`/`local` and reflects disabled state. `do_inspect()` calls it before the hub lookup for non-`source/path` identifiers; also updates its help text.
- `hermes_cli/main.py`: clarify the `skills inspect` argparse help/identifier text (local-first, then hub).
- `tests/hermes_cli/test_skills_hub.py`: cover local-skill resolution, builtin labelling, disabled marking, and hub fallthrough when no local skill matches.

## How to Test

1. On an install with a local skill (built-in or at `~/.hermes/skills/<name>/SKILL.md`), confirm `hermes skills inspect <name>` now prints the skill's frontmatter and a SKILL.md preview instead of `No skill named '<name>' found in any source`.
2. Confirm `hermes skills inspect <source>/<path>` (identifier containing `/`) still performs a hub lookup unchanged.
3. Run the tests: `pytest tests/hermes_cli/test_skills_hub.py -q`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_skills_hub.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (inspect help text) — the change is pure-Python (pathlib only), no subprocess/signal/path footguns; `scripts/check-windows-footguns.py` is clean
- [x] I've considered cross-platform impact (Windows, macOS)

<!-- autocontrib:worker-id=issue-new-d67b7cee kind=pr-open -->