### PR TITLE
fix: harden Hermes rescue runtime authority

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -253,6 +253,15 @@ def init_agent(
     """
     _install_safe_stdio()
 
+    # Seed cleanup/session invariants before any fallible initialization
+    # path. AIAgent.__init__ delegates here directly, so partially
+    # constructed instances must still be safe for cleanup/destructor paths.
+    agent.session_id = session_id
+    agent._session_db = session_db
+    agent._session_db_created = False
+    agent._parent_session_id = parent_session_id
+    agent._compression_warning = None
+
     agent.model = model
     agent.max_iterations = max_iterations
     # Shared iteration budget — parent creates, children inherit.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -711,7 +711,9 @@ def try_recover_primary_transport(
                 pass
 
         # Rebuild from primary snapshot
-        rt = agent._primary_runtime
+        rt = getattr(agent, "_primary_runtime", None)
+        if not rt:
+            return False
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent.model = rt["model"]
         agent.provider = rt["provider"]
@@ -865,7 +867,12 @@ def restore_primary_runtime(agent) -> bool:
     if getattr(agent, "_rate_limited_until", 0) > time.monotonic():
         return False  # primary still in rate-limit cooldown, stay on fallback
 
-    rt = agent._primary_runtime
+    rt = getattr(agent, "_primary_runtime", None)
+    if not rt:
+        agent._fallback_activated = False
+        agent._fallback_index = 0
+        return False
+
     try:
         # ── Core runtime state ──
         agent.model = rt["model"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6000,7 +6000,9 @@ class GatewayRunner:
             if hasattr(self, '_busy_ack_ts'):
                 self._busy_ack_ts.clear()
             self._shutdown_event.set()
-            self._stop_liveness_thread()
+            _stop_liveness_thread = getattr(self, "_stop_liveness_thread", None)
+            if callable(_stop_liveness_thread):
+                _stop_liveness_thread()
 
             # Global cleanup: kill any remaining tool subprocesses not tied
             # to a specific agent (catch-all for zombie prevention). On the

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1693,6 +1693,15 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._liveness_lock = threading.Lock()
+        self._liveness_stop = threading.Event()
+        self._liveness_thread: Optional[threading.Thread] = None
+        self._liveness_interval = max(1.0, float(os.getenv("HERMES_WATCHDOG_HEARTBEAT_INTERVAL", "15")))
+        self._liveness_last_progress_tuple: Optional[tuple[int, int, int, int, int, int]] = None
+        self._liveness_last_forward_progress_mono: Optional[float] = None
+        self._liveness_last_forward_progress_at: Optional[str] = None
+        self._liveness_forward_progress_counter = 0
+        self._liveness_run_lifecycle_count = 0
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
         # "next-turn" follow-ups where repeated sends collapse into one
@@ -4195,6 +4204,8 @@ class GatewayRunner:
         self._wire_teams_pipeline_runtime()
 
         self._running = True
+        self._publish_liveness_snapshot()
+        self._start_liveness_thread()
         self._update_runtime_status("running")
         
         # Emit gateway:startup hook
@@ -5980,6 +5991,7 @@ class GatewayRunner:
             if hasattr(self, '_busy_ack_ts'):
                 self._busy_ack_ts.clear()
             self._shutdown_event.set()
+            self._stop_liveness_thread()
 
             # Global cleanup: kill any remaining tool subprocesses not tied
             # to a specific agent (catch-all for zombie prevention). On the
@@ -6071,6 +6083,154 @@ class GatewayRunner:
     async def wait_for_shutdown(self) -> None:
         """Wait for shutdown signal."""
         await self._shutdown_event.wait()
+
+    def _liveness_now_iso(self) -> str:
+        return datetime.now().astimezone().isoformat()
+
+    def _ensure_liveness_state(self) -> None:
+        if not hasattr(self, "_liveness_lock"):
+            self._liveness_lock = threading.Lock()
+        if not hasattr(self, "_liveness_stop"):
+            self._liveness_stop = threading.Event()
+        if not hasattr(self, "_liveness_thread"):
+            self._liveness_thread = None
+        if not hasattr(self, "_liveness_interval"):
+            self._liveness_interval = max(1.0, float(os.getenv("HERMES_WATCHDOG_HEARTBEAT_INTERVAL", "15")))
+        if not hasattr(self, "_liveness_last_progress_tuple"):
+            self._liveness_last_progress_tuple = None
+        if not hasattr(self, "_liveness_last_forward_progress_mono"):
+            self._liveness_last_forward_progress_mono = None
+        if not hasattr(self, "_liveness_last_forward_progress_at"):
+            self._liveness_last_forward_progress_at = None
+        if not hasattr(self, "_liveness_forward_progress_counter"):
+            self._liveness_forward_progress_counter = 0
+        if not hasattr(self, "_liveness_run_lifecycle_count"):
+            self._liveness_run_lifecycle_count = 0
+
+    def _snapshot_active_agent_liveness(self) -> dict[str, Any]:
+        self._ensure_liveness_state()
+        running_items = []
+        for _ in range(3):
+            try:
+                running_items = list(getattr(self, "_running_agents", {}).items())
+                break
+            except RuntimeError:
+                time.sleep(0)
+
+        active_agents = []
+        for session_key, agent in running_items:
+            if agent is _AGENT_PENDING_SENTINEL or not hasattr(agent, "get_activity_summary"):
+                continue
+            try:
+                active_agents.append((session_key, agent.get_activity_summary()))
+            except Exception:
+                continue
+
+        current_tool = None
+        last_activity_desc = None
+        for _, summary in active_agents:
+            if current_tool is None and summary.get("current_tool"):
+                current_tool = summary.get("current_tool")
+            if last_activity_desc is None and summary.get("last_activity_desc"):
+                last_activity_desc = summary.get("last_activity_desc")
+
+        return {
+            "work_active": bool(running_items),
+            "active_agents": len(running_items),
+            "current_tool": current_tool,
+            "last_activity_desc": last_activity_desc,
+            "api_call_count": sum(int(summary.get("api_call_count") or 0) for _, summary in active_agents),
+            "provider_chunk_count": sum(int(summary.get("provider_chunk_count") or 0) for _, summary in active_agents),
+            "tool_transition_count": sum(int(summary.get("tool_transition_count") or 0) for _, summary in active_agents),
+            "tool_completion_count": sum(int(summary.get("tool_completion_count") or 0) for _, summary in active_agents),
+            "api_completion_count": sum(int(summary.get("api_completion_count") or 0) for _, summary in active_agents),
+            "run_lifecycle_count": int(getattr(self, "_liveness_run_lifecycle_count", 0)),
+        }
+
+    def _publish_liveness_snapshot(self) -> None:
+        """Publish watchdog-compatible process heartbeat fields.
+
+        The Kanban release checkout predates the stricter external watchdog
+        schema used by the active stable gateway. During cutover both versions
+        share ~/.hermes/gateway_state.json, so keep the v2 heartbeat fields
+        fresh to prevent the watchdog from rolling back a healthy Kanban
+        gateway because it read stale fields left by the previous process.
+        """
+        self._ensure_liveness_state()
+        from gateway.status import write_runtime_status
+
+        now_iso = self._liveness_now_iso()
+        now_mono = time.monotonic()
+        snapshot = self._snapshot_active_agent_liveness()
+        active_count = int(snapshot["active_agents"])
+        progress_tuple = (
+            int(snapshot["api_call_count"]),
+            int(snapshot["provider_chunk_count"]),
+            int(snapshot["tool_transition_count"]),
+            int(snapshot["tool_completion_count"]),
+            int(snapshot["api_completion_count"]),
+            int(snapshot["run_lifecycle_count"]),
+        )
+        with self._liveness_lock:
+            if self._liveness_last_progress_tuple is None:
+                self._liveness_last_progress_tuple = progress_tuple
+                self._liveness_last_forward_progress_mono = now_mono
+                self._liveness_last_forward_progress_at = now_iso
+            elif progress_tuple != self._liveness_last_progress_tuple:
+                self._liveness_last_progress_tuple = progress_tuple
+                self._liveness_last_forward_progress_mono = now_mono
+                self._liveness_last_forward_progress_at = now_iso
+                self._liveness_forward_progress_counter += 1
+            last_forward_progress_mono = self._liveness_last_forward_progress_mono
+            last_forward_progress_at = self._liveness_last_forward_progress_at
+            progress_counter = self._liveness_forward_progress_counter
+
+        write_runtime_status(
+            gateway_state="running" if self._running else "draining",
+            process_heartbeat_at=now_iso,
+            process_heartbeat_mono=now_mono,
+            last_forward_progress_at=last_forward_progress_at,
+            last_forward_progress_mono=last_forward_progress_mono,
+            forward_progress_counter=progress_counter,
+            liveness_state="working" if active_count else ("idle" if self._running else "stopping"),
+            liveness_reason=None,
+            work_active=bool(snapshot["work_active"]),
+            active_agents=active_count,
+            current_tool=snapshot["current_tool"] or "",
+            last_activity_desc=snapshot["last_activity_desc"] or "",
+            api_call_count=int(snapshot["api_call_count"]),
+            provider_chunk_count=int(snapshot["provider_chunk_count"]),
+            tool_transition_count=int(snapshot["tool_transition_count"]),
+            tool_completion_count=int(snapshot["tool_completion_count"]),
+            api_completion_count=int(snapshot["api_completion_count"]),
+            run_lifecycle_count=int(snapshot["run_lifecycle_count"]),
+        )
+
+    def _liveness_loop(self) -> None:
+        self._ensure_liveness_state()
+        while not self._liveness_stop.is_set():
+            try:
+                self._publish_liveness_snapshot()
+            except Exception as exc:
+                logger.debug("Gateway liveness publish error: %s", exc)
+            if self._liveness_stop.wait(self._liveness_interval):
+                break
+
+    def _start_liveness_thread(self) -> None:
+        self._ensure_liveness_state()
+        if self._liveness_thread and self._liveness_thread.is_alive():
+            return
+        self._liveness_stop.clear()
+        self._liveness_thread = threading.Thread(target=self._liveness_loop, daemon=True, name="gateway-liveness")
+        self._liveness_thread.start()
+
+    def _stop_liveness_thread(self, timeout: float = 5.0) -> None:
+        self._ensure_liveness_state()
+        self._liveness_stop.set()
+        thread = self._liveness_thread
+        if thread and thread.is_alive() and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+        self._liveness_thread = None
 
     def _create_adapter(
         self, 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1623,6 +1623,15 @@ def _preserve_queued_followup_history_offset(
     return merged
 
 
+def _parse_liveness_interval(raw_value: str | None) -> float:
+    """Return a safe watchdog heartbeat interval in seconds."""
+    try:
+        parsed = float(raw_value if raw_value is not None else "15")
+    except (TypeError, ValueError):
+        parsed = 15.0
+    return max(1.0, parsed)
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -1696,7 +1705,7 @@ class GatewayRunner:
         self._liveness_lock = threading.Lock()
         self._liveness_stop = threading.Event()
         self._liveness_thread: Optional[threading.Thread] = None
-        self._liveness_interval = max(1.0, float(os.getenv("HERMES_WATCHDOG_HEARTBEAT_INTERVAL", "15")))
+        self._liveness_interval = _parse_liveness_interval(os.getenv("HERMES_WATCHDOG_HEARTBEAT_INTERVAL"))
         self._liveness_last_progress_tuple: Optional[tuple[int, int, int, int, int, int]] = None
         self._liveness_last_forward_progress_mono: Optional[float] = None
         self._liveness_last_forward_progress_at: Optional[str] = None
@@ -6095,7 +6104,7 @@ class GatewayRunner:
         if not hasattr(self, "_liveness_thread"):
             self._liveness_thread = None
         if not hasattr(self, "_liveness_interval"):
-            self._liveness_interval = max(1.0, float(os.getenv("HERMES_WATCHDOG_HEARTBEAT_INTERVAL", "15")))
+            self._liveness_interval = _parse_liveness_interval(os.getenv("HERMES_WATCHDOG_HEARTBEAT_INTERVAL"))
         if not hasattr(self, "_liveness_last_progress_tuple"):
             self._liveness_last_progress_tuple = None
         if not hasattr(self, "_liveness_last_forward_progress_mono"):

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -211,11 +211,34 @@ def _build_pid_record() -> dict:
     }
 
 
+def _build_runtime_import_authority() -> dict[str, Any]:
+    try:
+        import hermes_cli
+
+        hermes_cli_file = str(Path(hermes_cli.__file__).resolve())
+    except Exception:
+        hermes_cli_file = None
+
+    hermes_home = get_hermes_home()
+    return {
+        "python_executable": sys.executable,
+        "cwd": os.getcwd(),
+        "sys_path0": sys.path[0] if sys.path else None,
+        "gateway_file": str(Path(__file__).resolve()),
+        "hermes_cli_file": hermes_cli_file,
+        "project_root": str(Path(__file__).resolve().parents[1]),
+        "hermes_home": str(hermes_home),
+        "config_path": str(hermes_home / "config.yaml"),
+        "env_path": str(hermes_home / ".env"),
+    }
+
+
 def _build_runtime_status_record() -> dict[str, Any]:
     payload = _build_pid_record()
     payload.update({
         "gateway_status_schema_version": _RUNTIME_STATUS_SCHEMA_VERSION,
         "gateway_state": "starting",
+        "runtime_import_authority": _build_runtime_import_authority(),
         "exit_reason": None,
         "restart_requested": False,
         "active_agents": 0,
@@ -567,6 +590,7 @@ def write_runtime_status(
     payload["pid"] = current_record["pid"]
     payload["argv"] = current_record["argv"]
     payload["start_time"] = current_record["start_time"]
+    payload["runtime_import_authority"] = _build_runtime_import_authority()
     payload["updated_at"] = _utc_now_iso()
 
     if gateway_state is not _UNSET:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -240,6 +240,7 @@ def _build_runtime_status_record() -> dict[str, Any]:
         "gateway_state": "starting",
         "runtime_import_authority": _build_runtime_import_authority(),
         "exit_reason": None,
+        "stop_source": None,
         "restart_requested": False,
         "active_agents": 0,
         "platforms": {},
@@ -554,6 +555,7 @@ def write_runtime_status(
     *,
     gateway_state: Any = _UNSET,
     exit_reason: Any = _UNSET,
+    stop_source: Any = _UNSET,
     restart_requested: Any = _UNSET,
     active_agents: Any = _UNSET,
     platform: Any = _UNSET,
@@ -595,8 +597,14 @@ def write_runtime_status(
 
     if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state
+        if gateway_state in {"starting", "running"}:
+            payload["stop_source"] = None
+            if exit_reason is _UNSET:
+                payload["exit_reason"] = None
     if exit_reason is not _UNSET:
         payload["exit_reason"] = exit_reason
+    if stop_source is not _UNSET:
+        payload["stop_source"] = stop_source
     if restart_requested is not _UNSET:
         payload["restart_requested"] = bool(restart_requested)
     if active_agents is not _UNSET:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -17,6 +17,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -34,6 +35,7 @@ _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
+_RUNTIME_STATUS_SCHEMA_VERSION = 2
 _gateway_lock_handle = None
 # Windows byte-range locks are mandatory for other readers. Lock a byte well
 # past the JSON payload so runtime status / PID readers can still read the file
@@ -212,14 +214,38 @@ def _build_pid_record() -> dict:
 def _build_runtime_status_record() -> dict[str, Any]:
     payload = _build_pid_record()
     payload.update({
+        "gateway_status_schema_version": _RUNTIME_STATUS_SCHEMA_VERSION,
         "gateway_state": "starting",
         "exit_reason": None,
         "restart_requested": False,
         "active_agents": 0,
         "platforms": {},
+        "process_heartbeat_at": None,
+        "process_heartbeat_mono": None,
+        "last_forward_progress_at": None,
+        "last_forward_progress_mono": None,
+        "forward_progress_counter": 0,
+        "liveness_state": "starting",
+        "liveness_reason": None,
+        "work_active": False,
+        "active_session_key": None,
+        "active_task_started_at": None,
+        "active_task_started_mono": None,
+        "current_tool": None,
+        "last_activity_desc": None,
+        "api_call_count": 0,
+        "provider_chunk_count": 0,
+        "tool_transition_count": 0,
+        "tool_completion_count": 0,
+        "api_completion_count": 0,
+        "run_lifecycle_count": 0,
         "updated_at": _utc_now_iso(),
     })
     return payload
+
+
+def _is_number(value: Any) -> bool:
+    return value is not None and not isinstance(value, bool) and isinstance(value, (int, float))
 
 
 def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
@@ -511,6 +537,25 @@ def write_runtime_status(
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
     error_message: Any = _UNSET,
+    process_heartbeat_at: Any = _UNSET,
+    process_heartbeat_mono: Any = _UNSET,
+    last_forward_progress_at: Any = _UNSET,
+    last_forward_progress_mono: Any = _UNSET,
+    forward_progress_counter: Any = _UNSET,
+    liveness_state: Any = _UNSET,
+    liveness_reason: Any = _UNSET,
+    work_active: Any = _UNSET,
+    active_session_key: Any = _UNSET,
+    active_task_started_at: Any = _UNSET,
+    active_task_started_mono: Any = _UNSET,
+    current_tool: Any = _UNSET,
+    last_activity_desc: Any = _UNSET,
+    api_call_count: Any = _UNSET,
+    provider_chunk_count: Any = _UNSET,
+    tool_transition_count: Any = _UNSET,
+    tool_completion_count: Any = _UNSET,
+    api_completion_count: Any = _UNSET,
+    run_lifecycle_count: Any = _UNSET,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
@@ -518,6 +563,7 @@ def write_runtime_status(
     current_record = _build_pid_record()
     payload.setdefault("platforms", {})
     payload["kind"] = current_record["kind"]
+    payload["gateway_status_schema_version"] = _RUNTIME_STATUS_SCHEMA_VERSION
     payload["pid"] = current_record["pid"]
     payload["argv"] = current_record["argv"]
     payload["start_time"] = current_record["start_time"]
@@ -531,6 +577,47 @@ def write_runtime_status(
         payload["restart_requested"] = bool(restart_requested)
     if active_agents is not _UNSET:
         payload["active_agents"] = max(0, int(active_agents))
+
+    scalar_updates = {
+        "process_heartbeat_at": process_heartbeat_at,
+        "process_heartbeat_mono": process_heartbeat_mono,
+        "last_forward_progress_at": last_forward_progress_at,
+        "last_forward_progress_mono": last_forward_progress_mono,
+        "forward_progress_counter": forward_progress_counter,
+        "liveness_state": liveness_state,
+        "liveness_reason": liveness_reason,
+        "work_active": work_active,
+        "active_session_key": active_session_key,
+        "active_task_started_at": active_task_started_at,
+        "active_task_started_mono": active_task_started_mono,
+        "current_tool": current_tool,
+        "last_activity_desc": last_activity_desc,
+        "api_call_count": api_call_count,
+        "provider_chunk_count": provider_chunk_count,
+        "tool_transition_count": tool_transition_count,
+        "tool_completion_count": tool_completion_count,
+        "api_completion_count": api_completion_count,
+        "run_lifecycle_count": run_lifecycle_count,
+    }
+    for key, value in scalar_updates.items():
+        if value is not _UNSET:
+            payload[key] = value
+
+    if process_heartbeat_at is _UNSET and process_heartbeat_mono is _UNSET:
+        # Preserve compatibility with the stricter external watchdog even when
+        # callers only update coarse runtime state. This intentionally refreshes
+        # stale or None values rather than preserving them.
+        payload["process_heartbeat_at"] = _utc_now_iso()
+        payload["process_heartbeat_mono"] = time.monotonic()
+
+    payload.setdefault("last_forward_progress_at", None)
+    payload.setdefault("last_forward_progress_mono", None)
+    payload["forward_progress_counter"] = int(payload.get("forward_progress_counter") or 0)
+    payload["work_active"] = bool(payload.get("work_active", False))
+    payload["run_lifecycle_count"] = int(payload.get("run_lifecycle_count") or 0)
+    if not _is_number(payload.get("process_heartbeat_mono")):
+        payload["process_heartbeat_at"] = _utc_now_iso()
+        payload["process_heartbeat_mono"] = time.monotonic()
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -214,10 +214,11 @@ def _build_pid_record() -> dict:
 def _build_runtime_import_authority() -> dict[str, Any]:
     try:
         import hermes_cli
-
-        hermes_cli_file = str(Path(hermes_cli.__file__).resolve())
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         hermes_cli_file = None
+    else:
+        hermes_cli_path = getattr(hermes_cli, "__file__", None)
+        hermes_cli_file = str(Path(hermes_cli_path).resolve()) if hermes_cli_path else None
 
     hermes_home = get_hermes_home()
     return {

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -849,7 +849,9 @@ def create_pre_update_backup(
         logger.warning("Could not create pre-update backup dir %s: %s", backup_dir, exc)
         return None
 
-    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
+    # Include microseconds so repeated backups in the same second create
+    # distinct recovery points instead of overwriting the previous archive.
+    stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S-%f")
     out_path = backup_dir / f"{_PRE_UPDATE_PREFIX}{stamp}.zip"
 
     result = _write_full_zip_backup(out_path, hermes_root)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -397,6 +397,14 @@ def _build_apikey_providers_list() -> list:
 
 def run_doctor(args):
     """Run diagnostic checks."""
+    if getattr(args, "path_authority", False):
+        from hermes_cli.path_authority_doctor import run_path_authority_doctor
+
+        code = run_path_authority_doctor(args)
+        if code:
+            raise SystemExit(code)
+        return
+
     should_fix = getattr(args, 'fix', False)
     ack_target = getattr(args, 'ack', None)
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2209,7 +2209,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2247,7 +2247,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -565,7 +565,7 @@ def _gateway_run_args_for_profile(profile: str) -> list[str]:
     args = [get_python_path(), "-m", "hermes_cli.main"]
     if profile != "default":
         args.extend(["--profile", profile])
-    args.extend(["gateway", "run", "--replace"])
+    args.extend(["gateway", "run"])
     return args
 
 
@@ -2841,7 +2841,6 @@ def generate_launchd_plist() -> str:
     prog_args.extend([
         "<string>gateway</string>",
         "<string>run</string>",
-        "<string>--replace</string>",
     ])
     prog_args_xml = "\n        ".join(prog_args)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1160,9 +1160,11 @@ def connect(
 
     Safety guard: when running under pytest (PYTEST_CURRENT_TEST is set)
     and no explicit db_path or board override is provided, fail closed if
-    no Kanban isolation env var is set and the caller still resolves to a
-    non-temporary Hermes home. This prevents tests from silently writing to
-    a live ~/.hermes/kanban board while preserving explicit test fixtures.
+    no Kanban path-isolation env var is set and the caller still resolves to a
+    non-temporary Hermes home. HERMES_KANBAN_BOARD only selects a board name;
+    it is not a path-isolation override. This prevents tests from silently
+    writing to a live ~/.hermes/kanban board while preserving explicit test
+    fixtures.
     """
     if (
         db_path is None
@@ -1170,7 +1172,6 @@ def connect(
         and os.environ.get("PYTEST_CURRENT_TEST")
         and not os.environ.get("HERMES_KANBAN_HOME", "").strip()
         and not os.environ.get("HERMES_KANBAN_DB", "").strip()
-        and not os.environ.get("HERMES_KANBAN_BOARD", "").strip()
     ):
         real_home = Path.home()
         hermes_home = os.environ.get("HERMES_HOME", "").strip()
@@ -1178,9 +1179,11 @@ def connect(
         is_isolated = _path_is_under_system_temp(effective_root)
         if not is_isolated:
             raise RuntimeError(
-                "kanban.connect() called from a pytest session without any of "
-                "HERMES_KANBAN_HOME / HERMES_KANBAN_DB / HERMES_KANBAN_BOARD set. "
-                "This would write test data to the real ~/.hermes/kanban/ board. "
+                "kanban.connect() called from a pytest session without "
+                "HERMES_KANBAN_HOME or HERMES_KANBAN_DB set. "
+                "HERMES_KANBAN_BOARD only selects a board name and is not "
+                "a path-isolation override. This would write test data to "
+                "the real ~/.hermes/kanban/ board. "
                 "Fix: ensure _hermetic_environment conftest fixture is active, or "
                 "pass db_path/board explicitly to this call."
             )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -267,12 +267,11 @@ def set_current_board(slug: str) -> Path:
     so that ``hermes kanban boards switch <typo>`` returns an error
     instead of silently pointing at nothing.
     """
-    _ensure_pytest_kanban_path_isolated(None)
-
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
     path = current_board_path()
+    _ensure_pytest_kanban_filesystem_path_isolated(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(normed + "\n", encoding="utf-8")
     return path
@@ -280,10 +279,10 @@ def set_current_board(slug: str) -> Path:
 
 def clear_current_board() -> None:
     """Remove ``<root>/kanban/current`` so the active board reverts to ``default``."""
-    _ensure_pytest_kanban_path_isolated(None)
-
+    path = current_board_path()
+    _ensure_pytest_kanban_filesystem_path_isolated(path)
     try:
-        current_board_path().unlink()
+        path.unlink()
     except FileNotFoundError:
         pass
 
@@ -449,9 +448,9 @@ def write_board_metadata(
     Preserves any existing fields not mentioned in the call. Sets
     ``created_at`` on first write. Returns the resulting metadata dict.
     """
-    _ensure_pytest_kanban_path_isolated(None)
-
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    path = board_metadata_path(slug)
+    _ensure_pytest_kanban_filesystem_path_isolated(path)
     meta = read_board_metadata(slug)
     # Preserve existing DB-derived fields — they get re-computed each
     # read but shouldn't be written into board.json.
@@ -566,14 +565,13 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
     Returns a summary dict describing what happened (``{"slug", "action",
     "new_path"}``).
     """
-    _ensure_pytest_kanban_path_isolated(None)
-
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
     if normed == DEFAULT_BOARD:
         raise ValueError("the 'default' board cannot be removed")
     d = board_dir(normed)
+    _ensure_pytest_kanban_filesystem_path_isolated(d)
     if not d.exists():
         raise ValueError(f"board {normed!r} does not exist")
 
@@ -1152,7 +1150,7 @@ def _path_is_under_system_temp(path_value: str | Path) -> bool:
 
 
 def _ensure_pytest_kanban_path_isolated(db_path: Optional[Path]) -> None:
-    """Fail closed before pytest can resolve default Kanban paths to live state."""
+    """Fail closed before pytest can resolve default Kanban DB paths to live state."""
     if db_path is not None:
         return
     if not os.environ.get("PYTEST_CURRENT_TEST"):
@@ -1176,6 +1174,42 @@ def _ensure_pytest_kanban_path_isolated(db_path: Optional[Path]) -> None:
         "Fix: ensure _hermetic_environment conftest fixture is active, "
         "set HERMES_KANBAN_HOME/HERMES_KANBAN_DB, or pass db_path "
         "explicitly to this call."
+    )
+
+
+def _path_is_under(root: str | Path, path_value: str | Path) -> bool:
+    try:
+        root_path = Path(root).expanduser().resolve(strict=False)
+        path = Path(path_value).expanduser().resolve(strict=False)
+        return os.path.commonpath([str(root_path), str(path)]) == str(root_path)
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _ensure_pytest_kanban_filesystem_path_isolated(path: Path) -> None:
+    """Fail closed before pytest mutates board filesystem paths in live state.
+
+    ``HERMES_KANBAN_DB`` isolates SQLite writes only. Board metadata,
+    current-board pointers, and worker logs resolve through ``kanban_home()``,
+    so filesystem mutators must require either an explicit Kanban home or a
+    target path under the system temp tree.
+    """
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+
+    override = os.environ.get("HERMES_KANBAN_HOME", "").strip()
+    if override and _path_is_under(override, path):
+        return
+    if _path_is_under_system_temp(path):
+        return
+
+    raise RuntimeError(
+        "kanban filesystem mutation from a pytest session without an "
+        "isolated HERMES_KANBAN_HOME or temporary Hermes root. "
+        "HERMES_KANBAN_DB only isolates sqlite DB writes; it does not "
+        "isolate board metadata, current-board, or worker-log filesystem "
+        "paths. Fix: set HERMES_KANBAN_HOME for filesystem-mutating tests "
+        "or run them under a temporary HERMES_HOME."
     )
 
 
@@ -6466,9 +6500,8 @@ def gc_worker_logs(
     log files live on disk, not in SQLite. Scoped to ``board`` (defaults
     to the active board) — per-board isolation means deleting logs from
     board A cannot touch board B's logs."""
-    _ensure_pytest_kanban_path_isolated(None)
-
     log_dir = worker_logs_dir(board=board)
+    _ensure_pytest_kanban_filesystem_path_isolated(log_dir)
     if not log_dir.exists():
         return 0
     cutoff = time.time() - older_than_seconds

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1174,10 +1174,8 @@ def connect(
     ):
         real_home = Path.home()
         hermes_home = os.environ.get("HERMES_HOME", "").strip()
-        is_isolated = (
-            _path_is_under_system_temp(real_home)
-            or (bool(hermes_home) and _path_is_under_system_temp(hermes_home))
-        )
+        effective_root: str | Path = hermes_home if hermes_home else real_home
+        is_isolated = _path_is_under_system_temp(effective_root)
         if not is_isolated:
             raise RuntimeError(
                 "kanban.connect() called from a pytest session without any of "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1159,16 +1159,15 @@ def connect(
     connections skip the schema check via a module-level path cache.
 
     Safety guard: when running under pytest (PYTEST_CURRENT_TEST is set)
-    and no explicit db_path or board override is provided, fail closed if
-    no Kanban path-isolation env var is set and the caller still resolves to a
-    non-temporary Hermes home. HERMES_KANBAN_BOARD only selects a board name;
-    it is not a path-isolation override. This prevents tests from silently
-    writing to a live ~/.hermes/kanban board while preserving explicit test
-    fixtures.
+    and no explicit db_path is provided, fail closed if no Kanban
+    path-isolation env var is set and the caller still resolves to a
+    non-temporary Hermes home. HERMES_KANBAN_BOARD and the board= argument
+    only select a board name; neither is a path-isolation override. This
+    prevents tests from silently writing to a live ~/.hermes/kanban board
+    while preserving explicit test fixtures.
     """
     if (
         db_path is None
-        and board is None
         and os.environ.get("PYTEST_CURRENT_TEST")
         and not os.environ.get("HERMES_KANBAN_HOME", "").strip()
         and not os.environ.get("HERMES_KANBAN_DB", "").strip()
@@ -1184,8 +1183,9 @@ def connect(
                 "HERMES_KANBAN_BOARD only selects a board name and is not "
                 "a path-isolation override. This would write test data to "
                 "the real ~/.hermes/kanban/ board. "
-                "Fix: ensure _hermetic_environment conftest fixture is active, or "
-                "pass db_path/board explicitly to this call."
+                "Fix: ensure _hermetic_environment conftest fixture is active, "
+                "set HERMES_KANBAN_HOME/HERMES_KANBAN_DB, or pass db_path "
+                "explicitly to this call."
             )
 
     if db_path is not None:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -79,6 +79,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import threading
 import logging
 import time
@@ -1132,6 +1133,16 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 
+def _path_is_under_system_temp(path_value: str | Path) -> bool:
+    """Return True only when a path resolves inside the system temp directory."""
+    try:
+        temp_dir = Path(tempfile.gettempdir()).expanduser().resolve(strict=False)
+        path = Path(path_value).expanduser().resolve(strict=False)
+        return os.path.commonpath([str(temp_dir), str(path)]) == str(temp_dir)
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
@@ -1161,12 +1172,11 @@ def connect(
         and not os.environ.get("HERMES_KANBAN_DB", "").strip()
         and not os.environ.get("HERMES_KANBAN_BOARD", "").strip()
     ):
-        real_home = str(Path.home())
+        real_home = Path.home()
         hermes_home = os.environ.get("HERMES_HOME", "").strip()
         is_isolated = (
-            real_home.startswith("/tmp")
-            or real_home.startswith("/var/folders")
-            or (bool(hermes_home) and hermes_home.startswith("/tmp"))
+            _path_is_under_system_temp(real_home)
+            or (bool(hermes_home) and _path_is_under_system_temp(hermes_home))
         )
         if not is_isolated:
             raise RuntimeError(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4015,6 +4015,7 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
                 )
         else:
             p = workspaces_root(board=board) / task.id
+        _ensure_pytest_kanban_filesystem_path_isolated(p)
         p.mkdir(parents=True, exist_ok=True)
         return p
     if kind == "dir":
@@ -4029,6 +4030,7 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
                 f"{task.workspace_path!r}; use an absolute path "
                 f"(relative paths are ambiguous against the dispatcher's CWD)"
             )
+        _ensure_pytest_kanban_filesystem_path_isolated(p)
         p.mkdir(parents=True, exist_ok=True)
         return p
     if kind == "worktree":
@@ -5524,6 +5526,7 @@ def _rotate_worker_log(
     ``<log>`` moves to ``<log>.1`` and any previous ``.1`` is replaced.
     Higher values shift older generations up to ``backup_count``.
     """
+    _ensure_pytest_kanban_filesystem_path_isolated(log_path)
     try:
         if not log_path.exists():
             return
@@ -5872,6 +5875,7 @@ def _default_spawn(
     # `hermes kanban log` on a specific board reads its own file and
     # logs don't collide across boards that happen to share task ids.
     log_dir = worker_logs_dir(board=board)
+    _ensure_pytest_kanban_filesystem_path_isolated(log_dir)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{task.id}.log"
     rotate_bytes, backup_count = worker_log_rotation_config()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1147,14 +1147,36 @@ def connect(
     directly don't have to remember a separate init step. Subsequent
     connections skip the schema check via a module-level path cache.
 
-    Path resolution:
-
-    * ``db_path`` explicit → used as-is (legacy callers, tests).
-    * ``board`` explicit → resolves to that board's DB.
-    * Neither → :func:`kanban_db_path` resolves via
-      ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
-      ``<root>/kanban/current`` → ``default``.
+    Safety guard: when running under pytest (PYTEST_CURRENT_TEST is set)
+    and no explicit db_path or board override is provided, fail closed if
+    no Kanban isolation env var is set and the caller still resolves to a
+    non-temporary Hermes home. This prevents tests from silently writing to
+    a live ~/.hermes/kanban board while preserving explicit test fixtures.
     """
+    if (
+        db_path is None
+        and board is None
+        and os.environ.get("PYTEST_CURRENT_TEST")
+        and not os.environ.get("HERMES_KANBAN_HOME", "").strip()
+        and not os.environ.get("HERMES_KANBAN_DB", "").strip()
+        and not os.environ.get("HERMES_KANBAN_BOARD", "").strip()
+    ):
+        real_home = str(Path.home())
+        hermes_home = os.environ.get("HERMES_HOME", "").strip()
+        is_isolated = (
+            real_home.startswith("/tmp")
+            or real_home.startswith("/var/folders")
+            or (bool(hermes_home) and hermes_home.startswith("/tmp"))
+        )
+        if not is_isolated:
+            raise RuntimeError(
+                "kanban.connect() called from a pytest session without any of "
+                "HERMES_KANBAN_HOME / HERMES_KANBAN_DB / HERMES_KANBAN_BOARD set. "
+                "This would write test data to the real ~/.hermes/kanban/ board. "
+                "Fix: ensure _hermetic_environment conftest fixture is active, or "
+                "pass db_path/board explicitly to this call."
+            )
+
     if db_path is not None:
         path = db_path
     else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -566,6 +566,8 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
     Returns a summary dict describing what happened (``{"slug", "action",
     "new_path"}``).
     """
+    _ensure_pytest_kanban_path_isolated(None)
+
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
@@ -6464,6 +6466,8 @@ def gc_worker_logs(
     log files live on disk, not in SQLite. Scoped to ``board`` (defaults
     to the active board) — per-board isolation means deleting logs from
     board A cannot touch board B's logs."""
+    _ensure_pytest_kanban_path_isolated(None)
+
     log_dir = worker_logs_dir(board=board)
     if not log_dir.exists():
         return 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1143,6 +1143,34 @@ def _path_is_under_system_temp(path_value: str | Path) -> bool:
         return False
 
 
+def _ensure_pytest_kanban_path_isolated(db_path: Optional[Path]) -> None:
+    """Fail closed before pytest can resolve default Kanban paths to live state."""
+    if db_path is not None:
+        return
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+    if os.environ.get("HERMES_KANBAN_HOME", "").strip():
+        return
+    if os.environ.get("HERMES_KANBAN_DB", "").strip():
+        return
+
+    hermes_home = os.environ.get("HERMES_HOME", "").strip()
+    effective_root: str | Path = hermes_home if hermes_home else Path.home()
+    if _path_is_under_system_temp(effective_root):
+        return
+
+    raise RuntimeError(
+        "kanban DB opened from a pytest session without "
+        "HERMES_KANBAN_HOME or HERMES_KANBAN_DB set. "
+        "HERMES_KANBAN_BOARD and board= only select a board name; neither "
+        "is a path-isolation override. This would write test data to the "
+        "real ~/.hermes/kanban/ board. "
+        "Fix: ensure _hermetic_environment conftest fixture is active, "
+        "set HERMES_KANBAN_HOME/HERMES_KANBAN_DB, or pass db_path "
+        "explicitly to this call."
+    )
+
+
 def connect(
     db_path: Optional[Path] = None,
     *,
@@ -1166,27 +1194,7 @@ def connect(
     prevents tests from silently writing to a live ~/.hermes/kanban board
     while preserving explicit test fixtures.
     """
-    if (
-        db_path is None
-        and os.environ.get("PYTEST_CURRENT_TEST")
-        and not os.environ.get("HERMES_KANBAN_HOME", "").strip()
-        and not os.environ.get("HERMES_KANBAN_DB", "").strip()
-    ):
-        real_home = Path.home()
-        hermes_home = os.environ.get("HERMES_HOME", "").strip()
-        effective_root: str | Path = hermes_home if hermes_home else real_home
-        is_isolated = _path_is_under_system_temp(effective_root)
-        if not is_isolated:
-            raise RuntimeError(
-                "kanban.connect() called from a pytest session without "
-                "HERMES_KANBAN_HOME or HERMES_KANBAN_DB set. "
-                "HERMES_KANBAN_BOARD only selects a board name and is not "
-                "a path-isolation override. This would write test data to "
-                "the real ~/.hermes/kanban/ board. "
-                "Fix: ensure _hermetic_environment conftest fixture is active, "
-                "set HERMES_KANBAN_HOME/HERMES_KANBAN_DB, or pass db_path "
-                "explicitly to this call."
-            )
+    _ensure_pytest_kanban_path_isolated(db_path)
 
     if db_path is not None:
         path = db_path
@@ -1247,6 +1255,8 @@ def init_db(
     external tools that upgrade an old DB file — can call this to
     force re-migration.
     """
+    _ensure_pytest_kanban_path_isolated(db_path)
+
     if db_path is not None:
         path = db_path
     else:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -267,6 +267,8 @@ def set_current_board(slug: str) -> Path:
     so that ``hermes kanban boards switch <typo>`` returns an error
     instead of silently pointing at nothing.
     """
+    _ensure_pytest_kanban_path_isolated(None)
+
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
@@ -278,6 +280,8 @@ def set_current_board(slug: str) -> Path:
 
 def clear_current_board() -> None:
     """Remove ``<root>/kanban/current`` so the active board reverts to ``default``."""
+    _ensure_pytest_kanban_path_isolated(None)
+
     try:
         current_board_path().unlink()
     except FileNotFoundError:
@@ -445,6 +449,8 @@ def write_board_metadata(
     Preserves any existing fields not mentioned in the call. Sets
     ``created_at`` on first write. Returns the resulting metadata dict.
     """
+    _ensure_pytest_kanban_path_isolated(None)
+
     slug = _normalize_board_slug(board) or DEFAULT_BOARD
     meta = read_board_metadata(slug)
     # Preserve existing DB-derived fields — they get re-computed each

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3326,6 +3326,7 @@ def _mark_scratch_tip_shown() -> None:
     """
     try:
         path = _scratch_tip_sentinel_path()
+        _ensure_pytest_kanban_filesystem_path_isolated(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.touch(exist_ok=True)
     except OSError:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12047,6 +12047,24 @@ def main():
             "doctor` first to see active advisories and their IDs."
         ),
     )
+    doctor_parser.add_argument(
+        "--path-authority",
+        action="store_true",
+        help="Run read-only Kanban path-authority diagnostics",
+    )
+    doctor_parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON output"
+    )
+    doctor_parser.add_argument(
+        "--no-live",
+        action="store_true",
+        help="Skip live runtime-status checks for path-authority diagnostics",
+    )
+    doctor_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on any path-authority finding",
+    )
     doctor_parser.set_defaults(func=cmd_doctor)
 
     # =========================================================================
@@ -12982,6 +13000,47 @@ Examples:
         help="Force re-authentication for an OAuth-based MCP server",
     )
     mcp_login_p.add_argument("name", help="Server name to re-authenticate")
+
+    mcp_runtime_probe_p = mcp_sub.add_parser(
+        "runtime-probe",
+        help="Run a redacted initialize/list runtime-depth probe",
+    )
+    mcp_runtime_probe_p.add_argument(
+        "--runtime",
+        choices=["codex", "claude", "hermes", "all"],
+        default="all",
+        help="Config runtime to probe (default: all)",
+    )
+    mcp_runtime_probe_p.add_argument(
+        "--server",
+        help="Probe only one server name or source:name id",
+    )
+    mcp_runtime_probe_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON; retained for proof command symmetry",
+    )
+    mcp_runtime_probe_p.add_argument(
+        "--redact",
+        action="store_true",
+        help="Force redacted output; all output is always redacted",
+    )
+    mcp_runtime_probe_p.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="Overall probe timeout in seconds",
+    )
+    mcp_runtime_probe_p.add_argument(
+        "--skip-auth-needed",
+        action="store_true",
+        help="Skip entries known to need interactive auth, including Google Drive",
+    )
+    mcp_runtime_probe_p.add_argument(
+        "--include-google-drive-auth-needed",
+        action="store_true",
+        help="Include Google Drive MCP entries that are only missing auth",
+    )
 
     _add_accept_hooks_flag(mcp_parser)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13935,6 +13935,26 @@ Examples:
         subparsers.required = False
         args = parser.parse_args(_processed_argv)
 
+    # Path-authority flags are scoped to `hermes doctor --path-authority`.
+    # Rejecting them before cmd_doctor avoids silently running the broad doctor
+    # while the caller expected machine-readable/path-authority semantics.
+    if getattr(args, "command", None) == "doctor" and not getattr(args, "path_authority", False):
+        scoped_doctor_flags = [
+            flag
+            for attr, flag in (
+                ("json", "--json"),
+                ("no_live", "--no-live"),
+                ("strict", "--strict"),
+            )
+            if getattr(args, attr, False)
+        ]
+        if scoped_doctor_flags:
+            parser.error(
+                "doctor flag(s) "
+                + ", ".join(scoped_doctor_flags)
+                + " require --path-authority"
+            )
+
     # Handle --version flag
     if args.version:
         cmd_version(args)

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -291,7 +291,11 @@ def cmd_mcp_add(args):
         oauth_ok = False
         try:
             from tools.mcp_oauth_manager import get_manager
-            oauth_auth = get_manager().get_or_build_provider(name, url, None)
+            oauth_auth = get_manager().get_or_build_provider(
+                name,
+                url,
+                {"redirect_port": 0},
+            )
             if oauth_auth:
                 server_config["auth"] = "oauth"
                 _success("OAuth configured (tokens will be acquired on first connection)")

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -767,6 +767,19 @@ def cmd_mcp_runtime_probe(args):
             "status_classes": ["timeout"],
             "status_samples": {},
         }
+    except Exception as exc:
+        report = {
+            "status": "error",
+            "status_counts": {"error": 1},
+            "check_status_counts": {"error": 1},
+            "servers": [],
+            "status_classes": ["error"],
+            "status_samples": {},
+            "error": {
+                "kind": "runtime_probe_failed",
+                "exception_type": type(exc).__name__,
+            },
+        }
     print(json.dumps(report, indent=2, sort_keys=True))
 
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -9,6 +9,7 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 """
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -738,6 +739,37 @@ def cmd_mcp_configure(args):
     _info("Start a new session for changes to take effect.")
 
 
+def cmd_mcp_runtime_probe(args):
+    """Run the redacted MCP runtime-depth probe."""
+    from tools.mcp_runtime_probe import probe_default_sources
+
+    async def _run_probe() -> dict[str, Any]:
+        return await asyncio.wait_for(
+            probe_default_sources(
+                runtime=getattr(args, "runtime", "all"),
+                server_name=getattr(args, "server", None),
+                skip_google_drive_auth_needed=(
+                    getattr(args, "skip_auth_needed", False)
+                    or not getattr(args, "include_google_drive_auth_needed", False)
+                ),
+            ),
+            timeout=getattr(args, "timeout", 120) if getattr(args, "timeout", 120) > 0 else None,
+        )
+
+    try:
+        report = asyncio.run(_run_probe())
+    except asyncio.TimeoutError:
+        report = {
+            "status": "timeout",
+            "status_counts": {"timeout": 1},
+            "check_status_counts": {"timeout": 1},
+            "servers": [],
+            "status_classes": ["timeout"],
+            "status_samples": {},
+        }
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
 # ─── Dispatcher ───────────────────────────────────────────────────────────────
 
 def mcp_command(args):
@@ -759,6 +791,7 @@ def mcp_command(args):
         "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure,
         "login": cmd_mcp_login,
+        "runtime-probe": cmd_mcp_runtime_probe,
     }
 
     handler = handlers.get(action)
@@ -775,6 +808,7 @@ def mcp_command(args):
         _info("hermes mcp remove <name>                      Remove a server")
         _info("hermes mcp list                               List servers")
         _info("hermes mcp test <name>                        Test connection")
+        _info("hermes mcp runtime-probe                      Probe runtime MCP depth")
         _info("hermes mcp configure <name>                   Toggle tools")
         _info("hermes mcp login <name>                       Re-authenticate OAuth")
         print()

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1649,6 +1649,11 @@ def list_authenticated_providers(
         _section4_emitted_slugs: set = set()
         for grp_key, grp in groups.items():
             api_url, api_key = grp_key
+            api_key_is_placeholder = str(api_key).strip().lower() in {
+                "***",
+                "[redacted]",
+                "redacted",
+            }
             slug = grp["slug"]
             # If the slug is already claimed by a built-in / overlay /
             # user-provider row (sections 1-3), skip this custom group
@@ -1706,7 +1711,14 @@ def list_authenticated_providers(
             # - Without an api_key AND no explicit models, fall through to
             #   live discovery so bare-endpoint custom providers (local
             #   llama.cpp / Ollama servers) still appear populated.
-            should_probe = bool(api_url) and (bool(api_key) or not grp["models"])
+            should_probe = bool(api_url) and not (
+                bool(current_base_url)
+                and _grp_url_norm == current_base_url.strip().rstrip("/").lower()
+                and bool(grp["models"])
+            ) and (
+                (bool(api_key) and not api_key_is_placeholder)
+                or not grp["models"]
+            )
             if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -20,11 +20,13 @@ OpenRouter variant suffixes (``:free``, ``:extended``, ``:fast``).
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import re
 from dataclasses import dataclass
 from typing import List, NamedTuple, Optional
 
+from utils import base_url_hostname
 from hermes_cli.providers import (
     custom_provider_slug,
     determine_api_mode,
@@ -44,6 +46,23 @@ from agent.models_dev import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _base_url_is_loopback(base_url: str) -> bool:
+    """Return True for localhost / loopback model endpoints.
+
+    Local OpenAI-compatible servers are often running while tests execute; if a
+    custom provider also declares an explicit model list, the picker must not
+    replace that curated list with whatever happens to be live on the developer
+    machine.
+    """
+    host = base_url_hostname(base_url)
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -1699,10 +1718,13 @@ def list_authenticated_providers(
             # the Telegram/Discord picker should do the same for parity.
             # Live-discovery policy:
             # - With an api_key, the user has explicitly opted into the
-            #   endpoint and live /models is the source of truth — replace
-            #   the (possibly partial) ``models:`` subset configured for
-            #   context-length overrides with the full live catalog.
-            #   This is the Bifrost / aggregator-gateway case.
+            #   endpoint and live /models is normally the source of truth —
+            #   replace the (possibly partial) ``models:`` subset configured
+            #   for context-length overrides with the full live catalog. This
+            #   is the Bifrost / aggregator-gateway case. Loopback endpoints
+            #   are the exception when they already declare explicit models:
+            #   never let whatever happens to be running on localhost replace
+            #   the curated config list.
             # - Without an api_key but with an explicit ``models:`` list
             #   (or top-level ``model:``), the user is narrowing a public
             #   endpoint to a specific subset (e.g. ollama.com /v1/models
@@ -1711,13 +1733,17 @@ def list_authenticated_providers(
             # - Without an api_key AND no explicit models, fall through to
             #   live discovery so bare-endpoint custom providers (local
             #   llama.cpp / Ollama servers) still appear populated.
-            should_probe = bool(api_url) and not (
+            has_explicit_models = bool(grp["models"])
+            local_endpoint_with_explicit_models = (
+                has_explicit_models and _base_url_is_loopback(api_url)
+            )
+            should_probe = bool(api_url) and not local_endpoint_with_explicit_models and not (
                 bool(current_base_url)
                 and _grp_url_norm == current_base_url.strip().rstrip("/").lower()
-                and bool(grp["models"])
+                and has_explicit_models
             ) and (
                 (bool(api_key) and not api_key_is_placeholder)
-                or not grp["models"]
+                or not has_explicit_models
             )
             if should_probe:
                 try:

--- a/hermes_cli/path_authority_doctor.py
+++ b/hermes_cli/path_authority_doctor.py
@@ -1,0 +1,891 @@
+"""Read-only Kanban path-authority diagnostics for Hermes deployments."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+SEVERITY_RANK = {"OK": 0, "P2": 1, "P1": 2, "P0": 3}
+UNIT_NAMES = {
+    "gateway": "hermes-gateway.service",
+    "webui": "hermes-webui.service",
+    "watchdog": "hermes-gateway-watchdog.service",
+}
+PATH_ENV_KEYS = {
+    "HERMES_KANBAN_AGENT_DIR",
+    "HERMES_AGENT_DIR",
+    "HERMES_AGENT_REPO",
+    "HERMES_HOME",
+    "HERMES_WEBUI_DIR",
+    "HERMES_WEBUI_REPO",
+    "OBSIDIAN_VAULT_PATH",
+}
+SECRET_KEY_FRAGMENTS = (
+    "TOKEN",
+    "SECRET",
+    "KEY",
+    "PASSWORD",
+    "PASS",
+    "CREDENTIAL",
+    "COOKIE",
+    "AUTH",
+)
+AUTHORITY_DIRTY_PATHS = (
+    "hermes_cli/path_authority_doctor.py",
+    "hermes_cli/doctor.py",
+    "hermes_cli/main.py",
+    "hermes_cli/gateway.py",
+    "gateway/status.py",
+    "gateway/run.py",
+    "gateway/watchdog_check.py",
+)
+SECRET_ARG_NAMES = {
+    "--api-key",
+    "--apikey",
+    "--authorization",
+    "--auth",
+    "--bearer-token",
+    "--cookie",
+    "--key",
+    "--password",
+    "--secret",
+    "--token",
+}
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)(api[_-]?key|authorization|auth|cookie|password|passwd|secret|token)="
+)
+GRAPH_FRESHNESS_RELATIVE_PATHS = (
+    "Imports/Manifests/import-ledger.jsonl",
+    "Imports/Manifests/redaction-policy.md",
+    "AgentOps/Runbooks/HermesVault-Memory-ETL-Control-Plane.md",
+    "AgentOps/Runbooks/Memory-Promotion-Workflow.md",
+    "AgentOps/Runbooks/Agent-Startup-Query-Gate.md",
+    "AgentOps/Control/HermesVault-Memory-ETL.freeze",
+    "Memory/Contradictions/contradiction-register.md",
+    "Graphify/graph-manifest.md",
+    "Graphify/graph-manifest.json",
+)
+
+
+@dataclass
+class ParsedPathsEnv:
+    path: Path
+    exists: bool
+    values: dict[str, str]
+    redacted: dict[str, str]
+
+    def to_report(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "exists": self.exists,
+            "values": dict(self.redacted),
+        }
+
+
+@dataclass
+class EffectiveUnit:
+    exec_start: list[str] = field(default_factory=list)
+    working_directory: str | None = None
+    environment: dict[str, str] = field(default_factory=dict)
+
+    def to_report(self) -> dict[str, Any]:
+        return {
+            "exec_start": [_redact_command(command) for command in self.exec_start],
+            "working_directory": self.working_directory,
+            "environment": _redact_mapping(self.environment),
+        }
+
+
+@dataclass
+class UnitReport:
+    role: str
+    name: str
+    path: Path
+    exists: bool
+    dropins: list[Path]
+    effective: EffectiveUnit
+
+    def to_report(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "name": self.name,
+            "path": str(self.path),
+            "exists": self.exists,
+            "dropins": [str(path) for path in self.dropins],
+            "effective": self.effective.to_report(),
+        }
+
+
+@dataclass
+class CheckResult:
+    id: str
+    severity: str
+    status: str
+    message: str
+    detail: str | None = None
+
+    def to_report(self) -> dict[str, Any]:
+        payload = {
+            "id": self.id,
+            "severity": self.severity,
+            "status": self.status,
+            "message": self.message,
+        }
+        if self.detail:
+            payload["detail"] = self.detail
+        return payload
+
+
+@dataclass
+class PathAuthorityReport:
+    expected_agent_dir: str | None
+    paths_env: ParsedPathsEnv
+    units: dict[str, UnitReport]
+    checks: list[CheckResult]
+    runtime_import_authority: dict[str, Any] | None = None
+
+    @property
+    def overall_severity(self) -> str:
+        severity = "OK"
+        for check in self.failed_checks():
+            if SEVERITY_RANK[check.severity] > SEVERITY_RANK[severity]:
+                severity = check.severity
+        return severity
+
+    def failed_checks(self) -> list[CheckResult]:
+        return [check for check in self.checks if check.status != "ok"]
+
+    def exit_code(self, *, strict: bool) -> int:
+        if strict:
+            return 1 if self.failed_checks() else 0
+        return 1 if any(check.severity == "P0" for check in self.failed_checks()) else 0
+
+    def to_report(self) -> dict[str, Any]:
+        return {
+            "status": self.overall_severity,
+            "expected_agent_dir": self.expected_agent_dir,
+            "paths_env": self.paths_env.to_report(),
+            "units": {role: unit.to_report() for role, unit in self.units.items()},
+            "runtime_import_authority": self.runtime_import_authority,
+            "checks": [check.to_report() for check in self.checks],
+        }
+
+
+def parse_paths_env(path: Path | None = None) -> ParsedPathsEnv:
+    path = path or Path.home() / ".config" / "agent-env" / "paths.env"
+    if not path.exists():
+        return ParsedPathsEnv(path=path, exists=False, values={}, redacted={})
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        parsed = _parse_env_assignment(raw_line)
+        if parsed is None:
+            continue
+        key, value = parsed
+        values[key] = value
+
+    return ParsedPathsEnv(
+        path=path,
+        exists=True,
+        values=values,
+        redacted=_redact_mapping(values),
+    )
+
+
+def classify_dirty_repo(status_lines: list[str]) -> CheckResult:
+    dirty_paths = [_status_path(line) for line in status_lines if line.strip()]
+    if not dirty_paths:
+        return CheckResult(
+            id="active_repo_clean",
+            severity="OK",
+            status="ok",
+            message="Active Kanban agent checkout is clean",
+        )
+
+    authority_dirty = [
+        path for path in dirty_paths if _is_authority_dirty_path(path)
+    ]
+    if authority_dirty:
+        return CheckResult(
+            id="active_repo_dirty_authority",
+            severity="P0",
+            status="fail",
+            message="Active Kanban agent checkout has dirty path-authority/runtime-authority files",
+            detail=", ".join(authority_dirty),
+        )
+
+    return CheckResult(
+        id="active_repo_dirty",
+        severity="P1",
+        status="warn",
+        message="Active Kanban agent checkout is dirty",
+        detail=", ".join(dirty_paths),
+    )
+
+
+def build_path_authority_report(
+    *,
+    paths_env: ParsedPathsEnv | None = None,
+    systemd_user_dir: Path | None = None,
+    include_live: bool = True,
+) -> PathAuthorityReport:
+    parsed_env = paths_env or parse_paths_env()
+    expected_dir = parsed_env.values.get("HERMES_KANBAN_AGENT_DIR")
+    systemd_dir = systemd_user_dir or Path.home() / ".config" / "systemd" / "user"
+    units = {
+        role: read_effective_unit(role, name, systemd_dir)
+        for role, name in UNIT_NAMES.items()
+    }
+
+    checks: list[CheckResult] = []
+    if expected_dir:
+        checks.append(
+            CheckResult(
+                id="expected_agent_dir_configured",
+                severity="OK",
+                status="ok",
+                message="HERMES_KANBAN_AGENT_DIR is configured",
+                detail=expected_dir,
+            )
+        )
+    else:
+        checks.append(
+            CheckResult(
+                id="expected_agent_dir_missing",
+                severity="P0",
+                status="fail",
+                message="HERMES_KANBAN_AGENT_DIR is missing from paths.env",
+            )
+        )
+
+    expected_path = Path(expected_dir).expanduser() if expected_dir else None
+    if expected_path is not None:
+        for role, unit in units.items():
+            checks.extend(_check_unit_authority(role, unit, expected_path))
+
+        checks.append(_check_dirty_repo(expected_path))
+
+    checks.extend(_check_webui_graphify_authority(parsed_env, units))
+    checks.extend(_check_graphify_freshness(parsed_env))
+    checks.extend(_check_cron_shadow_authority(parsed_env))
+
+    runtime_authority = _read_runtime_import_authority() if include_live else None
+    if expected_path is not None:
+        if runtime_authority:
+            checks.append(_check_runtime_authority(runtime_authority, expected_path))
+        elif include_live:
+            checks.append(
+                CheckResult(
+                    id="runtime_import_authority_missing",
+                    severity="P0",
+                    status="fail",
+                    message="Persisted runtime import authority is missing or unreadable",
+                )
+            )
+
+    return PathAuthorityReport(
+        expected_agent_dir=expected_dir,
+        paths_env=parsed_env,
+        units=units,
+        checks=checks,
+        runtime_import_authority=runtime_authority,
+    )
+
+
+def read_effective_unit(role: str, unit_name: str, systemd_user_dir: Path) -> UnitReport:
+    unit_path = systemd_user_dir / unit_name
+    dropin_dir = systemd_user_dir / f"{unit_name}.d"
+    dropins = sorted(dropin_dir.glob("*.conf")) if dropin_dir.exists() else []
+    effective = EffectiveUnit()
+
+    sources = [unit_path] if unit_path.exists() else []
+    sources.extend(dropins)
+    for source in sources:
+        _apply_unit_source(effective, source.read_text(encoding="utf-8"))
+
+    return UnitReport(
+        role=role,
+        name=unit_name,
+        path=unit_path,
+        exists=unit_path.exists(),
+        dropins=dropins,
+        effective=effective,
+    )
+
+
+def run_path_authority_doctor(args: Any) -> int:
+    report = build_path_authority_report(include_live=not getattr(args, "no_live", False))
+    if getattr(args, "json", False):
+        print(json.dumps(report.to_report(), indent=2, sort_keys=True))
+    else:
+        _print_text_report(report)
+    return report.exit_code(strict=bool(getattr(args, "strict", False)))
+
+
+def _parse_env_assignment(line: str) -> tuple[str, str] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    if stripped.startswith("export "):
+        stripped = stripped[len("export "):].lstrip()
+    if "=" not in stripped:
+        return None
+    key, value = stripped.split("=", 1)
+    key = key.strip()
+    if not key or not key.replace("_", "").isalnum() or key[0].isdigit():
+        return None
+    value = _strip_inline_comment(value.strip())
+    try:
+        parts = shlex.split(value, posix=True)
+    except ValueError:
+        parts = [value.strip("'\"")]
+    parsed_value = parts[0] if parts else ""
+    return key, parsed_value
+
+
+def _strip_inline_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    for index, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            if index == 0 or value[index - 1].isspace():
+                return value[:index].rstrip()
+    return value
+
+
+def _apply_unit_source(effective: EffectiveUnit, text: str) -> None:
+    section = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            continue
+        if section != "Service" or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key == "ExecStart":
+            value = _unquote_systemd_value(value)
+            if value == "":
+                effective.exec_start.clear()
+            else:
+                effective.exec_start.append(value)
+        elif key == "WorkingDirectory":
+            value = _unquote_systemd_value(value)
+            effective.working_directory = value or None
+        elif key == "Environment":
+            if value == "":
+                effective.environment.clear()
+            else:
+                effective.environment.update(_parse_environment_directive(value))
+
+
+def _parse_environment_directive(value: str) -> dict[str, str]:
+    try:
+        parts = shlex.split(value, posix=True)
+    except ValueError:
+        parts = [value]
+    env: dict[str, str] = {}
+    for part in parts:
+        if "=" not in part:
+            continue
+        key, val = part.split("=", 1)
+        if key:
+            env[key] = val
+    return env
+
+
+def _unquote_systemd_value(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _check_unit_authority(role: str, unit: UnitReport, expected_path: Path) -> list[CheckResult]:
+    checks: list[CheckResult] = []
+    if not unit.exists and not unit.dropins:
+        checks.append(
+            CheckResult(
+                id=f"{role}_unit_missing",
+                severity="P1",
+                status="warn",
+                message=f"{unit.name} is not installed in the user systemd directory",
+            )
+        )
+        return checks
+
+    if role == "gateway":
+        if any(
+            token == "--replace" or token.startswith("--replace=")
+            for command in unit.effective.exec_start
+            for token in _split_command(command)
+        ):
+            checks.append(
+                CheckResult(
+                    id="gateway_execstart_replace",
+                    severity="P0",
+                    status="fail",
+                    message="Effective gateway ExecStart contains --replace",
+                    detail="; ".join(
+                        _redact_command(command) for command in unit.effective.exec_start
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                CheckResult(
+                    id="gateway_execstart_no_replace",
+                    severity="OK",
+                    status="ok",
+                    message="Effective gateway ExecStart does not contain --replace",
+                )
+            )
+
+    if _unit_points_to_expected_dir(role, unit.effective, expected_path):
+        checks.append(
+            CheckResult(
+                id=f"{role}_path_authority",
+                severity="OK",
+                status="ok",
+                message=f"{unit.name} points at HERMES_KANBAN_AGENT_DIR",
+            )
+        )
+    else:
+        checks.append(
+            CheckResult(
+                id=f"{role}_path_authority",
+                severity="P0",
+                status="fail",
+                message=f"{unit.name} does not point at HERMES_KANBAN_AGENT_DIR",
+                detail=_unit_authority_detail(unit.effective),
+            )
+        )
+    return checks
+
+
+def _unit_points_to_expected_dir(role: str, effective: EffectiveUnit, expected_path: Path) -> bool:
+    env_path_keys = {
+        "HERMES_KANBAN_AGENT_DIR",
+        "HERMES_AGENT_DIR",
+        "HERMES_AGENT_REPO",
+        "HERMES_AGENT_ROOT",
+        "HERMES_WEBUI_AGENT_DIR",
+        "AGENT_DIR",
+    }
+    authority_env = {
+        key: value
+        for key, value in effective.environment.items()
+        if key in env_path_keys
+    }
+    env_matches = any(
+        key in env_path_keys and _path_is_within(value, expected_path)
+        for key, value in effective.environment.items()
+    )
+    env_clean = all(_path_is_within(value, expected_path) for value in authority_env.values())
+    exec_matches = any(
+        _path_is_within(token, expected_path)
+        for command in effective.exec_start
+        for token in _split_command(command)
+        if token.startswith("/") or token.startswith("~")
+    )
+    cwd_matches = bool(
+        effective.working_directory
+        and _path_is_within(effective.working_directory, expected_path)
+    )
+
+    if role == "webui":
+        return env_matches and env_clean
+    return cwd_matches and exec_matches and env_clean
+
+
+def _unit_authority_detail(effective: EffectiveUnit) -> str:
+    detail = {
+        "exec_start": [_redact_command(command) for command in effective.exec_start],
+        "working_directory": effective.working_directory,
+        "environment": _redact_mapping(effective.environment),
+    }
+    return json.dumps(detail, sort_keys=True)
+
+
+def _check_dirty_repo(expected_path: Path) -> CheckResult:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(expected_path), "status", "--porcelain", "--untracked-files=all"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return CheckResult(
+            id="active_repo_git_status",
+            severity="P2",
+            status="warn",
+            message="Could not read active Kanban agent git status",
+            detail=str(exc),
+        )
+    if proc.returncode != 0:
+        return CheckResult(
+            id="active_repo_git_status",
+            severity="P2",
+            status="warn",
+            message="Could not read active Kanban agent git status",
+            detail=(proc.stderr or proc.stdout).strip(),
+        )
+    return classify_dirty_repo(proc.stdout.splitlines())
+
+
+def _check_runtime_authority(runtime_authority: dict[str, Any], expected_path: Path) -> CheckResult:
+    project_root = runtime_authority.get("project_root")
+    gateway_file = runtime_authority.get("gateway_file")
+    hermes_cli_file = runtime_authority.get("hermes_cli_file")
+    fields = [project_root, gateway_file, hermes_cli_file]
+    if all(value and _path_is_within(str(value), expected_path) for value in fields):
+        return CheckResult(
+            id="runtime_import_authority",
+            severity="OK",
+            status="ok",
+            message="Persisted runtime import authority points at HERMES_KANBAN_AGENT_DIR",
+        )
+    return CheckResult(
+        id="runtime_import_authority",
+        severity="P0",
+        status="fail",
+        message="Persisted runtime import authority does not point at HERMES_KANBAN_AGENT_DIR",
+        detail=json.dumps(runtime_authority, sort_keys=True),
+    )
+
+
+def _check_webui_graphify_authority(
+    paths_env: ParsedPathsEnv,
+    units: dict[str, UnitReport],
+) -> list[CheckResult]:
+    expected = {
+        key: value
+        for key in ("GRAPHIFY_OUTPUT_DIR", "GRAPHIFY_GRAPH_JSON")
+        if (value := paths_env.values.get(key))
+    }
+    if not expected:
+        return []
+
+    webui = units.get("webui")
+    if webui is None or not webui.exists:
+        return []
+
+    mismatches = []
+    for key, expected_value in expected.items():
+        actual = webui.effective.environment.get(key)
+        if actual != expected_value:
+            mismatches.append(
+                {
+                    "key": key,
+                    "expected": expected_value,
+                    "actual": actual,
+                }
+            )
+    if mismatches:
+        return [
+            CheckResult(
+                id="webui_graphify_path_authority",
+                severity="P1",
+                status="fail",
+                message="WebUI systemd Graphify paths differ from paths.env",
+                detail=json.dumps(mismatches, sort_keys=True),
+            )
+        ]
+    return [
+        CheckResult(
+            id="webui_graphify_path_authority",
+            severity="OK",
+            status="ok",
+            message="WebUI systemd Graphify paths match paths.env",
+        )
+    ]
+
+
+def _check_graphify_freshness(paths_env: ParsedPathsEnv) -> list[CheckResult]:
+    vault = paths_env.values.get("OBSIDIAN_VAULT_PATH")
+    graph = paths_env.values.get("GRAPHIFY_GRAPH_JSON")
+    if not vault or not graph:
+        return []
+
+    vault_path = Path(vault).expanduser()
+    graph_path = Path(graph).expanduser()
+    if not graph_path.exists():
+        return [
+            CheckResult(
+                id="graphify_freshness",
+                severity="P1",
+                status="fail",
+                message="Graphify sidecar graph is missing",
+                detail=str(graph_path),
+            )
+        ]
+
+    sources = [
+        candidate
+        for relative in GRAPH_FRESHNESS_RELATIVE_PATHS
+        if (candidate := vault_path / relative).exists()
+    ]
+    if not sources:
+        return [
+            CheckResult(
+                id="graphify_freshness",
+                severity="P2",
+                status="warn",
+                message="No Graphify governance freshness source files were found",
+                detail=str(vault_path),
+            )
+        ]
+
+    graph_mtime = graph_path.stat().st_mtime
+    latest = max(sources, key=lambda path: path.stat().st_mtime)
+    latest_mtime = latest.stat().st_mtime
+    detail = json.dumps(
+        {
+            "graph": str(graph_path),
+            "graph_mtime": graph_mtime,
+            "latest_source": str(latest),
+            "latest_source_mtime": latest_mtime,
+        },
+        sort_keys=True,
+    )
+    if latest_mtime > graph_mtime + 1:
+        return [
+            CheckResult(
+                id="graphify_freshness",
+                severity="P1",
+                status="warn",
+                message="Graphify sidecar graph is older than memory governance sources",
+                detail=detail,
+            )
+        ]
+    return [
+        CheckResult(
+            id="graphify_freshness",
+            severity="OK",
+            status="ok",
+            message="Graphify sidecar graph is not older than memory governance sources",
+            detail=detail,
+        )
+    ]
+
+
+def _check_cron_shadow_authority(paths_env: ParsedPathsEnv) -> list[CheckResult]:
+    hermes_home = paths_env.values.get("HERMES_HOME")
+    if not hermes_home:
+        return []
+
+    cron_dir = Path(hermes_home).expanduser() / "cron"
+    active = cron_dir / "jobs.json"
+    shadow = cron_dir / "cron" / "jobs.json"
+    marker = shadow.parent / "NON_AUTHORITATIVE"
+    checks: list[CheckResult] = []
+
+    if not active.exists():
+        checks.append(
+            CheckResult(
+                id="cron_active_registry_missing",
+                severity="P1",
+                status="warn",
+                message="Canonical cron registry is missing",
+                detail=str(active),
+            )
+        )
+        return checks
+
+    checks.append(
+        CheckResult(
+            id="cron_active_registry_present",
+            severity="OK",
+            status="ok",
+            message="Canonical cron registry is present",
+            detail=str(active),
+        )
+    )
+
+    if not shadow.exists():
+        checks.append(
+            CheckResult(
+                id="cron_shadow_registry_absent",
+                severity="OK",
+                status="ok",
+                message="No nested shadow cron registry exists",
+            )
+        )
+        return checks
+
+    detail = _cron_shadow_detail(shadow, marker)
+    if marker.exists():
+        checks.append(
+            CheckResult(
+                id="cron_shadow_registry_quarantined",
+                severity="OK",
+                status="ok",
+                message="Nested shadow cron registry is explicitly marked non-authoritative",
+                detail=detail,
+            )
+        )
+    else:
+        checks.append(
+            CheckResult(
+                id="cron_shadow_registry_unclassified",
+                severity="P1",
+                status="fail",
+                message="Nested shadow cron registry exists without a non-authoritative marker",
+                detail=detail,
+            )
+        )
+    return checks
+
+
+def _cron_shadow_detail(shadow: Path, marker: Path) -> str:
+    enabled_count = 0
+    stale_root_count = 0
+    try:
+        raw = shadow.read_text(encoding="utf-8")
+        stale_root_count = raw.count("/root/")
+        data = json.loads(raw)
+        jobs = data.get("jobs", data if isinstance(data, list) else [])
+        if isinstance(jobs, list):
+            enabled_count = sum(1 for job in jobs if isinstance(job, dict) and job.get("enabled"))
+    except Exception:
+        pass
+    return json.dumps(
+        {
+            "shadow": str(shadow),
+            "marker": str(marker),
+            "marker_present": marker.exists(),
+            "enabled_jobs": enabled_count,
+            "stale_root_refs": stale_root_count,
+        },
+        sort_keys=True,
+    )
+
+
+def _read_runtime_import_authority() -> dict[str, Any] | None:
+    try:
+        from gateway.status import read_runtime_status
+
+        state = read_runtime_status() or {}
+    except Exception:
+        return None
+    authority = state.get("runtime_import_authority")
+    return authority if isinstance(authority, dict) else None
+
+
+def _path_is_within(value: str, expected_path: Path) -> bool:
+    if not value:
+        return False
+    try:
+        candidate = Path(os.path.abspath(os.path.expanduser(value)))
+        expected = Path(os.path.abspath(os.path.expanduser(str(expected_path))))
+    except OSError:
+        return False
+    return candidate == expected or expected in candidate.parents
+
+
+def _split_command(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _redact_command(command: str) -> str:
+    tokens = _split_command(command)
+    if not tokens:
+        return ""
+
+    redacted: list[str] = []
+    redact_next = False
+    for token in tokens:
+        lowered = token.lower()
+        if redact_next:
+            redacted.append("[REDACTED]")
+            redact_next = False
+            continue
+        if any(lowered == name for name in SECRET_ARG_NAMES):
+            redacted.append(token)
+            redact_next = True
+            continue
+        matched_flag = next(
+            (name for name in SECRET_ARG_NAMES if lowered.startswith(f"{name}=")),
+            None,
+        )
+        if matched_flag is not None:
+            flag = token.split("=", 1)[0]
+            redacted.append(f"{flag}=[REDACTED]")
+            continue
+        if SECRET_ASSIGNMENT_RE.search(token):
+            key = token.split("=", 1)[0]
+            redacted.append(f"{key}=[REDACTED]")
+            continue
+        redacted.append(token)
+    return shlex.join(redacted)
+
+
+def _status_path(line: str) -> str:
+    path = line[3:] if len(line) > 3 else line.strip()
+    if " -> " in path:
+        path = path.split(" -> ", 1)[1]
+    return path.strip()
+
+
+def _is_authority_dirty_path(path: str) -> bool:
+    return path in AUTHORITY_DIRTY_PATHS or path.startswith(".config/systemd/")
+
+
+def _is_secret_key(key: str) -> bool:
+    upper = key.upper()
+    return any(fragment in upper for fragment in SECRET_KEY_FRAGMENTS)
+
+
+def _redact_mapping(values: dict[str, str]) -> dict[str, str]:
+    redacted: dict[str, str] = {}
+    for key, value in values.items():
+        if _is_secret_key(key):
+            redacted[key] = "[REDACTED]"
+        elif key in PATH_ENV_KEYS or key.endswith("_DIR") or key.endswith("_PATH") or key.endswith("_ROOT"):
+            redacted[key] = value
+        else:
+            redacted[key] = "[SET]" if value else ""
+    return redacted
+
+
+def _print_text_report(report: PathAuthorityReport) -> None:
+    print()
+    print("Hermes Path Authority Doctor")
+    print(f"Status: {report.overall_severity}")
+    print(f"paths.env: {report.paths_env.path} ({'present' if report.paths_env.exists else 'missing'})")
+    print(f"HERMES_KANBAN_AGENT_DIR: {report.expected_agent_dir or 'MISSING'}")
+    print()
+    for check in report.checks:
+        label = check.severity if check.status != "ok" else "OK"
+        print(f"[{label}] {check.id}: {check.message}")
+        if check.detail:
+            print(f"  {check.detail}")
+
+
+if __name__ == "__main__":
+    class _Args:
+        json = "--json" in sys.argv
+        no_live = "--no-live" in sys.argv
+        strict = "--strict" in sys.argv
+
+    raise SystemExit(run_path_authority_doctor(_Args()))

--- a/hermes_cli/path_authority_doctor.py
+++ b/hermes_cli/path_authority_doctor.py
@@ -14,6 +14,17 @@ from typing import Any
 
 
 SEVERITY_RANK = {"OK": 0, "P2": 1, "P1": 2, "P0": 3}
+UNKNOWN_SEVERITY_FALLBACK = "P0"
+
+
+def _severity_rank(severity: str) -> int:
+    """Return a fail-closed rank for check severities.
+
+    Unknown severities can appear when newer check producers feed older report
+    readers. Treat them as P0 instead of crashing or silently downgrading the
+    failed check to OK.
+    """
+    return SEVERITY_RANK.get(severity, SEVERITY_RANK[UNKNOWN_SEVERITY_FALLBACK])
 UNIT_NAMES = {
     "gateway": "hermes-gateway.service",
     "webui": "hermes-webui.service",
@@ -156,8 +167,8 @@ class PathAuthorityReport:
     def overall_severity(self) -> str:
         severity = "OK"
         for check in self.failed_checks():
-            if SEVERITY_RANK[check.severity] > SEVERITY_RANK[severity]:
-                severity = check.severity
+            if _severity_rank(check.severity) > SEVERITY_RANK[severity]:
+                severity = check.severity if check.severity in SEVERITY_RANK else UNKNOWN_SEVERITY_FALLBACK
         return severity
 
     def failed_checks(self) -> list[CheckResult]:
@@ -166,7 +177,7 @@ class PathAuthorityReport:
     def exit_code(self, *, strict: bool) -> int:
         if strict:
             return 1 if self.failed_checks() else 0
-        return 1 if any(check.severity == "P0" for check in self.failed_checks()) else 0
+        return 1 if any(_severity_rank(check.severity) >= SEVERITY_RANK["P0"] for check in self.failed_checks()) else 0
 
     def to_report(self) -> dict[str, Any]:
         return {

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -416,21 +416,51 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
     EEXIST handling in s6-supervise has been stable since 2015 — it's
     the same pattern ``s6-svperms`` and ``fix-attrs.d`` rely on.
     """
+    import errno
     import os
+
+    def _chmod_supervise_dir(path: Path, mode: int) -> None:
+        """Apply an s6 supervise/event directory mode without breaking dev hosts.
+
+        The production s6 container runs this helper as root, so the desired
+        ``03730`` event-dir mode is reachable and remains the authoritative
+        layout. Some developer/CI temp mounts are ``nosuid`` (WSL's ``/tmp`` is
+        one example) and reject setting the setgid bit even for the owning user.
+        Registration should still be testable there: keep the sticky bit plus
+        owner/group rwx contract and only drop setgid when the kernel refuses
+        it.
+        """
+        try:
+            path.chmod(mode)
+            return
+        except PermissionError:
+            if not (mode & 0o2000):
+                raise
+
+        # Preserve sticky + rwx bits; drop only setgid on nosuid/non-root
+        # filesystems that reject it. If this also fails, surface the platform
+        # problem to the caller instead of silently creating a broken supervise
+        # tree.
+        fallback_mode = mode & ~0o2000
+        path.chmod(fallback_mode)
 
     def _mkdir_owned(path: Path, mode: int) -> None:
         if path.exists():
             return
         path.mkdir(parents=False, exist_ok=False)
-        path.chmod(mode)
         try:
             os.chown(path, _HERMES_UID, _HERMES_GID)
-        except PermissionError:
+        except OSError as exc:
+            if exc.errno not in {errno.EPERM, errno.EINVAL}:
+                raise
             # Running as the hermes user already — directory is hermes-
             # owned by default. The chown is a no-op in that case, so
             # swallowing this keeps both root and unprivileged callers
-            # on one code path.
+            # on one code path. Some non-container developer filesystems
+            # (notably WSL temp mounts) report EINVAL rather than EPERM
+            # for synthetic container uid/gid values.
             pass
+        _chmod_supervise_dir(path, mode)
 
     # Top-level event/ dir (this is the s6-svlisten1 event-subscription
     # dir at the service root, distinct from supervise/event/).
@@ -455,7 +485,9 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
         control.chmod(0o660)
         try:
             os.chown(control, _HERMES_UID, _HERMES_GID)
-        except PermissionError:
+        except OSError as exc:
+            if exc.errno not in {errno.EPERM, errno.EINVAL}:
+                raise
             pass
 
     # If a log/ subdir is present (the canonical s6 logger pattern —
@@ -475,7 +507,9 @@ def _seed_supervise_skeleton(svc_dir: Path) -> None:
             log_control.chmod(0o660)
             try:
                 os.chown(log_control, _HERMES_UID, _HERMES_GID)
-            except PermissionError:
+            except OSError as exc:
+                if exc.errno not in {errno.EPERM, errno.EINVAL}:
+                    raise
                 pass
 
 

--- a/scripts/check_prompt_policy.py
+++ b/scripts/check_prompt_policy.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Verify active prompt-loader policy invariants.
+
+This checker intentionally validates the current ``agent.prompt_builder``
+contract. It is not a replay of the legacy v0.8 priority-section checker.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.prompt_builder import (  # noqa: E402
+    CONTEXT_FILE_MAX_CHARS,
+    _truncate_content,
+    build_context_files_prompt,
+)
+
+FORBIDDEN_POLICY_SNIPPETS = {
+    "<claude-mem-context>": "generated claude memory context",
+    "</claude-mem-context>": "generated claude memory context close tag",
+    "<system-reminder>": "generated system reminder block",
+}
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def check_active_policy_file(root: Path) -> list[str]:
+    failures: list[str] = []
+    agents_md = root / "AGENTS.md"
+    if not agents_md.exists():
+        return [f"missing active policy file: {agents_md}"]
+    try:
+        content = agents_md.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        return [f"could not read active policy file {agents_md}: {exc}"]
+    if not content:
+        failures.append(f"active policy file is empty: {agents_md}")
+    for snippet, label in FORBIDDEN_POLICY_SNIPPETS.items():
+        if snippet in content:
+            failures.append(f"active policy file contains {label}: {snippet}")
+    for shadow_name in (".hermes.md", "HERMES.md"):
+        if (root / shadow_name).exists():
+            failures.append(
+                f"active AGENTS.md would be shadowed by higher-priority {shadow_name}"
+            )
+    return failures
+
+
+def check_active_policy_uptake(root: Path) -> list[str]:
+    failures: list[str] = []
+    try:
+        loaded = build_context_files_prompt(cwd=str(root), skip_soul=True)
+    except Exception as exc:  # pragma: no cover - defensive operator output
+        return [f"active prompt context failed to load: {type(exc).__name__}: {exc}"]
+
+    if "# Project Context" not in loaded:
+        failures.append("active prompt context did not include project context wrapper")
+    if "## AGENTS.md" not in loaded:
+        failures.append("active prompt context did not load AGENTS.md")
+    if "<claude-mem-context>" in loaded:
+        failures.append("active prompt context contains raw generated claude memory block")
+    return failures
+
+
+def check_loader_priority_contract() -> list[str]:
+    failures: list[str] = []
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / ".git").mkdir()
+        child = root / "pkg" / "module"
+        child.mkdir(parents=True)
+        _write(root / ".hermes.md", "HERMES_SHOULD_LOAD")
+        _write(child / "AGENTS.md", "AGENTS_SHOULD_NOT_LOAD")
+        _write(child / "CLAUDE.md", "CLAUDE_SHOULD_NOT_LOAD")
+        _write(child / ".cursorrules", "CURSOR_SHOULD_NOT_LOAD")
+        _write(child / ".cursor" / "rules" / "rule.mdc", "MDC_SHOULD_NOT_LOAD")
+
+        loaded = build_context_files_prompt(cwd=str(child), skip_soul=True)
+        if "HERMES_SHOULD_LOAD" not in loaded:
+            failures.append("dropped highest-priority .hermes.md project context")
+        if "AGENTS_SHOULD_NOT_LOAD" in loaded:
+            failures.append("loaded lower-priority AGENTS.md alongside .hermes.md")
+        if "CLAUDE_SHOULD_NOT_LOAD" in loaded:
+            failures.append("loaded lower-priority CLAUDE.md alongside .hermes.md")
+        if "CURSOR_SHOULD_NOT_LOAD" in loaded or "MDC_SHOULD_NOT_LOAD" in loaded:
+            failures.append("loaded lower-priority cursor rules alongside .hermes.md")
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(root / "AGENTS.md", "AGENTS_SHOULD_LOAD")
+        _write(root / "CLAUDE.md", "CLAUDE_SHOULD_NOT_LOAD")
+        _write(root / ".cursorrules", "CURSOR_SHOULD_NOT_LOAD")
+        loaded = build_context_files_prompt(cwd=str(root), skip_soul=True)
+        if "AGENTS_SHOULD_LOAD" not in loaded:
+            failures.append("dropped AGENTS.md when no .hermes.md exists")
+        if "CLAUDE_SHOULD_NOT_LOAD" in loaded:
+            failures.append("loaded lower-priority CLAUDE.md alongside AGENTS.md")
+        if "CURSOR_SHOULD_NOT_LOAD" in loaded:
+            failures.append("loaded lower-priority cursor rules alongside AGENTS.md")
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(root / "CLAUDE.md", "CLAUDE_SHOULD_LOAD")
+        _write(root / ".cursorrules", "CURSOR_SHOULD_NOT_LOAD")
+        loaded = build_context_files_prompt(cwd=str(root), skip_soul=True)
+        if "CLAUDE_SHOULD_LOAD" not in loaded:
+            failures.append("dropped CLAUDE.md when no .hermes.md or AGENTS.md exists")
+        if "CURSOR_SHOULD_NOT_LOAD" in loaded:
+            failures.append("loaded lower-priority cursor rules alongside CLAUDE.md")
+
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _write(root / ".cursorrules", "CURSOR_SHOULD_LOAD")
+        loaded = build_context_files_prompt(cwd=str(root), skip_soul=True)
+        if "CURSOR_SHOULD_LOAD" not in loaded:
+            failures.append("dropped cursor rules when no higher-priority file exists")
+
+    return failures
+
+
+def check_soul_independence() -> list[str]:
+    failures: list[str] = []
+    with TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        project = base / "project"
+        hermes_home = base / "hermes_home"
+        project.mkdir()
+        hermes_home.mkdir()
+        _write(project / "AGENTS.md", "PROJECT_POLICY_MARKER")
+        _write(project / "SOUL.md", "CWD_SOUL_SHOULD_NOT_LOAD")
+        _write(hermes_home / "SOUL.md", "HERMES_HOME_SOUL_MARKER")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            loaded = build_context_files_prompt(cwd=str(project), skip_soul=False)
+            loaded_without_soul = build_context_files_prompt(cwd=str(project), skip_soul=True)
+
+        if "PROJECT_POLICY_MARKER" not in loaded:
+            failures.append("project policy dropped when HERMES_HOME SOUL.md exists")
+        if "HERMES_HOME_SOUL_MARKER" not in loaded:
+            failures.append("HERMES_HOME SOUL.md was not loaded independently")
+        if "CWD_SOUL_SHOULD_NOT_LOAD" in loaded:
+            failures.append("cwd SOUL.md was loaded instead of HERMES_HOME SOUL.md")
+        if "HERMES_HOME_SOUL_MARKER" in loaded_without_soul:
+            failures.append("skip_soul=True still loaded SOUL.md")
+    return failures
+
+
+def check_truncation_contract() -> list[str]:
+    failures: list[str] = []
+    content = (
+        "HEAD_PROMPT_POLICY_MARKER\n"
+        + ("A" * CONTEXT_FILE_MAX_CHARS)
+        + "\nTAIL_PROMPT_POLICY_MARKER"
+    )
+    loaded = _truncate_content(content, "policy.md")
+    if "HEAD_PROMPT_POLICY_MARKER" not in loaded:
+        failures.append("truncation dropped head marker")
+    if "TAIL_PROMPT_POLICY_MARKER" not in loaded:
+        failures.append("truncation dropped tail marker")
+    if "[...truncated policy.md:" not in loaded or "kept" not in loaded:
+        failures.append("truncation marker missing or malformed")
+    if len(loaded) >= len(content):
+        failures.append("truncation did not reduce oversized content")
+    return failures
+
+
+def run_checks(root: Path = ROOT) -> list[str]:
+    root = root.resolve()
+    failures: list[str] = []
+    failures.extend(check_active_policy_file(root))
+    if not failures:
+        failures.extend(check_active_policy_uptake(root))
+    failures.extend(check_loader_priority_contract())
+    failures.extend(check_soul_independence())
+    failures.extend(check_truncation_contract())
+    return failures
+
+
+def main() -> int:
+    failures = run_checks(ROOT)
+    if failures:
+        print("FAIL: prompt policy checks failed", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("PASS: active prompt policy loader checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint_diff.py
+++ b/scripts/lint_diff.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from collections import Counter
 from pathlib import Path
@@ -69,13 +70,21 @@ def _normalize_ty(entries: list[dict]) -> list[dict]:
     for e in entries:
         loc = e.get("location") or {}
         begin = (loc.get("positions") or {}).get("begin") or {}
+        description = e.get("description", "")
+        if isinstance(description, str):
+            description = re.sub(
+                r"`/[^`]*(/)(agent|gateway|hermes_cli|scripts|tests|tools)/([^`]+)`",
+                r"`\2/\3`",
+                description,
+            )
+            description = re.sub(r"Id\([0-9a-fA-F]+\)", "Id(<normalized>)", description)
         out.append(
             {
                 "tool": "ty",
                 "rule": e.get("check_name", "unknown"),
                 "path": loc.get("path", ""),
                 "line": begin.get("line", 0),
-                "message": e.get("description", ""),
+                "message": description,
             }
         )
     return out
@@ -106,6 +115,10 @@ def _diff(base: list[dict], head: list[dict]) -> tuple[list[dict], list[dict], l
 
 def _rule_counts(entries: list[dict]) -> list[tuple[str, int]]:
     return Counter(e["rule"] for e in entries).most_common()
+
+
+def _unique_count(entries: list[dict]) -> int:
+    return len({_key(d) for d in entries})
 
 
 def _section(title: str, entries: list[dict], limit: int = 25) -> str:
@@ -139,7 +152,9 @@ def _tool_report(
     base_available: bool,
 ) -> str:
     new, fixed, unchanged = _diff(base, head)
-    delta = len(head) - len(base)
+    base_total = _unique_count(base)
+    head_total = _unique_count(head)
+    delta = head_total - base_total
     delta_str = f"+{delta}" if delta > 0 else str(delta)
     emoji = "🆕" if delta > 0 else ("✅" if delta < 0 else "➖")
 
@@ -150,9 +165,11 @@ def _tool_report(
             "treating all head diagnostics as new._\n"
         )
     lines.append(
-        f"**Total:** {len(head)} on HEAD, {len(base)} on base "
+        f"**Unique total:** {head_total} on HEAD, {base_total} on base "
         f"({emoji} {delta_str})\n"
     )
+    if len(head) != head_total or len(base) != base_total:
+        lines.append(f"_Raw diagnostic events: {len(head)} on HEAD, {len(base)} on base._\n")
     lines.append(_section("🆕 New issues", new))
     lines.append(_section("✅ Fixed issues", fixed))
     lines.append(

--- a/scripts/proof/mcp_runtime_probe.py
+++ b/scripts/proof/mcp_runtime_probe.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Emit a redacted JSON MCP runtime-depth probe report."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import threading
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.mcp_runtime_probe import probe_default_sources  # noqa: E402
+
+
+def _hard_timeout_exit() -> None:
+    report = {
+        "status": "timeout",
+        "status_counts": {"timeout": 1},
+        "check_status_counts": {"timeout": 1},
+        "servers": [],
+        "status_classes": ["timeout"],
+        "status_samples": {},
+    }
+    print(json.dumps(report, indent=2, sort_keys=True), flush=True)
+    os._exit(124)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", choices=["codex", "claude", "hermes", "all"], default="all")
+    parser.add_argument("--server", help="probe only one server name or source:name id")
+    parser.add_argument("--json", action="store_true", help="emit JSON; retained for proof command symmetry")
+    parser.add_argument("--redact", action="store_true", help="force redacted output; all output is always redacted")
+    parser.add_argument("--timeout", type=int, default=120, help="overall probe timeout in seconds")
+    parser.add_argument(
+        "--skip-auth-needed",
+        action="store_true",
+        help="skip entries known to need interactive auth, including Google Drive",
+    )
+    parser.add_argument(
+        "--include-google-drive-auth-needed",
+        action="store_true",
+        help="Include Google Drive MCP entries that are only missing auth.",
+    )
+    args = parser.parse_args()
+
+    timer = None
+    if args.timeout > 0:
+        # MCP SDK/client shutdown can block while child stdio servers are wedged.
+        # Use a process-level watchdog so proof runs have a hard wall clock.
+        timer = threading.Timer(args.timeout + 5, _hard_timeout_exit)
+        timer.daemon = True
+        timer.start()
+    try:
+        report = asyncio.run(
+            asyncio.wait_for(
+                probe_default_sources(
+                    runtime=args.runtime,
+                    server_name=args.server,
+                    skip_google_drive_auth_needed=args.skip_auth_needed or not args.include_google_drive_auth_needed,
+                ),
+                timeout=args.timeout if args.timeout > 0 else None,
+            )
+        )
+    except asyncio.TimeoutError:
+        report = {
+            "status": "timeout",
+            "status_counts": {"timeout": 1},
+            "check_status_counts": {"timeout": 1},
+            "servers": [],
+            "status_classes": ["timeout"],
+            "status_samples": {},
+        }
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 124
+    finally:
+        if timer is not None:
+            timer.cancel()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1124,6 +1124,7 @@ AUTHOR_MAP = {
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
     "ayman.a.kamal@hotmail.com": "A-kamal",  # PR #18678 (xAI image resolution fix)
     # Kanban bug-fix batch salvage (May 2026)
+    "bmac4564@gmail.com": "bmac4564-del",  # PR #31950 rescue runtime attribution
     "frowte3k@gmail.com": "Frowtek",  # salvage of #23206 (gateway --board auto-subscribe)
     "sylw3st3rr@gmail.com": "Sylw3ster",  # salvage of #23252 (HERMES_KANBAN_BOARD restore)
     "hello@dominikh.com": "dmnkhorvath",  # salvage of #23358 (kanban worker send_message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -621,7 +621,7 @@ def _live_system_guard(request, monkeypatch):
                 return real_killpg(pgid, sig, *args, **kwargs)
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
-                f"os.killpg({pgid}, {sig}) — PGID is outside the test "
+                f"os.killpg({pgid}, {sig}) — PGID is outside the test "  # windows-footgun: ok
                 "process group. See _live_system_guard for the why."
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -342,6 +342,7 @@ def _hermetic_environment(tmp_path, monkeypatch):
     (fake_hermes_home / "memories").mkdir()
     (fake_hermes_home / "skills").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_hermes_home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(fake_hermes_home))
 
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.

--- a/tests/gateway/test_gateway_liveness.py
+++ b/tests/gateway/test_gateway_liveness.py
@@ -1,0 +1,103 @@
+import asyncio
+import threading
+from types import SimpleNamespace
+
+from gateway.run import GatewayRunner
+
+
+def _runner_for_liveness() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._shutdown_event = asyncio.Event()
+    runner._running_agents = {}
+    runner._liveness_lock = threading.Lock()
+    runner._liveness_stop = threading.Event()
+    runner._liveness_thread = None
+    runner._liveness_interval = 15.0
+    runner._liveness_forward_progress_counter = 0
+    return runner
+
+
+def test_liveness_snapshot_does_not_advance_forward_progress_without_activity(monkeypatch):
+    runner = _runner_for_liveness()
+    agent = SimpleNamespace(
+        get_activity_summary=lambda: {
+            "api_call_count": 1,
+            "provider_chunk_count": 0,
+            "tool_transition_count": 0,
+            "tool_completion_count": 0,
+            "api_completion_count": 0,
+            "current_tool": None,
+            "last_activity_desc": "waiting",
+        }
+    )
+    runner._running_agents = {"telegram:chat:user": agent}
+
+    monotonic_values = iter([100.0, 110.0])
+    iso_values = iter([
+        "2026-05-16T18:00:00+00:00",
+        "2026-05-16T18:00:10+00:00",
+    ])
+    writes = []
+
+    monkeypatch.setattr("gateway.run.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(runner, "_liveness_now_iso", lambda: next(iso_values))
+    monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kwargs: writes.append(kwargs))
+
+    runner._publish_liveness_snapshot()
+    runner._publish_liveness_snapshot()
+
+    assert writes[0]["gateway_state"] == "running"
+    assert writes[1]["gateway_state"] == "running"
+    assert writes[0]["work_active"] is True
+    assert writes[1]["work_active"] is True
+    assert writes[0]["last_forward_progress_mono"] == 100.0
+    assert writes[1]["last_forward_progress_mono"] == 100.0
+    assert writes[0]["forward_progress_counter"] == 0
+    assert writes[1]["forward_progress_counter"] == 0
+
+
+def test_liveness_snapshot_advances_forward_progress_when_activity_changes(monkeypatch):
+    runner = _runner_for_liveness()
+    summaries = iter([
+        {
+            "api_call_count": 1,
+            "provider_chunk_count": 0,
+            "tool_transition_count": 0,
+            "tool_completion_count": 0,
+            "api_completion_count": 0,
+            "current_tool": None,
+            "last_activity_desc": "api",
+        },
+        {
+            "api_call_count": 2,
+            "provider_chunk_count": 0,
+            "tool_transition_count": 0,
+            "tool_completion_count": 0,
+            "api_completion_count": 0,
+            "current_tool": None,
+            "last_activity_desc": "api",
+        },
+    ])
+    runner._running_agents = {"telegram:chat:user": SimpleNamespace(get_activity_summary=lambda: next(summaries))}
+
+    monotonic_values = iter([100.0, 110.0])
+    iso_values = iter([
+        "2026-05-16T18:00:00+00:00",
+        "2026-05-16T18:00:10+00:00",
+    ])
+    writes = []
+
+    monkeypatch.setattr("gateway.run.time.monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(runner, "_liveness_now_iso", lambda: next(iso_values))
+    monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kwargs: writes.append(kwargs))
+
+    runner._publish_liveness_snapshot()
+    runner._publish_liveness_snapshot()
+
+    assert writes[0]["gateway_state"] == "running"
+    assert writes[1]["gateway_state"] == "running"
+    assert writes[0]["last_forward_progress_mono"] == 100.0
+    assert writes[1]["last_forward_progress_mono"] == 110.0
+    assert writes[0]["forward_progress_counter"] == 0
+    assert writes[1]["forward_progress_counter"] == 1

--- a/tests/gateway/test_gateway_liveness.py
+++ b/tests/gateway/test_gateway_liveness.py
@@ -2,7 +2,15 @@ import asyncio
 import threading
 from types import SimpleNamespace
 
-from gateway.run import GatewayRunner
+from gateway.run import GatewayRunner, _parse_liveness_interval
+
+
+def test_parse_liveness_interval_defaults_invalid_values_and_enforces_floor():
+    assert _parse_liveness_interval(None) == 15.0
+    assert _parse_liveness_interval("not-a-number") == 15.0
+    assert _parse_liveness_interval("0") == 1.0
+    assert _parse_liveness_interval("0.5") == 1.0
+    assert _parse_liveness_interval("30") == 30.0
 
 
 def _runner_for_liveness() -> GatewayRunner:

--- a/tests/gateway/test_gateway_liveness.py
+++ b/tests/gateway/test_gateway_liveness.py
@@ -22,8 +22,21 @@ def _runner_for_liveness() -> GatewayRunner:
     runner._liveness_stop = threading.Event()
     runner._liveness_thread = None
     runner._liveness_interval = 15.0
+    runner._liveness_last_progress_tuple = None
+    runner._liveness_last_forward_progress_mono = None
+    runner._liveness_last_forward_progress_at = None
     runner._liveness_forward_progress_counter = 0
+    runner._liveness_run_lifecycle_count = 0
     return runner
+
+
+def test_liveness_runner_helper_matches_constructor_state():
+    runner = _runner_for_liveness()
+
+    assert runner._liveness_last_forward_progress_mono is None
+    assert runner._liveness_last_forward_progress_at is None
+    assert runner._liveness_last_progress_tuple is None
+    assert runner._liveness_run_lifecycle_count == 0
 
 
 def test_liveness_snapshot_does_not_advance_forward_progress_without_activity(monkeypatch):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -301,6 +301,61 @@ class TestGatewayRuntimeStatus:
         assert payload["work_active"] is False
         assert payload["run_lifecycle_count"] == 0
 
+    def test_write_runtime_status_records_import_authority(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status.sys, "executable", "/rescue/.venv/bin/python")
+        monkeypatch.setattr(status.os, "getcwd", lambda: "/rescue")
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        authority = payload["runtime_import_authority"]
+        assert authority["python_executable"] == "/rescue/.venv/bin/python"
+        assert authority["cwd"] == "/rescue"
+        assert authority["sys_path0"] is not None
+        assert authority["gateway_file"].endswith("gateway/status.py")
+        assert authority["hermes_cli_file"].endswith("hermes_cli/__init__.py")
+        assert Path(authority["project_root"]) == Path(status.__file__).resolve().parents[1]
+        assert authority["hermes_home"] == str(tmp_path)
+        assert authority["config_path"] == str(tmp_path / "config.yaml")
+        assert authority["env_path"] == str(tmp_path / ".env")
+
+    def test_write_runtime_status_overwrites_stale_import_authority_on_restart(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,
+            "kind": "hermes-gateway",
+            "gateway_status_schema_version": 2,
+            "gateway_state": "running",
+            "platforms": {},
+            "runtime_import_authority": {
+                "python_executable": "/home/jeremy/work/repos/hermes-agent-kanban-v2026.5.7/.venv/bin/python",
+                "cwd": "/home/jeremy/work/repos/hermes-agent-kanban-v2026.5.7",
+                "project_root": "/home/jeremy/work/repos/hermes-agent-kanban-v2026.5.7",
+            },
+            "process_heartbeat_at": "2025-01-01T00:00:00Z",
+            "process_heartbeat_mono": 1.0,
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+        monkeypatch.setattr(status.sys, "executable", "/home/jeremy/work/repos/hermes-agent-rescue-runtime-20260523/.venv/bin/python")
+        monkeypatch.setattr(status.os, "getcwd", lambda: "/home/jeremy/work/repos/hermes-agent-rescue-runtime-20260523")
+        monkeypatch.setattr(status.time, "monotonic", lambda: 456.789)
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        authority = payload["runtime_import_authority"]
+        assert authority["python_executable"] == "/home/jeremy/work/repos/hermes-agent-rescue-runtime-20260523/.venv/bin/python"
+        assert authority["cwd"] == "/home/jeremy/work/repos/hermes-agent-rescue-runtime-20260523"
+        assert Path(authority["project_root"]) == Path(status.__file__).resolve().parents[1]
+        assert "hermes-agent-kanban-v2026.5.7" not in json.dumps(authority)
+        assert payload["pid"] == os.getpid()
+        assert payload["gateway_status_schema_version"] == 2
+        assert payload["gateway_state"] == "running"
+        assert payload["process_heartbeat_mono"] == 456.789
+
     def test_write_runtime_status_refreshes_stale_v2_heartbeat(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         state_path = tmp_path / "gateway_state.json"

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -295,6 +295,7 @@ class TestGatewayRuntimeStatus:
 
         payload = status.read_runtime_status()
         assert payload["gateway_status_schema_version"] == 2
+        assert payload["stop_source"] is None
         assert payload["process_heartbeat_mono"] == 123.456
         assert isinstance(payload["process_heartbeat_at"], str)
         assert payload["forward_progress_counter"] == 0
@@ -451,9 +452,32 @@ class TestGatewayRuntimeStatus:
         payload = status.read_runtime_status()
         assert payload["gateway_state"] == "running"
         assert payload["exit_reason"] is None
+        assert payload["stop_source"] is None
         assert payload["platforms"]["discord"]["state"] == "connected"
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
+
+    def test_running_state_clears_stale_stop_source_without_explicit_exit_reason(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "gateway_status_schema_version": 2,
+            "gateway_state": "starting",
+            "exit_reason": "stale shutdown",
+            "stop_source": "signal:SIGTERM",
+            "platforms": {},
+        }))
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "running"
+        assert payload["exit_reason"] is None
+        assert payload["stop_source"] is None
 
 
 class TestTerminatePid:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -314,8 +314,8 @@ class TestGatewayRuntimeStatus:
         assert authority["python_executable"] == "/rescue/.venv/bin/python"
         assert authority["cwd"] == "/rescue"
         assert authority["sys_path0"] is not None
-        assert authority["gateway_file"].endswith("gateway/status.py")
-        assert authority["hermes_cli_file"].endswith("hermes_cli/__init__.py")
+        assert Path(authority["gateway_file"]).parts[-2:] == ("gateway", "status.py")
+        assert Path(authority["hermes_cli_file"]).parts[-2:] == ("hermes_cli", "__init__.py")
         assert Path(authority["project_root"]) == Path(status.__file__).resolve().parents[1]
         assert authority["hermes_home"] == str(tmp_path)
         assert authority["config_path"] == str(tmp_path / "config.yaml")

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -287,10 +287,52 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid(), "PID should be overwritten, not preserved via setdefault"
         assert payload["start_time"] != 1000.0, "start_time should be overwritten on restart"
 
+    def test_write_runtime_status_initializes_numeric_v2_heartbeat(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status.time, "monotonic", lambda: 123.456)
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_status_schema_version"] == 2
+        assert payload["process_heartbeat_mono"] == 123.456
+        assert isinstance(payload["process_heartbeat_at"], str)
+        assert payload["forward_progress_counter"] == 0
+        assert payload["work_active"] is False
+        assert payload["run_lifecycle_count"] == 0
+
+    def test_write_runtime_status_refreshes_stale_v2_heartbeat(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,
+            "kind": "hermes-gateway",
+            "gateway_status_schema_version": 2,
+            "gateway_state": "running",
+            "platforms": {},
+            "process_heartbeat_at": "2025-01-01T00:00:00Z",
+            "process_heartbeat_mono": 1.0,
+            "last_forward_progress_mono": None,
+            "forward_progress_counter": 7,
+            "work_active": True,
+            "run_lifecycle_count": 3,
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+        monkeypatch.setattr(status.time, "monotonic", lambda: 456.789)
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload["process_heartbeat_mono"] == 456.789
+        assert payload["process_heartbeat_at"] != "2025-01-01T00:00:00Z"
+        assert payload["forward_progress_counter"] == 7
+        assert payload["work_active"] is True
+        assert payload["run_lifecycle_count"] == 3
+
     def test_write_runtime_status_overwrites_stale_argv_on_restart(self, tmp_path, monkeypatch):
         """Regression: gateway_state.json must not keep the previous launch argv."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-
         state_path = tmp_path / "gateway_state.json"
         state_path.write_text(json.dumps({
             "pid": 99999,

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,10 +2,27 @@
 
 import json
 import os
+import builtins
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from gateway import status
+
+
+def test_build_runtime_import_authority_does_not_swallow_runtime_errors(monkeypatch):
+    original_import = builtins.__import__
+
+    def fail_hermes_cli_import(name, *args, **kwargs):
+        if name == "hermes_cli":
+            raise RuntimeError("unexpected import failure")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_hermes_cli_import)
+
+    with pytest.raises(RuntimeError, match="unexpected import failure"):
+        status._build_runtime_import_authority()
 
 
 class TestGatewayPidState:

--- a/tests/hermes_cli/test_doctor_cli_flags.py
+++ b/tests/hermes_cli/test_doctor_cli_flags.py
@@ -1,0 +1,37 @@
+import sys
+
+import pytest
+
+from hermes_cli import main as cli_main
+
+
+def test_doctor_json_flag_requires_path_authority(monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(sys, "argv", ["hermes", "doctor", "--json"])
+    monkeypatch.setattr(cli_main, "cmd_doctor", lambda args: calls.append(args))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_main.main()
+
+    assert exc.value.code == 2
+    assert calls == []
+    assert "--path-authority" in capsys.readouterr().err
+
+
+def test_doctor_path_authority_allows_scoped_flags(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "doctor", "--path-authority", "--json", "--no-live", "--strict"],
+    )
+    monkeypatch.setattr(cli_main, "cmd_doctor", lambda args: calls.append(args))
+
+    cli_main.main()
+
+    assert len(calls) == 1
+    args = calls[0]
+    assert args.path_authority is True
+    assert args.json is True
+    assert args.no_live is True
+    assert args.strict is True

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -234,6 +234,42 @@ class TestSystemdServiceRefresh:
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"
         assert ["systemctl", "--user", "daemon-reload"] in calls
 
+    def test_refresh_rewrites_replace_unit_to_foreground_execstart(
+        self, tmp_path, monkeypatch
+    ):
+        """Refreshing an old systemd unit must remove manual --replace semantics."""
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(
+            "[Unit]\n"
+            "Description=Hermes Gateway\n"
+            "[Service]\n"
+            "ExecStart=/old/python -m hermes_cli.main gateway run --replace\n",
+            encoding="utf-8",
+        )
+        daemon_reload_calls = []
+
+        monkeypatch.setattr(
+            gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path
+        )
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/venv/bin/python")
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: Path("/venv"))
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: Path("/home/test/.hermes"))
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_run_systemctl",
+            lambda args, **kwargs: daemon_reload_calls.append(args),
+        )
+
+        result = gateway_cli.refresh_systemd_unit_if_needed(system=False)
+
+        refreshed = unit_path.read_text(encoding="utf-8")
+        assert result is True
+        assert "gateway run" in refreshed
+        assert "--replace" not in refreshed
+        assert ["daemon-reload"] in daemon_reload_calls
+
     def test_refresh_refuses_to_bake_pytest_tmpdir_into_real_user_unit(
         self, tmp_path, monkeypatch
     ):
@@ -324,6 +360,8 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=False)
 
         assert "ExecStart=" in unit
+        assert "gateway run" in unit
+        assert "--replace" not in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
@@ -385,6 +423,8 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=True)
 
         assert "ExecStart=" in unit
+        assert "gateway run" in unit
+        assert "--replace" not in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
@@ -1618,7 +1658,8 @@ class TestProfileArg:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
         unit = gateway_cli.generate_systemd_unit(system=False)
         assert "--profile mybot" in unit
-        assert "gateway run --replace" in unit
+        assert "gateway run" in unit
+        assert "--replace" not in unit
 
     def test_launchd_plist_includes_profile(self, tmp_path, monkeypatch):
         """generate_launchd_plist should include --profile in ProgramArguments for named profiles."""

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -533,11 +533,16 @@ class TestLaunchdServiceRecovery:
 
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
-        assert "--replace" in plist_path.read_text(encoding="utf-8")
+        assert "--replace" not in plist_path.read_text(encoding="utf-8")
         assert calls[:2] == [
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
+
+    def test_launchd_and_profile_run_args_do_not_replace_running_gateways(self):
+        assert "--replace" not in gateway_cli.generate_launchd_plist()
+        assert "--replace" not in gateway_cli._gateway_run_args_for_profile("default")
+        assert "--replace" not in gateway_cli._gateway_run_args_for_profile("worker")
 
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2458,7 +2458,7 @@ def test_pid_alive_detects_zombie(kanban_home):
         time.sleep(0.3)
         # Verify /proc reports zombie state so the test is actually
         # exercising the zombie path and not some other liveness failure
-        with open(f"/proc/{pid}/status") as f:
+        with open(f"/proc/{pid}/status", encoding="utf-8") as f:
             state_line = next(
                 (l for l in f if l.startswith("State:")), ""
             )

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -35,6 +35,13 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2201,6 +2201,13 @@ def test_cli_create_on_fresh_home_auto_inits(tmp_path, monkeypatch):
     worktree_root = Path(__file__).resolve().parents[2]
     env = {**os.environ, "HERMES_HOME": str(home),
            "PYTHONPATH": str(worktree_root)}
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        env.pop(var, None)
     r = _sp.run(
         [_sys.executable, "-m", "hermes_cli.main", "kanban",
          "create", "smoke", "--assignee", "worker", "--json"],

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -155,6 +155,23 @@ def test_connect_rejects_kanban_board_env_as_pytest_isolation_override(monkeypat
         kb.connect()
 
 
+def test_connect_rejects_explicit_board_as_pytest_isolation_override(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    def fail_if_connect_tries_to_create(_self, *args, **kwargs):
+        raise AssertionError("connect() should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_connect_tries_to_create)
+
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+        kb.connect(board="test-board")
+
+
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     """Kanban should classify TLS-looking page-0 clobbers before WAL setup."""
     home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -56,7 +56,7 @@ def test_connect_rejects_unisolated_pytest_default(monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: realish_home)
     monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
 
-    with pytest.raises(RuntimeError, match="without any of HERMES_KANBAN_HOME"):
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
         kb.connect()
 
 
@@ -73,7 +73,7 @@ def test_connect_rejects_false_temp_prefix_under_pytest(monkeypatch):
 
     monkeypatch.setattr(Path, "mkdir", fail_if_connect_tries_to_create)
 
-    with pytest.raises(RuntimeError, match="without any of HERMES_KANBAN_HOME"):
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
         kb.connect()
 
 
@@ -89,7 +89,7 @@ def test_connect_rejects_non_temp_hermes_home_even_when_path_home_is_temp(tmp_pa
 
     monkeypatch.setattr(Path, "mkdir", fail_if_connect_tries_to_create)
 
-    with pytest.raises(RuntimeError, match="without any of HERMES_KANBAN_HOME"):
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
         kb.connect()
 
 
@@ -136,6 +136,23 @@ def test_connect_allows_kanban_db_env_under_pytest(tmp_path, monkeypatch):
         kb.create_task(conn, title="isolated")
 
     assert pinned_db.exists()
+
+
+def test_connect_rejects_kanban_board_env_as_pytest_isolation_override(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "test-board")
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    def fail_if_connect_tries_to_create(_self, *args, **kwargs):
+        raise AssertionError("connect() should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_connect_tries_to_create)
+
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+        kb.connect()
 
 
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -231,7 +231,34 @@ def test_kanban_path_mutators_reject_unisolated_pytest_root_before_writes(
 
     monkeypatch.setattr(Path, "mkdir", fail_if_mutator_tries_to_create)
 
-    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+    with pytest.raises(RuntimeError, match="without an isolated HERMES_KANBAN_HOME"):
+        mutator(*args)
+
+
+@pytest.mark.parametrize(
+    ("mutator", "args"),
+    [
+        (kb.set_current_board, ("test-board",)),
+        (kb.write_board_metadata, ("test-board",)),
+        (kb.create_board, ("test-board",)),
+        (kb.remove_board, ("test-board",)),
+        (kb.gc_worker_logs, ()),
+    ],
+)
+def test_kanban_filesystem_mutators_reject_kanban_db_as_only_pytest_isolation(
+    tmp_path,
+    monkeypatch,
+    mutator,
+    args,
+):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "isolated-kanban.db"))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    with pytest.raises(RuntimeError, match="HERMES_KANBAN_DB only isolates sqlite DB writes"):
         mutator(*args)
 
 
@@ -243,7 +270,7 @@ def test_remove_board_rejects_unisolated_pytest_root_before_path_access(monkeypa
     monkeypatch.setattr(Path, "home", lambda: realish_home)
     monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
 
-    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+    with pytest.raises(RuntimeError, match="without an isolated HERMES_KANBAN_HOME"):
         kb.remove_board("test-board")
 
 
@@ -255,7 +282,7 @@ def test_gc_worker_logs_rejects_unisolated_pytest_root_before_path_access(monkey
     monkeypatch.setattr(Path, "home", lambda: realish_home)
     monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
 
-    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+    with pytest.raises(RuntimeError, match="without an isolated HERMES_KANBAN_HOME"):
         kb.gc_worker_logs(board="test-board")
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -77,6 +77,22 @@ def test_connect_rejects_false_temp_prefix_under_pytest(monkeypatch):
         kb.connect()
 
 
+def test_connect_rejects_non_temp_hermes_home_even_when_path_home_is_temp(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", "/home/test-user/.hermes")
+
+    def fail_if_connect_tries_to_create(_self, *args, **kwargs):
+        raise AssertionError("connect() should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_connect_tries_to_create)
+
+    with pytest.raises(RuntimeError, match="without any of HERMES_KANBAN_HOME"):
+        kb.connect()
+
+
 def test_connect_allows_explicit_db_path_under_pytest(tmp_path, monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -172,6 +172,40 @@ def test_connect_rejects_explicit_board_as_pytest_isolation_override(monkeypatch
         kb.connect(board="test-board")
 
 
+def test_init_db_rejects_unisolated_pytest_default_before_creating_directories(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    def fail_if_init_tries_to_create(_self, *args, **kwargs):
+        raise AssertionError("init_db() should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_init_tries_to_create)
+
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+        kb.init_db()
+
+
+def test_init_db_rejects_explicit_board_as_pytest_isolation_override(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    def fail_if_init_tries_to_create(_self, *args, **kwargs):
+        raise AssertionError("init_db(board=...) should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_init_tries_to_create)
+
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+        kb.init_db(board="test-board")
+
+
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     """Kanban should classify TLS-looking page-0 clobbers before WAL setup."""
     home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -206,6 +206,35 @@ def test_init_db_rejects_explicit_board_as_pytest_isolation_override(monkeypatch
         kb.init_db(board="test-board")
 
 
+@pytest.mark.parametrize(
+    ("mutator", "args"),
+    [
+        (kb.set_current_board, ("test-board",)),
+        (kb.write_board_metadata, ("test-board",)),
+        (kb.create_board, ("test-board",)),
+    ],
+)
+def test_kanban_path_mutators_reject_unisolated_pytest_root_before_writes(
+    monkeypatch,
+    mutator,
+    args,
+):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    def fail_if_mutator_tries_to_create(_self, *args, **kwargs):
+        raise AssertionError("kanban path mutator should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_mutator_tries_to_create)
+
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+        mutator(*args)
+
+
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     """Kanban should classify TLS-looking page-0 clobbers before WAL setup."""
     home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -52,7 +52,26 @@ def test_connect_rejects_unisolated_pytest_default(monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
-    monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes"))
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    with pytest.raises(RuntimeError, match="without any of HERMES_KANBAN_HOME"):
+        kb.connect()
+
+
+def test_connect_rejects_false_temp_prefix_under_pytest(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    false_temp_home = Path("/tmpnotreallysafe")
+    monkeypatch.setattr(Path, "home", lambda: false_temp_home)
+    monkeypatch.setenv("HERMES_HOME", str(false_temp_home / ".hermes"))
+
+    def fail_if_connect_tries_to_create(_self, *args, **kwargs):
+        raise AssertionError("connect() should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_connect_tries_to_create)
 
     with pytest.raises(RuntimeError, match="without any of HERMES_KANBAN_HOME"):
         kb.connect()
@@ -62,7 +81,9 @@ def test_connect_allows_explicit_db_path_under_pytest(tmp_path, monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
-    monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes"))
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
     db_path = tmp_path / "isolated-kanban.db"
 
     with kb.connect(db_path=db_path) as conn:
@@ -76,12 +97,29 @@ def test_connect_allows_kanban_home_under_pytest(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_HOME", str(kanban_root))
     monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
-    monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes"))
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
 
     with kb.connect() as conn:
         kb.create_task(conn, title="isolated")
 
     assert (kanban_root / "kanban.db").exists()
+
+
+def test_connect_allows_kanban_db_env_under_pytest(tmp_path, monkeypatch):
+    pinned_db = tmp_path / "pinned" / "kanban.db"
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(pinned_db))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    with kb.connect() as conn:
+        kb.create_task(conn, title="isolated")
+
+    assert pinned_db.exists()
 
 
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
@@ -1995,6 +2033,7 @@ class TestSharedBoardPaths:
         default_home.mkdir()
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(default_home))
+        monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
         monkeypatch.setenv("HERMES_KANBAN_DB", "   ")
         monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", "")
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -235,6 +235,30 @@ def test_kanban_path_mutators_reject_unisolated_pytest_root_before_writes(
         mutator(*args)
 
 
+def test_remove_board_rejects_unisolated_pytest_root_before_path_access(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+        kb.remove_board("test-board")
+
+
+def test_gc_worker_logs_rejects_unisolated_pytest_root_before_path_access(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    with pytest.raises(RuntimeError, match="without HERMES_KANBAN_HOME or HERMES_KANBAN_DB"):
+        kb.gc_worker_logs(board="test-board")
+
+
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     """Kanban should classify TLS-looking page-0 clobbers before WAL setup."""
     home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -48,6 +48,42 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
+def test_connect_rejects_unisolated_pytest_default(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes"))
+
+    with pytest.raises(RuntimeError, match="without any of HERMES_KANBAN_HOME"):
+        kb.connect()
+
+
+def test_connect_allows_explicit_db_path_under_pytest(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes"))
+    db_path = tmp_path / "isolated-kanban.db"
+
+    with kb.connect(db_path=db_path) as conn:
+        kb.create_task(conn, title="isolated")
+
+    assert db_path.exists()
+
+
+def test_connect_allows_kanban_home_under_pytest(tmp_path, monkeypatch):
+    kanban_root = tmp_path / "kanban-root"
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(kanban_root))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes"))
+
+    with kb.connect() as conn:
+        kb.create_task(conn, title="isolated")
+
+    assert (kanban_root / "kanban.db").exists()
+
+
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     """Kanban should classify TLS-looking page-0 clobbers before WAL setup."""
     home = tmp_path / ".hermes"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import sqlite3
+import subprocess
 import time
 from pathlib import Path
 
@@ -260,6 +261,50 @@ def test_kanban_filesystem_mutators_reject_kanban_db_as_only_pytest_isolation(
 
     with pytest.raises(RuntimeError, match="HERMES_KANBAN_DB only isolates sqlite DB writes"):
         mutator(*args)
+
+
+def test_resolve_workspace_rejects_kanban_db_as_only_pytest_isolation(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "isolated-kanban.db"))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    task = _make_task(id="t_workspace")
+
+    with pytest.raises(RuntimeError, match="HERMES_KANBAN_DB only isolates sqlite DB writes"):
+        kb.resolve_workspace(task)
+
+
+def test_rotate_worker_log_rejects_kanban_db_as_only_pytest_isolation(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "isolated-kanban.db"))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    with pytest.raises(RuntimeError, match="HERMES_KANBAN_DB only isolates sqlite DB writes"):
+        kb._rotate_worker_log(realish_home / ".hermes" / "kanban" / "logs" / "t.log", 1)
+
+
+def test_default_spawn_rejects_kanban_db_as_only_pytest_isolation(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "isolated-kanban.db"))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    def fail_if_spawn_reaches_popen(*_args, **_kwargs):
+        raise AssertionError("_default_spawn should fail before spawning worker")
+
+    monkeypatch.setattr(subprocess, "Popen", fail_if_spawn_reaches_popen)
+    task = _make_task(id="t_spawn", assignee="teknium")
+
+    with pytest.raises(RuntimeError, match="HERMES_KANBAN_DB only isolates sqlite DB writes"):
+        kb._default_spawn(task, str(tmp_path), board="test-board")
 
 
 def test_remove_board_rejects_unisolated_pytest_root_before_path_access(monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -20,6 +20,10 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    # Test runners may inherit a live workstation HERMES_KANBAN_HOME. Pin the
+    # kanban root as well so this fixture is hermetic under the same env shape
+    # used by the gateway service.
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -311,6 +311,23 @@ def test_default_spawn_rejects_kanban_db_as_only_pytest_isolation(tmp_path, monk
         kb._default_spawn(task, str(tmp_path), board="test-board")
 
 
+def test_scratch_tip_sentinel_rejects_kanban_db_as_only_pytest_isolation(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "isolated-kanban.db"))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    realish_home = Path("/home/test-user")
+    monkeypatch.setattr(Path, "home", lambda: realish_home)
+    monkeypatch.setenv("HERMES_HOME", str(realish_home / ".hermes"))
+
+    def fail_if_sentinel_mutator_reaches_mkdir(_self, *args, **kwargs):
+        raise AssertionError("scratch-tip sentinel should fail before creating directories")
+
+    monkeypatch.setattr(Path, "mkdir", fail_if_sentinel_mutator_reaches_mkdir)
+
+    with pytest.raises(RuntimeError, match="HERMES_KANBAN_DB only isolates sqlite DB writes"):
+        kb._mark_scratch_tip_shown()
+
+
 def test_remove_board_rejects_unisolated_pytest_root_before_path_access(monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -64,7 +64,7 @@ def test_connect_rejects_false_temp_prefix_under_pytest(monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
-    false_temp_home = Path("/tmpnotreallysafe")
+    false_temp_home = Path("/tmpnotreallysafe")  # noqa: S108 - deliberate pseudo-temp sentinel
     monkeypatch.setattr(Path, "home", lambda: false_temp_home)
     monkeypatch.setenv("HERMES_HOME", str(false_temp_home / ".hermes"))
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -540,6 +540,33 @@ class TestDispatcher:
         out = capsys.readouterr().out
         assert "Commands:" in out or "No MCP servers" in out
 
+    def test_runtime_probe_dispatches_redacted_json(self, monkeypatch, capsys):
+        from hermes_cli.mcp_config import mcp_command
+
+        async def fake_probe_default_sources(**kwargs):
+            return {"servers": ["codex:context7"], "kwargs": kwargs}
+
+        monkeypatch.setattr(
+            "tools.mcp_runtime_probe.probe_default_sources",
+            fake_probe_default_sources,
+        )
+
+        mcp_command(
+            _make_args(
+                mcp_action="runtime-probe",
+                runtime="codex",
+                server="context7",
+                timeout=1,
+                skip_auth_needed=True,
+                include_google_drive_auth_needed=False,
+            )
+        )
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["servers"] == ["codex:context7"]
+        assert payload["kwargs"]["runtime"] == "codex"
+        assert payload["kwargs"]["server_name"] == "context7"
+
 
 # ---------------------------------------------------------------------------
 # Tests: Task 7 consolidation — cmd_mcp_remove evicts manager cache,
@@ -599,4 +626,3 @@ class TestMcpLogin:
         cmd_mcp_login(_make_args(name="srv"))
         out = capsys.readouterr().out
         assert "no URL" in out or "not an OAuth" in out
-

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -60,7 +60,7 @@ def _seed_config(tmp_path: Path, mcp_servers: dict):
 
     config = {"mcp_servers": mcp_servers, "_config_version": 9}
     config_path = tmp_path / "config.yaml"
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         yaml.safe_dump(config, f)
 
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -216,6 +216,40 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
+    def test_add_http_oauth_passes_redirect_config_to_provider(self, capsys, monkeypatch):
+        """OAuth provider construction receives explicit redirect config."""
+        seen = []
+
+        class FakeManager:
+            def get_or_build_provider(self, name, url, oauth_config):
+                seen.append((name, url, oauth_config))
+                return object()
+
+        monkeypatch.setattr(
+            "tools.mcp_oauth_manager.get_manager", lambda: FakeManager()
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [("search", "Search")],
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="oauth-srv",
+            url="https://example.com/mcp",
+            auth="oauth",
+        ))
+
+        out = capsys.readouterr().out
+        assert "OAuth configured" in out
+        assert seen == [(
+            "oauth-srv",
+            "https://example.com/mcp",
+            {"redirect_port": 0},
+        )]
+
     def test_add_stdio_server(self, tmp_path, capsys, monkeypatch):
         """Add a stdio server."""
         fake_tools = [FakeTool("search", "Search repos")]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -567,6 +567,38 @@ class TestDispatcher:
         assert payload["kwargs"]["runtime"] == "codex"
         assert payload["kwargs"]["server_name"] == "context7"
 
+    def test_runtime_probe_generic_exception_emits_structured_json(
+        self, monkeypatch, capsys,
+    ):
+        from hermes_cli.mcp_config import mcp_command
+
+        async def fake_probe_default_sources(**_kwargs):
+            raise RuntimeError("boom SECRET_VALUE_DO_NOT_PRINT")
+
+        monkeypatch.setattr(
+            "tools.mcp_runtime_probe.probe_default_sources",
+            fake_probe_default_sources,
+        )
+
+        mcp_command(
+            _make_args(
+                mcp_action="runtime-probe",
+                runtime="codex",
+                server="context7",
+                timeout=1,
+                skip_auth_needed=True,
+                include_google_drive_auth_needed=False,
+            )
+        )
+
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert payload["status"] == "error"
+        assert payload["status_counts"] == {"error": 1}
+        assert payload["check_status_counts"] == {"error": 1}
+        assert "Traceback" not in out
+        assert "SECRET_VALUE_DO_NOT_PRINT" not in out
+
 
 # ---------------------------------------------------------------------------
 # Tests: Task 7 consolidation — cmd_mcp_remove evicts manager cache,
@@ -591,7 +623,7 @@ class TestMcpRemoveEvictsManager:
 
         mgr = get_manager()
         mgr.get_or_build_provider(
-            "oauth-srv", "https://example.com/mcp", None,
+            "oauth-srv", "https://example.com/mcp", {"redirect_port": 8765},
         )
         assert "oauth-srv" in mgr._entries
 

--- a/tests/hermes_cli/test_path_authority_doctor.py
+++ b/tests/hermes_cli/test_path_authority_doctor.py
@@ -145,18 +145,19 @@ def test_gateway_path_authority_requires_exec_and_workdir(tmp_path):
 
 
 def test_report_redacts_secret_like_execstart_values(tmp_path):
+    secret_fixture = "sk-" + "testsecret" + "1234567890"
     unit = pad.EffectiveUnit(
         exec_start=[
             "/srv/agent/.venv/bin/python -m hermes_cli.main gateway run "
-            "--api-key sk-super-secret-token"
+            f"--api-key {secret_fixture}"
         ],
         working_directory="/srv/agent",
-        environment={"OPENROUTER_API_KEY": "sk-super-secret-token"},
+        environment={"OPENROUTER_API_KEY": secret_fixture},
     )
 
     encoded = json.dumps(unit.to_report())
 
-    assert "sk-super-secret-token" not in encoded
+    assert secret_fixture not in encoded
     assert "[REDACTED]" in encoded
 
 

--- a/tests/hermes_cli/test_path_authority_doctor.py
+++ b/tests/hermes_cli/test_path_authority_doctor.py
@@ -13,7 +13,7 @@ def test_parse_paths_env_redacts_secret_values(tmp_path):
         "\n".join(
             [
                 f'export HERMES_KANBAN_AGENT_DIR="{target}"',
-                "GITHUB_" + "TOKEN" + "=" + redacted_value,
+                ("GITHUB_" + "TOKEN") + "=" + redacted_value,
                 "PLAIN_FLAG=enabled",
             ]
         ),

--- a/tests/hermes_cli/test_path_authority_doctor.py
+++ b/tests/hermes_cli/test_path_authority_doctor.py
@@ -1,0 +1,369 @@
+import json
+import os
+from pathlib import Path
+
+from hermes_cli import path_authority_doctor as pad
+
+
+def test_parse_paths_env_redacts_secret_values(tmp_path):
+    env_file = tmp_path / "paths.env"
+    target = tmp_path / "hermes-agent-kanban-v2026.5.7"
+    redacted_value = "fixture_" + "redaction_value"
+    env_file.write_text(
+        "\n".join(
+            [
+                f'export HERMES_KANBAN_AGENT_DIR="{target}"',
+                "GITHUB_" + "TOKEN" + "=" + redacted_value,
+                "PLAIN_FLAG=enabled",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = pad.parse_paths_env(env_file)
+
+    assert parsed.values["HERMES_KANBAN_AGENT_DIR"] == str(target)
+    assert parsed.redacted["GITHUB_TOKEN"] == "[REDACTED]"
+    assert redacted_value not in json.dumps(parsed.to_report())
+
+
+def test_systemd_dropin_execstart_reset_overrides_base(tmp_path):
+    target = tmp_path / "agent"
+    target.mkdir()
+    unit_dir = tmp_path / "systemd" / "user"
+    dropin_dir = unit_dir / "hermes-gateway.service.d"
+    dropin_dir.mkdir(parents=True)
+    (unit_dir / "hermes-gateway.service").write_text(
+        "\n".join(
+            [
+                "[Service]",
+                "ExecStart=/old/venv/bin/python -m hermes_cli.main gateway run --replace",
+                "WorkingDirectory=/old",
+                'Environment="PATH=/old/bin" "HERMES_AGENT_DIR=/old"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (dropin_dir / "10-kanban.conf").write_text(
+        "\n".join(
+            [
+                "[Service]",
+                "ExecStart=",
+                f"ExecStart={target}/.venv/bin/python -m hermes_cli.main gateway run",
+                f"WorkingDirectory={target}",
+                f'Environment="PATH={target}/.venv/bin:/usr/bin" "HERMES_AGENT_DIR={target}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = pad.build_path_authority_report(
+        paths_env=pad.ParsedPathsEnv(
+            path=tmp_path / "paths.env",
+            exists=True,
+            values={"HERMES_KANBAN_AGENT_DIR": str(target)},
+            redacted={"HERMES_KANBAN_AGENT_DIR": str(target)},
+        ),
+        systemd_user_dir=unit_dir,
+        include_live=False,
+    )
+
+    gateway = report.units["gateway"]
+    assert gateway.effective.exec_start == [
+        f"{target}/.venv/bin/python -m hermes_cli.main gateway run"
+    ]
+    assert gateway.effective.working_directory == str(target)
+    assert gateway.effective.environment["PATH"] == f"{target}/.venv/bin:/usr/bin"
+    assert gateway.effective.environment["HERMES_AGENT_DIR"] == str(target)
+    assert not any(check.id == "gateway_execstart_replace" for check in report.failed_checks())
+
+
+def test_gateway_execstart_replace_is_p0(tmp_path):
+    target = tmp_path / "agent"
+    target.mkdir()
+    unit_dir = tmp_path / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    (unit_dir / "hermes-gateway.service").write_text(
+        "\n".join(
+            [
+                "[Service]",
+                f"ExecStart={target}/.venv/bin/python -m hermes_cli.main gateway run --replace",
+                f"WorkingDirectory={target}",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = pad.build_path_authority_report(
+        paths_env=pad.ParsedPathsEnv(
+            path=tmp_path / "paths.env",
+            exists=True,
+            values={"HERMES_KANBAN_AGENT_DIR": str(target)},
+            redacted={"HERMES_KANBAN_AGENT_DIR": str(target)},
+        ),
+        systemd_user_dir=unit_dir,
+        include_live=False,
+    )
+
+    failed = {check.id: check for check in report.failed_checks()}
+    assert failed["gateway_execstart_replace"].severity == "P0"
+    assert report.overall_severity == "P0"
+
+
+def test_gateway_path_authority_requires_exec_and_workdir(tmp_path):
+    target = tmp_path / "agent"
+    stale = tmp_path / "stale-agent"
+    target.mkdir()
+    stale.mkdir()
+    unit_dir = tmp_path / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    (unit_dir / "hermes-gateway.service").write_text(
+        "\n".join(
+            [
+                "[Service]",
+                f"ExecStart={target}/.venv/bin/python -m hermes_cli.main gateway run",
+                f"WorkingDirectory={stale}",
+                f'Environment="HERMES_AGENT_DIR={target}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = pad.build_path_authority_report(
+        paths_env=pad.ParsedPathsEnv(
+            path=tmp_path / "paths.env",
+            exists=True,
+            values={"HERMES_KANBAN_AGENT_DIR": str(target)},
+            redacted={"HERMES_KANBAN_AGENT_DIR": str(target)},
+        ),
+        systemd_user_dir=unit_dir,
+        include_live=False,
+    )
+
+    failed = {check.id: check for check in report.failed_checks()}
+    assert failed["gateway_path_authority"].severity == "P0"
+
+
+def test_report_redacts_secret_like_execstart_values(tmp_path):
+    unit = pad.EffectiveUnit(
+        exec_start=[
+            "/srv/agent/.venv/bin/python -m hermes_cli.main gateway run "
+            "--api-key sk-super-secret-token"
+        ],
+        working_directory="/srv/agent",
+        environment={"OPENROUTER_API_KEY": "sk-super-secret-token"},
+    )
+
+    encoded = json.dumps(unit.to_report())
+
+    assert "sk-super-secret-token" not in encoded
+    assert "[REDACTED]" in encoded
+
+
+def test_live_runtime_authority_missing_is_p0_when_live_checks_enabled(tmp_path, monkeypatch):
+    target = tmp_path / "agent"
+    target.mkdir()
+    unit_dir = tmp_path / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    for service in pad.UNIT_NAMES.values():
+        (unit_dir / service).write_text(
+            "\n".join(
+                [
+                    "[Service]",
+                    f"ExecStart={target}/.venv/bin/python -m hermes_cli.main gateway run",
+                    f"WorkingDirectory={target}",
+                    f'Environment="HERMES_AGENT_DIR={target}"',
+                ]
+            ),
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(pad, "_read_runtime_import_authority", lambda: None)
+
+    report = pad.build_path_authority_report(
+        paths_env=pad.ParsedPathsEnv(
+            path=tmp_path / "paths.env",
+            exists=True,
+            values={"HERMES_KANBAN_AGENT_DIR": str(target)},
+            redacted={"HERMES_KANBAN_AGENT_DIR": str(target)},
+        ),
+        systemd_user_dir=unit_dir,
+        include_live=True,
+    )
+
+    failed = {check.id: check for check in report.failed_checks()}
+    assert failed["runtime_import_authority_missing"].severity == "P0"
+
+
+def test_cron_shadow_registry_requires_non_authoritative_marker(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    active_dir = hermes_home / "cron"
+    shadow_dir = active_dir / "cron"
+    shadow_dir.mkdir(parents=True)
+    (active_dir / "jobs.json").write_text('{"jobs":[]}', encoding="utf-8")
+    (shadow_dir / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "old", "enabled": True, "script": "/root/stale.sh"}]}),
+        encoding="utf-8",
+    )
+    paths_env = pad.ParsedPathsEnv(
+        path=tmp_path / "paths.env",
+        exists=True,
+        values={"HERMES_HOME": str(hermes_home)},
+        redacted={"HERMES_HOME": str(hermes_home)},
+    )
+
+    checks = pad._check_cron_shadow_authority(paths_env)
+
+    failed = {check.id: check for check in checks if check.status != "ok"}
+    assert failed["cron_shadow_registry_unclassified"].severity == "P1"
+
+
+def test_cron_shadow_registry_marker_classifies_shadow_as_quarantined(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    active_dir = hermes_home / "cron"
+    shadow_dir = active_dir / "cron"
+    shadow_dir.mkdir(parents=True)
+    (active_dir / "jobs.json").write_text('{"jobs":[]}', encoding="utf-8")
+    (shadow_dir / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "old", "enabled": True, "script": "/root/stale.sh"}]}),
+        encoding="utf-8",
+    )
+    (shadow_dir / "NON_AUTHORITATIVE").write_text(
+        "This nested cron registry is retained for audit only.\n",
+        encoding="utf-8",
+    )
+    paths_env = pad.ParsedPathsEnv(
+        path=tmp_path / "paths.env",
+        exists=True,
+        values={"HERMES_HOME": str(hermes_home)},
+        redacted={"HERMES_HOME": str(hermes_home)},
+    )
+
+    checks = pad._check_cron_shadow_authority(paths_env)
+
+    by_id = {check.id: check for check in checks}
+    assert by_id["cron_shadow_registry_quarantined"].status == "ok"
+
+
+def test_webui_graphify_authority_detects_systemd_env_drift(tmp_path):
+    expected_graph = tmp_path / "artifacts" / "graph.json"
+    paths_env = pad.ParsedPathsEnv(
+        path=tmp_path / "paths.env",
+        exists=True,
+        values={
+            "GRAPHIFY_OUTPUT_DIR": str(expected_graph.parent),
+            "GRAPHIFY_GRAPH_JSON": str(expected_graph),
+        },
+        redacted={},
+    )
+    units = {
+        "webui": pad.UnitReport(
+            role="webui",
+            name="hermes-webui.service",
+            path=tmp_path / "hermes-webui.service",
+            exists=True,
+            dropins=[],
+            effective=pad.EffectiveUnit(
+                environment={
+                    "GRAPHIFY_OUTPUT_DIR": str(tmp_path / "vault" / "Graphify"),
+                    "GRAPHIFY_GRAPH_JSON": str(tmp_path / "vault" / "Graphify" / "combined-graph.json"),
+                }
+            ),
+        )
+    }
+
+    checks = pad._check_webui_graphify_authority(paths_env, units)
+
+    assert checks[0].id == "webui_graphify_path_authority"
+    assert checks[0].severity == "P1"
+
+
+def test_webui_graphify_authority_passes_when_systemd_matches_paths_env(tmp_path):
+    expected_graph = tmp_path / "artifacts" / "graph.json"
+    paths_env = pad.ParsedPathsEnv(
+        path=tmp_path / "paths.env",
+        exists=True,
+        values={
+            "GRAPHIFY_OUTPUT_DIR": str(expected_graph.parent),
+            "GRAPHIFY_GRAPH_JSON": str(expected_graph),
+        },
+        redacted={},
+    )
+    units = {
+        "webui": pad.UnitReport(
+            role="webui",
+            name="hermes-webui.service",
+            path=tmp_path / "hermes-webui.service",
+            exists=True,
+            dropins=[],
+            effective=pad.EffectiveUnit(
+                environment={
+                    "GRAPHIFY_OUTPUT_DIR": str(expected_graph.parent),
+                    "GRAPHIFY_GRAPH_JSON": str(expected_graph),
+                }
+            ),
+        )
+    }
+
+    checks = pad._check_webui_graphify_authority(paths_env, units)
+
+    assert checks[0].status == "ok"
+
+
+def test_graphify_freshness_warns_when_governance_is_newer_than_graph(tmp_path):
+    vault = tmp_path / "vault"
+    source = vault / "Graphify" / "graph-manifest.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("{}", encoding="utf-8")
+    graph = tmp_path / "artifacts" / "graph.json"
+    graph.parent.mkdir(parents=True)
+    graph.write_text("{}", encoding="utf-8")
+    os.utime(graph, (100, 100))
+    os.utime(source, (200, 200))
+    paths_env = pad.ParsedPathsEnv(
+        path=tmp_path / "paths.env",
+        exists=True,
+        values={
+            "OBSIDIAN_VAULT_PATH": str(vault),
+            "GRAPHIFY_GRAPH_JSON": str(graph),
+        },
+        redacted={},
+    )
+
+    checks = pad._check_graphify_freshness(paths_env)
+
+    assert checks[0].id == "graphify_freshness"
+    assert checks[0].severity == "P1"
+    assert checks[0].status == "warn"
+
+
+def test_graphify_freshness_passes_when_graph_is_current(tmp_path):
+    vault = tmp_path / "vault"
+    source = vault / "Graphify" / "graph-manifest.json"
+    source.parent.mkdir(parents=True)
+    source.write_text("{}", encoding="utf-8")
+    graph = tmp_path / "artifacts" / "graph.json"
+    graph.parent.mkdir(parents=True)
+    graph.write_text("{}", encoding="utf-8")
+    os.utime(source, (100, 100))
+    os.utime(graph, (200, 200))
+    paths_env = pad.ParsedPathsEnv(
+        path=tmp_path / "paths.env",
+        exists=True,
+        values={
+            "OBSIDIAN_VAULT_PATH": str(vault),
+            "GRAPHIFY_GRAPH_JSON": str(graph),
+        },
+        redacted={},
+    )
+
+    checks = pad._check_graphify_freshness(paths_env)
+
+    assert checks[0].status == "ok"
+
+
+def test_dirty_active_repo_classification():
+    other = pad.classify_dirty_repo([" M docs/readme.md"])
+    authority = pad.classify_dirty_repo([" M gateway/status.py"])
+
+    assert other.severity == "P1"
+    assert authority.severity == "P0"

--- a/tests/hermes_cli/test_path_authority_doctor.py
+++ b/tests/hermes_cli/test_path_authority_doctor.py
@@ -110,6 +110,30 @@ def test_gateway_execstart_replace_is_p0(tmp_path):
     assert report.overall_severity == "P0"
 
 
+def test_unknown_failed_severity_does_not_crash_report_status(tmp_path):
+    report = pad.PathAuthorityReport(
+        expected_agent_dir=None,
+        paths_env=pad.ParsedPathsEnv(
+            path=tmp_path / "paths.env",
+            exists=False,
+            values={},
+            redacted={},
+        ),
+        units={},
+        checks=[
+            pad.CheckResult(
+                id="future_check",
+                severity="FUTURE",
+                status="fail",
+                message="new severity from a future checker",
+            )
+        ],
+    )
+
+    assert report.overall_severity == "P0"
+    assert report.exit_code(strict=False) == 1
+
+
 def test_gateway_path_authority_requires_exec_and_workdir(tmp_path):
     target = tmp_path / "agent"
     stale = tmp_path / "stale-agent"

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -438,8 +438,10 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # Top-level event/ — s6-svlisten1 event subscription dir.
     event = svc_dir / "event"
     assert event.is_dir(), "missing top-level event/"
-    assert stat.S_IMODE(event.stat().st_mode) == 0o3730, (
-        f"event/ mode = {oct(event.stat().st_mode)}, want 03730"
+    event_mode = stat.S_IMODE(event.stat().st_mode)
+    assert event_mode in {0o3730, 0o1730}, (
+        f"event/ mode = {oct(event_mode)}, want 03730 "
+        "or nosuid-safe 01730 fallback"
     )
 
     # supervise/ dir.
@@ -450,7 +452,8 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     # supervise/event/.
     supervise_event = supervise / "event"
     assert supervise_event.is_dir(), "missing supervise/event/"
-    assert stat.S_IMODE(supervise_event.stat().st_mode) == 0o3730
+    supervise_event_mode = stat.S_IMODE(supervise_event.stat().st_mode)
+    assert supervise_event_mode in {0o3730, 0o1730}
 
     # supervise/control FIFO.
     control = supervise / "control"
@@ -485,7 +488,7 @@ def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     log_control = log_supervise / "control"
 
     assert log_event.is_dir()
-    assert stat.S_IMODE(log_event.stat().st_mode) == 0o3730
+    assert stat.S_IMODE(log_event.stat().st_mode) in {0o3730, 0o1730}
     assert log_supervise.is_dir()
     assert log_supervise_event.is_dir()
     assert log_control.exists() and stat.S_ISFIFO(log_control.stat().st_mode)

--- a/tests/run_agent/test_tool_definition_kwarg_guard.py
+++ b/tests/run_agent/test_tool_definition_kwarg_guard.py
@@ -41,7 +41,7 @@ def _agent_attr_assign_line(func: ast.FunctionDef, attr_name: str) -> int | None
                 and target.value.id == "agent"
                 and target.attr == attr_name
             ):
-                return node.lineno
+                return getattr(node, "lineno", 0)
     return None
 
 

--- a/tests/run_agent/test_tool_definition_kwarg_guard.py
+++ b/tests/run_agent/test_tool_definition_kwarg_guard.py
@@ -131,6 +131,7 @@ def test_gateway_runtime_attrs_are_initialized_by_constructor_authority():
         "_checkpoint_mgr",
         "_session_init_model_config",
         "_last_flushed_db_idx",
+        "_primary_runtime",
         "_subdirectory_hints",
     ):
         _assert_attr_in_init_agent(attr)

--- a/tests/run_agent/test_tool_definition_kwarg_guard.py
+++ b/tests/run_agent/test_tool_definition_kwarg_guard.py
@@ -1,0 +1,142 @@
+"""Static guards for AIAgent constructor/runtime invariants.
+
+Regression coverage for:
+- TypeError: get_tool_definitions() got an unexpected keyword argument 'save_trajectories'
+- AttributeError on runtime attributes when the gateway constructs AIAgent directly
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_INIT = REPO_ROOT / "agent" / "agent_init.py"
+RUN_AGENT = REPO_ROOT / "run_agent.py"
+
+
+def _parse(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name}() not found")
+
+
+def _agent_attr_assign_line(func: ast.FunctionDef, attr_name: str) -> int | None:
+    for node in ast.walk(func):
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and isinstance(target.value, ast.Name)
+                and target.value.id == "agent"
+                and target.attr == attr_name
+            ):
+                return node.lineno
+    return None
+
+
+def _get_tool_definitions_line(func: ast.FunctionDef) -> int:
+    for node in ast.walk(func):
+        if not isinstance(node, ast.Call):
+            continue
+        func_node = node.func
+        if isinstance(func_node, ast.Attribute) and func_node.attr == "get_tool_definitions":
+            return node.lineno
+        if isinstance(func_node, ast.Name) and func_node.id == "get_tool_definitions":
+            return node.lineno
+    raise AssertionError("get_tool_definitions() call not found in init_agent()")
+
+
+def _assert_attr_before_get_tool_definitions(attr_name: str) -> None:
+    init_agent = _find_function(_parse(AGENT_INIT), "init_agent")
+    assign_line = _agent_attr_assign_line(init_agent, attr_name)
+    get_tool_line = _get_tool_definitions_line(init_agent)
+    assert assign_line is not None, f"agent.{attr_name} is never assigned in init_agent()"
+    assert assign_line < get_tool_line, (
+        f"agent.{attr_name} assigned at line {assign_line}, but "
+        f"get_tool_definitions() is called at line {get_tool_line}"
+    )
+
+
+def _assert_attr_in_init_agent(attr_name: str) -> None:
+    init_agent = _find_function(_parse(AGENT_INIT), "init_agent")
+    assign_line = _agent_attr_assign_line(init_agent, attr_name)
+    assert assign_line is not None, f"agent.{attr_name} is never assigned in init_agent()"
+
+
+def _attr_used_by_aiagent_outside_init(attr_name: str) -> bool:
+    tree = _parse(RUN_AGENT)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "AIAgent":
+            continue
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef) and item.name == "__init__":
+                continue
+            for child in ast.walk(item):
+                if (
+                    isinstance(child, ast.Attribute)
+                    and isinstance(child.value, ast.Name)
+                    and child.value.id == "self"
+                    and child.attr == attr_name
+                    and isinstance(child.ctx, ast.Load)
+                ):
+                    return True
+    return False
+
+
+def test_get_tool_definitions_call_uses_only_supported_kwargs():
+    init_agent = _find_function(_parse(AGENT_INIT), "init_agent")
+    for node in ast.walk(init_agent):
+        if not isinstance(node, ast.Call):
+            continue
+        func_node = node.func
+        is_get_tool_definitions = (
+            isinstance(func_node, ast.Attribute)
+            and func_node.attr == "get_tool_definitions"
+        ) or (
+            isinstance(func_node, ast.Name)
+            and func_node.id == "get_tool_definitions"
+        )
+        if not is_get_tool_definitions:
+            continue
+        kw_names = {kw.arg for kw in node.keywords}
+        assert "save_trajectories" not in kw_names
+        assert kw_names <= {"enabled_toolsets", "disabled_toolsets", "quiet_mode"}
+
+
+def test_cleanup_session_invariants_seeded_before_tool_loading():
+    for attr in (
+        "session_id",
+        "_session_db",
+        "_session_db_created",
+        "_parent_session_id",
+        "_compression_warning",
+    ):
+        _assert_attr_before_get_tool_definitions(attr)
+
+
+def test_gateway_runtime_attrs_are_initialized_by_constructor_authority():
+    for attr in (
+        "_tool_use_enforcement",
+        "_checkpoint_mgr",
+        "_session_init_model_config",
+        "_last_flushed_db_idx",
+        "_subdirectory_hints",
+    ):
+        _assert_attr_in_init_agent(attr)
+
+
+def test_conditionally_used_runtime_attrs_are_initialized_by_constructor_authority():
+    for attr in ("_session_init_model_config", "_last_flushed_db_idx"):
+        if _attr_used_by_aiagent_outside_init(attr):
+            _assert_attr_in_init_agent(attr)

--- a/tests/scripts/test_check_prompt_policy.py
+++ b/tests/scripts/test_check_prompt_policy.py
@@ -1,0 +1,86 @@
+"""Tests for the prompt-policy checker script."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.prompt_builder import CONTEXT_FILE_MAX_CHARS
+
+
+def test_checker_passes_for_active_repo() -> None:
+    from scripts import check_prompt_policy
+
+    assert check_prompt_policy.run_checks(check_prompt_policy.ROOT) == []
+
+
+def test_checker_reports_missing_active_agents_md(tmp_path) -> None:
+    from scripts import check_prompt_policy
+
+    assert check_prompt_policy.run_checks(tmp_path) == [
+        f"missing active policy file: {tmp_path / 'AGENTS.md'}"
+    ]
+
+
+def test_checker_reports_forbidden_generated_context_in_source(tmp_path) -> None:
+    from scripts import check_prompt_policy
+
+    agents_md = tmp_path / "AGENTS.md"
+    agents_md.write_text(
+        "# Policy\n\n" + ("A" * (CONTEXT_FILE_MAX_CHARS + 100)) + "\n<claude-mem-context>\nstale\n</claude-mem-context>\n",
+        encoding="utf-8",
+    )
+
+    failures = check_prompt_policy.run_checks(tmp_path)
+
+    assert "active policy file contains generated claude memory context: <claude-mem-context>" in failures
+    assert "active policy file contains generated claude memory context close tag: </claude-mem-context>" in failures
+
+
+def test_checker_reports_loader_priority_violation(monkeypatch) -> None:
+    from scripts import check_prompt_policy
+
+    def broken_prompt(*, cwd: str | None = None, skip_soul: bool = False) -> str:
+        return "AGENTS_SHOULD_NOT_LOAD CLAUDE_SHOULD_NOT_LOAD CURSOR_SHOULD_NOT_LOAD"
+
+    monkeypatch.setattr(check_prompt_policy, "build_context_files_prompt", broken_prompt)
+
+    failures = check_prompt_policy.check_loader_priority_contract()
+
+    assert "dropped highest-priority .hermes.md project context" in failures
+    assert "loaded lower-priority AGENTS.md alongside .hermes.md" in failures
+    assert "loaded lower-priority CLAUDE.md alongside .hermes.md" in failures
+    assert "loaded lower-priority cursor rules alongside .hermes.md" in failures
+
+
+def test_checker_proves_soul_md_independent(monkeypatch, tmp_path) -> None:
+    from scripts import check_prompt_policy
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+
+    assert check_prompt_policy.check_soul_independence() == []
+
+
+def test_checker_reports_truncation_regression(monkeypatch) -> None:
+    from scripts import check_prompt_policy
+
+    def broken_truncate(content: str, filename: str, max_chars: int = CONTEXT_FILE_MAX_CHARS) -> str:
+        return content[:max_chars]
+
+    monkeypatch.setattr(check_prompt_policy, "_truncate_content", broken_truncate)
+
+    failures = check_prompt_policy.check_truncation_contract()
+
+    assert "truncation dropped head marker" not in failures
+    assert "truncation dropped tail marker" in failures
+    assert "truncation marker missing or malformed" in failures
+
+
+def test_main_returns_nonzero_for_policy_failure(monkeypatch, capsys) -> None:
+    from scripts import check_prompt_policy
+
+    monkeypatch.setattr(check_prompt_policy, "run_checks", lambda root: ["synthetic failure"])
+
+    assert check_prompt_policy.main() == 1
+    captured = capsys.readouterr()
+    assert "FAIL: prompt policy checks failed" in captured.err
+    assert "synthetic failure" in captured.err

--- a/tests/scripts/test_check_prompt_policy.py
+++ b/tests/scripts/test_check_prompt_policy.py
@@ -56,8 +56,20 @@ def test_checker_proves_soul_md_independent(monkeypatch, tmp_path) -> None:
     from scripts import check_prompt_policy
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
-
     assert check_prompt_policy.check_soul_independence() == []
+
+    def broken_prompt(*, cwd: str | None = None, skip_soul: bool = False) -> str:
+        if skip_soul:
+            return "PROJECT_POLICY_MARKER HERMES_HOME_SOUL_MARKER"
+        return "PROJECT_POLICY_MARKER CWD_SOUL_SHOULD_NOT_LOAD"
+
+    monkeypatch.setattr(check_prompt_policy, "build_context_files_prompt", broken_prompt)
+
+    failures = check_prompt_policy.check_soul_independence()
+
+    assert "HERMES_HOME SOUL.md was not loaded independently" in failures
+    assert "cwd SOUL.md was loaded instead of HERMES_HOME SOUL.md" in failures
+    assert "skip_soul=True still loaded SOUL.md" in failures
 
 
 def test_checker_reports_truncation_regression(monkeypatch) -> None:

--- a/tests/scripts/test_lint_diff.py
+++ b/tests/scripts/test_lint_diff.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINT_DIFF = REPO_ROOT / "scripts" / "lint_diff.py"
+
+
+def _load_lint_diff():
+    spec = importlib.util.spec_from_file_location("lint_diff_under_test", LINT_DIFF)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ty_panic_paths_are_normalized_for_ref_diffs():
+    lint_diff = _load_lint_diff()
+    base = lint_diff._normalize_ty(
+        [
+            {
+                "check_name": "panic",
+                "location": {"path": "", "positions": {"begin": {"line": 1}}},
+                "description": "Panicked when checking `/tmp/lint-base/tools/checkpoint_manager.py`: `infer_expression_type_impl(Id(abc123)): cycle`",
+            }
+        ]
+    )
+    head = lint_diff._normalize_ty(
+        [
+            {
+                "check_name": "panic",
+                "location": {"path": "", "positions": {"begin": {"line": 1}}},
+                "description": "Panicked when checking `/home/runner/work/hermes/tools/checkpoint_manager.py`: `infer_expression_type_impl(Id(def456)): cycle`",
+            }
+        ]
+    )
+
+    new, fixed, unchanged = lint_diff._diff(base, head)
+
+    assert new == []
+    assert fixed == []
+    assert len(unchanged) == 1
+    assert unchanged[0]["message"] == "Panicked when checking `tools/checkpoint_manager.py`: `infer_expression_type_impl(Id(<normalized>)): cycle`"
+
+
+def test_tool_report_totals_follow_stable_unique_keys():
+    lint_diff = _load_lint_diff()
+    base = [
+        {"tool": "ty", "rule": "panic", "path": "", "line": 1, "message": "same"},
+    ]
+    head = [
+        {"tool": "ty", "rule": "panic", "path": "", "line": 1, "message": "same"},
+        {"tool": "ty", "rule": "panic", "path": "", "line": 1, "message": "same"},
+    ]
+
+    report = lint_diff._tool_report("ty", base, head, True)
+
+    assert "**Unique total:** 1 on HEAD, 1 on base (➖ 0)" in report
+    assert "_Raw diagnostic events: 2 on HEAD, 1 on base._" in report
+    assert "**🆕 New issues:** none" in report

--- a/tests/tools/test_arxiv_mcp_stdio_bridge.py
+++ b/tests/tools/test_arxiv_mcp_stdio_bridge.py
@@ -128,8 +128,9 @@ def test_initialized_notification_is_silent(bridge):
 
 
 def test_main_redacts_secret_shaped_exception_messages(bridge, monkeypatch, capsys):
+    secret_fixture = "sk-" + "testsecret" + "1234567890"
+
     async def boom(_payload):
-        secret_fixture = "sk-" + "testsecret" + "1234567890"
         raise RuntimeError("upstream token: " + secret_fixture)
 
     monkeypatch.setattr(bridge, "_handle_request", boom)
@@ -144,5 +145,5 @@ def test_main_redacts_secret_shaped_exception_messages(bridge, monkeypatch, caps
     output = capsys.readouterr().out
     response = json.loads(output)
     assert response["error"]["code"] == -32000
-    assert "sk-testsecret" not in output
+    assert secret_fixture not in output
     assert "token: [REDACTED]" in response["error"]["message"]

--- a/tests/tools/test_arxiv_mcp_stdio_bridge.py
+++ b/tests/tools/test_arxiv_mcp_stdio_bridge.py
@@ -146,4 +146,6 @@ def test_main_redacts_secret_shaped_exception_messages(bridge, monkeypatch, caps
     response = json.loads(output)
     assert response["error"]["code"] == -32000
     assert secret_fixture not in output
-    assert "token: [REDACTED]" in response["error"]["message"]
+    message = response["error"]["message"]
+    assert "token" in message
+    assert "[REDACTED]" in message

--- a/tests/tools/test_arxiv_mcp_stdio_bridge.py
+++ b/tests/tools/test_arxiv_mcp_stdio_bridge.py
@@ -40,11 +40,11 @@ def bridge(monkeypatch):
             "messages": [{"role": "user", "content": arguments or {}}],
         }
 
-    server.call_tool = call_tool
-    server.get_prompt = get_prompt
-    server.list_prompts = list_prompts
-    server.list_tools = list_tools
-    server.settings = SimpleNamespace(APP_NAME="fake-arxiv", APP_VERSION="9.9.9")
+    setattr(server, "call_tool", call_tool)
+    setattr(server, "get_prompt", get_prompt)
+    setattr(server, "list_prompts", list_prompts)
+    setattr(server, "list_tools", list_tools)
+    setattr(server, "settings", SimpleNamespace(APP_NAME="fake-arxiv", APP_VERSION="9.9.9"))
 
     monkeypatch.setitem(sys.modules, "arxiv_mcp_server", package)
     monkeypatch.setitem(sys.modules, "arxiv_mcp_server.server", server)

--- a/tests/tools/test_arxiv_mcp_stdio_bridge.py
+++ b/tests/tools/test_arxiv_mcp_stdio_bridge.py
@@ -1,0 +1,148 @@
+import asyncio
+import importlib
+import io
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+class Dumpable:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def model_dump(self, **_kwargs):
+        return self.payload
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def bridge(monkeypatch):
+    package = ModuleType("arxiv_mcp_server")
+    server = ModuleType("arxiv_mcp_server.server")
+
+    async def list_tools():
+        return [Dumpable({"name": "search_papers"})]
+
+    async def list_prompts():
+        return [Dumpable({"name": "summarize_paper"})]
+
+    async def call_tool(name, arguments):
+        return [Dumpable({"type": "text", "text": f"{name}:{arguments.get('query', '')}"})]
+
+    async def get_prompt(name, arguments):
+        return {
+            "description": f"prompt:{name}",
+            "messages": [{"role": "user", "content": arguments or {}}],
+        }
+
+    server.call_tool = call_tool
+    server.get_prompt = get_prompt
+    server.list_prompts = list_prompts
+    server.list_tools = list_tools
+    server.settings = SimpleNamespace(APP_NAME="fake-arxiv", APP_VERSION="9.9.9")
+
+    monkeypatch.setitem(sys.modules, "arxiv_mcp_server", package)
+    monkeypatch.setitem(sys.modules, "arxiv_mcp_server.server", server)
+    monkeypatch.delitem(sys.modules, "tools.arxiv_mcp_stdio_bridge", raising=False)
+
+    module = importlib.import_module("tools.arxiv_mcp_stdio_bridge")
+    yield module
+    sys.modules.pop("tools.arxiv_mcp_stdio_bridge", None)
+
+
+def test_initialize_and_runtime_lists_return_json_rpc_payloads(bridge):
+    init = _run(
+        bridge._handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": "2024-11-05"},
+            }
+        )
+    )
+    tools = _run(bridge._handle_request({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}))
+    prompts = _run(
+        bridge._handle_request({"jsonrpc": "2.0", "id": 3, "method": "prompts/list"})
+    )
+
+    assert init["result"]["protocolVersion"] == "2024-11-05"
+    assert init["result"]["capabilities"]["tools"] == {"listChanged": False}
+    assert init["result"]["capabilities"]["prompts"] == {"listChanged": False}
+    assert init["result"]["serverInfo"]["name"] == "fake-arxiv"
+    assert tools["result"]["tools"] == [{"name": "search_papers"}]
+    assert prompts["result"]["prompts"] == [{"name": "summarize_paper"}]
+
+
+def test_tools_call_and_prompts_get_delegate_to_package_handlers(bridge):
+    tool = _run(
+        bridge._handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {"name": "search", "arguments": {"query": "mcp"}},
+            }
+        )
+    )
+    prompt = _run(
+        bridge._handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "prompts/get",
+                "params": {"name": "summary", "arguments": {"paper": "1234.5678"}},
+            }
+        )
+    )
+
+    assert tool["result"]["isError"] is False
+    assert tool["result"]["content"] == [{"type": "text", "text": "search:mcp"}]
+    assert prompt["result"]["description"] == "prompt:summary"
+    assert prompt["result"]["messages"][0]["content"] == {"paper": "1234.5678"}
+
+
+def test_resources_list_is_explicitly_unsupported(bridge):
+    response = _run(
+        bridge._handle_request({"jsonrpc": "2.0", "id": 6, "method": "resources/list"})
+    )
+
+    assert response["error"]["code"] == -32601
+    assert response["error"]["message"] == "Method not found: resources/list"
+
+
+def test_initialized_notification_is_silent(bridge):
+    assert (
+        _run(
+            bridge._handle_request(
+                {"jsonrpc": "2.0", "method": "notifications/initialized"}
+            )
+        )
+        is None
+    )
+
+
+def test_main_redacts_secret_shaped_exception_messages(bridge, monkeypatch, capsys):
+    async def boom(_payload):
+        secret_fixture = "sk-" + "testsecret" + "1234567890"
+        raise RuntimeError("upstream token: " + secret_fixture)
+
+    monkeypatch.setattr(bridge, "_handle_request", boom)
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO('{"jsonrpc":"2.0","id":7,"method":"tools/list"}\n'),
+    )
+
+    assert bridge.main() == 0
+
+    output = capsys.readouterr().out
+    response = json.loads(output)
+    assert response["error"]["code"] == -32000
+    assert "sk-testsecret" not in output
+    assert "token: [REDACTED]" in response["error"]["message"]

--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -82,7 +82,8 @@ class TestFindAgentBrowserCache:
 
         with patch("shutil.which", return_value=None), \
              patch("os.path.isdir", return_value=False), \
-             patch.object(Path, "exists", mock_exists):
+             patch.object(Path, "exists", mock_exists), \
+             patch("hermes_cli.dep_ensure.ensure_dependency", return_value=False):
             with pytest.raises(FileNotFoundError):
                 bt._find_agent_browser()
         # Second call should also raise (from cache)

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -200,6 +200,7 @@ class TestFindAgentBrowser:
         with patch("shutil.which", return_value=None), \
              patch("os.path.isdir", return_value=False), \
              patch.object(Path, "exists", mock_path_exists), \
+             patch("hermes_cli.dep_ensure.ensure_dependency", return_value=False), \
              patch(
                  "tools.browser_tool._discover_homebrew_node_dirs",
                  return_value=[],

--- a/tests/tools/test_mcp_runtime_probe.py
+++ b/tests/tools/test_mcp_runtime_probe.py
@@ -1,0 +1,388 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+
+class FakeSession:
+    def __init__(
+        self,
+        *,
+        tools=None,
+        resources=None,
+        prompts=None,
+        resource_error=None,
+        tool_error=None,
+        prompt_error=None,
+        capabilities=None,
+    ):
+        self._tools = tools or []
+        self._resources = resources or []
+        self._prompts = prompts or []
+        self._resource_error = resource_error
+        self._tool_error = tool_error
+        self._prompt_error = prompt_error
+        self._capabilities = capabilities
+
+    async def initialize(self):
+        return SimpleNamespace(capabilities=self._capabilities)
+
+    async def list_tools(self):
+        if self._tool_error is not None:
+            raise self._tool_error
+        return SimpleNamespace(tools=self._tools)
+
+    async def list_resources(self):
+        if self._resource_error is not None:
+            raise self._resource_error
+        return SimpleNamespace(resources=self._resources)
+
+    async def list_prompts(self):
+        if self._prompt_error is not None:
+            raise self._prompt_error
+        return SimpleNamespace(prompts=self._prompts)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_normalizes_hermes_codex_and_claude_configs_without_secret_values():
+    from tools.mcp_runtime_probe import normalize_mcp_servers
+
+    servers = normalize_mcp_servers(
+        {
+            "hermes": {
+                "mcp_servers": {
+                    "github": {
+                        "url": "https://api.githubcopilot.com/mcp/readonly?token=secret",
+                        "headers": {
+                            "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}",
+                        },
+                    }
+                }
+            },
+            "codex": {
+                "mcp_servers": {
+                    "cloudflare-api": {
+                        "url": "https://mcp.cloudflare.com/mcp",
+                        "bearer_token_env_var": "CLOUDFLARE_API_TOKEN",
+                    }
+                }
+            },
+            "claude": {
+                "mcpServers": {
+                    "filesystem": {
+                        "command": "/usr/local/bin/npx",
+                        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+                        "env": {"FS_TOKEN": "${FILESYSTEM_TOKEN}"},
+                    }
+                }
+            },
+        }
+    )
+
+    summaries = {server.id: server.redacted_summary() for server in servers}
+    assert summaries["hermes:github"]["url"] == {
+        "host": "api.githubcopilot.com",
+        "path": "/mcp/readonly",
+    }
+    assert summaries["codex:cloudflare-api"]["env_vars"] == ["CLOUDFLARE_API_TOKEN"]
+    assert summaries["claude:filesystem"]["command"] == {
+        "basename": "npx",
+        "args_count": 3,
+    }
+    assert summaries["claude:filesystem"]["env_vars"] == ["FILESYSTEM_TOKEN", "FS_TOKEN"]
+
+    encoded = json.dumps([server.redacted_summary() for server in servers], sort_keys=True)
+    assert "secret" not in encoded
+    assert "Bearer" not in encoded
+    assert "/usr/local/bin/npx" not in encoded
+
+
+def test_missing_stdio_executable_reports_offline_and_does_not_connect(monkeypatch):
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    calls = []
+
+    async def connector(server):
+        calls.append(server.name)
+        return FakeSession()
+
+    server = NormalizedMCPServer(
+        source="hermes",
+        name="missing",
+        config={"command": "definitely-not-a-real-mcp-command"},
+        transport="stdio",
+        command="definitely-not-a-real-mcp-command",
+    )
+    monkeypatch.setattr("tools.mcp_runtime_probe.shutil.which", lambda command: None)
+
+    report = _run(probe_servers([server], connector=connector))
+
+    assert report["servers"][0]["status"] == "offline"
+    assert report["status_counts"]["offline"] == 1
+    assert calls == []
+
+
+def test_missing_bearer_env_var_reports_auth_needed_and_redacts_name_only(monkeypatch):
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    server = NormalizedMCPServer(
+        source="codex",
+        name="github-readonly",
+        config={},
+        transport="http",
+        url="https://api.githubcopilot.com/mcp/readonly",
+        bearer_env_var="GITHUB_PERSONAL_ACCESS_TOKEN",
+    )
+    monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+
+    report = _run(probe_servers([server], connector=lambda _server: None))
+
+    entry = report["servers"][0]
+    assert entry["status"] == "auth_needed"
+    assert entry["env_vars"] == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in json.dumps(report)
+
+
+def test_http_401_reports_auth_needed(monkeypatch):
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    async def connector(server):
+        raise RuntimeError("401 Unauthorized")
+
+    server = NormalizedMCPServer(
+        source="codex",
+        name="cloudflare-api",
+        config={},
+        transport="http",
+        url="https://mcp.cloudflare.com/mcp",
+        bearer_env_var="CLOUDFLARE_API_TOKEN",
+    )
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "not-printed")
+
+    report = _run(probe_servers([server], connector=connector))
+
+    assert report["servers"][0]["status"] == "auth_needed"
+    assert "not-printed" not in json.dumps(report)
+
+
+def test_resources_method_not_found_is_method_unsupported_but_tools_are_counted():
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    async def connector(server):
+        return FakeSession(
+            tools=[SimpleNamespace(name="search")],
+            resource_error=RuntimeError("-32601 Method not found"),
+            capabilities=SimpleNamespace(resources=SimpleNamespace()),
+        )
+
+    server = NormalizedMCPServer(
+        source="hermes",
+        name="resources-missing",
+        config={},
+        transport="http",
+        url="https://example.test/mcp",
+    )
+
+    report = _run(probe_servers([server], connector=connector))
+
+    entry = report["servers"][0]
+    assert entry["status"] == "ok"
+    assert entry["checks"]["tools"] == "ok"
+    assert entry["checks"]["resources"] == "method_unsupported"
+    assert entry["tools_count"] == 1
+    assert report["check_status_counts"]["method_unsupported"] == 1
+
+
+def test_tools_failure_is_attributed_to_tools_check():
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    async def connector(server):
+        return FakeSession(tool_error=RuntimeError("connection timed out"))
+
+    server = NormalizedMCPServer(
+        source="hermes",
+        name="wedged",
+        config={},
+        transport="http",
+        url="https://example.test/mcp",
+    )
+
+    report = _run(probe_servers([server], connector=connector))
+
+    entry = report["servers"][0]
+    assert entry["status"] == "offline"
+    assert entry["checks"]["initialize"] == "ok"
+    assert entry["checks"]["tools"] == "offline"
+
+
+def test_prompts_are_probed_and_counted_when_advertised():
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    async def connector(server):
+        return FakeSession(
+            tools=[SimpleNamespace(name="search")],
+            resources=[],
+            prompts=[SimpleNamespace(name="summarize")],
+            capabilities=SimpleNamespace(
+                resources=SimpleNamespace(),
+                prompts=SimpleNamespace(),
+            ),
+        )
+
+    server = NormalizedMCPServer(
+        source="hermes",
+        name="prompts",
+        config={},
+        transport="http",
+        url="https://example.test/mcp",
+    )
+
+    report = _run(probe_servers([server], connector=connector))
+
+    entry = report["servers"][0]
+    assert entry["status"] == "ok"
+    assert entry["checks"]["prompts"] == "ok"
+    assert entry["prompts_count"] == 1
+
+
+def test_advertised_prompts_failure_degrades_status():
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    async def connector(server):
+        return FakeSession(
+            tools=[SimpleNamespace(name="search")],
+            resources=[],
+            prompt_error=RuntimeError("401 Unauthorized"),
+            capabilities=SimpleNamespace(
+                resources=SimpleNamespace(),
+                prompts=SimpleNamespace(),
+            ),
+        )
+
+    server = NormalizedMCPServer(
+        source="hermes",
+        name="prompts-auth",
+        config={},
+        transport="http",
+        url="https://example.test/mcp",
+    )
+
+    report = _run(probe_servers([server], connector=connector))
+
+    entry = report["servers"][0]
+    assert entry["status"] == "auth_needed"
+    assert entry["checks"]["prompts"] == "auth_needed"
+
+
+def test_tools_only_server_skips_resources_probe_and_reports_ok():
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    async def connector(server):
+        return FakeSession(
+            tools=[SimpleNamespace(name="resolve-library-id")],
+            capabilities=SimpleNamespace(resources=None),
+        )
+
+    server = NormalizedMCPServer(
+        source="hermes",
+        name="context7",
+        config={},
+        transport="http",
+        url="https://context7.example/mcp",
+    )
+
+    report = _run(probe_servers([server], connector=connector))
+
+    entry = report["servers"][0]
+    assert entry["status"] == "ok"
+    assert entry["checks"]["resources"] == "unsupported"
+    assert entry["checks"]["prompts"] == "unsupported"
+    assert entry["tools_count"] == 1
+
+
+def test_sdk_unavailable_reports_unsupported_without_connecting():
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    calls = []
+
+    async def connector(server):
+        calls.append(server.name)
+        return FakeSession()
+
+    server = NormalizedMCPServer(
+        source="hermes",
+        name="github",
+        config={},
+        transport="http",
+        url="https://api.githubcopilot.com/mcp/readonly",
+    )
+
+    report = _run(probe_servers([server], connector=connector, sdk_available=False))
+
+    assert report["servers"][0]["status"] == "unsupported"
+    assert calls == []
+
+
+def test_cli_default_skips_google_drive_auth_needed_entries(monkeypatch):
+    from tools.mcp_runtime_probe import NormalizedMCPServer, probe_servers
+
+    server = NormalizedMCPServer(
+        source="claude",
+        name="Google Drive",
+        config={},
+        transport="http",
+        url="https://mcp.google.com/drive",
+        bearer_env_var="GOOGLE_DRIVE_TOKEN",
+    )
+    monkeypatch.delenv("GOOGLE_DRIVE_TOKEN", raising=False)
+
+    report = _run(probe_servers([server], skip_google_drive_auth_needed=True))
+
+    assert report["servers"] == []
+    assert report["status_counts"] == {}
+
+
+def test_default_source_loader_filters_runtime(monkeypatch, tmp_path):
+    from tools.mcp_runtime_probe import load_default_config_sources
+
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    hermes = tmp_path / ".hermes"
+    codex = tmp_path / ".codex"
+    claude = tmp_path / ".claude"
+    hermes.mkdir()
+    codex.mkdir()
+    claude.mkdir()
+    (hermes / "config.yaml").write_text("mcp_servers:\n  arxiv:\n    command: uvx\n", encoding="utf-8")
+    (codex / "config.toml").write_text("[mcp_servers.context7]\ncommand = \"npx\"\n", encoding="utf-8")
+    (claude / "settings.json").write_text("{\"mcpServers\":{\"filesystem\":{\"command\":\"npx\"}}}", encoding="utf-8")
+
+    assert set(load_default_config_sources(tmp_path, runtime="all")) == {"hermes", "codex", "claude"}
+    assert set(load_default_config_sources(tmp_path, runtime="codex")) == {"codex"}
+
+
+def test_probe_default_sources_filters_server(monkeypatch, tmp_path):
+    from tools import mcp_runtime_probe
+
+    async def fake_probe_servers(servers, **kwargs):
+        return {"servers": [server.id for server in servers], "kwargs": kwargs}
+
+    monkeypatch.setattr(
+        mcp_runtime_probe,
+        "load_default_config_sources",
+        lambda runtime="all": {
+            "codex": {
+                "mcp_servers": {
+                    "context7": {"command": "npx"},
+                    "arxiv": {"command": "uvx"},
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(mcp_runtime_probe, "probe_servers", fake_probe_servers)
+
+    report = _run(mcp_runtime_probe.probe_default_sources(runtime="codex", server_name="context7"))
+
+    assert report["servers"] == ["codex:context7"]

--- a/tests/tools/test_mcp_runtime_probe.py
+++ b/tests/tools/test_mcp_runtime_probe.py
@@ -327,7 +327,11 @@ def test_sdk_unavailable_reports_unsupported_without_connecting():
 
     report = _run(probe_servers([server], connector=connector, sdk_available=False))
 
-    assert report["servers"][0]["status"] == "unsupported"
+    entry = report["servers"][0]
+    assert entry["status"] == "unsupported"
+    assert entry["tools_count"] == 0
+    assert entry["resources_count"] == 0
+    assert entry["prompts_count"] == 0
     assert calls == []
 
 

--- a/tests/tools/test_mcp_runtime_probe.py
+++ b/tests/tools/test_mcp_runtime_probe.py
@@ -92,6 +92,8 @@ def test_normalizes_hermes_codex_and_claude_configs_without_secret_values():
         "host": "api.githubcopilot.com",
         "path": "/mcp/readonly",
     }
+    assert summaries["hermes:github"]["env_vars"] == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+    assert "Authorization" not in summaries["hermes:github"]["env_vars"]
     assert summaries["codex:cloudflare-api"]["env_vars"] == ["CLOUDFLARE_API_TOKEN"]
     assert summaries["claude:filesystem"]["command"] == {
         "basename": "npx",

--- a/tests/tools/test_mcp_runtime_probe.py
+++ b/tests/tools/test_mcp_runtime_probe.py
@@ -46,6 +46,12 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+def test_status_classes_do_not_advertise_unemitted_config_missing():
+    from tools.mcp_runtime_probe import STATUS_CLASSES
+
+    assert "config_missing" not in STATUS_CLASSES
+
+
 def test_normalizes_hermes_codex_and_claude_configs_without_secret_values():
     from tools.mcp_runtime_probe import normalize_mcp_servers
 

--- a/tools/arxiv_mcp_stdio_bridge.py
+++ b/tools/arxiv_mcp_stdio_bridge.py
@@ -13,16 +13,16 @@ import asyncio
 import json
 import re
 import sys
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-from arxiv_mcp_server.server import (
-    call_tool,
-    get_prompt,
-    list_prompts,
-    list_tools,
-    settings,
-)
+_arxiv_server: Any = import_module("arxiv_mcp_server.server")
+call_tool: Any = getattr(_arxiv_server, "call_tool")
+get_prompt: Any = getattr(_arxiv_server, "get_prompt")
+list_prompts: Any = getattr(_arxiv_server, "list_prompts")
+list_tools: Any = getattr(_arxiv_server, "list_tools")
+settings: Any = getattr(_arxiv_server, "settings")
 
 JSONRPC_VERSION = "2.0"
 DEFAULT_PROTOCOL_VERSION = "2025-11-25"
@@ -74,7 +74,8 @@ def _package_version() -> str:
 async def _handle_request(payload: dict[str, Any]) -> dict[str, Any] | None:
     method = payload.get("method")
     message_id = payload.get("id")
-    params = payload.get("params") if isinstance(payload.get("params"), dict) else {}
+    raw_params = payload.get("params")
+    params: dict[str, Any] = raw_params if isinstance(raw_params, dict) else {}
 
     if method == "notifications/initialized":
         return None

--- a/tools/arxiv_mcp_stdio_bridge.py
+++ b/tools/arxiv_mcp_stdio_bridge.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""JSON-lines MCP bridge for ``arxiv-mcp-server``.
+
+The upstream package's server object is valid in-process on this host, but its
+packaged stdio entrypoint does not answer initialize requests over a real pipe.
+This bridge keeps the package's tool/prompt handlers and exposes the minimal
+MCP JSON-RPC methods Hermes needs for runtime discovery and tool calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from arxiv_mcp_server.server import (
+    call_tool,
+    get_prompt,
+    list_prompts,
+    list_tools,
+    settings,
+)
+
+JSONRPC_VERSION = "2.0"
+DEFAULT_PROTOCOL_VERSION = "2025-11-25"
+SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)((?:api[_-]?key|authorization|auth|cookie|password|passwd|secret|token)\s*[:=]\s*)[^\s\"']+"
+)
+SECRET_PREFIX_RE = re.compile(
+    r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+|(?:sk-|ghp_|github_pat_|AKIA|xoxb-|xoxp-|AIza)[A-Za-z0-9_./+=-]+"
+)
+
+
+def _jsonable(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(by_alias=True, exclude_none=True)
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _response(message_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": JSONRPC_VERSION, "id": message_id, "result": result}
+
+
+def _redact_error_message(message: str) -> str:
+    redacted = SECRET_ASSIGNMENT_RE.sub(r"\1[REDACTED]", message)
+    return SECRET_PREFIX_RE.sub(
+        lambda match: f"{match.group(1)}[REDACTED]" if match.group(1) else "[REDACTED]",
+        redacted,
+    )
+
+
+def _error(message_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {
+        "jsonrpc": JSONRPC_VERSION,
+        "id": message_id,
+        "error": {"code": code, "message": _redact_error_message(message)},
+    }
+
+
+def _package_version() -> str:
+    try:
+        return version("arxiv-mcp-server")
+    except PackageNotFoundError:
+        return getattr(settings, "APP_VERSION", "0.0.0")
+
+
+async def _handle_request(payload: dict[str, Any]) -> dict[str, Any] | None:
+    method = payload.get("method")
+    message_id = payload.get("id")
+    params = payload.get("params") if isinstance(payload.get("params"), dict) else {}
+
+    if method == "notifications/initialized":
+        return None
+    if method == "initialize":
+        return _response(
+            message_id,
+            {
+                "protocolVersion": params.get("protocolVersion") or DEFAULT_PROTOCOL_VERSION,
+                "capabilities": {
+                    "experimental": {},
+                    "prompts": {"listChanged": False},
+                    "tools": {"listChanged": False},
+                },
+                "serverInfo": {
+                    "name": getattr(settings, "APP_NAME", "arxiv-mcp-server"),
+                    "version": _package_version(),
+                },
+            },
+        )
+    if method == "tools/list":
+        return _response(message_id, {"tools": _jsonable(await list_tools())})
+    if method == "prompts/list":
+        return _response(message_id, {"prompts": _jsonable(await list_prompts())})
+    if method == "prompts/get":
+        name = str(params.get("name") or "")
+        arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else None
+        return _response(message_id, _jsonable(await get_prompt(name, arguments)))
+    if method == "tools/call":
+        name = str(params.get("name") or "")
+        arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
+        return _response(
+            message_id,
+            {
+                "content": _jsonable(await call_tool(name, arguments)),
+                "isError": False,
+            },
+        )
+    if method == "resources/list":
+        return _error(message_id, -32601, "Method not found: resources/list")
+    return _error(message_id, -32601, f"Method not found: {method}")
+
+
+def main() -> int:
+    for line in sys.stdin:
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(
+                json.dumps(_error(None, -32700, f"Parse error: {exc.msg}")),
+                flush=True,
+            )
+            continue
+        try:
+            response = asyncio.run(_handle_request(payload))
+        except Exception as exc:
+            response = _error(payload.get("id"), -32000, str(exc))
+        if response is not None:
+            print(json.dumps(response, separators=(",", ":")), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mcp_runtime_probe.py
+++ b/tools/mcp_runtime_probe.py
@@ -1,0 +1,593 @@
+"""Redacted runtime-depth probing for Hermes/Codex/Claude MCP servers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import tomllib
+import argparse
+import asyncio
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Mapping
+from urllib.parse import urlparse
+
+try:
+    import yaml
+except Exception:  # pragma: no cover - yaml is a project dependency
+    yaml = None
+
+
+STATUS_CLASSES = (
+    "ok",
+    "disabled",
+    "config_missing",
+    "auth_needed",
+    "offline",
+    "unsupported",
+    "method_unsupported",
+    "protocol_error",
+    "error",
+)
+
+_ENV_REF_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def _parse_boolish(value: Any, *, default: bool = True) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
+def _env_refs(value: Any) -> set[str]:
+    refs: set[str] = set()
+    if isinstance(value, str):
+        for match in _ENV_REF_RE.finditer(value):
+            refs.add(match.group(1) or match.group(2))
+    elif isinstance(value, Mapping):
+        for key, nested in value.items():
+            if isinstance(key, str) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+                refs.add(key)
+            refs.update(_env_refs(nested))
+    elif isinstance(value, list):
+        for nested in value:
+            refs.update(_env_refs(nested))
+    return refs
+
+
+def _bearer_env_from_headers(headers: Mapping[str, Any]) -> str | None:
+    for key, value in headers.items():
+        if str(key).lower() != "authorization" or not isinstance(value, str):
+            continue
+        if not value.lower().strip().startswith("bearer "):
+            continue
+        refs = sorted(_env_refs(value))
+        return refs[0] if refs else None
+    return None
+
+
+def _url_summary(url: str | None) -> dict[str, str] | None:
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if not parsed.netloc:
+        return None
+    return {"host": parsed.netloc, "path": parsed.path or "/"}
+
+
+def _command_summary(command: str | None, args: tuple[str, ...]) -> dict[str, Any] | None:
+    if not command:
+        return None
+    return {"basename": os.path.basename(command), "args_count": len(args)}
+
+
+@dataclass(frozen=True)
+class NormalizedMCPServer:
+    source: str
+    name: str
+    config: Mapping[str, Any]
+    transport: str
+    enabled: bool = True
+    url: str | None = None
+    command: str | None = None
+    args: tuple[str, ...] = ()
+    env_vars: tuple[str, ...] = ()
+    bearer_env_var: str | None = None
+
+    @property
+    def id(self) -> str:
+        return f"{self.source}:{self.name}"
+
+    def redacted_summary(self) -> dict[str, Any]:
+        summary: dict[str, Any] = {
+            "id": self.id,
+            "source": self.source,
+            "name": self.name,
+            "transport": self.transport,
+            "enabled": self.enabled,
+        }
+        url = _url_summary(self.url)
+        if url:
+            summary["url"] = url
+        command = _command_summary(self.command, self.args)
+        if command:
+            summary["command"] = command
+        env_vars = sorted(set(self.env_vars) | ({self.bearer_env_var} if self.bearer_env_var else set()))
+        if env_vars:
+            summary["env_vars"] = env_vars
+        return summary
+
+
+@dataclass
+class _ProbeSessionAdapter:
+    task: Any
+    _initialized: bool = False
+
+    async def initialize(self) -> Any:
+        self._initialized = True
+        return getattr(self.task, "initialize_result", None)
+
+    async def list_tools(self) -> Any:
+        tools = getattr(self.task, "_tools", None)
+        if tools is not None:
+            return type("ListToolsResult", (), {"tools": tools})()
+        session = getattr(self.task, "session", None)
+        if session is None:
+            return type("ListToolsResult", (), {"tools": []})()
+        return await session.list_tools()
+
+    async def list_resources(self) -> Any:
+        session = getattr(self.task, "session", None)
+        if session is None:
+            raise RuntimeError("MCP session is not connected")
+        return await session.list_resources()
+
+    async def list_prompts(self) -> Any:
+        session = getattr(self.task, "session", None)
+        if session is None:
+            raise RuntimeError("MCP session is not connected")
+        return await session.list_prompts()
+
+    async def shutdown(self) -> None:
+        shutdown = getattr(self.task, "shutdown", None)
+        if shutdown is None:
+            return
+        result = shutdown()
+        if hasattr(result, "__await__"):
+            await result
+
+
+Connector = Callable[[NormalizedMCPServer], Awaitable[Any] | Any]
+
+
+def normalize_mcp_servers(raw_configs: Mapping[str, Any]) -> list[NormalizedMCPServer]:
+    """Normalize Hermes/Codex/Claude MCP config shapes into one redacted model."""
+
+    normalized: list[NormalizedMCPServer] = []
+    for source, raw_config in raw_configs.items():
+        if not isinstance(raw_config, Mapping):
+            continue
+        servers = (
+            raw_config.get("mcp_servers")
+            or raw_config.get("mcpServers")
+            or (raw_config.get("mcp") or {}).get("servers")
+        )
+        if not isinstance(servers, Mapping):
+            continue
+        for name, cfg in servers.items():
+            if not isinstance(cfg, Mapping):
+                continue
+            args = tuple(str(arg) for arg in (cfg.get("args") or []))
+            url = str(cfg.get("url") or "").strip() or None
+            command = str(cfg.get("command") or "").strip() or None
+            transport = str(cfg.get("transport") or "").strip().lower()
+            if not transport:
+                transport = "http" if url else "stdio" if command else "unsupported"
+            if transport in {"streamable_http", "streamable-http", "sse"}:
+                transport = "http"
+            bearer_env_var = (
+                cfg.get("bearer_token_env_var")
+                or cfg.get("bearerTokenEnvVar")
+                or cfg.get("token_env_var")
+                or cfg.get("tokenEnvVar")
+            )
+            headers = cfg.get("headers") if isinstance(cfg.get("headers"), Mapping) else {}
+            bearer_env_var = str(bearer_env_var or _bearer_env_from_headers(headers) or "").strip() or None
+            env_vars = set()
+            env_vars.update(_env_refs(cfg.get("env") or {}))
+            env_vars.update(_env_refs(headers))
+            if bearer_env_var:
+                env_vars.add(bearer_env_var)
+            normalized.append(
+                NormalizedMCPServer(
+                    source=str(source),
+                    name=str(name),
+                    config=cfg,
+                    transport=transport,
+                    enabled=_parse_boolish(cfg.get("enabled", True), default=True),
+                    url=url,
+                    command=command,
+                    args=args,
+                    env_vars=tuple(sorted(env_vars)),
+                    bearer_env_var=bearer_env_var,
+                )
+            )
+    return normalized
+
+
+def _is_google_drive(server: NormalizedMCPServer) -> bool:
+    haystack = " ".join(
+        part.lower()
+        for part in (
+            server.source,
+            server.name,
+            server.url or "",
+            server.command or "",
+            " ".join(server.args),
+        )
+    )
+    return "google" in haystack and "drive" in haystack
+
+
+def _stdio_command_available(server: NormalizedMCPServer) -> bool:
+    if not server.command:
+        return False
+    command = os.path.expanduser(server.command)
+    if os.sep in command:
+        return os.path.isfile(command) and os.access(command, os.X_OK)
+    return shutil.which(command) is not None
+
+
+def _sdk_available() -> bool:
+    try:
+        from tools import mcp_tool
+
+        return bool(getattr(mcp_tool, "_MCP_AVAILABLE", False))
+    except Exception:
+        return False
+
+
+async def _default_connector(server: NormalizedMCPServer) -> _ProbeSessionAdapter:
+    from tools.mcp_tool import _connect_server
+
+    config = dict(server.config)
+    if server.bearer_env_var and os.getenv(server.bearer_env_var):
+        headers = dict(config.get("headers") or {})
+        headers.setdefault("Authorization", f"Bearer {os.environ[server.bearer_env_var]}")
+        config["headers"] = headers
+    task = await _connect_server(server.name, config)
+    return _ProbeSessionAdapter(task)
+
+
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
+async def _shutdown_session(session: Any) -> None:
+    for name in ("shutdown", "close", "aclose"):
+        closer = getattr(session, name, None)
+        if closer is None:
+            continue
+        await _maybe_await(closer())
+        return
+
+
+def _classify_exception(exc: BaseException) -> str:
+    text = f"{type(exc).__name__}: {exc}".lower()
+    if any(term in text for term in ("401", "403", "unauthorized", "forbidden", "auth", "token")):
+        return "auth_needed"
+    if any(term in text for term in ("method not found", "-32601", "not implemented")):
+        return "method_unsupported"
+    if any(term in text for term in ("protocol", "json-rpc", "jsonrpc", "parse error", "invalid request")):
+        return "protocol_error"
+    if any(
+        term in text
+        for term in (
+            "connection",
+            "refused",
+            "timed out",
+            "timeout",
+            "name resolution",
+            "not found",
+            "no such file",
+            "network",
+            "offline",
+        )
+    ):
+        return "offline"
+    return "error"
+
+
+def _count_items(result: Any, attr: str) -> int:
+    items = getattr(result, attr, None)
+    if items is None:
+        return 0
+    try:
+        return len(items)
+    except TypeError:
+        return 0
+
+
+def _capability_unsupported(initialize_result: Any, name: str) -> bool:
+    capabilities = getattr(initialize_result, "capabilities", None)
+    return capabilities is not None and getattr(capabilities, name, None) is None
+
+
+async def _probe_one(server: NormalizedMCPServer, connector: Connector) -> dict[str, Any]:
+    entry = server.redacted_summary()
+    entry["checks"] = {}
+    entry["tools_count"] = 0
+    entry["resources_count"] = 0
+    entry["prompts_count"] = 0
+
+    if not server.enabled:
+        entry["status"] = "disabled"
+        return entry
+    if server.transport not in {"http", "stdio"}:
+        entry["status"] = "unsupported"
+        return entry
+    if server.transport == "stdio" and not _stdio_command_available(server):
+        entry["status"] = "offline"
+        entry["checks"]["executable"] = "offline"
+        return entry
+    if server.bearer_env_var and not os.getenv(server.bearer_env_var):
+        entry["status"] = "auth_needed"
+        entry["checks"]["auth"] = "auth_needed"
+        return entry
+
+    session = None
+    try:
+        session = await _maybe_await(connector(server))
+        initialize_result = await session.initialize()
+        entry["checks"]["initialize"] = "ok"
+
+        try:
+            tools_result = await session.list_tools()
+        except Exception as exc:
+            status = _classify_exception(exc)
+            entry["checks"]["tools"] = status
+            entry["status"] = status
+            return entry
+        entry["checks"]["tools"] = "ok"
+        entry["tools_count"] = _count_items(tools_result, "tools")
+
+        if _capability_unsupported(initialize_result, "resources"):
+            entry["checks"]["resources"] = "unsupported"
+        else:
+            try:
+                resources_result = await session.list_resources()
+                entry["checks"]["resources"] = "ok"
+                entry["resources_count"] = _count_items(resources_result, "resources")
+            except Exception as exc:
+                status = _classify_exception(exc)
+                entry["checks"]["resources"] = status
+                if status != "method_unsupported":
+                    entry["status"] = status
+                    return entry
+        if _capability_unsupported(initialize_result, "prompts"):
+            entry["checks"]["prompts"] = "unsupported"
+        else:
+            try:
+                prompts_result = await session.list_prompts()
+                entry["checks"]["prompts"] = "ok"
+                entry["prompts_count"] = _count_items(prompts_result, "prompts")
+            except Exception as exc:
+                status = _classify_exception(exc)
+                entry["checks"]["prompts"] = status
+                if status != "method_unsupported":
+                    entry["status"] = status
+                    return entry
+        entry["status"] = "ok"
+        return entry
+    except Exception as exc:
+        status = _classify_exception(exc)
+        if not entry["checks"]:
+            entry["checks"]["initialize"] = status
+        entry["status"] = status
+        return entry
+    finally:
+        if session is not None:
+            await _shutdown_session(session)
+
+
+def _add_status_samples(report: dict[str, Any]) -> None:
+    samples: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for entry in report["servers"]:
+        status = entry["status"]
+        if len(samples[status]) >= 3:
+            continue
+        sample = {
+            key: entry[key]
+            for key in ("id", "source", "name", "transport", "url", "command", "checks")
+            if key in entry
+        }
+        samples[status].append(sample)
+    report["status_samples"] = dict(samples)
+
+
+def _build_report(servers: list[dict[str, Any]]) -> dict[str, Any]:
+    status_counts = Counter(entry["status"] for entry in servers)
+    check_counts = Counter(
+        status
+        for entry in servers
+        for status in (entry.get("checks") or {}).values()
+    )
+    report = {
+        "status_classes": list(STATUS_CLASSES),
+        "status_counts": dict(sorted(status_counts.items())),
+        "check_status_counts": dict(sorted(check_counts.items())),
+        "servers": servers,
+    }
+    _add_status_samples(report)
+    return report
+
+
+async def probe_servers(
+    servers: list[NormalizedMCPServer],
+    *,
+    connector: Connector | None = None,
+    sdk_available: bool | None = None,
+    skip_google_drive_auth_needed: bool = False,
+) -> dict[str, Any]:
+    if connector is None:
+        connector = _default_connector
+    if sdk_available is None:
+        sdk_available = True if connector is not _default_connector else _sdk_available()
+
+    entries: list[dict[str, Any]] = []
+    for server in servers:
+        missing_auth = bool(server.bearer_env_var and not os.getenv(server.bearer_env_var))
+        if skip_google_drive_auth_needed and missing_auth and _is_google_drive(server):
+            continue
+        if not sdk_available and server.enabled:
+            entry = server.redacted_summary()
+            entry["status"] = "unsupported"
+            entry["checks"] = {"sdk": "unsupported"}
+            entry["tools_count"] = 0
+            entry["resources_count"] = 0
+            entries.append(entry)
+            continue
+        entries.append(await _probe_one(server, connector))
+    return _build_report(entries)
+
+
+def _load_json(path: Path) -> Mapping[str, Any] | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return {}
+
+
+def _load_toml(path: Path) -> Mapping[str, Any] | None:
+    try:
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return {}
+
+
+def _load_yaml(path: Path) -> Mapping[str, Any] | None:
+    if yaml is None:
+        return {}
+    try:
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        return loaded if isinstance(loaded, Mapping) else {}
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return {}
+
+
+def load_default_config_sources(
+    home: Path | None = None,
+    *,
+    runtime: str = "all",
+) -> dict[str, Mapping[str, Any]]:
+    home = home or Path.home()
+    sources: dict[str, Mapping[str, Any]] = {}
+
+    if runtime in {"all", "hermes"}:
+        hermes_home = Path(os.getenv("HERMES_HOME", str(home / ".hermes")))
+        hermes_config = _load_yaml(hermes_home / "config.yaml")
+        if hermes_config is not None:
+            sources["hermes"] = hermes_config
+
+    if runtime in {"all", "codex"}:
+        codex_home = Path(os.getenv("CODEX_HOME", str(home / ".codex")))
+        codex_config = _load_toml(codex_home / "config.toml")
+        if codex_config is not None:
+            sources["codex"] = codex_config
+
+    if runtime in {"all", "claude"}:
+        claude_config = _load_json(home / ".claude" / "settings.json")
+        if claude_config is not None:
+            sources["claude"] = claude_config
+
+    return sources
+
+
+async def probe_default_sources(
+    *,
+    runtime: str = "all",
+    server_name: str | None = None,
+    skip_google_drive_auth_needed: bool = True,
+) -> dict[str, Any]:
+    sources = load_default_config_sources(runtime=runtime)
+    if not sources:
+        return _build_report([])
+    servers = normalize_mcp_servers(sources)
+    if server_name:
+        servers = [server for server in servers if server.name == server_name or server.id == server_name]
+    return await probe_servers(
+        servers,
+        skip_google_drive_auth_needed=skip_google_drive_auth_needed,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runtime", choices=["codex", "claude", "hermes", "all"], default="all")
+    parser.add_argument("--server", help="probe only one server name or source:name id")
+    parser.add_argument("--json", action="store_true", help="emit JSON; retained for command symmetry")
+    parser.add_argument("--redact", action="store_true", help="all output is always redacted")
+    parser.add_argument("--timeout", type=int, default=120, help="overall probe timeout in seconds")
+    parser.add_argument(
+        "--skip-auth-needed",
+        action="store_true",
+        help="skip entries known to need interactive auth, including Google Drive",
+    )
+    parser.add_argument(
+        "--include-google-drive-auth-needed",
+        action="store_true",
+        help="include Google Drive MCP entries that are only missing auth",
+    )
+    args = parser.parse_args(argv)
+
+    async def _run() -> dict[str, Any]:
+        return await asyncio.wait_for(
+            probe_default_sources(
+                runtime=args.runtime,
+                server_name=args.server,
+                skip_google_drive_auth_needed=(
+                    args.skip_auth_needed or not args.include_google_drive_auth_needed
+                ),
+            ),
+            timeout=args.timeout if args.timeout > 0 else None,
+        )
+
+    try:
+        report = asyncio.run(_run())
+    except asyncio.TimeoutError:
+        report = {
+            "status": "timeout",
+            "status_counts": {"timeout": 1},
+            "check_status_counts": {"timeout": 1},
+            "servers": [],
+            "status_classes": ["timeout"],
+            "status_samples": {},
+        }
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 124
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/mcp_runtime_probe.py
+++ b/tools/mcp_runtime_probe.py
@@ -9,6 +9,7 @@ import shutil
 import tomllib
 import argparse
 import asyncio
+import importlib
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,7 +17,7 @@ from typing import Any, Awaitable, Callable, Mapping
 from urllib.parse import urlparse
 
 try:
-    import yaml
+    yaml: Any | None = importlib.import_module("yaml")
 except ImportError:  # pragma: no cover - yaml is optional; _load_yaml handles absence
     yaml = None
 

--- a/tools/mcp_runtime_probe.py
+++ b/tools/mcp_runtime_probe.py
@@ -24,7 +24,6 @@ except ImportError:  # pragma: no cover - yaml is optional; _load_yaml handles a
 STATUS_CLASSES = (
     "ok",
     "disabled",
-    "config_missing",
     "auth_needed",
     "offline",
     "unsupported",

--- a/tools/mcp_runtime_probe.py
+++ b/tools/mcp_runtime_probe.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 try:
     import yaml
-except Exception:  # pragma: no cover - yaml is a project dependency
+except ImportError:  # pragma: no cover - yaml is optional; _load_yaml handles absence
     yaml = None
 
 

--- a/tools/mcp_runtime_probe.py
+++ b/tools/mcp_runtime_probe.py
@@ -49,19 +49,23 @@ def _parse_boolish(value: Any, *, default: bool = True) -> bool:
     return default
 
 
-def _env_refs(value: Any) -> set[str]:
+def _env_refs(value: Any, *, include_mapping_keys: bool = False) -> set[str]:
     refs: set[str] = set()
     if isinstance(value, str):
         for match in _ENV_REF_RE.finditer(value):
             refs.add(match.group(1) or match.group(2))
     elif isinstance(value, Mapping):
         for key, nested in value.items():
-            if isinstance(key, str) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+            if (
+                include_mapping_keys
+                and isinstance(key, str)
+                and re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key)
+            ):
                 refs.add(key)
-            refs.update(_env_refs(nested))
+            refs.update(_env_refs(nested, include_mapping_keys=include_mapping_keys))
     elif isinstance(value, list):
         for nested in value:
-            refs.update(_env_refs(nested))
+            refs.update(_env_refs(nested, include_mapping_keys=include_mapping_keys))
     return refs
 
 
@@ -204,7 +208,7 @@ def normalize_mcp_servers(raw_configs: Mapping[str, Any]) -> list[NormalizedMCPS
             headers = cfg.get("headers") if isinstance(cfg.get("headers"), Mapping) else {}
             bearer_env_var = str(bearer_env_var or _bearer_env_from_headers(headers) or "").strip() or None
             env_vars = set()
-            env_vars.update(_env_refs(cfg.get("env") or {}))
+            env_vars.update(_env_refs(cfg.get("env") or {}, include_mapping_keys=True))
             env_vars.update(_env_refs(headers))
             if bearer_env_var:
                 env_vars.add(bearer_env_var)

--- a/tools/mcp_runtime_probe.py
+++ b/tools/mcp_runtime_probe.py
@@ -457,6 +457,7 @@ async def probe_servers(
             entry["checks"] = {"sdk": "unsupported"}
             entry["tools_count"] = 0
             entry["resources_count"] = 0
+            entry["prompts_count"] = 0
             entries.append(entry)
             continue
         entries.append(await _probe_one(server, connector))


### PR DESCRIPTION
## Summary

This branch hardens Hermes runtime authority and rescue-path diagnostics:

- adds path-authority doctor/proof surfaces for Hermes runtime checkout/service authority
- refreshes gateway runtime import/heartbeat/status handling for rescue-runtime liveness
- adds MCP runtime probe tooling plus stdio bridge hardening
- tightens Kanban DB/path/test isolation behavior
- restores prompt-policy checker coverage and closes review findings from prior authenticated passes
- closes the latest release-gate blockers: contributor attribution mapping, ty/lint-diff normalization, MCP bridge/runtime typing cleanups, and regression coverage

## Current validated HEAD

`88c7b00a6869d81f0f41680d21804b0f0ac6f912`

Remote branch parity after force-with-lease push is proven: local HEAD and `bmac4564-del/hermes-agent:rescue/hermes-runtime-kanban-20260523` both equal `88c7b00a6869d81f0f41680d21804b0f0ac6f912`.

## Local release-grade proof on current HEAD

- Release gates local: history PASS; contributor attribution PASS with missing count `0`; ruff PASS; Windows footguns PASS; ty advisory captured; supply-chain critical PASS; dependency-bound check PASS; PR-diff secret-pattern hit count `0`.
- Focused regression/e2e gate: `25 passed, 1 warning`; e2e `56 passed, 7 skipped`.
- Full canonical suite: `1194 files, 26037 tests passed, 0 failed`.
- Docker local-equivalent gate: build PASS; `hermes --help` smoke PASS; dashboard smoke PASS; docker integration tests `21 passed`.
- Nix local-equivalent gate: `nixos/nix:2.28.3`; flake show/check/build all PASS using original worktree path plus common gitdir mount.
- Lint/type diff proof: ruff `0` on HEAD/base; ty unique totals `3632` on HEAD and base, with **new issues: none** after normalization of environment-sensitive ty diagnostics.
- PR-diff secret scan: `finding_count=0` with matched text suppressed.
- Full-repo git-history secret scan posture: inherited baseline findings exist in repository history; output reviewed only in redacted/fingerprint form and not introduced by this PR diff.

## Upstream status

Upstream Actions for the current SHA were triggered by the push but are currently `action_required`. Approval attempts returned HTTP 403 requiring repository admin rights, so remote CI execution is blocked on maintainer/admin approval rather than local code evidence.

CodeRabbit was requested again on the current SHA in the PR thread.