### PR TITLE
feat(skills): add optional civitai skill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,22 @@
 # HYPERLIQUID_USER_ADDRESS=0x0000000000000000000000000000000000000000
 
 # =============================================================================
+# CIVITAI SKILL
+# =============================================================================
+# Optional API key for authenticated Civitai requests.
+# Required for NSFW access and higher rate limits.
+# Get your key at: https://civitai.com/user/account
+# CIVITAI_API_KEY=
+
+# Advanced: Civitai Meilisearch search-only key.
+# The skill includes a working public default, so most users can leave this unset.
+# MEILISEARCH_KEY=
+
+# Optional default ComfyUI models directory used by the Civitai skill
+# when generating ready-to-run download commands.
+# CIVITAI_COMFYUI_PATH=
+
+# =============================================================================
 # TERMINAL TOOL CONFIGURATION
 # =============================================================================
 # Backend type: "local", "singularity", "docker", "modal", or "ssh"

--- a/optional-skills/creative/civitai/SKILL.md
+++ b/optional-skills/creative/civitai/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: civitai
+description: Search Civitai for AI models (LoRA, Checkpoint, Flux, SDXL, Pony,
+  Illustrious, Wan Video, Hunyuan Video, Mochi, LTXV, CogVideoX), browse top
+  example media (images and videos) with generation prompts, identify
+  .safetensors files by hash, and produce ready-to-run download commands for
+  ComfyUI.
+version: 1.1.0
+author: Lulu Xiao (inspired by timoncool/civitai-mcp-ultimate, MIT)
+license: MIT
+metadata:
+  hermes:
+    tags:
+      - aigc
+      - image-generation
+      - stable-diffusion
+      - lora
+      - safetensor
+      - flux
+      - sd3
+      - wan-video
+      - hunyuan-video
+      - creative
+      - generative-ai
+      - civitai
+    config:
+      - key: civitai.comfyui_path
+        description: Default ComfyUI models directory for download commands
+        default: ""
+        prompt: "ComfyUI models path"
+---
+
+# Civitai
+
+Search & inspect Civitai AI image/video models — listings, metadata,
+example media with prompts, hash lookups, ComfyUI download commands.
+
+> **Windows:** use `python` instead of `python3` in every command below.
+
+> **"images" commands return videos too.** The `images` / `top-images` /
+> `prompts` subcommands surface whichever media type the model produced.
+> For video models (Wan Video, Hunyuan Video, Mochi, LTXV, LTXV2,
+> CogVideoX), video URLs are the **correct, expected** result — don't
+> refuse with "no images found". Use `--content-type {image,video}` to
+> filter.
+
+## When to Use
+
+Triggers: **Civitai**, LoRA, Checkpoint, Flux, SDXL, Pony, Illustrious,
+Wan Video, Hunyuan Video, Mochi, LTXV, CogVideoX, Stable Diffusion model,
+AI video model, ComfyUI download, generation prompts, `.safetensors`, or
+asks to identify a model file, mine prompts, or compare AI-art / AI-video models.
+
+## API key (optional)
+
+`CIVITAI_API_KEY` is **not required**. SFW search, model details, hash
+lookups, prompt mining, and download-command generation work without it.
+Set it to lift rate limits, access NSFW, or generate runnable download
+commands.
+
+Setup: <https://civitai.com> → **Account settings** → **API Keys** →
+**Add API key** (token shown once). Add `CIVITAI_API_KEY=<token>` to the
+Hermes env file (`hermes config env-path`, usually `~/.hermes/.env`,
+`chmod 600`). Verify:
+`python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --type LORA --limit 1`
+— no `auth failed` = live.
+
+**Never echo the token, pass it as a CLI argument, or commit `.env`.**
+Scripts read from `os.environ` and never print the value.
+`error: auth failed — check CIVITAI_API_KEY` = key invalid.
+
+## NSFW filtering
+
+**`--nsfw` works on all four search subcommands** (`models`, `top-models`,
+`images`, `top-images`):
+
+```bash
+python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --nsfw --type LORA --base-model "Pony"
+python3 ${HERMES_SKILL_DIR}/scripts/search.py images    --nsfw --model-id <id>
+```
+
+For granular per-level control on **image commands only**, use
+`--browsing-level` (`PG`=1, `PG-13`=2, `R`=4, `X`=8, `XXX`=16; OR-combine
+with commas, e.g. `X,XXX`; `all`=31). It's rejected by model commands.
+If both flags are passed to an image command, `--browsing-level` wins.
+Without an API key, NSFW silently downgrades to SFW (with a stderr
+warning on image commands).
+
+## Quick Reference
+
+All commands prefix with `python3 ${HERMES_SKILL_DIR}/scripts/`.
+
+| Intent | Command |
+|---|---|
+| Top models for a base model | `search.py top-models --type LORA --base-model "..."` |
+| Search models by name | `search.py models --query "..."` |
+| **Batch fetch many models in one call** | `search.py models --ids "1,2,3,..." --limit 100 --json` |
+| Top media (images + videos) this week | `search.py top-images --period Week --has-meta` |
+| Media for a model (images **or** videos) | `search.py images --model-id <id> --has-meta` |
+| Full model details + versions | `show.py model <id>` |
+| Version details + file hashes | `show.py version <vid>` |
+| Working prompts (image **or** video) | `show.py prompts <id>` |
+| Identify .safetensors by hash | `show.py hash <SHA256_or_AutoV2>` |
+| Download command for ComfyUI | `download.py <id> --comfyui-path "..."` |
+
+Every script supports `--json` and `--help`. IDs in output use `#` prefix
+(greppable as `#\d+`). **For many models at once, prefer batch fetch
+(`--ids`) over looping** — see Pitfalls #6.
+
+## Procedure
+
+### Recipe 1 — Top LoRAs for a base model
+
+```bash
+# SFW
+python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --type LORA --base-model "Flux.1 D" --period Month --limit 10
+# Include NSFW
+python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --type LORA --base-model "Pony" --period Month --limit 10 --nsfw
+```
+
+### Recipe 2 — Search models by name
+
+```bash
+python3 ${HERMES_SKILL_DIR}/scripts/search.py models --query "hands fix" --type LORA --limit 5
+```
+
+Text queries route through Meilisearch; combining `--query` with `--type`
+/ `--base-model` / `--tag` / `--username` works. REST is used only for
+`--ids` / `--favorites`.
+
+### Recipe 3 — Mine working prompts (image or video)
+
+```bash
+python3 ${HERMES_SKILL_DIR}/scripts/show.py prompts 257749 --limit 5
+```
+
+Auto-resolves latest version. Returns prompts, negatives, sampler/steps/
+CFG/seed, and stacked LoRAs. Works identically for video models.
+
+### Recipe 4 — Identify a local .safetensors
+
+```bash
+python3 ${HERMES_SKILL_DIR}/scripts/show.py hash E837144C55
+```
+
+Accepts SHA256, AutoV2 (10-char prefix), CRC32, or BLAKE3 (auto-uppercased).
+
+### Recipe 5 — ComfyUI download command
+
+```bash
+python3 ${HERMES_SKILL_DIR}/scripts/download.py 257749 --comfyui-path "D:/ComfyUI/models"
+```
+
+**Agent: forward `civitai.comfyui_path` from the skill activation message
+as `--comfyui-path` when set.** The script doesn't read `config.yaml`. If
+unset, output uses a `<COMFYUI_PATH>` placeholder. Emits `curl`, `wget`,
+and PowerShell variants — references `$CIVITAI_API_KEY` by name, never
+prints the value. `--version-id` overrides "latest".
+
+### Recipe 6 — Media for a model (images or videos)
+
+```bash
+# Image or video model — same command, returns whatever the model produced
+python3 ${HERMES_SKILL_DIR}/scripts/search.py images --model-id <id> --has-meta --limit 5
+# Include NSFW
+python3 ${HERMES_SKILL_DIR}/scripts/search.py images --model-id <id> --has-meta --nsfw
+# Force one media type
+python3 ${HERMES_SKILL_DIR}/scripts/search.py images --model-id <id> --content-type video --has-meta
+```
+
+`--model-id` auto-resolves to the latest version — see Pitfalls #2.
+
+### Workflow A — Find best LoRA → mine prompts → download
+
+```bash
+python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --type LORA --base-model "Flux.1 D" --period Week --limit 10
+python3 ${HERMES_SKILL_DIR}/scripts/show.py model <ID>
+python3 ${HERMES_SKILL_DIR}/scripts/show.py prompts <ID> --limit 3
+python3 ${HERMES_SKILL_DIR}/scripts/download.py <ID> --comfyui-path "<configured-path-or-omit>"
+```
+
+### Workflow B — Compare popularity across base models
+
+```bash
+python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --type Checkpoint --base-model "Flux.1 D" --period Month --limit 20
+python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --type Checkpoint --base-model "SDXL 1.0" --period Month --limit 20
+```
+
+### Delivering media
+
+After fetching image or video URLs, append `[[as_document]]` to the final
+response so Hermes delivers media as file attachments — quality matters
+for AI media, and inline previews compress lossily (or, for video, may
+not play at all).
+
+## Enum cheat sheet
+
+### Model Types (`--type`)
+
+`Checkpoint`, `LORA`, `LoCon`, `DoRA`, `TextualInversion`, `Hypernetwork`,
+`Controlnet`, `Poses`, `AestheticGradient`, `Wildcards`, `MotionModule`,
+`VAE`, `Upscaler`, `Workflows`, `Detection`, `Other`.
+
+### Base Models (`--base-model`)
+
+| Family | Values |
+|---|---|
+| SD 1.x | `SD 1.4`, `SD 1.5`, `SD 1.5 LCM`, `SD 1.5 Hyper` |
+| SD 2.x | `SD 2.0`, `SD 2.1` |
+| SDXL | `SDXL 1.0`, `SDXL Lightning`, `SDXL Hyper` |
+| Flux | `Flux.1 S`, `Flux.1 D`, `Flux.1 Krea`, `Flux.1 Kontext`, `Flux.2 D`, `Flux.2 Klein 9B/4B` |
+| Anime | `Pony`, `Pony V7`, `Illustrious`, `NoobAI`, `Anima` |
+| Z-Image | `ZImageBase`, `ZImageTurbo` |
+| Other | `Qwen`, `Chroma`, `HiDream`, `AuraFlow`, `Hunyuan 1`, `Kolors`, `PixArt a/E`, `Lumina` |
+| Video | `CogVideoX`, `Hunyuan Video`, `LTXV`, `LTXV2`, `Mochi`, `Wan Video 1.3B/14B/2.2/2.5` |
+
+### Sort (`--sort`)
+
+- **Models (Meilisearch):** `Most Downloaded`, `Highest Rated`, `Most Collected`, `Most Comments`, `Most Tipped`, `Newest`, `Oldest`
+- **Models (REST fallback):** only `Highest Rated`, `Most Downloaded`, `Newest` (others silently downgraded)
+- **Images:** `Most Reactions`, `Most Comments`, `Most Collected`, `Newest`, `Oldest`
+
+### Period (`--period`)
+
+`AllTime`, `Year`, `Month`, `Week`, `Day`.
+
+### Content Type (`--content-type`)
+
+`image`, `video` (image commands only).
+
+### ComfyUI folder map (`download.py`)
+
+`Checkpoint`→`checkpoints/`, `LORA`/`LoCon`/`DoRA`→`loras/`,
+`TextualInversion`→`embeddings/`, `Controlnet`→`controlnet/`,
+`VAE`→`vae/`, `Upscaler`→`upscale_models/`,
+`Hypernetwork`→`hypernetworks/`, `Poses`→`poses/`, others→`other/`.
+
+## Pitfalls
+
+1. **REST text-search is broken (since May 2025).** `GET /models?query=...`
+   returns empty; `search.py models --query ...` auto-routes to Meilisearch.
+   REST is only used for `--ids` / `--favorites`. If a `--query` search
+   comes back empty, try `--username` — most reliable filter.
+
+2. **`/images?modelId=...` is silently ignored — only `modelVersionId`
+   works.** `search.py images --model-id <ID>` and `show.py prompts <ID>`
+   both auto-resolve to the latest version and emit
+   `# resolved model <ID> → version <VID>` on stderr. For an older version,
+   call `show.py model <ID>` first to list versions, then pass
+   `--model-version-id`.
+
+3. **`--browsing-level` is a bitmask.** `X,XXX` → 24; `all` → 31. Levels
+   not in the OR are excluded.
+
+4. **`get_creators` / `get_tags` aren't exposed** — those endpoints are
+   slow (30s+) and frequently 500. Use `search.py models --username "name"`
+   for creators; `search.py top-images --tag "anime"` for tag discovery.
+
+5. **Meilisearch key is Civitai's public frontend key.** The hardcoded
+   `MEILI_KEY` in `_common.py` is the search-only key shipped in
+   civitai.com's JS bundle — every visitor's browser receives it. Not a
+   secret, not tied to any account; that's why model search works without
+   `$CIVITAI_API_KEY`. Civitai rotates it occasionally.
+
+   **If a Meili call fails with `meilisearch http 401/403`, the key has
+   rotated.** Recovery: open <https://civitai.com>, DevTools → Network,
+   filter `multi-search`, trigger a search, click the POST to
+   `search-new.civitai.com/multi-search`, and copy the value after
+   `Authorization: Bearer` (64-char hex). Update `MEILI_KEY` in
+   `scripts/_common.py`, **or** set `MEILISEARCH_KEY=<new_key>` in the
+   Hermes env file (env wins). For remote sandboxes, add
+   `MEILISEARCH_KEY` to `terminal.env_passthrough` in `config.yaml`.
+
+   Sanity-check:
+
+   ```bash
+   curl -X POST https://search-new.civitai.com/multi-search \
+     -H "Authorization: Bearer <new_key>" -H "Content-Type: application/json" \
+     -d '{"queries":[{"q":"test","indexUid":"models_v9","limit":1}]}'
+   ```
+
+   `results` in response = live; another 401/403 = wrong string copied.
+
+6. **Don't fan out parallel API calls — Civitai rate-limits aggressively.**
+   20+ parallel `show.py model <id>` invocations (concurrent.futures,
+   repeated `execute_code` shells, etc.) reliably hit 429/502. Scripts
+   retry with backoff (3 attempts, ~8s) but parallel callers collide on
+   backoff windows and most still fail. Better patterns:
+
+   1. **Batch fetch with `--ids`** — `/models` accepts up to 100 IDs per
+      call and returns full `modelVersions` per model. Use this for any
+      list of IDs from a search. **Pass `--nsfw` if any IDs may be NSFW** —
+      flags don't carry between calls; without it Civitai silently drops
+      NSFW models and the script warns which IDs are missing.
+
+      ```bash
+      python3 ${HERMES_SKILL_DIR}/scripts/search.py models --ids "1,2,3,...,27" --limit 100 --json --nsfw
+      ```
+
+   2. **Serial loop** — if batch isn't an option (e.g. `show.py prompts`
+      per version), one shell at a time with a small `sleep`:
+
+      ```bash
+      for id in 1 2 3; do
+        python3 ${HERMES_SKILL_DIR}/scripts/show.py model $id --json
+        sleep 1
+      done
+      ```
+
+   Rule of thumb: **one Civitai shell process at a time**.
+
+7. **`show.py … --json` and `search.py models --ids --json` are slimmed.**
+   Raw `/models/{id}` payloads can exceed 100 KB (HTML descriptions, image
+   arrays, six hash formats); a 16-ID batch easily hits 600 KB+. Hermes's
+   terminal cap is ~20-50 KB; oversized JSON gets truncated mid-stream and
+   breaks `json.loads` — this caused the historical "5/22 parse" bug.
+
+   Since v1.1.0, `show.py {model,version,prompts} --json` and
+   `search.py models --ids --json` route through `slim_*` helpers that
+   strip HTML descriptions, per-version `images` arrays, all hashes except
+   SHA256/AutoV2, non-LoRA `resources` (prompts), and versions beyond #20
+   (a `_versions_truncated: true` flag surfaces when clipped). Preserved:
+   id/name/type/stats/creator/tags, per-version id/name/baseModel/
+   trainedWords, full file info (name, sizeKB, primary, scan results,
+   hashes, downloadUrl). For the raw payload, `web_fetch
+   https://civitai.com/api/v1/models/<id>` to a file — don't capture
+   through `terminal` stdout.
+
+## Safety
+
+- **Store `CIVITAI_API_KEY` in `.env` only.** Scripts read from
+  environment, never echo the value.
+- **`download.py` shell-escapes untrusted strings.** Filenames, URLs,
+  target paths wrapped with `shlex.quote()` (bash) / PowerShell
+  single-quote literals. Only `$CIVITAI_API_KEY` is unquoted, so the
+  shell expands it at run time.
+- **Append `[[as_document]]`** for image/video previews so Hermes delivers
+  them as file attachments rather than lossy inline previews.
+- **Treat unfamiliar models with caution.** `show.py version <vid>` shows
+  `pickleScanResult` and `virusScanResult`. If either is not `Success`,
+  warn the user before generating a download command.
+
+## Verification
+
+```bash
+# Quick check
+python3 ${HERMES_SKILL_DIR}/scripts/search.py top-models --type LORA --base-model "Flux.1 D" --limit 1
+# Comprehensive
+python3 ${HERMES_SKILL_DIR}/scripts/health_check.py
+```
+
+Quick check expects one LoRA card (`#ID`, name, creator, base model,
+downloads, tags). Errors: `auth failed` = key invalid;
+`meilisearch http 401` = Meili key rotated (Pitfalls #5);
+`network error after retries` = host unreachable. SFW results work
+without env vars. `health_check.py` runs static + network + auth +
+functional checks; exits 0 on success.

--- a/optional-skills/creative/civitai/scripts/_common.py
+++ b/optional-skills/creative/civitai/scripts/_common.py
@@ -1,0 +1,300 @@
+"""Civitai skill — shared helpers (HTTP, Meilisearch, formatting)."""
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_BASE = "https://civitai.com/api/v1"
+MEILI_URL = "https://search-new.civitai.com/multi-search"
+
+# NOTE FOR SECURITY SCANNERS:
+# The 64-char hex string below is NOT a secret. It is Civitai's public
+# Meilisearch search-only key, embedded in the JavaScript bundle that every
+# browser visiting civitai.com downloads. It is not tied to any account and
+# is the documented way to query Civitai's search index. If it rotates, the
+# user can override it via the MEILISEARCH_KEY env var — see SKILL.md
+# Pitfalls #5 for the recovery procedure.
+_MEILI_PUBLIC_KEY = "8c46eb2508e21db1e9828a97968d91ab1ca1caa5f70a00e88a2ba1e286603b61"
+MEILI_KEY = os.environ.get("MEILISEARCH_KEY") or _MEILI_PUBLIC_KEY
+
+UA = "civitai-skill/1.0"
+
+SORT_MAP = {
+    "Most Downloaded": "metrics.downloadCount:desc",
+    "Highest Rated":   "metrics.thumbsUpCount:desc",
+    "Most Collected":  "metrics.collectedCount:desc",
+    "Most Comments":   "metrics.commentCount:desc",
+    "Most Tipped":     "metrics.tippedAmountCount:desc",
+    "Newest":          "createdAt:desc",
+    "Oldest":          "createdAt:asc",
+}
+
+ATTRS = [
+    "id", "name", "type", "nsfw", "nsfwLevel", "metrics", "user",
+    "triggerWords", "tags", "version", "createdAt",
+]
+
+BROWSING_LEVEL_MAP = {
+    "PG": 1, "PG-13": 2, "PG13": 2, "R": 4, "X": 8, "XXX": 16,
+}
+
+
+def die(msg, code=2):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def _esc(s):
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _coerce(v):
+    """Coerce a query-param value to the form urlencode expects."""
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    if isinstance(v, list):
+        return [str(x) for x in v]
+    return str(v)
+
+
+def api_get(path, params=None):
+    url = f"{API_BASE}/{path.lstrip('/')}"
+    if params:
+        clean = {k: _coerce(v) for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean, doseq=True)
+
+    headers = {"User-Agent": UA}
+    key = os.environ.get("CIVITAI_API_KEY", "")
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+
+    for attempt in range(3):
+        try:
+            req = urllib.request.Request(url, headers=headers)
+            with urllib.request.urlopen(req, timeout=30) as r:
+                return json.loads(r.read())
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 502, 503, 504) and attempt < 2:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            if e.code == 404:
+                die(f"not found: {path}")
+            if e.code in (401, 403):
+                die("auth failed — check CIVITAI_API_KEY")
+            if e.code == 429:
+                die("rate limited, try again later")
+            die(f"http {e.code}: {e.read()[:200].decode(errors='replace')}")
+        except urllib.error.URLError:
+            if attempt < 2:
+                time.sleep(2 ** attempt)
+                continue
+            die("network error after retries")
+    die("retries exhausted")
+
+
+def meili_search(q, types=None, base_model=None, tag=None, username=None,
+                 sort="Most Downloaded", nsfw=None, limit=20, offset=0):
+    f = []
+    if types:
+        c = [f'type = "{_esc(t)}"' for t in types]
+        f.append(c[0] if len(c) == 1 else "(" + " OR ".join(c) + ")")
+    if base_model:
+        f.append(f'version.baseModel = "{_esc(base_model)}"')
+    if tag:
+        f.append(f'tags.name = "{_esc(tag.lower())}"')
+    if username:
+        f.append(f'user.username = "{_esc(username)}"')
+    if nsfw is False:
+        f.append("nsfwLevel = 1")
+
+    inner = {
+        "q": q or "",
+        "indexUid": "models_v9",
+        "limit": min(limit, 100),
+        "offset": offset,
+        "sort": [SORT_MAP.get(sort, "metrics.downloadCount:desc")],
+        "attributesToRetrieve": ATTRS,
+    }
+    if f:
+        inner["filter"] = " AND ".join(f)
+
+    body = json.dumps({"queries": [inner]}).encode()
+    req = urllib.request.Request(
+        MEILI_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {MEILI_KEY}",
+            "Content-Type": "application/json",
+            "User-Agent": UA,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return json.loads(r.read())["results"][0]
+    except urllib.error.HTTPError as e:
+        die(f"meilisearch http {e.code}: {e.read()[:200].decode(errors='replace')}")
+    except urllib.error.URLError:
+        die("network error reaching Meilisearch")
+
+
+def parse_browsing_level(s):
+    if not s or s.lower() == "all":
+        return 31
+    m = 0
+    for part in s.upper().replace(" ", "").split(","):
+        m |= BROWSING_LEVEL_MAP.get(part, 0)
+    return m or 31
+
+
+def fmt_size(kb):
+    try:
+        kb = float(kb)
+    except (TypeError, ValueError):
+        return "?"
+    if kb >= 1024 * 1024:
+        return f"{kb / 1024 / 1024:.2f} GB"
+    if kb >= 1024:
+        return f"{kb / 1024:.1f} MB"
+    return f"{kb:.0f} KB"
+
+
+def fmt_int(n):
+    try:
+        return f"{int(n):,}"
+    except (TypeError, ValueError):
+        return str(n)
+
+
+def truncate(s, n=500):
+    if not s:
+        return ""
+    s = str(s).replace("\r\n", " ").replace("\n", " ").strip()
+    return s if len(s) <= n else s[:n].rstrip() + "…"
+
+
+def emit_json(data):
+    print(json.dumps(data, indent=2, default=str))
+
+
+# --------------------------------------------------------------------------- #
+# JSON slimming helpers — shared by show.py and search.py
+#
+# Hermes terminal transport caps stdout around 20-50 KB; raw Civitai /models
+# payloads can exceed 100 KB per model (HTML descriptions, per-version image
+# arrays, six redundant hash formats). When --ids fetches 16+ models in one
+# call, the response easily reaches 600 KB+. Oversized JSON gets truncated
+# mid-stream and breaks json.loads downstream. These helpers strip everything
+# an agent doesn't need from --json output so it stays well under the cap.
+# --------------------------------------------------------------------------- #
+
+MAX_VERSIONS_IN_JSON = 20
+
+
+def slim_files(files):
+    """Trim each file dict to fields agents consume.
+
+    Keeps only SHA256 + AutoV2 hashes (drops AutoV1, AutoV3, CRC32, BLAKE3).
+    """
+    out = []
+    for f in (files or []):
+        raw = f.get("hashes") or {}
+        hashes = {k: raw[k] for k in ("SHA256", "AutoV2") if raw.get(k)}
+        out.append({
+            "name":             f.get("name"),
+            "sizeKB":           f.get("sizeKB"),
+            "type":             f.get("type"),
+            "primary":          f.get("primary"),
+            "pickleScanResult": f.get("pickleScanResult"),
+            "virusScanResult":  f.get("virusScanResult"),
+            "hashes":           hashes,
+            "downloadUrl":      f.get("downloadUrl"),
+        })
+    return out
+
+
+def slim_model(m):
+    """Compact /models/{id} payload safe for terminal stdout.
+
+    Drops HTML description blob and per-version image arrays; caps versions
+    at MAX_VERSIONS_IN_JSON. Surfaces a _versions_truncated flag so callers
+    can detect clipped models. Used by show.py model and by search.py models
+    when --json is set on a REST path (--ids or non-query search).
+    """
+    raw_versions = m.get("modelVersions") or []
+    truncated = len(raw_versions) > MAX_VERSIONS_IN_JSON
+    versions_slim = []
+    for v in raw_versions[:MAX_VERSIONS_IN_JSON]:
+        versions_slim.append({
+            "id":           v.get("id"),
+            "name":         v.get("name"),
+            "baseModel":    v.get("baseModel"),
+            "createdAt":    v.get("createdAt"),
+            "publishedAt":  v.get("publishedAt"),
+            "status":       v.get("status"),
+            "trainedWords": v.get("trainedWords"),
+            "files":        slim_files(v.get("files")),
+        })
+    return {
+        "id":                  m.get("id"),
+        "name":                m.get("name"),
+        "type":                m.get("type"),
+        "nsfw":                m.get("nsfw"),
+        "stats":               m.get("stats"),
+        "creator":             m.get("creator"),
+        "tags":                m.get("tags"),
+        "modelVersions":       versions_slim,
+        "_versions_truncated": truncated,
+    }
+
+
+def slim_version(v):
+    """Compact single-version payload for --json (show.py version)."""
+    pm = v.get("model") or {}
+    return {
+        "id":           v.get("id"),
+        "modelId":      v.get("modelId"),
+        "name":         v.get("name"),
+        "baseModel":    v.get("baseModel"),
+        "trainedWords": v.get("trainedWords"),
+        "model":        {"name": pm.get("name"), "type": pm.get("type")},
+        "files":        slim_files(v.get("files")),
+    }
+
+
+def slim_prompt_image(im):
+    """Compact image entry for prompt-mining --json (show.py prompts)."""
+    meta = im.get("meta") or {}
+    stats = im.get("stats") or {}
+    user = im.get("username") or (im.get("user") or {}).get("username")
+    reactions = sum(stats.get(k, 0) for k in
+                    ("heartCount", "likeCount", "laughCount", "cryCount"))
+    loras = []
+    for r in (meta.get("resources") or []):
+        if (r.get("type") or "").lower() in ("lora", "locon", "dora"):
+            loras.append({
+                "name":   r.get("name"),
+                "type":   r.get("type"),
+                "weight": r.get("weight"),
+            })
+    return {
+        "id":        im.get("id"),
+        "username":  user,
+        "reactions": reactions,
+        "baseModel": im.get("baseModel"),
+        "url":       f"https://civitai.com/images/{im.get('id', '')}",
+        "meta": {
+            "prompt":         meta.get("prompt"),
+            "negativePrompt": meta.get("negativePrompt"),
+            "steps":          meta.get("steps"),
+            "sampler":        meta.get("sampler"),
+            "cfgScale":       meta.get("cfgScale"),
+            "seed":           meta.get("seed"),
+            "resources":      loras,
+        },
+    }

--- a/optional-skills/creative/civitai/scripts/download.py
+++ b/optional-skills/creative/civitai/scripts/download.py
@@ -1,0 +1,150 @@
+"""civitai download: emit curl/wget/PowerShell commands for ComfyUI.
+
+The agent is responsible for forwarding `civitai.comfyui_path` (from the skill
+activation message) as `--comfyui-path`. This script does NOT read config.yaml
+itself — see SKILL.md Recipe 5.
+
+Untrusted strings (filenames, URLs, target paths from the API) are escaped:
+  - bash (curl/wget):   shlex.quote() — wraps with single quotes, neutralizing $ and `
+  - PowerShell:         literal single-quoted strings with '' doubling
+The $CIVITAI_API_KEY (or $env:CIVITAI_API_KEY) reference is the ONLY token left
+unquoted, so the shell still expands it at run time.
+"""
+import argparse
+import shlex
+
+from _common import api_get, fmt_size, die, emit_json
+
+COMFYUI_FOLDER_MAP = {
+    "Checkpoint":        "checkpoints",
+    "LORA":              "loras",
+    "LoCon":             "loras",
+    "DoRA":              "loras",
+    "TextualInversion":  "embeddings",
+    "Hypernetwork":      "hypernetworks",
+    "Controlnet":        "controlnet",
+    "VAE":               "vae",
+    "Upscaler":          "upscale_models",
+    "Poses":             "poses",
+    "AestheticGradient": "aesthetic_gradients",
+    "MotionModule":      "animatediff_motion_lora",
+    "Wildcards":         "wildcards",
+}
+
+
+def _ps_quote(s):
+    """Wrap a string as a PowerShell single-quoted literal (no interpolation).
+
+    PowerShell escapes a literal single quote by doubling it: 'don''t'.
+    """
+    return "'" + str(s).replace("'", "''") + "'"
+
+
+def main():
+    p = argparse.ArgumentParser(
+        prog="download.py",
+        description="Emit shell commands to download a Civitai model into ComfyUI.",
+    )
+    p.add_argument("model_id", type=int)
+    p.add_argument("--version-id", type=int,
+                   help="Specific version (default: latest)")
+    p.add_argument(
+        "--comfyui-path",
+        default="",
+        help=("ComfyUI models root, e.g. D:/ComfyUI/models. The agent should "
+              "pass the configured civitai.comfyui_path here when set; "
+              "otherwise output uses a <COMFYUI_PATH> placeholder."),
+    )
+    p.add_argument("--format", choices=["all", "curl", "wget", "ps"],
+                   default="all")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args()
+
+    m = api_get(f"models/{args.model_id}")
+    mtype = m.get("type", "Other")
+    name = m.get("name", "?")
+    versions = m.get("modelVersions") or []
+    if not versions:
+        die(f"model {args.model_id} has no versions")
+
+    if args.version_id:
+        v = next((x for x in versions if x.get("id") == args.version_id), None)
+        if v is None:
+            die(f"version {args.version_id} not found on model {args.model_id}")
+    else:
+        v = versions[0]
+
+    vid = v.get("id")
+    files = v.get("files") or []
+    if not files:
+        die(f"version {vid} has no files")
+
+    subfolder = COMFYUI_FOLDER_MAP.get(mtype, "other")
+    base = (args.comfyui_path or "<COMFYUI_PATH>").rstrip("/\\").replace("\\", "/")
+
+    payload = []
+    for f in files:
+        target = f"{base}/{subfolder}/{f.get('name', '?')}"
+        payload.append({
+            "filename":    f.get("name", "?"),
+            "size_kb":     f.get("sizeKB"),
+            "primary":     bool(f.get("primary")),
+            "target":      target,
+            "url":         f.get("downloadUrl", "?"),
+            "hashes":      f.get("hashes") or {},
+            "pickle_scan": f.get("pickleScanResult", "?"),
+            "virus_scan":  f.get("virusScanResult", "?"),
+        })
+
+    if args.json:
+        emit_json({
+            "model_id":     args.model_id,
+            "name":         name,
+            "type":         mtype,
+            "version_id":   vid,
+            "version_name": v.get("name", "?"),
+            "subfolder":    subfolder,
+            "files":        payload,
+        })
+        return
+
+    print(f"Download commands for #{args.model_id} \"{name}\"")
+    print(f"Version #{vid} \"{v.get('name', '?')}\" · type: {mtype} · "
+          f"subfolder: {subfolder}/")
+    if not args.comfyui_path:
+        print("# (no --comfyui-path provided — using placeholder <COMFYUI_PATH>; "
+              "agent should forward civitai.comfyui_path when configured)")
+    print()
+
+    # The auth header is hardcoded (no API data) — we WANT shell variable
+    # expansion of $CIVITAI_API_KEY, so we leave it unquoted/unescaped.
+    auth_bash = '"Authorization: Bearer $CIVITAI_API_KEY"'
+
+    for f in payload:
+        flag = " [PRIMARY]" if f["primary"] else ""
+        print(f"# {f['filename']}{flag} — {fmt_size(f['size_kb'])}")
+        if f["hashes"].get("AutoV2"):
+            print(f"# AutoV2: {f['hashes']['AutoV2']}")
+        if f["hashes"].get("SHA256"):
+            print(f"# SHA256: {f['hashes']['SHA256']}")
+        print(f"# Scan: pickle={f['pickle_scan']} · virus={f['virus_scan']}")
+
+        url, tgt = f["url"], f["target"]
+        url_sh = shlex.quote(url)
+        tgt_sh = shlex.quote(tgt)
+        url_ps = _ps_quote(url)
+        tgt_ps = _ps_quote(tgt)
+
+        if args.format in ("all", "curl"):
+            print(f"curl -L -H {auth_bash} -o {tgt_sh} {url_sh}")
+        if args.format in ("all", "wget"):
+            print(f"wget --header={auth_bash} -O {tgt_sh} {url_sh}")
+        if args.format in ("all", "ps"):
+            print(f'Invoke-WebRequest -Uri {url_ps} '
+                  f'-Headers @{{"Authorization"="Bearer $env:CIVITAI_API_KEY"}} '
+                  f'-OutFile {tgt_ps}')
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/civitai/scripts/health_check.py
+++ b/optional-skills/creative/civitai/scripts/health_check.py
@@ -1,0 +1,283 @@
+"""civitai skill — health check. Static + network + auth + functional + config.
+
+Usage:
+  python3 health_check.py                     # full check
+  python3 health_check.py --offline           # static only (no network)
+  python3 health_check.py --json              # structured output
+  python3 health_check.py --comfyui-path PATH # also verify ComfyUI dir layout
+
+Exits 0 if all checks pass (skips allowed), 1 if any fail. Designed to be
+runnable both interactively and from CI / installer post-hooks.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = ["_common.py", "search.py", "show.py", "download.py"]
+SAFE_MODEL_ID = 257749       # "Realistic Vision V6.0" — stable SFW sentinel
+SAFE_HASH = "E837144C55"     # AutoV2 hash of the above
+MEILI_DEFAULT_KEY = "8c46eb2508e21db1e9828a97968d91ab1ca1caa5f70a00e88a2ba1e286603b61"
+SYMBOL = {"ok": "  ok  ", "skip": " skip ", "fail": " FAIL "}
+
+
+def _c(group, name, status, detail=""):
+    return {"group": group, "name": name, "status": status, "detail": detail}
+
+
+def _http(url, key=None, body=None, timeout=12):
+    t0 = time.time()
+    headers = {"User-Agent": "civitai-skill-healthcheck/1.0"}
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    if body:
+        headers["Content-Type"] = "application/json"
+    try:
+        req = urllib.request.Request(url, data=body, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, int((time.time() - t0) * 1000), r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, int((time.time() - t0) * 1000), e.read()
+    except urllib.error.URLError as e:
+        return None, int((time.time() - t0) * 1000), str(e).encode()
+
+
+def static_checks():
+    out = []
+    v = sys.version_info
+    out.append(_c(
+        "Static", "Python ≥ 3.7",
+        "ok" if v >= (3, 7) else "fail",
+        f"got {v.major}.{v.minor}.{v.micro}",
+    ))
+    for s in SCRIPTS:
+        p = os.path.join(HERE, s)
+        if os.path.exists(p):
+            out.append(_c("Static", f"{s} present", "ok"))
+        else:
+            out.append(_c("Static", f"{s} present", "fail", f"missing at {p}"))
+
+    # Importability of _common
+    try:
+        sys.path.insert(0, HERE)
+        __import__("_common")
+        out.append(_c("Static", "_common.py importable", "ok"))
+    except Exception as e:
+        out.append(_c("Static", "_common.py importable", "fail", str(e)))
+
+    # --help on each executable script
+    for s in ("search.py", "show.py", "download.py"):
+        try:
+            r = subprocess.run(
+                [sys.executable, os.path.join(HERE, s), "--help"],
+                capture_output=True, timeout=10,
+            )
+            out.append(_c(
+                "Static", f"{s} --help",
+                "ok" if r.returncode == 0 else "fail",
+                "" if r.returncode == 0 else f"exit {r.returncode}",
+            ))
+        except Exception as e:
+            out.append(_c("Static", f"{s} --help", "fail", str(e)))
+    return out
+
+
+def network_checks():
+    out = []
+    code, ms, _ = _http("https://civitai.com/api/v1/models?limit=1")
+    out.append(_c(
+        "Network", "civitai.com reachable",
+        "ok" if code == 200 else "fail",
+        f"HTTP {code} in {ms}ms" if code else f"network error after {ms}ms",
+    ))
+    code, ms, _ = _http("https://search-new.civitai.com/")
+    # Any HTTP code means the host responded; the root is allowed to 404
+    out.append(_c(
+        "Network", "search-new.civitai.com reachable",
+        "ok" if code is not None else "fail",
+        f"HTTP {code} in {ms}ms" if code else f"network error after {ms}ms",
+    ))
+    return out
+
+
+def auth_checks():
+    key = os.environ.get("CIVITAI_API_KEY")
+    if not key:
+        return [_c("Auth", "CIVITAI_API_KEY", "skip", "unset — SFW-only mode is fine")]
+    code, ms, _ = _http("https://civitai.com/api/v1/models?limit=1", key=key)
+    if code == 200:
+        return [_c("Auth", "CIVITAI_API_KEY", "ok", f"accepted ({ms}ms)")]
+    if code in (401, 403):
+        return [_c(
+            "Auth", "CIVITAI_API_KEY", "fail",
+            f"rejected with HTTP {code} — key is set but invalid",
+        )]
+    return [_c("Auth", "CIVITAI_API_KEY", "fail", f"unexpected HTTP {code}")]
+
+
+def functional_checks():
+    out = []
+    key = os.environ.get("CIVITAI_API_KEY")
+
+    # 1. Known model
+    code, ms, body = _http(
+        f"https://civitai.com/api/v1/models/{SAFE_MODEL_ID}", key=key,
+    )
+    if code == 200:
+        try:
+            name = json.loads(body).get("name", "?")
+            out.append(_c(
+                "Functional", f"GET /models/{SAFE_MODEL_ID}",
+                "ok", f'resolved to "{name}" ({ms}ms)',
+            ))
+        except Exception as e:
+            out.append(_c("Functional", "GET /models", "fail", f"non-JSON: {e}"))
+    else:
+        out.append(_c("Functional", "GET /models", "fail", f"HTTP {code}"))
+
+    # 2. Hash lookup
+    code, _, body = _http(
+        f"https://civitai.com/api/v1/model-versions/by-hash/{SAFE_HASH}", key=key,
+    )
+    if code == 200:
+        try:
+            mid = json.loads(body).get("modelId", "?")
+            out.append(_c("Functional", f"by-hash/{SAFE_HASH}", "ok", f"→ model #{mid}"))
+        except Exception:
+            out.append(_c("Functional", "by-hash", "fail", "non-JSON"))
+    else:
+        out.append(_c(
+            "Functional", "by-hash", "skip",
+            f"HTTP {code} (sentinel may have been retired)",
+        ))
+
+    # 3. Meilisearch
+    mkey = os.environ.get("MEILISEARCH_KEY") or MEILI_DEFAULT_KEY
+    payload = json.dumps({"queries": [{
+        "q": "anime", "indexUid": "models_v9", "limit": 5,
+        "filter": 'type = "LORA"', "sort": ["metrics.downloadCount:desc"],
+    }]}).encode()
+    code, ms, resp = _http(
+        "https://search-new.civitai.com/multi-search",
+        key=mkey, body=payload,
+    )
+    if code == 200:
+        try:
+            hits = json.loads(resp)["results"][0].get("hits", [])
+            out.append(_c(
+                "Functional", "Meilisearch 'anime'+LORA",
+                "ok" if hits else "fail",
+                f"{len(hits)} hits ({ms}ms)",
+            ))
+        except Exception as e:
+            out.append(_c("Functional", "Meilisearch", "fail", f"parse: {e}"))
+    else:
+        out.append(_c("Functional", "Meilisearch", "fail", f"HTTP {code}"))
+
+    # 4. download.py emit + key-leak guard
+    try:
+        r = subprocess.run(
+            [sys.executable, os.path.join(HERE, "download.py"),
+             str(SAFE_MODEL_ID), "--format", "curl"],
+            capture_output=True, text=True, timeout=20,
+        )
+        if r.returncode != 0:
+            out.append(_c(
+                "Functional", "download.py emits", "fail",
+                f"exit {r.returncode}: {r.stderr[:120]}",
+            ))
+        elif "curl -L" not in r.stdout:
+            out.append(_c("Functional", "download.py emits", "fail", "no curl line"))
+        elif key and key in r.stdout:
+            # Key VALUE leaked — critical security failure
+            out.append(_c(
+                "Functional", "download.py emits", "fail",
+                "KEY VALUE LEAKED in output — abort install!",
+            ))
+        else:
+            out.append(_c(
+                "Functional", "download.py emits", "ok",
+                "curl/wget/ps lines emit, no key leak",
+            ))
+    except Exception as e:
+        out.append(_c("Functional", "download.py emits", "fail", str(e)))
+    return out
+
+
+def config_checks(path):
+    if not path:
+        return []
+    if not os.path.isdir(path):
+        return [_c(
+            "Config", f"--comfyui-path {path}", "fail",
+            "directory does not exist",
+        )]
+    missing = [
+        s for s in ("checkpoints", "loras")
+        if not os.path.isdir(os.path.join(path, s))
+    ]
+    if missing:
+        return [_c(
+            "Config", f"--comfyui-path {path}", "skip",
+            f"missing subfolders: {missing}",
+        )]
+    return [_c(
+        "Config", f"--comfyui-path {path}", "ok",
+        "checkpoints/, loras/ present",
+    )]
+
+
+def _emit_text(checks):
+    by_group = {}
+    for c in checks:
+        by_group.setdefault(c["group"], []).append(c)
+    print("Civitai Skill — Health Check\n" + "=" * 28)
+    for g, items in by_group.items():
+        print(f"\n[{g}]")
+        for c in items:
+            line = f"{SYMBOL[c['status']]} {c['name']}"
+            if c["detail"]:
+                line += f" — {c['detail']}"
+            print(line)
+    ok = sum(1 for c in checks if c["status"] == "ok")
+    sk = sum(1 for c in checks if c["status"] == "skip")
+    fl = sum(1 for c in checks if c["status"] == "fail")
+    print(f"\nSummary: {ok} ok, {sk} skip, {fl} fail")
+
+
+def main():
+    p = argparse.ArgumentParser(
+        prog="health_check.py",
+        description="Civitai skill health check (static, network, auth, functional, config).",
+    )
+    p.add_argument("--offline", action="store_true",
+                   help="Skip network/auth/functional")
+    p.add_argument("--json", action="store_true",
+                   help="Emit JSON instead of text")
+    p.add_argument("--comfyui-path",
+                   help="Also verify this ComfyUI models path")
+    args = p.parse_args()
+
+    checks = static_checks()
+    if not args.offline:
+        net = network_checks()
+        checks += net
+        if any(c["status"] == "ok" for c in net):
+            checks += auth_checks()
+            checks += functional_checks()
+    checks += config_checks(args.comfyui_path)
+
+    if args.json:
+        print(json.dumps(checks, indent=2))
+    else:
+        _emit_text(checks)
+    sys.exit(0 if all(c["status"] != "fail" for c in checks) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/civitai/scripts/search.py
+++ b/optional-skills/creative/civitai/scripts/search.py
@@ -1,0 +1,319 @@
+"""civitai search: models / images / top-models / top-images."""
+import argparse
+import os
+import sys
+
+from _common import (
+    api_get, meili_search, parse_browsing_level,
+    fmt_int, truncate, die, emit_json, slim_model,
+)
+
+MODEL_TYPES = [
+    "Checkpoint", "LORA", "LoCon", "DoRA", "TextualInversion", "Hypernetwork",
+    "Controlnet", "Poses", "AestheticGradient", "Wildcards", "MotionModule",
+    "VAE", "Upscaler", "Workflows", "Detection", "Other",
+]
+PERIODS = ["AllTime", "Year", "Month", "Week", "Day"]
+MODEL_SORTS = [
+    "Most Downloaded", "Highest Rated", "Most Collected", "Most Comments",
+    "Most Tipped", "Newest", "Oldest",
+]
+IMAGE_SORTS = [
+    "Most Reactions", "Most Comments", "Most Collected", "Newest", "Oldest",
+]
+REST_SORTS = {"Highest Rated", "Most Downloaded", "Newest"}
+
+
+def _has_key():
+    return bool(os.environ.get("CIVITAI_API_KEY"))
+
+
+def _g(args, k, d=None):
+    return getattr(args, k, d)
+
+
+def _print_list(items, fmt, header):
+    if not items:
+        print("No results.")
+        return
+    print(f"{header} · {len(items)}\n")
+    print("\n\n".join(fmt(i, x) for i, x in enumerate(items, 1)) + "\n")
+
+
+def _fmt_model(idx, h):
+    metrics = h.get("metrics") or h.get("stats") or {}
+    user = h.get("user") or h.get("creator") or {}
+    version = h.get("version") or ((h.get("modelVersions") or [{}])[0])
+    trig = h.get("triggerWords") or version.get("trainedWords") or []
+    tags = h.get("tags") or []
+
+    out = [
+        f"{idx}. #{h.get('id', '?')} \"{h.get('name', '?')}\" by {user.get('username', '?')}",
+        f"   {h.get('type', '?')} · base: {version.get('baseModel', '?')} · "
+        f"↓ {fmt_int(metrics.get('downloadCount', 0))} · "
+        f"★ {fmt_int(metrics.get('thumbsUpCount', 0))}",
+    ]
+    if trig:
+        out.append(f"   trigger: {', '.join(str(w) for w in trig[:5])}")
+    if tags:
+        tn = [t.get("name", "?") if isinstance(t, dict) else str(t) for t in tags[:5]]
+        out.append(f"   tags: {', '.join(tn)}")
+    return "\n".join(out)
+
+
+def _fmt_image(idx, im):
+    iid = im.get("id", "?")
+    user = im.get("username") or (im.get("user") or {}).get("username", "?")
+    stats = im.get("stats") or {}
+    react = sum(stats.get(k, 0) for k in ("heartCount", "likeCount", "laughCount", "cryCount"))
+    meta = im.get("meta") or {}
+
+    def _names(seq, n):
+        return [t.get("name") if isinstance(t, dict) else str(t)
+                for t in (seq or [])[:n]]
+
+    sub = []
+    for label, key in (("Tools", "tools"), ("Technique", "techniques")):
+        names = _names(im.get(key), 3)
+        if names:
+            sub.append(f"{label}: {', '.join(names)}")
+    sub.append(f"Base: {im.get('baseModel', '?')}")
+
+    out = [
+        f"{idx}. Image #{iid} by {user} · {fmt_int(react)} reactions",
+        "   " + " · ".join(sub),
+    ]
+    if meta.get("prompt"):
+        out.append(f"   Prompt: {truncate(meta['prompt'], 300)}")
+    if meta.get("negativePrompt"):
+        out.append(f"   Negative: {truncate(meta['negativePrompt'], 200)}")
+    p = [f"{k}: {meta[k]}"
+         for k in ("steps", "sampler", "cfgScale", "seed")
+         if meta.get(k) is not None]
+    if p:
+        out.append("   " + " · ".join(p))
+
+    loras = []
+    for r in (meta.get("resources") or []):
+        if (r.get("type") or "").lower() in ("lora", "locon", "dora"):
+            w = r.get("weight")
+            loras.append(f"{r.get('name', '?')}" + (f" ({w})" if w is not None else ""))
+    if loras:
+        out.append(f"   LoRAs: {', '.join(loras[:5])}")
+    out.append(f"   URL: https://civitai.com/images/{iid}")
+    return "\n".join(out)
+
+
+def _nsfw_flag(args):
+    """Resolve --nsfw into the tri-state expected by the API helpers.
+
+    True  → include NSFW (requires a valid CIVITAI_API_KEY)
+    False → forced SFW (either user passed nothing, or --nsfw without a key)
+    None  → defer to server default
+
+    --nsfw is the single unified opt-in across all four subcommands; there
+    is no --sfw-only because the default already excludes NSFW unless the
+    user asks for it.
+    """
+    if _g(args, "nsfw"):
+        if _has_key():
+            return True
+        print("warning: --nsfw without CIVITAI_API_KEY — SFW results",
+              file=sys.stderr)
+        return False
+    return None
+
+
+def _do_models(args):
+    rest_only = bool(_g(args, "ids") or _g(args, "favorites"))
+    nsfw = _nsfw_flag(args)
+    q = _g(args, "query")
+
+    if q and not rest_only:
+        r = meili_search(
+            q,
+            types=_g(args, "type"),
+            base_model=_g(args, "base_model"),
+            tag=_g(args, "tag"),
+            username=_g(args, "username"),
+            sort=args.sort,
+            nsfw=nsfw,
+            limit=args.limit,
+        )
+        if args.json:
+            emit_json(r)
+            return
+        _print_list(r.get("hits", []), _fmt_model, "Models (Meilisearch)")
+        if r.get("hits"):
+            print(f"— {fmt_int(r.get('estimatedTotalHits', 0))} estimated · "
+                  f"{r.get('processingTimeMs', '?')}ms (Meilisearch)")
+        return
+
+    sort = args.sort if args.sort in REST_SORTS else "Most Downloaded"
+    bm = _g(args, "base_model")
+    raw_ids = _g(args, "ids")
+    params = {
+        "limit":      min(args.limit, 100),
+        "types":      _g(args, "type"),
+        "sort":       sort,
+        "period":     args.period,
+        "username":   _g(args, "username"),
+        "tag":        _g(args, "tag"),
+        "favorites":  _g(args, "favorites") or None,
+        "ids":        raw_ids,
+        "nsfw":       nsfw,
+        "baseModels": [bm] if bm else None,
+    }
+    data = api_get("models", params)
+
+    # Detect Civitai's silent NSFW-drop when --ids was used. The REST endpoint
+    # quietly excludes NSFW models from the response when nsfw isn't true,
+    # without erroring or flagging which IDs were dropped. Diff requested vs
+    # returned and surface the gap so the agent can choose to retry with --nsfw.
+    if raw_ids:
+        try:
+            requested = {int(x.strip()) for x in raw_ids.split(",") if x.strip()}
+        except ValueError:
+            requested = set()
+        returned = {m.get("id") for m in (data.get("items") or []) if m.get("id")}
+        missing = requested - returned
+        if missing and requested:
+            sample = ",".join(str(x) for x in sorted(missing)[:8])
+            more = f" (+{len(missing) - 8} more)" if len(missing) > 8 else ""
+            if not _g(args, "nsfw"):
+                print(
+                    f"warning: {len(missing)}/{len(requested)} requested IDs "
+                    f"missing from response — Civitai silently drops NSFW "
+                    f"models when --nsfw isn't set. Add --nsfw to fetch all. "
+                    f"Missing: {sample}{more}",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"warning: {len(missing)}/{len(requested)} requested IDs "
+                    f"missing from response (deleted, private, or unavailable). "
+                    f"Missing: {sample}{more}",
+                    file=sys.stderr,
+                )
+
+    if args.json:
+        # Slim each model — raw REST payloads can hit 600 KB+ for a 16-ID
+        # batch fetch and blow past the terminal transport cap.
+        items = [slim_model(m) for m in (data.get("items") or [])]
+        emit_json({"items": items, "metadata": data.get("metadata") or {}})
+        return
+    _print_list(data.get("items", []), _fmt_model, "Models (REST)")
+
+
+def _do_images(args):
+    mvid = _g(args, "model_version_id")
+    mid = _g(args, "model_id")
+    if mid and not mvid:
+        m = api_get(f"models/{mid}")
+        versions = m.get("modelVersions") or []
+        if not versions:
+            die(f"model {mid} has no versions")
+        mvid = versions[0]["id"]
+        print(f"# resolved model {mid} → version {mvid}", file=sys.stderr)
+
+    # --nsfw is the unified shorthand across all four subcommands. On image
+    # commands it desugars to --browsing-level X,XXX when no explicit
+    # --browsing-level was given. Explicit --browsing-level always wins so
+    # power users can still filter by individual levels (e.g. R only).
+    bl = _g(args, "browsing_level")
+    if not bl and _g(args, "nsfw"):
+        bl = "X,XXX"
+    if bl and not _has_key() and parse_browsing_level(bl) & 24:
+        print("warning: NSFW without CIVITAI_API_KEY — downgrading to R",
+              file=sys.stderr)
+        bl = "R"
+
+    params = {
+        "modelVersionId": mvid,
+        "username":       _g(args, "username"),
+        "sort":           args.sort,
+        "period":         args.period,
+        "limit":          min(args.limit, 200),
+        "hasMeta":        True if _g(args, "has_meta") else None,
+        "type":           _g(args, "content_type"),
+        "browsingLevel":  parse_browsing_level(bl) if bl else None,
+        "tag":            _g(args, "tag"),
+        "baseModel":      _g(args, "base_model"),
+    }
+    data = api_get("images", params)
+    if args.json:
+        emit_json(data)
+        return
+    _print_list(data.get("items", []), _fmt_image, "Images")
+
+
+def _common_args(x, image=False):
+    x.add_argument("--limit", "-n", type=int, default=5 if image else 10)
+    x.add_argument("--json", action="store_true")
+    x.add_argument("--period", choices=PERIODS, default="Month")
+
+
+def main():
+    p = argparse.ArgumentParser(prog="search.py", description="Search Civitai")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pm = sub.add_parser("models",
+                        help="Search models (Meilisearch w/ query, REST otherwise)")
+    pm.add_argument("--query", "-q")
+    pm.add_argument("--base-model", "-b")
+    pm.add_argument("--username", "-u")
+    pm.add_argument("--tag")
+    pm.add_argument("--type", "-t", action="append", choices=MODEL_TYPES,
+                    help="Repeat for multiple")
+    pm.add_argument("--ids", help="Comma-separated model IDs (REST only)")
+    pm.add_argument("--sort", choices=MODEL_SORTS, default="Most Downloaded")
+    pm.add_argument("--nsfw", action="store_true")
+    pm.add_argument("--favorites", action="store_true")
+    _common_args(pm)
+
+    pi = sub.add_parser("images",
+                        help="Browse images (auto-resolves --model-id to latest version)")
+    pi.add_argument("--model-id", type=int)
+    pi.add_argument("--model-version-id", type=int)
+    pi.add_argument("--username")
+    pi.add_argument("--tag")
+    pi.add_argument("--base-model")
+    pi.add_argument("--browsing-level", help='Bitmask: "PG", "X,XXX", "all"')
+    pi.add_argument("--nsfw", action="store_true",
+                    help="Shorthand for --browsing-level X,XXX (overridden if "
+                         "--browsing-level is also passed)")
+    pi.add_argument("--content-type", choices=["image", "video"])
+    pi.add_argument("--sort", choices=IMAGE_SORTS, default="Most Reactions")
+    pi.add_argument("--has-meta", action="store_true")
+    _common_args(pi, image=True)
+
+    pt = sub.add_parser("top-models",
+                        help="Top models by sort+period (Meilisearch wrapper)")
+    pt.add_argument("--type", "-t", action="append", choices=MODEL_TYPES)
+    pt.add_argument("--base-model", "-b")
+    pt.add_argument("--nsfw", action="store_true")
+    pt.add_argument("--sort", choices=MODEL_SORTS, default="Most Downloaded")
+    _common_args(pt)
+
+    pti = sub.add_parser("top-images", help="Top images by sort+period")
+    pti.add_argument("--sort", choices=IMAGE_SORTS, default="Most Reactions")
+    pti.add_argument("--content-type", choices=["image", "video"])
+    pti.add_argument("--browsing-level",
+                     help='Bitmask: "PG", "X,XXX", "all"')
+    pti.add_argument("--nsfw", action="store_true",
+                     help="Shorthand for --browsing-level X,XXX (overridden if "
+                          "--browsing-level is also passed)")
+    pti.add_argument("--tag")
+    pti.add_argument("--base-model")
+    pti.add_argument("--has-meta", action="store_true")
+    _common_args(pti, image=True)
+
+    args = p.parse_args()
+    if args.cmd in ("models", "top-models"):
+        _do_models(args)
+    else:
+        _do_images(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/creative/civitai/scripts/show.py
+++ b/optional-skills/creative/civitai/scripts/show.py
@@ -1,0 +1,200 @@
+"""civitai show: model / version / hash / prompts."""
+import argparse
+import sys
+
+from _common import (
+    api_get, fmt_size, fmt_int, truncate, die, emit_json,
+    slim_model, slim_version, slim_prompt_image,
+)
+
+PROMPT_SORTS = [
+    "Most Reactions", "Most Comments", "Most Collected", "Newest", "Oldest",
+]
+
+
+def _do_model(args):
+    m = api_get(f"models/{args.model_id}")
+    if args.json:
+        emit_json(slim_model(m))
+        return
+
+    mid = m.get("id", "?")
+    versions = m.get("modelVersions") or []
+    base = (versions[0] if versions else {}).get("baseModel", "?")
+    tags = m.get("tags") or []
+    tn = ", ".join(
+        t.get("name", "?") if isinstance(t, dict) else str(t)
+        for t in tags[:8]
+    )
+
+    creator = (m.get("creator") or {}).get("username", "?")
+    print(f"Model #{mid} \"{m.get('name', '?')}\" by {creator}")
+    print(f"Type: {m.get('type', '?')} · Base: {base} · Tags: {tn}")
+    print("\nVersions (newest first):")
+    for v in versions:
+        files = v.get("files") or []
+        pf = next((f for f in files if f.get("primary")),
+                  files[0] if files else {})
+        primary = " primary" if pf.get("primary") else ""
+        print(f"  #{v.get('id', '?'):<8} {v.get('name', '?'):<25} — "
+              f"{fmt_size(pf.get('sizeKB'))}{primary}")
+
+    desc = truncate(m.get("description") or "", 500)
+    if desc:
+        print(f"\nDescription: {desc}")
+    print(f"URL: https://civitai.com/models/{mid}")
+
+
+def _do_version(args):
+    v = api_get(f"model-versions/{args.version_id}")
+    if args.json:
+        emit_json(slim_version(v))
+        return
+
+    vid = v.get("id", "?")
+    mid = v.get("modelId", "?")
+    pm = v.get("model") or {}
+    trained = v.get("trainedWords") or []
+
+    print(f"Version #{vid} — \"{v.get('name', '?')}\"")
+    print(f"Parent: #{mid} \"{pm.get('name', '?')}\"")
+    print(f"Base: {v.get('baseModel', '?')} · Trigger: "
+          f"{', '.join(str(w) for w in trained[:8]) or '(none)'}")
+
+    for f in (v.get("files") or []):
+        flag = " [PRIMARY]" if f.get("primary") else ""
+        meta = f.get("metadata") or {}
+        fmt = f.get("type") or meta.get("format", "?")
+        fp = meta.get("fp", "")
+        hashes = f.get("hashes") or {}
+
+        size_line = f"  Size: {fmt_size(f.get('sizeKB'))} · Format: {fmt}"
+        if fp:
+            size_line += f" · {fp}"
+        if meta.get("size"):
+            size_line += f" · {meta['size']}"
+
+        print(f"\nFile: {f.get('name', '?')}{flag}")
+        print(size_line)
+        for h in ("SHA256", "AutoV2", "CRC32", "BLAKE3"):
+            if hashes.get(h):
+                print(f"  {h}: {hashes[h]}")
+        print(f"  Scan: pickle={f.get('pickleScanResult', '?')} · "
+              f"virus={f.get('virusScanResult', '?')}")
+        print(f"  URL: {f.get('downloadUrl', '?')}")
+
+
+def _do_hash(args):
+    h = args.hash.strip().upper()
+    v = api_get(f"model-versions/by-hash/{h}")
+    if args.json:
+        emit_json(v)
+        return
+
+    vid = v.get("id", "?")
+    mid = v.get("modelId", "?")
+    pm = v.get("model") or {}
+    print(f"Match: {h}")
+    print(f"Version #{vid} \"{v.get('name', '?')}\"")
+    print(f"Parent: #{mid} \"{pm.get('name', '?')}\" · "
+          f"Type: {pm.get('type', '?')} · Base: {v.get('baseModel', '?')}")
+    print(f"URL: https://civitai.com/models/{mid}?modelVersionId={vid}")
+
+
+def _do_prompts(args):
+    m = api_get(f"models/{args.model_id}")
+    versions = m.get("modelVersions") or []
+    if not versions:
+        die(f"model {args.model_id} has no versions")
+    vid = versions[0]["id"]
+    print(f"# resolved model {args.model_id} → version {vid}", file=sys.stderr)
+
+    data = api_get("images", {
+        "modelVersionId": vid,
+        "sort":           args.sort,
+        "limit":          min(args.limit, 50),
+        "hasMeta":        True,
+    })
+    if args.json:
+        emit_json({
+            "modelId":   args.model_id,
+            "modelName": m.get("name"),
+            "versionId": vid,
+            "items":     [slim_prompt_image(im) for im in (data.get("items") or [])],
+        })
+        return
+
+    items = data.get("items") or []
+    if not items:
+        print("No images with meta.")
+        return
+
+    print(f"Prompts for #{args.model_id} \"{m.get('name', '?')}\" · "
+          f"{len(items)} images\n")
+    for i, im in enumerate(items, 1):
+        meta = im.get("meta") or {}
+        iid = im.get("id", "?")
+        user = im.get("username") or (im.get("user") or {}).get("username", "?")
+        stats = im.get("stats") or {}
+        react = sum(stats.get(k, 0)
+                    for k in ("heartCount", "likeCount", "laughCount", "cryCount"))
+
+        print(f"{i}. Image #{iid} by {user} · {fmt_int(react)} reactions")
+        if meta.get("prompt"):
+            print(f"   Prompt: {truncate(meta['prompt'], 500)}")
+        if meta.get("negativePrompt"):
+            print(f"   Negative: {truncate(meta['negativePrompt'], 300)}")
+        p = [f"{k}: {meta[k]}"
+             for k in ("steps", "sampler", "cfgScale", "seed")
+             if meta.get(k) is not None]
+        if p:
+            print("   " + " · ".join(p))
+
+        loras = []
+        for r in (meta.get("resources") or []):
+            if (r.get("type") or "").lower() in ("lora", "locon", "dora"):
+                w = r.get("weight")
+                loras.append(f"{r.get('name', '?')}"
+                             + (f" ({w})" if w is not None else ""))
+        if loras:
+            print(f"   LoRAs: {', '.join(loras[:5])}")
+        print(f"   URL: https://civitai.com/images/{iid}\n")
+
+
+def main():
+    p = argparse.ArgumentParser(
+        prog="show.py",
+        description="Show Civitai model/version/hash/prompts",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pm = sub.add_parser("model", help="Full model details with versions")
+    pm.add_argument("model_id", type=int)
+    pm.add_argument("--json", action="store_true")
+
+    pv = sub.add_parser("version", help="Version details with file hashes + scans")
+    pv.add_argument("version_id", type=int)
+    pv.add_argument("--json", action="store_true")
+
+    ph = sub.add_parser("hash", help="Reverse-lookup by SHA256/AutoV2/CRC32/BLAKE3")
+    ph.add_argument("hash")
+    ph.add_argument("--json", action="store_true")
+
+    pp = sub.add_parser("prompts", help="Mine working prompts from images of a model")
+    pp.add_argument("model_id", type=int)
+    pp.add_argument("--sort", choices=PROMPT_SORTS, default="Most Reactions")
+    pp.add_argument("--limit", "-n", type=int, default=5)
+    pp.add_argument("--json", action="store_true")
+
+    args = p.parse_args()
+    dispatch = {
+        "model":   _do_model,
+        "version": _do_version,
+        "hash":    _do_hash,
+        "prompts": _do_prompts,
+    }
+    dispatch[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_civitai_skill.py
+++ b/tests/skills/test_civitai_skill.py
@@ -1,0 +1,1494 @@
+"""Unit tests for the civitai skill scripts.
+
+Covers every CLI subcommand in search.py, show.py, download.py — plus the
+helpers in _common.py and the health_check.py harness. All network I/O is
+mocked at the urllib layer (and subprocess where needed) so the suite is
+fully offline and deterministic.
+
+Run with::
+
+    pytest hermesroot/tests/skills/test_civitai_skill.py -v
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import sys
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _find_scripts_dir() -> Path:
+    """Locate the civitai/scripts/ directory.
+
+    Strategy:
+      1. Honor CIVITAI_SCRIPTS_DIR env var if set (CI / restructured layouts).
+      2. Walk up from this test file looking for any */civitai/scripts/_common.py
+         under common skill-host roots (skills/, optional-skills/, plus a bare
+         civitai/ for repos that drop the category dir).
+      3. Fail loudly if not found — better than a confusing import error later.
+    """
+    override = os.environ.get("CIVITAI_SCRIPTS_DIR")
+    if override:
+        return Path(override).resolve()
+
+    here = Path(__file__).resolve()
+    # Sentinel file inside the scripts directory we're looking for.
+    sentinel = "_common.py"
+    # Candidate skill-tree roots, relative to each ancestor of this file.
+    rel_candidates = (
+        Path("optional-skills") / "creative" / "civitai" / "scripts",
+        Path("skills") / "creative" / "civitai" / "scripts",
+        Path("optional-skills") / "civitai" / "scripts",
+        Path("skills") / "civitai" / "scripts",
+        Path("civitai") / "scripts",
+    )
+    for parent in here.parents:
+        for rel in rel_candidates:
+            candidate = parent / rel
+            if (candidate / sentinel).is_file():
+                return candidate
+
+    raise RuntimeError(
+        "Could not locate civitai/scripts/ — set CIVITAI_SCRIPTS_DIR to "
+        "the absolute path of the scripts directory."
+    )
+
+
+SCRIPTS_DIR = _find_scripts_dir()
+
+# Make `from _common import ...` inside the scripts resolve against SCRIPTS_DIR.
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load(name: str):
+    """Load a script as a module, registering it under its bare name so that
+    sibling scripts can `from _common import ...` without surprises."""
+    if name in sys.modules:
+        return sys.modules[name]
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load _common.py first — the others depend on it.
+common = _load("_common")
+search_mod = _load("search")
+show_mod = _load("show")
+download_mod = _load("download")
+health_check_mod = _load("health_check")
+
+
+# --------------------------------------------------------------------------- #
+# Mock helpers
+# --------------------------------------------------------------------------- #
+class _MockResp:
+    """Minimal context-manager mimic of a urllib response object."""
+
+    def __init__(self, payload, status: int = 200):
+        if isinstance(payload, (bytes, bytearray)):
+            self._body = bytes(payload)
+        elif isinstance(payload, str):
+            self._body = payload.encode("utf-8")
+        else:
+            self._body = json.dumps(payload).encode("utf-8")
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def _route(responses: dict):
+    """Build a urlopen side_effect that dispatches by URL substring match."""
+
+    def _side_effect(req, timeout=None):  # noqa: ARG001
+        url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+        for needle, resp in responses.items():
+            if needle in url:
+                if isinstance(resp, Exception):
+                    raise resp
+                return _MockResp(resp)
+        raise AssertionError(f"Unexpected URL in test: {url}")
+
+    return _side_effect
+
+
+def _http_error(url: str, code: int, body: bytes = b"err") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(url, code, "err", {}, io.BytesIO(body))
+
+
+def _run_main(module, argv, env=None):
+    """Invoke a script's main() with sys.argv patched."""
+    full_argv = [module.__name__] + list(argv)
+    with patch.object(sys, "argv", full_argv):
+        if env is not None:
+            with patch.dict(os.environ, env, clear=False):
+                module.main()
+        else:
+            module.main()
+
+
+# --------------------------------------------------------------------------- #
+# Fixture payloads
+# --------------------------------------------------------------------------- #
+SAMPLE_MODEL = {
+    "id": 257749,
+    "name": "Realistic Vision V6.0",
+    "type": "Checkpoint",
+    "creator": {"username": "SG_161222"},
+    "tags": [{"name": "photorealism"}, {"name": "base model"}],
+    "description": "A great realism checkpoint.",
+    "modelVersions": [
+        {
+            "id": 999111,
+            "name": "V6.0 B1",
+            "baseModel": "SD 1.5",
+            "trainedWords": ["analog photo"],
+            "files": [
+                {
+                    "name": "realisticVision_v60B1.safetensors",
+                    "sizeKB": 2_097_152,
+                    "primary": True,
+                    "downloadUrl": "https://civitai.com/api/download/models/999111",
+                    "hashes": {
+                        "AutoV2": "E837144C55",
+                        "SHA256": "E837144C55" + "0" * 54,
+                    },
+                    "pickleScanResult": "Success",
+                    "virusScanResult": "Success",
+                    "metadata": {
+                        "format": "SafeTensor",
+                        "fp": "fp16",
+                        "size": "pruned",
+                    },
+                }
+            ],
+        },
+        {
+            "id": 999000,
+            "name": "V5.1",
+            "baseModel": "SD 1.5",
+            "files": [],
+        },
+    ],
+}
+
+SAMPLE_VERSION = {
+    "id": 999111,
+    "modelId": 257749,
+    "name": "V6.0 B1",
+    "baseModel": "SD 1.5",
+    "trainedWords": ["analog photo"],
+    "model": {"name": "Realistic Vision V6.0", "type": "Checkpoint"},
+    "files": SAMPLE_MODEL["modelVersions"][0]["files"],
+}
+
+SAMPLE_IMAGES = {
+    "items": [
+        {
+            "id": 5551,
+            "username": "alice",
+            "stats": {
+                "heartCount": 5,
+                "likeCount": 10,
+                "laughCount": 0,
+                "cryCount": 0,
+            },
+            "meta": {
+                "prompt": "a beautiful landscape, photorealistic",
+                "negativePrompt": "blurry, low quality",
+                "steps": 30,
+                "sampler": "DPM++ 2M",
+                "cfgScale": 7,
+                "seed": 42,
+                "resources": [
+                    {"type": "lora", "name": "detail_tweaker", "weight": 0.8}
+                ],
+            },
+            "tools": [{"name": "Automatic1111"}],
+            "techniques": [{"name": "txt2img"}],
+            "baseModel": "SD 1.5",
+        }
+    ]
+}
+
+SAMPLE_MEILI_RESPONSE = {
+    "results": [
+        {
+            "hits": [
+                {
+                    "id": 257749,
+                    "name": "Realistic Vision V6.0",
+                    "type": "Checkpoint",
+                    "user": {"username": "SG_161222"},
+                    "version": {"baseModel": "SD 1.5"},
+                    "metrics": {"downloadCount": 200_000, "thumbsUpCount": 5_000},
+                    "triggerWords": ["analog photo"],
+                    "tags": [{"name": "photorealism"}],
+                },
+                {
+                    "id": 1,
+                    "name": "Tiny LoRA",
+                    "type": "LORA",
+                    "user": {"username": "bob"},
+                    "version": {"baseModel": "Flux.1 D"},
+                    "metrics": {"downloadCount": 1234, "thumbsUpCount": 56},
+                },
+            ],
+            "estimatedTotalHits": 2,
+            "processingTimeMs": 4,
+        }
+    ]
+}
+
+
+# =========================================================================== #
+# _common.py
+# =========================================================================== #
+class TestCommonFormatters:
+    def test_fmt_size_gb(self):
+        assert common.fmt_size(2 * 1024 * 1024) == "2.00 GB"
+
+    def test_fmt_size_mb(self):
+        assert common.fmt_size(2048) == "2.0 MB"
+
+    def test_fmt_size_kb(self):
+        assert common.fmt_size(512) == "512 KB"
+
+    def test_fmt_size_invalid(self):
+        assert common.fmt_size(None) == "?"
+        assert common.fmt_size("nope") == "?"
+
+    def test_fmt_int_with_commas(self):
+        assert common.fmt_int(1234567) == "1,234,567"
+
+    def test_fmt_int_invalid_passes_through(self):
+        assert common.fmt_int("nope") == "nope"
+
+    def test_truncate_short_unchanged(self):
+        assert common.truncate("hello") == "hello"
+
+    def test_truncate_long_appends_ellipsis(self):
+        out = common.truncate("x" * 600, n=500)
+        assert len(out) == 501  # 500 chars + ellipsis
+        assert out.endswith("…")
+
+    def test_truncate_collapses_newlines(self):
+        assert common.truncate("a\nb\r\nc") == "a b c"
+
+    def test_truncate_none_returns_empty(self):
+        assert common.truncate(None) == ""
+
+    def test_emit_json_writes_to_stdout(self, capsys):
+        common.emit_json({"a": 1, "b": [1, 2]})
+        assert json.loads(capsys.readouterr().out) == {"a": 1, "b": [1, 2]}
+
+
+class TestParseBrowsingLevel:
+    def test_default_all(self):
+        assert common.parse_browsing_level("") == 31
+        assert common.parse_browsing_level(None) == 31
+        assert common.parse_browsing_level("all") == 31
+
+    def test_individual_levels(self):
+        assert common.parse_browsing_level("PG") == 1
+        assert common.parse_browsing_level("X") == 8
+        assert common.parse_browsing_level("XXX") == 16
+
+    def test_combo_or_mask(self):
+        # X | XXX  =  8 | 16  =  24
+        assert common.parse_browsing_level("X,XXX") == 24
+
+    def test_pg13_aliases_both_accepted(self):
+        assert common.parse_browsing_level("PG-13") == 2
+        assert common.parse_browsing_level("PG13") == 2
+
+    def test_unknown_falls_back_to_all(self):
+        assert common.parse_browsing_level("WEIRD") == 31
+
+
+class TestDie:
+    def test_die_exits_2_with_stderr(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            common.die("boom")
+        assert exc.value.code == 2
+        assert "error: boom" in capsys.readouterr().err
+
+    def test_die_custom_code(self):
+        with pytest.raises(SystemExit) as exc:
+            common.die("nope", code=7)
+        assert exc.value.code == 7
+
+
+class TestApiGet:
+    def test_basic_get(self):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "civitai.com/api/v1/models/257749": SAMPLE_MODEL,
+        })):
+            out = common.api_get("models/257749")
+        assert out["id"] == 257749
+
+    def test_includes_auth_header_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("CIVITAI_API_KEY", "secret-token")
+        seen = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            seen["headers"] = dict(req.headers)
+            return _MockResp({"ok": True})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            common.api_get("models/1")
+
+        # urllib lower-cases header keys when stored on Request.headers
+        auth = seen["headers"].get("Authorization") or seen["headers"].get("authorization")
+        assert auth == "Bearer secret-token"
+
+    def test_no_auth_header_when_key_unset(self, monkeypatch):
+        monkeypatch.delenv("CIVITAI_API_KEY", raising=False)
+        seen = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            seen["headers"] = dict(req.headers)
+            return _MockResp({"ok": True})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            common.api_get("models/1")
+
+        assert "Authorization" not in seen["headers"]
+        assert "authorization" not in seen["headers"]
+
+    def test_query_param_encoding(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            common.api_get("models", {
+                "limit": 5,
+                "sort": "Newest",
+                "types": ["LORA", "Checkpoint"],
+                "nsfw": False,
+                "skip": None,    # dropped
+            })
+
+        url = captured["url"]
+        assert "limit=5" in url
+        assert "sort=Newest" in url
+        assert "types=LORA" in url and "types=Checkpoint" in url
+        assert "nsfw=false" in url
+        assert "skip" not in url
+
+    def test_404_dies_not_found(self, capsys):
+        err = _http_error("https://civitai.com/api/v1/models/0", 404)
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(SystemExit):
+                common.api_get("models/0")
+        assert "not found" in capsys.readouterr().err
+
+    def test_401_dies_auth(self, capsys):
+        err = _http_error("https://civitai.com/api/v1/models/1", 401)
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(SystemExit):
+                common.api_get("models/1")
+        assert "auth failed" in capsys.readouterr().err
+
+    def test_403_dies_auth(self, capsys):
+        err = _http_error("https://civitai.com/api/v1/models/1", 403)
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(SystemExit):
+                common.api_get("models/1")
+        assert "auth failed" in capsys.readouterr().err
+
+    def test_429_dies_after_retries(self, capsys):
+        err = _http_error("https://civitai.com/api/v1/models/1", 429)
+        with patch("urllib.request.urlopen", side_effect=err):
+            with patch.object(common.time, "sleep"):  # speed up retry waits
+                with pytest.raises(SystemExit):
+                    common.api_get("models/1")
+        assert "rate limited" in capsys.readouterr().err
+
+    def test_retry_recovers_after_transient_503(self):
+        responses = [_http_error("u", 503), _MockResp({"id": 1})]
+        with patch("urllib.request.urlopen", side_effect=responses):
+            with patch.object(common.time, "sleep"):
+                out = common.api_get("models/1")
+        assert out == {"id": 1}
+
+    def test_unknown_5xx_dies(self, capsys):
+        err = _http_error("u", 500, body=b"internal error blob")
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(SystemExit):
+                common.api_get("models/1")
+        assert "http 500" in capsys.readouterr().err
+
+
+class TestMeiliSearch:
+    def test_constructs_filter_sort_and_index(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["body"] = json.loads(req.data.decode())
+            captured["url"] = req.full_url
+            return _MockResp(SAMPLE_MEILI_RESPONSE)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            r = common.meili_search(
+                "anime",
+                types=["LORA"],
+                base_model="Flux.1 D",
+                tag="Anime",
+                username="bob",
+                sort="Newest",
+                nsfw=False,
+                limit=3,
+            )
+
+        assert "multi-search" in captured["url"]
+        q = captured["body"]["queries"][0]
+        assert q["q"] == "anime"
+        assert q["limit"] == 3
+        assert q["indexUid"] == "models_v9"
+        assert q["sort"] == ["createdAt:desc"]
+
+        f = q["filter"]
+        assert 'type = "LORA"' in f
+        assert 'version.baseModel = "Flux.1 D"' in f
+        assert 'tags.name = "anime"' in f      # auto-lowercased
+        assert 'user.username = "bob"' in f
+        assert "nsfwLevel = 1" in f
+
+        assert r["hits"][0]["id"] == 257749
+
+    def test_multiple_types_joined_by_or(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["body"] = json.loads(req.data.decode())
+            return _MockResp(SAMPLE_MEILI_RESPONSE)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            common.meili_search("x", types=["LORA", "Checkpoint"])
+
+        f = captured["body"]["queries"][0]["filter"]
+        assert 'type = "LORA"' in f
+        assert 'type = "Checkpoint"' in f
+        assert " OR " in f
+
+    def test_default_sort_when_unknown(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["body"] = json.loads(req.data.decode())
+            return _MockResp(SAMPLE_MEILI_RESPONSE)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            common.meili_search("x", sort="NotARealSort")
+
+        q = captured["body"]["queries"][0]
+        assert q["sort"] == ["metrics.downloadCount:desc"]
+
+    def test_meili_auth_failure_dies(self, capsys):
+        err = _http_error("https://search-new.civitai.com/multi-search", 401)
+        with patch("urllib.request.urlopen", side_effect=err):
+            with pytest.raises(SystemExit):
+                common.meili_search("x")
+        assert "meilisearch http 401" in capsys.readouterr().err
+
+    def test_meili_uses_env_key_when_set(self, monkeypatch):
+        # The module reads MEILISEARCH_KEY at import time, so we just verify
+        # the constant resolves to the documented default when env is unset.
+        # (Setting it post-import has no effect — by design.)
+        monkeypatch.delenv("MEILISEARCH_KEY", raising=False)
+        assert len(common.MEILI_KEY) == 64  # 64-char hex string
+
+
+# =========================================================================== #
+# search.py
+# =========================================================================== #
+class TestSearchModels:
+    def test_query_routes_to_meilisearch(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "multi-search": SAMPLE_MEILI_RESPONSE,
+        })):
+            _run_main(search_mod, ["models", "--query", "realistic", "--limit", "2"])
+
+        out = capsys.readouterr().out
+        assert "Meilisearch" in out
+        assert "#257749" in out
+        assert "Realistic Vision V6.0" in out
+        assert "SG_161222" in out
+
+    def test_query_json_output(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "multi-search": SAMPLE_MEILI_RESPONSE,
+        })):
+            _run_main(search_mod, ["models", "--query", "anything", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["hits"][0]["id"] == 257749
+        assert parsed["estimatedTotalHits"] == 2
+
+    def test_no_query_uses_rest(self, capsys):
+        rest_payload = {"items": [SAMPLE_MEILI_RESPONSE["results"][0]["hits"][0]]}
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp(rest_payload)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, ["models", "--type", "Checkpoint", "--limit", "1"])
+
+        assert "civitai.com/api/v1/models" in captured["url"]
+        assert "multi-search" not in captured["url"]
+        assert "Models (REST)" in capsys.readouterr().out
+
+    def test_ids_forces_rest_even_with_query(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, ["models", "--query", "ignored", "--ids", "1,2,3"])
+
+        assert "civitai.com/api/v1/models" in captured["url"]
+        # ids reach the URL (may be percent-encoded)
+        assert "ids=1%2C2%2C3" in captured["url"] or "ids=1,2,3" in captured["url"]
+
+    def test_rest_sort_downgrade(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            # 'Most Tipped' is not REST-supported and should silently downgrade
+            _run_main(search_mod, ["models", "--sort", "Most Tipped"])
+
+        assert "sort=Most+Downloaded" in captured["url"]
+
+    def test_no_results_prints_message(self, capsys):
+        empty = {"results": [{"hits": [], "estimatedTotalHits": 0, "processingTimeMs": 1}]}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "multi-search": empty,
+        })):
+            _run_main(search_mod, ["models", "--query", "zzz"])
+
+        assert "No results." in capsys.readouterr().out
+
+
+class TestSearchImages:
+    def test_model_id_auto_resolves_to_version(self, capsys, monkeypatch):
+        monkeypatch.delenv("CIVITAI_API_KEY", raising=False)
+        captured_urls = []
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured_urls.append(req.full_url)
+            if "/models/257749" in req.full_url:
+                return _MockResp(SAMPLE_MODEL)
+            if "/images" in req.full_url:
+                return _MockResp(SAMPLE_IMAGES)
+            raise AssertionError(f"Unexpected URL: {req.full_url}")
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, ["images", "--model-id", "257749", "--has-meta"])
+
+        cap = capsys.readouterr()
+        assert "# resolved model 257749 → version 999111" in cap.err
+        image_urls = [u for u in captured_urls if "/images" in u]
+        assert any("modelVersionId=999111" in u for u in image_urls)
+        assert "hasMeta=true" in image_urls[0]
+
+    def test_model_version_id_direct(self, capsys):
+        captured_urls = []
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured_urls.append(req.full_url)
+            return _MockResp(SAMPLE_IMAGES)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, ["images", "--model-version-id", "999111"])
+
+        assert any("modelVersionId=999111" in u for u in captured_urls)
+        out = capsys.readouterr().out
+        assert "Image #5551" in out
+        assert "Prompt:" in out
+        assert "LoRAs:" in out
+        assert "DPM++ 2M" in out
+
+    def test_browsing_level_nsfw_downgrade_without_key(self, capsys, monkeypatch):
+        monkeypatch.delenv("CIVITAI_API_KEY", raising=False)
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, [
+                "images", "--model-version-id", "1", "--browsing-level", "X,XXX",
+            ])
+
+        err = capsys.readouterr().err
+        assert "downgrading to R" in err
+        # R = 4
+        assert "browsingLevel=4" in captured["url"]
+
+    def test_browsing_level_with_key_respected(self, monkeypatch):
+        monkeypatch.setenv("CIVITAI_API_KEY", "secret")
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, [
+                "images", "--model-version-id", "1", "--browsing-level", "X,XXX",
+            ])
+
+        # X | XXX = 24
+        assert "browsingLevel=24" in captured["url"]
+
+    def test_nsfw_flag_desugars_to_x_xxx_with_key(self, monkeypatch):
+        """--nsfw on images should be equivalent to --browsing-level X,XXX."""
+        monkeypatch.setenv("CIVITAI_API_KEY", "secret")
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, [
+                "images", "--model-version-id", "1", "--nsfw",
+            ])
+
+        # --nsfw → X|XXX = 24
+        assert "browsingLevel=24" in captured["url"]
+
+    def test_nsfw_flag_downgrades_to_r_without_key(self, capsys, monkeypatch):
+        """--nsfw without a key emits a warning and downgrades to R."""
+        monkeypatch.delenv("CIVITAI_API_KEY", raising=False)
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, [
+                "images", "--model-version-id", "1", "--nsfw",
+            ])
+
+        assert "browsingLevel=4" in captured["url"]  # R = 4
+        assert "NSFW" in capsys.readouterr().err
+
+    def test_explicit_browsing_level_wins_over_nsfw_flag(self, monkeypatch):
+        """If both --nsfw and --browsing-level are passed, --browsing-level wins."""
+        monkeypatch.setenv("CIVITAI_API_KEY", "secret")
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp({"items": []})
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, [
+                "images", "--model-version-id", "1",
+                "--nsfw", "--browsing-level", "R",
+            ])
+
+        # R = 4, not the X|XXX=24 that --nsfw alone would set
+        assert "browsingLevel=4" in captured["url"]
+
+    def test_json_output(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/images": SAMPLE_IMAGES,
+        })):
+            _run_main(search_mod, ["images", "--model-version-id", "1", "--json"])
+
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["items"][0]["id"] == 5551
+
+
+class TestSearchTopModels:
+    def test_basic_hits_rest_with_filters(self, capsys):
+        # top-models has no --query option, so q is None and the code routes
+        # through the REST /models endpoint with type+baseModels+sort filters.
+        rest_payload = {"items": SAMPLE_MEILI_RESPONSE["results"][0]["hits"]}
+        captured_urls = []
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured_urls.append(req.full_url)
+            return _MockResp(rest_payload)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, [
+                "top-models", "--type", "LORA",
+                "--base-model", "Flux.1 D", "--limit", "2",
+            ])
+
+        url = captured_urls[0]
+        assert "civitai.com/api/v1/models" in url
+        assert "types=LORA" in url
+        assert "baseModels=Flux.1+D" in url or "baseModels=Flux.1%20D" in url
+        out = capsys.readouterr().out
+        assert "Models (REST)" in out
+        assert "#257749" in out or "Tiny LoRA" in out
+
+    def test_top_models_json(self, capsys):
+        rest_payload = {"items": SAMPLE_MEILI_RESPONSE["results"][0]["hits"]}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "civitai.com/api/v1/models": rest_payload,
+        })):
+            _run_main(search_mod, [
+                "top-models", "--type", "Checkpoint", "--json",
+            ])
+
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["items"][0]["id"] == 257749
+
+
+class TestSearchTopImages:
+    def test_basic(self, capsys):
+        captured_urls = []
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured_urls.append(req.full_url)
+            return _MockResp(SAMPLE_IMAGES)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(search_mod, [
+                "top-images", "--period", "Week", "--has-meta", "--limit", "3",
+            ])
+
+        assert any("/images" in u for u in captured_urls)
+        assert any("period=Week" in u for u in captured_urls)
+        out = capsys.readouterr().out
+        assert "Image #5551" in out
+
+
+# =========================================================================== #
+# show.py
+# =========================================================================== #
+class TestShowModel:
+    def test_text_output(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(show_mod, ["model", "257749"])
+
+        out = capsys.readouterr().out
+        assert "#257749" in out
+        assert "Realistic Vision V6.0" in out
+        assert "SD 1.5" in out
+        assert "#999111" in out        # version listed
+        assert "URL: https://civitai.com/models/257749" in out
+
+    def test_json(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["id"] == 257749
+        assert parsed["modelVersions"][0]["id"] == 999111
+
+
+class TestShowSlimJSON:
+    """JSON output is slimmed to stay under terminal transport caps (~50 KB).
+
+    Without this, large /models/{id} payloads (HTML descriptions, image
+    arrays, many versions) get truncated mid-stream and break json.loads.
+    """
+
+    def test_slim_model_drops_description_blob(self, capsys):
+        fat = {
+            **SAMPLE_MODEL,
+            # Simulate the 10-50 KB HTML description Civitai returns.
+            "description": "<p>" + ("x" * 50_000) + "</p>",
+        }
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": fat,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        out = capsys.readouterr().out
+        # The description is what blows the payload up; it must not appear.
+        assert "description" not in json.loads(out)
+        # And total output must comfortably parse and stay small.
+        assert len(out) < 10_000
+        assert json.loads(out)["id"] == 257749
+
+    def test_slim_model_drops_per_version_images(self, capsys):
+        fat_versions = [
+            {
+                **SAMPLE_MODEL["modelVersions"][0],
+                # 50 fake image entries per version — these inflate the payload
+                # without giving an agent anything actionable.
+                "images": [{"url": f"https://example.com/{i}.png",
+                            "meta": {"prompt": "x" * 200}} for i in range(50)],
+            }
+        ]
+        fat = {**SAMPLE_MODEL, "modelVersions": fat_versions}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": fat,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        v0 = parsed["modelVersions"][0]
+        assert "images" not in v0
+
+    def test_slim_model_caps_versions_at_20(self, capsys):
+        many = [
+            {"id": 1000 + i, "name": f"v{i}", "baseModel": "SD 1.5", "files": []}
+            for i in range(55)
+        ]
+        fat = {**SAMPLE_MODEL, "modelVersions": many}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": fat,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert len(parsed["modelVersions"]) == 20
+        assert parsed["_versions_truncated"] is True
+        # Truncation surfaces the *oldest* dropped: kept the first 20 newest.
+        assert parsed["modelVersions"][0]["id"] == 1000
+        assert parsed["modelVersions"][-1]["id"] == 1019
+
+    def test_slim_model_does_not_truncate_when_under_cap(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["_versions_truncated"] is False
+
+    def test_slim_files_drops_extra_hash_formats(self, capsys):
+        # Civitai emits 6 hash formats per file; we only need 2.
+        fat_file = {
+            **SAMPLE_MODEL["modelVersions"][0]["files"][0],
+            "hashes": {
+                "AutoV1": "old1",
+                "AutoV2": "E837144C55",
+                "AutoV3": "new3",
+                "SHA256": "E837144C55" + "0" * 54,
+                "CRC32":  "deadbeef",
+                "BLAKE3": "b" * 64,
+            },
+        }
+        fat_versions = [{**SAMPLE_MODEL["modelVersions"][0], "files": [fat_file]}]
+        fat = {**SAMPLE_MODEL, "modelVersions": fat_versions}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": fat,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        kept = parsed["modelVersions"][0]["files"][0]["hashes"]
+        assert set(kept.keys()) == {"SHA256", "AutoV2"}
+        assert kept["AutoV2"] == "E837144C55"
+
+    def test_slim_model_preserves_essentials(self, capsys):
+        """Anything an agent might actually use must survive slimming."""
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        p = json.loads(capsys.readouterr().out)
+        # Top-level identity + discovery fields
+        for k in ("id", "name", "type", "creator", "tags"):
+            assert k in p, f"slim_model dropped essential top-level field {k}"
+        # Per-version download essentials
+        v = p["modelVersions"][0]
+        for k in ("id", "name", "baseModel", "trainedWords", "files"):
+            assert k in v, f"slim_model dropped essential version field {k}"
+        f = v["files"][0]
+        for k in ("name", "sizeKB", "primary", "hashes",
+                  "pickleScanResult", "virusScanResult", "downloadUrl"):
+            assert k in f, f"slim_files dropped essential file field {k}"
+
+    def test_slim_version_drops_redundant_hashes(self, capsys):
+        fat = {
+            **SAMPLE_VERSION,
+            "files": [{
+                **SAMPLE_VERSION["files"][0],
+                "hashes": {
+                    "AutoV1": "1", "AutoV2": "E837144C55",
+                    "SHA256": "x" * 64, "CRC32": "d", "BLAKE3": "b" * 64,
+                },
+            }],
+        }
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/model-versions/999111": fat,
+        })):
+            _run_main(show_mod, ["version", "999111", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        kept = parsed["files"][0]["hashes"]
+        assert set(kept.keys()) == {"SHA256", "AutoV2"}
+
+    def test_slim_prompts_envelope_and_lora_filter(self, capsys):
+        # Add a non-lora resource to confirm it gets filtered out.
+        fat_images = {
+            "items": [{
+                **SAMPLE_IMAGES["items"][0],
+                "meta": {
+                    **SAMPLE_IMAGES["items"][0]["meta"],
+                    "resources": [
+                        {"type": "lora",  "name": "good_lora", "weight": 0.8},
+                        {"type": "checkpoint", "name": "should_drop"},
+                        {"type": "vae",  "name": "also_drop"},
+                    ],
+                },
+            }],
+        }
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            if "/models/257749" in req.full_url:
+                return _MockResp(SAMPLE_MODEL)
+            if "/images" in req.full_url:
+                return _MockResp(fat_images)
+            raise AssertionError(req.full_url)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(show_mod, ["prompts", "257749", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["modelId"] == 257749
+        assert parsed["versionId"] == 999111
+        item = parsed["items"][0]
+        # reactions collapsed from stats
+        assert item["reactions"] == 15  # heart 5 + like 10
+        # URL helpfully attached
+        assert item["url"] == "https://civitai.com/images/5551"
+        # Non-LoRA resources dropped
+        names = [r["name"] for r in item["meta"]["resources"]]
+        assert names == ["good_lora"]
+
+    def test_slim_output_stays_under_transport_cap(self, capsys):
+        """End-to-end: a pathological model with HTML + images + many versions
+        must still emit parseable JSON well under the 50 KB transport cap."""
+        pathological = {
+            **SAMPLE_MODEL,
+            "description": "<html>" + ("y" * 80_000) + "</html>",
+            "modelVersions": [
+                {
+                    "id":     i,
+                    "name":   f"v{i}",
+                    "baseModel": "SD 1.5",
+                    "description": "<p>" + ("z" * 10_000) + "</p>",
+                    "files":  SAMPLE_MODEL["modelVersions"][0]["files"],
+                    "images": [{"url": f"u{j}", "meta": {"prompt": "p" * 500}}
+                               for j in range(30)],
+                }
+                for i in range(50)
+            ],
+        }
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": pathological,
+        })):
+            _run_main(show_mod, ["model", "257749", "--json"])
+
+        out = capsys.readouterr().out
+        # Must parse — the whole point of slimming.
+        parsed = json.loads(out)
+        # 80 KB of description + 50 × 10 KB version-descriptions + 50 × 30
+        # image entries = ~600 KB raw; slim output must be drastically smaller.
+        assert len(out) < 20_000, f"slim output is {len(out)} bytes — too fat"
+        assert parsed["_versions_truncated"] is True
+
+
+class TestShowVersion:
+    def test_text_output_includes_hashes_and_scans(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/model-versions/999111": SAMPLE_VERSION,
+        })):
+            _run_main(show_mod, ["version", "999111"])
+
+        out = capsys.readouterr().out
+        assert "Version #999111" in out
+        assert "[PRIMARY]" in out
+        assert "AutoV2: E837144C55" in out
+        assert "SHA256:" in out
+        assert "pickle=Success" in out
+        assert "virus=Success" in out
+        assert "fp16" in out
+
+    def test_json(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/model-versions/999111": SAMPLE_VERSION,
+        })):
+            _run_main(show_mod, ["version", "999111", "--json"])
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["id"] == 999111
+
+
+class TestShowHash:
+    def test_text(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/by-hash/E837144C55": SAMPLE_VERSION,
+        })):
+            _run_main(show_mod, ["hash", "e837144c55"])
+
+        out = capsys.readouterr().out
+        assert "Match: E837144C55" in out
+        assert "Version #999111" in out
+        assert "Realistic Vision V6.0" in out
+
+    def test_uppercases_hash_in_request_url(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            captured["url"] = req.full_url
+            return _MockResp(SAMPLE_VERSION)
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(show_mod, ["hash", "abc123def"])
+
+        assert "ABC123DEF" in captured["url"]
+
+
+class TestShowPrompts:
+    def test_text(self, capsys):
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            if "/models/257749" in req.full_url:
+                return _MockResp(SAMPLE_MODEL)
+            if "/images" in req.full_url:
+                return _MockResp(SAMPLE_IMAGES)
+            raise AssertionError(f"Unexpected URL: {req.full_url}")
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(show_mod, ["prompts", "257749", "--limit", "5"])
+
+        cap = capsys.readouterr()
+        assert "resolved model 257749 → version 999111" in cap.err
+        assert "Prompts for #257749" in cap.out
+        assert "a beautiful landscape" in cap.out
+        assert "Negative: blurry" in cap.out
+        assert "LoRAs:" in cap.out
+        assert "DPM++ 2M" in cap.out
+
+    def test_no_images_message(self, capsys):
+        def fake_urlopen(req, timeout=None):  # noqa: ARG001
+            if "/models/" in req.full_url:
+                return _MockResp(SAMPLE_MODEL)
+            if "/images" in req.full_url:
+                return _MockResp({"items": []})
+            raise AssertionError(f"Unexpected URL: {req.full_url}")
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            _run_main(show_mod, ["prompts", "257749"])
+
+        assert "No images with meta." in capsys.readouterr().out
+
+    def test_no_versions_dies(self, capsys):
+        empty_model = {**SAMPLE_MODEL, "modelVersions": []}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": empty_model,
+        })):
+            with pytest.raises(SystemExit):
+                _run_main(show_mod, ["prompts", "257749"])
+
+        assert "has no versions" in capsys.readouterr().err
+
+
+# =========================================================================== #
+# download.py
+# =========================================================================== #
+class TestDownload:
+    def test_emits_all_three_formats(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, [
+                "257749", "--comfyui-path", "/data/ComfyUI/models",
+            ])
+
+        out = capsys.readouterr().out
+        assert "curl -L" in out
+        assert "wget --header=" in out
+        assert "Invoke-WebRequest" in out
+        assert "/data/ComfyUI/models/checkpoints/realisticVision_v60B1.safetensors" in out
+        assert "$CIVITAI_API_KEY" in out
+        assert "AutoV2: E837144C55" in out
+        assert "pickle=Success" in out
+
+    def test_curl_only(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, [
+                "257749", "--format", "curl", "--comfyui-path", "/x",
+            ])
+
+        out = capsys.readouterr().out
+        assert "curl -L" in out
+        assert "wget --header=" not in out
+        assert "Invoke-WebRequest" not in out
+
+    def test_wget_only(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, [
+                "257749", "--format", "wget", "--comfyui-path", "/x",
+            ])
+
+        out = capsys.readouterr().out
+        assert "wget --header=" in out
+        assert "curl -L" not in out
+
+    def test_powershell_only(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, [
+                "257749", "--format", "ps", "--comfyui-path", "/x",
+            ])
+
+        out = capsys.readouterr().out
+        assert "Invoke-WebRequest" in out
+        assert "curl -L" not in out
+
+    def test_does_not_leak_key_value(self, capsys, monkeypatch):
+        monkeypatch.setenv("CIVITAI_API_KEY", "my-super-secret-token")
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, ["257749", "--comfyui-path", "/x"])
+
+        out = capsys.readouterr().out
+        assert "my-super-secret-token" not in out
+        assert "$CIVITAI_API_KEY" in out
+
+    def test_version_id_specific(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, [
+                "257749", "--version-id", "999111", "--comfyui-path", "/x",
+            ])
+
+        assert "Version #999111" in capsys.readouterr().out
+
+    def test_version_id_not_found_dies(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            with pytest.raises(SystemExit):
+                _run_main(download_mod, ["257749", "--version-id", "424242"])
+
+        assert "not found" in capsys.readouterr().err
+
+    def test_no_comfy_path_uses_placeholder(self, capsys):
+        # download.py no longer scrapes config.yaml; with no --comfyui-path,
+        # the placeholder behavior kicks in naturally.
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, ["257749"])
+
+        assert "<COMFYUI_PATH>" in capsys.readouterr().out
+
+    def test_json_output(self, capsys):
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": SAMPLE_MODEL,
+        })):
+            _run_main(download_mod, [
+                "257749", "--comfyui-path", "/x", "--json",
+            ])
+
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["model_id"] == 257749
+        assert rendered["type"] == "Checkpoint"
+        assert rendered["subfolder"] == "checkpoints"
+        assert rendered["version_id"] == 999111
+        f0 = rendered["files"][0]
+        assert f0["primary"] is True
+        assert f0["hashes"]["AutoV2"] == "E837144C55"
+        assert f0["pickle_scan"] == "Success"
+        assert "/x/checkpoints/" in f0["target"]
+
+    def test_lora_subfolder_mapping(self, capsys):
+        lora_model = {**SAMPLE_MODEL, "type": "LORA"}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": lora_model,
+        })):
+            _run_main(download_mod, [
+                "257749", "--comfyui-path", "/m", "--json",
+            ])
+
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["subfolder"] == "loras"
+        assert "/m/loras/" in rendered["files"][0]["target"]
+
+    def test_dora_subfolder_mapping(self, capsys):
+        dora_model = {**SAMPLE_MODEL, "type": "DoRA"}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": dora_model,
+        })):
+            _run_main(download_mod, [
+                "257749", "--comfyui-path", "/m", "--json",
+            ])
+
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["subfolder"] == "loras"
+
+    def test_vae_subfolder_mapping(self, capsys):
+        vae_model = {**SAMPLE_MODEL, "type": "VAE"}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/257749": vae_model,
+        })):
+            _run_main(download_mod, [
+                "257749", "--comfyui-path", "/m", "--json",
+            ])
+
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["subfolder"] == "vae"
+
+    def test_unknown_type_falls_back_to_other(self, capsys):
+        weird = {**SAMPLE_MODEL, "type": "Workflows"}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/1": weird,
+        })):
+            _run_main(download_mod, ["1", "--comfyui-path", "/m", "--json"])
+
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["subfolder"] == "other"
+
+    def test_no_versions_dies(self, capsys):
+        no_versions = {**SAMPLE_MODEL, "modelVersions": []}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/1": no_versions,
+        })):
+            with pytest.raises(SystemExit):
+                _run_main(download_mod, ["1", "--comfyui-path", "/x"])
+
+        assert "no versions" in capsys.readouterr().err
+
+    def test_no_files_dies(self, capsys):
+        no_files = {**SAMPLE_MODEL, "modelVersions": [{
+            "id": 1, "name": "v", "baseModel": "SD 1.5", "files": [],
+        }]}
+        with patch("urllib.request.urlopen", side_effect=_route({
+            "/models/1": no_files,
+        })):
+            with pytest.raises(SystemExit):
+                _run_main(download_mod, ["1", "--comfyui-path", "/x"])
+
+        assert "no files" in capsys.readouterr().err
+
+
+# =========================================================================== #
+# health_check.py
+# =========================================================================== #
+class TestHealthCheck:
+    def test_static_checks_pass(self):
+        results = health_check_mod.static_checks()
+        statuses = [r["status"] for r in results]
+        assert "fail" not in statuses, f"static_checks reported failures: {results}"
+        names = [r["name"] for r in results]
+        for s in ("_common.py present", "search.py present",
+                   "show.py present", "download.py present"):
+            assert s in names
+
+    def test_static_checks_detect_missing_script(self, tmp_path, monkeypatch):
+        # Point HERE at an empty dir and verify static_checks flags missing files.
+        monkeypatch.setattr(health_check_mod, "HERE", str(tmp_path))
+        results = health_check_mod.static_checks()
+        statuses_by_name = {r["name"]: r["status"] for r in results}
+        assert statuses_by_name["_common.py present"] == "fail"
+        assert statuses_by_name["search.py present"] == "fail"
+
+    def test_offline_mode_skips_network(self, capsys, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["health_check.py", "--offline", "--json"])
+        with pytest.raises(SystemExit) as exc:
+            health_check_mod.main()
+
+        rendered = json.loads(capsys.readouterr().out)
+        groups = {c["group"] for c in rendered}
+        assert "Network" not in groups
+        assert "Auth" not in groups
+        assert "Functional" not in groups
+        # offline can still fail if static fails — accept either 0 or 1
+        assert exc.value.code in (0, 1)
+
+    def test_network_checks_ok(self):
+        def fake_http(url, key=None, body=None, timeout=12):  # noqa: ARG001
+            return 200, 100, b"{}"
+
+        with patch.object(health_check_mod, "_http", side_effect=fake_http):
+            results = health_check_mod.network_checks()
+
+        assert all(r["status"] == "ok" for r in results)
+
+    def test_network_failure_marks_fail(self):
+        def fake_http(url, key=None, body=None, timeout=12):  # noqa: ARG001
+            return None, 100, b"oops"
+
+        with patch.object(health_check_mod, "_http", side_effect=fake_http):
+            results = health_check_mod.network_checks()
+
+        assert any(r["status"] == "fail" for r in results)
+
+    def test_search_new_root_404_still_ok(self):
+        # Root path of search-new is allowed to 404 — any HTTP response = reachable
+        def fake_http(url, key=None, body=None, timeout=12):  # noqa: ARG001
+            if "search-new" in url:
+                return 404, 50, b""
+            return 200, 50, b"{}"
+
+        with patch.object(health_check_mod, "_http", side_effect=fake_http):
+            results = health_check_mod.network_checks()
+
+        assert all(r["status"] == "ok" for r in results)
+
+    def test_auth_check_skipped_without_key(self, monkeypatch):
+        monkeypatch.delenv("CIVITAI_API_KEY", raising=False)
+        results = health_check_mod.auth_checks()
+        assert len(results) == 1
+        assert results[0]["status"] == "skip"
+
+    def test_auth_check_ok_with_valid_key(self, monkeypatch):
+        monkeypatch.setenv("CIVITAI_API_KEY", "valid")
+        with patch.object(health_check_mod, "_http", return_value=(200, 50, b"{}")):
+            results = health_check_mod.auth_checks()
+        assert results[0]["status"] == "ok"
+
+    def test_auth_check_fail_with_bad_key(self, monkeypatch):
+        monkeypatch.setenv("CIVITAI_API_KEY", "bad")
+        with patch.object(health_check_mod, "_http", return_value=(401, 50, b"nope")):
+            results = health_check_mod.auth_checks()
+        assert results[0]["status"] == "fail"
+        assert "401" in results[0]["detail"]
+
+    def test_functional_checks_happy_path(self, monkeypatch):
+        monkeypatch.delenv("CIVITAI_API_KEY", raising=False)
+        meili_body = json.dumps({"results": [{"hits": [{"id": 1}]}]}).encode()
+        model_body = json.dumps({"name": "Realistic Vision V6.0"}).encode()
+        by_hash_body = json.dumps({"modelId": 257749}).encode()
+
+        def fake_http(url, key=None, body=None, timeout=12):  # noqa: ARG001
+            if "multi-search" in url:
+                return 200, 50, meili_body
+            if "by-hash" in url:
+                return 200, 50, by_hash_body
+            if "/models/" in url:
+                return 200, 50, model_body
+            return 200, 50, b"{}"
+
+        with patch.object(health_check_mod, "_http", side_effect=fake_http), \
+             patch.object(
+                 health_check_mod.subprocess, "run",
+                 return_value=MagicMock(returncode=0, stdout="curl -L test", stderr="")):
+            results = health_check_mod.functional_checks()
+
+        statuses = [r["status"] for r in results]
+        assert "fail" not in statuses, f"functional reported failures: {results}"
+
+    def test_functional_detects_key_leak(self, monkeypatch):
+        monkeypatch.setenv("CIVITAI_API_KEY", "leaky-token-xyz")
+        with patch.object(health_check_mod, "_http", return_value=(200, 50, b'{"name":"x"}')), \
+             patch.object(
+                 health_check_mod.subprocess, "run",
+                 return_value=MagicMock(
+                     returncode=0,
+                     stdout="curl -L https://example.com -H 'Authorization: Bearer leaky-token-xyz'",
+                     stderr="")):
+            results = health_check_mod.functional_checks()
+
+        leak_checks = [r for r in results if "download.py" in r["name"]]
+        assert leak_checks and leak_checks[0]["status"] == "fail"
+        assert "LEAKED" in leak_checks[0]["detail"]
+
+    def test_config_check_missing_dir(self):
+        results = health_check_mod.config_checks("/nonexistent/path/xyz123")
+        assert results[0]["status"] == "fail"
+
+    def test_config_check_ok_when_subfolders_present(self, tmp_path):
+        (tmp_path / "checkpoints").mkdir()
+        (tmp_path / "loras").mkdir()
+        results = health_check_mod.config_checks(str(tmp_path))
+        assert results[0]["status"] == "ok"
+
+    def test_config_check_skip_when_subfolders_missing(self, tmp_path):
+        results = health_check_mod.config_checks(str(tmp_path))
+        assert results[0]["status"] == "skip"
+
+    def test_config_check_empty_path_returns_nothing(self):
+        assert health_check_mod.config_checks("") == []
+
+    def test_full_run_with_everything_mocked(self, capsys, monkeypatch):
+        monkeypatch.delenv("CIVITAI_API_KEY", raising=False)
+
+        meili_body = json.dumps({"results": [{"hits": [{"id": 1}]}]}).encode()
+        model_body = json.dumps({"name": "Realistic Vision V6.0"}).encode()
+        by_hash_body = json.dumps({"modelId": 257749}).encode()
+
+        def fake_http(url, key=None, body=None, timeout=12):  # noqa: ARG001
+            if "multi-search" in url:
+                return 200, 50, meili_body
+            if "by-hash" in url:
+                return 200, 50, by_hash_body
+            if "/models/" in url:
+                return 200, 50, model_body
+            if "search-new.civitai.com" in url:
+                return 404, 50, b""
+            return 200, 50, b'{"items":[]}'
+
+        monkeypatch.setattr(sys, "argv", ["health_check.py", "--json"])
+        with patch.object(health_check_mod, "_http", side_effect=fake_http), \
+             patch.object(
+                 health_check_mod.subprocess, "run",
+                 return_value=MagicMock(returncode=0, stdout="curl -L test", stderr="")):
+            with pytest.raises(SystemExit) as exc:
+                health_check_mod.main()
+
+        rendered = json.loads(capsys.readouterr().out)
+        groups = {c["group"] for c in rendered}
+        assert {"Static", "Network", "Auth", "Functional"} <= groups
+        fails = [c for c in rendered if c["status"] == "fail"]
+        assert not fails, f"unexpected failures: {fails}"
+        assert exc.value.code == 0
+
+    def test_text_emit_writes_groups_and_summary(self, capsys):
+        sample = [
+            {"group": "Static", "name": "x", "status": "ok", "detail": ""},
+            {"group": "Static", "name": "y", "status": "skip", "detail": "why"},
+            {"group": "Network", "name": "z", "status": "fail", "detail": "boom"},
+        ]
+        health_check_mod._emit_text(sample)
+        out = capsys.readouterr().out
+        assert "[Static]" in out
+        assert "[Network]" in out
+        assert "boom" in out
+        assert "1 ok" in out and "1 skip" in out and "1 fail" in out


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Adds a new optional skill at optional-skills/creative/civitai/ that lets Hermes agents work with Civitai, the largest AI image-/video-generation model hub. The skill exposes five capabilities through three Python scripts plus a health-check harness:

