### PR TITLE
fix(gateway): fire raw post-delivery callback under generationed pop

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2590,8 +2590,11 @@ class BasePlatformAdapter(ABC):
                 return None
             self._post_delivery_callbacks.pop(session_key, None)
             return callback if callable(callback) else None
-        if generation is not None:
-            return None
+        # Raw (generation-less) entry: it carries no generation ownership, so a
+        # generationed pop must still fire it — it cannot belong to a different
+        # run. Previously this returned None whenever ``generation is not None``,
+        # silently dropping the callback (e.g. the `✓ Goal achieved` notice when
+        # register saw generation=None but pop snapshotted a real generation). See #31922.
         self._post_delivery_callbacks.pop(session_key, None)
         return entry if callable(entry) else None
 

--- a/tests/gateway/test_post_delivery_callback_chaining.py
+++ b/tests/gateway/test_post_delivery_callback_chaining.py
@@ -111,3 +111,27 @@ class TestPostDeliveryCallbackChaining:
     def test_non_callable_is_noop(self, adapter):
         adapter.register_post_delivery_callback("s", "not-callable")  # type: ignore[arg-type]
         assert adapter._post_delivery_callbacks == {}
+
+    def test_raw_callback_fires_for_generationed_pop(self, adapter):
+        """Regression for #31922: a callback registered WITHOUT a generation
+        carries no ownership, so a generationed pop must still fire it — it
+        cannot belong to a different run. Previously the pop returned None
+        whenever generation was not None, silently dropping the callback
+        (e.g. the `✓ Goal achieved` notice)."""
+        fired = []
+        adapter.register_post_delivery_callback("s", lambda: fired.append("raw"))
+        cb = adapter.pop_post_delivery_callback("s", generation=7)
+        assert cb is not None
+        cb()
+        assert fired == ["raw"]
+        # And the entry is consumed, not left dangling.
+        assert adapter._post_delivery_callbacks == {}
+
+    def test_raw_callback_still_fires_for_generationless_pop(self, adapter):
+        """The pre-existing generation-less path must keep working."""
+        fired = []
+        adapter.register_post_delivery_callback("s", lambda: fired.append("raw"))
+        cb = adapter.pop_post_delivery_callback("s")
+        assert cb is not None
+        cb()
+        assert fired == ["raw"]


### PR DESCRIPTION
Fixes #31922.

## Summary
`pop_post_delivery_callback` silently dropped a deferred callback whenever it was called **with** a generation but the stored entry was a **raw** (generation-less) callable. That's the path behind the dropped `✓ Goal achieved` notice (and any other deferred post-delivery send): the callback gets registered with `generation=None` (the active-session run generation isn't bound yet at register time), but `pop` is called with a real generation snapshotted after the agent run (`gateway/run.py`, by design — see the comment at the pop call site). The strict branch then hit:

```python
if generation is not None:
    return None   # <- raw entry + generationed pop = callback eaten, not even popped
```

## Fix
A raw entry carries **no generation ownership**, so it cannot belong to a different/stale run — a generationed pop must still fire it. Removed the `generation is not None -> return None` early-out for the raw-callable case; it now pops and returns the callback regardless of the pop's generation. Generation ownership is fully preserved for tuple (owned) entries — the stale-run protection (`int(entry_generation) != int(generation) -> None`) is untouched. Only the un-owned raw case changes.

The reporter's RCA was spot-on; this implements the minimal-risk version of it.

## Real-behavior proof
```
$ python -c "<register raw callback (generation=None), pop with generation=7>"
pop returned: callback
fired: ['goal-achieved']
PROOF: raw callback now fires under generationed pop -> goal notice delivered
```
Before: that pop returned `None` and the notice was never sent.

## Test plan
```
uv sync --extra dev
.venv/bin/python -m pytest tests/gateway/test_post_delivery_callback_chaining.py tests/gateway/test_goal_status_notice.py -q
# 14 passed
```
Added two regression tests to `test_post_delivery_callback_chaining.py`: a raw callback fires (and is consumed) under a generationed pop; and the pre-existing generation-less pop path still works. Existing generation-ownership and chaining tests remain green.
