### PR TITLE
fix: close file handle if _write_gateway_lock_record() raises

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -431,10 +431,14 @@ def acquire_gateway_runtime_lock() -> bool:
     path = _get_gateway_lock_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = open(path, "a+", encoding="utf-8")
-    if not _try_acquire_file_lock(handle):
+    try:
+        if not _try_acquire_file_lock(handle):
+            handle.close()
+            return False
+        _write_gateway_lock_record(handle)
+    except Exception:
         handle.close()
-        return False
-    _write_gateway_lock_record(handle)
+        raise
     _gateway_lock_handle = handle
     return True
 


### PR DESCRIPTION
## Problem
In `acquire_gateway_runtime_lock()` (gateway/status.py:433), `open()` returns a handle that is stored in `_gateway_lock_handle` only AFTER `_write_gateway_lock_record()` succeeds. If the write raises (disk full, json.dump error, OSError from flush/fsync), the handle leaks — it hasn't been stored yet, so `release_gateway_runtime_lock()` can never close it.

## Fix
Wrap the lock-acquire + write sequence in `try/except` that closes the handle on any exception before re-raising.

## Change
```python
# Before
handle = open(path, "a+", encoding="utf-8")
if not _try_acquire_file_lock(handle):
    handle.close()
    return False
_write_gateway_lock_record(handle)
_gateway_lock_handle = handle

# After
handle = open(path, "a+", encoding="utf-8")
try:
    if not _try_acquire_file_lock(handle):
        handle.close()
        return False
    _write_gateway_lock_record(handle)
except Exception:
    handle.close()
    raise
_gateway_lock_handle = handle
```