### PR TITLE
fix(kanban): gate notifier watcher and harden WAL/transaction locks

### DIFF
--- a/docs/kanban/multi-gateway.md
+++ b/docs/kanban/multi-gateway.md
@@ -1,0 +1,54 @@
+# Multi-gateway deployment
+
+Hermes supports multiple gateway processes running concurrently — one per profile
+(default, writer, admin, coder, researcher). Each gateway opens its own connection
+to platform APIs and delivers messages for its profile's subscribers.
+
+## Single-dispatcher posture
+
+Only one gateway owns the kanban dispatcher. The owning gateway has
+`kanban.dispatch_in_gateway: true` (the default). All other gateways set
+`kanban.dispatch_in_gateway: false`.
+
+**Why this matters:** gateways with `dispatch_in_gateway: true` open per-board
+SQLite connections for the notifier watcher. Multiple gateways doing this concurrently
+amplifies WAL reader counts on the `-shm` shared-memory page table. Under memory
+pressure, this increases the risk of `-shm` state inconsistency.
+
+## Configuration
+
+On the dispatch-owning gateway (typically the `default` profile), no change needed —
+`dispatch_in_gateway` defaults to `true`.
+
+On every other profile gateway, add to `~/.hermes/config.yaml`:
+
+```yaml
+kanban:
+  dispatch_in_gateway: false
+```
+
+Or set the env var: `HERMES_KANBAN_DISPATCH_IN_GATEWAY=false`
+
+## What each gateway does
+
+| Gateway role | dispatch_in_gateway | Opens per-board DBs? | Runs dispatcher? |
+|---|---|---|---|
+| default (dispatch owner) | true (default) | yes | yes |
+| writer, admin, coder, etc. | false | no | no |
+
+Non-dispatch gateways still deliver messages for their own platform adapters
+(Telegram, Discord, etc.) — they just don't poll kanban boards.
+
+## ASCII diagram
+
+```
+  [default gateway]          [writer gateway]       [coder gateway]
+  dispatch_in_gateway=true   d_i_g=false            d_i_g=false
+         |                        |                       |
+         v                        v                       v
+  kanban_db.connect()        (skips notifier)       (skips notifier)
+  per-board polling          platform adapters      platform adapters
+  dispatcher tick
+```
+
+Only the dispatch-owning gateway holds open file descriptors on `kanban.db` files.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4708,6 +4708,30 @@ class GatewayRunner:
         cross boards, so delivery semantics are unchanged — this is
         purely a fan-out of the single-DB poll.
         """
+        # Gate: only the dispatch-owning gateway opens kanban DBs for notifier polling.
+        # Non-dispatch gateways have no subscriptions to deliver — all kanban state lives
+        # in the dispatch owner's per-board DBs. This prevents N-gateway -shm contention.
+        # TODO: gate per-board when t_e077d4ee (per-board dispatcher_owner) lands.
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning("kanban notifier: config loader unavailable; disabled")
+            return
+        env_override = os.environ.get("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "").strip().lower()
+        if env_override in {"0", "false", "no", "off"}:
+            logger.info("kanban notifier: disabled via HERMES_KANBAN_DISPATCH_IN_GATEWAY env")
+            return
+        try:
+            cfg = _load_config()
+        except Exception as exc:
+            logger.warning("kanban notifier: cannot load config (%s); disabled", exc)
+            return
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        if not kanban_cfg.get("dispatch_in_gateway", True):
+            logger.info(
+                "kanban notifier: disabled via config kanban.dispatch_in_gateway=false"
+            )
+            return
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4711,7 +4711,7 @@ class GatewayRunner:
         # Gate: only the dispatch-owning gateway opens kanban DBs for notifier polling.
         # Non-dispatch gateways have no subscriptions to deliver — all kanban state lives
         # in the dispatch owner's per-board DBs. This prevents N-gateway -shm contention.
-        # TODO: gate per-board when t_e077d4ee (per-board dispatcher_owner) lands.
+        # TODO: gate per-board when per-board dispatcher_owner tracking lands.
         try:
             from hermes_cli.config import load_config as _load_config
         except Exception:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1468,12 +1468,46 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
 
 @contextlib.contextmanager
 def write_txn(conn: sqlite3.Connection):
-    """Context manager for an IMMEDIATE write transaction.
+    """Context manager for an IMMEDIATE write transaction with optional board-level lock.
 
     Use for any multi-statement write (creating a task + link, claiming a
     task + recording an event, etc.).  A claim CAS inside this context is
     atomic -- at most one concurrent writer can succeed.
+
+    On Unix, acquires an exclusive flock on ``<board_dir>/kanban.write.lock``
+    before BEGIN IMMEDIATE to serialize concurrent writers at the OS level,
+    reducing SQLITE_BUSY under heavy multi-process write load. Disabled on
+    Windows (fcntl unavailable) and for :memory: DBs. Falls through without
+    crash if the lock file cannot be created (e.g. read-only filesystem).
     """
+    import sys as _sys
+
+    lock_fd = None
+    if _sys.platform != "win32":
+        try:
+            row = conn.execute("PRAGMA database_list").fetchone()
+            db_file = row[2] if row and row[2] else None
+        except Exception:
+            db_file = None
+        if db_file and db_file != ":memory:":
+            board_dir = os.path.dirname(db_file)
+            lock_path = os.path.join(board_dir, "kanban.write.lock")
+            try:
+                import fcntl as _fcntl
+
+                lock_fd = open(lock_path, "w", encoding="utf-8")
+                _fcntl.flock(lock_fd, _fcntl.LOCK_EX)
+            except OSError:
+                logger.debug(
+                    "write_txn: could not acquire board write lock at %s; proceeding",
+                    lock_path,
+                )
+                if lock_fd is not None:
+                    try:
+                        lock_fd.close()
+                    except OSError:
+                        pass
+                lock_fd = None
     conn.execute("BEGIN IMMEDIATE")
     try:
         yield conn
@@ -1482,6 +1516,15 @@ def write_txn(conn: sqlite3.Connection):
         raise
     else:
         conn.execute("COMMIT")
+    finally:
+        if lock_fd is not None:
+            try:
+                import fcntl as _fcntl
+
+                _fcntl.flock(lock_fd, _fcntl.LOCK_UN)
+                lock_fd.close()
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1498,7 +1498,7 @@ def write_txn(conn: sqlite3.Connection):
                 lock_fd = open(lock_path, "w", encoding="utf-8")
                 _fcntl.flock(lock_fd, _fcntl.LOCK_EX)
             except OSError:
