### PR TITLE
fix(cli,gateway): strip outer brackets/quotes from /resume args + accept session IDs

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6527,6 +6527,19 @@ class HermesCLI:
         parts = cmd_original.split(None, 1)
         target = parts[1].strip() if len(parts) > 1 else ""
 
+        # Strip common outer brackets/quotes users may type literally from the
+        # usage hint (e.g. ``/resume <abc123>`` or ``/resume [abc123]``).  The
+        # `/resume` help text shows angle brackets as a placeholder and a few
+        # users copy them through verbatim.  Stripping them keeps the lookup
+        # working without changing the help string.
+        if len(target) >= 2 and (
+            (target[0] == "<" and target[-1] == ">")
+            or (target[0] == "[" and target[-1] == "]")
+            or (target[0] == '"' and target[-1] == '"')
+            or (target[0] == "'" and target[-1] == "'")
+        ):
+            target = target[1:-1].strip()
+
         if not target:
             _cprint("  Usage: /resume <number|session_id_or_title>")
             if self._show_recent_sessions(reason="resume"):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12743,6 +12743,16 @@ class GatewayRunner:
         session_key = self._session_key_for_source(source)
         name = event.get_command_args().strip()
 
+        # Strip common outer brackets/quotes users may type literally from the
+        # usage hint (e.g. ``/resume <abc123>``). Mirrors the CLI behavior.
+        if len(name) >= 2 and (
+            (name[0] == "<" and name[-1] == ">")
+            or (name[0] == "[" and name[-1] == "]")
+            or (name[0] == '"' and name[-1] == '"')
+            or (name[0] == "'" and name[-1] == "'")
+        ):
+            name = name[1:-1].strip()
+
         def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
             sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
@@ -12780,7 +12790,13 @@ class GatewayRunner:
             target_id = target.get("id")
             name = target.get("title") or name
         else:
-            target_id = self._session_db.resolve_session_by_title(name)
+            # Try direct session ID lookup first (so `/resume <session_id>`
+            # works in the gateway, not just `/resume <title>`).
+            session = self._session_db.get_session(name)
+            if session:
+                target_id = session["id"]
+            else:
+                target_id = self._session_db.resolve_session_by_title(name)
         if not target_id:
             return t("gateway.resume.not_found", name=name)
         # Compression creates child continuations that hold the live transcript.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1290,6 +1290,7 @@ AUTHOR_MAP = {
     "edison@mcclean.codes": "McClean-Edison",  # PR #29817 (register_auxiliary_task plugin API)
     "zhangsamuel12@gmail.com": "SamuelZ12",  # PR #7480 (show recap after in-session resume)
     "490408354@qq.com": "daizhonggeng",  # PR #9020 (numbered /resume selection)
+    "claw@openclaw.ai": "wanwan2qq",  # PR #10215 (strip brackets/quotes from /resume; gateway session-ID lookup)
 }
 
 

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -75,3 +75,44 @@ class TestCliResumeCommand:
         assert "out of range" in printed.lower()
         assert "/resume" in printed
         assert cli_obj.session_id == "current_session"
+
+    def test_handle_resume_strips_outer_brackets(self):
+        """Users copy `<session_id>` from the usage hint literally.
+
+        Strip outer ``<>``, ``[]``, ``""``, and ``''`` before lookup so
+        ``/resume <abc123>`` works the same as ``/resume abc123``.
+        """
+        cli_obj = _make_cli()
+        cli_obj._session_db.get_session.return_value = {"id": "sess_alpha", "title": "Alpha"}
+        cli_obj._session_db.get_messages_as_conversation.return_value = []
+        cli_obj._session_db.resolve_resume_session_id.return_value = "sess_alpha"
+
+        for raw in ("<sess_alpha>", "[sess_alpha]", '"sess_alpha"', "'sess_alpha'"):
+            cli_obj.session_id = "current_session"
+            with (
+                patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="sess_alpha"),
+                patch("cli._cprint"),
+            ):
+                cli_obj._handle_resume_command(f"/resume {raw}")
+            assert cli_obj.session_id == "sess_alpha", (
+                f"bracket-stripping failed for {raw!r}: session_id stayed {cli_obj.session_id}"
+            )
+
+    def test_handle_resume_does_not_strip_partial_brackets(self):
+        """Mismatched or single brackets must pass through unmodified.
+
+        ``"<half`` (just an open angle) is not a wrapping pair, so the
+        lookup should treat it verbatim — preserving the existing
+        not-found error path instead of mangling the input.
+        """
+        cli_obj = _make_cli()
+        cli_obj._session_db.get_session.return_value = None
+
+        with (
+            patch("hermes_cli.main._resolve_session_by_name_or_id", return_value=None),
+            patch("cli._cprint") as mock_cprint,
+        ):
+            cli_obj._handle_resume_command("/resume <half")
+
+        printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+        assert "<half" in printed

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -301,3 +301,60 @@ class TestHandleResumeCommand:
 
         assert real_key not in runner._agent_cache
         db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_strips_outer_brackets(self, tmp_path):
