### PR TITLE
fix(gateway): preserve transformed stream edit fallback

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17783,27 +17783,11 @@ class GatewayRunner:
                 )
                 response["already_sent"] = True
             elif not _is_empty_sentinel and _transformed and _sc is not None:
-                # Plugin hooks transformed the response after streaming — edit the
-                # existing streamed message instead of sending a duplicate.
-                _sc_msg_id = _sc.message_id
-                if _sc_msg_id:
-                    try:
-                        await _sc.adapter.edit_message(
-                            chat_id=source.chat_id,
-                            message_id=_sc_msg_id,
-                            content=response["final_response"],
-                            finalize=True,
-                        )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
-                    except Exception as _edit_err:
-                        logger.warning(
-                            "Failed to edit streamed message for session %s: %s",
-                            session_key or "?", _edit_err,
-                        )
+                await _edit_transformed_streamed_response(
+                    response=response,
+                    stream_consumer=_sc,
+                    session_key=session_key,
+                )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as
@@ -17852,6 +17836,45 @@ class GatewayRunner:
                 logger.debug("Post-delivery cleanup registration failed: %s", _rpe)
 
         return response
+
+
+async def _edit_transformed_streamed_response(
+    *,
+    response: dict,
+    stream_consumer,
+    session_key: str | None = None,
+) -> None:
+    """Update an existing streamed message with post-stream plugin changes.
+
+    Only mark ``already_sent`` when the platform edit succeeds.  If the edit
+    fails, the caller's normal final-send path remains available as a fallback.
+    """
+    message_id = stream_consumer.message_id
+    if not message_id:
+        return
+    try:
+        edit_result = await stream_consumer._edit_message(
+            message_id=message_id,
+            content=response["final_response"],
+            finalize=True,
+        )
+        if getattr(edit_result, "success", False):
+            response["already_sent"] = True
+            logger.info(
+                "Edited streamed message %s for session %s to include plugin-transformed content.",
+                message_id, session_key or "?",
+            )
+        else:
+            logger.warning(
+                "Failed to edit streamed message for session %s: %s",
+                session_key or "?",
+                getattr(edit_result, "error", None) or "unknown error",
+            )
+    except Exception as edit_err:
+        logger.warning(
+            "Failed to edit streamed message for session %s: %s",
+            session_key or "?", edit_err,
+        )
 
 
 def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30192,27 +30192,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         session_key or "?",
                     )
             elif not _is_empty_sentinel and _transformed and _sc is not None:
-                # Plugin hooks transformed the response after streaming — edit the
-                # existing streamed message instead of sending a duplicate.
-                _sc_msg_id = _sc.message_id
-                if _sc_msg_id:
-                    try:
-                        await _sc.adapter.edit_message(
-                            chat_id=source.chat_id,
-                            message_id=_sc_msg_id,
-                            content=response["final_response"],
-                            finalize=True,
-                        )
-                        response["already_sent"] = True
-                        logger.info(
-                            "Edited streamed message %s for session %s to include plugin-transformed content.",
-                            _sc_msg_id, session_key or "?",
-                        )
-                    except Exception as _edit_err:
-                        logger.warning(
-                            "Failed to edit streamed message for session %s: %s",
-                            session_key or "?", _edit_err,
-                        )
+                await _edit_transformed_streamed_response(
+                    response=response,
+                    stream_consumer=_sc,
+                    session_key=session_key,
+                )
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as
@@ -30538,6 +30522,45 @@ def _start_gateway_housekeeping(stop_event: threading.Event, adapters=None, loop
 
         stop_event.wait(timeout=interval)
     logger.info("Gateway housekeeping stopped")
+
+
+async def _edit_transformed_streamed_response(
+    *,
+    response: dict,
+    stream_consumer,
+    session_key: str | None = None,
+) -> None:
+    """Update a streamed message with post-stream plugin changes.
+
+    Only mark already_sent when the platform edit succeeds. If the edit fails,
+    the caller's normal final-send path remains available as a fallback.
+    """
+    message_id = stream_consumer.message_id
+    if not message_id:
+        return
+    try:
+        edit_result = await stream_consumer._edit_message(
+            message_id=message_id,
+            content=response["final_response"],
+            finalize=True,
+        )
+        if getattr(edit_result, "success", False):
+            response["already_sent"] = True
+            logger.info(
+                "Edited streamed message %s for session %s to include plugin-transformed content.",
+                message_id, session_key or "?",
+            )
+        else:
+            logger.warning(
+                "Failed to edit streamed message for session %s: %s",
+                session_key or "?",
+                getattr(edit_result, "error", None) or "unknown error",
+            )
+    except Exception as edit_err:
+        logger.warning(
+            "Failed to edit streamed message for session %s: %s",
+            session_key or "?", edit_err,
+        )
 
 
 def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -100,6 +100,10 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
 
 
 class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM, *, edit_success=True):
