### PR TITLE
fix: bootstrap Models dashboard first-paint data

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -860,6 +860,33 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _build_models_dashboard_bootstrap() -> dict:
+    """Best-effort data for the Models dashboard first paint.
+
+    The SPA still refreshes via API after load, but embedding the initial data
+    avoids a blank/partial first paint when a mobile browser or reverse proxy
+    transiently fails the runtime fetch.
+    """
+    data: dict = {}
+    try:
+        data["models30"] = _build_models_analytics(30)
+    except Exception as exc:
+        data["models_error"] = str(exc)
+    try:
+        data["auxiliary"] = _build_auxiliary_models()
+    except Exception as exc:
+        data["aux_error"] = str(exc)
+    try:
+        cfg = _normalize_config_for_web(load_config())
+        dashboard = cfg.get("dashboard") if isinstance(cfg, dict) else {}
+        data["show_token_analytics"] = (
+            isinstance(dashboard, dict) and dashboard.get("show_token_analytics") is True
+        )
+    except Exception:
+        data["show_token_analytics"] = False
+    return data
+
+
 @app.get("/api/config")
 async def get_config():
     config = _normalize_config_for_web(load_config())
@@ -1005,6 +1032,34 @@ def get_model_options():
         raise HTTPException(status_code=500, detail="Failed to list model options")
 
 
+def _build_auxiliary_models() -> dict:
+    cfg = load_config()
+    aux_cfg = cfg.get("auxiliary", {})
+    if not isinstance(aux_cfg, dict):
+        aux_cfg = {}
+
+    tasks = []
+    for slot in _AUX_TASK_SLOTS:
+        slot_cfg = aux_cfg.get(slot, {}) if isinstance(aux_cfg.get(slot), dict) else {}
+        tasks.append({
+            "task": slot,
+            "provider": str(slot_cfg.get("provider", "auto") or "auto"),
+            "model": str(slot_cfg.get("model", "") or ""),
+            "base_url": str(slot_cfg.get("base_url", "") or ""),
+        })
+
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        main = {
+            "provider": str(model_cfg.get("provider", "") or ""),
+            "model": str(model_cfg.get("default", model_cfg.get("name", "")) or ""),
+        }
+    else:
+        main = {"provider": "", "model": str(model_cfg) if model_cfg else ""}
+
+    return {"tasks": tasks, "main": main}
+
+
 @app.get("/api/model/auxiliary")
 def get_auxiliary_models():
     """Return current auxiliary task assignments.
@@ -1019,31 +1074,7 @@ def get_auxiliary_models():
       }
     """
     try:
-        cfg = load_config()
-        aux_cfg = cfg.get("auxiliary", {})
-        if not isinstance(aux_cfg, dict):
-            aux_cfg = {}
-
-        tasks = []
-        for slot in _AUX_TASK_SLOTS:
-            slot_cfg = aux_cfg.get(slot, {}) if isinstance(aux_cfg.get(slot), dict) else {}
-            tasks.append({
-                "task": slot,
-                "provider": str(slot_cfg.get("provider", "auto") or "auto"),
-                "model": str(slot_cfg.get("model", "") or ""),
-                "base_url": str(slot_cfg.get("base_url", "") or ""),
-            })
-
-        model_cfg = cfg.get("model", {})
-        if isinstance(model_cfg, dict):
-            main = {
-                "provider": str(model_cfg.get("provider", "") or ""),
-                "model": str(model_cfg.get("default", model_cfg.get("name", "")) or ""),
-            }
-        else:
-            main = {"provider": "", "model": str(model_cfg) if model_cfg else ""}
-
-        return {"tasks": tasks, "main": main}
+        return _build_auxiliary_models()
     except Exception:
         _log.exception("GET /api/model/auxiliary failed")
         raise HTTPException(status_code=500, detail="Failed to read auxiliary config")
@@ -3181,13 +3212,8 @@ async def get_usage_analytics(days: int = 30):
         db.close()
 
 
-@app.get("/api/analytics/models")
-async def get_models_analytics(days: int = 30):
-    """Rich per-model analytics for the Models dashboard page.
-
-    Returns token/cost/session breakdown per model plus capability metadata
-    from models.dev (context window, vision, tools, reasoning, etc.).
-    """
+def _build_models_analytics(days: int = 30) -> dict:
+    """Rich per-model analytics for the Models dashboard page."""
     from hermes_state import SessionDB
 
     db = SessionDB()
@@ -3272,6 +3298,12 @@ async def get_models_analytics(days: int = 30):
         }
     finally:
         db.close()
