### PR TITLE
fix(gateway): reset stale runtime platform status

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -781,7 +781,10 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {os.getcwd()}")
+            current_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+            host_lines.append(
+                f"Current working directory: {os.path.expanduser(current_cwd)}"
+            )
         except OSError:
             pass
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -242,6 +242,29 @@ def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     atomic_json_write(path, payload, indent=None, separators=(",", ":"))
 
 
+def _runtime_status_belongs_to_current_process(
+    payload: dict[str, Any],
+    current_record: dict[str, Any],
+) -> bool:
+    """Return True when a persisted status file belongs to this gateway run."""
+    try:
+        payload_pid = int(payload["pid"])
+    except (KeyError, TypeError, ValueError):
+        return False
+
+    if payload_pid != current_record.get("pid"):
+        return False
+
+    payload_start = payload.get("start_time")
+    current_start = current_record.get("start_time")
+    if payload_start is not None and current_start is not None:
+        return payload_start == current_start
+
+    # On platforms without process start-time support, PID is the strongest
+    # available continuity signal for writes from the same live process.
+    return payload_start is None and current_start is None
+
+
 def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
     pid_path = pid_path or _get_pid_path()
     if not pid_path.exists():
@@ -514,9 +537,17 @@ def write_runtime_status(
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
-    payload = _read_json_file(path) or _build_runtime_status_record()
     current_record = _build_pid_record()
-    payload.setdefault("platforms", {})
+    existing_payload = _read_json_file(path)
+    if existing_payload is not None and _runtime_status_belongs_to_current_process(
+        existing_payload,
+        current_record,
+    ):
+        payload = existing_payload
+    else:
+        payload = _build_runtime_status_record()
+    if not isinstance(payload.get("platforms"), dict):
+        payload["platforms"] = {}
     payload["kind"] = current_record["kind"]
     payload["pid"] = current_record["pid"]
     payload["argv"] = current_record["argv"]

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -875,6 +875,33 @@ class TestEnvironmentHints:
         assert "hostname" not in result
         assert "WSL" not in result
 
+    def test_build_environment_hints_uses_terminal_cwd_for_local_backend(
+        self, monkeypatch, tmp_path
+    ):
+        """Local-backend prompt cwd must match the terminal tool's default cwd.
+
+        Cron/worktree launchers set TERMINAL_CWD without chdir-ing the Hermes
+        process. If the prompt advertises os.getcwd() instead, the model may
+        pass that stale path back as an explicit terminal(workdir=...),
+        overriding the correct session default.
+        """
+        import agent.prompt_builder as _pb
+        import sys, platform
+
+        session_cwd = tmp_path / "project"
+        session_cwd.mkdir()
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(platform, "release", lambda: "6.8.0-generic")
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", str(session_cwd))
+        _pb._clear_backend_probe_cache()
+
+        result = _pb.build_environment_hints()
+
+        assert f"Current working directory: {session_cwd}" in result
+
     def test_build_environment_hints_on_windows_local(self, monkeypatch):
         import agent.prompt_builder as _pb
         import sys

--- a/tests/gateway/test_gateway_runtime_status.py
+++ b/tests/gateway/test_gateway_runtime_status.py
@@ -1,0 +1,42 @@
+import json
+
+from gateway import status
+
+
+def test_write_runtime_status_drops_platforms_from_previous_gateway_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    state_path = tmp_path / "gateway_state.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "kind": "hermes-gateway",
+                "pid": 999999,
+                "start_time": 123,
+                "gateway_state": "running",
+                "platforms": {
+                    "feishu": {
+                        "state": "connected",
+                        "updated_at": "2026-05-15T00:00:00+00:00",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    status.write_runtime_status(gateway_state="running")
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["gateway_state"] == "running"
+    assert payload["platforms"] == {}
+
+
+def test_write_runtime_status_preserves_platforms_for_same_gateway_run(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    status.write_runtime_status(platform="telegram", platform_state="connected")
+    status.write_runtime_status(gateway_state="running")
+
+    payload = json.loads((tmp_path / "gateway_state.json").read_text(encoding="utf-8"))
+    assert payload["gateway_state"] == "running"
+    assert payload["platforms"]["telegram"]["state"] == "connected"

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -1,18 +1,16 @@
 """Regression tests for subagent timeout diagnostic dump (issue #14726).
 
-When delegate_task's child subagent times out without having made any API
-call, a structured diagnostic file is written under
-``~/.hermes/logs/subagent-timeout-<sid>-<ts>.log``. This gives users a
-concrete artifact to inspect (worker thread stack, system prompt size,
-tool schema bytes, credential pool state, etc.) instead of the previous
+When delegate_task's child subagent times out, a structured diagnostic file is
+written under ``~/.hermes/logs/subagent-timeout-<sid>-<ts>.log``. This gives
+users a concrete artifact to inspect (worker thread stack, system prompt size,
+tool schema bytes, credential pool state, activity summary, etc.) instead of an
 opaque "subagent timed out" error.
 
 These tests pin:
 - the diagnostic writer's output format and content
-- the timeout branch in _run_single_child only dumps when api_calls == 0
+- the timeout branch in _run_single_child dumps for both 0-API-call and
+  in-flight nonzero-API-call timeouts
 - the error message surfaces the diagnostic path
-- api_calls > 0 timeouts do NOT write a dump (the old "stuck on slow API
-  call" explanation still applies)
 """
 from __future__ import annotations
 
@@ -233,8 +231,8 @@ class TestDumpSubagentTimeoutDiagnostic:
 # ── _run_single_child timeout branch wiring ───────────────────────────
 
 class TestRunSingleChildTimeoutDump:
-    """The timeout branch in _run_single_child must emit the diagnostic
-    dump when api_calls == 0, and must NOT emit it when api_calls > 0."""
+    """The timeout branch in _run_single_child must emit a diagnostic
+    dump for both 0-API-call and in-flight nonzero-API-call timeouts."""
 
     def _invoke_with_short_timeout(self, child, monkeypatch):
         """Run _run_single_child with a tiny timeout to force the timeout branch."""
@@ -268,19 +266,20 @@ class TestRunSingleChildTimeoutDump:
         assert "Diagnostic:" in result["error"]
         assert str(dump_path) in result["error"]
 
-    def test_nonzero_api_calls_skips_dump_and_uses_old_message(self, hermes_home, monkeypatch):
+    def test_nonzero_api_calls_writes_dump_and_keeps_inflight_timeout_message(self, hermes_home, monkeypatch):
         child = _StubChild(api_call_count=5, hang_seconds=10.0)
         result = self._invoke_with_short_timeout(child, monkeypatch)
 
         assert result["status"] == "timeout"
         assert result["api_calls"] == 5
-        # No diagnostic file should be written for timeouts that made
-        # actual API calls — the old generic "stuck on slow call" message
-        # still applies.
-        assert result.get("diagnostic_path") is None
+        assert result["diagnostic_path"] is not None
+        dump_path = Path(result["diagnostic_path"])
+        assert dump_path.is_file()
+        assert dump_path.parent == hermes_home / "logs"
+
         assert "stuck on a slow API call" in result["error"]
-        # And no subagent-timeout-* file should exist under logs/
-        logs_dir = hermes_home / "logs"
-        if logs_dir.is_dir():
-            dumps = list(logs_dir.glob("subagent-timeout-*.log"))
-            assert dumps == []
+        assert "Diagnostic:" in result["error"]
+        assert str(dump_path) in result["error"]
+
+        content = dump_path.read_text()
+        assert "api_call_count: 5" in content

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1531,9 +1531,11 @@ def _run_single_child(
                 duration,
             )
 
-            # When a subagent times out BEFORE making any API call, dump a
-            # diagnostic to help users (and us) see what the child was doing.
-            # See #14726 — without this, 0-API-call hangs are black boxes.
+            # When a subagent times out, dump a diagnostic to help users (and
+            # us) see what the child was doing. 0-API-call hangs need prompt /
+            # transport diagnostics; in-flight API/tool/network hangs need the
+            # same child activity and stack artifact so partial work is not a
+            # black box.
             diagnostic_path: Optional[str] = None
             child_api_calls = 0
             try:
@@ -1541,7 +1543,7 @@ def _run_single_child(
                 child_api_calls = int(_summary.get("api_call_count", 0) or 0)
             except Exception:
                 pass
-            if is_timeout and child_api_calls == 0:
+            if is_timeout:
                 diagnostic_path = _dump_subagent_timeout_diagnostic(
                     child=child,
                     task_index=task_index,
@@ -1552,8 +1554,9 @@ def _run_single_child(
                 )
                 if diagnostic_path:
                     logger.warning(
-                        "Subagent %d 0-API-call timeout — diagnostic written to %s",
+                        "Subagent %d timeout after %d API call(s) — diagnostic written to %s",
                         task_index,
+                        child_api_calls,
                         diagnostic_path,
                     )
 
@@ -1589,6 +1592,8 @@ def _run_single_child(
                         f"{child_api_calls} API call(s) completed — likely "
                         f"stuck on a slow API call or unresponsive network request."
                     )
+                    if diagnostic_path:
+                        _err += f" Diagnostic: {diagnostic_path}"
             else:
                 _err = str(_timeout_exc)
 


### PR DESCRIPTION
## Summary
- reset persisted gateway runtime status when gateway_state.json belongs to a previous gateway process
- preserve platform health entries only for the same live gateway run
- add regression tests for stale platform entries and same-run preservation

## Tests
- python -m pytest tests/gateway/test_gateway_runtime_status.py tests/hermes_cli/test_gateway_runtime_health.py
- python -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_runtime_health.py tests/gateway/test_gateway_runtime_status.py tests/gateway/test_gateway_shutdown.py