### PR TITLE
fix(ci): add fix@local to AUTHOR_MAP for Tranquil-Flow

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -523,6 +523,7 @@ AUTHOR_MAP = {
     "shannon@nousresearch.com": "shannonsands",
     "abdi.moya@gmail.com": "AxDSan",
     "eri@plasticlabs.ai": "Erosika",
+    "fix@local": "Tranquil-Flow",
     "hjcpuro@gmail.com": "hjc-puro",
     "xaydinoktay@gmail.com": "aydnOktay",
     "abdullahfarukozden@gmail.com": "Farukest",


### PR DESCRIPTION
## What
Add `fix@local` → `Tranquil-Flow` mapping to `scripts/release.py` AUTHOR_MAP.

## Root Cause
PR #22105 (`fix/21589-discord-goal-slash-command`) has a commit authored with email `fix@local` (display name "Fix Bot"). This email is not in AUTHOR_MAP, causing the Contributor Attribution Check CI workflow to fail.

The PR author is `Tranquil-Flow`, so the email maps to that GitHub username.

## Fix
Added `"fix@local": "Tranquil-Flow"` to the manual mapping section in `scripts/release.py` AUTHOR_MAP.

## Related
- PR #22105
- CI run: https://github.com/NousResearch/hermes-agent/actions/runs/26392838715