### PR TITLE
chore(attribution): add hermes-ci-bot to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,6 +48,7 @@ AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "kenyon1977@gmail.com": "kenyonxu",
+    "hermes-ci-bot@nousresearch.com": "hermes-ci-bot",
     "cipherframe@users.noreply.github.com": "CipherFrame",
     "121752779+jacevys@users.noreply.github.com": "jacevys",
     "me@promplate.dev": "CNSeniorious000",


### PR DESCRIPTION
## What
Add `hermes-ci-bot@nousresearch.com` → `hermes-ci-bot` mapping to `scripts/release.py` AUTHOR_MAP.

## Root Cause
CI Attribution Check (run [26394035819](https://github.com/NousResearch/hermes-agent/actions/runs/26394035819)) failed on branch `fix/custom-provider-compression-ctx` because the email `hermes-ci-bot@nousresearch.com` is not in AUTHOR_MAP.

## Fix
- Verified the GitHub user `hermes-ci-bot` exists via `gh api search/users`
- Added the mapping to AUTHOR_MAP