### PR TITLE
fix(honcho): pass session_id to peer.chat() in dialectic_query()

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -566,21 +566,27 @@ class HonchoSessionManager:
             level = self._default_reasoning_level()
 
         try:
+            honcho_session_id = session.honcho_session_id
             if self._ai_observe_others:
                 # AI peer can observe other peers — use assistant as observer.
                 ai_peer_obj = self._get_or_create_peer(session.assistant_peer_id)
                 if target_peer_id == session.assistant_peer_id:
-                    result = ai_peer_obj.chat(query, reasoning_level=level) or ""
+                    result = ai_peer_obj.chat(
+                        query, session=honcho_session_id, reasoning_level=level,
+                    ) or ""
                 else:
                     result = ai_peer_obj.chat(
                         query,
+                        session=honcho_session_id,
                         target=target_peer_id,
                         reasoning_level=level,
                     ) or ""
             else:
                 # Without cross-observation, each peer queries its own context.
                 target_peer = self._get_or_create_peer(target_peer_id)
-                result = target_peer.chat(query, reasoning_level=level) or ""
+                result = target_peer.chat(
+                    query, session=honcho_session_id, reasoning_level=level,
+                ) or ""
 
             # Apply Hermes-side char cap before caching
             if result and self._dialectic_max_chars and len(result) > self._dialectic_max_chars:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -846,6 +846,63 @@ class TestDialecticInputGuard:
         assert len(actual_query) <= 100
 
 
+class TestDialecticSessionForwarding:
+    """Verify that dialectic_query forwards session= to peer.chat() in every
+    branch: assistant self-query, assistant observing user, and the
+    non-cross-observation path."""
+
+    @staticmethod
+    def _make_manager(ai_observe_others=True):
+        """Create a HonchoSessionManager with a cached session and mocked peer."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(
+            api_key="test-key", enabled=True, recall_mode="hybrid",
+            ai_observe_others=ai_observe_others,
+        )
+        mgr = HonchoSessionManager(config=cfg)
+
+        session = HonchoSession(
+            key="test", user_peer_id="user-1", assistant_peer_id="ai-1",
+            honcho_session_id="sid-1",
+        )
+        mgr._cache["test"] = session
+
+        mock_peer = MagicMock()
+        mock_peer.chat.return_value = "answer"
+        mgr._get_or_create_peer = MagicMock(return_value=mock_peer)
+
+        return mgr, mock_peer, session
+
+    def test_ai_self_query_forwards_session(self):
+        """When _ai_observe_others is True and peer='ai', the assistant peer
+        queries itself — session= must be forwarded to chat()."""
+        mgr, mock_peer, session = self._make_manager(ai_observe_others=True)
+        mgr.dialectic_query("test", "hello", peer="ai")
+        mock_peer.chat.assert_called_once()
+        kwargs = mock_peer.chat.call_args.kwargs
+        assert kwargs.get("session") == "sid-1"
+
+    def test_ai_observing_user_forwards_session(self):
+        """When _ai_observe_others is True and peer='user', the assistant peer
+        observes the user — session= and target= must be forwarded to chat()."""
+        mgr, mock_peer, session = self._make_manager(ai_observe_others=True)
+        mgr.dialectic_query("test", "hello", peer="user")
+        mock_peer.chat.assert_called_once()
+        kwargs = mock_peer.chat.call_args.kwargs
+        assert kwargs.get("session") == "sid-1"
+        assert kwargs.get("target") == "user-1"
+
+    def test_non_cross_observation_forwards_session(self):
+        """When _ai_observe_others is False, each peer queries its own context
+        — session= must still be forwarded to chat()."""
+        mgr, mock_peer, session = self._make_manager(ai_observe_others=False)
+        mgr.dialectic_query("test", "hello", peer="user")
+        mock_peer.chat.assert_called_once()
+        kwargs = mock_peer.chat.call_args.kwargs
+        assert kwargs.get("session") == "sid-1"
+
+
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Bug Description

The Honcho dialectic endpoint receives no `session_id` from Hermes, so the dialectic LLM has zero session context. When the warm prompt asks "Given what's been discussed in this session so far, what context about this user is most relevant to the current conversation?", the LLM can't answer meaningfully — it falls back to vague `search_messages("context session")` queries that retrieve meta-conversations about contexts/sessions instead of the actual session content.

Fixes the irrelevant-context injection problem reported by self-hosted Honcho users.

## Root Cause

`dialectic_query()` in `plugins/memory/honcho/session.py` calls `peer.chat()` without passing the `session` parameter. The SDK supports it (`Peer.chat(query, session=..., target=..., reasoning_level=...)`) and correctly sends `session_id` in the API body, but Hermes never passed it.

The `session.honcho_session_id` is readily available in the method — it was simply never forwarded.

**Code path when session_id is missing:**
1. SDK sends `POST /peers/{id}/chat` with no `session_id` in body
2. Honcho API passes `session_name=None` to `agentic_chat()`
3. `DialecticAgent.__init__` sets `self.session_name = None`
4. `_initialize_session_history()` bails immediately: `if max_tokens == 0 or not self.session_name: return`
5. Dialectic LLM has no session history → vague searches → irrelevant results

## Fix

Pass `session=session.honcho_session_id` to all three `peer.chat()` call sites in `dialectic_query()`. This enables:

1. **Session history injection** — up to `SESSION_HISTORY_MAX_TOKENS` of session messages are injected into the dialectic's system prompt as `<session_history>`
2. **Session-scoped message search** — `search_messages`/`grep_messages` tools scope to the current session, while `search_memory` (observations) remains global

## How to Verify

1. Enable Honcho with `dialecticCadence` ≥ 1 and `SESSION_HISTORY_MAX_TOKENS > 0` on the server
2. Start a conversation, send a few messages
3. On the next dialectic fire, check the Honcho API logs — the dialectic request should now include `session_id` in the body
4. The dialectic LLM should produce session-relevant context instead of generic/vague results

## Test Plan

- [x] Existing 115 tests in `tests/honcho_plugin/test_session.py` pass
- [x] Manual verification with self-hosted Honcho (session history now injected)

## Risk Assessment

**Low** — The `session` parameter was already supported by the SDK and the Honcho API. This is a wiring fix, not a behavioral change. When `session_id` is provided:

- Message search tools scope to that session (correct — you want to search the current conversation)
- Memory/observation search remains global (correct — you want cross-session knowledge)
- Session history is injected into the system prompt (the feature that was already implemented but never activated from Hermes)

For users with `SESSION_HISTORY_MAX_TOKENS = 0` (default in some configs), the session history injection is skipped server-side, so passing `session_id` is harmless.

### Relationship to PR #30154

This fix is **complementary but distinct** from #30154, which scopes the base context layer (representation/peer card) to the session. That change is appropriate for long-lived sessions (`per-directory`, `per-repo`) but **regresses `per-session` mode** — fresh ephemeral sessions would return empty context, losing the accumulated user model. This fix benefits ALL session strategies: the dialectic simply needs to know what the current conversation is about, regardless of session lifetime.