+
+
+@app.get("/api/analytics/models")
+async def get_models_analytics(days: int = 30):
+    """Return token/cost/session breakdown per model plus capabilities."""
+    return _build_models_analytics(days)
 
 
 # ---------------------------------------------------------------------------
@@ -3727,10 +3759,12 @@ def mount_spa(application: FastAPI):
         """
         html = _index_path.read_text()
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
+        bootstrap_json = json.dumps(_build_models_dashboard_bootstrap(), ensure_ascii=False).replace("</", "<\\/")
         token_script = (
             f'<script>window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
-            f'window.__HERMES_BASE_PATH__="{prefix}";</script>'
+            f'window.__HERMES_BASE_PATH__="{prefix}";'
+            f"window.__HERMES_BOOTSTRAP__={bootstrap_json};</script>"
         )
         if prefix:
             # Rewrite absolute asset URLs baked into the Vite build so the

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,13 @@ declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
     __HERMES_BASE_PATH__?: string;
+    __HERMES_BOOTSTRAP__?: {
+      models30?: ModelsAnalyticsResponse;
+      auxiliary?: AuxiliaryModelsResponse;
+      show_token_analytics?: boolean;
+      models_error?: string;
+      aux_error?: string;
+    };
   }
 }
 let _sessionToken: string | null = null;

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Brain,
   ChevronDown,
@@ -767,16 +767,20 @@ function ModelSettingsPanel({
 /* ──────────────────────────────────────────────────────────────────── */
 
 export default function ModelsPage() {
+  const bootstrap = typeof window !== "undefined" ? window.__HERMES_BOOTSTRAP__ : undefined;
   const [days, setDays] = useState(30);
-  const [data, setData] = useState<ModelsAnalyticsResponse | null>(null);
-  const [aux, setAux] = useState<AuxiliaryModelsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<ModelsAnalyticsResponse | null>(bootstrap?.models30 ?? null);
+  const [aux, setAux] = useState<AuxiliaryModelsResponse | null>(bootstrap?.auxiliary ?? null);
+  const [loading, setLoading] = useState(!bootstrap?.models30);
+  const [error, setError] = useState<string | null>(
+    bootstrap?.models_error ? `Bootstrap analytics unavailable: ${bootstrap.models_error}` : null,
+  );
   const [saveKey, setSaveKey] = useState(0);
+  const skippedBootstrapLoad = useRef(false);
   // Gate the token/cost UI on `dashboard.show_token_analytics`.  See
   // hermes_cli/config.py for the rationale: the numbers exclude auxiliary
   // calls and retries, so they're misleading next to provider billing.
-  const [showTokens, setShowTokens] = useState(false);
+  const [showTokens, setShowTokens] = useState(bootstrap?.show_token_analytics === true);
   const { t } = useI18n();
   const { setAfterTitle, setEnd } = usePageHeader();
 
@@ -863,8 +867,13 @@ export default function ModelsPage() {
   }, [days, loading, load, setAfterTitle, setEnd, t.common.refresh]);
 
   useEffect(() => {
+    if (bootstrap?.models30 && days === 30 && !skippedBootstrapLoad.current) {
+      skippedBootstrapLoad.current = true;
+      setLoading(false);
+      return;
+    }
     load();
-  }, [load]);
+  }, [load, days, bootstrap?.models30]);
 
   return (
     <div className="flex min-w-0 max-w-full flex-col gap-6">


### PR DESCRIPTION
## Summary

Fixes a mobile/WebKit-visible partial-load failure on the Models dashboard by bootstrapping the Models page first-paint data into the dashboard HTML.

The SPA still refreshes via API after it loads, but the initial Models page state no longer depends on browser runtime fetches for:

- 30-day model analytics
- auxiliary model assignments
- `dashboard.show_token_analytics`

This makes the Models page resilient when mobile browsers or reverse proxies transiently fail those runtime GET requests and surface only a generic `Load failed` error.

## What changed

- Extracted reusable server-side builders for:
  - model analytics
  - auxiliary model assignments
- Added a best-effort Models dashboard bootstrap object injected into `index.html` as `window.__HERMES_BOOTSTRAP__`.
- Updated `ModelsPage` to initialize state from the bootstrap data and skip the first 30d load when bootstrap data exists.
- Kept the normal API refresh path for manual refresh and period changes.

## Verification

- `python3 -m py_compile hermes_cli/web_server.py`
- `cd web && npm run build`
- Universal/localization audit: no deployment-specific domains or public-read allowlist changes included in this PR.

## Notes

This PR intentionally does not hardcode any deployment hostname and does not make read APIs public. It only makes first paint robust by reusing data the dashboard server already has while rendering the SPA shell.
