### PR TITLE
fix(ci): add time.sleep(1.0) yield to prevent ASGI TestClient broadcast race

### DIFF
--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2341,6 +2341,7 @@ class TestPtyWebSocket:
                 # receive_text().  Without this, under heavy CI load the
                 # receive can race the broadcast and hang until
                 # pytest-timeout kills us.
+                time.sleep(1.0)
                 import queue, threading
                 recv_q: queue.Queue = queue.Queue()
 
@@ -2353,10 +2354,10 @@ class TestPtyWebSocket:
                 t = threading.Thread(target=_recv, daemon=True)
                 t.start()
                 try:
-                    received = recv_q.get(timeout=10.0)
+                    received = recv_q.get(timeout=30.0)
                 except queue.Empty:
                     raise AssertionError(
-                        "broadcast not received within 10s — server likely "
+                        "broadcast not received within 30s — server likely "
                         "dropped the frame silently (see _broadcast_event "
                         "except Exception: pass)"
                     )


### PR DESCRIPTION
## What

Fix flaky test `test_pub_broadcasts_to_events_subscribers` — ASGI TestClient race condition.

## Root Cause

Comment-code desync (Pitfall #12): lines 2337-2343 describe the need for a yield to the ASGI background thread after `pub.send_text()`, but the actual `time.sleep()` was never written. Under CI load, the main thread enters `recv_q.get()` before the ASGI background thread processes the frame via `_broadcast_event`, causing the test to hang until killed by pytest-timeout.

## Fix

- Add `time.sleep(1.0)` after `pub.send_text()` to yield CPU to the ASGI thread
- Increase `recv_q.get()` timeout from 10s → 30s for CI load headroom

## CI Failure

https://github.com/NousResearch/hermes-agent/actions/runs/26386399780
Branch: `fix/agent-402-billing-retry-loop-31273` (branch deleted; bug confirmed on main)

## Flake Reproduction

```
FAILED tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_pub_broadcasts_to_events_subscribers
AssertionError: broadcast not received within 10s — server likely dropped the frame silently
```