+        """Users may copy `<session_id>` from the usage hint literally.
+
+        The gateway should strip outer ``<>``, ``[]``, ``""``, and ``''``
+        before lookup so ``/resume <abc123>`` works the same as
+        ``/resume abc123``.
+        """
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("abc123", "telegram")
+        db.set_session_title("abc123", "Bracketed")
+        db.create_session("current_session_001", "telegram")
+
+        for raw in ("<abc123>", "[abc123]", '"abc123"', "'abc123'"):
+            event = _make_event(text=f"/resume {raw}")
+            runner = _make_runner(
+                session_db=db,
+                current_session_id="current_session_001",
+                event=event,
+            )
+            result = await runner._handle_resume_command(event)
+            # Either the session was resumed (and we get a "Resumed" / "Already on" reply)
+            # or it was found-then-redirected. Failure mode = "No session found matching '<abc123>'".
+            assert "abc123" not in str(result) or "not found" not in str(result).lower(), (
+                f"bracket stripping failed for {raw!r}: gateway returned {result!r}"
+            )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_resolves_by_session_id(self, tmp_path):
+        """The gateway should accept a bare session ID, not just a title.
+
+        Before this fix, /resume in the gateway only called
+        ``resolve_session_by_title``, so ``/resume <session_id>`` always
+        returned "Session not found" even for valid IDs.
+        """
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("unnamed_session_xyz", "telegram")
+        # Deliberately no title set — this session can ONLY be resolved by ID.
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume unnamed_session_xyz")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        # Should NOT be the not-found error.
+        assert "not found" not in str(result).lower(), (
+            f"session-id lookup failed: {result!r}"
+        )
+        db.close()


### PR DESCRIPTION
## Summary
`/resume <abc123>` now works exactly like `/resume abc123` — the angle brackets from the usage hint no longer trip the lookup. The gateway also accepts bare session IDs (it was title-only before).

Two related fixes in one PR:
1. Strip outer `<>`, `[]`, `""`, `''` from `/resume` args before lookup. Applies to BOTH the CLI and the gateway.
2. Gateway tries `get_session(name)` first, then falls back to `resolve_session_by_title(name)`. Before this, the gateway could only resume by title, so `/resume <session_id>` always returned "Session not found" even when the ID was valid.

## Changes
- `cli.py` — bracket-stripping block in `_handle_resume_command`, between argument extraction and the empty-target guard.
- `gateway/run.py` — bracket-stripping block in `_handle_resume_command`, plus the session-ID-first lookup branch.
- `tests/cli/test_cli_resume_command.py` — bracketed-target resolves, mismatched-bracket passes through verbatim.
- `tests/gateway/test_resume_command.py` — bracketed gateway lookup, bare-session-ID resolution.
- `scripts/release.py` — `AUTHOR_MAP` entry mapping `claw@openclaw.ai` to `@wanwan2qq` for the attribution check.

## Validation
| | Before | After |
|---|---|---|
| CLI `/resume <abc123>` | "Session not found" | resumes session `abc123` |
| Gateway `/resume <abc123>` | "Session not found" | resumes session `abc123` |
| Gateway `/resume <bare_id>` (no title) | "Session not found" | resumes via `get_session()` fallback |
| CLI `/resume <half` (unmatched) | passes through verbatim | passes through verbatim (unchanged) |

Targeted tests: 101/101 passing across `tests/cli/test_cli_resume_command.py`, `tests/cli/test_resume_display.py`, `tests/cli/test_cli_init.py`, `tests/gateway/test_resume_command.py`.

## Salvage notes
Surgical reapply of PR #10215 by @wanwan2qq (commit `28040a80f` authored by `Claw Assistant <claw@openclaw.ai>`). The original branch was based on a many-months-old `main` and a direct cherry-pick would have reverted 3,153 unrelated files (-812k LOC) including the entire `/resume` numbered-selection work, the recap wire-up, and the full-title fix that landed just hours ago. The substantive change (~22 LOC of bracket stripping + session-ID lookup) was reapplied by hand onto current `main`, with the original commit attributed via `git commit --author=`.

Original PR #10215 will be closed pointing to this one.

## Infographic

![resume-strip-brackets](https://v3b.fal.media/files/b/0a9b9966/y_UcrmJ7uynVfpyXQm8lo_9jbA5Xab.png)

https://v3b.fal.media/files/b/0a9b9966/y_UcrmJ7uynVfpyXQm8lo_9jbA5Xab.png
