### PR TITLE
fix(dashboard): correct approvals.mode select options

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -318,7 +318,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "approvals.mode": {
         "type": "select",
         "description": "Dangerous command approval mode",
-        "options": ["ask", "yolo", "deny"],
+        "options": ["manual", "smart", "off"],
     },
     "context.engine": {
         "type": "select",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -384,6 +384,26 @@ class TestBuildSchemaFromConfig:
         assert "python3.13" in runtime_entry["options"]
         assert len(runtime_entry["options"]) >= 3
 
+    def test_approvals_mode_options_match_config_values(self):
+        """approvals.mode select options must match the values accepted by config.py.
+
+        Previously the dashboard showed ['ask', 'yolo', 'deny'] which are stale
+        names that don't correspond to any real config value. The correct values
+        are 'manual', 'smart', and 'off' (see hermes_cli/config.py).
+        'smart' was missing entirely, making it unreachable from the UI.
+        """
+        from hermes_cli.web_server import CONFIG_SCHEMA
+        entry = CONFIG_SCHEMA["approvals.mode"]
+        assert entry["type"] == "select"
+        options = entry["options"]
+        assert "manual" in options, "'manual' missing from approvals.mode options"
+        assert "smart" in options, "'smart' missing from approvals.mode options"
+        assert "off" in options, "'off' missing from approvals.mode options"
+        # Stale names that were previously shown but don't match config values
+        assert "ask" not in options, "stale option 'ask' should not appear"
+        assert "yolo" not in options, "stale option 'yolo' should not appear"
+        assert "deny" not in options, "stale option 'deny' should not appear"
+
     def test_empty_prefix_produces_correct_keys(self):
         from hermes_cli.web_server import _build_schema_from_config
         test_config = {"model": "test", "nested": {"key": "val"}}


### PR DESCRIPTION
## Summary

The web UI `CONFIG_SCHEMA` in `hermes_cli/web_server.py` showed `['ask', 'yolo', 'deny']` as the options for `approvals.mode`. These are stale names that don't correspond to any real config values — and `smart` mode was entirely missing, making it unreachable from the dashboard.

## Changes

- **`hermes_cli/web_server.py`**: corrected `approvals.mode` options from `['ask', 'yolo', 'deny']` to `['manual', 'smart', 'off']` to match the values defined in `hermes_cli/config.py`
- **`tests/hermes_cli/test_web_server.py`**: added `test_approvals_mode_options_match_config_values` to `TestBuildSchemaFromConfig` to pin the correct option names and guard against future drift

## Testing

```
pytest tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig -v
# 9 passed in 0.78s
```

Verified locally via the dashboard UI — all three options render correctly and selecting each writes the right config value without errors.

Closes #31925