### PR TITLE
fix(mcp): add --yes/-y to mcp add for non-interactive tool enablement

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12963,6 +12963,12 @@ Examples:
         default=[],
         help="Environment variables for stdio servers (KEY=VALUE)",
     )
+    mcp_add_p.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Auto-enable all discovered tools without the interactive prompt "
+             "(non-interactive: shell scripts, cron, CI). See #31970.",
+    )
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -366,15 +366,23 @@ def cmd_mcp_add(args):
         print(f"    {color(tool_name, Colors.GREEN):40s} {short}")
     print()
 
-    # Ask: enable all, select, or cancel
-    try:
-        choice = input(
-            color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
-        ).strip().lower()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        _info("Cancelled.")
-        return
+    # Ask: enable all, select, or cancel — unless --yes/-y was passed,
+    # in which case skip the prompt and take the "enable all" branch (the
+    # empty / "y" default below). Matches `pip install -y`, `apt-get -y`,
+    # `hermes claw migrate --yes`. Required for shell scripts, cron, and
+    # CI/CD that can't drive an interactive prompt. See #31970.
+    if getattr(args, "yes", False):
+        _info(f"--yes: auto-enabling all {len(tools)} tools.")
+        choice = ""
+    else:
+        try:
+            choice = input(
+                color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
+            ).strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            _info("Cancelled.")
+            return
 
     if choice in {"n", "no"}:
         _info("Cancelled — server not saved.")

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -55,7 +55,12 @@ def _error(text: str):
     print(color(f"  ✗ {text}", Colors.RED))
 
 
-def _confirm(question: str, default: bool = True) -> bool:
+def _confirm(question: str, default: bool = True, *, yes: bool = False) -> bool:
+    """Yes/no prompt. When ``yes`` is set, return ``default`` without prompting —
+    lets callers thread an outer ``--yes`` flag through every confirmation site
+    without rewriting the call sites' control flow. See #31970."""
+    if yes:
+        return default
     default_str = "Y/n" if default else "y/N"
     try:
         val = input(color(f"  {question} [{default_str}]: ", Colors.YELLOW)).strip().lower()
@@ -234,6 +239,12 @@ def cmd_mcp_add(args):
     cmd_args = getattr(args, "args", None) or []
     auth_type = getattr(args, "auth", None)
     preset_name = getattr(args, "preset", None)
+    # Non-interactive mode — threaded into every prompt below so scripts/cron/CI
+    # never block. With --yes: confirmations take their existing default value
+    # (safe by design — overwrite-protect stays False), the auth-confirm uses
+    # the --auth flag's presence instead of asking, and a missing API-key env
+    # var fails loudly rather than prompting. See #31970.
+    _yes = getattr(args, "yes", False)
     raw_env = getattr(args, "env", None)
 
     server_config: Dict[str, Any] = {}
@@ -267,7 +278,7 @@ def cmd_mcp_add(args):
     # Check if server already exists
     existing = _get_mcp_servers()
     if name in existing:
-        if not _confirm(f"Server '{name}' already exists. Overwrite?", default=False):
+        if not _confirm(f"Server '{name}' already exists. Overwrite?", default=False, yes=_yes):
             _info("Cancelled.")
             return
 
@@ -302,7 +313,7 @@ def cmd_mcp_add(args):
 
         if not oauth_ok:
             _info("This server may not support OAuth.")
-            if _confirm("Continue without authentication?", default=True):
+            if _confirm("Continue without authentication?", default=True, yes=_yes):
                 # Don't store auth: oauth — server doesn't support it
                 pass
             else:
@@ -310,10 +321,17 @@ def cmd_mcp_add(args):
                 return
 
     elif url:
-        # Prompt for API key / Bearer token for HTTP servers
+        # Prompt for API key / Bearer token for HTTP servers.
+        # Under --yes: skip the auth-confirm prompt entirely and infer intent
+        # from --auth — present means "yes auth", absent means "no auth".
+        # This is the contract scripts/CI rely on: if you wanted auth, you'd
+        # have passed --auth explicitly. See #31970.
         print()
         _info(f"Connecting to {url}")
