### PR TITLE
fix(cli): redirect resume status lines to stderr in quiet mode (#11793)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4756,9 +4756,22 @@ class HermesCLI:
         # is non-empty and we skip the DB round-trip.
         if self._resumed and self._session_db and not self.conversation_history:
             session_meta = self._session_db.get_session(self.session_id)
+            # In quiet mode (`hermes chat -Q` / --quiet, surfaced via
+            # tool_progress_mode == "off"), resume status lines go to stderr
+            # so stdout stays machine-readable for automation wrappers that
+            # do `$(hermes chat -Q --resume <id> -q "...")`. Without this,
+            # the resume banner pollutes captured stdout. See #11793.
+            _quiet_mode = getattr(self, "tool_progress_mode", "full") == "off"
             if not session_meta:
-                _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
-                _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
+                if _quiet_mode:
+                    print(f"Session not found: {self.session_id}", file=sys.stderr)
+                    print(
+                        "Use a session ID from a previous CLI run (hermes sessions list).",
+                        file=sys.stderr,
+                    )
+                else:
+                    _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
+                    _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
                 return False
             # If the requested session is the (empty) head of a compression
             # chain, walk to the descendant that actually holds the messages.
@@ -4785,16 +4798,30 @@ class HermesCLI:
                 title_part = ""
                 if session_meta.get("title"):
                     title_part = f" \"{session_meta['title']}\""
-                ChatConsole().print(
-                    f"[bold {_accent_hex()}]↻ Resumed session[/] "
-                    f"[bold]{_escape(self.session_id)}[/]"
-                    f"[bold {_accent_hex()}]{_escape(title_part)}[/] "
-                    f"({msg_count} user message{'s' if msg_count != 1 else ''}, {len(restored)} total messages)"
-                )
+                if _quiet_mode:
+                    print(
+                        f"↻ Resumed session {self.session_id}{title_part} "
+                        f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
+                        f"{len(restored)} total messages)",
+                        file=sys.stderr,
+                    )
+                else:
+                    ChatConsole().print(
+                        f"[bold {_accent_hex()}]↻ Resumed session[/] "
+                        f"[bold]{_escape(self.session_id)}[/]"
+                        f"[bold {_accent_hex()}]{_escape(title_part)}[/] "
+                        f"({msg_count} user message{'s' if msg_count != 1 else ''}, {len(restored)} total messages)"
+                    )
             else:
-                ChatConsole().print(
-                    f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
-                )
+                if _quiet_mode:
+                    print(
+                        f"Session {self.session_id} found but has no messages. Starting fresh.",
+                        file=sys.stderr,
+                    )
+                else:
+                    ChatConsole().print(
+                        f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
+                    )
             # Re-open the session (clear ended_at so it's active again)
             try:
                 self._session_db._conn.execute(

--- a/tests/cli/test_resume_quiet_stderr.py
+++ b/tests/cli/test_resume_quiet_stderr.py
@@ -1,0 +1,121 @@
+"""Tests for /resume status lines going to stderr in quiet mode (#11793).
+
+The fix in cli._init_agent routes three messages to stderr when
+``tool_progress_mode == "off"`` (set by ``hermes chat --quiet``):
+
+  * "Session not found: ..."
+  * "↻ Resumed session ... (N user messages, M total messages)"
+  * "Session ... found but has no messages. Starting fresh."
+
+Interactive mode (tool_progress_mode == "full") still uses ChatConsole.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli import HermesCLI
+
+
+def _make_cli(quiet=False, session_id="20260524_111111_xyz", db=None):
+    """Build a minimal HermesCLI bound to only what _init_agent needs for
+    the resume code path: _resumed, _session_db, conversation_history,
+    session_id, and tool_progress_mode."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = session_id
+    cli._resumed = True
+    cli.conversation_history = []
+    cli._session_db = db
+    cli.tool_progress_mode = "off" if quiet else "full"
+    cli.session_start = datetime.now()
+    cli.agent = None
+    # We need _init_agent to reach the resume block (line ~4757) but not
+    # proceed into actual AIAgent construction. _ensure_runtime_credentials
+    # must return True (False returns early at line 4743). _install_tool_callbacks,
+    # _ensure_tirith_security are stubbed; the resume block will either return
+    # False (session-not-found) or reach the eventual AIAgent() call which
+    # we'll let raise — we only check stdout/stderr printed BEFORE that.
+    cli._install_tool_callbacks = lambda: None
+    cli._ensure_tirith_security = lambda: None
+    cli._ensure_runtime_credentials = lambda: True
+    return cli
+
+
+class TestResumeQuietStderr:
+    def test_session_not_found_goes_to_stderr_in_quiet_mode(self, capsys):
+        db = MagicMock()
+        db.get_session.return_value = None
+        cli = _make_cli(quiet=True, db=db)
+
+        with patch("cli._prepare_deferred_agent_startup"):
+            result = cli._init_agent()
+
+        captured = capsys.readouterr()
+        assert result is False
+        # stdout must stay clean
+        assert "Session not found" not in captured.out
+        # the resume status goes to stderr
+        assert "Session not found" in captured.err
+        assert "hermes sessions list" in captured.err
+
+    def test_session_not_found_goes_to_stdout_in_full_mode(self, capsys):
+        db = MagicMock()
+        db.get_session.return_value = None
+        cli = _make_cli(quiet=False, db=db)
+
+        with patch("cli._prepare_deferred_agent_startup"):
+            result = cli._init_agent()
+
+        captured = capsys.readouterr()
+        assert result is False
+        # Interactive mode keeps the existing _cprint path → stdout.
+        assert "Session not found" in captured.out
+
+    def test_resumed_banner_goes_to_stderr_in_quiet_mode(self, capsys):
+        db = MagicMock()
+        db.get_session.return_value = {"id": "20260524_111111_xyz", "title": "demo"}
+        db.resolve_resume_session_id.return_value = "20260524_111111_xyz"
+        db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hey"},
+        ]
+        db._conn = MagicMock()  # for the reopen execute() call
+
+        cli = _make_cli(quiet=True, db=db)
+        # Stop _init_agent right after the resume banner: prevent it from
+        # constructing a real AIAgent (the next code path).
+        with patch("cli._prepare_deferred_agent_startup"):
+            try:
+                cli._init_agent()
+            except Exception:
+                # The post-resume agent-init machinery may fail in this
+                # stubbed context (no API key, no real config) — we only
+                # care about the printed banner that comes earlier.
+                pass
+
+        captured = capsys.readouterr()
+        # Banner on stderr — stdout stays clean for automation.
+        assert "↻ Resumed session" not in captured.out
+        assert "↻ Resumed session" in captured.err
+        assert "20260524_111111_xyz" in captured.err
+        assert "demo" in captured.err
+
+    def test_no_messages_goes_to_stderr_in_quiet_mode(self, capsys):
+        db = MagicMock()
+        db.get_session.return_value = {"id": "20260524_111111_xyz"}
+        db.resolve_resume_session_id.return_value = "20260524_111111_xyz"
+        db.get_messages_as_conversation.return_value = []
+        db._conn = MagicMock()
+
+        cli = _make_cli(quiet=True, db=db)
+        with patch("cli._prepare_deferred_agent_startup"):
+            try:
+                cli._init_agent()
+            except Exception:
+                pass
+
+        captured = capsys.readouterr()
+        assert "has no messages" not in captured.out
+        assert "has no messages" in captured.err
+        assert "Starting fresh" in captured.err


### PR DESCRIPTION
## Summary
`hermes chat --quiet --resume <id> -q "..."` now keeps stdout machine-readable. The three resume status lines that previously polluted stdout — `↻ Resumed session`, `Session not found`, `Session has no messages` — now go to stderr in quiet mode. Fixes #11793.

Why this matters: automation wrappers do `$(hermes chat --quiet --resume "$SESSION" -q "...")` to capture the agent's answer. Before this fix, the resume banner ended up in the captured variable alongside the answer, breaking parseability. After this fix, `2>/dev/null` cleanly separates the answer (stdout) from status noise (stderr), matching the existing `session_id` convention.

## Changes
- `cli.py` — `_init_agent` resume block now branches on `tool_progress_mode == "off"`. Quiet mode routes the three status lines through `print(..., file=sys.stderr)`. Full mode is unchanged — it still uses the Rich-rendered `ChatConsole` path.
- `tests/cli/test_resume_quiet_stderr.py` — 4 tests cover the new behavior: quiet→stderr for session-not-found, full→stdout for session-not-found (unchanged), quiet→stderr for the resumed banner, quiet→stderr for the no-messages branch.

## Validation
| | Before | After |
|---|---|---|
| `--quiet --resume <good_id>` stdout | "↻ Resumed session..." + answer + "session_id:..." | answer only |
| `--quiet --resume <bad_id>` stdout | "Session not found:..." | empty (error on stderr) |
| `--quiet --resume <empty_session>` stdout | "Session has no messages..." | empty (status on stderr) |
| Interactive `--resume <good_id>` | Rich-styled banner on stdout | unchanged |
| Automation wrapper `$(hermes -Q --resume X -q "...")` | gets banner + answer | gets answer only |

Targeted tests: `tests/cli/test_resume_quiet_stderr.py` — 4/4 passing.

## Salvage notes
Surgical reapply of PR #11868 by @malaiwah (Michel Belleau, `michel.belleau@malaiwah.com`). The original branch was stale against current `main`; reapplied onto current `cli.py` by hand with original commit attribution preserved via `git commit --author=`.

Original PR #11868 will be closed pointing to this one. Issue #11793 closed by the merge commit footer.

## Infographic

![resume-quiet-stderr](https://v3b.fal.media/files/b/0a9b99bc/2t7wKw60_30AEpI03-aEv_OGCqoNg5.png)

https://v3b.fal.media/files/b/0a9b99bc/2t7wKw60_30AEpI03-aEv_OGCqoNg5.png
