### PR TITLE
fix(cli): skip cross-mount paths in `@` file autocomplete on Windows (#31915)

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1621,7 +1621,21 @@ class SlashCommandCompleter(Completer):
                         continue
                     if count >= limit:
                         break
-                    display_path = os.path.relpath(full_path)
+                    try:
+                        display_path = os.path.relpath(full_path)
+                    except ValueError:
+                        # Windows: os.path.relpath() raises ValueError for
+                        # cross-mount paths (a different drive letter from cwd
+                        # or a UNC/device path).  A user browsing an absolute
+                        # `@file:`/`@folder:` path on another drive would
+                        # otherwise crash the prompt_toolkit event loop.  Skip
+                        # the entry rather than propagating the error.
+                        logger.debug(
+                            "Skipping cross-mount path during explicit "
+                            "@file:/@folder: autocomplete: %s",
+                            full_path,
+                        )
+                        continue
                     suffix = "/" if is_dir else ""
                     meta = "dir" if is_dir else _file_size_label(full_path)
                     completion = f"{prefix}{display_path}{suffix}"
@@ -1668,7 +1682,22 @@ class SlashCommandCompleter(Completer):
                     raw = proc.stdout.strip().split("\n")
                     # Store relative paths
                     for p in raw[:5000]:
-                        rel = os.path.relpath(p, cwd) if os.path.isabs(p) else p
+                        if os.path.isabs(p):
+                            try:
+                                rel = os.path.relpath(p, cwd)
+                            except ValueError:
+                                # Windows: os.path.relpath() raises ValueError
+                                # for cross-mount paths (e.g. \\.\\ device paths
+                                # or a different drive letter from cwd).  Skip
+                                # these paths rather than crashing the
+                                # prompt_toolkit event loop in @-autocomplete.
+                                logger.debug(
+                                    "Skipping cross-mount path during file autocomplete: %s",
+                                    p,
+                                )
+                                continue
+                        else:
+                            rel = p
                         files.append(rel)
                     break
             except (subprocess.TimeoutExpired, OSError):

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1734,7 +1734,21 @@ class SlashCommandCompleter(Completer):
                         continue
                     if count >= limit:
                         break
-                    display_path = os.path.relpath(full_path)
+                    try:
+                        display_path = os.path.relpath(full_path)
+                    except ValueError:
+                        # Windows: os.path.relpath() raises ValueError for
+                        # cross-mount paths (a different drive letter from cwd
+                        # or a UNC/device path).  A user browsing an absolute
+                        # `@file:`/`@folder:` path on another drive would
+                        # otherwise crash the prompt_toolkit event loop.  Skip
+                        # the entry rather than propagating the error (#31915).
+                        logger.debug(
+                            "Skipping cross-mount path during explicit "
+                            "@file:/@folder: autocomplete: %s",
+                            full_path,
+                        )
+                        continue
                     suffix = "/" if is_dir else ""
                     meta = "dir" if is_dir else _file_size_label(full_path)
                     completion = f"{prefix}{display_path}{suffix}"

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -225,3 +225,130 @@ class TestFileSizeLabel:
 
     def test_nonexistent(self):
         assert _file_size_label("/nonexistent_xyz") == ""
+
+
+class TestGetProjectFilesWindowsCrossMount:
+    """_get_project_files() should skip paths on a different Windows mount point.
+
+    Regression coverage for #31915 — typing ``@`` to invoke file autocomplete
+    on Windows used to crash the prompt_toolkit event loop when ``rg``/``fd``
+    returned a path on a different drive or a UNC/device path (e.g.
+    ``\\\\.\\nul``), because ``os.path.relpath`` raises ``ValueError`` in
+    that case.  These tests simulate the failure on any platform so the
+    regression is caught in CI without needing a Windows runner.
+    """
+
+    @staticmethod
+    def _install_cross_mount_fakes(monkeypatch, bad_path):
+        """Patch subprocess/os helpers so ``bad_path`` triggers the cross-mount branch.
+
+        Returns nothing — patches are scoped to the test via ``monkeypatch``.
+        """
+        import subprocess as _subprocess
+
+        class FakeProc:
+            returncode = 0
+            stdout = bad_path + "\n"
+            stderr = ""
+
+        monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: FakeProc())
+
+        original_relpath = os.path.relpath
+        original_isabs = os.path.isabs
+
+        def patched_relpath(path, start=None):
+            if path == bad_path:
+                raise ValueError("path is on mount 'X:', start on mount 'Y:'")
+            return original_relpath(path, start) if start is not None else original_relpath(path)
+
+        monkeypatch.setattr(os.path, "relpath", patched_relpath)
+        monkeypatch.setattr(
+            os.path, "isabs", lambda p: p == bad_path or original_isabs(p)
+        )
+
+    def test_cross_drive_path_is_skipped(self, monkeypatch, tmp_path):
+        """Cross-drive path (e.g. ``D:\\file.txt`` when cwd is on ``C:``) is
+        skipped without raising, protecting the prompt_toolkit event loop."""
+        cwd = str(tmp_path)
+        cross_drive_path = "D:\\other\\file.txt" if os.sep != "/" else "/mnt/other/file.txt"
+
+        self._install_cross_mount_fakes(monkeypatch, cross_drive_path)
+
+        completer = SlashCommandCompleter()
+        completer._file_cache_cwd = cwd
+
+        files = completer._get_project_files()
+
+        assert cross_drive_path not in files
+
+    def test_unc_device_path_is_skipped(self, monkeypatch, tmp_path):
+        """UNC/device paths (``\\\\.\\nul``, ``\\\\?\\C:\\...``) also trigger
+        the ``ValueError`` branch and must be skipped without crashing."""
+        cwd = str(tmp_path)
+        unc_device_path = "\\\\.\\nul"
+
+        self._install_cross_mount_fakes(monkeypatch, unc_device_path)
+
+        completer = SlashCommandCompleter()
+        completer._file_cache_cwd = cwd
+
+        files = completer._get_project_files()
+
+        assert unc_device_path not in files
+
+    def test_skip_emits_debug_log(self, monkeypatch, tmp_path, caplog):
+        """When a cross-mount path is skipped, a debug log line should be
+        emitted so the suppression is observable in future Windows triage."""
+        import logging as _logging
+
+        cwd = str(tmp_path)
+        cross_drive_path = "D:\\other\\file.txt"
+
+        self._install_cross_mount_fakes(monkeypatch, cross_drive_path)
+
+        completer = SlashCommandCompleter()
+        completer._file_cache_cwd = cwd
+
+        with caplog.at_level(_logging.DEBUG, logger="hermes_cli.commands"):
+            completer._get_project_files()
+
+        skipped = [
+            r for r in caplog.records
+            if r.name == "hermes_cli.commands"
+            and "Skipping cross-mount path" in r.getMessage()
+        ]
+        assert skipped, "expected a debug log entry when a cross-mount path is skipped"
+        assert cross_drive_path in skipped[0].getMessage()
+
+
+class TestExplicitAtPathCrossMount:
+    """Regression tests for cross-mount handling in the explicit
+    ``@file:``/``@folder:`` completion branch (commands.py ~L1623).
+
+    A user browsing an absolute path on another Windows drive must not crash
+    the prompt_toolkit event loop when ``os.path.relpath`` raises ``ValueError``.
+    """
+
+    def test_cross_drive_explicit_file_path_is_skipped(self, monkeypatch, tmp_path):
+        # Create a real entry so listdir/isdir behave, but force relpath to
+        # raise for it, emulating a cross-drive absolute path on Windows.
+        entry_name = "cross.txt"
+        (tmp_path / entry_name).write_text("x")
+        search_dir = str(tmp_path)
+
+        original_relpath = os.path.relpath
+
+        def patched_relpath(path, start=None):
+            if os.path.basename(str(path)) == entry_name:
+                raise ValueError("path is on mount 'X:', start on mount 'Y:'")
+            return original_relpath(path, start) if start is not None else original_relpath(path)
+
+        monkeypatch.setattr(os.path, "relpath", patched_relpath)
+
+        completer = SlashCommandCompleter()
+        word = f"@file:{search_dir}/"
+
+        # Must not raise, and the un-relative-able entry must be omitted.
+        completions = list(completer._context_completions(word))
+        names = _display_names(completions)
+        assert entry_name not in names

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -118,3 +118,96 @@ class TestFileSizeLabel:
 
     def test_nonexistent(self):
         assert _file_size_label("/nonexistent_xyz") == ""
