### PR TITLE
fix(test): mock copilot token seed in auth_remove suppression test

### DIFF
--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1607,6 +1607,19 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
         },
     )
 
+    # Mock copilot token resolution so the gh_cli entry survives
+    # borrowed-credential pruning inside load_pool().  Without this the
+    # entry is pruned because `gh_cli` is a borrowed source and the test
+    # environment has no real `gh auth token` to re-seed it.
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("ghp_fake", "gh auth token"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        lambda token: token,
+    )
+
     from types import SimpleNamespace
     from hermes_cli.auth import is_source_suppressed
     from hermes_cli.auth_commands import auth_remove_command


### PR DESCRIPTION
## What

Fixes `test_auth_remove_copilot_suppresses_all_variants` regression on `main` caused by #31416.

## Root Cause

PR #31416 changed `_prune_stale_seeded_entries()` to treat `gh_cli` as a borrowed credential source. During `load_pool("copilot")`, when `resolve_copilot_token()` returns no token (no real `gh` CLI in the test environment), the `gh_cli` entry is pruned. The test then calls `resolve_target("1")` on an empty pool and gets "No credential #1. Provider: copilot."

## Fix

Mock `resolve_copilot_token` and `get_copilot_api_token` so the `gh_cli` entry is re-seeded during `load_pool()`, surviving the borrowed-credential pruning.

## Verification

```bash
pytest tests/hermes_cli/test_auth_commands.py::test_auth_remove_copilot_suppresses_all_variants -xvs
# 1 passed

pytest tests/hermes_cli/test_auth_commands.py -x
# 46 passed
```