### PR TITLE
fix(core): forward session_id to dispatcher in handle_function_call

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -837,12 +837,14 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 enabled_tools=sandbox_enabled,
+                session_id=session_id,
             )
         else:
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                session_id=session_id,
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 


### PR DESCRIPTION
## Summary
- **Forward active session_id**: In `model_tools.py`, pass `session_id=session_id` to both standard and code-sandbox tool dispatches in `handle_function_call`. This ensures plugins like `hermes-flamepy` (`flmexec`) can retrieve the session ID directly from the active tool invocation context.

## Test Plan
- Sourced the local environment and ran execution commands on the Flame cluster.
- Verified that `session_id` is successfully received by `flmexec` and no longer throws missing session ID errors.