### PR TITLE
fix(compression): break the infinite compression loop (salvage of #31730)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -484,8 +484,7 @@ def run_conversation(
             tools=agent.tools or None,
         )
 
-        if _preflight_tokens >= agent.context_compressor.threshold_tokens \
-           and agent.context_compressor.should_compress(_preflight_tokens):
+        if agent.context_compressor.should_compress(_preflight_tokens):
             logger.info(
                 "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                 f"{_preflight_tokens:,}",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -484,7 +484,8 @@ def run_conversation(
             tools=agent.tools or None,
         )
 
-        if _preflight_tokens >= agent.context_compressor.threshold_tokens:
+        if _preflight_tokens >= agent.context_compressor.threshold_tokens \
+           and agent.context_compressor.should_compress(_preflight_tokens):
             logger.info(
                 "Preflight compression: ~%s tokens >= %s threshold (model %s, ctx %s)",
                 f"{_preflight_tokens:,}",
@@ -4180,6 +4181,7 @@ def run_conversation(
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,
+        "session_id": agent.session_id,
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8692,6 +8692,7 @@ class GatewayRunner:
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
+                self.session_store._save()
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -56,6 +56,7 @@ AUTHOR_MAP = {
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "schepers.zander1@gmail.com": "Strontvod",
+    "ed@bebop.crew": "someaka",
     "anadi.jaggia@gmail.com": "Jaggia",
     "32201324+simpolism@users.noreply.github.com": "simpolism",
     "simpolism@gmail.com": "simpolism",

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -1,0 +1,111 @@
+"""Regression tests for #29335 — gateway must persist ``session_entry.session_id``
+after the agent's compression path mutates it.
+
+When ``_compress_context()`` rolls the agent forward into a new session, the
+agent now returns the new ``session_id`` in its result dict. The gateway
+updates ``session_entry.session_id`` in memory AND must call
+``session_store._save()`` so the new mapping survives a gateway restart.
+Without ``_save()``, the next turn loads the OLD session's transcript and
+re-triggers compression forever.
+
+Three sites in ``gateway/run.py`` mutate ``session_entry.session_id`` after
+a compression-induced session split. All three MUST be followed by a
+``_save()`` call. This test pins that invariant.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from gateway import run as gateway_run
+
+
+def _session_id_assignments_followed_by_save(source: str) -> list[tuple[int, bool]]:
+    """For each ``session_entry.session_id = ...`` assignment in *source*,
+    return ``(lineno, saved_within_5_stmts)`` — True iff a
+    ``self.session_store._save()`` call appears in the same block within the
+    next 5 statements (covers normal control flow without false-flagging
+    cleanup that lives 200 lines away).
+    """
+    tree = ast.parse(textwrap.dedent(source))
+    results: list[tuple[int, bool]] = []
+
+    class _Visitor(ast.NodeVisitor):
+        def _is_session_id_assign(self, node: ast.AST) -> bool:
+            if not isinstance(node, ast.Assign):
+                return False
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and target.attr == "session_id"
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "session_entry"
+                ):
+                    return True
+            return False
+
+        def _block_has_save_after(self, body: list[ast.stmt], idx: int) -> bool:
+            for stmt in body[idx : idx + 6]:
+                for sub in ast.walk(stmt):
+                    if (
+                        isinstance(sub, ast.Call)
+                        and isinstance(sub.func, ast.Attribute)
+                        and sub.func.attr == "_save"
+                    ):
+                        return True
+            return False
+
+        def _walk_body(self, body: list[ast.stmt]) -> None:
+            for i, stmt in enumerate(body):
+                if self._is_session_id_assign(stmt):
+                    results.append((stmt.lineno, self._block_has_save_after(body, i)))
+                for child in ast.iter_child_nodes(stmt):
+                    if isinstance(child, (ast.If, ast.For, ast.While, ast.With,
+                                          ast.Try, ast.AsyncWith, ast.AsyncFor)):
+                        self._walk_node(child)
+
+        def _walk_node(self, node: ast.AST) -> None:
+            for attr in ("body", "orelse", "finalbody"):
+                inner = getattr(node, attr, None)
+                if isinstance(inner, list):
+                    self._walk_body(inner)
+            if hasattr(node, "handlers"):
+                for handler in node.handlers:
+                    self._walk_body(handler.body)
+
+        def visit(self, node: ast.AST) -> None:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._walk_body(node.body)
+            for child in ast.iter_child_nodes(node):
+                self.visit(child)
+
+    _Visitor().visit(tree)
+    return results
+
+
+def test_every_post_compression_session_id_assignment_persists():
+    """Every ``session_entry.session_id = ...`` in gateway/run.py must be
+    followed by a ``session_store._save()`` call within the same block.
+
+    Regression for #29335 — the assignment at the end of
+    ``_handle_message_with_agent`` used to skip ``_save()`` while two sibling
+    sites (hygiene rewrite, manual /compress) already persisted. The agent
+    would compress correctly, the gateway would update its in-memory
+    session_id, then drop it on next gateway restart.
+    """
+    source = inspect.getsource(gateway_run)
+    assignments = _session_id_assignments_followed_by_save(source)
+    assert assignments, (
+        "No ``session_entry.session_id = ...`` assignments found in gateway/run.py — "
+        "either the structure changed or the AST walker is broken."
+    )
+    missing = [lineno for lineno, saved in assignments if not saved]
+    assert not missing, (
+        f"{len(missing)} ``session_entry.session_id = ...`` site(s) in gateway/run.py "
+        f"are not followed by ``session_store._save()`` within the same block "
+        f"(lines: {missing}). Every post-compression session_id update must persist "
+        f"or the next turn loads the pre-compression transcript and triggers an "
+        f"infinite compression loop. See issue #29335."
+    )

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -543,6 +543,40 @@ class TestPreflightCompression:
 
         mock_compress.assert_not_called()
 
+    def test_preflight_respects_anti_thrash(self, agent):
+        """Preflight must call ``should_compress()`` so anti-thrash applies.
+
+        Regression for #29335 — preflight used to bypass ``should_compress()``
+        and re-trigger every turn even when the prior two passes each saved
+        <10% (the canonical infinite-compression-loop signal).
+        """
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 2000
+        agent.context_compressor.threshold_tokens = 200
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded"})
+
+        ok_resp = _mock_response(content="No preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        with (
+            patch.object(agent.context_compressor, "should_compress", return_value=False) as mock_should,
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        # The gate consulted should_compress — anti-thrash had a chance to vote.
+        mock_should.assert_called()
+        # And vetoed: even though tokens >= threshold, no compression ran.
+        mock_compress.assert_not_called()
+        assert result["completed"] is True
+
 
 class TestToolResultPreflightCompression:
     """Compression should trigger when tool results push context past the threshold."""


### PR DESCRIPTION
## Summary

Compression no longer infinite-loops. Salvage of #31730 (@someaka) with a polish + two invariant-pinning tests on top.

## Root cause (from #29335)

Three coupled defects cause an infinite compression loop:

1. `_compress_context()` rolls the agent forward into a new session, but `run_conversation()` never put `session_id` in its result dict — the gateway's guard for "did the session change?" was dead code.
2. Preflight compression compared `_preflight_tokens >= threshold_tokens` directly, bypassing `should_compress()` which carries the anti-thrash logic. When the system prompt + tool schemas dominate token count, compression saves <10% but preflight re-fires every turn anyway.
3. Gateway updated `session_entry.session_id` in memory after compression but never called `session_store._save()` — the two sibling sites in the same file (hygiene rewrite at L8437, manual `/compress` at L12122) already persisted; this third site was missed.

## Changes

- `agent/conversation_loop.py`: add `"session_id": agent.session_id` to the result dict; gate preflight on `agent.context_compressor.should_compress(_preflight_tokens)` instead of a raw threshold compare. (Contributor commit, authorship preserved.)
- `agent/conversation_loop.py` (polish): drop the redundant `_preflight_tokens >= threshold_tokens` clause the contributor PR added next to the new `should_compress()` call — `should_compress()` already short-circuits when `tokens < threshold_tokens`, so the explicit comparison was dead on the True branch.
- `gateway/run.py`: call `self.session_store._save()` after the post-compression `session_entry.session_id = ...` assignment. (Contributor commit.)
- `tests/run_agent/test_413_compression.py`: one new test pinning that preflight calls `should_compress()` so anti-thrash has a vote — mocks `should_compress` to return False even with tokens past the raw threshold and asserts no compression runs.
- `tests/gateway/test_compression_session_id_persistence.py`: new file, one test. AST scan over `gateway/run.py` asserts every `session_entry.session_id = ...` assignment is followed by a `session_store._save()` call within the same block. Empirically verified the test catches the bug: drop the new `_save()` line → test reports `line 8694 missing _save()`, restore it → green.
- `scripts/release.py`: AUTHOR_MAP entry mapping `ed@bebop.crew` → `someaka`.

## Validation

|                           | Before                 | After                |
|---------------------------|------------------------|----------------------|
| 200k-token session resume | infinite compress loop | one compress, normal |
| Anti-thrash on preflight  | bypassed               | applies              |
| Gateway restart after compression | reverts to old session | survives        |

```
tests/run_agent/test_413_compression.py                        16 passed
tests/gateway/test_compression_session_id_persistence.py        1 passed
                                                              17 passed in 5.31s
```

## Notes

- Salvage of #31730 by @someaka. Contributor's commit is preserved with original authorship; the polish + tests are a separate follow-up so per-commit blame stays clean.
- Closes #31730, fixes #29335.
- The AST-scan test pins the contract for all three `session_entry.session_id` assignments in `gateway/run.py` — adding a fourth site in the future without `_save()` will fail this test, not silently break compression a year from now.

## Infographic

![compression-loop-fix](https://v3b.fal.media/files/b/0a9b996a/Mo11p3PvjLcGS427b8Y99_8VQk1iYx.png)
