### PR TITLE
fix(kanban): preserve notifications and workspace for decomposed tasks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4937,9 +4937,14 @@ class GatewayRunner:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            if getattr(send_result, "success", True) is False:
+                                err = getattr(send_result, "error", None)
+                                raise RuntimeError(
+                                    err or "adapter.send returned success=False"
+                                )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3709,13 +3709,20 @@ def decompose_triage_task(
     child_ids: list[str] = []
     with write_txn(conn):
         root_row = conn.execute(
-            "SELECT id, status, tenant FROM tasks WHERE id = ?", (task_id,)
+            "SELECT id, status, tenant, workspace_kind, workspace_path "
+            "FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if root_row is None:
             return None
         if root_row["status"] != "triage":
             return None
         tenant = root_row["tenant"]
+        child_workspace_kind = "scratch"
+        child_workspace_path = None
+        if root_row["workspace_kind"] == "dir" and root_row["workspace_path"]:
+            child_workspace_kind = "dir"
+            child_workspace_path = root_row["workspace_path"]
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -3729,13 +3736,15 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
                     body if isinstance(body, str) else None,
                     assignee,
+                    child_workspace_kind,
+                    child_workspace_path,
                     tenant,
                     now,
                     (author or "decomposer"),
@@ -3744,6 +3753,19 @@ def decompose_triage_task(
             _append_event(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
+            )
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO kanban_notify_subs
+                    (task_id, platform, chat_id, thread_id, user_id,
+                     notifier_profile, created_at, last_event_id)
+                SELECT ?, platform, chat_id, thread_id, user_id,
+                       notifier_profile, ?,
+                       COALESCE((SELECT MAX(id) FROM task_events), 0)
+                  FROM kanban_notify_subs
+                 WHERE task_id = ?
+                """,
+                (new_id, now, task_id),
             )
             child_ids.append(new_id)
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from gateway.config import Platform
+from gateway.platforms.base import SendResult
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 
@@ -149,6 +150,17 @@ class FailingAdapter:
         raise RuntimeError("simulated send failure")
 
 
+class SoftFailAdapter:
+    """Adapter whose send() reports failure without raising."""
+
+    def __init__(self):
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        self.attempts += 1
+        return SendResult(success=False, error="simulated soft failure")
+
+
 def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     """A raising adapter rewinds the claim so the next tick can retry.
 
@@ -170,6 +182,22 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     # Send was attempted (so we exercised the failure path, not just the
     # disconnect path) and the claim was rewound — the unseen-events query
     # still returns the event for retry on the next tick.
+    assert adapter.attempts >= 1, "send should have been attempted at least once"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+
+def test_kanban_notifier_rewinds_claim_on_send_result_failure(tmp_path, monkeypatch):
+    """SendResult(success=False) is a delivery failure, not a delivered event."""
+    db_path = tmp_path / "send-result-failure.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = SoftFailAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
     assert adapter.attempts >= 1, "send should have been attempted at least once"
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
 

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -166,3 +166,78 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
 
     assert any("Decomposed into" in (c.body or "") for c in comments)
     assert any(ev.kind == "decomposed" for ev in events)
+
+
+def test_decompose_children_inherit_root_dir_workspace(kanban_home, tmp_path):
+    workspace = tmp_path / "project"
+    workspace.mkdir()
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="split real project work",
+            triage=True,
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[
+                {"title": "backend", "assignee": "backend"},
+                {"title": "frontend", "assignee": "frontend"},
+            ],
+            author="alice",
+        )
+
+        assert child_ids is not None
+        children = [kb.get_task(conn, cid) for cid in child_ids]
+
+    assert [(c.workspace_kind, c.workspace_path) for c in children if c] == [
+        ("dir", str(workspace)),
+        ("dir", str(workspace)),
+    ]
+
+
+def test_decompose_children_inherit_root_notify_subscriptions(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="needs fanout")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="dingtalk",
+            chat_id="chat-1",
+            thread_id="thread-1",
+            user_id="user-1",
+            notifier_profile="default",
+        )
+
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[
+                {"title": "backend", "assignee": "backend"},
+                {"title": "frontend", "assignee": "frontend"},
+            ],
+            author="alice",
+        )
+
+        assert child_ids is not None
+        child_subs = [kb.list_notify_subs(conn, cid) for cid in child_ids]
+
+    observed = [
+        [
+            sub["platform"],
+            sub["chat_id"],
+            sub["thread_id"],
+            sub["user_id"],
+            sub["notifier_profile"],
+        ]
+        for [sub] in child_subs
+    ]
+    assert observed == [
+        ["dingtalk", "chat-1", "thread-1", "user-1", "default"],
+        ["dingtalk", "chat-1", "thread-1", "user-1", "default"],
+    ]


### PR DESCRIPTION
## What does this PR do?

Fixes two notification-loss paths in Kanban workflows and preserves project workspace context for decomposed child tasks.

- The gateway Kanban notifier now treats adapter.send() returning SendResult(success=False) as a failed delivery. This uses the existing failure path so the pre-send event claim is rewound and a later notifier tick can retry.
- decompose_triage_task() now copies the root task's notify subscriptions to every decomposed child task, so child blocked/completed events reach the originating gateway chat.
- decompose_triage_task() now preserves an explicit root workspace_kind='dir' + workspace_path for child tasks, avoiding scratch workspaces for decomposed project work.

## Related Issue

Fixes #31901

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/run.py: check SendResult.success in _kanban_notifier_watcher and route soft send failures through the existing rewind/failure counter path.
- hermes_cli/kanban_db.py: copy root dir workspace and root notify subscriptions when decomposing a triage task.
- tests/gateway/test_kanban_notifier.py: add regression coverage for SendResult(success=False) preserving unseen notification events for retry.
- tests/hermes_cli/test_kanban_decompose_db.py: add regression coverage for child workspace inheritance and child notification subscription inheritance.

## How to Test

1. scripts/run_tests.sh tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_decompose_db.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_db.py -- -q
   - Local result: 210 passed, 0 failed
2. scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py -- -q
   - Local result after installing the web extra for dashboard imports: 164 passed, 0 failed
3. uv run --extra dev ruff check gateway/run.py hermes_cli/kanban_db.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_kanban_decompose_db.py
   - Local result: All checks passed
4. git diff --check
   - Local result: clean

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] cli-config.yaml.example update N/A
- [x] CONTRIBUTING.md / AGENTS.md update N/A
- [x] Cross-platform impact considered: SQLite and gateway SendResult handling only; no OS-specific APIs added
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Focused local regression tests were added and passed. No UI screenshots are applicable.