### PR TITLE
fix(core): forward session_id to dispatcher and allow overriding python version in setup

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -837,12 +837,14 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 enabled_tools=sandbox_enabled,
+                session_id=session_id,
             )
         else:
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                session_id=session_id,
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -33,7 +33,7 @@ cd "$SCRIPT_DIR"
 # wrong user's home directory when running under sudo -u <user>.  See #21269.
 export UV_NO_CONFIG=1
 
-PYTHON_VERSION="3.11"
+PYTHON_VERSION="${PYTHON_VERSION:-3.11}"
 
 is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]


### PR DESCRIPTION
## Summary
- **Forward active session_id**: In `model_tools.py`, pass `session_id=session_id` to both standard and code-sandbox tool dispatches in `handle_function_call`. This ensures plugins like `hermes-flamepy` (`flmexec`) can retrieve the session ID directly from the active tool invocation context.
- **Python version override in setup**: In `setup-hermes.sh`, change `PYTHON_VERSION` to check if a custom version is already set in the environment (`PYTHON_VERSION="\${PYTHON_VERSION:-3.11}"`). This is extremely helpful for setups requiring non-standard python major/minor versions.

## Test Plan
- Sourced the local environment and ran execution commands on the Flame cluster.
- Verified that `session_id` is successfully received by `flmexec` and no longer throws missing session ID errors.
- Verified that `setup-hermes.sh` correctly executes with custom Python versions.