+        super().__init__(platform=platform)
+        self.edit_success = edit_success
+
     async def edit_message(
         self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
     ) -> SendResult:
@@ -111,7 +115,31 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
                 "metadata": metadata,
             }
         )
-        return SendResult(success=True, message_id=message_id)
+        if self.edit_success:
+            return SendResult(success=True, message_id=message_id)
+        return SendResult(success=False, error="edit failed")
+
+
+class FailingMetadataEditProgressCaptureAdapter(MetadataEditProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform, edit_success=False)
+
+
+class _StreamConsumerStub:
+    def __init__(self, adapter, *, message_id="progress-1", metadata=None):
+        self.adapter = adapter
+        self.chat_id = "chat-1"
+        self.message_id = message_id
+        self.metadata = metadata
+
+    async def _edit_message(self, *, message_id, content, finalize=False):
+        return await self.adapter.edit_message(
+            self.chat_id,
+            message_id,
+            content,
+            finalize=finalize,
+            metadata=self.metadata,
+        )
 
 
 class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
@@ -996,6 +1024,52 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
     assert any("[plugin appended this]" in text for text in edited_texts), (
         f"expected transformed text in adapter.edits, got: {edited_texts!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_transformed_stream_edit_uses_consumer_metadata():
+    from gateway.run import _edit_transformed_streamed_response
+
+    adapter = MetadataEditProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    response = {"final_response": "original\n\n[plugin appended this]"}
+    consumer = _StreamConsumerStub(
+        adapter,
+        metadata={"thread_id": "17585", "message_thread_id": "17585"},
+    )
+
+    await _edit_transformed_streamed_response(
+        response=response,
+        stream_consumer=consumer,
+        session_key="sess",
+    )
+
+    assert response.get("already_sent") is True
+    assert adapter.edits == [
+        {
+            "chat_id": "chat-1",
+            "message_id": "progress-1",
+            "content": "original\n\n[plugin appended this]",
+            "metadata": {"thread_id": "17585", "message_thread_id": "17585"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transformed_stream_edit_failure_keeps_final_send_fallback():
+    from gateway.run import _edit_transformed_streamed_response
+
+    adapter = FailingMetadataEditProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    response = {"final_response": "original\n\n[plugin appended this]"}
+    consumer = _StreamConsumerStub(adapter)
+
+    await _edit_transformed_streamed_response(
+        response=response,
+        stream_consumer=consumer,
+        session_key="sess",
+    )
+
+    assert response.get("already_sent") is not True
+    assert adapter.edits[0]["content"] == "original\n\n[plugin appended this]"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -132,6 +132,10 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
 
 
 class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM, *, edit_success=True):
+        super().__init__(platform=platform)
+        self.edit_success = edit_success
+
     async def edit_message(
         self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
     ) -> SendResult:
@@ -143,7 +147,31 @@ class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
                 "metadata": metadata,
             }
         )
-        return SendResult(success=True, message_id=message_id)
+        if self.edit_success:
+            return SendResult(success=True, message_id=message_id)
+        return SendResult(success=False, error="edit failed")
+
+
+class FailingMetadataEditProgressCaptureAdapter(MetadataEditProgressCaptureAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform=platform, edit_success=False)
+
+
+class _StreamConsumerStub:
+    def __init__(self, adapter, *, message_id="progress-1", metadata=None):
+        self.adapter = adapter
+        self.chat_id = "chat-1"
+        self.message_id = message_id
+        self.metadata = metadata
+
+    async def _edit_message(self, *, message_id, content, finalize=False):
+        return await self.adapter.edit_message(
+            self.chat_id,
+            message_id,
+            content,
+            finalize=finalize,
+            metadata=self.metadata,
+        )
 
 
 class RetryableFirstEditProgressCaptureAdapter(ProgressCaptureAdapter):
@@ -1237,6 +1265,80 @@ async def test_transformed_response_edits_streamed_message_in_place(monkeypatch,
     assert any("[plugin appended this]" in text for text in edited_texts), (
         f"expected transformed text in adapter.edits, got: {edited_texts!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_transformed_stream_edit_uses_consumer_metadata():
+    from gateway.run import _edit_transformed_streamed_response
+
+    adapter = MetadataEditProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    response = {"final_response": "original\n\n[plugin appended this]"}
+    consumer = _StreamConsumerStub(
+        adapter,
+        metadata={"thread_id": "17585", "message_thread_id": "17585"},
+    )
+
+    await _edit_transformed_streamed_response(
+        response=response,
+        stream_consumer=consumer,
+        session_key="sess",
+    )
+
+    assert response.get("already_sent") is True
+    assert adapter.edits == [
+        {
+            "chat_id": "chat-1",
+            "message_id": "progress-1",
+            "content": "original\n\n[plugin appended this]",
+            "metadata": {"thread_id": "17585", "message_thread_id": "17585"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_transformed_stream_edit_failure_keeps_final_send_fallback():
+    from gateway.run import _edit_transformed_streamed_response
+
+    adapter = FailingMetadataEditProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    response = {"final_response": "original\n\n[plugin appended this]"}
+    consumer = _StreamConsumerStub(adapter)
+
+    await _edit_transformed_streamed_response(
+        response=response,
+        stream_consumer=consumer,
+        session_key="sess",
+    )
+
+    assert response.get("already_sent") is not True
+    assert adapter.edits[0]["content"] == "original\n\n[plugin appended this]"
+
+
+@pytest.mark.asyncio
+async def test_transformed_stream_edit_failure_delivers_final_via_normal_send(
+    monkeypatch, tmp_path
+):
+    """A failed in-place edit must leave the complete final-send fallback active."""
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        TransformedStreamAgent,
+        session_id="sess-transformed-stream-edit-failure",
+        config_data={
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        },
+        platform=Platform.MATRIX,
+        chat_id="!room:matrix.example.org",
+        chat_type="group",
+        thread_id="$thread",
+        adapter_cls=FailingMetadataEditProgressCaptureAdapter,
+    )
+
+    assert result.get("already_sent") is not True
+    assert any(
+        "[plugin appended this]" in call["content"]
+        for call in adapter.sent
+    ), f"expected complete transformed fallback send, got: {adapter.sent!r}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes transformed streaming responses so the gateway only suppresses the normal final send after a successful in-place edit of the streamed message.

When a `transform_llm_output` hook changes the final response after streaming has already delivered text, the gateway now reuses `GatewayStreamConsumer._edit_message()` instead of calling the adapter directly. This preserves existing routing metadata for platforms such as Telegram topics, and it keeps the final-send fallback available when the platform edit returns `SendResult(success=False)`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Added `_edit_transformed_streamed_response()` helper for post-stream plugin-transformed final responses.
  - Reuses the stream consumer edit path so existing metadata forwarding remains intact.
  - Sets `response["already_sent"] = True` only when the edit result reports success.
  - Leaves the normal final-send path available when the edit fails or raises.
- `tests/gateway/test_run_progress_topics.py`
  - Adds coverage that transformed stream edits preserve consumer metadata.
  - Adds coverage that failed transformed stream edits do not mark the response as already sent.

## How to Test

1. Run the focused regression tests:

   ```bash
   PYTHONPATH=. /tmp/hermes-agent-test-venv/bin/python -m pytest tests/gateway/test_run_progress_topics.py::test_transformed_stream_edit_uses_consumer_metadata tests/gateway/test_run_progress_topics.py::test_transformed_stream_edit_failure_keeps_final_send_fallback -q
   ```

2. Run syntax checks:

   ```bash
   PYTHONPATH=. /tmp/hermes-agent-test-venv/bin/python -m py_compile gateway/run.py tests/gateway/test_run_progress_topics.py
   ```

3. Optional manual scenario: enable gateway streaming and a `transform_llm_output` hook that appends text after streaming, then verify the transformed final text edits the streamed message in place without suppressing delivery on edit failure.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests:

```text
..                                                                       [100%]
2 passed in 5.24s
```

Syntax check:

```text
PYTHONPATH=. /tmp/hermes-agent-test-venv/bin/python -m py_compile gateway/run.py tests/gateway/test_run_progress_topics.py
```