-        needs_auth = _confirm("Does this server require authentication?", default=True)
+        if _yes:
+            needs_auth = bool(auth_type)
+        else:
+            needs_auth = _confirm("Does this server require authentication?", default=True)
         if needs_auth:
             if auth_type == "header" or not auth_type:
                 env_key = _env_key_for_server(name)
@@ -321,6 +339,17 @@ def cmd_mcp_add(args):
                 if existing_key:
                     _success(f"{env_key}: already configured")
                     api_key = existing_key
+                elif _yes:
+                    # Non-interactive: must already have the env var. Fail
+                    # loudly with a clear remediation hint rather than blocking
+                    # on a password prompt cron/CI can't satisfy.
+                    _error(
+                        f"--yes: auth required but {env_key} is not set. "
+                        f"Set the env var (e.g. `echo '{env_key}=...' >> "
+                        f"{display_hermes_home()}/.env`) and re-run, or omit "
+                        f"--auth to add the server without authentication."
+                    )
+                    return
                 else:
                     api_key = _prompt("API key / Bearer token", password=True)
                     if api_key:
@@ -342,7 +371,7 @@ def cmd_mcp_add(args):
         tools = _probe_single_server(name, server_config)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
-        if _confirm("Save config anyway (you can test later)?", default=False):
+        if _confirm("Save config anyway (you can test later)?", default=False, yes=_yes):
             server_config["enabled"] = False
             _save_mcp_server(name, server_config)
             _success(f"Saved '{name}' to config (disabled)")
@@ -351,7 +380,7 @@ def cmd_mcp_add(args):
 
     if not tools:
         _warning("Server connected but reported no tools.")
-        if _confirm("Save config anyway?", default=True):
+        if _confirm("Save config anyway?", default=True, yes=_yes):
             _save_mcp_server(name, server_config)
             _success(f"Saved '{name}' to config")
         return

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -56,7 +56,14 @@ def _error(text: str):
     print(color(f"  ✗ {text}", Colors.RED))
 
 
-def _confirm(question: str, default: bool = True) -> bool:
+def _confirm(question: str, default: bool = True, *, yes: bool = False) -> bool:
+    """Yes/no prompt; with ``yes`` set, return ``default`` without prompting.
+
+    Lets callers thread an outer ``--yes`` flag through every confirmation
+    site without restructuring their control flow.
+    """
+    if yes:
+        return default
     default_str = "Y/n" if default else "y/N"
     try:
         val = input(color(f"  {question} [{default_str}]: ", Colors.YELLOW)).strip().lower()
@@ -450,6 +457,12 @@ def cmd_mcp_add(args):
     preset_name = getattr(args, "preset", None)
     raw_env = getattr(args, "env", None)
     raw_connect_timeout = getattr(args, "connect_timeout", None)
+    # Non-interactive mode, threaded into every prompt below so scripts, cron
+    # and CI never block.  Confirmations take their documented default (so
+    # overwrite-protection stays off), the auth question is answered by the
+    # presence of --auth instead of a prompt, and a missing API key fails
+    # loudly rather than stalling on a password prompt nothing can answer.
+    assume_yes = getattr(args, "yes", False)
 
     server_config: Dict[str, Any] = {}
     try:
@@ -482,7 +495,11 @@ def cmd_mcp_add(args):
     # Check if server already exists
     existing = _get_mcp_servers()
     if name in existing:
-        if not _confirm(f"Server '{name}' already exists. Overwrite?", default=False):
+        if not _confirm(
+            f"Server '{name}' already exists. Overwrite?",
+            default=False,
+            yes=assume_yes,
+        ):
             _info("Cancelled.")
             return
 
@@ -527,7 +544,7 @@ def cmd_mcp_add(args):
 
         if not oauth_ok:
             _info("This server may not support OAuth.")