Discovery — search and rank LoRAs, Checkpoints, etc. 
Metadata inspection — full model details, version-level files with hashes and scan results.
Prompt mining — extract working generation prompts  from example images and videos a model produced.
Hash-based identification — reverse-lookup a local .safetensors and tell user what it is.
ComfyUI download commands — emit ready-to-run curl / wget / PowerShell with correct folder mapping per model type.


## Related Issue
Fixes #N/A

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->
New files under optional-skills/creative/civitai/:
SKILL.md (348 lines) — frontmatter (name, description, version 1.1.0, author, license, hermes tags + civitai.comfyui_path config), Windows + "images return videos too" callouts, When to Use, API key (optional) setup, NSFW filtering section, Quick Reference table, 6 recipes + 2 workflows, enum cheat sheet, 7 Pitfalls (REST query broken / model-id resolution / browsing-level bitmask / slow get_creators & get_tags / Meili key rotation recovery / rate-limit fan-out / slim JSON), Safety, Verification.

scripts/_common.py — HTTP wrappers (api_get with retry/backoff, meili_search), formatters, browsing-level parser, shared slim_files / slim_model / slim_version / slim_prompt_image JSON helpers. Public Meili key annotated for security scanners.

scripts/search.py — models, images, top-models, top-images subcommands. Unified --nsfw. Silent-NSFW-drop warning when --ids returns fewer items than requested.

