### PR TITLE
fix(codex): combine Responses timeout fixes

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -64,6 +64,43 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+def _api_payload_for_stale_timeout(api_kwargs: dict) -> list:
+    """Return the request payload used to estimate non-stream stale timeout.
+
+    Chat Completions requests carry ``messages``. Responses/Codex requests
+    carry ``input`` plus optional ``instructions`` and ``tools``. Without
+    this, large Responses requests are estimated as nearly empty and miss the
+    larger-context timeout bump.
+    """
+    messages = api_kwargs.get("messages")
+    if messages:
+        return messages if isinstance(messages, list) else [messages]
+
+    payload = []
+    instructions = api_kwargs.get("instructions")
+    if instructions:
+        payload.append({"role": "system", "content": instructions})
+
+    response_input = api_kwargs.get("input")
+    if isinstance(response_input, list):
+        payload.extend(response_input)
+    elif response_input:
+        payload.append(response_input)
+
+    tools = api_kwargs.get("tools")
+    if tools:
+        payload.append({"role": "system", "content": tools})
+    return payload
+
+
+def _estimate_payload_tokens(payload: object) -> int:
+    """Cheap, conservative token estimate for log messages/timeouts."""
+    if not payload:
+        return 0
+    items = payload if isinstance(payload, list) else [payload]
+    return sum(len(str(item)) for item in items) // 4
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -200,9 +237,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # httpx timeout (default 1800s) with zero feedback.  The stale
     # detector kills the connection early so the main retry loop can
     # apply richer recovery (credential rotation, provider fallback).
-    _stale_timeout = agent._compute_non_stream_stale_timeout(
-        api_kwargs.get("messages", [])
-    )
+    _stale_timeout = agent._compute_non_stream_stale_timeout(api_kwargs)
 
     _call_start = time.time()
     agent._touch_activity("waiting for non-streaming API response")
@@ -226,7 +261,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
         # arrives within the configured timeout.
         _elapsed = time.time() - _call_start
         if _elapsed > _stale_timeout:
