### PR TITLE
fix(tui): drop /quit alias 'q' so /q routes to backend /queue

### DIFF
--- a/ui-tui/src/__tests__/slashParity.test.ts
+++ b/ui-tui/src/__tests__/slashParity.test.ts
@@ -110,4 +110,13 @@ describe('slash parity matrix', () => {
       expect(routes[name], `mutating command must not fallback: ${name}`).not.toBe('fallback')
     }
   })
+
+  it('does not shadow the backend /queue alias `q` with a TUI-local command', () => {
+    // Regression for #31983: the TUI `quit` command used to carry an alias
+    // `q`, which collides with the Python-side `/queue` alias. TUI-local
+    // commands dispatch before the backend, so `/q` resolved to /quit
+    // (session.die) instead of queueing a prompt. `q` must NOT be a local
+    // name/alias so it falls through to the backend /queue.
+    expect(LOCAL_COMMAND_NAMES.has('q')).toBe(false)
+  })
 })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -110,7 +110,11 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
-    aliases: ['exit', 'q'],
+    // NB: no 'q' alias — it collides with the Python-side `/queue` alias
+    // (hermes_cli/commands.py), and TUI-local commands are dispatched before
+    // the backend, so `/q` was resolving to /quit (exit) instead of /queue.
+    // `/quit` and `/exit` are explicit enough for exiting. See #31983.
+    aliases: ['exit'],
     help: 'exit hermes',
     name: 'quit',
     run: (_arg, ctx) => ctx.session.die()


### PR DESCRIPTION
Fixes #31983.

## Summary
In the TUI, typing `/q` exited Hermes instead of queuing a prompt. The `quit` command carried alias `q` (`ui-tui/src/app/slash/commands/core.ts`), which collides with the Python-side `/queue` alias `q` (`hermes_cli/commands.py`). TUI-local commands dispatch before the backend, so `/q` always resolved to `/quit` → `ctx.session.die()`.

## Fix
Remove `q` from the `quit` aliases (now just `['exit']`). `/quit` and `/exit` are explicit enough for exiting, so `/q` falls through to the backend where it correctly maps to `/queue`.

## Test
Added a regression test to `src/__tests__/slashParity.test.ts` asserting `q` is not a TUI-local name/alias (so it can't shadow the backend `/queue`). The existing parity suite only deduped an alias *set*, so this collision was previously silent.

```
$ cd ui-tui && npm run build --prefix packages/hermes-ink && ./node_modules/.bin/vitest run src/__tests__/slashParity.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Verified the test guards the regression: with the `q` alias restored, the new test fails (`1 failed`); with the fix, it passes.

Note: `npm run type-check` reports pre-existing errors in `packages/hermes-ink/src/utils/execFileNoThrow.ts` and `src/app/useMainApp.ts` that are present on `main` independent of this change (confirmed by stashing the diff); this PR touches only the `quit` alias array and the parity test, both of which lint clean.
