### PR TITLE
fix(cron): layer agent.disabled_toolsets onto cron baseline (#25752, salvage)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -57,6 +57,29 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
+    """Toolsets a cron-spawned agent must never receive.
+
+    Three protected toolsets are always disabled in cron context:
+      - ``cronjob`` — would let a cron-spawned agent schedule more cron jobs
+      - ``messaging`` — interactive, needs a live gateway session
+      - ``clarify`` — interactive, blocks waiting for user input
+
+    User-level ``agent.disabled_toolsets`` from config.yaml is layered on top
+    so per-job ``enabled_toolsets`` cannot bypass policy that applies to
+    ordinary agent runs (#25752 — LLM-supplied enabled_toolsets was widening
+    past config.yaml's denylist).
+    """
+    disabled = ["cronjob", "messaging", "clarify"]
+    agent_cfg = (cfg or {}).get("agent") or {}
+    user_disabled = agent_cfg.get("disabled_toolsets") or []
+    for name in user_disabled:
+        name = str(name).strip()
+        if name and name not in disabled:
+            disabled.append(name)
+    return disabled
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
@@ -1574,7 +1597,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             provider_sort=pr.get("sort"),
             openrouter_min_coding_score=(_cfg.get("openrouter") or {}).get("min_coding_score"),
             enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
-            disabled_toolsets=["cronjob", "messaging", "clarify"],
+            disabled_toolsets=_resolve_cron_disabled_toolsets(_cfg),
             quiet_mode=True,
             # Cron jobs should always inherit the user's SOUL.md identity from
             # HERMES_HOME. When a workdir is configured, also inject project

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -80,6 +80,7 @@ AUTHOR_MAP = {
     "leeseoki@makestar.com": "leeseoki0",
     "kronexoi13@gmail.com": "kronexoi",
     "hua.zhong@kingsmith.com": "vgocoder",
+    "hermes@marian.local": "Schrotti77",
     "leovillalbajr@gmail.com": "Lempkey",
     "nidhi2894@gmail.com": "nidhi-singh02",
     "30312689+aashizpoudel@users.noreply.github.com": "aashizpoudel",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1021,6 +1021,42 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
 
+    def test_run_job_disabled_toolsets_layer_user_config_on_baseline(self, tmp_path):
+        """agent.disabled_toolsets must be honoured in cron — issue #25752.
+
+        The bug: per-job enabled_toolsets was returned verbatim, letting an
+        LLM-supplied cronjob() call re-enable tools the operator had globally
+        disabled. The fix: ALWAYS include agent.disabled_toolsets in the
+        disabled_toolsets passed to AIAgent, on top of the cron baseline
+        (cronjob/messaging/clarify). AIAgent's disabled_toolsets takes
+        precedence over enabled_toolsets, so this stops the bypass.
+        """
+        (tmp_path / "config.yaml").write_text(
+            "agent:\n"
+            "  disabled_toolsets:\n"
+            "    - terminal\n"
+            "    - file\n",
+            encoding="utf-8",
+        )
+        job = {
+            "id": "policy-job",
+            "name": "test",
+            "prompt": "hello",
+            "enabled_toolsets": ["web", "terminal", "file"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert set(kwargs["disabled_toolsets"]) >= {
+            "cronjob", "messaging", "clarify", "terminal", "file",
+        }
+
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now
         resolves them from ``hermes tools`` platform config for ``cron``


### PR DESCRIPTION
Salvage of #25786 by @Schrotti77 with implementation simplified.

## Summary
Closes #25752 — LLM-supplied per-job `enabled_toolsets` was bypassing `agent.disabled_toolsets` from config.yaml. Layer user-disabled toolsets on top of the cron baseline (`cronjob/messaging/clarify`) so AIAgent's disabled-side precedence stops the bypass.

## Threat
A cron-spawned agent can call `cronjob(action='add', enabled_toolsets=['terminal','file'], prompt='cat ~/.ssh/id_rsa')` and the new job receives the toolsets verbatim, even if the operator added `terminal` + `file` to `agent.disabled_toolsets` in config.yaml.

## Why fix at the disabled-side, not the enabled-side
Three other concurrent PRs (#25842 vanthinh6886, #25815 emma-xiang, #25780 he-yufeng) proposed intersection-side variants on `_resolve_cron_enabled_toolsets`. All correct in shape, but `AIAgent.disabled_toolsets` takes precedence over `enabled_toolsets` regardless of how the enabled list is computed — fixing at the disabled boundary is more robust against future changes to the resolve path.

## Salvage simplifications on top of #25786
The original PR introduced a 23-line `_normalize_toolset_list()` helper that handled str/list/tuple/set/garbage input shapes. `agent.disabled_toolsets` is always parsed as a YAML list — the elaborate normalizer was theatre for input shapes we never produce. Replaced with the existing convention (`agent_cfg.get('disabled_toolsets') or []`) used by `hermes_cli/tools_config.py` and `cli.py`. Result: 22 lines of helper instead of 41.

## Changes
- `cron/scheduler.py`: new `_resolve_cron_disabled_toolsets(cfg)` helper, wired at the `run_job()` AIAgent construction call site.
- `tests/cron/test_scheduler.py`: regression test reproducing the #25752 PoC.

## Test plan
```
pytest tests/cron/test_scheduler.py -k 'disabled_toolsets or enabled_toolsets'  # 3 passed
pytest tests/cron/                                                              # 374 passed
```

Co-authored-by: Schrotti77 <hermes@marian.local>

Closes #25752
Closes #25786