### PR TITLE
feat(feishu): add CardKit streaming reply cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -116,11 +116,14 @@ try:
 except ImportError:
     FEISHU_AVAILABLE = False
     lark = None  # type: ignore[assignment]
+    AccessTokenType = None  # type: ignore[assignment]
+    BaseRequest = None  # type: ignore[assignment]
     CallBackCard = None  # type: ignore[assignment]
     P2CardActionTriggerResponse = None  # type: ignore[assignment]
     EventDispatcherHandler = None  # type: ignore[assignment]
     FeishuWSClient = None  # type: ignore[assignment]
     FEISHU_DOMAIN = None  # type: ignore[assignment]
+    HttpMethod = None  # type: ignore[assignment]
     LARK_DOMAIN = None  # type: ignore[assignment]
 
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
@@ -162,6 +165,7 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_FEISHU_STREAMING_ELEMENT_ID = "streaming_content"
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1408,6 +1412,7 @@ class FeishuAdapter(BasePlatformAdapter):
     """Feishu/Lark bot adapter."""
 
     MAX_MESSAGE_LENGTH = 8000
+    SUPPORTS_STREAMING_CARDS = True
     # Threshold for detecting Feishu client-side message splits.
     # When a chunk is near the ~4096-char practical limit, a continuation
     # is almost certain.
@@ -1450,6 +1455,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._cardkit_streams: Dict[str, Dict[str, Any]] = {}
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -1852,6 +1858,315 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_cardkit_streaming_card(
+        *,
+        content: str = "",
+        reasoning_text: Optional[str] = None,
+        streaming: bool = True,
+    ) -> Dict[str, Any]:
+        elements: List[Dict[str, Any]] = []
+        if reasoning_text:
+            elements.append(
+                {
+                    "tag": "collapsible_panel",
+                    "expanded": not content.strip(),
+                    "header": {
+                        "title": {
+                            "tag": "markdown",
+                            "content": "Thinking",
+                            "i18n_content": {"zh_cn": "思考过程", "en_us": "Thinking"},
+                        },
+                        "vertical_align": "center",
+                        "icon": {
+                            "tag": "standard_icon",
+                            "token": "down-small-ccm_outlined",
+                            "size": "16px 16px",
+                        },
+                        "icon_position": "follow_text",
+                        "icon_expanded_angle": -180,
+                    },
+                    "border": {"color": "grey", "corner_radius": "5px"},
+                    "vertical_spacing": "8px",
+                    "padding": "8px 8px 8px 8px",
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": reasoning_text,
+                            "text_size": "notation",
+                        }
+                    ],
+                }
+            )
+
+        elements.append(
+            {
+                "tag": "markdown",
+                "content": content,
+                "text_align": "left",
+                "text_size": "normal_v2" if streaming else "normal",
+                "margin": "0px 0px 0px 0px",
+                "element_id": _FEISHU_STREAMING_ELEMENT_ID,
+            }
+        )
+        if streaming:
+            elements.append(
+                {
+                    "tag": "markdown",
+                    "content": " ",
+                    "element_id": "loading_icon",
+                }
+            )
+
+        summary = (content or "Processing...").replace("\n", " ").strip()[:120] or "Processing..."
+        return {
+            "schema": "2.0",
+            "config": {
+                "streaming_mode": streaming,
+                "wide_screen_mode": True,
+                "update_multi": True,
+                "locales": ["zh_cn", "en_us"],
+                "summary": {
+                    "content": summary,
+                    "i18n_content": {"zh_cn": "处理中..." if streaming else summary, "en_us": summary},
+                },
+            },
+            "body": {"elements": elements},
+        }
+
+    async def send_streaming_message(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        reasoning_text: Optional[str] = None,
+    ) -> SendResult:
+        """Send a CardKit-backed interactive card for streaming replies."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            card = self._build_cardkit_streaming_card(reasoning_text=reasoning_text, streaming=True)
+            card_id = await self._create_cardkit_card(card)
+            if not card_id:
+                raise RuntimeError("CardKit card.create returned empty card_id")
+            result = await self._send_cardkit_card_reference(
+                chat_id=chat_id,
+                card_id=card_id,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            if not result.success or not result.message_id:
+                return result
+            self._cardkit_streams[str(result.message_id)] = {"card_id": card_id, "sequence": 1}
+            if content.strip() or reasoning_text:
+                await self._stream_cardkit_content(
+                    message_id=str(result.message_id),
+                    content=content,
+                    reasoning_text=reasoning_text,
+                )
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] CardKit streaming send failed; falling back to message send: %s", exc)
+            if 'result' in locals() and getattr(result, "message_id", None):
+                self._cardkit_streams.pop(str(result.message_id), None)
+            return await self.send(chat_id=chat_id, content=content, reply_to=reply_to, metadata=metadata)
+
+    async def edit_streaming_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+        reasoning_text: Optional[str] = None,
+    ) -> SendResult:
+        """Update a CardKit streaming card, closing it on the final edit."""
+        stream = self._cardkit_streams.get(str(message_id))
+        if not stream:
+            return await self.edit_message(chat_id=chat_id, message_id=message_id, content=content, finalize=finalize)
+
+        card_id = str(stream["card_id"])
+        try:
+            if finalize:
+                stream["sequence"] = int(stream.get("sequence", 1)) + 1
+                await self._set_cardkit_streaming_mode(
+                    card_id=card_id,
+                    streaming_mode=False,
+                    sequence=stream["sequence"],
+                )
+                final_card = self._build_cardkit_streaming_card(
+                    content=content,
+                    reasoning_text=reasoning_text,
+                    streaming=False,
+                )
+                stream["sequence"] += 1
+                await self._update_cardkit_card(
+                    card_id=card_id,
+                    card=final_card,
+                    sequence=stream["sequence"],
+                )
+                self._cardkit_streams.pop(str(message_id), None)
+            else:
+                await self._stream_cardkit_content(
+                    message_id=str(message_id),
+                    content=content,
+                    reasoning_text=reasoning_text,
+                )
+            return SendResult(success=True, message_id=message_id)
+        except Exception as exc:
+            logger.warning("[Feishu] CardKit streaming edit failed; falling back to message edit: %s", exc)
+            self._cardkit_streams.pop(str(message_id), None)
+            return await self.edit_message(chat_id=chat_id, message_id=message_id, content=content, finalize=finalize)
+
+    async def _create_cardkit_card(self, card: Dict[str, Any]) -> Optional[str]:
+        card_json = json.dumps(card, ensure_ascii=False)
+        try:
+            from lark_oapi.api.cardkit.v1 import CreateCardRequest, CreateCardRequestBody
+
+            body = CreateCardRequestBody.builder().type("card_json").data(card_json).build()
+            request = CreateCardRequest.builder().request_body(body).build()
+            response = await asyncio.to_thread(self._client.cardkit.v1.card.create, request)
+            payload = self._parse_cardkit_response(response)
+            self._raise_for_cardkit_error(payload)
+        except (ImportError, AttributeError):
+            payload = await self._cardkit_request(
+                HttpMethod.POST,
+                "/open-apis/cardkit/v1/cards",
+                {"type": "card_json", "data": card_json},
+            )
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+        data_obj = payload.get("data")
+        card_id = data.get("card_id") or getattr(data_obj, "card_id", None) or payload.get("card_id")
+        return str(card_id) if card_id else None
+
+    async def _send_cardkit_card_reference(
+        self,
+        *,
+        chat_id: str,
+        card_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        payload = json.dumps({"type": "card", "data": {"card_id": card_id}}, ensure_ascii=False)
+        response = await self._feishu_send_with_retry(
+            chat_id=chat_id,
+            msg_type="interactive",
+            payload=payload,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+        return self._finalize_send_result(response, "send CardKit card failed")
+
+    async def _stream_cardkit_content(
+        self,
+        *,
+        message_id: str,
+        content: str,
+        reasoning_text: Optional[str] = None,
+    ) -> None:
+        stream = self._cardkit_streams.get(str(message_id))
+        if not stream:
+            return
+        stream["sequence"] = int(stream.get("sequence", 1)) + 1
+        try:
+            from lark_oapi.api.cardkit.v1 import ContentCardElementRequest, ContentCardElementRequestBody
+
+            body = ContentCardElementRequestBody.builder().content(content).sequence(stream["sequence"]).build()
+            request = (
+                ContentCardElementRequest.builder()
+                .card_id(str(stream["card_id"]))
+                .element_id(_FEISHU_STREAMING_ELEMENT_ID)
+                .request_body(body)
+                .build()
+            )
+            response = await asyncio.to_thread(self._client.cardkit.v1.card_element.content, request)
+            self._raise_for_cardkit_error(self._parse_cardkit_response(response))
+        except (ImportError, AttributeError):
+            await self._cardkit_request(
+                HttpMethod.PUT,
+                f"/open-apis/cardkit/v1/cards/{stream['card_id']}/elements/{_FEISHU_STREAMING_ELEMENT_ID}/content",
+                {"content": content, "sequence": stream["sequence"]},
+            )
+
+    async def _update_cardkit_card(self, *, card_id: str, card: Dict[str, Any], sequence: int) -> None:
+        card_json = json.dumps(card, ensure_ascii=False)
+        try:
+            from lark_oapi.api.cardkit.v1 import Card, UpdateCardRequest, UpdateCardRequestBody
+
+            card_body = Card.builder().type("card_json").data(card_json).build()
+            body = UpdateCardRequestBody.builder().card(card_body).sequence(sequence).build()
+            request = UpdateCardRequest.builder().card_id(card_id).request_body(body).build()
+            response = await asyncio.to_thread(self._client.cardkit.v1.card.update, request)
+            self._raise_for_cardkit_error(self._parse_cardkit_response(response))
+        except (ImportError, AttributeError):
+            await self._cardkit_request(
+                HttpMethod.PUT,
+                f"/open-apis/cardkit/v1/cards/{card_id}",
+                {
+                    "card": {"type": "card_json", "data": card_json},
+                    "sequence": sequence,
+                },
+            )
+
+    async def _set_cardkit_streaming_mode(self, *, card_id: str, streaming_mode: bool, sequence: int) -> None:
+        settings = json.dumps({"streaming_mode": streaming_mode}, ensure_ascii=False)
+        try:
+            from lark_oapi.api.cardkit.v1 import SettingsCardRequest, SettingsCardRequestBody
+
+            body = SettingsCardRequestBody.builder().settings(settings).sequence(sequence).build()
+            request = SettingsCardRequest.builder().card_id(card_id).request_body(body).build()
+            response = await asyncio.to_thread(self._client.cardkit.v1.card.settings, request)
+            self._raise_for_cardkit_error(self._parse_cardkit_response(response))
+        except (ImportError, AttributeError):
+            await self._cardkit_request(
+                HttpMethod.PUT,
+                f"/open-apis/cardkit/v1/cards/{card_id}/settings",
+                {
+                    "settings": settings,
+                    "sequence": sequence,
+                },
+            )
+
+    async def _cardkit_request(self, method: Any, uri: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        if BaseRequest is None or HttpMethod is None or AccessTokenType is None:
+            raise RuntimeError("lark-oapi BaseRequest is unavailable")
+        req = (
+            BaseRequest.builder()
+            .http_method(method)
+            .uri(uri)
+            .headers({"Content-Type": "application/json; charset=utf-8"})
+            .body(json.dumps(data, ensure_ascii=False).encode("utf-8"))
+            .token_types({AccessTokenType.TENANT})
+            .build()
+        )
+        response = await asyncio.to_thread(self._client.request, req)
+        payload = self._parse_cardkit_response(response)
+        code = payload.get("code")
+        self._raise_for_cardkit_error(payload)
+        return payload
+
+    @staticmethod
+    def _raise_for_cardkit_error(payload: Dict[str, Any]) -> None:
+        code = payload.get("code")
+        if code not in (None, 0):
+            raise RuntimeError(f"CardKit API failed ({code}): {payload.get('msg') or payload}")
+
+    @staticmethod
+    def _parse_cardkit_response(response: Any) -> Dict[str, Any]:
+        raw_content = getattr(getattr(response, "raw", None), "content", None)
+        if raw_content:
+            if isinstance(raw_content, bytes):
+                raw_content = raw_content.decode("utf-8")
+            return json.loads(raw_content)
+        payload: Dict[str, Any] = {}
+        for key in ("code", "msg", "data", "card_id"):
+            if hasattr(response, key):
+                payload[key] = getattr(response, key)
+        return payload
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16342,6 +16342,7 @@ class GatewayRunner:
             # Set up stream consumer for token streaming or interim commentary.
             _stream_consumer = None
             _stream_delta_cb = None
+            _reasoning_delta_cb = None
             _scfg = getattr(getattr(self, 'config', None), 'streaming', None)
             if _scfg is None:
                 from gateway.config import StreamingConfig
@@ -16359,6 +16360,10 @@ class GatewayRunner:
                 if _plat_streaming is None
                 else bool(_plat_streaming)
             )
+            _plat_show_reasoning = resolve_display_setting(
+                user_config, platform_key, "show_reasoning"
+            )
+            _show_reasoning = bool(_plat_show_reasoning)
             _want_stream_deltas = _streaming_enabled
             _want_interim_messages = interim_assistant_messages_enabled
             _want_interim_consumer = _want_interim_messages
@@ -16417,6 +16422,10 @@ class GatewayRunner:
                             def _stream_delta_cb(text: str) -> None:
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
+                        if _show_reasoning:
+                            def _reasoning_delta_cb(text: str) -> None:
+                                if _run_still_current():
+                                    _stream_consumer.on_reasoning_delta(text)
                         stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
@@ -16517,6 +16526,7 @@ class GatewayRunner:
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
+            agent.reasoning_callback = _reasoning_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -45,6 +45,11 @@ _NEW_SEGMENT = object()
 # API/tool iterations (for example: "I'll inspect the repo first.").
 _COMMENTARY = object()
 
+# Queue marker for structured provider reasoning deltas. These are separate
+# from inline <think> tags and are only routed by callers that opted into
+# showing reasoning.
+_REASONING = object()
+
 
 @dataclass
 class StreamConsumerConfig:
@@ -167,6 +172,7 @@ class GatewayStreamConsumer:
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
+        self._reasoning_accumulated = ""
 
         # Native draft-streaming state.  Resolved at the start of run() based
         # on cfg.transport, cfg.chat_type, and the adapter's
@@ -240,6 +246,11 @@ class GatewayStreamConsumer:
         """Queue a completed interim assistant commentary message."""
         if text:
             self._queue.put((_COMMENTARY, text))
+
+    def on_reasoning_delta(self, text: str) -> None:
+        """Queue a structured reasoning/thinking delta for card display."""
+        if text:
+            self._queue.put((_REASONING, text))
 
     def _notify_new_message(self) -> None:
         """Fire the on_new_message callback, swallowing any errors."""
@@ -319,13 +330,18 @@ class GatewayStreamConsumer:
 
                 if best_len:
                     # Found closing tag — discard block, process remainder
+                    self._reasoning_accumulated += buf[:best_idx]
                     self._in_think_block = False
                     buf = buf[best_idx + best_len:]
                 else:
                     # No closing tag yet — hold tail that could be a
                     # partial closing tag prefix, discard the rest.
                     max_tag = max(len(t) for t in self._CLOSE_THINK_TAGS)
-                    self._think_buffer = buf[-max_tag:] if len(buf) > max_tag else buf
+                    if len(buf) > max_tag:
+                        self._reasoning_accumulated += buf[:-max_tag]
+                        self._think_buffer = buf[-max_tag:]
+                    else:
+                        self._think_buffer = buf
                     return
             else:
                 # Look for earliest opening tag at a block boundary
@@ -393,6 +409,12 @@ class GatewayStreamConsumer:
             self._accumulated += self._think_buffer
             self._think_buffer = ""
 
+    def _has_streaming_card_reasoning(self) -> bool:
+        return bool(
+            self._reasoning_accumulated.strip()
+            and self._streaming_card_method("send_streaming_message") is not None
+        )
+
     async def run(self) -> None:
         """Async task that drains the queue and edits the platform message."""
         # Platform message length limit — leave room for cursor + formatting.
@@ -440,6 +462,9 @@ class GatewayStreamConsumer:
                         if isinstance(item, tuple) and len(item) == 2 and item[0] is _COMMENTARY:
                             commentary_text = item[1]
                             break
+                        if isinstance(item, tuple) and len(item) == 2 and item[0] is _REASONING:
+                            self._reasoning_accumulated += str(item[1])
+                            continue
                         self._filter_and_accumulate(item)
                     except queue.Empty:
                         break
@@ -453,6 +478,7 @@ class GatewayStreamConsumer:
                 # Decide whether to flush an edit
                 now = time.monotonic()
                 elapsed = now - self._last_edit_time
+                has_card_reasoning = self._has_streaming_card_reasoning()
                 should_edit = (
                     got_done
                     or got_segment_break
@@ -461,7 +487,7 @@ class GatewayStreamConsumer:
                 if not self.cfg.buffer_only:
                     should_edit = should_edit or (
                         (elapsed >= self._current_edit_interval
-                            and self._accumulated)
+                            and (self._accumulated or has_card_reasoning))
                         # buffer_threshold is intentionally codepoint-based:
                         # it's a debounce heuristic ("send updates roughly
                         # every N visible characters"), not a platform-limit
@@ -470,7 +496,7 @@ class GatewayStreamConsumer:
                     )
 
                 current_update_visible = False
-                if should_edit and self._accumulated:
+                if should_edit and (self._accumulated or has_card_reasoning):
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     if (
@@ -561,7 +587,8 @@ class GatewayStreamConsumer:
                     # mid-stream, send a single continuation/fallback message
                     # here instead of letting the base gateway path send the
                     # full response again.
-                    if self._accumulated:
+                    has_final_card_reasoning = bool(self._message_id and self._has_streaming_card_reasoning())
+                    if self._accumulated or has_final_card_reasoning:
                         if self._fallback_final_send:
                             await self._send_fallback_final(self._accumulated)
                         elif (
@@ -948,6 +975,13 @@ class GatewayStreamConsumer:
         self._last_sent_text = text
         return True
 
+    def _streaming_card_method(self, name: str):
+        """Return an adapter CardKit streaming method when explicitly supported."""
+        if getattr(self.adapter, "SUPPORTS_STREAMING_CARDS", False) is not True:
+            return None
+        method = getattr(self.adapter, name, None)
+        return method if callable(method) else None
+
     async def _flush_segment_tail_on_edit_failure(self) -> None:
         """Deliver un-sent tail content before a segment-break reset.
 
