### PR TITLE
docs: clean up bundled skill related metadata

### DIFF
--- a/skills/apple/macos-computer-use/SKILL.md
+++ b/skills/apple/macos-computer-use/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   hermes:
     tags: [computer-use, macos, desktop, automation, gui]
     category: desktop
-    related_skills: [browser]
+    related_skills: []
 ---
 
 # macOS Computer Use (universal, any-model)

--- a/skills/creative/architecture-diagram/SKILL.md
+++ b/skills/creative/architecture-diagram/SKILL.md
@@ -9,7 +9,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [architecture, diagrams, SVG, HTML, visualization, infrastructure, cloud]
-    related_skills: [concept-diagrams, excalidraw]
+    related_skills: [excalidraw]
 ---
 
 # Architecture Diagram Skill

--- a/skills/creative/comfyui/SKILL.md
+++ b/skills/creative/comfyui/SKILL.md
@@ -23,7 +23,7 @@ metadata:
       - creative
       - generative-ai
       - video-generation
-    related_skills: [stable-diffusion-image-generation, image_gen]
+    related_skills: []
     category: creative
 ---
 

--- a/skills/creative/touchdesigner-mcp/SKILL.md
+++ b/skills/creative/touchdesigner-mcp/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [TouchDesigner, MCP, twozero, creative-coding, real-time-visuals, generative-art, audio-reactive, VJ, installation, GLSL]
-    related_skills: [native-mcp, ascii-video, manim-video, hermes-video]
+    related_skills: [native-mcp, ascii-video, manim-video]
 
 ---
 

--- a/skills/mcp/native-mcp/SKILL.md
+++ b/skills/mcp/native-mcp/SKILL.md
@@ -8,7 +8,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [MCP, Tools, Integrations]
-    related_skills: [mcporter]
+    related_skills: []
 ---
 
 # Native MCP Client

--- a/skills/media/heartmula/SKILL.md
+++ b/skills/media/heartmula/SKILL.md
@@ -6,7 +6,7 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [music, audio, generation, ai, heartmula, heartcodec, lyrics, songs]
-    related_skills: [audiocraft]
+    related_skills: [audiocraft-audio-generation]
 ---
 
 # HeartMuLa - Open-Source Music Generation

--- a/skills/mlops/inference/obliteratus/SKILL.md
+++ b/skills/mlops/inference/obliteratus/SKILL.md
@@ -9,7 +9,7 @@ platforms: [linux, macos]
 metadata:
   hermes:
     tags: [Abliteration, Uncensoring, Refusal-Removal, LLM, Weight-Projection, SVD, Mechanistic-Interpretability, HuggingFace, Model-Surgery]
-    related_skills: [vllm, gguf, huggingface-tokenizers]
+    related_skills: [serving-llms-vllm, llama-cpp, huggingface-hub]
 ---
 
 # OBLITERATUS Skill

--- a/skills/research/research-paper-writing/SKILL.md
+++ b/skills/research/research-paper-writing/SKILL.md
@@ -11,7 +11,7 @@ metadata:
   hermes:
     tags: [Research, Paper Writing, Experiments, ML, AI, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, LaTeX, Citations, Statistical Analysis]
     category: research
-    related_skills: [arxiv, ml-paper-writing, subagent-driven-development, plan]
+    related_skills: [arxiv, subagent-driven-development, plan]
     requires_toolsets: [terminal, files]
 
 ---

--- a/skills/software-development/hermes-s6-container-supervision/SKILL.md
+++ b/skills/software-development/hermes-s6-container-supervision/SKILL.md
@@ -7,7 +7,7 @@ license: MIT
 metadata:
   hermes:
     tags: [docker, s6, supervision, gateway, profiles]
-    related_skills: [hermes-agent, hermes-agent-dev]
+    related_skills: [hermes-agent]
 ---
 
 # Hermes s6-overlay Container Supervision


### PR DESCRIPTION
## Summary
- Remove stale/nonexistent bundled skill related_skills references
- Map obvious renamed related skill refs to current bundled skill names
- Include the new s6 supervision skill metadata ref from current main

## Verification
- Parsed all bundled skills under skills/**/SKILL.md
- Verified 90 skill files, 0 frontmatter errors, 0 broken related_skills refs

## Scope
- Metadata/docs-only SKILL.md frontmatter cleanup
- No runtime, config, provider, model, tool-permission, gateway, credential, deletion, archive, or pruning changes