### PR TITLE
chore(release): add kasunvinod to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -127,6 +127,7 @@ AUTHOR_MAP = {
     "73686890+InB4DevOps@users.noreply.github.com": "InB4DevOps",
     "147827411+EloquentBrush@users.noreply.github.com": "AhmetArif0",
     "97489706+purzbeats@users.noreply.github.com": "purzbeats",
+    "kasunvinod@users.noreply.github.com": "kasunvinod",
     "hugosequier@gmail.com": "Hugo-SEQUIER",
     "kylejeong21@gmail.com": "Kylejeong2",
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",


### PR DESCRIPTION
## What
Add `kasunvinod@users.noreply.github.com` → `kasunvinod` mapping to `scripts/release.py` AUTHOR_MAP.

## Why
CI attribution check failed on `fix/codex-responses-timeout-combined` (branch deleted, no open PR). The unmapped email belongs to contributor **Kasun Athaudahetti** (`kasunvinod` on GitHub).

## Verification
```
gh api 'search/users?q=kasunvinod' --jq '.items[0].login'
# → kasunvinod
```

CI Run: https://github.com/NousResearch/hermes-agent/actions/runs/26390137325