### PR TITLE
test(auth): stub gh_cli resolver in copilot suppress test

### DIFF
--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1611,6 +1611,22 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
     from hermes_cli.auth import is_source_suppressed
     from hermes_cli.auth_commands import auth_remove_command
 
+    # PR #31416 prunes "borrowed" pool entries whose source isn't currently
+    # active.  In production the copilot gh_cli entry is kept alive each
+    # load by `resolve_copilot_token()` returning the live `gh auth token`
+    # output.  In tests there's no `gh` CLI, so stub the resolver so the
+    # seeded entry survives the load → resolve_target round trip.
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("ghp_fake", "gh"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        lambda token: token,
+        raising=False,
+    )
+
     auth_remove_command(SimpleNamespace(provider="copilot", target="1"))
 
     assert is_source_suppressed("copilot", "gh_cli")


### PR DESCRIPTION
## Summary
Fixes the pre-existing failure of `tests/hermes_cli/test_auth_commands.py::test_auth_remove_copilot_suppresses_all_variants` that's been blocking main since #31416 landed.

## Root cause
#31416 added `_prune_stale_seeded_entries` to drop 'borrowed' credential-pool entries (gh_cli, env:*, etc.) on load when their source isn't currently active. In production the copilot gh_cli entry is kept alive each load by `resolve_copilot_token()` returning the live `gh auth token` output (via `_seed_from_singletons` adding "gh_cli" to `active_sources`).

The test wrote a gh_cli copilot row directly into `auth.json` but never stubbed `resolve_copilot_token`. Under the new prune policy the seeded entry gets pruned before `resolve_target("1")` can find it → `SystemExit: No credential #1. Provider: copilot.`.

## Fix
Stub `resolve_copilot_token` + `get_copilot_api_token` so the seeded entry survives the load, then `auth_remove_command` can target it and write the suppression flags the test asserts on. Test-only — no production code change.

## Validation
- The single failing test: PASSED
- All 46 tests in `tests/hermes_cli/test_auth_commands.py`: PASSED
- Last 2 main CI runs (a6b0414, d7c5d5d) failed this exact test before this PR; the failure mode reproduces 1:1 locally without the fix.