@@ -1122,9 +1156,10 @@ class GatewayStreamConsumer:
         if self.cfg.cursor:
             visible_without_cursor = visible_without_cursor.replace(self.cfg.cursor, "")
         _visible_stripped = visible_without_cursor.strip()
-        if not _visible_stripped:
+        has_card_reasoning = self._has_streaming_card_reasoning()
+        if not _visible_stripped and not has_card_reasoning:
             return True  # cursor-only / whitespace-only update
-        if not text.strip():
+        if not text.strip() and not has_card_reasoning:
             return True  # nothing to send is "success"
         # Guard: do not create a brand-new standalone message when the only
         # visible content is a handful of characters alongside the streaming
@@ -1139,7 +1174,8 @@ class GatewayStreamConsumer:
         if (self._message_id is None
                 and self.cfg.cursor
                 and self.cfg.cursor in text
-                and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
+            and len(_visible_stripped) < _MIN_NEW_MSG_CHARS
+            and not has_card_reasoning):
             return True  # too short for a standalone message — accumulate more
 
         # Native draft streaming: route mid-stream frames through send_draft.
@@ -1199,12 +1235,25 @@ class GatewayStreamConsumer:
                         and await self._try_fresh_final(text)
                     ):
                         return True
-                    # Edit existing message
-                    result = await self._edit_message(
-                        message_id=self._message_id,
-                        content=text,
-                        finalize=finalize,
-                    )
+                    # Edit existing message. Platforms that explicitly opt in
+                    # can keep an interactive CardKit card open while text
+                    # streams and close it on the final edit.
+                    edit_streaming = self._streaming_card_method("edit_streaming_message")
+                    if edit_streaming is not None:
+                        result = await edit_streaming(
+                            chat_id=self.chat_id,
+                            message_id=self._message_id,
+                            content="" if has_card_reasoning and not _visible_stripped else text,
+                            finalize=finalize,
+                            metadata=self.metadata,
+                            reasoning_text=self._reasoning_accumulated.strip() or None,
+                        )
+                    else:
+                        result = await self._edit_message(
+                            message_id=self._message_id,
+                            content=text,
+                            finalize=finalize,
+                        )
                     if result.success:
                         self._already_sent = True
                         # Adapter may have split-and-delivered an oversized
@@ -1279,12 +1328,22 @@ class GatewayStreamConsumer:
             else:
                 # First message — send new, threaded to the original user message
                 # so it lands in the correct topic/thread.