+
+
+class TestGetProjectFilesWindowsCrossMount:
+    """_get_project_files() should skip paths on a different Windows mount point.
+
+    Regression coverage for #31915 — typing ``@`` to invoke file autocomplete
+    on Windows used to crash the prompt_toolkit event loop when ``rg``/``fd``
+    returned a path on a different drive or a UNC/device path (e.g.
+    ``\\\\.\\nul``), because ``os.path.relpath`` raises ``ValueError`` in
+    that case.  These tests simulate the failure on any platform so the
+    regression is caught in CI without needing a Windows runner.
+    """
+
+    @staticmethod
+    def _install_cross_mount_fakes(monkeypatch, bad_path):
+        """Patch subprocess/os helpers so ``bad_path`` triggers the cross-mount branch."""
+        import subprocess as _subprocess
+
+        class FakeProc:
+            returncode = 0
+            stdout = bad_path + "\n"
+            stderr = ""
+
+        monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: FakeProc())
+
+        original_relpath = os.path.relpath
+        original_isabs = os.path.isabs
+
+        def patched_relpath(path, start=None):
+            if path == bad_path:
+                raise ValueError("path is on mount 'X:', start on mount 'Y:'")
+            return original_relpath(path, start) if start is not None else original_relpath(path)
+
+        monkeypatch.setattr(os.path, "relpath", patched_relpath)
+        monkeypatch.setattr(
+            os.path, "isabs", lambda p: p == bad_path or original_isabs(p)
+        )
+
+    def test_cross_drive_path_is_skipped(self, monkeypatch, tmp_path):
+        cwd = str(tmp_path)
+        cross_drive_path = "D:\\other\\file.txt" if os.sep != "/" else "/mnt/other/file.txt"
+
+        self._install_cross_mount_fakes(monkeypatch, cross_drive_path)
+
+        completer = SlashCommandCompleter()
+        completer._file_cache_cwd = cwd
+
+        files = completer._get_project_files()
+
+        assert cross_drive_path not in files
+
+    def test_unc_device_path_is_skipped(self, monkeypatch, tmp_path):
+        cwd = str(tmp_path)
+        unc_device_path = "\\\\.\\nul"
+
+        self._install_cross_mount_fakes(monkeypatch, unc_device_path)
+
+        completer = SlashCommandCompleter()
+        completer._file_cache_cwd = cwd
+
+        files = completer._get_project_files()
+
+        assert unc_device_path not in files
+
+
+class TestExplicitAtPathCrossMount:
+    """Regression tests for cross-mount handling in the explicit
+    ``@file:``/``@folder:`` completion branch.
+
+    A user browsing an absolute path on another Windows drive must not crash
+    the prompt_toolkit event loop when ``os.path.relpath`` raises ``ValueError``.
+    """
+
+    def test_cross_drive_explicit_file_path_is_skipped(self, monkeypatch, tmp_path):
+        entry_name = "cross.txt"
+        (tmp_path / entry_name).write_text("x")
+        search_dir = str(tmp_path)
+
+        original_relpath = os.path.relpath
+
+        def patched_relpath(path, start=None):
+            if os.path.basename(str(path)) == entry_name:
+                raise ValueError("path is on mount 'X:', start on mount 'Y:'")
+            return original_relpath(path, start) if start is not None else original_relpath(path)
+
+        monkeypatch.setattr(os.path, "relpath", patched_relpath)
+
+        completer = SlashCommandCompleter()
+        word = f"@file:{search_dir}/"
+
+        completions = list(completer._context_completions(word))
+        names = _display_names(completions)
+        assert entry_name not in names


### PR DESCRIPTION
Fixes #31915.

On Windows, typing `@` to invoke file autocomplete crashed the prompt_toolkit event loop with `ValueError: path is on mount X, start on mount Y`.

**Root cause:** `_get_project_files()` calls `os.path.relpath(p, cwd)` for every absolute path returned by `rg`/`fd`. On Windows this raises `ValueError` for cross-drive paths (e.g. `D:\\file.txt` when `cwd` is on `C:`) or UNC device paths like `\\.\nul`.

**Fix:** wrap the call in `try/except ValueError` and `continue` — cross-mount paths are silently skipped instead of crashing.

**Tests:** new `TestGetProjectFilesWindowsCrossMount` in `tests/hermes_cli/test_path_completion.py` monkeypatches relpath to raise ValueError and confirms no crash + path excluded. All 27 existing tests pass.

Closes #31915