-            _est_ctx = sum(len(str(v)) for v in api_kwargs.get("messages", [])) // 4
+            try:
+                _est_ctx = _ra()._estimate_non_stream_request_context_tokens(api_kwargs)
+            except Exception:
+                _est_ctx = _estimate_payload_tokens(_api_payload_for_stale_timeout(api_kwargs))
             logger.warning(
                 "Non-streaming API call stale for %.0fs (threshold %.0fs). "
                 "model=%s context=~%s tokens. Killing connection.",
@@ -363,6 +401,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             request_overrides=agent.request_overrides,
+            timeout=agent._resolved_api_call_timeout(),
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -745,7 +745,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
-        "extra_headers", "extra_body",
+        "extra_headers", "extra_body", "timeout",
     }
     normalized: Dict[str, Any] = {
         "model": model,
@@ -771,6 +771,13 @@ def _preflight_codex_api_kwargs(
     max_output_tokens = api_kwargs.get("max_output_tokens")
     if isinstance(max_output_tokens, (int, float)) and max_output_tokens > 0:
         normalized["max_output_tokens"] = int(max_output_tokens)
+    timeout = api_kwargs.get("timeout")
+    if (
+        isinstance(timeout, (int, float))
+        and not isinstance(timeout, bool)
+        and 0 < float(timeout) < float("inf")
+    ):
+        normalized["timeout"] = float(timeout)
     temperature = api_kwargs.get("temperature")
     if isinstance(temperature, (int, float)):
         normalized["temperature"] = float(temperature)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -50,6 +50,7 @@ class ResponsesApiTransport(ProviderTransport):
             reasoning_config: dict | None — {effort, enabled}
             session_id: str | None — used for prompt_cache_key + xAI conv header
             max_tokens: int | None — max_output_tokens
+            timeout: float | None — per-request timeout
             request_overrides: dict | None — extra kwargs merged in
             provider: str | None — provider name for backend-specific logic
             base_url: str | None — endpoint URL
@@ -142,6 +143,16 @@ class ResponsesApiTransport(ProviderTransport):
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        timeout = kwargs.get("timeout", params.get("timeout"))
+        if (
+            isinstance(timeout, (int, float))
+            and not isinstance(timeout, bool)
+            and 0 < float(timeout) < float("inf")
+        ):
+            kwargs["timeout"] = float(timeout)
+        else:
+            kwargs.pop("timeout", None)
 
         if is_codex_backend:
             prompt_cache_key = kwargs.get("prompt_cache_key")

--- a/run_agent.py
+++ b/run_agent.py
@@ -100,6 +100,52 @@ else:
     logger.info("No .env file found. Using system environment variables.")
 
 
+def _estimate_non_stream_request_context_tokens(api_payload: Any) -> int:
+    """Estimate request context/load tokens from API kwargs or legacy messages.
+
+    The stale-call detector historically accepted a Chat Completions
+    ``messages`` list and used a cheap character/4 estimate.  Responses API
+    requests carry their conversational payload in ``input`` with additional
+    load in ``instructions`` and ``tools``, so estimate those fields when a
+    full kwargs dict is available.
+    """
+
+    def _chars(value: Any) -> int:
+        if value is None:
+            return 0
+        if isinstance(value, str):
+            return len(value)
+        return len(str(value))
+
+    def _message_chars(messages: Any) -> int:
+        if not isinstance(messages, list):
+            return _chars(messages)
+        return sum(_chars(item) for item in messages)
+
+    if isinstance(api_payload, list):
+        return _message_chars(api_payload) // 4
+
+    if isinstance(api_payload, dict):
+        messages = api_payload.get("messages")
+        if isinstance(messages, list):
+            total_chars = _message_chars(messages)
+            if "tools" in api_payload:
+                total_chars += _chars(api_payload.get("tools"))
+            return total_chars // 4
+
+        if "input" in api_payload:
+            total_chars = (
+                _chars(api_payload.get("input"))
+                + _chars(api_payload.get("instructions"))
+                + _chars(api_payload.get("tools"))
+            )
+            return total_chars // 4
+
+        return sum(_chars(value) for value in api_payload.values()) // 4
+
+    return _chars(api_payload) // 4
+
+
 # Import our tool system
 from model_tools import (
     get_tool_definitions,
@@ -902,14 +948,14 @@ class AIAgent:
 
         return 300.0, True
 
-    def _compute_non_stream_stale_timeout(self, messages: list[dict[str, Any]]) -> float:
+    def _compute_non_stream_stale_timeout(self, api_payload: Any) -> float:
         """Compute the effective non-stream stale timeout for this request."""
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
         if uses_implicit_default and base_url and is_local_endpoint(base_url):
             return float("inf")
 
-        est_tokens = sum(len(str(v)) for v in messages) // 4
+        est_tokens = _estimate_non_stream_request_context_tokens(api_payload)
         if est_tokens > 100_000:
             return max(stale_base, 600.0)
         if est_tokens > 50_000:

--- a/tests/agent/test_non_stream_stale_timeout.py
+++ b/tests/agent/test_non_stream_stale_timeout.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+from agent.chat_completion_helpers import (
+    _api_payload_for_stale_timeout,
+    _estimate_payload_tokens,
+)
+from run_agent import AIAgent
+
+
+def test_stale_payload_uses_responses_input_and_instructions():
+    payload = _api_payload_for_stale_timeout(
+        {
+            "model": "gpt-5.5",
+            "instructions": "system prompt",
+            "input": [{"role": "user", "content": "hello"}],
+        }
+    )
+
+    assert payload == [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "hello"},
+    ]
+
+
+def test_stale_payload_prefers_chat_messages_when_present():
+    messages = [{"role": "user", "content": "chat path"}]
+
+    assert _api_payload_for_stale_timeout(
+        {"messages": messages, "input": [{"role": "user", "content": "responses path"}]}
+    ) is messages
+
+
+def test_codex_responses_payload_gets_large_context_timeout_bump(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch.object(AIAgent, "__init__", lambda self, **kw: None):
+        agent = AIAgent()
+
+    setattr(agent, "provider", "openai-codex")
+    setattr(agent, "model", "gpt-5.5")
+    setattr(agent, "base_url", "https://chatgpt.com/backend-api/codex")
+    setattr(agent, "_base_url", agent.base_url)
+
+    payload = _api_payload_for_stale_timeout(
+        {
+            "instructions": "system",
+            "input": [{"role": "user", "content": "x" * 240_000}],
+        }
+    )
+
+    assert _estimate_payload_tokens(payload) > 50_000
+    assert agent._compute_non_stream_stale_timeout(payload) == 450.0

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -146,6 +146,16 @@ class TestCodexBuildKwargs:
         )
         assert kw.get("max_output_tokens") == 4096
 
+    def test_timeout(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            timeout=123.5,
+        )
+        assert kw["timeout"] == 123.5
+
     def test_codex_backend_no_max_output_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1345,6 +1345,41 @@ class TestBuildApiKwargs:
         assert kwargs["messages"] is messages
         assert kwargs["timeout"] == 1800.0
 
+    def test_non_stream_stale_timeout_counts_large_responses_payload(self, agent, monkeypatch):
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *_args, **_kwargs: None)
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        api_kwargs = {
+            "model": "gpt-5.5",
+            "instructions": "i" * 80_000,
+            "input": [{"role": "user", "content": "u" * 120_000}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "terminal",
+                    "description": "t" * 20_000,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "p" * 4_000}
+                        },
+                    },
+                }
+            ],
+            "store": False,
+        }
+
+        assert agent._compute_non_stream_stale_timeout(api_kwargs) == 450.0
+
+    def test_non_stream_stale_timeout_keeps_chat_messages_estimate(self, agent, monkeypatch):
+        monkeypatch.setattr(run_agent, "get_provider_stale_timeout", lambda *_args, **_kwargs: None)
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        messages = [{"role": "user", "content": "x" * 220_000}]
+
+        legacy_timeout = agent._compute_non_stream_stale_timeout(messages)
+
+        assert legacy_timeout == 450.0
+        assert agent._compute_non_stream_stale_timeout({"messages": messages}) == legacy_timeout
+
     def test_public_moonshot_kimi_k2_5_omits_temperature(self, agent):
         """Kimi models should NOT have client-side temperature overrides.
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -306,9 +306,23 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert kwargs["parallel_tool_calls"] is True
     assert isinstance(kwargs["prompt_cache_key"], str)
     assert len(kwargs["prompt_cache_key"]) > 0
-    assert "timeout" not in kwargs
+    assert kwargs["timeout"] == 1800.0
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs
+
+
+def test_build_api_kwargs_codex_preserves_configured_timeout(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr(run_agent, "get_provider_request_timeout", lambda *_args, **_kwargs: 123.0)
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Ping"},
+        ]
+    )
+
+    assert kwargs["timeout"] == 123.0
 
 
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
@@ -1051,6 +1065,28 @@ def test_preflight_codex_api_kwargs_allows_service_tier(monkeypatch):
     from agent.codex_responses_adapter import _preflight_codex_api_kwargs
     result = _preflight_codex_api_kwargs(kwargs)
     assert result["service_tier"] == "priority"
+
+
+def test_preflight_codex_api_kwargs_preserves_positive_timeout(monkeypatch):
+    _build_agent(monkeypatch)
+    kwargs = _codex_request_kwargs()
+    kwargs["timeout"] = 42.5
+
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+    result = _preflight_codex_api_kwargs(kwargs)
+    assert result["timeout"] == 42.5
+
+
+def test_preflight_codex_api_kwargs_omits_invalid_timeout(monkeypatch):
+    _build_agent(monkeypatch)
+
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+    for timeout in (0, -1, "slow", True, None):
+        kwargs = _codex_request_kwargs()
+        kwargs["timeout"] = timeout
+        result = _preflight_codex_api_kwargs(kwargs)
+        assert "timeout" not in result
 
 
 def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):


### PR DESCRIPTION
## Summary

Backports and combines two Codex Responses timeout fixes onto current `main`:

- References #24126: preserve configured request timeouts through the Codex Responses request path.
- References #31855: estimate non-stream stale timeouts from the full Responses payload instead of only Chat Completions `messages`.

This also resolves the current helper-based refactor conflict by applying the stale-timeout logic in `agent/chat_completion_helpers.py`, while keeping `run_agent.py` as a forwarder. It preserves xAI Responses `extra_body` preflight support while adding `timeout` to the allowlist.

## Test plan

- `git diff --check`
- `.venv/bin/python -m compileall -q run_agent.py agent/transports/codex.py agent/codex_responses_adapter.py agent/chat_completion_helpers.py`
- `HERMES_HOME=/private/tmp/hermes-agent-test-home venv/bin/python -m pytest tests/agent/test_non_stream_stale_timeout.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_run_agent.py::TestBuildApiKwargs -q -o addopts=`

Result: `140 passed, 1 warning`.