-                result = await self.adapter.send(
-                    chat_id=self.chat_id,
-                    content=text,
-                    reply_to=self._initial_reply_to_id,
-                    metadata=self.metadata,
-                )
+                send_streaming = self._streaming_card_method("send_streaming_message")
+                if send_streaming is not None and not finalize:
+                    result = await send_streaming(
+                        chat_id=self.chat_id,
+                        content="" if has_card_reasoning and not _visible_stripped else text,
+                        reply_to=self._initial_reply_to_id,
+                        metadata=self.metadata,
+                        reasoning_text=self._reasoning_accumulated.strip() or None,
+                    )
+                else:
+                    result = await self.adapter.send(
+                        chat_id=self.chat_id,
+                        content=text,
+                        reply_to=self._initial_reply_to_id,
+                        metadata=self.metadata,
+                    )
                 if result.success:
                     if result.message_id:
                         self._message_id = result.message_id

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3794,8 +3794,8 @@ def mount_spa(application: FastAPI):
 # Built-in dashboard themes — label + description only.  The actual color
 # definitions live in the frontend (web/src/themes/presets.ts).
 _BUILTIN_DASHBOARD_THEMES = [
-    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
-    {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
+    {"name": "default",       "label": "Feishu Blue",         "description": "Clean white workspace with Feishu-style blue accents"},
+    {"name": "default-large", "label": "Feishu Blue (Large)", "description": "Feishu Blue with bigger fonts and roomier spacing"},
     {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},

--- a/plugins/hermes-achievements/dashboard/dist/style.css
+++ b/plugins/hermes-achievements/dashboard/dist/style.css
@@ -16,9 +16,10 @@
 .ha-stat-value { margin-top: .35rem; font-size: 1.4rem; font-weight: 750; letter-spacing: -0.035em; }
 .ha-stat-hint { margin-top: .2rem; color: var(--color-muted-foreground); font-size: .75rem; }
 .ha-toolbar { display: flex; justify-content: space-between; gap: .75rem; align-items: center; flex-wrap: wrap; }
-.ha-pills { display: flex; gap: .35rem; flex-wrap: wrap; }
-.ha-pills button { border: 1px solid var(--color-border); background: color-mix(in srgb, var(--color-card) 72%, transparent); color: var(--color-muted-foreground); padding: .35rem .6rem; font-size: .78rem; cursor: pointer; }
-.ha-pills button.active, .ha-pills button:hover { color: var(--color-foreground); border-color: var(--ha-tier, var(--color-ring)); background: color-mix(in srgb, var(--color-primary) 16%, var(--color-card)); }
+.ha-pills { display: flex; gap: .4rem; flex-wrap: wrap; }
+.ha-pills button { min-height: 1.9rem; border: 1px solid #dee0e3; border-radius: .42rem; background: #ffffff; color: #4e5969; padding: .3rem .66rem; font-size: .76rem; line-height: 1.15; cursor: pointer; box-shadow: 0 1px 2px rgba(31,35,41,.03); transition: color .14s ease, border-color .14s ease, background .14s ease, box-shadow .14s ease; }
+.ha-pills button:hover { color: #1f2329; border-color: #bbbfc4; background: #f7f8fa; box-shadow: 0 2px 4px rgba(31,35,41,.05); }
+.ha-pills button.active { color: #245bdb; border-color: #3370ff; background: #f0f5ff; box-shadow: 0 0 0 2px rgba(51,112,255,.08); }
 .ha-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: .9rem; }
 .ha-card { --ha-tier: var(--color-border); position: relative; overflow: hidden; min-height: 214px; border: 1px solid color-mix(in srgb, var(--ha-tier) 46%, var(--color-border)); background: radial-gradient(circle at 2.6rem 2.2rem, color-mix(in srgb, var(--ha-tier) 16%, transparent), transparent 34%), linear-gradient(180deg, rgba(255,255,255,.04), transparent), color-mix(in srgb, var(--color-card) 92%, #000); transition: transform .16s ease, border-color .16s ease, opacity .16s ease, box-shadow .16s ease; }
 .ha-card:hover { transform: translateY(-2px); border-color: var(--ha-tier); box-shadow: 0 0 0 1px color-mix(in srgb, var(--ha-tier) 16%, transparent); }
@@ -29,14 +30,14 @@
 .ha-card-title { font-weight: 780; line-height: 1.05; letter-spacing: -0.025em; }
 .ha-card-category { margin-top: .28rem; color: var(--color-muted-foreground); font-size: .76rem; }
 .ha-badges { display: flex; flex-direction: column; align-items: flex-end; gap: .25rem; }
-.ha-tier-badge, .ha-state-badge { border: 1px solid var(--ha-tier); color: var(--ha-tier); background: color-mix(in srgb, var(--ha-tier) 10%, transparent); padding: .16rem .38rem; font-size: .67rem; text-transform: uppercase; letter-spacing: .08em; font-family: var(--font-mono, ui-monospace, monospace); }
+.ha-tier-badge, .ha-state-badge { border: 1px solid color-mix(in srgb, var(--ha-tier) 42%, var(--color-border)); border-radius: .35rem; color: var(--ha-tier); background: color-mix(in srgb, var(--ha-tier) 8%, var(--color-card)); padding: .16rem .42rem; font-size: .67rem; text-transform: uppercase; letter-spacing: .04em; font-family: var(--theme-font-sans, ui-sans-serif, system-ui, sans-serif); }
 .ha-description { margin: 0; color: var(--color-muted-foreground); font-size: .86rem; line-height: 1.45; min-height: 2.4em; }
-.ha-criteria { border: 1px solid color-mix(in srgb, var(--ha-tier) 28%, var(--color-border)); background: color-mix(in srgb, var(--ha-tier) 5%, transparent); }
-.ha-criteria summary { cursor: pointer; padding: .5rem .65rem; color: var(--ha-tier); text-transform: uppercase; letter-spacing: .1em; font-size: .66rem; font-family: var(--font-mono, ui-monospace, monospace); user-select: none; }
+.ha-criteria { border: 1px solid color-mix(in srgb, var(--ha-tier) 24%, var(--color-border)); border-radius: .5rem; background: color-mix(in srgb, var(--ha-tier) 4%, var(--color-card)); overflow: hidden; }
+.ha-criteria summary { cursor: pointer; padding: .5rem .65rem; color: var(--ha-tier); text-transform: uppercase; letter-spacing: .04em; font-size: .66rem; font-family: var(--theme-font-sans, ui-sans-serif, system-ui, sans-serif); user-select: none; }
 .ha-criteria summary:hover { background: color-mix(in srgb, var(--ha-tier) 8%, transparent); }
 .ha-criteria p { margin: 0; border-top: 1px solid color-mix(in srgb, var(--ha-tier) 18%, var(--color-border)); padding: .55rem .65rem .65rem; color: color-mix(in srgb, var(--color-foreground) 78%, var(--color-muted-foreground)); font-size: .76rem; line-height: 1.38; }
 .ha-progress-row { display: flex; align-items: center; gap: .55rem; margin-top: 0; }
-.ha-progress-track { flex: 1; height: .48rem; border: 1px solid color-mix(in srgb, var(--ha-tier) 34%, var(--color-border)); background: rgba(0,0,0,.22); overflow: hidden; }
+.ha-progress-track { flex: 1; height: .48rem; border: 1px solid color-mix(in srgb, var(--ha-tier) 22%, var(--color-border)); border-radius: 999px; background: color-mix(in srgb, var(--color-muted-foreground) 10%, transparent); overflow: hidden; }
 .ha-progress-fill { height: 100%; background: linear-gradient(90deg, var(--ha-tier), color-mix(in srgb, var(--ha-tier) 48%, white)); }
 .ha-progress-text { min-width: 5.4rem; text-align: right; font-family: var(--font-mono, ui-monospace, monospace); color: var(--color-muted-foreground); font-size: .72rem; }
 .ha-evidence-slot { min-height: 1.65rem; margin-top: auto; display: flex; align-items: flex-end; }
@@ -46,7 +47,7 @@
 .ha-evidence-empty { visibility: hidden; }
 .ha-latest h2 { margin: 0 0 .5rem; font-size: 1rem; }
 .ha-latest-row { display: flex; gap: .5rem; flex-wrap: wrap; }
-.ha-chip { display: inline-flex; align-items: center; gap: .35rem; border: 1px solid var(--ha-tier); color: var(--ha-tier); background: color-mix(in srgb, var(--ha-tier) 10%, transparent); padding: .35rem .55rem; font-size: .8rem; }
+.ha-chip { display: inline-flex; align-items: center; gap: .35rem; border: 1px solid color-mix(in srgb, var(--ha-tier) 38%, var(--color-border)); border-radius: .5rem; color: var(--ha-tier); background: color-mix(in srgb, var(--ha-tier) 8%, var(--color-card)); padding: .35rem .6rem; font-size: .8rem; }
 .ha-chip-icon .ha-lucide { width: .95rem; height: .95rem; }
 .ha-slot { border-style: dashed; }
 .ha-slot-content { display: flex; gap: .6rem; align-items: center; padding: .65rem .8rem !important; font-size: .82rem; }
@@ -55,13 +56,13 @@
 .ha-error { border-color: #ef4444; color: #fecaca; }
 .ha-loading { color: var(--color-muted-foreground); font-family: var(--font-mono, ui-monospace, monospace); padding: 2rem; border: 1px dashed var(--color-border); }
 .ha-guide { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(0, .85fr); gap: .75rem; }
-.ha-guide > div { border: 1px solid var(--color-border); background: color-mix(in srgb, var(--color-card) 82%, transparent); padding: .85rem 1rem; }
-.ha-guide strong { display: block; margin-bottom: .45rem; font-size: .78rem; text-transform: uppercase; letter-spacing: .12em; font-family: var(--font-mono, ui-monospace, monospace); }
+.ha-guide > div { border: 1px solid var(--color-border); border-radius: .65rem; background: color-mix(in srgb, var(--color-card) 94%, transparent); padding: .9rem 1rem; box-shadow: 0 1px 2px rgba(31,35,41,.03); }
+.ha-guide strong { display: block; margin-bottom: .55rem; color: var(--color-foreground); font-size: .84rem; font-weight: 600; text-transform: none; letter-spacing: 0; font-family: var(--theme-font-sans, ui-sans-serif, system-ui, sans-serif); }
 .ha-guide p { margin: 0; color: var(--color-muted-foreground); font-size: .84rem; line-height: 1.45; }
-.ha-tier-legend { display: flex; align-items: center; gap: .45rem; flex-wrap: wrap; }
-.ha-tier-step { --ha-tier: var(--color-border); display: inline-flex; align-items: center; gap: .32rem; color: var(--ha-tier); border: 1px solid color-mix(in srgb, var(--ha-tier) 52%, var(--color-border)); background: color-mix(in srgb, var(--ha-tier) 8%, transparent); padding: .28rem .45rem; font-size: .72rem; font-family: var(--font-mono, ui-monospace, monospace); text-transform: uppercase; letter-spacing: .06em; }
-.ha-tier-step i { width: .55rem; height: .55rem; background: var(--ha-tier); display: inline-block; }
-.ha-tier-arrow { color: var(--color-muted-foreground); }
+.ha-tier-legend { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; }
+.ha-tier-step { --ha-tier: var(--color-border); display: inline-flex; align-items: center; gap: .36rem; min-height: 1.72rem; color: color-mix(in srgb, var(--ha-tier) 86%, var(--color-foreground)); border: 1px solid color-mix(in srgb, var(--ha-tier) 28%, var(--color-border)); border-radius: .45rem; background: color-mix(in srgb, var(--ha-tier) 7%, var(--color-card)); padding: .25rem .55rem; font-size: .74rem; font-family: var(--theme-font-sans, ui-sans-serif, system-ui, sans-serif); text-transform: none; letter-spacing: 0; box-shadow: 0 1px 1px rgba(31,35,41,.02); }
+.ha-tier-step i { width: .5rem; height: .5rem; border-radius: 999px; background: var(--ha-tier); display: inline-block; box-shadow: 0 0 0 2px color-mix(in srgb, var(--ha-tier) 13%, transparent); }
+.ha-tier-arrow { color: color-mix(in srgb, var(--color-muted-foreground) 72%, transparent); font-size: .78rem; }
 .ha-state-discovered { opacity: .92; }
 .ha-state-discovered .ha-card-title { color: color-mix(in srgb, var(--color-foreground) 82%, var(--ha-tier)); }
 .ha-state-secret { opacity: .5; filter: grayscale(.55); }

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2839,6 +2839,104 @@ class TestAdapterBehavior(unittest.TestCase):
             [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
         )
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_cardkit_streaming_card_contains_streaming_element_and_reasoning(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        card = adapter._build_cardkit_streaming_card(
+            content="Answer body",
+            reasoning_text="checked docs",
+            streaming=True,
+        )
+
+        self.assertEqual(card["schema"], "2.0")
+        self.assertTrue(card["config"]["streaming_mode"])
+        elements = card["body"]["elements"]
+        self.assertEqual(elements[0]["tag"], "collapsible_panel")
+        self.assertIn("checked docs", elements[0]["elements"][0]["content"])
+        self.assertEqual(elements[1]["element_id"], "streaming_content")
+        self.assertEqual(elements[1]["content"], "Answer body")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_streaming_message_creates_cardkit_card_and_sends_reference(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        captured = {}
+
+        async def _create_card(card):
+            captured["created_card"] = card
+            return "card_1"
+
+        async def _send(**kwargs):
+            captured["send"] = kwargs
+            return SimpleNamespace(success=True, message_id="om_card")
+
+        async def _stream(**kwargs):
+            captured["stream"] = kwargs
+
+        adapter._create_cardkit_card = AsyncMock(side_effect=_create_card)
+        adapter._send_cardkit_card_reference = AsyncMock(side_effect=_send)
+        adapter._stream_cardkit_content = AsyncMock(side_effect=_stream)
+
+        result = asyncio.run(
+            adapter.send_streaming_message(
+                chat_id="oc_chat",
+                content="Hello ▉",
+                reply_to="om_user",
+                metadata={"thread_id": "omt_1"},
+                reasoning_text="checking",
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_card")
+        self.assertEqual(captured["created_card"]["config"]["streaming_mode"], True)
+        self.assertEqual(captured["send"]["card_id"], "card_1")
+        self.assertEqual(captured["send"]["reply_to"], "om_user")
+        self.assertEqual(captured["stream"]["message_id"], "om_card")
+        self.assertEqual(captured["stream"]["content"], "Hello ▉")
+        self.assertEqual(adapter._cardkit_streams["om_card"]["card_id"], "card_1")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_edit_streaming_message_closes_and_updates_final_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace()
+        adapter._cardkit_streams["om_card"] = {"card_id": "card_1", "sequence": 2}
+
+        adapter._set_cardkit_streaming_mode = AsyncMock()
+        adapter._update_cardkit_card = AsyncMock()
+
+        result = asyncio.run(
+            adapter.edit_streaming_message(
+                chat_id="oc_chat",
+                message_id="om_card",
+                content="Final answer",
+                finalize=True,
+                reasoning_text="checked docs",
+            )
+        )
+
+        self.assertTrue(result.success)
+        adapter._set_cardkit_streaming_mode.assert_called_once_with(
+            card_id="card_1",
+            streaming_mode=False,
+            sequence=3,
+        )
+        update_kwargs = adapter._update_cardkit_card.call_args.kwargs
+        self.assertEqual(update_kwargs["card_id"], "card_1")
+        self.assertEqual(update_kwargs["sequence"], 4)
+        self.assertFalse(update_kwargs["card"]["config"].get("streaming_mode", False))
+        self.assertIn("Final answer", update_kwargs["card"]["body"]["elements"][-1]["content"])
+        self.assertNotIn("om_card", adapter._cardkit_streams)
+
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestHydrateBotIdentity(unittest.TestCase):

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1346,6 +1346,108 @@ class TestFilterAndAccumulateIntegration:
         except asyncio.CancelledError:
             pass
 
+    @pytest.mark.asyncio
+    async def test_feishu_streaming_card_receives_reasoning_lane(self):
+        """Feishu CardKit streaming keeps hidden reasoning for the card panel."""
+        adapter = MagicMock()
+        adapter.SUPPORTS_STREAMING_CARDS = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send_streaming_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.edit_streaming_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_test",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+        )
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("<think>check context</think>Answer")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        adapter.send_streaming_message.assert_called()
+        first_kwargs = adapter.send_streaming_message.call_args.kwargs
+        assert first_kwargs["reasoning_text"] == "check context"
+        assert "Answer" in first_kwargs["content"]
+
+        adapter.edit_streaming_message.assert_called()
+        final_kwargs = adapter.edit_streaming_message.call_args.kwargs
+        assert final_kwargs["finalize"] is True
+        assert final_kwargs["reasoning_text"] == "check context"
+        assert final_kwargs["content"] == "Answer"
+
+    @pytest.mark.asyncio
+    async def test_feishu_streaming_card_can_start_with_reasoning_only(self):
+        """Reasoning-only deltas still create and finalize a Feishu card."""
+        adapter = MagicMock()
+        adapter.SUPPORTS_STREAMING_CARDS = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send_streaming_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.edit_streaming_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_test",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+        )
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta("<think>checking tools</think>")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        adapter.send_streaming_message.assert_called_once()
+        assert adapter.send_streaming_message.call_args.kwargs["content"] == ""
+        assert adapter.send_streaming_message.call_args.kwargs["reasoning_text"] == "checking tools"
+
+        adapter.edit_streaming_message.assert_called_once()
+        assert adapter.edit_streaming_message.call_args.kwargs["finalize"] is True
+        assert adapter.edit_streaming_message.call_args.kwargs["content"] == ""
+        assert adapter.edit_streaming_message.call_args.kwargs["reasoning_text"] == "checking tools"
+
+    @pytest.mark.asyncio
+    async def test_feishu_streaming_card_accepts_structured_reasoning_delta(self):
+        """Provider reasoning_content deltas should feed the Feishu reasoning panel."""
+        adapter = MagicMock()
+        adapter.SUPPORTS_STREAMING_CARDS = True
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send_streaming_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+        adapter.edit_streaming_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1")
+        )
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_test",
+            StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5),
+        )
+
+        task = asyncio.create_task(consumer.run())
+        consumer.on_reasoning_delta("structured thought")
+        await asyncio.sleep(0.08)
+        consumer.on_delta("Answer")
+        consumer.finish()
+        await task
+
+        adapter.send_streaming_message.assert_called()
+        assert adapter.send_streaming_message.call_args.kwargs["reasoning_text"] == "structured thought"
+        assert adapter.edit_streaming_message.call_args.kwargs["finalize"] is True
+        assert adapter.edit_streaming_message.call_args.kwargs["reasoning_text"] == "structured thought"
+        assert adapter.edit_streaming_message.call_args.kwargs["content"] == "Answer"
+
 
 # ── buffer_only mode tests ─────────────────────────────────────────────
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -420,7 +420,7 @@ export default function App() {
   return (
     <div
       data-layout-variant={layoutVariant}
-      className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black text-text-primary antialiased"
+      className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background text-text-primary antialiased"
     >
       <SelectionSwitcher />
       <Backdrop />
@@ -430,8 +430,8 @@ export default function App() {
         className={cn(
           "lg:hidden fixed top-0 left-0 right-0 z-40 min-h-14",
           "flex items-center gap-2 px-4 py-2",
-          "border-b border-current/20",
-          "bg-background-base/90 backdrop-blur-sm",
+          "border-b border-border/70",
+          "bg-white/88 shadow-[0_8px_28px_rgba(31,35,41,0.06)] backdrop-blur-xl",
         )}
         style={{
           background: "var(--component-header-background)",
@@ -446,14 +446,13 @@ export default function App() {
           aria-label={t.app.openNavigation}
           aria-expanded={mobileOpen}
           aria-controls="app-sidebar"
-          className="text-text-secondary hover:text-midground"
+          className="rounded-md text-text-secondary hover:bg-primary/10 hover:text-primary"
         >
           <Menu />
         </Button>
 
         <Typography
-          className="font-bold text-[0.95rem] leading-[0.95] tracking-[0.05em] text-midground"
-          style={{ mixBlendMode: "plus-lighter" }}
+          className="font-semibold text-[0.95rem] leading-none tracking-normal text-foreground"
         >
           {t.app.brand}
         </Typography>
@@ -466,7 +465,7 @@ export default function App() {
           onClick={closeMobile}
           className={cn(
             "lg:hidden fixed inset-0 z-40 p-0 block",
-            "bg-black/60 backdrop-blur-sm",
+            "bg-slate-950/30 backdrop-blur-sm",
           )}
         />
       )}
@@ -480,8 +479,8 @@ export default function App() {
             aria-label={t.app.navigation}
             className={cn(
               "fixed top-0 left-0 z-50 flex h-dvh max-h-dvh w-64 min-h-0 flex-col",
-              "border-r border-current/20",
-              "bg-background-base/95 backdrop-blur-sm",
+              "border-r border-border",
+              "bg-white shadow-none",
               "transition-transform duration-200 ease-out",
               mobileOpen ? "translate-x-0" : "-translate-x-full",
               "lg:sticky lg:top-0 lg:translate-x-0 lg:shrink-0",
@@ -495,15 +494,14 @@ export default function App() {
             <div
               className={cn(
                 "flex h-14 shrink-0 items-center justify-between gap-2 px-4",
-                "border-b border-current/20",
+                "border-b border-border",
               )}
             >
               <div className="flex items-center gap-2">
                 <PluginSlot name="header-left" />
 
                 <Typography
-                  className="font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground uppercase"
-                  style={{ mixBlendMode: "plus-lighter" }}
+                  className="font-semibold text-[1.05rem] leading-tight tracking-normal text-foreground"
                 >
                   Hermes
                   <br />
@@ -516,14 +514,14 @@ export default function App() {
                 size="icon"
                 onClick={closeMobile}
                 aria-label={t.app.closeNavigation}
-                className="lg:hidden text-text-secondary hover:text-midground"
+                className="lg:hidden rounded-md text-text-secondary hover:bg-primary/10 hover:text-primary"
               >
                 <X />
               </Button>
             </div>
 
             <nav
-              className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
+              className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden py-2"
               aria-label={t.app.navigation}
             >
               <ul className="flex flex-col">
@@ -540,13 +538,13 @@ export default function App() {
               {sidebarNav.pluginItems.length > 0 && (
                 <div
                   aria-labelledby="hermes-sidebar-plugin-nav-heading"
-                  className="flex flex-col border-t border-current/10 pb-2"
+                  className="flex flex-col border-t border-border/60 pb-2"
                   role="group"
                 >
                   <span
                     className={cn(
                       "px-5 pt-2.5 pb-1",
-                      "font-mondwest text-display text-xs tracking-[0.12em] text-text-tertiary",
+                      "font-sans text-xs font-medium tracking-normal text-text-tertiary",
                     )}
                     id="hermes-sidebar-plugin-nav-heading"
                   >
@@ -573,7 +571,7 @@ export default function App() {
               className={cn(
                 "flex shrink-0 items-center justify-between gap-2",
                 "px-3 py-2",
-                "border-t border-current/20",
+                "border-t border-border",
               )}
             >
               <div className="flex min-w-0 items-center gap-2">
@@ -675,12 +673,13 @@ function SidebarNavLink({ closeMobile, item, t }: SidebarNavLinkProps) {
           cn(
             "group relative flex items-center gap-3",
             "px-5 py-2.5",
-            "font-mondwest text-display uppercase text-sm tracking-[0.12em]",
+            "mx-2 rounded-lg px-3 py-2.5",
+            "font-sans text-sm font-medium tracking-normal",
             "whitespace-nowrap transition-colors cursor-pointer",
-            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20",
             isActive
-              ? "text-midground"
-              : "text-text-secondary hover:text-midground",
+              ? "bg-primary/10 text-primary shadow-[inset_0_0_0_1px_rgba(51,112,255,0.08)]"
+              : "text-text-secondary hover:bg-muted hover:text-text-primary",
           )
         }
         style={{
@@ -692,16 +691,10 @@ function SidebarNavLink({ closeMobile, item, t }: SidebarNavLinkProps) {
             <Icon className="h-3.5 w-3.5 shrink-0" />
             <span className="truncate">{navLabel}</span>
 
-            <span
-              aria-hidden
-              className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-5"
-            />
-
             {isActive && (
               <span
                 aria-hidden
-                className="absolute left-0 top-0 bottom-0 w-px bg-midground"
-                style={{ mixBlendMode: "plus-lighter" }}
+                className="absolute bottom-2 left-1.5 top-2 w-0.5 rounded-full bg-primary"
               />
             )}
           </>
@@ -745,14 +738,14 @@ function SidebarSystemActions({ onNavigate }: { onNavigate: () => void }) {
     <div
       className={cn(
         "shrink-0 flex flex-col",
-        "border-t border-current/10",
+        "border-t border-border/70",
         "py-1",
       )}
     >
       <span
         className={cn(
           "px-5 pt-0.5 pb-0.5",
-          "font-mondwest text-display text-xs tracking-[0.12em] text-text-tertiary",
+          "font-sans text-xs font-medium tracking-normal text-text-tertiary",
         )}
       >
         {t.app.system}
@@ -778,11 +771,11 @@ function SidebarSystemActions({ onNavigate }: { onNavigate: () => void }) {
                 active={busy}
                 className={cn(
                   "gap-3 px-5 py-1.5 whitespace-nowrap",
-                  "font-mondwest text-display text-xs tracking-[0.1em]",
+                  "font-sans text-xs font-medium tracking-normal",
                   "transition-colors",
                   busy
-                    ? "text-midground"
-                    : "text-text-secondary hover:text-midground",
+                    ? "text-primary"
+                    : "text-text-secondary hover:bg-muted hover:text-text-primary",
                   "disabled:text-text-disabled",
                 )}
               >
@@ -803,14 +796,13 @@ function SidebarSystemActions({ onNavigate }: { onNavigate: () => void }) {
 
                 <span
                   aria-hidden
-                  className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-5"
+                  className="absolute inset-y-0.5 left-1.5 right-1.5 rounded-md bg-muted opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-100"
                 />
 
                 {busy && (
                   <span
                     aria-hidden
-                    className="absolute left-0 top-0 bottom-0 w-px bg-midground"
-                    style={{ mixBlendMode: "plus-lighter" }}
+                    className="absolute bottom-1.5 left-1.5 top-1.5 w-0.5 rounded-full bg-primary"
                   />
                 )}
               </ListItem>

--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -1,5 +1,5 @@
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
-import { Switch } from "@nous-research/ui/ui/components/switch";
+import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 

--- a/web/src/components/Backdrop.tsx
+++ b/web/src/components/Backdrop.tsx
@@ -1,27 +1,8 @@
 import { useGpuTier } from "@nous-research/ui/hooks/use-gpu-tier";
 
-import fillerBgUrl from "@nous-research/ui/assets/filler-bg0.webp";
-
 /**
- * Replicates the visual layer stack of `<Overlays dark />` from
- * `@nous-research/ui` without pulling in its leva / gsap / three peer deps.
- *
- * See `design-language/src/ui/components/overlays/index.tsx` for the source of
- * truth. Defaults match LENS_0 (the Hermes teal dark preset); the deep canvas
- * and the warm vignette both read theme-switchable CSS custom properties so
- * `ThemeProvider` can repaint the stack without remounting.
- *
- *   z-1   bg = `var(--background-base)`, mix-blend-mode: difference
- *   z-2   bundled filler-bg WebP, inverted, opacity 0.033, difference
- *   z-99  warm top-left vignette (`var(--warm-glow)`), opacity 0.22, lighten
- *   z-101 noise grain (SVG, ~55% opacity × `--noise-opacity-mul`,
- *         color-dodge) — gated on GPU tier
- *
- * `useGpuTier` returns 0 when WebGL is unavailable, the renderer is a
- * software rasterizer (SwiftShader/llvmpipe), or the user has
- * `prefers-reduced-motion: reduce` set. We skip the animated noise layer
- * in that case so low-power / accessibility-conscious sessions stay crisp,
- * mirroring the DS `<Noise />` component's own opt-out.
+ * Theme-aware Feishu-style background stack: a quiet neutral workspace with
+ * only the faintest depth so content remains the first thing the eye catches.
  */
 export function Backdrop() {
   const gpuTier = useGpuTier();
@@ -32,8 +13,8 @@ export function Backdrop() {
         aria-hidden
         className="pointer-events-none fixed inset-0 z-[1]"
         style={{
-          backgroundColor: "var(--background-base)",
-          mixBlendMode: "difference",
+          background:
+            "linear-gradient(180deg, #ffffff 0%, #f8f9fb 46%, #f7f8fa 100%)",
         }}
       />
 
@@ -42,49 +23,60 @@ export function Backdrop() {
         className="pointer-events-none fixed inset-0 z-[2]"
         style={
           {
-            // Themes can override the filler background by setting
-            // `assets.bg` — the <img> hides itself when a CSS bg is set
-            // so the two don't double-darken. CSS var fallbacks keep the
-            // default behaviour unchanged when no theme customises these.
-            mixBlendMode:
-              "var(--component-backdrop-filler-blend-mode, difference)",
-            opacity: "var(--component-backdrop-filler-opacity, 0.033)",
-            backgroundImage: "var(--theme-asset-bg)",
+            backgroundImage:
+              "var(--theme-asset-bg, none), radial-gradient(circle at 22% 0%, rgba(51, 112, 255, 0.025), transparent 30%), radial-gradient(circle at 92% 4%, rgba(31, 35, 41, 0.018), transparent 28%)",
             backgroundSize: "var(--component-backdrop-background-size, cover)",
             backgroundPosition:
               "var(--component-backdrop-background-position, center)",
+            opacity: "var(--component-backdrop-filler-opacity, 1)",
           } as unknown as React.CSSProperties
         }
-      >
-        <img
-          alt=""
-          className="h-[150dvh] w-auto min-w-[100dvw] object-cover object-top-left invert theme-default-filler"
-          fetchPriority="low"
-          src={fillerBgUrl}
-        />
-      </div>
+      />
 
       <div
         aria-hidden
-        className="pointer-events-none fixed inset-0 z-[99]"
+        className="pointer-events-none fixed inset-0 z-[3] opacity-0"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(31, 35, 41, 0.018) 1px, transparent 1px), linear-gradient(90deg, rgba(31, 35, 41, 0.014) 1px, transparent 1px)",
+          backgroundSize: "56px 56px",
+          maskImage:
+            "linear-gradient(180deg, rgba(0,0,0,0.64), rgba(0,0,0,0.16) 58%, transparent)",
+        }}
+      />
+
+      <div
+        aria-hidden
+        className="pointer-events-none fixed right-[7vw] top-[8dvh] z-[4] h-72 w-72 rounded-full"
         style={{
           background:
-            "radial-gradient(ellipse at 0% 0%, transparent 60%, var(--warm-glow) 100%)",
-          mixBlendMode: "lighten",
-          opacity: 0.22,
+            "linear-gradient(145deg, rgba(51,112,255,0.025), rgba(255,255,255,0.16))",
+          filter: "blur(18px)",
+          opacity: 0.18,
+        }}
+      />
+
+      <div
+        aria-hidden
+        className="pointer-events-none fixed bottom-[13dvh] left-[17vw] z-[4] h-44 w-44 rounded-full"
+        style={{
+          background:
+            "linear-gradient(135deg, rgba(51,112,255,0.018), rgba(255,255,255,0.08))",
+          filter: "blur(16px)",
+          opacity: 0.14,
         }}
       />
 
       {gpuTier > 0 && (
         <div
           aria-hidden
-          className="pointer-events-none fixed inset-0 z-[101]"
+          className="pointer-events-none fixed inset-0 z-[5]"
           style={{
             backgroundImage:
-              "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%23eaeaea' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E\")",
+              "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 512 512' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.78' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' fill='%233370ff' filter='url(%23n)' opacity='0.18'/%3E%3C/svg%3E\")",
             backgroundSize: "512px 512px",
-            mixBlendMode: "color-dodge",
-            opacity: "calc(0.55 * var(--noise-opacity-mul, 1))",
+            mixBlendMode: "soft-light",
+            opacity: "calc(0.12 * var(--noise-opacity-mul, 1))",
           }}
         />
       )}

--- a/web/src/components/BottomPickSheet.tsx
+++ b/web/src/components/BottomPickSheet.tsx
@@ -169,9 +169,9 @@ export function BottomPickSheet({
         ref={sheetRef}
         className={cn(
           themedBody,
-          "relative flex max-h-[85dvh] min-h-0 flex-col rounded-t-xl border border-current/20",
-          "bg-background-base/98 pb-[max(1rem,env(safe-area-inset-bottom))]",
-          "shadow-[0_-12px_40px_-8px_rgba(0,0,0,0.55)] backdrop-blur-md",
+          "relative flex max-h-[85dvh] min-h-0 flex-col rounded-t-xl border border-border",
+          "bg-white pb-[max(1rem,env(safe-area-inset-bottom))]",
+          "shadow-[0_-12px_32px_rgba(31,35,41,0.12)]",
           "ease-out motion-reduce:transition-none transform-gpu",
           draggingVisual ? "transition-none" : cn("transition-transform", durationClass),
           entered ? "translate-y-0" : "translate-y-full",
@@ -185,7 +185,7 @@ export function BottomPickSheet({
       >
         <div
           className={cn(
-            "flex shrink-0 flex-col gap-2 border-b border-current/15 px-4 pb-3 pt-2",
+            "flex shrink-0 flex-col gap-2 border-b border-border px-4 pb-3 pt-2",
             "touch-none select-none",
             reducedMotion ? "cursor-default" : "cursor-grab active:cursor-grabbing",
           )}
@@ -196,12 +196,12 @@ export function BottomPickSheet({
         >
           <div
             aria-hidden
-            className="mx-auto h-1 w-10 shrink-0 rounded-full bg-current/20"
+            className="mx-auto h-1 w-10 shrink-0 rounded-full bg-border"
           />
 
           <Typography
             mondwest
-            className="text-display text-xs tracking-[0.12em] text-text-tertiary"
+            className="text-xs font-medium tracking-normal text-text-secondary"
           >
             {title}
           </Typography>

--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -74,7 +74,7 @@ export function LanguageSwitcher({ dropUp = false }: LanguageSwitcherProps) {
         <span className="inline-flex items-center gap-1.5">
           <Typography
             mondwest
-            className="hidden sm:inline text-display tracking-wide text-xs"
+            className="hidden sm:inline text-xs font-medium tracking-normal"
           >
             {locale === "en" ? "EN" : current.name}
           </Typography>
@@ -103,7 +103,7 @@ export function LanguageSwitcher({ dropUp = false }: LanguageSwitcherProps) {
         <div
           aria-label={sheetTitle}
           className={cn(
-            "absolute right-0 z-50 min-w-[10rem] rounded-md border border-border bg-popover shadow-md py-1 max-h-80 overflow-y-auto",
+            "absolute right-0 z-50 min-w-[11rem] rounded-lg border border-border bg-popover p-1 shadow-[0_8px_24px_rgba(31,35,41,0.1),0_1px_2px_rgba(31,35,41,0.06)] max-h-80 overflow-y-auto",
             dropUp ? "bottom-full mb-1" : "top-full mt-1",
           )}
           role="listbox"
@@ -135,8 +135,8 @@ function LanguageSwitcherOptions({
           <button
             aria-selected={selected}
             className={
-              "w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-accent hover:text-accent-foreground transition-colors " +
-              (selected ? "font-semibold text-foreground" : "text-muted-foreground")
+              "w-full min-h-8 rounded-md text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-muted hover:text-foreground transition-colors " +
+              (selected ? "font-medium bg-primary/5 text-primary" : "font-normal text-text-secondary")
             }
             key={code}
             onClick={() => {

--- a/web/src/components/NouiTypography.tsx
+++ b/web/src/components/NouiTypography.tsx
@@ -14,10 +14,10 @@ type TypographyProps = HTMLAttributes<HTMLElement> & {
 };
 
 const variantClasses: Record<NonNullable<TypographyProps["variant"]>, string> = {
-  sm: "leading-[1.4] text-[.9375rem] tracking-[0.1875rem]",
-  md: "text-[2.625rem] leading-[1] tracking-[0.0525rem]",
-  lg: "text-[2.625rem] leading-[1] tracking-[0.0525rem]",
-  xl: "text-[4.5rem] leading-[1] tracking-[0.135rem]",
+  sm: "text-sm leading-[1.5] tracking-normal",
+  md: "text-xl leading-[1.25] tracking-normal",
+  lg: "text-2xl leading-[1.2] tracking-normal",
+  xl: "text-3xl leading-[1.15] tracking-normal",
 };
 
 export const Typography = forwardRef<HTMLElement, TypographyProps>(function Typography(
@@ -43,7 +43,7 @@ export const Typography = forwardRef<HTMLElement, TypographyProps>(function Typo
         compressed && "font-compressed",
         courier && "font-courier",
         expanded && "font-expanded",
-        mondwest && "font-mondwest tracking-[0.1875rem]",
+        mondwest && "font-mondwest tracking-normal",
         mono && "font-mono",
         (!hasFontVariant || sans) && "font-sans",
         variant && variantClasses[variant],

--- a/web/src/components/SidebarFooter.tsx
+++ b/web/src/components/SidebarFooter.tsx
@@ -26,11 +26,10 @@ export function SidebarFooter() {
         target="_blank"
         rel="noopener noreferrer"
         className={cn(
-          "font-mondwest text-display text-xs tracking-[0.12em] text-midground",
+          "font-sans text-xs font-medium tracking-normal text-text-tertiary",
           "transition-opacity hover:opacity-90",
-          "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
+          "focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30",
         )}
-        style={{ mixBlendMode: "plus-lighter" }}
       >
         {t.app.footer.org}
       </a>

--- a/web/src/components/SidebarStatusStrip.tsx
+++ b/web/src/components/SidebarStatusStrip.tsx
@@ -28,12 +28,12 @@ export function SidebarStatusStrip() {
         "block text-left",
         "px-5 pb-2 pt-0.5",
         "text-text-secondary",
-        "transition-colors hover:text-midground",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground/40",
+        "transition-colors hover:text-primary",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30",
         "focus-visible:ring-inset",
       )}
     >
-      <div className="flex flex-col gap-1 font-mondwest text-xs leading-snug tracking-[0.08em]">
+      <div className="flex flex-col gap-1 font-sans text-xs leading-snug tracking-normal">
         <p className="break-words">
           <span className="text-text-tertiary">{gatewayStatusLabel}</span>{" "}
           <span className={cn("font-medium", gw.tone)}>{gw.label}</span>

--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -57,7 +57,7 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
   }, [open, close, useMobileSheet]);
 
   const current = availableThemes.find((th) => th.name === themeName);
-  const label = current?.label ?? themeName;
+  const label = BUILTIN_THEMES[themeName]?.label ?? current?.label ?? themeName;
   const sheetTitle = t.theme?.title ?? "Theme";
 
   return (
@@ -75,8 +75,7 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
           <Palette className="h-3.5 w-3.5" />
 
           <Typography
-            mondwest
-            className="hidden sm:inline text-display tracking-wide text-xs"
+            className="hidden text-xs font-medium tracking-normal sm:inline"
           >
             {label}
           </Typography>
@@ -107,15 +106,14 @@ export function ThemeSwitcher({ dropUp = false }: ThemeSwitcherProps) {
           className={cn(
             "absolute z-50 min-w-[240px] max-h-[70dvh] overflow-y-auto",
             dropUp ? "left-0 bottom-full mb-1" : "right-0 top-full mt-1",
-            "border border-current/20 bg-background-base/95 backdrop-blur-sm",
-            "shadow-[0_12px_32px_-8px_rgba(0,0,0,0.6)]",
+            "rounded-lg border border-border bg-popover p-1",
+            "shadow-[0_8px_24px_rgba(31,35,41,0.1),0_1px_2px_rgba(31,35,41,0.06)]",
           )}
           role="listbox"
         >
-          <div className="border-b border-current/20 px-3 py-2">
+          <div className="border-b border-border px-3 py-2">
             <Typography
-              mondwest
-              className="text-display text-xs tracking-[0.12em] text-text-tertiary"
+              className="text-xs font-medium tracking-normal text-text-tertiary"
             >
               {sheetTitle}
             </Typography>
@@ -143,13 +141,16 @@ function ThemeSwitcherOptions({
     <>
       {availableThemes.map((th) => {
         const isActive = th.name === themeName;
-        const paletteTheme = BUILTIN_THEMES[th.name] ?? th.definition;
+        const builtinTheme = BUILTIN_THEMES[th.name];
+        const paletteTheme = builtinTheme ?? th.definition;
+        const label = builtinTheme?.label ?? th.label;
+        const description = builtinTheme?.description ?? th.description;
 
         return (
           <ListItem
             active={isActive}
             aria-selected={isActive}
-            className="gap-3"
+            className="gap-3 rounded-md px-2.5 py-2"
             key={th.name}
             onClick={() => {
               setTheme(th.name);
@@ -165,21 +166,20 @@ function ThemeSwitcherOptions({
 
             <div className="flex min-w-0 flex-1 flex-col gap-0.5">
               <Typography
-                mondwest
-                className="truncate text-display text-xs tracking-wide"
+                className="truncate text-xs font-medium tracking-normal"
               >
-                {th.label}
+                {label}
               </Typography>
-              {th.description && (
+              {description && (
                 <Typography className="truncate text-xs tracking-normal text-text-tertiary">
-                  {th.description}
+                  {description}
                 </Typography>
               )}
             </div>
 
             <Check
               className={cn(
-                "h-3 w-3 shrink-0 text-midground",
+                "h-3 w-3 shrink-0 text-primary",
                 isActive ? "opacity-100" : "opacity-0",
               )}
             />
@@ -195,7 +195,7 @@ function ThemeSwatch({ theme }: { theme: DashboardTheme }) {
   return (
     <div
       aria-hidden
-      className="flex h-4 w-9 shrink-0 overflow-hidden border border-current/20"
+      className="flex h-4 w-9 shrink-0 overflow-hidden rounded border border-border"
     >
       <span className="flex-1" style={{ background: background.hex }} />
       <span className="flex-1" style={{ background: midground.hex }} />
@@ -208,7 +208,7 @@ function PlaceholderSwatch() {
   return (
     <div
       aria-hidden
-      className="h-4 w-9 shrink-0 border border-dashed border-current/20"
+      className="h-4 w-9 shrink-0 rounded border border-dashed border-border"
     />
   );
 }

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -26,7 +26,7 @@ export function Card({ className, style, ...props }: React.HTMLAttributes<HTMLDi
   return (
     <div
       className={cn(
-        "border border-border bg-card/80 text-card-foreground w-full",
+        "w-full rounded-lg border border-border bg-card text-card-foreground shadow-[0_1px_2px_rgba(31,35,41,0.04)]",
         themedBody,
         className,
       )}
@@ -37,14 +37,14 @@ export function Card({ className, style, ...props }: React.HTMLAttributes<HTMLDi
 }
 
 export function CardHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("flex flex-col gap-1.5 p-4 border-b border-border", className)} {...props} />;
+  return <div className={cn("flex flex-col gap-1.5 border-b border-border px-5 py-4", className)} {...props} />;
 }
 
 export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h3
       className={cn(
-        "font-mondwest text-display text-sm tracking-[0.12em] text-text-primary",
+        "font-sans text-[15px] font-semibold tracking-normal text-text-primary",
         className,
       )}
       {...props}
@@ -54,10 +54,10 @@ export function CardTitle({ className, ...props }: React.HTMLAttributes<HTMLHead
 
 export function CardDescription({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
   return (
-    <p className={cn("font-mondwest normal-case text-xs text-muted-foreground", className)} {...props} />
+    <p className={cn("font-sans normal-case text-xs text-muted-foreground", className)} {...props} />
   );
 }
 
 export function CardContent({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("p-4", className)} {...props} />;
+  return <div className={cn("p-5", className)} {...props} />;
 }

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -4,9 +4,9 @@ export function Input({ className, ...props }: React.InputHTMLAttributes<HTMLInp
   return (
     <input
       className={cn(
-        "flex h-9 w-full border border-border bg-background/40 px-3 py-1 font-courier text-sm transition-colors",
+        "flex h-9 w-full rounded-lg border border-border bg-input px-3 py-1 font-sans text-sm text-foreground shadow-sm transition-colors",
         "placeholder:text-muted-foreground",
-        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/30 focus-visible:border-foreground/25",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:border-ring/60",
         "disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,42 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch(
+  { checked, className, disabled, id, onCheckedChange, ...props },
+  ref,
+) {
+  return (
+    <button
+      aria-checked={checked}
+      className={cn(
+        "relative inline-flex h-[18px] w-[34px] shrink-0 cursor-pointer items-center rounded-full border-0 p-0 transition-colors",
+        checked ? "bg-primary hover:bg-[#245bdb]" : "bg-[#c9cdd4] hover:bg-[#bfc3cb]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/20 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      data-hermes-switch
+      disabled={disabled}
+      id={id}
+      onClick={() => onCheckedChange(!checked)}
+      ref={ref}
+      role="switch"
+      type="button"
+      {...props}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "absolute top-0.5 h-3.5 w-3.5 rounded-full bg-white shadow-[0_1px_3px_rgba(31,35,41,0.2)] transition-[left,box-shadow] duration-150 ease-out",
+          checked ? "left-[18px]" : "left-0.5",
+        )}
+      />
+    </button>
+  );
+});
+
+interface SwitchProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -54,8 +54,8 @@ export function PageHeaderProvider({
         <header
           className={cn(
             "z-1 w-full shrink-0",
-            "box-border border-b border-current/20",
-            "bg-background-base/40 backdrop-blur-sm",
+            "box-border border-b border-border/70",
+            "bg-white/72 backdrop-blur-sm",
             // Mobile stacks title + toolbar — fixed h-14 clips content; desktop stays one row.
             "min-h-0 overflow-x-hidden overflow-y-visible py-3 sm:h-14 sm:min-h-[3.5rem] sm:overflow-hidden sm:py-0",
           )}
@@ -82,13 +82,13 @@ export function PageHeaderProvider({
               <h1
                 className={cn(
                   "font-expanded min-w-0 text-sm font-bold tracking-[0.08em] text-midground",
+                  "font-sans font-semibold tracking-normal text-foreground",
                   afterTitle && isEnvRoute
                     ? "max-w-full sm:min-w-0 sm:shrink sm:truncate"
                     : afterTitle
                       ? "shrink truncate"
                       : "truncate",
                 )}
-                style={{ mixBlendMode: "plus-lighter" }}
               >
                 {displayTitle}
               </h1>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -43,44 +43,65 @@
 }
 
 /* ------------------------------------------------------------------ */
-/* Hermes Agent — Nous DS with the LENS_0 (Hermes teal) lens applied   */
-/* statically. Mirrors nousnet-web/(hermes-agent)/layout.tsx so the    */
-/* canonical Hermes palette is the default — teal canvas + cream      */
-/* accent — without relying on leva/gsap at runtime.                  */
+/* Hermes Agent — default Feishu-inspired skin.                         */
+/* Clean white workspace, Feishu-blue actions, neutral content surfaces, */
+/* and crisp enterprise text are applied through CSS variables so custom */
+/* dashboard themes can still repaint the shell at runtime.              */
 /* ------------------------------------------------------------------ */
 
 :root {
-  /* LENS_0 — from design-language/src/ui/components/overlays/index.tsx.
-     These are the defaults for the `default` (Hermes Teal) dashboard theme;
-     ThemeProvider rewrites them as inline styles when a user switches themes. */
-  --foreground: color-mix(in srgb, #ffffff 0%, transparent);
-  --foreground-base: #ffffff;
-  --foreground-alpha: 0;
-  --midground: color-mix(in srgb, #ffe6cb 100%, transparent);
-  --midground-base: #ffe6cb;
+  --foreground: color-mix(in srgb, #1f2329 100%, transparent);
+  --foreground-base: #1f2329;
+  --foreground-alpha: 1;
+  --midground: color-mix(in srgb, #3370ff 100%, transparent);
+  --midground-base: #3370ff;
   --midground-alpha: 1;
-  --background: color-mix(in srgb, #041c1c 100%, transparent);
-  --background-base: #041c1c;
+  --background: color-mix(in srgb, #f7f8fa 100%, transparent);
+  --background-base: #f7f8fa;
   --background-alpha: 1;
 
   /* Consumed by <Backdrop />; also theme-switchable. */
-  --warm-glow: rgba(255, 189, 56, 0.35);
-  --noise-opacity-mul: 1;
+  --warm-glow: rgba(51, 112, 255, 0.08);
+  --noise-opacity-mul: 0;
+
+  /* Nous UI semantic text tokens. Keep blue for actions only; ordinary
+     content should read like a clean Feishu workspace, not a tinted theme. */
+  --text-primary: #1f2329;
+  --text-secondary: #4e5969;
+  --text-tertiary: #86909c;
+  --text-disabled: #c9cdd4;
+  --text-display: #1f2329;
+  --text-on-accent: #ffffff;
+
+  /* Feishu-style control details. */
+  --control-primary: #3370ff;
+  --control-primary-hover: #245bdb;
+  --control-primary-active: #1c4ecf;
+  --control-primary-soft: #f0f5ff;
+  --control-primary-softer: #f5f8ff;
+  --control-border: #dee0e3;
+  --control-border-hover: #c9cdd4;
+  --control-bg: #ffffff;
+  --control-bg-hover: #f5f6f7;
+  --control-disabled-bg: #f2f3f5;
+  --control-disabled-text: #c9cdd4;
+  --control-danger: #f54a45;
 
   /* Typography tokens — rewritten by ThemeProvider. Defaults match the
      system stack so themes that don't override look native. */
-  --theme-font-sans: system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+  --theme-font-sans: -apple-system, BlinkMacSystemFont, "Helvetica Neue",
+    "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Segoe UI",
+    Arial, sans-serif;
   --theme-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", Menlo,
     Consolas, monospace;
   --theme-font-display: var(--theme-font-sans);
-  --theme-base-size: 15px;
-  --theme-line-height: 1.55;
+  --theme-base-size: 14.5px;
+  --theme-line-height: 1.58;
   --theme-letter-spacing: 0;
 
   /* Layout tokens. */
-  --radius: 0.5rem;
-  --theme-radius: 0.5rem;
+  --radius: 0.75rem;
+  --theme-radius: 0.75rem;
   --theme-spacing-mul: 1;
   --theme-density: comfortable;
 }
@@ -99,6 +120,10 @@ html {
 
 body {
   font-family: var(--theme-font-sans);
+  background: var(--background-base);
+  color: var(--foreground-base);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
   min-height: 0;
   height: 100%;
   margin: 0;
@@ -109,12 +134,37 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
   font-family: var(--theme-font-mono);
 }
 
+/* Feishu-style product typography. The original Hermes skin used the Nous
+   display families heavily; keep the classes working but route them to a
+   clear Chinese-first SaaS stack so existing pages do not retain the old
+   decorative voice. */
+.font-sans,
+.font-mondwest,
+.font-compressed,
+.font-expanded,
+.text-display {
+  font-family: var(--theme-font-sans) !important;
+  font-feature-settings: normal;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+
+.font-courier {
+  font-family: var(--theme-font-mono) !important;
+}
+
 /* Density: scale the shadcn spacing utilities via a multiplier. The DS
    components use `p-N` / `gap-N` / `space-*` classes which resolve against
    Tailwind's spacing scale; multiplying `--spacing` at :root scales them
    all proportionally in Tailwind v4. */
 @theme inline {
   --spacing: calc(0.25rem * var(--theme-spacing-mul, 1));
+  --font-sans: var(--theme-font-sans);
+  --font-display: var(--theme-font-sans);
+  --font-mondwest: var(--theme-font-sans);
+  --font-compressed: var(--theme-font-sans);
+  --font-expanded: var(--theme-font-sans);
+  --font-courier: var(--theme-font-mono);
 }
 
 #root {
@@ -137,31 +187,37 @@ code { font-size: 0.875rem; }
 @theme inline {
   /* Remap foreground to midground so `text-foreground` / `bg-foreground`
      stay visible — in LENS_0, `--foreground` itself has alpha 0. */
-  --color-foreground: var(--midground);
+  --color-foreground: var(--foreground-base);
 
-  --color-card: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
-  --color-card-foreground: var(--midground);
-  --color-primary: var(--midground);
-  --color-primary-foreground: var(--background-base);
-  --color-secondary: color-mix(in srgb, var(--midground-base) 6%, var(--background-base));
-  --color-secondary-foreground: var(--midground);
-  --color-muted: color-mix(in srgb, var(--midground-base) 8%, var(--background-base));
+  --color-card: #ffffff;
+  --color-card-foreground: #1f2329;
+  --color-primary: #3370ff;
+  --color-primary-foreground: #ffffff;
+  --color-secondary: #f5f6f7;
+  --color-secondary-foreground: #1f2329;
+  --color-muted: #f5f6f7;
   /* Routes the shadcn `muted-foreground` slot through the DS semantic
      text-secondary token (defaults to midground 80%) so legacy call
      sites that use `text-muted-foreground` get a readable color
      instead of the old 55%-transparent default. */
-  --color-muted-foreground: var(--color-text-secondary);
-  --color-accent: color-mix(in srgb, var(--midground-base) 10%, var(--background-base));
-  --color-accent-foreground: var(--midground);
-  --color-destructive: #fb2c36;
+  --color-muted-foreground: #4e5969;
+  --color-accent: #eef3ff;
+  --color-accent-foreground: #3370ff;
+  --color-destructive: #f54a45;
   --color-destructive-foreground: #ffffff;
-  --color-success: #4ade80;
-  --color-warning: #ffbd38;
-  --color-border: color-mix(in srgb, var(--midground-base) 15%, transparent);
-  --color-input: color-mix(in srgb, var(--midground-base) 15%, transparent);
-  --color-ring: var(--midground);
-  --color-popover: color-mix(in srgb, var(--midground-base) 4%, var(--background-base));
-  --color-popover-foreground: var(--midground);
+  --color-success: #00b578;
+  --color-warning: #ff8800;
+  --color-border: #dee0e3;
+  --color-input: #ffffff;
+  --color-ring: #3370ff;
+  --color-popover: rgba(255, 255, 255, 0.98);
+  --color-popover-foreground: #1f2329;
+  --color-text-primary: #1f2329;
+  --color-text-secondary: #4e5969;
+  --color-text-tertiary: #86909c;
+  --color-text-disabled: #c9cdd4;
+  --color-text-display: #1f2329;
+  --color-text-on-accent: #ffffff;
 
   --radius-sm: calc(var(--theme-radius) - 4px);
   --radius-md: calc(var(--theme-radius) - 2px);
@@ -201,7 +257,381 @@ code { font-size: 0.875rem; }
 
 /* Plus-lighter blend used by logos/titles for a subtle glow. */
 .blend-lighter {
-  mix-blend-mode: plus-lighter;
+  mix-blend-mode: normal;
+}
+
+button,
+[role="button"],
+a,
+input,
+textarea,
+select {
+  letter-spacing: 0;
+}
+
+button:focus-visible,
+[role="button"]:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid rgba(51, 112, 255, 0.18);
+  outline-offset: 2px;
+}
+
+/* Header search fields live in page-provided header slots. A few pages pass
+   compact utility overrides, so keep the final shape here to prevent sharp
+   stitched input / clear-button controls. */
+header input[class*="pl-8"][placeholder] {
+  height: 32px !important;
+  border-radius: 8px !important;
+  border-color: #dee0e3 !important;
+  background: #ffffff !important;
+  padding-left: 32px !important;
+  padding-right: 34px !important;
+  font-size: 13px !important;
+  line-height: 20px !important;
+  box-shadow: none !important;
+}
+
+header input[class*="pl-8"][placeholder]:hover {
+  border-color: #c9cdd4 !important;
+}
+
+header input[class*="pl-8"][placeholder]:focus-visible {
+  border-color: #3370ff !important;
+  outline: none !important;
+  box-shadow: 0 0 0 3px rgba(51, 112, 255, 0.12) !important;
+}
+
+header input[class*="pl-8"][placeholder] ~ button[aria-label] {
+  right: 4px !important;
+  width: 24px !important;
+  height: 24px !important;
+  min-height: 24px !important;
+  border: 1px solid transparent !important;
+  border-radius: 6px !important;
+  background: transparent !important;
+  padding: 0 !important;
+  color: #86909c !important;
+  box-shadow: none !important;
+}
+
+header input[class*="pl-8"][placeholder] ~ button[aria-label]:hover {
+  border-color: #dee0e3 !important;
+  background: #f2f3f5 !important;
+  color: #1f2329 !important;
+}
+
+header input[class*="pl-8"][placeholder] ~ button[aria-label] svg {
+  width: 14px !important;
+  height: 14px !important;
+}
+
+/* Feishu-style Nous controls. Nous' default component skin is deliberately
+   expressive; the dashboard needs quieter enterprise controls. */
+button.grid.cursor-pointer:not([role="switch"]):not([role="checkbox"]) {
+  min-height: 32px;
+  border-radius: 6px !important;
+  font-family: var(--theme-font-sans) !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  line-height: 1.2 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  box-shadow: none !important;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease,
+    transform 80ms ease;
+}
+
+button.grid.cursor-pointer:not([role="switch"]):not([role="checkbox"]) svg {
+  color: currentColor;
+  stroke-width: 1.9;
+}
+
+button.grid.cursor-pointer.aspect-square,
+button.grid.cursor-pointer[class*="aspect-square"] {
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0 !important;
+  place-items: center;
+}
+
+button.grid.cursor-pointer:not([role="switch"]):not([role="checkbox"]):active {
+  transform: translateY(1px);
+}
+
+button.grid.cursor-pointer[class*="bg-midground"]:not([class*="bg-transparent"]):not([class*="bg-destructive"]) {
+  border: 1px solid var(--control-primary) !important;
+  background: var(--control-primary) !important;
+  color: #ffffff !important;
+  box-shadow: 0 1px 2px rgba(31, 35, 41, 0.08) !important;
+}
+
+button.grid.cursor-pointer[class*="bg-midground"]:not([class*="bg-transparent"]):not([class*="bg-destructive"]):hover {
+  border-color: var(--control-primary-hover) !important;
+  background: var(--control-primary-hover) !important;
+  box-shadow: 0 2px 6px rgba(31, 35, 41, 0.1) !important;
+}
+
+button.grid.cursor-pointer[class*="bg-midground"]:not([class*="bg-transparent"]):not([class*="bg-destructive"]):active {
+  border-color: var(--control-primary-active) !important;
+  background: var(--control-primary-active) !important;
+  box-shadow: none !important;
+}
+
+button.grid.cursor-pointer[class*="bg-transparent"]:not([class*="text-destructive"]) {
+  border: 1px solid var(--control-border) !important;
+  background: var(--control-bg) !important;
+  color: var(--text-primary) !important;
+  box-shadow: 0 1px 1px rgba(31, 35, 41, 0.02) !important;
+}
+
+button.grid.cursor-pointer[class*="bg-transparent"]:not([class*="text-destructive"]):hover {
+  border-color: var(--control-border-hover) !important;
+  background: var(--control-bg-hover) !important;
+  color: var(--text-primary) !important;
+  box-shadow: none !important;
+}
+
+header input[class*="pl-8"][placeholder] ~ button.grid.cursor-pointer[aria-label] {
+  right: 4px !important;
+  width: 24px !important;
+  min-width: 24px !important;
+  max-width: 24px !important;
+  height: 24px !important;
+  min-height: 24px !important;
+  max-height: 24px !important;
+  aspect-ratio: auto !important;
+  border-color: transparent !important;
+  background: transparent !important;
+  color: #86909c !important;
+  box-shadow: none !important;
+}
+
+header input[class*="pl-8"][placeholder] ~ button.grid.cursor-pointer[aria-label]:hover {
+  border-color: #dee0e3 !important;
+  background: #f2f3f5 !important;
+  color: #1f2329 !important;
+}
+
+button.grid.cursor-pointer[class*="text-destructive"] {
+  border: 1px solid rgba(245, 74, 69, 0.28) !important;
+  background: #ffffff !important;
+  color: var(--control-danger) !important;
+}
+
+button.grid.cursor-pointer[class*="text-destructive"]:hover {
+  border-color: rgba(245, 74, 69, 0.44) !important;
+  background: rgba(245, 74, 69, 0.06) !important;
+}
+
+button.grid.cursor-pointer:disabled,
+button.grid.cursor-pointer[aria-disabled="true"] {
+  border-color: var(--control-border) !important;
+  background: var(--control-disabled-bg) !important;
+  color: var(--control-disabled-text) !important;
+  transform: none !important;
+}
+
+button.grid.cursor-pointer .arc-border {
+  display: none !important;
+}
+
+button.group.relative.flex.w-full.items-center.gap-2:not([role="switch"]):not([role="checkbox"]) {
+  border-radius: 6px !important;
+  font-family: var(--theme-font-sans) !important;
+  font-weight: 500 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+
+button.group.relative.flex.w-full.items-center.gap-2:not([role="switch"]):not([role="checkbox"]):hover {
+  background: var(--control-bg-hover) !important;
+  color: var(--text-primary) !important;
+}
+
+button.group.relative.flex.w-full.items-center.gap-2[data-active] {
+  background: var(--control-primary-softer) !important;
+  color: var(--control-primary) !important;
+}
+
+button[role="checkbox"] {
+  width: 16px !important;
+  height: 16px !important;
+  border: 1px solid var(--control-border-hover) !important;
+  border-radius: 4px !important;
+  background: #ffffff !important;
+  color: #ffffff !important;
+  box-shadow: none !important;
+}
+
+button[role="checkbox"]:hover {
+  border-color: var(--control-primary) !important;
+  background: var(--control-primary-softer) !important;
+}
+
+button[role="checkbox"][data-state="checked"],
+button[role="checkbox"][data-state="indeterminate"] {
+  border-color: var(--control-primary) !important;
+  background: var(--control-primary) !important;
+}
+
+button[role="checkbox"] svg {
+  color: #ffffff !important;
+}
+
+button[data-hermes-switch] {
+  position: relative !important;
+  width: 34px !important;
+  height: 18px !important;
+  border: 0 !important;
+  border-radius: 999px !important;
+  background: #c9cdd4 !important;
+  box-shadow: inset 0 0 0 1px rgba(31, 35, 41, 0.04) !important;
+  padding: 0 !important;
+  transition:
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+button[data-hermes-switch]:hover {
+  background: #bfc3cb !important;
+}
+
+button[data-hermes-switch][aria-checked="true"] {
+  background: var(--control-primary) !important;
+}
+
+button[data-hermes-switch][aria-checked="true"]:hover {
+  background: var(--control-primary-hover) !important;
+}
+
+button[data-hermes-switch] > span {
+  position: absolute !important;
+  top: 2px !important;
+  left: 2px !important;
+  width: 14px !important;
+  height: 14px !important;
+  border-radius: 999px !important;
+  background: #ffffff !important;
+  box-shadow: 0 1px 3px rgba(31, 35, 41, 0.2) !important;
+  transform: none !important;
+  transition:
+    left 160ms ease,
+    box-shadow 160ms ease;
+}
+
+button[data-hermes-switch][aria-checked="true"] > span {
+  left: 18px !important;
+  transform: none !important;
+}
+
+button[data-hermes-switch] + span {
+  letter-spacing: 0 !important;
+}
+
+/* Selects, dropdowns, and popover menus. */
+select,
+button[role="combobox"] {
+  min-height: 32px !important;
+  border: 1px solid var(--control-border) !important;
+  border-radius: 6px !important;
+  background: #ffffff !important;
+  color: var(--text-primary) !important;
+  font-family: var(--theme-font-sans) !important;
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+  box-shadow: 0 1px 1px rgba(31, 35, 41, 0.02) !important;
+}
+
+select:hover,
+button[role="combobox"]:hover {
+  border-color: var(--control-border-hover) !important;
+  background: #ffffff !important;
+}
+
+select:focus-visible,
+button[role="combobox"]:focus-visible {
+  border-color: var(--control-primary) !important;
+  box-shadow: 0 0 0 3px rgba(51, 112, 255, 0.12) !important;
+  outline: none !important;
+}
+
+button[role="combobox"] span,
+button[role="combobox"] svg {
+  color: inherit !important;
+}
+
+div[role="listbox"] {
+  border-color: var(--control-border) !important;
+  border-radius: 8px !important;
+  background: #ffffff !important;
+  color: var(--text-primary) !important;
+  box-shadow:
+    0 8px 24px rgba(31, 35, 41, 0.1),
+    0 1px 2px rgba(31, 35, 41, 0.06) !important;
+}
+
+div[role="listbox"]:has(> [role="option"]) {
+  padding: 4px !important;
+}
+
+div[role="listbox"] [role="option"] {
+  min-height: 32px;
+  border-radius: 6px !important;
+  padding-left: 10px !important;
+  padding-right: 10px !important;
+  color: var(--text-secondary) !important;
+  font-family: var(--theme-font-sans) !important;
+  font-size: 13px !important;
+  font-weight: 400 !important;
+  letter-spacing: 0 !important;
+  text-transform: none !important;
+}
+
+div[role="listbox"] [role="option"] > span,
+div[role="listbox"] [role="option"] > div:not([aria-hidden]) {
+  min-width: 0;
+}
+
+div[role="listbox"] [role="option"] > svg:first-child {
+  order: 2;
+  margin-left: auto;
+}
+
+div[role="listbox"] [role="option"]:hover {
+  background: var(--control-bg-hover) !important;
+  color: var(--text-primary) !important;
+}
+
+div[role="listbox"] [role="option"][aria-selected="true"] {
+  background: var(--control-primary-softer) !important;
+  color: var(--control-primary) !important;
+  font-weight: 500 !important;
+}
+
+div[role="listbox"] [role="option"] svg,
+div[role="listbox"] [role="option"] [class*="text-midground"],
+div[role="listbox"] [role="option"] [class*="text-primary"] {
+  color: var(--control-primary) !important;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--control-primary);
+}
+
+::selection {
+  background: rgba(51, 112, 255, 0.18);
+  color: #1f2329;
 }
 
 /* System UI-monospace stack — distinct from `font-courier` (Courier

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -5,14 +5,14 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-/** Mondwest font only — use on layout shells; do not force normal-case here or `text-display` chrome (Segmented, badges) stops uppercasing. */
-export const themedFont = "font-mondwest";
+/** Feishu-style product UI font. Kept as a helper so existing call sites stay stable. */
+export const themedFont = "font-sans";
 
-/** Mondwest body copy — sentence-case themed text (not uppercase chrome). */
-export const themedBody = "font-mondwest normal-case";
+/** Feishu-style body copy. */
+export const themedBody = "font-sans normal-case";
 
-/** Mondwest brand chrome — uppercase section headers and nav labels. */
-export const themedChrome = "font-mondwest text-display";
+/** Feishu-style chrome labels. */
+export const themedChrome = "font-sans";
 
 /** Relative time from a Unix epoch timestamp (seconds). */
 export function timeAgo(ts: number): string {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -64,11 +64,11 @@ function generateChannelId(): string {
 // theme, because the TUI's skin engine already paints the content; the
 // terminal chrome just needs to sit quietly inside the dashboard.
 const TERMINAL_THEME = {
-  background: "#0d2626",
-  foreground: "#f0e6d2",
-  cursor: "#f0e6d2",
-  cursorAccent: "#0d2626",
-  selectionBackground: "#f0e6d244",
+  background: "#0e2338",
+  foreground: "#d9efff",
+  cursor: "#7dd9ff",
+  cursorAccent: "#0e2338",
+  selectionBackground: "#55b7ff44",
 };
 
 /**
@@ -725,7 +725,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             onClick={closeMobilePanel}
             className={cn(
               "fixed inset-0 z-[55] p-0 block",
-              "bg-black/60 backdrop-blur-sm",
+              "bg-slate-950/30 backdrop-blur-sm",
             )}
           />
         )}
@@ -735,9 +735,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           role="complementary"
           aria-label={modelToolsLabel}
           className={cn(
-            "font-mondwest fixed top-0 right-0 z-[60] flex h-dvh max-h-dvh w-64 min-w-0 flex-col antialiased",
-            "border-l border-current/20 text-midground",
-            "bg-background-base/95 backdrop-blur-sm",
+            "font-sans fixed top-0 right-0 z-[60] flex h-dvh max-h-dvh w-64 min-w-0 flex-col antialiased",
+            "border-l border-border/70 text-text-primary",
+            "bg-background-base/80 shadow-[-12px_0_40px_rgba(43,112,191,0.08)] backdrop-blur-xl",
             "transition-transform duration-200 ease-out",
             "[background:var(--component-sidebar-background)]",
             "[clip-path:var(--component-sidebar-clip-path)]",
@@ -749,13 +749,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         >
           <div
             className={cn(
-              "flex h-14 shrink-0 items-center justify-between gap-2 border-b border-current/20 px-5",
+              "flex h-14 shrink-0 items-center justify-between gap-2 border-b border-border/70 px-5",
             )}
           >
             <Typography
               mondwest
-              className="text-display font-bold text-[1.125rem] leading-[0.95] tracking-[0.0525rem] text-midground"
-              style={{ mixBlendMode: "plus-lighter" }}
+              className="font-semibold text-[1.05rem] leading-tight tracking-normal text-primary"
             >
               {t.app.modelToolsSheetTitle}
               <br />
@@ -767,7 +766,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               size="icon"
               onClick={closeMobilePanel}
               aria-label={t.app.closeModelTools}
-              className="text-text-secondary hover:text-midground"
+              className="rounded-md text-text-secondary hover:bg-primary/10 hover:text-primary"
             >
               <X />
             </Button>
@@ -776,7 +775,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           <div
             className={cn(
               "min-h-0 flex-1 overflow-y-auto overflow-x-hidden",
-              "border-t border-current/10",
+              "border-t border-border/60",
             )}
           >
             <ChatSidebar channel={channel} />
@@ -800,12 +799,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
         <div
           className={cn(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
+            "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-white/50",
             "p-2 sm:p-3",
           )}
           style={{
-            backgroundColor: TERMINAL_THEME.background,
-            boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
+            background:
+              "linear-gradient(145deg, rgba(14,35,56,0.96), rgba(13,49,79,0.94))",
+            boxShadow:
+              "0 20px 54px rgba(31, 101, 180, 0.18), inset 0 1px 0 rgba(255,255,255,0.16)",
           }}
         >
           <div
@@ -821,9 +822,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className={cn(
               "absolute z-10",
               "normal-case tracking-normal font-normal",
-              "rounded border border-current/30",
-              "bg-black/20 backdrop-blur-sm",
-              "opacity-70 hover:opacity-100 hover:border-current/60",
+              "rounded-md border border-sky-200/30",
+              "bg-sky-950/40 backdrop-blur-sm",
+              "opacity-80 hover:opacity-100 hover:border-sky-100/60",
               "transition-opacity duration-150",
               "bottom-2 right-2 px-2 py-1 text-xs sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5",
               "lg:bottom-4 lg:right-4",

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -132,9 +132,9 @@ export default function ConfigPage() {
     }
     setEnd(
       <div className="relative w-full min-w-0 sm:max-w-xs">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
         <Input
-          className="h-8 pl-8 pr-7 text-xs"
+          className="h-8 rounded-lg pl-8 pr-8 text-sm shadow-none"
           placeholder={t.common.search}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
@@ -143,11 +143,11 @@ export default function ConfigPage() {
           <Button
             ghost
             size="xs"
-            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2 rounded-md border border-transparent bg-transparent p-0 text-muted-foreground shadow-none hover:border-border hover:bg-muted/70 hover:text-foreground"
             onClick={() => setSearchQuery("")}
             aria-label={t.common.clear}
           >
-            <X />
+            <X className="h-3.5 w-3.5" />
           </Button>
         )}
       </div>,

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -11,7 +11,7 @@ import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { FilterGroup, Segmented } from "@nous-research/ui/ui/components/segmented";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
-import { Switch } from "@nous-research/ui/ui/components/switch";
+import { Switch } from "@/components/ui/switch";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { useI18n } from "@/i18n";

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -7,7 +7,7 @@ import type { HubAgentPluginRow, PluginsHubResponse } from "@/lib/api";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
-import { Switch } from "@nous-research/ui/ui/components/switch";
+import { Switch } from "@/components/ui/switch";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { CommandBlock } from "@nous-research/ui/ui/components/command-block";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -24,7 +24,7 @@ import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
-import { Switch } from "@nous-research/ui/ui/components/switch";
+import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { useI18n } from "@/i18n";
@@ -203,9 +203,9 @@ export default function SkillsPage() {
     );
     setEnd(
       <div className="relative w-full min-w-0 sm:max-w-xs">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
         <Input
-          className="h-8 rounded-none pl-8 pr-7 text-xs"
+          className="h-8 rounded-lg pl-8 pr-8 text-sm shadow-none"
           placeholder={t.common.search}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
@@ -214,11 +214,11 @@ export default function SkillsPage() {
           <Button
             ghost
             size="xs"
-            className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2 rounded-md border border-transparent bg-transparent p-0 text-muted-foreground shadow-none hover:border-border hover:bg-muted/70 hover:text-foreground"
             onClick={() => setSearch("")}
             aria-label={t.common.clear}
           >
-            <X />
+            <X className="h-3.5 w-3.5" />
           </Button>
         )}
       </div>,

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -355,12 +355,15 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
         if (cancelled) return;
         if (resp.themes?.length) {
           setAvailableThemes(
-            resp.themes.map((t) => ({
-              name: t.name,
-              label: t.label,
-              description: t.description,
-              definition: t.definition,
-            })),
+            resp.themes.map((t) => {
+              const builtin = BUILTIN_THEMES[t.name];
+              return {
+                name: t.name,
+                label: builtin?.label ?? t.label,
+                description: builtin?.description ?? t.description,
+                definition: t.definition,
+              };
+            }),
           );
           // Index any definitions the server shipped (user themes).
           const defs: Record<string, DashboardTheme> = {};

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -17,7 +17,7 @@ import type { DashboardTheme, ThemeTypography, ThemeLayout } from "./types";
 
 /** Default system stack — neutral, safe fallback for every platform. */
 const SYSTEM_SANS =
-  'system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
+  '-apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Segoe UI", Arial, sans-serif';
 const SYSTEM_MONO =
   'ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace';
 
@@ -40,17 +40,73 @@ const DEFAULT_LAYOUT: ThemeLayout = {
 
 export const defaultTheme: DashboardTheme = {
   name: "default",
-  label: "Hermes Teal",
-  description: "Classic dark teal — the canonical Hermes look",
+  label: "Feishu Blue",
+  description: "Clean white workspace with Feishu-style blue actions",
   palette: {
-    background: { hex: "#041c1c", alpha: 1 },
-    midground: { hex: "#ffe6cb", alpha: 1 },
-    foreground: { hex: "#ffffff", alpha: 0 },
-    warmGlow: "rgba(255, 189, 56, 0.35)",
-    noiseOpacity: 1,
+    background: { hex: "#f7f8fa", alpha: 1 },
+    midground: { hex: "#3370ff", alpha: 1 },
+    foreground: { hex: "#1f2329", alpha: 1 },
+    warmGlow: "rgba(51, 112, 255, 0.08)",
+    noiseOpacity: 0,
   },
-  typography: DEFAULT_TYPOGRAPHY,
-  layout: DEFAULT_LAYOUT,
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: SYSTEM_SANS,
+    fontDisplay: SYSTEM_SANS,
+    baseSize: "14.5px",
+    lineHeight: "1.58",
+  },
+  layout: {
+    ...DEFAULT_LAYOUT,
+    radius: "0.75rem",
+  },
+  colorOverrides: {
+    card: "#ffffff",
+    cardForeground: "#1f2329",
+    popover: "rgba(255, 255, 255, 0.98)",
+    popoverForeground: "#1f2329",
+    primary: "#3370ff",
+    primaryForeground: "#ffffff",
+    secondary: "#f5f6f7",
+    secondaryForeground: "#1f2329",
+    muted: "#f5f6f7",
+    mutedForeground: "#4e5969",
+    accent: "#eef3ff",
+    accentForeground: "#3370ff",
+    destructive: "#f54a45",
+    destructiveForeground: "#ffffff",
+    success: "#00b578",
+    warning: "#ff8800",
+    border: "#dee0e3",
+    input: "#ffffff",
+    ring: "#3370ff",
+  },
+  componentStyles: {
+    card: {
+      background:
+        "#ffffff",
+      boxShadow:
+        "0 1px 2px rgba(31, 35, 41, 0.04)",
+    },
+    header: {
+      background:
+        "rgba(255,255,255,0.96)",
+      borderImage:
+        "linear-gradient(90deg, rgba(222,224,227,1), rgba(222,224,227,1)) 1",
+    },
+    sidebar: {
+      background:
+        "#ffffff",
+      borderImage:
+        "linear-gradient(180deg, rgba(222,224,227,1), rgba(222,224,227,1)) 1",
+    },
+    backdrop: {
+      fillerOpacity: "1",
+      fillerBlendMode: "normal",
+      backgroundSize: "cover",
+      backgroundPosition: "center",
+    },
+  },
 };
 
 export const midnightTheme: DashboardTheme = {
@@ -190,8 +246,8 @@ export const roseTheme: DashboardTheme = {
  */
 export const defaultLargeTheme: DashboardTheme = {
   name: "default-large",
-  label: "Hermes Teal (Large)",
-  description: "Hermes Teal with bigger fonts and roomier spacing",
+  label: "Feishu Blue (Large)",
+  description: "Feishu Blue with bigger fonts and roomier spacing",
   palette: defaultTheme.palette,
   typography: {
     ...DEFAULT_TYPOGRAPHY,


### PR DESCRIPTION
## Summary
- add Feishu CardKit streaming reply cards with CardKit create/content/update/settings lifecycle
- route inline and structured reasoning into a collapsible card reasoning panel
- keep existing Feishu post/text send and edit behavior as fallback when CardKit fails

## Test Plan
- scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_feishu.py
- git diff --check