-            if _confirm("Continue without authentication?", default=True):
+            if _confirm("Continue without authentication?", default=True, yes=assume_yes):
                 # Don't store auth: oauth — server doesn't support it
                 pass
             else:
@@ -538,13 +555,25 @@ def cmd_mcp_add(args):
         # Prompt for API key / Bearer token for HTTP servers
         print()
         _info(f"Connecting to {url}")
-        needs_auth = _confirm("Does this server require authentication?", default=True)
+        if assume_yes:
+            # Infer intent from --auth: passing it means "yes, authenticate";
+            # omitting it means "no auth".  Asking is not an option here.
+            needs_auth = bool(auth_type)
+        else:
+            needs_auth = _confirm("Does this server require authentication?", default=True)
         if needs_auth:
             if auth_type == "header" or not auth_type:
                 env_key = _env_key_for_server(name)
                 existing_key = get_env_value(env_key)
                 if existing_key:
                     _success(f"{env_key}: already configured")
+                elif assume_yes:
+                    _error(
+                        f"--yes: auth requested but {env_key} is not set. Add it to "
+                        f"{display_hermes_home()}/.env and re-run, or drop --auth to "
+                        f"add '{name}' without authentication."
+                    )
+                    return
                 else:
                     api_key = _prompt("API key / Bearer token", password=True)
                     if api_key:
@@ -566,7 +595,11 @@ def cmd_mcp_add(args):
         tools = _probe_single_server(name, server_config)
     except Exception as exc:
         _error(f"Failed to connect: {exc}")
-        if _confirm("Save config anyway (you can test later)?", default=False):
+        if _confirm(
+            "Save config anyway (you can test later)?",
+            default=False,
+            yes=assume_yes,
+        ):
             server_config["enabled"] = False
             if _save_mcp_server(name, server_config):
                 _success(f"Saved '{name}' to config (disabled)")
@@ -575,7 +608,7 @@ def cmd_mcp_add(args):
 
     if not tools:
         _warning("Server connected but reported no tools.")
-        if _confirm("Save config anyway?", default=True):
+        if _confirm("Save config anyway?", default=True, yes=assume_yes):
             if _save_mcp_server(name, server_config):
                 _success(f"Saved '{name}' to config")
         return
@@ -590,15 +623,20 @@ def cmd_mcp_add(args):
         print(f"    {color(tool_name, Colors.GREEN):40s} {short}")
     print()
 
-    # Ask: enable all, select, or cancel
-    try:
-        choice = input(
-            color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
-        ).strip().lower()
-    except (KeyboardInterrupt, EOFError):
-        print()
-        _info("Cancelled.")
-        return
+    # Ask: enable all, select, or cancel.  Under --yes take the documented
+    # [Y/n/select] default, which the empty string already routes to.
+    if assume_yes:
+        _info(f"--yes: auto-enabling all {len(tools)} tools.")
+        choice = ""
+    else:
+        try:
+            choice = input(
+                color(f"  Enable all {len(tools)} tools? [Y/n/select]: ", Colors.YELLOW)
+            ).strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            _info("Cancelled.")
+            return
 
     if choice in {"n", "no"}:
         _info("Cancelled — server not saved.")

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -71,6 +71,14 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         default=[],
         help="Environment variables for stdio servers (KEY=VALUE)",
     )
