### PR TITLE
docs: add agent task queue issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_task.yml
+++ b/.github/ISSUE_TEMPLATE/agent_task.yml
@@ -1,0 +1,144 @@
+name: "🤖 Agent Task"
+description: Structured work packet for Librarian → Architect/Hero8 → Coder/Hero7 or Copilot → Reviewer/Hero8.
+title: "[Agent Task]: "
+labels: ["needs-triage", "status/needs-plan"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when an issue is intended to be picked up by an agent or converted into an agent-ready task queue item.
+
+        Default routing:
+        **Librarian researches → Hero8 architects/plans → Hero7 or Copilot implements → Hero8 reviews.**
+
+  - type: dropdown
+    id: lane
+    attributes:
+      label: Agent lane
+      description: Which lane owns the next action?
+      options:
+        - Librarian research
+        - Hero8 architecture / planning
+        - Hero7 implementation
+        - Copilot implementation
+        - Hero8 review
+        - GuardianCOO audit / release gate
+        - Human decision needed
+    validations:
+      required: true
+
+  - type: dropdown
+    id: task-type
+    attributes:
+      label: Task type
+      options:
+        - Research
+        - Bug fix
+        - Feature
+        - Refactor
+        - Security / privacy hardening
+        - Tests / CI
+        - Documentation
+        - Operations / release
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 - critical
+        - P1 - high
+        - P2 - medium
+        - P3 - low
+    validations:
+      required: true
+
+  - type: textarea
+    id: objective
+    attributes:
+      label: Objective
+      description: What should be true when this task is complete?
+      placeholder: |
+        Make Hermes able to...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and evidence
+      description: Include links, logs, source notes, related issues, prior decisions, and relevant files.
+      placeholder: |
+        Related issue/PR/session/source:
+        Relevant files:
+        Evidence:
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: Checkboxes should be concrete enough for a coding agent and reviewer to verify.
+      placeholder: |
+        - [ ] Behavior is implemented end-to-end
+        - [ ] Targeted tests pass
+        - [ ] Documentation or help text is updated if user-facing
+        - [ ] No secrets, credentials, PHI, or sensitive user data are exposed
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation-notes
+    attributes:
+      label: Implementation notes / likely files
+      description: Optional hints for Hero7, Copilot, or a human implementer. Avoid over-prescribing if exploration is needed.
+      placeholder: |
+        Likely files:
+        Suggested approach:
+        Constraints:
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What should the agent not change?
+      placeholder: |
+        Do not change...
+
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Risk level
+      options:
+        - Low
+        - Medium
+        - High
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: approval-gates
+    attributes:
+      label: Approval gates
+      description: Check anything that requires explicit human approval before the final action.
+      options:
+        - label: Merge to default/protected branch
+        - label: Release or publish package/image/docs site
+        - label: Production-impacting workflow dispatch or deployment
+        - label: Secrets, repo settings, webhooks, permissions, or branch protection
+        - label: Safety-sensitive, privacy-sensitive, clinical, education, or vulnerable-user impact
+
+  - type: textarea
+    id: handoff
+    attributes:
+      label: Agent handoff instructions
+      description: Tell the next agent exactly what to do and what proof to return.
+      placeholder: |
+        Next agent:
+        Required proof:
+        Stop/ask conditions:
+    validations:
+      required: true

--- a/docs/agent-task-queue.md
+++ b/docs/agent-task-queue.md
@@ -1,0 +1,113 @@
+# Agent task queue workflow
+
+This repository can use GitHub Issues as a lightweight task queue for agent-assisted work.
+
+## Default routing
+
+1. **Librarian researches**
+   - Gather source links, logs, related issues, prior decisions, and constraints.
+   - Leave a concise evidence brief in the issue.
+   - Do not implement code from the research lane.
+
+2. **Hero8 architects / plans**
+   - Convert research into a concrete implementation issue.
+   - Add acceptance criteria, risk level, approval gates, likely files, and stop/ask conditions.
+   - Mark the issue ready for a coding agent only when the task is independently actionable.
+
+3. **Hero7 or Copilot implements**
+   - Create a feature branch.
+   - Make the smallest vertical-slice change that satisfies the issue.
+   - Run targeted checks.
+   - Open a PR and link it to the issue.
+   - Comment with changed files, tests run, failures, and remaining risks.
+
+4. **Hero8 reviews**
+   - Review the diff against the acceptance criteria.
+   - Check tests and risk/approval gates.
+   - Request changes or mark ready for human approval.
+   - Do not merge, release, deploy, or change repo settings without explicit approval.
+
+5. **GuardianCOO audits when needed**
+   - Use for security, privacy, production-impacting, or safety-sensitive changes.
+   - Provide evidence and a recommendation, not unchecked implementation changes.
+
+## Label taxonomy
+
+Recommended labels for the agent queue:
+
+### Lane
+
+- `lane/librarian`
+- `lane/architect`
+- `lane/coder`
+- `lane/reviewer`
+- `lane/guardian`
+
+### Status
+
+- `status/researching`
+- `status/needs-plan`
+- `status/ready-for-coder`
+- `status/in-progress`
+- `status/pr-open`
+- `status/reviewing`
+- `status/changes-requested`
+- `status/ready-for-approval`
+- `status/done`
+
+### Agent
+
+- `agent/librarian`
+- `agent/hero8`
+- `agent/hero7`
+- `agent/guardiancoo`
+- `agent/copilot`
+
+### Risk and approval
+
+- `risk/low`
+- `risk/medium`
+- `risk/high`
+- `approval/required`
+- `production-impacting`
+- `safety-sensitive`
+
+### Type
+
+Use the existing `type/*` labels where possible. Add `type/research` for evidence-only work.
+
+## Issue quality bar
+
+An agent-ready issue should include:
+
+- Objective
+- Context and evidence
+- Acceptance criteria
+- Likely files or areas, if known
+- Out of scope
+- Risk level
+- Approval gates
+- Handoff instructions with required proof
+
+If those fields are missing, keep the issue in `status/needs-plan` instead of handing it to a coding agent.
+
+## Work log standard
+
+Every agent comment should include:
+
+- Agent/lane
+- Action taken
+- Evidence or links
+- Tests/checks run
+- Remaining risk
+- Next requested action
+
+## Merge and release gates
+
+Explicit human approval is required before:
+
+- Merging to the default or protected branch
+- Publishing releases, packages, images, or docs deployments
+- Dispatching production-impacting workflows
+- Changing secrets, permissions, branch protection, webhooks, or repo settings
+- Taking action that affects safety-sensitive, clinical, education, privacy, or vulnerable-user workflows

--- a/scripts/create-agent-task-labels.sh
+++ b/scripts/create-agent-task-labels.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${1:-NousResearch/hermes-agent}"
+
+labels=(
+  "lane/librarian|Research and evidence-gathering work for agents|5319E7"
+  "lane/architect|Planning/specification work before implementation|7057FF"
+  "lane/coder|Implementation-ready work for coding agents|0052CC"
+  "lane/reviewer|Review, verification, and acceptance work|0E8A16"
+  "lane/guardian|Audit, release-gate, safety, and security review|B60205"
+  "status/researching|Evidence gathering is in progress|D876E3"
+  "status/needs-plan|Needs an implementation plan or acceptance criteria|FBCA04"
+  "status/ready-for-coder|Ready for Hero7, Copilot, or another coding agent|0E8A16"
+  "status/in-progress|Agent or human is actively working this task|1D76DB"
+  "status/pr-open|A pull request is open and linked|5319E7"
+  "status/reviewing|Awaiting or undergoing review|D4C5F9"
+  "status/changes-requested|Reviewer requested changes before acceptance|D93F0B"
+  "status/ready-for-approval|Ready for explicit human approval/merge decision|0E8A16"
+  "status/done|Accepted and complete|0E8A16"
+  "agent/librarian|Assigned or suitable for Librarian research agent|C5DEF5"
+  "agent/hero8|Assigned or suitable for Hero8 architect/reviewer|BFDADC"
+  "agent/hero7|Assigned or suitable for Hero7 coding agent|C2E0C6"
+  "agent/guardiancoo|Assigned or suitable for GuardianCOO audit agent|F9D0C4"
+  "agent/copilot|Suitable for GitHub Copilot coding agent|EDEDED"
+  "approval/required|Requires explicit approval before merge, release, deploy, or risky write|B60205"
+  "production-impacting|Could affect production behavior, deployment, user data, or billing|D93F0B"
+  "safety-sensitive|Touches safety, privacy, vulnerable users, or clinical/education-sensitive scope|B60205"
+  "risk/low|Low implementation or operational risk|0E8A16"
+  "risk/medium|Moderate implementation or operational risk|FBCA04"
+  "risk/high|High risk; needs careful review and approval|B60205"
+  "type/research|Research-only task or evidence brief|C5DEF5"
+)
+
+for entry in "${labels[@]}"; do
+  IFS='|' read -r name desc color <<< "$entry"
+  if gh label view "$name" --repo "$REPO" >/dev/null 2>&1; then
+    gh label edit "$name" --repo "$REPO" --description "$desc" --color "$color"
+  else
+    gh label create "$name" --repo "$REPO" --description "$desc" --color "$color"
+  fi
+done


### PR DESCRIPTION
## Summary

Adds a structured GitHub Issues workflow for agent-assisted work:

- New `Agent Task` issue template for Librarian → Hero8 Architect → Hero7/Copilot Coder → Hero8 Reviewer routing.
- Documentation for labels, lane/status transitions, work-log standards, and approval gates.
- Helper script to create/update the recommended labels with `gh`.

## Why

GitHub Issues can act as a durable agent task queue: persistent memory, structured handoffs, linked PRs, and an auditable work log. This makes issues easier for coding agents and reviewers to pick up independently.

## Verification

- Parsed `.github/ISSUE_TEMPLATE/agent_task.yml` with PyYAML successfully.
- Ran `scripts/create-agent-task-labels.sh Mitosis50/hermes-agent` successfully on the fork.
- Verified the recommended labels exist on the fork with `gh label list`.

## Approval / safety

This PR only adds docs, one issue template, and a label helper script. It does not change runtime code or workflows.