### PR TITLE
test(auth): align copilot-remove test with borrowed-credential policy (#31416)

### DIFF
--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1590,20 +1590,16 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
     hermes_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
+    # The copilot pool entry is no longer persisted directly in auth.json —
+    # `(copilot, gh_cli)` is borrowed and stripped by
+    # sanitize_borrowed_credential_payload (PR #31416, May 2026). Tokens are
+    # hydrated at runtime via resolve_copilot_token(). Mock that path so the
+    # pool has an entry to remove.
     _write_auth_store(
         tmp_path,
         {
             "version": 1,
-            "credential_pool": {
-                "copilot": [{
-                    "id": "c1",
-                    "label": "gh auth token",
-                    "auth_type": "api_key",
-                    "priority": 0,
-                    "source": "gh_cli",
-                    "access_token": "ghp_fake",
-                }]
-            },
+            "credential_pool": {"copilot": []},
         },
     )
 
@@ -1611,7 +1607,14 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
     from hermes_cli.auth import is_source_suppressed
     from hermes_cli.auth_commands import auth_remove_command
 
-    auth_remove_command(SimpleNamespace(provider="copilot", target="1"))
+    with patch(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        return_value=("ghp_fake", "gh"),
+    ), patch(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        return_value="ghu_fake_api",
+    ):
+        auth_remove_command(SimpleNamespace(provider="copilot", target="1"))
 
     assert is_source_suppressed("copilot", "gh_cli")
     assert is_source_suppressed("copilot", "env:COPILOT_GITHUB_TOKEN")


### PR DESCRIPTION
## Summary
`tests/hermes_cli/test_auth_commands.py::test_auth_remove_copilot_suppresses_all_variants` now passes on current `main`. Pre-existing failure introduced by PR #31416 (avoid persisting borrowed credential secrets, merged May 25 2026).

## Root cause
PR #31416 added `sanitize_borrowed_credential_payload()` to `agent/credential_pool.py`. The new policy: any `(provider, source)` tuple NOT in `_PERSISTABLE_PROVIDER_SOURCES` is "borrowed" and gets its `access_token` stripped at the disk boundary. `(copilot, gh_cli)` is correctly classified as borrowed — `gh auth token` is the canonical source of truth, not `auth.json`.

The test fixture pre-seeded an `access_token` directly into a `copilot/gh_cli` pool entry and expected `load_pool` to surface it. Under the new policy that token gets stripped, `pool.entries()` returns empty, and `resolve_target("1")` correctly says "No credential #1."

The behavior under test (suppression of `gh_cli` + all `env:*` variants on remove) is unchanged. Only the fixture's seeding mechanism needs updating to match the new contract.

## Changes
- `tests/hermes_cli/test_auth_commands.py` — `test_auth_remove_copilot_suppresses_all_variants` now seeds the pool via mocked `resolve_copilot_token()` / `get_copilot_api_token()` (the actual runtime hydration path), matching production behavior.

## Validation
| | Before | After |
|---|---|---|
| `test_auth_remove_copilot_suppresses_all_variants` | FAIL (`SystemExit: No credential #1`) | PASS |
| Rest of `test_auth_commands.py` | 45 pass | 46 pass |
| Behavior under test (suppression contract) | unchanged | unchanged |

Reproduced the failure on stock `origin/main` HEAD with no other patches applied. CI run from PR #31929 surfaced it.

## Why fix-it-first PR
Per [`references/green-ci-policy.md`](../tree/main/.hermes/skills/github/hermes-agent-dev/references/green-ci-policy.md): when a pre-existing failure blocks an unrelated PR, the right move is a separate fix-it PR. This test failure was blocking my `/resume` bracket-stripping salvage (#31929); landing this first lets that PR rebase onto a clean main.

## Infographic

![auth-test-realignment](https://v3b.fal.media/files/b/0a9b99e7/UbnXaIc3cO0K5-hC7YINq_CtkbmY2r.png)

https://v3b.fal.media/files/b/0a9b99e7/UbnXaIc3cO0K5-hC7YINq_CtkbmY2r.png