+    mcp_add_p.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Non-interactive: take the default answer for every prompt and "
+             "auto-enable all discovered tools (shell scripts, cron, CI). "
+             "Place before --args, which consumes the rest of the line",
+    )
 
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -216,6 +216,44 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
+    def test_add_yes_flag_skips_tool_selection_prompt(self, tmp_path, capsys, monkeypatch):
+        """--yes auto-enables all discovered tools without the input() prompt.
+
+        Required for non-interactive callers (shell scripts, cron, CI). The
+        test wires input() with EXACTLY one entry ("n" for auth) — if the
+        tool-selection prompt still fires, the next input() would raise
+        StopIteration and the test fails. See #31970.
+        """
+        fake_tools = [
+            FakeTool("create_service", "Deploy from repo"),
+            FakeTool("list_services", "List all services"),
+        ]
+
+        def mock_probe(name, config, **kw):
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        # Exactly one input: "n" for "auth needed?". The tool-selection
+        # prompt must NOT consume a second input — that's the contract.
+        inputs = iter(["n"])
+        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(name="auto", url="https://mcp.example.com/mcp", yes=True))
+        out = capsys.readouterr().out
+        assert "Saved" in out
+        assert "2/2 tools" in out
+        # The --yes path emits an explicit info line so operators can see
+        # the prompt was skipped on purpose.
+        assert "auto-enabling" in out
+
+        from hermes_cli.config import load_config
+        config = load_config()
+        assert "auto" in config.get("mcp_servers", {})
+
     def test_add_stdio_server(self, tmp_path, capsys, monkeypatch):
         """Add a stdio server."""
         fake_tools = [FakeTool("search", "Search repos")]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -216,13 +216,14 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
-    def test_add_yes_flag_skips_tool_selection_prompt(self, tmp_path, capsys, monkeypatch):
-        """--yes auto-enables all discovered tools without the input() prompt.
+    def test_add_yes_flag_skips_all_interactive_prompts(self, tmp_path, capsys, monkeypatch):
+        """--yes runs cmd_mcp_add fully non-interactively for HTTP-no-auth.
 
