### PR TITLE
diag(xai-oauth): log loopback callback hits + wait-timeout outcome (#27385)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2470,6 +2470,32 @@ def _make_xai_callback_handler(expected_path: str) -> tuple[type[BaseHTTPRequest
                 "error_description": params.get("error_description", [None])[0],
             }
 
+            # Diagnostic logging — emits at INFO so reporters of loopback bugs
+            # (#27385 — "callback received but Hermes times out") can produce
+            # actionable evidence without a code change.  Logged values are
+            # fingerprints / booleans only; no actual code/state strings leak
+            # into the log file.  Run with ``HERMES_LOG_LEVEL=INFO`` (or check
+            # ``~/.hermes/logs/agent.log`` which captures INFO+ unconditionally).
+            try:
+                logger.info(
+                    "xAI loopback callback received: path=%s has_code=%s has_state=%s has_error=%s "
+                    "ua=%s",
+                    parsed.path,
+                    incoming["code"] is not None,
+                    incoming["state"] is not None,
+                    incoming["error"] is not None,
+                    (self.headers.get("User-Agent") or "")[:80],
+                )
+                if incoming["error"]:
+                    logger.info(
+                        "xAI loopback callback carries error=%s error_description=%s",
+                        incoming["error"],
+                        (incoming["error_description"] or "")[:200],
+                    )
+            except Exception:
+                # Logging must never break the OAuth flow.
+                pass
+
             # Treat a hit on the callback path with neither `code` nor `error`
             # as a missing OAuth callback (e.g. xAI's auth backend failed to
             # redirect and the user navigated to the bare loopback URL by hand).
@@ -2574,6 +2600,17 @@ def _xai_wait_for_callback(
         server.shutdown()
         server.server_close()
         thread.join(timeout=1.0)
+    # Diagnostic: distinguish "no callback ever arrived" from "callback
+    # arrived but result wasn't populated" (#27385).  The per-hit handler
+    # also logs at INFO; if neither line appears, xAI's IDP never reached
+    # the loopback at all (firewall, port-binding, IPv6/IPv4 mismatch).
+    logger.info(
+        "xAI loopback wait timed out after %.0fs with no usable callback "
+        "(result.code=%s result.error=%s)",
+        max(5.0, timeout_seconds),
+        result["code"] is not None,
+        result["error"] is not None,
+    )
     raise AuthError(
         "xAI authorization timed out waiting for the local callback.",
         provider="xai-oauth",


### PR DESCRIPTION
## Summary

Adds two INFO log lines to the xAI OAuth loopback flow so reports like #27385 ("browser saw the success page but Hermes still timed out") are triageable from `agent.log` instead of guesswork. Zero behavioral change.

## Changes

`hermes_cli/auth.py` — two `logger.info` lines:

1. **Per callback hit** (inside `_XAICallbackHandler.do_GET`): path, `has_code`, `has_state`, `has_error`, truncated `User-Agent`. Booleans / fingerprints only — no actual `code`/`state` strings leak into the log file.
2. **On wait timeout** (inside `_xai_wait_for_callback`): reports whether `result.code` or `result.error` was populated at the deadline.

Together they distinguish three failure modes for the same surface error (`xai_callback_timeout`):

| Hit log present? | `has_code` / `has_error` | What it means |
|---|---|---|
| ❌ No | n/a | xAI's IDP never reached the loopback at all (firewall, port-binding, IPv6/IPv4 mismatch, browser blocked private-network access) |
| ✓ Yes | both False | xAI hit the loopback without OAuth params — handler already 400s with the "not received" page |
| ✓ Yes | `has_code=True` | Callback was successful but the wait loop didn't see it — would indicate a real bug (race / lock contention) |

Today the handler is silent on receipt and the wait function only raises without logging, so #27385 reporters can't tell us which of the three they're hitting.

## Validation

```
scripts/run_tests.sh tests/hermes_cli/test_auth_xai_oauth_provider.py \
                     tests/hermes_cli/test_xai_oauth_pkce_token_exchange.py \
                     tests/run_agent/test_codex_xai_oauth_recovery.py
=== 3 files, 133 tests passed, 0 failed ===
```

Logging guarded with a broad `try/except` so log emission can never break the OAuth flow.

## Privacy note

The callback hit log captures booleans, the URL path, and a truncated User-Agent. The `error` and `error_description` fields are logged in full only when present (those are xAI's own error strings, not user secrets). The `code` and `state` query parameters — the actual OAuth secrets — are never logged.