scripts/show.py — model, version, hash, prompts subcommands. All --json paths route through slim helpers.

scripts/download.py — shlex.quote() for bash, PS single-quote literals; no config.yaml scrape (agent forwards civitai.comfyui_path via --comfyui-path).

scripts/health_check.py — static + network + auth + functional + config check harness. Detects key-value leaks in download output. Exits 0 on success.

New test file under hermesroot/tests/skills/:

test_civitai_skill.py — 100 tests, fully offline (urllib mocked at request level), <1s to run. _find_scripts_dir() walks up looking for the skill so it works whether placed in skills/ or optional-skills/; honors a CIVITAI_SCRIPTS_DIR env override for CI / restructured layouts.

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. On the run health check
Prompt agent: "Please health check civitai skill."
OR
```
 python3 optional-skills/creative/civitai/scripts/health_check.py
```
2. Full unit test suite:
```
pytest hermesroot/tests/skills/test_civitai_skill.py -v
```
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
Using the skill on Windows
<img width="2528" height="1512" alt="image" src="https://github.com/user-attachments/assets/ba1e13e2-5122-4873-b56b-e04312ef9c37" />
<img width="1760" height="721" alt="image" src="https://github.com/user-attachments/assets/ab0da188-eb7e-4335-a2de-4a6d2130a704" />

Using the skill in WSL
<img width="2258" height="1427" alt="image" src="https://github.com/user-attachments/assets/632ac02e-0f20-401f-ad4b-1c13fe218485" />
<img width="1875" height="310" alt="image" src="https://github.com/user-attachments/assets/af8ec98e-0011-40bf-9cf8-cfa1bdcce879" />
