### PR TITLE
fix: guard _discord_request() callers against None on HTTP 204

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -86,7 +86,7 @@ def _discord_request(
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
-                return None
+                return [] if method == "GET" else None
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         error_body = ""


### PR DESCRIPTION
## Problem
When the Discord API returns HTTP 204 (No Content), `_discord_request()` returns `None`. All GET callers iterate or subscript the result without a None guard, causing `TypeError` crashes:

- `_list_guilds()`: `for g in guilds` → TypeError
- `_server_info()`: `g["id"]` → TypeError
- `_list_channels()`: `for ch in channels` → TypeError
- `_channel_info()`: `ch["id"]` → TypeError
- `_list_roles()`: `sorted(roles, ...)` → TypeError
- `_search_members()`: `for m in members` → TypeError
- `_get_messages()`: `for msg in messages` → TypeError
- `_get_pins()`: `for msg in messages` → TypeError

## Fix
Return empty list `[]` for GET 204 responses instead of `None`. Non-GET methods (DELETE, PUT) don't have callers that iterate the result, so returning `None` is safe for those.

## Change
1 line changed in `tools/discord_tool.py`:
```python
# Before
return None

# After
return [] if method == "GET" else None
```