### PR TITLE
docs(signal): document Java 25, ACI UUID allowlist, 409 recovery, bbernhard warning

### DIFF
--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -19,8 +19,35 @@ The Signal adapter uses `httpx` (already a core Hermes dependency) for all commu
 ## Prerequisites
 
 - **signal-cli** — Java-based Signal client ([GitHub](https://github.com/AsamK/signal-cli))
-- **Java 17+** runtime — required by signal-cli
+- **Java 25+** runtime — required by signal-cli 0.14.x (see [Java version](#java-version) below)
 - **A phone number** with Signal installed (for linking as a secondary device)
+
+:::danger Do not use `bbernhard/signal-cli-rest-api`
+Most third-party Signal-on-Docker tutorials point at [`bbernhard/signal-cli-rest-api`](https://github.com/bbernhard/signal-cli-rest-api), which exposes `/v1/about`, `/v2/send`, `/v1/health`, etc. Hermes speaks to signal-cli's **native** daemon (`/api/v1/check`, `/api/v1/events` SSE, `/api/v1/rpc`) — the JSON-RPC body and SSE event schemas differ, so messages never deliver even when the health check looks green (symptom: `Signal SSE: connected` repeating every ~2 s in `gateway.log`). Install upstream `signal-cli` directly using the steps below.
+:::
+
+### Java version
+
+Signal's servers reject all pre-0.14 clients (`StatusCode: 499 DeprecatedVersionException`), so signal-cli 0.14.x is the only supported line. 0.14.x is compiled with class-file version 69 and **requires Java 25 or newer** — running it on `openjdk-21-jre-headless` (Debian's current default) fails with:
+
+```
+UnsupportedClassVersionError: org/asamk/signal/Main has been compiled by a more recent
+version of the Java Runtime (class file version 69.0), this version of the Java Runtime
+only recognizes class file versions up to 65.0
+```
+
+Recipe for pinning Adoptium Temurin 25 (works on Debian/Ubuntu, including WSL2):
+
+```bash
+sudo mkdir -p /opt/java
+curl -fsSL "https://api.adoptium.net/v3/binary/latest/25/ga/linux/x64/jre/hotspot/normal/eclipse?project=jdk" \
+  | sudo tar xz -C /opt/java
+sudo ln -sf /opt/java/jdk-25* /opt/java/current
+export JAVA_HOME=/opt/java/current
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+If you run signal-cli under systemd, also pin `Environment=JAVA_HOME=/opt/java/current` in the unit file so the daemon does not fall back to the system JRE.
 
 ### Installing signal-cli
 
@@ -103,8 +130,8 @@ Add to `~/.hermes/.env`:
 SIGNAL_HTTP_URL=http://127.0.0.1:8080
 SIGNAL_ACCOUNT=+1234567890
 
-# Security (recommended)
-SIGNAL_ALLOWED_USERS=+1234567890,+0987654321    # Comma-separated E.164 numbers or UUIDs
+# Security (recommended) — see "Allowlist with Phone Number Privacy" below
+SIGNAL_ALLOWED_USERS=+1234567890,+0987654321    # Comma-separated E.164 numbers or ACI UUIDs
 
 # Optional
 SIGNAL_GROUP_ALLOWED_USERS=groupId1,groupId2     # Enable groups (omit to disable, * for all)
@@ -130,6 +157,22 @@ DM access follows the same pattern as all other Hermes platforms:
 1. **`SIGNAL_ALLOWED_USERS` set** → only those users can message
 2. **No allowlist set** → unknown users get a DM pairing code (approve via `hermes pairing approve signal CODE`)
 3. **`SIGNAL_ALLOW_ALL_USERS=true`** → anyone can message (use with caution)
+
+### Allowlist with Phone Number Privacy
+
+Signal has enabled [Phone Number Privacy](https://signal.org/blog/phone-number-privacy-usernames/) by default since 2023. With it on, inbound messages arrive with the sender's **ACI UUID** rather than their E.164 phone number, so an allowlist that only lists phone numbers will silently reject every real DM:
+
+```
+WARNING gateway.run: Unauthorized user: 00000000-aaaa-bbbb-cccc-000000000000 (DisplayName) on signal
+```
+
+The adapter compares the inbound identifier literally against `SIGNAL_ALLOWED_USERS`, so the fix is to put **both** identifiers in the list:
+
+```bash
+SIGNAL_ALLOWED_USERS=+15551234567,00000000-aaaa-bbbb-cccc-000000000000
+```
+
+The UUID for any user is logged in the `Unauthorized user:` warning the first time they message you — copy it from there into `SIGNAL_ALLOWED_USERS` and restart the gateway. The phone number form is still required for outbound delivery targets such as `SIGNAL_HOME_CHANNEL`.
 
 ### Group Access
 
@@ -217,12 +260,28 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | Problem | Solution |
 |---------|----------|
 | **"Cannot reach signal-cli"** during setup | Ensure signal-cli daemon is running: `signal-cli --account +YOUR_NUMBER daemon --http 127.0.0.1:8080` |
-| **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's number in E.164 format (with `+` prefix) |
-| **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH, or use Docker |
-| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. |
+| **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's **ACI UUID** (see [Allowlist with Phone Number Privacy](#allowlist-with-phone-number-privacy)) — phone-number-only allowlists silently reject real DMs |
+| **`UnsupportedClassVersionError: ... class file version 69.0`** | signal-cli 0.14.x requires Java 25+; see [Java version](#java-version) — `openjdk-21-jre-headless` is too old |
+| **`Verify error: StatusCode: 499 DeprecatedVersionException`** | signal-cli &lt; 0.14 is server-rejected — upgrade to 0.14.x and pin Java 25+ |
+| **`Signal SSE: connected` repeating every ~2 s with no messages delivering** | You are pointed at `bbernhard/signal-cli-rest-api` instead of the native daemon. Switch to upstream `signal-cli --http` (see warning under [Prerequisites](#prerequisites)). |
+| **`signal-cli register` returns 409 `AlreadyVerifiedException`** | See [Recovering from a stuck registration](#recovering-from-a-stuck-registration) below — `--reregister` and `verify` cannot fix this on their own |
+| **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH (third-party Docker wrappers are not compatible — see warning under [Prerequisites](#prerequisites)) |
+| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 25+ is installed. |
 | **Group messages ignored** | Configure `SIGNAL_GROUP_ALLOWED_USERS` with specific group IDs, or `*` to allow all groups. |
 | **Bot responds to no one** | Configure `SIGNAL_ALLOWED_USERS`, use DM pairing, or explicitly allow all users through gateway policy if you want broader access. |
 | **Duplicate messages** | Ensure only one signal-cli instance is listening on your phone number |
+
+### Recovering from a stuck registration
+
+A `409 AlreadyVerifiedException` from `signal-cli register` means Signal's server already has the number in a verified-but-uninitialized state — typically from a previous interrupted captcha/verify flow, or from a prior install via a third-party REST wrapper. From `signal-cli` alone this is unrecoverable: `--reregister` hits the same endpoint and returns the same 409, and `signal-cli verify <code>` returns `No registration verification session active`.
+
+Confirmed working recovery:
+
+1. Put the SIM in a phone, install the **Signal mobile app**, and complete a normal registration as the primary device.
+2. In the app, go to **Settings → Account → Delete Account** to clear the server-side registration state.
+3. Re-run `signal-cli register --captcha "<captcha>"` — it now succeeds.
+
+This is the only reliable path; advice to "wait 24 h" or "try a different number" is unreliable and the session lifetime is undocumented.
 
 ---
 
@@ -246,7 +305,7 @@ The adapter monitors the SSE connection and automatically reconnects if:
 |----------|----------|---------|-------------|
 | `SIGNAL_HTTP_URL` | Yes | — | signal-cli HTTP endpoint |
 | `SIGNAL_ACCOUNT` | Yes | — | Bot phone number (E.164) |
-| `SIGNAL_ALLOWED_USERS` | No | — | Comma-separated phone numbers/UUIDs |
+| `SIGNAL_ALLOWED_USERS` | No | — | Comma-separated E.164 numbers and/or ACI UUIDs (UUIDs required to match real DMs under Phone Number Privacy — see [allowlist guidance](#allowlist-with-phone-number-privacy)) |
 | `SIGNAL_GROUP_ALLOWED_USERS` | No | — | Group IDs to monitor, or `*` for all (omit to disable groups) |
 | `SIGNAL_ALLOW_ALL_USERS` | No | `false` | Allow any user to interact (skip allowlist) |
 | `SIGNAL_HOME_CHANNEL` | No | — | Default delivery target for cron jobs |

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -36,13 +36,13 @@ version of the Java Runtime (class file version 69.0), this version of the Java 
 only recognizes class file versions up to 65.0
 ```
 
-Recipe for pinning Adoptium Temurin 25 (works on Debian/Ubuntu, including WSL2):
+Recipe for pinning Adoptium Temurin 25 (works on Debian/Ubuntu, including WSL2). signal-cli only needs a JRE; Adoptium ships the JRE under a directory named `jdk-25.<patch>+<build>-jre`, which the symlink glob below matches:
 
 ```bash
 sudo mkdir -p /opt/java
-curl -fsSL "https://api.adoptium.net/v3/binary/latest/25/ga/linux/x64/jre/hotspot/normal/eclipse?project=jdk" \
+curl -fsSL "https://api.adoptium.net/v3/binary/latest/25/ga/linux/x64/jre/hotspot/normal/eclipse" \
   | sudo tar xz -C /opt/java
-sudo ln -sf /opt/java/jdk-25* /opt/java/current
+sudo ln -sf /opt/java/jdk-25*-jre /opt/java/current
 export JAVA_HOME=/opt/java/current
 export PATH="$JAVA_HOME/bin:$PATH"
 ```
@@ -262,7 +262,7 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | **"Cannot reach signal-cli"** during setup | Ensure signal-cli daemon is running: `signal-cli --account +YOUR_NUMBER daemon --http 127.0.0.1:8080` |
 | **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's **ACI UUID** (see [Allowlist with Phone Number Privacy](#allowlist-with-phone-number-privacy)) — phone-number-only allowlists silently reject real DMs |
 | **`UnsupportedClassVersionError: ... class file version 69.0`** | signal-cli 0.14.x requires Java 25+; see [Java version](#java-version) — `openjdk-21-jre-headless` is too old |
-| **`Verify error: StatusCode: 499 DeprecatedVersionException`** | signal-cli &lt; 0.14 is server-rejected — upgrade to 0.14.x and pin Java 25+ |
+| **`Verify error: StatusCode: 499 DeprecatedVersionException`** | `signal-cli < 0.14` is server-rejected — upgrade to 0.14.x and pin Java 25+ |
 | **`Signal SSE: connected` repeating every ~2 s with no messages delivering** | You are pointed at `bbernhard/signal-cli-rest-api` instead of the native daemon. Switch to upstream `signal-cli --http` (see warning under [Prerequisites](#prerequisites)). |
 | **`signal-cli register` returns 409 `AlreadyVerifiedException`** | See [Recovering from a stuck registration](#recovering-from-a-stuck-registration) below — `--reregister` and `verify` cannot fix this on their own |
 | **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH (third-party Docker wrappers are not compatible — see warning under [Prerequisites](#prerequisites)) |


### PR DESCRIPTION
## What does this PR do?

Documents the four signal-cli setup pitfalls reported in #31674 — each one cost the reporter ~30 minutes to diagnose because the existing `signal.md` either omits or contradicts the current reality:

1. **Java 25 pinning** — `signal-cli` 0.14.x is compiled to class-file version 69 and refuses to run under Java 21 (still Debian's default). The pre-0.14 fallback is server-rejected with `DeprecatedVersionException`, so 0.14.x + Java 25 is the only working combination. The current doc says "Java 17+" — strictly wrong. Adds a `Java version` section with an Adoptium Temurin 25 install recipe and a `JAVA_HOME` systemd note.
2. **ACI UUID allowlist under Phone Number Privacy** — Signal hid inbound sender phone numbers behind ACI UUIDs by default in 2023. The adapter compares the inbound identifier literally against `SIGNAL_ALLOWED_USERS`, so a phone-number-only allowlist silently rejects every real DM. Adds an `Allowlist with Phone Number Privacy` section showing the UUID format and how to copy it out of the `Unauthorized user:` warning.
3. **`409 AlreadyVerifiedException` recovery** — `signal-cli register --reregister` and `signal-cli verify` cannot clear a server-side stuck registration. Adds a `Recovering from a stuck registration` subsection with the confirmed mobile-app reset path.
4. **`bbernhard/signal-cli-rest-api` warning** — most third-party Signal-on-Docker tutorials point at this REST wrapper, which exposes `/v1/about` / `/v2/send` / `/v1/health` instead of the native `/api/v1/check` / `/api/v1/events` / `/api/v1/rpc` Hermes targets. Health-check looks green but messages never deliver (symptom: `Signal SSE: connected` repeating every ~2 s). Adds a `:::danger` callout under Prerequisites and a troubleshooting row keyed on that exact log symptom.

Each new Troubleshooting row is keyed on the exact error string a user will see in logs (`UnsupportedClassVersionError`, `DeprecatedVersionException`, `AlreadyVerifiedException`, repeating SSE connect) so search-from-logs works.

Pure docs change — no Python or YAML touched.

## Related Issue

Fixes #31674

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/messaging/signal.md` — Prerequisites: bump Java requirement to 25+, add `:::danger` warning against `bbernhard/signal-cli-rest-api`, add new `Java version` subsection with Adoptium Temurin 25 install recipe. Access Control: add new `Allowlist with Phone Number Privacy` subsection. Troubleshooting: add five new error-keyed rows + a new `Recovering from a stuck registration` subsection. Env Var Reference: clarify `SIGNAL_ALLOWED_USERS` accepts both E.164 numbers and ACI UUIDs.

## How to Test

1. Render the docs locally (Docusaurus): `cd website && npm install && npm run start` (or just preview the diff on GitHub — pure markdown).
2. Verify the new in-page anchor links resolve: `#java-version`, `#allowlist-with-phone-number-privacy`, `#recovering-from-a-stuck-registration`, `#prerequisites`.
3. Spot-check the `:::danger`, `:::caution`, and `:::warning` admonitions render in the Docusaurus theme.

No Python test surface — pure docs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(signal):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open or closed PR touches the four pitfalls in `signal.md`; #31777 (LeonSGP43) is orthogonal (wizard automation in `hermes_cli/gateway.py`, no `signal.md` touch)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass — N/A (docs-only)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A (docs-only)
- [x] I've tested on my platform: macOS 15.x (markdown source verified)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR *is* the documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Linux/WSL2 recipe added; macOS install path (`brew install signal-cli`) unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- **#31777 (LeonSGP43, open)** — Adds a managed `signal-cli daemon --http` systemd/launchd service installer in `hermes_cli/gateway.py`. Targets pitfall 1 (Java/daemon setup) at the code level. **Orthogonal to this PR**, which is the user-facing docs in `website/docs/...`. Even if #31777 lands, users following the docs path or reading the troubleshooting table benefit from the explicit Java 25 callout, the UUID-allowlist guidance, the 409-recovery procedure, and the bbernhard warning — none of which #31777 addresses.
- **Reporter `bjoerneman` offered** in the issue body to send a docs PR. I went ahead so the fix lands quickly, but happy to close in their favor if they prefer to file their own version.

> Audited siblings: confirmed no other `website/docs/user-guide/messaging/*.md` file references signal-cli or the bbernhard wrapper, so the warning only needs to live in `signal.md`. No widening needed.