### PR TITLE
feat(dashboard): native Windows ConPTY support for /chat tab

### DIFF
--- a/hermes_cli/pty_bridge_win.py
+++ b/hermes_cli/pty_bridge_win.py
@@ -1,0 +1,216 @@
+"""Windows ConPTY bridge for `hermes dashboard` chat tab.
+
+Drop-in replacement for ``pty_bridge.PtyBridge`` on native Windows.
+Uses ``pywinpty`` (the same ConPTY wrapper that powers VS Code's
+integrated terminal) to spawn a child process behind a Windows
+pseudo-console.
+
+This module is imported *only* on Windows when ``pty_bridge`` fails to
+load (due to missing fcntl/termios).  It exposes the same public API:
+``PtyBridge``, ``PtyUnavailableError``.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Optional, Sequence
+
+try:
+    from winpty import PtyProcess as WinPtyProcess  # type: ignore[import]
+    _WINPTY_AVAILABLE = True
+except ImportError:
+    WinPtyProcess = None  # type: ignore[assignment,misc]
+    _WINPTY_AVAILABLE = False
+
+__all__ = ["PtyBridge", "PtyUnavailableError"]
+
+
+class PtyUnavailableError(RuntimeError):
+    """Raised when a PTY cannot be created on this platform.
+
+    On Windows this means ``pywinpty`` is not installed.  The dashboard
+    surfaces the message to the user as a chat-tab banner.
+    """
+
+
+class PtyBridge:
+    """Windows ConPTY wrapper matching the POSIX PtyBridge interface.
+
+    Uses a background reader thread to buffer output from the ConPTY,
+    since pywinpty's ``read()`` is blocking with no timeout parameter.
+    The public ``read(timeout)`` method drains the buffer non-blockingly.
+    """
+
+    def __init__(self, proc: "WinPtyProcess"):
+        self._proc = proc
+        self._closed = False
+        self._buf = bytearray()
+        self._buf_lock = threading.Lock()
+        self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
+        self._reader_thread.start()
+
+    def _reader_loop(self) -> None:
+        """Background thread: continuously reads from the ConPTY."""
+        while not self._closed:
+            try:
+                if not self._proc.isalive() and self._proc.eof():
+                    break
+                data = self._proc.read(65536)
+                if data:
+                    raw = data.encode("utf-8", errors="surrogateescape") if isinstance(data, str) else data
+                    with self._buf_lock:
+                        self._buf.extend(raw)
+                else:
+                    time.sleep(0.01)
+            except EOFError:
+                break
+            except Exception:
+                if self._closed:
+                    break
+                time.sleep(0.01)
+
+    # -- lifecycle --------------------------------------------------------
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """True if pywinpty is installed and a ConPTY can be spawned."""
+        return bool(_WINPTY_AVAILABLE)
+
+    @classmethod
+    def spawn(
+        cls,
+        argv: Sequence[str],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[dict] = None,
+        cols: int = 80,
+        rows: int = 24,
+    ) -> "PtyBridge":
+        """Spawn ``argv`` behind a new ConPTY and return a bridge.
+
+        Raises :class:`PtyUnavailableError` if ``pywinpty`` is missing.
+        Raises :class:`FileNotFoundError` or :class:`OSError` for
+        ordinary exec failures (missing binary, bad cwd, etc.).
+        """
+        if not _WINPTY_AVAILABLE:
+            raise PtyUnavailableError(
+                "pywinpty is not installed. Install with: pip install pywinpty"
+            )
+
+        spawn_env = (os.environ.copy() if env is None else env.copy())
+        if not spawn_env.get("TERM"):
+            spawn_env["TERM"] = "xterm-256color"
+
+        proc = WinPtyProcess.spawn(
+            list(argv),
+            cwd=cwd,
+            env=spawn_env,
+            dimensions=(rows, cols),
+        )
+        return cls(proc)
+
+    @property
+    def pid(self) -> int:
+        return int(self._proc.pid)
+
+    def is_alive(self) -> bool:
+        if self._closed:
+            return False
+        try:
+            return bool(self._proc.isalive())
+        except Exception:
+            return False
+
+    # -- I/O --------------------------------------------------------------
+
+    def read(self, timeout: float = 0.2) -> Optional[bytes]:
+        """Read up to 64 KiB of raw bytes from the ConPTY.
+
+        Returns:
+            * bytes — child output
+            * empty bytes (``b""``) — no data available within ``timeout``
+            * None — child has exited and buffer is drained
+
+        Never blocks longer than ``timeout`` seconds.
+        """
+        if self._closed:
+            return None
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._buf_lock:
+                if self._buf:
+                    data = bytes(self._buf)
+                    self._buf.clear()
+                    return data
+            if not self.is_alive():
+                with self._buf_lock:
+                    if self._buf:
+                        data = bytes(self._buf)
+                        self._buf.clear()
+                        return data
+                return None
+            time.sleep(0.01)
+
+        with self._buf_lock:
+            if self._buf:
+                data = bytes(self._buf)
+                self._buf.clear()
+                return data
+        return b""
+
+    def write(self, data: bytes) -> None:
+        """Write raw bytes to the ConPTY (i.e. the child's stdin)."""
+        if self._closed or not data:
+            return
+        try:
+            text = data.decode("utf-8", errors="surrogateescape")
+            self._proc.write(text)
+        except (OSError, EOFError):
+            return
+
+    def resize(self, cols: int, rows: int) -> None:
+        """Forward a terminal resize to the ConPTY."""
+        if self._closed:
+            return
+        try:
+            self._proc.setwinsize(max(1, rows), max(1, cols))
+        except Exception:
+            pass
+
+    # -- teardown ---------------------------------------------------------
+
+    def close(self) -> None:
+        """Terminate the child and clean up.  Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._proc.isalive():
+            try:
+                self._proc.sendintr()
+                deadline = time.monotonic() + 1.0
+                while self._proc.isalive() and time.monotonic() < deadline:
+                    time.sleep(0.05)
+            except Exception:
+                pass
+
+        if self._proc.isalive():
+            try:
+                self._proc.terminate(force=True)
+            except Exception:
+                pass
+
+        try:
+            self._proc.close(force=True)
+        except Exception:
+            pass
+
+    # Context-manager sugar
+    def __enter__(self) -> "PtyBridge":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        self.close()

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3292,19 +3292,24 @@ import re
 import asyncio
 
 # PTY bridge is POSIX-only (depends on fcntl/termios/ptyprocess).  On native
-# Windows the import raises; catch and leave PtyBridge=None so the rest of
-# the dashboard (sessions, jobs, metrics, config editor) still loads and the
-# /api/pty endpoint cleanly refuses with a WSL-suggested message.
+# Windows, fall back to the ConPTY bridge (pywinpty).  If neither is available
+# the /api/pty endpoint cleanly refuses with a user-facing message.
 try:
     from hermes_cli.pty_bridge import PtyBridge, PtyUnavailableError
     _PTY_BRIDGE_AVAILABLE = True
 except ImportError as _pty_import_err:  # pragma: no cover - Windows-only path
-    PtyBridge = None  # type: ignore[assignment]
-    _PTY_BRIDGE_AVAILABLE = False
+    # Try Windows ConPTY bridge as fallback
+    try:
+        from hermes_cli.pty_bridge_win import PtyBridge, PtyUnavailableError  # type: ignore[assignment,no-redef]
+        _PTY_BRIDGE_AVAILABLE = PtyBridge.is_available()
+    except ImportError:
+        PtyBridge = None  # type: ignore[assignment]
+        _PTY_BRIDGE_AVAILABLE = False
 
-    class PtyUnavailableError(RuntimeError):  # type: ignore[no-redef]
-        """Stub on platforms where pty_bridge can't be imported."""
-        pass
+    if not _PTY_BRIDGE_AVAILABLE:
+        class PtyUnavailableError(RuntimeError):  # type: ignore[no-redef]
+            """Stub on platforms where pty_bridge can't be imported."""
+            pass
 
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2


### PR DESCRIPTION
Add a Windows-specific PTY bridge using pywinpty so the dashboard /chat tab works natively on Windows without requiring WSL2.

The existing pty_bridge.py depends on fcntl/termios/ptyprocess (POSIX-only). On Windows, importing it raises ImportError and the chat tab shows a 'WSL required' banner.  This commit adds pty_bridge_win.py which wraps pywinpty (ConPTY — the same API that VS Code's integrated terminal uses) behind the identical PtyBridge interface.

Changes:
- Add hermes_cli/pty_bridge_win.py implementing PtyBridge via ConPTY
- Update web_server.py import to fall back to the Windows bridge when the POSIX bridge fails to load

The pywinpty dependency is already declared in [pty] extras (pyproject.toml line 103) — this commit provides the code that uses it.

## What does this PR do?

Enables the dashboard `/chat` tab to work natively on Windows using ConPTY (via `pywinpty`), eliminating the requirement for WSL2.

The existing `pty_bridge.py` imports `fcntl`, `termios`, and `ptyprocess` at module level — all POSIX-only. On Windows this raises `ImportError`, and the `/api/pty` WebSocket endpoint sends a "WSL required" banner to the client. This PR adds `pty_bridge_win.py` as a drop-in Windows implementation behind the same `PtyBridge` interface, using `pywinpty` — the same ConPTY wrapper that powers VS Code's integrated terminal.

The approach is minimal and non-breaking:
- POSIX path is unchanged (still preferred when available)
- Windows bridge is only imported as a fallback when the POSIX bridge fails to load
- The `pywinpty` dependency is already declared in `[pty]` extras (`pyproject.toml` line 103) but had no consuming code until now — the comment in `pty_bridge.py` line 13 notes this was "tracked as a future enhancement"

## Related Issue

No existing issue — the gap was documented inline in `pty_bridge.py` (line 12-13: "Windows ConPTY... would need a separate Windows implementation (`pywinpty`) — that's tracked as a future enhancement").

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **New:** `hermes_cli/pty_bridge_win.py` — Windows ConPTY bridge implementing the `PtyBridge` interface (spawn, read, write, resize, close) using `pywinpty`. Uses a background reader thread to buffer ConPTY output since `pywinpty`'s `read()` has no timeout parameter.
- **Modified:** `hermes_cli/web_server.py` (lines ~3294-3310) — updated the import fallback to try `pty_bridge_win` before giving up. Sets `_PTY_BRIDGE_AVAILABLE = PtyBridge.is_available()` so the existing WebSocket handler works without further changes.

## How to Test

1. On a Windows machine with Python 3.11+ and `pywinpty` installed (included in `[all]` extras):
   ```
   pip install -e ".[all]"
   hermes dashboard --no-open
   ```
2. Open `http://127.0.0.1:9119` in a browser and navigate to the `/chat` tab
3. Verify the terminal emulator connects and you can interact with the Hermes TUI (type a message, see response streaming)
4. Resize the browser window and confirm the terminal reflows
5. On macOS/Linux, verify `pty_bridge.py` (POSIX) is still used and behavior is unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (24H2), Python 3.11, pywinpty 2.0.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="2063" height="1227" alt="Screenshot 2026-05-25 002800" src="https://github.com/user-attachments/assets/fe7a80d1-2da0-4193-a5f8-0e7c8337199d" />


```
# Before (Windows, native Python):
Chat unavailable: the embedded terminal requires a POSIX PTY, which native Windows Python doesn't provide.
Install Hermes inside WSL2 to use the dashboard's /chat tab — the rest of the dashboard works here.

# After (same machine):
[dashboard /chat tab loads, TUI renders in xterm.js, full interactivity]
```