-                logger.debug(
+                _log.debug(
                     "write_txn: could not acquire board write lock at %s; proceeding",
                     lock_path,
                 )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,9 +16,11 @@ Key design decisions:
 
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
+import sys
 import threading
 import time
 from pathlib import Path
@@ -125,10 +127,22 @@ def format_session_db_unavailable(prefix: str = "Session database not available"
     return f"{prefix}: {cause}{hint}."
 
 
+def _wal_init_lock_path(db_path: str) -> "Optional[str]":
+    """Return flock path for WAL init serialization, or None if not applicable."""
+    if db_path == ":memory:":
+        return None
+    if os.environ.get("HERMES_WAL_INIT_FLOCK_DISABLE"):
+        return None
+    if sys.platform == "win32":
+        return None
+    return db_path + ".wal-init.lock"
+
+
 def apply_wal_with_fallback(
     conn: sqlite3.Connection,
     *,
     db_label: str = "state.db",
+    db_path: "Optional[str]" = None,
 ) -> str:
     """Set ``journal_mode=WAL`` on ``conn``, falling back to DELETE on failure.
 
@@ -148,17 +162,55 @@ def apply_wal_with_fallback(
     Shared by :class:`SessionDB` and ``hermes_cli.kanban_db.connect`` so
     both databases get identical fallback behavior.
     """
+    # Derive db_path from the connection's filename if not provided.
+    if db_path is None:
+        try:
+            row = conn.execute("PRAGMA database_list").fetchone()
+            if row and row[2]:
+                db_path = row[2]
+        except Exception:
+            pass
+
+    lock_path = _wal_init_lock_path(db_path) if db_path else None
+    lock_fd = None
+    if lock_path:
+        try:
+            import fcntl as _fcntl
+
+            lock_fd = open(lock_path, "w", encoding="utf-8")
+            _fcntl.flock(lock_fd, _fcntl.LOCK_EX)
+        except OSError:
+            logger.debug(
+                "apply_wal_with_fallback: could not acquire wal-init lock at %s; proceeding",
+                lock_path,
+            )
+            if lock_fd is not None:
+                try:
+                    lock_fd.close()
+                except OSError:
+                    pass
+            lock_fd = None
     try:
-        conn.execute("PRAGMA journal_mode=WAL")
-        return "wal"
-    except sqlite3.OperationalError as exc:
-        msg = str(exc).lower()
-        if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
-            # Unrelated OperationalError — don't silently swallow.
-            raise
-        _log_wal_fallback_once(db_label, exc)
-        conn.execute("PRAGMA journal_mode=DELETE")
-        return "delete"
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            return "wal"
+        except sqlite3.OperationalError as exc:
+            msg = str(exc).lower()
+            if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
+                # Unrelated OperationalError — don't silently swallow.
+                raise
+            _log_wal_fallback_once(db_label, exc)
+            conn.execute("PRAGMA journal_mode=DELETE")
+            return "delete"
+    finally:
+        if lock_fd is not None:
+            try:
+                import fcntl as _fcntl
+
+                _fcntl.flock(lock_fd, _fcntl.LOCK_UN)
+                lock_fd.close()
+            except OSError:
+                pass
 
 
 def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1287,6 +1287,7 @@ AUTHOR_MAP = {
     "edison@mcclean.codes": "McClean-Edison",  # PR #29817 (register_auxiliary_task plugin API)
     "zhangsamuel12@gmail.com": "SamuelZ12",  # PR #7480 (show recap after in-session resume)
     "490408354@qq.com": "daizhonggeng",  # PR #9020 (numbered /resume selection)
+    "steveonjava@gmail.com": "steveonjava",
 }
 
 

--- a/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
+++ b/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
@@ -1,0 +1,108 @@
+"""Tests for the dispatch_in_gateway gate on _kanban_notifier_watcher.
+
+Acceptance criteria covered:
+- Non-dispatch gateways (dispatch_in_gateway=false) exit before opening any DB.
+- Dispatch-owning gateways (dispatch_in_gateway=true) proceed past the gate.
+- HERMES_KANBAN_DISPATCH_IN_GATEWAY env var disables without config load.
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+def _make_runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {}
+    runner._kanban_sub_fail_counts = {}
+    return runner
+
+
+def _fake_config(dispatch_in_gateway):
+    return {"kanban": {"dispatch_in_gateway": dispatch_in_gateway}}
+
+
+def test_notifier_watcher_skips_when_dispatch_disabled(monkeypatch):
+    """With dispatch_in_gateway=false the watcher returns before opening any DB."""
+    runner = _make_runner()
+
+    with patch("hermes_cli.config.load_config", return_value=_fake_config(False)):
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            asyncio.run(runner._kanban_notifier_watcher())
+            mock_connect.assert_not_called()
+
+
+def test_notifier_watcher_no_db_handle_on_non_dispatch_gateway(monkeypatch):
+    """After early return, kanban_db.connect was never called (negative test)."""
+    runner = _make_runner()
+
+    with patch("hermes_cli.config.load_config", return_value=_fake_config(False)):
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            asyncio.run(runner._kanban_notifier_watcher())
+
+    mock_connect.assert_not_called()
+
+
+def test_notifier_watcher_env_override_disables(monkeypatch):
+    """HERMES_KANBAN_DISPATCH_IN_GATEWAY=false skips config load entirely."""
+    runner = _make_runner()
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "false")
+
+    with patch("hermes_cli.config.load_config") as mock_load_config:
+        with patch("hermes_cli.kanban_db.connect") as mock_connect:
+            asyncio.run(runner._kanban_notifier_watcher())
+
+    mock_load_config.assert_not_called()
+    mock_connect.assert_not_called()
+
+
+def test_notifier_watcher_env_override_zero_disables(monkeypatch):
+    """HERMES_KANBAN_DISPATCH_IN_GATEWAY=0 also disables."""
+    runner = _make_runner()
+    monkeypatch.setenv("HERMES_KANBAN_DISPATCH_IN_GATEWAY", "0")
+
+    with patch("hermes_cli.config.load_config") as mock_load_config:
+        asyncio.run(runner._kanban_notifier_watcher())
+
+    mock_load_config.assert_not_called()
+
+
+def test_notifier_watcher_runs_when_dispatch_enabled(monkeypatch, tmp_path):
+    """With dispatch_in_gateway=true the watcher proceeds past the gate.
+
+    We verify it doesn't return early by checking that kanban_db.list_boards
+    is called (the watcher fan-outs over boards after passing the gate).
+    """
+    runner = _make_runner()
+    past_gate = []
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+        # First sleep is the 5s initial delay; stop running so the loop exits cleanly
+        # without needing a second sleep, but we need to let _collect run first.
+        # We stop after the second sleep (the per-interval sleep inside the loop).
+        if len(sleep_calls) >= 2:
+            runner._running = False
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        # Run sync function directly in-thread
+        return fn(*args, **kwargs)
+
+    import hermes_cli.kanban_db as _kb
+
+    with patch("hermes_cli.config.load_config", return_value=_fake_config(True)):
+        with patch.object(
+            _kb,
+            "list_boards",
+            side_effect=lambda *a, **kw: past_gate.append(True) or [],
+        ):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with patch("asyncio.to_thread", side_effect=fake_to_thread):
+                    asyncio.run(runner._kanban_notifier_watcher())
+
+    assert past_gate, "list_boards should be called when dispatch_in_gateway=true"

--- a/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
+++ b/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
@@ -9,15 +9,17 @@ Acceptance criteria covered:
 import asyncio
 from unittest.mock import MagicMock, patch
 
-import pytest
-
+from gateway.config import Platform
 from gateway.run import GatewayRunner
 
 
-def _make_runner():
+def _make_runner(with_adapter=False):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
-    runner.adapters = {}
+    if with_adapter:
+        runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    else:
+        runner.adapters = {}
     runner._kanban_sub_fail_counts = {}
     return runner
 
@@ -77,20 +79,20 @@ def test_notifier_watcher_runs_when_dispatch_enabled(monkeypatch, tmp_path):
     We verify it doesn't return early by checking that kanban_db.list_boards
     is called (the watcher fan-outs over boards after passing the gate).
     """
-    runner = _make_runner()
+    # Use a runner with an adapter so active_platforms is non-empty and
+    # _collect proceeds to the list_boards call.
+    runner = _make_runner(with_adapter=True)
     past_gate = []
     sleep_calls = []
 
     async def fake_sleep(delay):
         sleep_calls.append(delay)
-        # First sleep is the 5s initial delay; stop running so the loop exits cleanly
-        # without needing a second sleep, but we need to let _collect run first.
-        # We stop after the second sleep (the per-interval sleep inside the loop).
+        # Stop after the second sleep (initial delay + first per-interval sleep)
+        # so the loop body executes once then terminates.
         if len(sleep_calls) >= 2:
             runner._running = False
 
     async def fake_to_thread(fn, *args, **kwargs):
-        # Run sync function directly in-thread
         return fn(*args, **kwargs)
 
     import hermes_cli.kanban_db as _kb

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import sqlite3
+import stat
+import sys
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -27,6 +30,7 @@ def kanban_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # Schema / init
 # ---------------------------------------------------------------------------
+
 
 def test_init_db_is_idempotent(kanban_home):
     # Second call should not error or drop data.
@@ -128,8 +132,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
             row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")
         }
         event_columns = {
-            row["name"]
-            for row in migrated.execute("PRAGMA table_info(task_events)")
+            row["name"] for row in migrated.execute("PRAGMA table_info(task_events)")
         }
         indexes = {
             row["name"]
@@ -153,6 +156,7 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------
+
 
 def test_create_task_no_parents_is_ready(kanban_home):
     with kb.connect() as conn:
@@ -216,6 +220,7 @@ def test_branch_name_requires_worktree_workspace(kanban_home):
 # Links + dependency resolution
 # ---------------------------------------------------------------------------
 
+
 def test_link_demotes_ready_child_to_todo_when_parent_not_done(kanban_home):
     with kb.connect() as conn:
         a = kb.create_task(conn, title="a")
@@ -258,8 +263,11 @@ def test_recompute_ready_cascades_through_chain(kanban_home):
         a = kb.create_task(conn, title="a")
         b = kb.create_task(conn, title="b", parents=[a])
         c = kb.create_task(conn, title="c", parents=[b])
-        assert [kb.get_task(conn, x).status for x in (a, b, c)] == \
-               ["ready", "todo", "todo"]
+        assert [kb.get_task(conn, x).status for x in (a, b, c)] == [
+            "ready",
+            "todo",
+            "todo",
+        ]
         kb.complete_task(conn, a)
         assert kb.get_task(conn, b).status == "ready"
         kb.complete_task(conn, b)
@@ -271,7 +279,10 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         # Complete the parent
         kb.claim_task(conn, parent)
@@ -308,6 +319,7 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
 # ---------------------------------------------------------------------------
 # Atomic claim (CAS)
 # ---------------------------------------------------------------------------
+
 
 def test_claim_once_wins_second_loses(kanban_home):
     with kb.connect() as conn:
@@ -347,7 +359,10 @@ def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
         assert kb.claim_task(conn, t) is None
 
         events = kb.list_events(conn, t)
-        assert any(e.kind == "scheduled" and e.payload == {"reason": "run next week"} for e in events)
+        assert any(
+            e.kind == "scheduled" and e.payload == {"reason": "run next week"}
+            for e in events
+        )
 
 
 def test_unblock_scheduled_rechecks_parent_gate(kanban_home):
@@ -395,7 +410,8 @@ def test_stale_claim_reclaimed(kanban_home, monkeypatch):
 
 
 def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """A stale-by-TTL claim whose worker PID is still alive should be
     extended, not reclaimed (#23025). Slow models can spend longer than
@@ -419,7 +435,8 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         killed: list[int] = []
         reclaimed = kb.release_stale_claims(
-            conn, signal_fn=lambda _p, sig: killed.append(sig),
+            conn,
+            signal_fn=lambda _p, sig: killed.append(sig),
         )
         assert reclaimed == 0
         task = kb.get_task(conn, t)
@@ -429,8 +446,10 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
         assert killed == []  # live worker not killed
 
         kinds = [
-            r["kind"] for r in conn.execute(
-                "SELECT kind FROM task_events WHERE task_id = ?", (t,),
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?",
+                (t,),
             ).fetchall()
         ]
         assert "claim_extended" in kinds
@@ -438,7 +457,8 @@ def test_stale_claim_with_live_pid_extends_instead_of_reclaiming(
 
 
 def test_stale_claim_with_live_pid_uses_env_ttl_override(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     import hermes_cli.kanban_db as _kb
 
@@ -465,7 +485,8 @@ def test_stale_claim_with_live_pid_uses_env_ttl_override(
 
 
 def test_stale_claim_reclaim_event_records_diagnostic_payload(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """``reclaimed`` events should carry claim_expires, last_heartbeat_at,
     and worker_pid so operators can diagnose why a claim went stale
@@ -482,16 +503,14 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
         old_expires = int(time.time()) - 3600
         hb_at = int(time.time()) - 1800
         conn.execute(
-            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
-            "WHERE id = ?",
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? WHERE id = ?",
             (old_expires, hb_at, t),
         )
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
         row = conn.execute(
-            "SELECT payload FROM task_events "
-            "WHERE task_id = ? AND kind = 'reclaimed'",
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'reclaimed'",
             (t,),
         ).fetchone()
         assert row is not None
@@ -503,7 +522,8 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
 
 
 def test_detect_crashed_workers_systemic_failure_fast_block(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """When many tasks crash with the same error, trip the breaker faster."""
     import hermes_cli.kanban_db as _kb
@@ -534,7 +554,8 @@ def test_detect_crashed_workers_systemic_failure_fast_block(
 
 
 def test_detect_crashed_workers_isolated_failure_normal_retry(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """Below the systemic threshold, tasks retain normal retry budget."""
     import hermes_cli.kanban_db as _kb
@@ -577,7 +598,10 @@ def test_max_runtime_uses_current_run_start_after_retry(kanban_home, monkeypatch
     with kb.connect() as conn:
         host = kb._claimer_id().split(":", 1)[0]
         t = kb.create_task(
-            conn, title="retry", assignee="a", max_runtime_seconds=10,
+            conn,
+            title="retry",
+            assignee="a",
+            max_runtime_seconds=10,
         )
 
         kb.claim_task(conn, t, claimer=f"{host}:first")
@@ -661,6 +685,7 @@ def test_concurrent_claims_only_one_wins(kanban_home):
 # Complete / block / unblock / archive / assign
 # ---------------------------------------------------------------------------
 
+
 def test_complete_records_result(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x")
@@ -705,6 +730,7 @@ def test_unblock_resets_failure_counters(kanban_home):
 # Parent-completion invariant at the claim gate (RCA t_a6acd07d)
 # ---------------------------------------------------------------------------
 
+
 def test_claim_rejects_when_parents_not_done(kanban_home):
     """claim_task must refuse ready->running if any parent isn't 'done'.
 
@@ -716,14 +742,18 @@ def test_claim_rejects_when_parents_not_done(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         # Child correctly starts 'todo' because parent is not 'done'.
         assert kb.get_task(conn, child).status == "todo"
         # Simulate the race: a racy writer force-promotes the child to
         # 'ready' while parent is still pending.
         conn.execute(
-            "UPDATE tasks SET status='ready' WHERE id=?", (child,),
+            "UPDATE tasks SET status='ready' WHERE id=?",
+            (child,),
         )
         conn.commit()
         assert kb.get_task(conn, child).status == "ready"
@@ -734,8 +764,7 @@ def test_claim_rejects_when_parents_not_done(kanban_home):
     with kb.connect() as conn:
         assert kb.get_task(conn, child).status == "todo"
         events = conn.execute(
-            "SELECT kind, payload FROM task_events "
-            "WHERE task_id = ? ORDER BY id",
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
             (child,),
         ).fetchall()
     kinds = [e["kind"] for e in events]
@@ -749,7 +778,10 @@ def test_claim_succeeds_once_parents_done(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         kb.claim_task(conn, parent)
         assert kb.complete_task(conn, parent, result="ok")
@@ -765,7 +797,10 @@ def test_create_with_parents_stays_todo_until_parents_done(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         assert kb.get_task(conn, child).status == "todo"
         # Dispatcher tick between create and some later event must NOT
@@ -790,12 +825,16 @@ def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
-            conn, title="child", assignee="a", parents=[parent],
+            conn,
+            title="child",
+            assignee="a",
+            parents=[parent],
         )
         # Force child into 'blocked' regardless of parent progress
         # (simulates a worker that self-blocked, or an operator block).
         conn.execute(
-            "UPDATE tasks SET status='blocked' WHERE id=?", (child,),
+            "UPDATE tasks SET status='blocked' WHERE id=?",
+            (child,),
         )
         conn.commit()
         assert kb.unblock_task(conn, child)
@@ -874,11 +913,37 @@ def test_delete_archived_task_removes_related_rows(kanban_home):
 
         assert kb.delete_archived_task(conn, tid) is True
         assert kb.get_task(conn, tid) is None
-        assert conn.execute("SELECT COUNT(*) FROM task_links WHERE child_id = ? OR parent_id = ?", (tid, tid)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM task_comments WHERE task_id = ?", (tid,)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM task_events WHERE task_id = ?", (tid,)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
-        assert conn.execute("SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)).fetchone()[0] == 0
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_links WHERE child_id = ? OR parent_id = ?",
+                (tid, tid),
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_comments WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_events WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM task_runs WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (tid,)
+            ).fetchone()[0]
+            == 0
+        )
 
 
 def test_delete_archived_task_rejects_non_archived_rows(kanban_home):
@@ -920,6 +985,7 @@ def test_list_tasks_order_by(kanban_home):
         except ValueError as e:
             assert "order_by must be one of" in str(e)
 
+
 def test_delete_task_removes_task_and_cascades(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="to-delete", assignee="alice")
@@ -952,6 +1018,7 @@ def test_delete_task_cascades_links(kanban_home):
 # ---------------------------------------------------------------------------
 # Comments / events / worker context
 # ---------------------------------------------------------------------------
+
 
 def test_comments_recorded_in_order(kanban_home):
     with kb.connect() as conn:
@@ -999,6 +1066,7 @@ def test_worker_context_includes_parent_results_and_comments(kanban_home):
 # Dispatcher
 # ---------------------------------------------------------------------------
 
+
 def test_dispatch_dry_run_does_not_claim(kanban_home, all_assignees_spawnable):
     with kb.connect() as conn:
         t1 = kb.create_task(conn, title="a", assignee="alice")
@@ -1026,6 +1094,7 @@ def test_dispatch_skips_nonspawnable_into_separate_bucket(kanban_home, monkeypat
     the dedicated ``skipped_nonspawnable`` bucket so health telemetry
     can suppress false-positive "stuck" warnings."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         t = kb.create_task(conn, title="for-terminal", assignee="orion-cc")
@@ -1040,6 +1109,7 @@ def test_has_spawnable_ready_false_when_only_terminal_lanes(kanban_home, monkeyp
     assigned to a control-plane lane — used by gateway/CLI dispatchers
     to silence the stuck-warn while terminals still have queued work."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         kb.create_task(conn, title="t1", assignee="orion-cc")
@@ -1052,9 +1122,8 @@ def test_has_spawnable_ready_true_when_real_profile_present(kanban_home, monkeyp
     has an assignee that maps to a real Hermes profile — preserves the
     real "stuck" signal when a daily/agent task is queued."""
     from hermes_cli import profiles
-    monkeypatch.setattr(
-        profiles, "profile_exists", lambda name: name == "daily"
-    )
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "daily")
     with kb.connect() as conn:
         kb.create_task(conn, title="terminal-task", assignee="orion-cc")
         kb.create_task(conn, title="hermes-task", assignee="daily")
@@ -1167,6 +1236,7 @@ def test_dispatch_reclaims_stale_before_spawning(kanban_home):
 # Respawn guard (check_respawn_guard + dispatch_once integration)
 # ---------------------------------------------------------------------------
 
+
 def test_respawn_guard_none_on_fresh_task(kanban_home):
     """A fresh task with no failures or runs is not guarded."""
     with kb.connect() as conn:
@@ -1256,7 +1326,9 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
         kb.add_comment(
-            conn, t, "worker",
+            conn,
+            t,
+            "worker",
             "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
         )
         reason = kb.check_respawn_guard(conn, t)
@@ -1349,9 +1421,7 @@ def test_dispatch_respawn_guard_skips_recent_success(
         assert kb.get_task(conn, t).status == "ready"  # not blocked, just skipped
 
 
-def test_dispatch_respawn_guard_skips_active_pr(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_respawn_guard_skips_active_pr(kanban_home, all_assignees_spawnable):
     """dispatch_once skips (but does not block) a task with an active PR comment."""
     spawned_ids = []
 
@@ -1361,7 +1431,9 @@ def test_dispatch_respawn_guard_skips_active_pr(
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
         kb.add_comment(
-            conn, t, "worker",
+            conn,
+            t,
+            "worker",
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
         )
         res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
@@ -1391,9 +1463,7 @@ def test_dispatch_respawn_guard_dry_run_no_auto_block(
         assert kb.get_task(conn, t).status == "ready"  # dry_run: no writes
 
 
-def test_dispatch_respawn_guard_allows_clean_task(
-    kanban_home, all_assignees_spawnable
-):
+def test_dispatch_respawn_guard_allows_clean_task(kanban_home, all_assignees_spawnable):
     """A task with no guard triggers is spawned normally."""
     spawned_ids = []
 
@@ -1436,6 +1506,7 @@ def test_dispatch_respawn_guard_emits_event_for_skipped_task(
 # Workspace resolution
 # ---------------------------------------------------------------------------
 
+
 def test_scratch_workspace_created_under_hermes_home(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x")
@@ -1473,6 +1544,7 @@ def test_worktree_workspace_returns_intended_path(kanban_home, tmp_path):
 # ---------------------------------------------------------------------------
 # Scratch cleanup containment (#28818)
 # ---------------------------------------------------------------------------
+
 
 def test_cleanup_workspace_removes_managed_scratch_dir(kanban_home):
     """A scratch workspace under the kanban workspaces root is removed."""
@@ -1512,7 +1584,9 @@ def test_cleanup_workspace_refuses_path_outside_scratch_root(kanban_home, tmp_pa
         conn.commit()
         kb.complete_task(conn, t, result="ok")
 
-    assert real_source.exists(), "User source tree must not be deleted by scratch cleanup"
+    assert real_source.exists(), (
+        "User source tree must not be deleted by scratch cleanup"
+    )
     assert (real_source / ".git").exists()
     assert (real_source / "README.md").read_text(encoding="utf-8") == "important"
 
@@ -1549,7 +1623,9 @@ def test_cleanup_workspace_honors_workspaces_root_env_override(tmp_path, monkeyp
 
 def test_is_managed_scratch_path_accepts_per_board_workspaces(kanban_home, tmp_path):
     """Per-board scratch dirs under ``<kanban_home>/kanban/boards/<slug>/workspaces`` are managed."""
-    board_scratch = kanban_home / "kanban" / "boards" / "my-board" / "workspaces" / "task-1"
+    board_scratch = (
+        kanban_home / "kanban" / "boards" / "my-board" / "workspaces" / "task-1"
+    )
     board_scratch.mkdir(parents=True)
     assert kb._is_managed_scratch_path(board_scratch)
 
@@ -1605,6 +1681,7 @@ def test_is_managed_scratch_path_rejects_kanban_metadata_subtrees(kanban_home):
 # ---------------------------------------------------------------------------
 # Tenancy
 # ---------------------------------------------------------------------------
+
 
 def test_tenant_column_filters_listings(kanban_home):
     with kb.connect() as conn:
@@ -1671,11 +1748,10 @@ def test_tenant_propagates_to_events(kanban_home):
 # Originating session id (ACP propagation)
 # ---------------------------------------------------------------------------
 
+
 def test_create_task_stamps_session_id(kanban_home):
     with kb.connect() as conn:
-        tid = kb.create_task(
-            conn, title="from chat", session_id="acp-sess-123"
-        )
+        tid = kb.create_task(conn, title="from chat", session_id="acp-sess-123")
         t = kb.get_task(conn, tid)
     assert t is not None
     assert t.session_id == "acp-sess-123"
@@ -1710,8 +1786,7 @@ def test_session_id_index_exists(kanban_home):
     full-scan the tasks table."""
     with kb.connect() as conn:
         rows = conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='index' "
-            "AND tbl_name='tasks'"
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tasks'"
         ).fetchall()
     names = {r["name"] for r in rows}
     assert "idx_tasks_session_id" in names
@@ -1721,19 +1796,15 @@ def test_session_id_compose_with_tenant_filter(kanban_home):
     """A client may want both `tenant=scarf:foo` AND `session=acp-x` —
     the filters must AND, not replace."""
     with kb.connect() as conn:
+        kb.create_task(conn, title="match", tenant="scarf:foo", session_id="acp-x")
+        kb.create_task(conn, title="wrong-tenant", tenant="other", session_id="acp-x")
         kb.create_task(
-            conn, title="match", tenant="scarf:foo", session_id="acp-x"
+            conn,
+            title="wrong-session",
+            tenant="scarf:foo",
+            session_id="acp-y",
         )
-        kb.create_task(
-            conn, title="wrong-tenant", tenant="other", session_id="acp-x"
-        )
-        kb.create_task(
-            conn, title="wrong-session",
-            tenant="scarf:foo", session_id="acp-y",
-        )
-        rows = kb.list_tasks(
-            conn, tenant="scarf:foo", session_id="acp-x"
-        )
+        rows = kb.list_tasks(conn, tenant="scarf:foo", session_id="acp-x")
     assert [t.title for t in rows] == ["match"]
 
 
@@ -1747,6 +1818,7 @@ def test_session_id_compose_with_tenant_filter(kanban_home):
 # where `kanban_db_path()` resolved to the active profile's HERMES_HOME.
 # ---------------------------------------------------------------------------
 
+
 class TestSharedBoardPaths:
     """`kanban_home`/`kanban_db_path`/`workspaces_root`/`worker_log_path`
     must anchor at the **shared root**, not the active profile's HERMES_HOME."""
@@ -1756,9 +1828,7 @@ class TestSharedBoardPaths:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
 
-    def test_default_install_anchors_at_home_dot_hermes(
-        self, tmp_path, monkeypatch
-    ):
+    def test_default_install_anchors_at_home_dot_hermes(self, tmp_path, monkeypatch):
         # Standard install: HERMES_HOME == ~/.hermes, no profile active.
         default_home = tmp_path / ".hermes"
         default_home.mkdir()
@@ -1772,9 +1842,7 @@ class TestSharedBoardPaths:
             == default_home / "kanban" / "logs" / "t_demo.log"
         )
 
-    def test_profile_worker_resolves_to_shared_root(
-        self, tmp_path, monkeypatch
-    ):
+    def test_profile_worker_resolves_to_shared_root(self, tmp_path, monkeypatch):
         # Reproduces the bug: dispatcher uses ~/.hermes/kanban.db,
         # worker spawned with -p <profile> previously resolved to
         # ~/.hermes/profiles/<profile>/kanban.db. After the fix both
@@ -1799,9 +1867,7 @@ class TestSharedBoardPaths:
         # explicitly NOT what we resolve to anymore.
         assert kb.kanban_db_path() != profile_home / "kanban.db"
 
-    def test_dispatcher_and_profile_worker_converge(
-        self, tmp_path, monkeypatch
-    ):
+    def test_dispatcher_and_profile_worker_converge(self, tmp_path, monkeypatch):
         # End-to-end convergence: resolve the path under each side's
         # HERMES_HOME and confirm equality. This is the property the
         # dispatcher/worker handoff actually depends on.
@@ -1840,9 +1906,7 @@ class TestSharedBoardPaths:
         assert kb.kanban_home() == custom_root
         assert kb.kanban_db_path() == custom_root / "kanban.db"
 
-    def test_docker_profile_layout_uses_grandparent(
-        self, tmp_path, monkeypatch
-    ):
+    def test_docker_profile_layout_uses_grandparent(self, tmp_path, monkeypatch):
         # Docker profile shape: HERMES_HOME=/opt/hermes/profiles/coder;
         # `get_default_hermes_root()` walks up to /opt/hermes because
         # the immediate parent dir is named "profiles".
@@ -1854,9 +1918,7 @@ class TestSharedBoardPaths:
         assert kb.kanban_home() == custom_root
         assert kb.kanban_db_path() == custom_root / "kanban.db"
 
-    def test_explicit_override_via_hermes_kanban_home(
-        self, tmp_path, monkeypatch
-    ):
+    def test_explicit_override_via_hermes_kanban_home(self, tmp_path, monkeypatch):
         # Explicit override: HERMES_KANBAN_HOME beats every other
         # resolution rule.
         default_home = tmp_path / ".hermes"
@@ -1883,9 +1945,7 @@ class TestSharedBoardPaths:
 
         assert kb.kanban_home() == default_home
 
-    def test_dispatcher_and_worker_share_a_real_database(
-        self, tmp_path, monkeypatch
-    ):
+    def test_dispatcher_and_worker_share_a_real_database(self, tmp_path, monkeypatch):
         # Belt-and-suspenders: round-trip a task across the two
         # HERMES_HOME perspectives via a real SQLite file. Without the
         # fix the worker would open a different file and see no rows.
@@ -1907,9 +1967,7 @@ class TestSharedBoardPaths:
         assert task is not None
         assert task.title == "cross-profile"
 
-    def test_hermes_kanban_db_pin_beats_kanban_home(
-        self, tmp_path, monkeypatch
-    ):
+    def test_hermes_kanban_db_pin_beats_kanban_home(self, tmp_path, monkeypatch):
         # HERMES_KANBAN_DB pins the file path directly and beats both
         # HERMES_KANBAN_HOME and the `get_default_hermes_root()` path.
         # This is the env the dispatcher injects into workers.
@@ -1950,9 +2008,7 @@ class TestSharedBoardPaths:
         # kanban_db_path still follows HERMES_KANBAN_HOME.
         assert kb.kanban_db_path() == umbrella / "kanban.db"
 
-    def test_empty_per_path_overrides_fall_through(
-        self, tmp_path, monkeypatch
-    ):
+    def test_empty_per_path_overrides_fall_through(self, tmp_path, monkeypatch):
         # Empty/whitespace pins are treated as unset, same as
         # HERMES_KANBAN_HOME.
         default_home = tmp_path / ".hermes"
@@ -2018,6 +2074,7 @@ class TestSharedBoardPaths:
 # ---------------------------------------------------------------------------
 # latest_summary / latest_summaries — surface task_runs.summary handoffs
 # ---------------------------------------------------------------------------
+
 
 def test_latest_summary_returns_none_when_no_runs(kanban_home):
     """A freshly-created task has no runs and therefore no summary."""
@@ -2092,10 +2149,10 @@ def test_latest_summaries_batch_omits_tasks_without_summary(kanban_home):
         assert kb.latest_summaries(conn, []) == {}
 
 
-
 # ---------------------------------------------------------------------------
 # NFS / network-filesystem fallback (see hermes_state.apply_wal_with_fallback)
 # ---------------------------------------------------------------------------
+
 
 def test_connect_falls_back_to_delete_on_locking_protocol(kanban_home, caplog):
     """kanban_db.connect() must handle ``locking protocol`` on NFS/SMB.
@@ -2120,17 +2177,18 @@ def test_connect_falls_back_to_delete_on_locking_protocol(kanban_home, caplog):
             return super().execute(sql, *args, **kwargs)
 
     def wal_blocking_connect(*args, **kwargs):
-        return real_connect(
-            *args, factory=_WalBlockingConnection, **kwargs
-        )
+        return real_connect(*args, factory=_WalBlockingConnection, **kwargs)
 
-    with _patch("hermes_cli.kanban_db.sqlite3.connect", side_effect=wal_blocking_connect):
+    with _patch(
+        "hermes_cli.kanban_db.sqlite3.connect", side_effect=wal_blocking_connect
+    ):
         with caplog.at_level("WARNING", logger="hermes_state"):
             conn = kb.connect()
 
     # One fallback warning, naming kanban.db
     warnings = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if r.levelname == "WARNING" and "kanban.db" in r.getMessage()
     ]
     assert len(warnings) >= 1, (
@@ -2198,9 +2256,11 @@ def test_archive_task_triggers_recompute_ready_for_dependents(kanban_home):
             "parent is archived"
         )
 
+
 # ---------------------------------------------------------------------------
 # _add_column_if_missing / _migrate_add_optional_columns idempotency (#21708)
 # ---------------------------------------------------------------------------
+
 
 def test_add_column_if_missing_is_idempotent_on_race(kanban_home):
     """``_add_column_if_missing`` must swallow 'duplicate column name' errors.
@@ -2216,9 +2276,7 @@ def test_add_column_if_missing_is_idempotent_on_race(kanban_home):
 
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
-    conn.execute(
-        "CREATE TABLE tasks (id INTEGER PRIMARY KEY, title TEXT NOT NULL)"
-    )
+    conn.execute("CREATE TABLE tasks (id INTEGER PRIMARY KEY, title TEXT NOT NULL)")
 
     # First call adds the column — returns True.
     added = kb._add_column_if_missing(conn, "tasks", "extra_col", "extra_col TEXT")
@@ -2383,7 +2441,9 @@ def test_resolve_hermes_argv_hermes_bin_bare_name_ignores_cwd(monkeypatch, tmp_p
     assert kb._resolve_hermes_argv() == [sys.executable, "-m", "hermes_cli.main"]
 
 
-def test_resolve_hermes_argv_hermes_bin_bare_cmd_uses_module_fallback(monkeypatch, tmp_path):
+def test_resolve_hermes_argv_hermes_bin_bare_cmd_uses_module_fallback(
+    monkeypatch, tmp_path
+):
     """A PATH-resolved HERMES_BIN batch shim is not used as worker argv[0]."""
     import sys
     import hermes_cli.kanban_db as kb
@@ -2541,6 +2601,7 @@ def test_task_age_handles_corrupt_started_and_completed():
 def test_task_age_well_formed_task():
     """Regression: the safe-int path must not change behavior for normal data."""
     import time
+
     now = int(time.time())
     t = _make_task(
         created_at=now - 60,
@@ -2596,7 +2657,9 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_create_task_scratch_without_workspace_ignores_board_default_workdir(kanban_home, monkeypatch):
+def test_create_task_scratch_without_workspace_ignores_board_default_workdir(
+    kanban_home, monkeypatch
+):
     """Scratch tasks must NOT inherit board.default_workdir — would point auto-cleanup
     at the user's source tree on completion (#28818)."""
     default_wd = "/home/user/project"
@@ -2610,7 +2673,9 @@ def test_create_task_scratch_without_workspace_ignores_board_default_workdir(kan
     assert t.workspace_path is None
 
 
-def test_create_task_dir_without_workspace_inherits_board_default_workdir(kanban_home, monkeypatch):
+def test_create_task_dir_without_workspace_inherits_board_default_workdir(
+    kanban_home, monkeypatch
+):
     """Board default_workdir is for persistent dir/worktree workspaces, not scratch."""
     default_wd = "/home/user/project"
     kb.create_board("work-proj-dir", default_workdir=default_wd)
@@ -2644,7 +2709,9 @@ def test_create_task_with_explicit_workspace_ignores_board_default(kanban_home):
 
     explicit = "/my/explicit/path"
     with kb.connect(board="custom-ws-board") as conn:
-        tid = kb.create_task(conn, title="explicit", workspace_path=explicit, board="custom-ws-board")
+        tid = kb.create_task(
+            conn, title="explicit", workspace_path=explicit, board="custom-ws-board"
+        )
         t = kb.get_task(conn, tid)
     assert t is not None
     assert t.workspace_path == explicit
@@ -2656,7 +2723,9 @@ def test_create_task_with_explicit_workspace_ignores_board_default(kanban_home):
 # ---------------------------------------------------------------------------
 
 
-def test_dispatch_max_in_progress_skips_when_at_limit(kanban_home, all_assignees_spawnable):
+def test_dispatch_max_in_progress_skips_when_at_limit(
+    kanban_home, all_assignees_spawnable
+):
     """When max_in_progress=N and N tasks are already running, spawn nothing."""
     spawns = []
 
@@ -2677,7 +2746,9 @@ def test_dispatch_max_in_progress_skips_when_at_limit(kanban_home, all_assignees
     assert len(spawns) == 0, f"expected 0 spawns, got {len(spawns)}"
 
 
-def test_dispatch_max_in_progress_spawns_up_to_cap(kanban_home, all_assignees_spawnable):
+def test_dispatch_max_in_progress_spawns_up_to_cap(
+    kanban_home, all_assignees_spawnable
+):
     """When max_in_progress=3 and only 1 is running, spawn up to 2 more."""
     spawns = []
 
@@ -2697,7 +2768,9 @@ def test_dispatch_max_in_progress_spawns_up_to_cap(kanban_home, all_assignees_sp
     assert len(spawns) == 2, f"expected 2 spawns (cap 3 - 1 running), got {len(spawns)}"
 
 
-def test_dispatch_max_in_progress_none_is_unlimited(kanban_home, all_assignees_spawnable):
+def test_dispatch_max_in_progress_none_is_unlimited(
+    kanban_home, all_assignees_spawnable
+):
     """Default None means no limit — all ready tasks are spawned."""
     spawns = []
 
@@ -2710,6 +2783,7 @@ def test_dispatch_max_in_progress_none_is_unlimited(kanban_home, all_assignees_s
         kb.dispatch_once(conn, spawn_fn=fake_spawn, max_in_progress=None)
 
     assert len(spawns) == 4, f"expected 4 spawns (unlimited), got {len(spawns)}"
+
 
 # Review column dispatch
 # ---------------------------------------------------------------------------
@@ -2765,7 +2839,8 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
 
 
 def test_dispatch_review_spawns_with_correct_skills(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """Review tasks get sdlc-review skill set before spawning."""
     spawned_tasks = []
@@ -2794,7 +2869,8 @@ def test_dispatch_review_skips_unassigned(kanban_home):
 
 
 def test_dispatch_review_counts_toward_max_spawn(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """Review spawns count against max_spawn alongside ready tasks."""
     spawns = []
@@ -2816,7 +2892,8 @@ def test_dispatch_review_counts_toward_max_spawn(
 
 
 def test_dispatch_review_spawns_when_ready_empty(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """When only review tasks exist, they still get dispatched."""
     spawns = []
@@ -2849,10 +2926,12 @@ def test_has_spawnable_review_false_on_empty(kanban_home):
 
 
 def test_has_spawnable_review_false_when_only_terminal_lanes(
-    kanban_home, monkeypatch,
+    kanban_home,
+    monkeypatch,
 ):
     """has_spawnable_review returns False when review tasks are terminal lanes."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         t = kb.create_task(conn, title="review", assignee="orion-cc")
@@ -2863,6 +2942,7 @@ def test_has_spawnable_review_false_when_only_terminal_lanes(
 def test_dispatch_review_skips_nonspawnable(kanban_home, monkeypatch):
     """Review tasks with non-existent profiles go to skipped_nonspawnable."""
     from hermes_cli import profiles
+
     monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
     with kb.connect() as conn:
         t = kb.create_task(conn, title="review", assignee="orion-cc")
@@ -2878,7 +2958,8 @@ def test_review_status_in_valid_statuses():
 
 
 def test_dispatch_review_does_not_claim_ready_tasks(
-    kanban_home, all_assignees_spawnable,
+    kanban_home,
+    all_assignees_spawnable,
 ):
     """Review dispatch uses claim_review_task, which only claims review tasks."""
     with kb.connect() as conn:
@@ -2887,8 +2968,10 @@ def test_dispatch_review_does_not_claim_ready_tasks(
         claimed = kb.claim_review_task(conn, t)
     assert claimed is None
 
+
 # Stale detection — detect_stale_running
 # ---------------------------------------------------------------------------
+
 
 def test_detect_stale_returns_running_task_with_no_heartbeat(kanban_home, monkeypatch):
     """A task running > timeout with zero heartbeats gets reclaimed as stale."""
@@ -2915,7 +2998,9 @@ def test_detect_stale_returns_running_task_with_no_heartbeat(kanban_home, monkey
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         killed = []
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: killed.append(s),
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: killed.append(s),
         )
         assert t in stale, "Task with no heartbeat for >4h should be reclaimed"
         task = kb.get_task(conn, t)
@@ -2935,8 +3020,7 @@ def test_detect_stale_returns_task_with_stale_heartbeat(kanban_home, monkeypatch
         heartbeat_2h_ago = int(time.time()) - (2 * 3600)
         with kb.write_txn(conn):
             conn.execute(
-                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? "
-                "WHERE id = ?",
+                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? WHERE id = ?",
                 (five_hours_ago, heartbeat_2h_ago, t),
             )
             conn.execute(
@@ -2947,7 +3031,9 @@ def test_detect_stale_returns_task_with_stale_heartbeat(kanban_home, monkeypatch
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert t in stale, (
             "Task with heartbeat >1h old and started >4h ago should be stale"
@@ -2968,8 +3054,7 @@ def test_detect_stale_skips_task_with_recent_heartbeat(kanban_home, monkeypatch)
         heartbeat_now = int(time.time())  # heartbeat just happened
         with kb.write_txn(conn):
             conn.execute(
-                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? "
-                "WHERE id = ?",
+                "UPDATE tasks SET started_at = ?, last_heartbeat_at = ? WHERE id = ?",
                 (five_hours_ago, heartbeat_now, t),
             )
             conn.execute(
@@ -2980,7 +3065,9 @@ def test_detect_stale_skips_task_with_recent_heartbeat(kanban_home, monkeypatch)
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "Task with recent heartbeat should not be reclaimed"
         assert kb.get_task(conn, t).status == "running"
@@ -3009,7 +3096,9 @@ def test_detect_stale_skips_recently_started_task(kanban_home, monkeypatch):
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "Task started <4h ago should not be reclaimed"
         assert kb.get_task(conn, t).status == "running"
@@ -3036,7 +3125,9 @@ def test_detect_stale_skips_when_timeout_zero(kanban_home, monkeypatch):
             )
 
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=0, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=0,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "timeout=0 should disable stale detection"
         assert kb.get_task(conn, t).status == "running"
@@ -3066,7 +3157,9 @@ def test_detect_stale_skips_blocked_tasks(kanban_home, monkeypatch):
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert stale == [], "Blocked task should not be reclaimed by stale detection"
         assert kb.get_task(conn, t).status == "blocked"
@@ -3108,7 +3201,9 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
 
         monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
         stale = kb.detect_stale_running(
-            conn, stale_timeout_seconds=14400, signal_fn=lambda p, s: None,
+            conn,
+            stale_timeout_seconds=14400,
+            signal_fn=lambda p, s: None,
         )
         assert t in stale, "Task should be reclaimed by stale detection"
 
@@ -3129,14 +3224,13 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
             (t,),
         ).fetchall()
         kinds = [e["kind"] for e in events]
-        assert "stale" in kinds, (
-            f"Expected 'stale' event in task_events; got {kinds!r}"
-        )
+        assert "stale" in kinds, f"Expected 'stale' event in task_events; got {kinds!r}"
 
 
 # ---------------------------------------------------------------------------
 # Corruption guard (issue #30687)
 # ---------------------------------------------------------------------------
+
 
 def _write_corrupt_db(path: Path) -> bytes:
     """Write a kanban DB with a VALID SQLite header but malformed page content.
@@ -3239,6 +3333,7 @@ def test_init_db_allows_missing_then_healthy(tmp_path):
 # First-use tip for scratch workspaces
 # ---------------------------------------------------------------------------
 
+
 def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
     """First scratch workspace materialization warns + emits an event.
 
@@ -3264,7 +3359,8 @@ def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
 
     # Warning was logged exactly once.
     tip_records = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if "scratch workspaces are ephemeral" in r.getMessage()
     ]
     assert len(tip_records) == 1, (
@@ -3280,8 +3376,7 @@ def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
         ).fetchall()
     kinds = [e["kind"] for e in events]
     assert "tip_scratch_workspace" in kinds, (
-        f"Expected tip_scratch_workspace event on first scratch task; "
-        f"got {kinds!r}"
+        f"Expected tip_scratch_workspace event on first scratch task; got {kinds!r}"
     )
 
     # Second scratch materialization on the same install stays silent.
@@ -3290,7 +3385,8 @@ def test_maybe_emit_scratch_tip_fires_once_per_install(kanban_home, caplog):
         with kb.connect() as conn:
             kb._maybe_emit_scratch_tip(conn, t2, "scratch")
     tip_records2 = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if "scratch workspaces are ephemeral" in r.getMessage()
     ]
     assert tip_records2 == [], (
@@ -3328,14 +3424,121 @@ def test_maybe_emit_scratch_tip_skips_non_scratch_workspaces(kanban_home, caplog
     # for a real scratch user.
     assert not kb._scratch_tip_shown()
     tip_records = [
-        r for r in caplog.records
+        r
+        for r in caplog.records
         if "scratch workspaces are ephemeral" in r.getMessage()
     ]
     assert tip_records == []
     with kb.connect() as conn:
         for tid in (t_wt, t_dir):
             events = conn.execute(
-                "SELECT kind FROM task_events WHERE task_id = ?", (tid,),
+                "SELECT kind FROM task_events WHERE task_id = ?",
+                (tid,),
             ).fetchall()
             assert "tip_scratch_workspace" not in [e["kind"] for e in events]
 
+
+# ---------------------------------------------------------------------------
+# write_txn flock serialization
+# ---------------------------------------------------------------------------
+
+
+def test_write_txn_flock_serializes_concurrent_writers(kanban_home):
+    """5 concurrent threads each INSERT one row via write_txn; all 5 must succeed."""
+    conn_main = kb.connect()
+    conn_main.execute(
+        "CREATE TABLE IF NOT EXISTS _flock_test (id INTEGER PRIMARY KEY AUTOINCREMENT)"
+    )
+    conn_main.commit()
+    conn_main.close()
+
+    def _insert_one():
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                conn.execute("INSERT INTO _flock_test DEFAULT VALUES")
+            return True
+        finally:
+            conn.close()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(_insert_one) for _ in range(5)]
+        results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+    assert all(results)
+
+    conn = kb.connect()
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM _flock_test").fetchone()[0]
+    finally:
+        conn.close()
+
+    assert count == 5
+
+
+def test_write_txn_flock_disabled_on_memory_db(tmp_path):
+    """write_txn on :memory: must not create a kanban.write.lock file."""
+    conn = sqlite3.connect(":memory:", isolation_level=None)
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    try:
+        with kb.write_txn(conn):
+            conn.execute("INSERT INTO t VALUES (1)")
+    finally:
+        conn.close()
+
+    lock_files = list(tmp_path.glob("kanban.write.lock"))
+    assert lock_files == []
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="chmod read-only unreliable on Windows"
+)
+def test_write_txn_flock_graceful_on_readonly_dir(tmp_path, monkeypatch):
+    """write_txn doesn't raise when the board dir is read-only (flock degrades gracefully)."""
+    ro_dir = tmp_path / "readonly_board"
+    ro_dir.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(ro_dir / "kanban.db"))
+
+    conn = sqlite3.connect(str(ro_dir / "kanban.db"), isolation_level=None)
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.close()
+
+    original_mode = ro_dir.stat().st_mode
+    try:
+        ro_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+        conn = sqlite3.connect(str(ro_dir / "kanban.db"), isolation_level=None)
+        try:
+            with kb.write_txn(conn):
+                pass
+        finally:
+            conn.close()
+    finally:
+        ro_dir.chmod(original_mode)
+
+
+def test_write_txn_windows_skip(kanban_home):
+    """On 'win32', write_txn skips flock and the transaction still succeeds."""
+    import fcntl as _fcntl_mod
+
+    flock_called = []
+    real_flock = _fcntl_mod.flock
+
+    def tracking_flock(fd, op):
+        flock_called.append(op)
+        return real_flock(fd, op)
+
+    with (
+        patch("sys.platform", "win32"),
+        patch.object(_fcntl_mod, "flock", side_effect=tracking_flock),
+    ):
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                conn.execute("SELECT 1")
+        finally:
+            conn.close()
+
+    assert flock_called == [], f"Expected no flock calls on win32, got {flock_called}"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3493,26 +3493,42 @@ def test_write_txn_flock_disabled_on_memory_db(tmp_path):
 @pytest.mark.skipif(
     sys.platform == "win32", reason="chmod read-only unreliable on Windows"
 )
-def test_write_txn_flock_graceful_on_readonly_dir(tmp_path, monkeypatch):
-    """write_txn doesn't raise when the board dir is read-only (flock degrades gracefully)."""
-    ro_dir = tmp_path / "readonly_board"
-    ro_dir.mkdir()
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
-    monkeypatch.setenv("HERMES_KANBAN_DB", str(ro_dir / "kanban.db"))
+def test_write_txn_flock_graceful_on_readonly_lock_dir(tmp_path, monkeypatch):
+    """write_txn degrades gracefully when the lock file directory is read-only.
 
-    conn = sqlite3.connect(str(ro_dir / "kanban.db"), isolation_level=None)
-    conn.execute("CREATE TABLE t (x INTEGER)")
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.close()
+    The DB itself is writable; only the directory where kanban.write.lock
+    would be created is read-only.  The flock is skipped and the transaction
+    still succeeds.
+    """
+    ro_dir = tmp_path / "readonly_lock_dir"
+    ro_dir.mkdir()
+
+    # DB lives in a writable location; we trick PRAGMA database_list into
+    # returning a path inside the read-only dir so write_txn tries to create
+    # the lock there, gets OSError, and gracefully degrades.
+    db_file = tmp_path / "writable.db"
+    conn_setup = sqlite3.connect(str(db_file), isolation_level=None)
+    conn_setup.execute("CREATE TABLE t (x INTEGER)")
+    conn_setup.execute("PRAGMA journal_mode=WAL")
+    conn_setup.close()
 
     original_mode = ro_dir.stat().st_mode
     try:
         ro_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
 
-        conn = sqlite3.connect(str(ro_dir / "kanban.db"), isolation_level=None)
+        class _RoDirConn(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):
+                if sql.strip().upper() == "PRAGMA database_list":
+                    class _Cursor:
+                        def fetchone(self_):
+                            return (0, "main", str(ro_dir / "kanban.db"))
+                    return _Cursor()
+                return super().execute(sql, *args, **kwargs)
+
+        conn = sqlite3.connect(str(db_file), factory=_RoDirConn, isolation_level=None)
         try:
             with kb.write_txn(conn):
-                pass
+                conn.execute("INSERT INTO t VALUES (42)")
         finally:
             conn.close()
     finally:

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -13,7 +13,11 @@ See: https://www.sqlite.org/wal.html — "WAL does not work over a network
 filesystem".
 """
 
+import concurrent.futures
+import os
 import sqlite3
+import stat
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -142,16 +146,15 @@ class TestApplyWalWithFallback:
         with caplog.at_level("WARNING", logger="hermes_state"):
             # Three separate connections to "the same DB" via the same label
             for i in range(3):
-                conn, _ = _open_blocking(
-                    tmp_path / f"dup-{i}.db", isolation_level=None
-                )
+                conn, _ = _open_blocking(tmp_path / f"dup-{i}.db", isolation_level=None)
                 mode = apply_wal_with_fallback(conn, db_label="shared.db")
                 assert mode == "delete"
                 conn.close()
 
         # Exactly one warning across all three calls
         warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelname == "WARNING" and "shared.db" in r.getMessage()
         ]
         assert len(warnings) == 1, (
@@ -172,7 +175,9 @@ class TestApplyWalWithFallback:
 
         warnings = [r for r in caplog.records if r.levelname == "WARNING"]
         labels_warned = {
-            lbl for r in warnings for lbl in ("state.db", "kanban.db")
+            lbl
+            for r in warnings
+            for lbl in ("state.db", "kanban.db")
             if lbl in r.getMessage()
         }
         assert labels_warned == {"state.db", "kanban.db"}, (
@@ -233,7 +238,9 @@ class TestGetLastInitError:
                 return super().execute(sql, *args, **kwargs)
 
         def gated_connect(*args, **kwargs):
-            return real_connect(str(target), factory=_BothPragmasFailConnection, **kwargs)
+            return real_connect(
+                str(target), factory=_BothPragmasFailConnection, **kwargs
+            )
 
         with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
             with pytest.raises(sqlite3.OperationalError):
@@ -303,3 +310,86 @@ class TestSessionDbUsesWalFallback:
             assert get_last_init_error() is None
         finally:
             db.close()
+
+
+class TestWalInitFlock:
+    def test_wal_init_flock_serializes_concurrent_callers(self, tmp_path):
+        """5 threads calling apply_wal_with_fallback concurrently all complete cleanly."""
+        db_file = tmp_path / "concurrent.db"
+
+        def _open_and_init():
+            conn = sqlite3.connect(str(db_file), isolation_level=None)
+            try:
+                apply_wal_with_fallback(
+                    conn, db_label="concurrent.db", db_path=str(db_file)
+                )
+                return True
+            finally:
+                conn.close()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(_open_and_init) for _ in range(5)]
+            results = [f.result() for f in concurrent.futures.as_completed(futures)]
+
+        assert all(results)
+
+        conn = sqlite3.connect(str(db_file), isolation_level=None)
+        try:
+            row = conn.execute("PRAGMA integrity_check").fetchone()
+            assert row[0] == "ok"
+            mode_row = conn.execute("PRAGMA journal_mode").fetchone()
+            assert mode_row[0].lower() == "wal"
+        finally:
+            conn.close()
+
+    def test_wal_init_flock_disabled_by_env(self, tmp_path, monkeypatch):
+        """HERMES_WAL_INIT_FLOCK_DISABLE=1 prevents creation of .wal-init.lock file."""
+        db_file = tmp_path / "no-lock.db"
+        monkeypatch.setenv("HERMES_WAL_INIT_FLOCK_DISABLE", "1")
+
+        conn = sqlite3.connect(str(db_file), isolation_level=None)
+        try:
+            apply_wal_with_fallback(conn, db_label="no-lock.db", db_path=str(db_file))
+        finally:
+            conn.close()
+
+        lock_file = tmp_path / "no-lock.db.wal-init.lock"
+        assert not lock_file.exists()
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="chmod read-only unreliable on Windows"
+    )
+    def test_wal_init_flock_graceful_on_readonly_dir(self, tmp_path):
+        """apply_wal_with_fallback doesn't raise when lock file dir is read-only."""
+        ro_dir = tmp_path / "readonly"
+        ro_dir.mkdir()
+        db_file = ro_dir / "test.db"
+
+        conn = sqlite3.connect(str(db_file), isolation_level=None)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.close()
+
+        original_mode = ro_dir.stat().st_mode
+        try:
+            ro_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+
+            conn = sqlite3.connect(str(db_file), isolation_level=None)
+            try:
+                apply_wal_with_fallback(
+                    conn, db_label="readonly.db", db_path=str(db_file)
+                )
+            finally:
+                conn.close()
+        finally:
+            ro_dir.chmod(original_mode)
+
+    def test_wal_init_flock_not_created_for_memory_db(self, tmp_path):
+        """No .wal-init.lock file is created for :memory: connections."""
+        conn = sqlite3.connect(":memory:", isolation_level=None)
+        try:
+            apply_wal_with_fallback(conn, db_label="memory.db", db_path=":memory:")
+        finally:
+            conn.close()
+
+        lock_files = list(tmp_path.glob("*.wal-init.lock"))
+        assert lock_files == []

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -359,25 +359,30 @@ class TestWalInitFlock:
     @pytest.mark.skipif(
         sys.platform == "win32", reason="chmod read-only unreliable on Windows"
     )
-    def test_wal_init_flock_graceful_on_readonly_dir(self, tmp_path):
-        """apply_wal_with_fallback doesn't raise when lock file dir is read-only."""
+    def test_wal_init_flock_graceful_on_readonly_lock_dir(self, tmp_path):
+        """apply_wal_with_fallback degrades gracefully when the lock file dir is read-only.
+
+        The DB itself is writable so WAL succeeds; the lock file path is inside
+        a read-only directory so open() raises OSError. The flock path must be
+        skipped without propagating the error.
+        """
+        db_file = tmp_path / "ok.db"
         ro_dir = tmp_path / "readonly"
         ro_dir.mkdir()
-        db_file = ro_dir / "test.db"
-
-        conn = sqlite3.connect(str(db_file), isolation_level=None)
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.close()
 
         original_mode = ro_dir.stat().st_mode
         try:
             ro_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
 
+            # db_path points into the read-only dir so lock file creation fails,
+            # but the connection is on a writable db_file.
+            fake_db_path = str(ro_dir / "kanban.db")
             conn = sqlite3.connect(str(db_file), isolation_level=None)
             try:
-                apply_wal_with_fallback(
-                    conn, db_label="readonly.db", db_path=str(db_file)
+                mode = apply_wal_with_fallback(
+                    conn, db_label="readonly-lock.db", db_path=fake_db_path
                 )
+                assert mode == "wal"
             finally:
                 conn.close()
         finally:


### PR DESCRIPTION
## What does this PR do?

Fixes concurrent shared-memory (shm) contention on per-board kanban DBs caused by multiple gateway processes running the notifier watcher simultaneously. The notifier watcher is now gated behind `kanban.dispatch_in_gateway` (same pattern as the dispatcher), ensuring only the dispatch-owning gateway opens per-board DB connections. Adds defense-in-depth via file-locking (`fcntl.flock`) around WAL initialization and IMMEDIATE transactions to prevent corruption under kernel EIO events and lock-file contention.

## Related Issue

Coordinates with #25660 (multi-agent single-gateway refactor).
Related: #31158 (WAL/SHM cache poisoning symptom).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests
- [ ] Refactor

## Changes Made

1. **gateway/run.py**: Gate `_kanban_notifier_watcher` method on `kanban.dispatch_in_gateway` config flag (matching the dispatcher pattern).
2. **hermes_state.py**: Add exclusive file-locking (`fcntl.flock`) around `PRAGMA journal_mode=WAL` in `apply_wal_with_fallback` to serialize WAL init across processes. Disabled on Windows and for `:memory:` DBs.
3. **hermes_cli/kanban_db.py**: Add exclusive file-locking around `BEGIN IMMEDIATE` in `write_txn` to serialize write transactions at board level. Disabled on Windows.
4. **New tests**: `test_kanban_notifier_watcher_dispatch_gate.py` (notifier gate behavior), `test_kanban_db.py` (write_txn flock behavior), `test_hermes_state_wal_fallback.py` (WAL init flock under concurrent load).
5. **docs/kanban/multi-gateway.md**: Architecture documentation clarifying single-dispatcher and single-notifier-reader posture.
6. **scripts/release.py**: AUTHOR_MAP entry for contributor.

## How to Test

1. **Notifier gate**: Spin up a gateway with `dispatch_in_gateway: false`; after 60s, verify `lsof` shows 0 kanban.db handles (notifier exits early, never connects).
2. **Notifier normal operation**: Spin up a gateway with `dispatch_in_gateway: true` (default); verify existing notifier tests pass and subscriptions deliver end-to-end.
3. **Write lock serialization**: Run `test_write_txn_flock_serializes_concurrent_writers` — 5 threads issue concurrent writes; all complete without SQLITE_BUSY.
4. **WAL lock serialization**: Run `test_wal_init_flock_serializes_concurrent_callers` — 5 threads call `apply_wal_with_fallback` on same DB; final DB integrity is OK.
5. **Graceful degradation**: Run `test_wal_init_flock_graceful_on_readonly_dir` and `test_write_txn_flock_graceful_on_readonly_dir` — operations log warnings but don't crash on non-writable lock-file paths.
6. **Full suite**: `scripts/run_tests.sh` passes (CI-hermetic, 4 xdist workers), `ruff check . && ruff format --check .` clean.

## Checklist
- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] No duplicate PRs (refreshed prior-art search at packaging time; no new overlaps found)
- [x] pytest tests/ -q passes (verified by chain)
- [x] Added tests for changes (11 new tests added)
- [x] Updated docs/config as needed (docs/kanban/multi-gateway.md created)

---

**Author:** steveonjava  
**AUTHOR_MAP status:** `steve@steveonjava.com` → `steveonjava` added per contributor-check requirement.
