### PR TITLE
fix(ci): remove stale landingpage reference from skills-index deployment

### DIFF
--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Stage deployment
         run: |
           mkdir -p _site/docs
-          cp -r landingpage/* _site/
           cp -r website/build/* _site/docs/
           echo "hermes-agent.nousresearch.com" > _site/CNAME
 


### PR DESCRIPTION
## What

Fixes the failing `Build Skills Index` workflow that fails every scheduled run with `cp: cannot stat 'landingpage/*': No such file or directory`.

## Root Cause

The `landingpage/` directory was deleted in commit `139b9ae1e` (feat: add vercel deployment, remove old landing page) but the `skills-index.yml` workflow still tried to `cp -r landingpage/* _site/` in the Stage deployment step.

## Fix

Remove the stale `cp -r landingpage/* _site/` line from the Stage deployment step. The landing page is now served via Vercel, so GitHub Pages deployment only needs the Docusaurus docs site.