### PR TITLE
[codex] Suppress Telegram compaction status noise

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -75,6 +75,8 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
+    r"|compacting\s+context\s+—\s+summarizing\s+earlier\s+conversation"
+    r"|compacting\s+context\s+-\s+summarizing\s+earlier\s+conversation"
     r"|preflight\s+compression"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -12,6 +12,7 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
     noisy_messages = [
         "⚠ Auxiliary title generation failed: HTTP 400: Operation contains cybersecurity risk",
         "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+        "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
         "ℹ Configured compression model 'small-model' failed (timeout). Recovered using main model — check auxiliary.compression.model in config.yaml.",
         "⏳ Retrying in 4.2s (attempt 1/3)...",
         "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",


### PR DESCRIPTION
## Summary
- suppress Telegram status noise for context-compaction messages using em dash and ASCII hyphen forms
- add coverage to the Telegram noise filter test

## Verification
- python -m pytest tests/gateway/test_telegram_noise_filter.py -q -o 'addopts='