-        Required for non-interactive callers (shell scripts, cron, CI). The
-        test wires input() with EXACTLY one entry ("n" for auth) — if the
-        tool-selection prompt still fires, the next input() would raise
-        StopIteration and the test fails. See #31970.
+        Wires input() to fail on ANY call — every prompt site (auth-confirm,
+        save-anyway, tool-selection) must be bypassed. The earlier scoped
+        version of this test only covered the tool-selection prompt; this
+        widened version pins the contract reviewer of #31979 asked about.
+        See #31970.
         """
         fake_tools = [
             FakeTool("create_service", "Deploy from repo"),
@@ -232,13 +233,13 @@ class TestMcpAdd:
         def mock_probe(name, config, **kw):
             return [(t.name, t.description) for t in fake_tools]
 
-        monkeypatch.setattr(
-            "hermes_cli.mcp_config._probe_single_server", mock_probe
-        )
-        # Exactly one input: "n" for "auth needed?". The tool-selection
-        # prompt must NOT consume a second input — that's the contract.
-        inputs = iter(["n"])
-        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", mock_probe)
+
+        def _no_input_allowed(prompt=""):
+            raise AssertionError(
+                f"--yes must not block on any input() prompt; got: {prompt!r}"
+            )
+        monkeypatch.setattr("builtins.input", _no_input_allowed)
 
         from hermes_cli.mcp_config import cmd_mcp_add
 
@@ -246,13 +247,42 @@ class TestMcpAdd:
         out = capsys.readouterr().out
         assert "Saved" in out
         assert "2/2 tools" in out
-        # The --yes path emits an explicit info line so operators can see
-        # the prompt was skipped on purpose.
         assert "auto-enabling" in out
 
         from hermes_cli.config import load_config
         config = load_config()
         assert "auto" in config.get("mcp_servers", {})
+
+    def test_add_yes_with_auth_but_missing_env_var_fails_loudly(self, tmp_path, capsys, monkeypatch):
+        """--yes + --auth header but no MCP_*_API_KEY env var → hard error,
+        not a silent block on the password prompt.
+
+        Cron/CI that asked for auth without credentials should fail with an
+        actionable remediation hint (set the env var), never wedge on a
+        prompt nothing can answer. Reviewer carve-out for #31979.
+        """
+        def _probe_should_not_run(name, config, **kw):
+            raise AssertionError("--yes auth-missing path must error before probe")
+        monkeypatch.setattr("hermes_cli.mcp_config._probe_single_server", _probe_should_not_run)
+
+        def _no_input_allowed(prompt=""):
+            raise AssertionError(f"--yes must not prompt; got: {prompt!r}")
+        monkeypatch.setattr("builtins.input", _no_input_allowed)
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="needs-auth", url="https://mcp.example.com/mcp",
+            auth="header", yes=True,
+        ))
+        out = capsys.readouterr().out
+        # Loud, actionable error — names the env var the operator must set.
+        assert "--yes" in out
+        assert "MCP_NEEDS_AUTH_API_KEY" in out
+        # Did NOT save — the server was rejected non-interactively.
+        from hermes_cli.config import load_config
+        config = load_config()
+        assert "needs-auth" not in config.get("mcp_servers", {})
 
     def test_add_stdio_server(self, tmp_path, capsys, monkeypatch):
         """Add a stdio server."""

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -206,6 +206,70 @@ class TestMcpAdd:
         assert "ink" in config.get("mcp_servers", {})
         assert config["mcp_servers"]["ink"]["url"] == "https://mcp.ml.ink/mcp"
 
+    def test_add_yes_skips_every_prompt(self, tmp_path, capsys, monkeypatch):
+        """--yes drives a full add without touching input() even once.
+
+        input() is wired to raise, so any surviving prompt site (auth,
+        save-anyway, tool selection) fails the test rather than hanging it.
+        """
+        fake_tools = [
+            FakeTool("create_service", "Deploy from repo"),
+            FakeTool("list_services", "List all services"),
+        ]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, config, **kw: [(t.name, t.description) for t in fake_tools],
+        )
+
+        def _no_input(prompt=""):
+            raise AssertionError(f"--yes must not prompt; got {prompt!r}")
+
+        monkeypatch.setattr("builtins.input", _no_input)
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(name="auto", url="https://mcp.example.com/mcp", yes=True))
+        out = capsys.readouterr().out
+        assert "auto-enabling" in out
+        assert "2/2 tools" in out
+
+        from hermes_cli.config import load_config
+
+        assert "auto" in load_config().get("mcp_servers", {})
+
+    def test_add_yes_with_auth_but_no_key_errors(self, tmp_path, capsys, monkeypatch):
+        """--yes --auth header without the env var fails loudly, never prompts.
+
+        Cron/CI that asked for auth but has no credential should get an
+        actionable error, not a password prompt nothing can answer.
+        """
+        def _probe_should_not_run(name, config, **kw):
+            raise AssertionError("must error before probing")
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", _probe_should_not_run
+        )
+
+        def _no_input(prompt=""):
+            raise AssertionError(f"--yes must not prompt; got {prompt!r}")
+
+        monkeypatch.setattr("builtins.input", _no_input)
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+
+        cmd_mcp_add(_make_args(
+            name="needs-auth",
+            url="https://mcp.example.com/mcp",
+            auth="header",
+            yes=True,
+        ))
+        out = capsys.readouterr().out
+        assert "MCP_NEEDS_AUTH_API_KEY" in out
+
+        from hermes_cli.config import load_config
+
+        assert "needs-auth" not in load_config().get("mcp_servers", {})
 
     def test_add_stdio_server_with_env(self, tmp_path, capsys, monkeypatch):
         """Stdio servers can persist explicit environment variables."""

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,17 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+@pytest.mark.parametrize("flag", ["-y", "--yes"])
+def test_mcp_add_accepts_yes_flag(flag):
+    # `hermes mcp add` must be drivable from scripts/cron/CI; the flag lives on
+    # the real builder, not on a hand-rolled parser (see #31970).
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_mcp_parser(sub, cmd_mcp=_h("mcp"))
+    ns = parser.parse_args(["mcp", "add", "srv", "--url", "https://x/mcp", flag])
+    assert ns.yes is True
+    # Absent by default — interactive behaviour is unchanged.
+    ns = parser.parse_args(["mcp", "add", "srv", "--url", "https://x/mcp"])
+    assert ns.yes is False


### PR DESCRIPTION
hermes mcp add always prompts "Enable all N tools? [Y/n/select]" after discovery, with no way to bypass from CLI flags. Breaks shell scripts, cron jobs, and CI/CD pipelines that can't drive an interactive prompt (issue #31970).

Add the flag at the mcp_add argparse + gate the input() call in cmd_mcp_add. When --yes is set, take the "enable all" branch directly and emit an explicit info line so operators see the prompt was skipped on purpose. Mirrors `pip install -y`, `apt-get -y`, `hermes claw migrate --yes`.

- hermes_cli/main.py: add -y/--yes flag to mcp_add_p
- hermes_cli/mcp_config.py: cmd_mcp_add gates input() on getattr(args, "yes", False); skips straight to the default enable-all path (choice="")
- tests/hermes_cli/test_mcp_config.py: new test_add_yes_flag_skips_tool_selection_prompt wires input() with EXACTLY one entry ("n" for auth) — the tool-selection prompt must NOT consume a second input. Verified the test fails without the gate (StopIteration on second input()) and passes with it.

Fixes #31970

## What does this PR do?

  `hermes mcp add` always prompts `Enable all N tools? [Y/n/select]` after discovering tools, with no way to bypass from CLI flags. Breaks shell scripts, cron jobs, and CI/CD pipelines that can't drive an interactive prompt (issue #31970).

  Add `-y`/`--yes` to the `mcp add` argparse + gate the `input()` call in `cmd_mcp_add`. When `--yes` is set, skip the prompt and take the "enable all" branch directly (matching `pip install -y`, `apt-get -y`, `hermes claw migrate --yes`). An explicit info line is emitted so operators see the prompt was skipped on purpose.

  ## Changes Made

  - `hermes_cli/main.py` — add `-y`/`--yes` flag to `mcp_add_p`.
  - `hermes_cli/mcp_config.py` — `cmd_mcp_add` gates the `input()` call on `getattr(args, "yes", False)` and falls through to the empty-default ("enable all") branch.
  - `tests/hermes_cli/test_mcp_config.py` — new `test_add_yes_flag_skips_tool_selection_prompt`: wires `input()` with **exactly one** entry (`"n"` for auth). If the tool-selection prompt still fires, the next `input()` raises `StopIteration` and the test fails — that's the contract being pinned.

  ## How to Test

  ```bash
  pytest tests/hermes_cli/test_mcp_config.py -k 'add' -v   # 11 passed
  pytest tests/hermes_cli/test_mcp_config.py -q            # 33 passed
  ```

  Verified the new test **fails** when the `getattr(args, "yes", False)` gate is removed (input() consumed twice → StopIteration on second call) and **passes** with the gate.

  Manual smoke (an existing HTTP server config):
  ```bash
  hermes mcp add ink --url https://mcp.example.com/mcp -y
  # Output: "--yes: auto-enabling all N tools." then "Saved: ink (N/N tools)"
  # No interactive prompt; safe for cron/CI.
  ```

  ## Related Issue

  Fixes #31970

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests
  - [ ] ♻️  Refactor
  - [ ] 🎯 New skill

  ## Checklist

  ### Code
  - [x] I've read the Contributing Guide
  - [x] Conventional Commits (`fix(mcp): ...`)
  - [x] Searched existing PRs — no PR references #31970; lane clean
  - [x] Only changes related to this fix — single commit, 3 files, `+61 / -9`
  - [ ] `pytest tests/ -q` — ran `tests/hermes_cli/test_mcp_config.py` (33 passed); did not run the whole repo suite locally, relying on CI
  - [x] Added tests with verified regression discipline
  - [x] Tested on: Ubuntu 24.04, Python 3.13.5

  ### Documentation & Housekeeping
  - [x] Docs — flag is self-documenting via `--help`; behavior change is logged at runtime via the `_info("--yes: auto-enabling …")` line
  - [x] cli-config.yaml.example — N/A (CLI flag only, no config key)
  - [x] CONTRIBUTING/AGENTS — N/A
  - [x] Cross-platform — pure argparse + control-flow; platform-agnostic
  - [x] Tool schemas — N/A
