### PR TITLE
fix(gateway): bound Telegram general pool on proxy path to cap fd leak

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -319,6 +319,32 @@ def _wrap_markdown_tables(text: str) -> str:
     return '\n'.join(out)
 
 
+def _bounded_proxy_limits():
+    """httpx connection limits for the proxy request path (#31599).
+
+    When Telegram traffic is routed through a local HTTP proxy, half-closed
+    connections accumulate in the general request pool faster than httpx
+    evicts them — httpcore's tunnel-proxy path does not always release the
+    underlying socket on ConnectError. Over days of flaky-proxy operation the
+    unbounded ``connection_pool_size`` default lets these dead sockets pile up
+    until the process hits its fd limit and every send fails. Bounding the
+    pool caps the leak and surfaces it immediately instead of after ~2 days.
+    Override the caps via env if a deployment legitimately needs more.
+    """
+    import httpx
+
+    def _cap(name: str, default: int) -> int:
+        try:
+            return int(os.getenv(name, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    return httpx.Limits(
+        max_connections=_cap("HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS", 20),
+        max_keepalive_connections=_cap("HERMES_TELEGRAM_PROXY_MAX_KEEPALIVE", 10),
+    )
+
+
 class TelegramAdapter(BasePlatformAdapter):
     """
     Telegram bot adapter.
@@ -1430,8 +1456,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                # Bound the pool on the proxy path so leaked half-closed sockets
+                # can't exhaust the fd limit over days of flaky-proxy operation (#31599).
+                proxy_limits = _bounded_proxy_limits()
+                request = HTTPXRequest(**request_kwargs, proxy=proxy_url, httpx_kwargs={"limits": proxy_limits})
+                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url, httpx_kwargs={"limits": proxy_limits})
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)

--- a/tests/gateway/test_telegram_proxy_pool_bound.py
+++ b/tests/gateway/test_telegram_proxy_pool_bound.py
@@ -1,0 +1,36 @@
+"""Tests for the bounded proxy connection pool (issue #31599).
+
+When Telegram runs behind a flaky local HTTP proxy, half-closed sockets
+accumulate in the general request pool faster than httpx evicts them and
+eventually exhaust the process fd limit. The fix bounds the pool on the
+proxy path via ``httpx.Limits`` so the leak is capped and surfaces
+immediately instead of wedging the gateway after ~2 days.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from gateway.platforms.telegram import _bounded_proxy_limits
+
+
+def test_default_caps_are_bounded():
+    limits = _bounded_proxy_limits()
+    assert isinstance(limits, httpx.Limits)
+    assert limits.max_connections == 20
+    assert limits.max_keepalive_connections == 10
+
+
+def test_env_overrides(monkeypatch):
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS", "40")
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_MAX_KEEPALIVE", "5")
+    limits = _bounded_proxy_limits()
+    assert limits.max_connections == 40
+    assert limits.max_keepalive_connections == 5
+
+
+def test_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS", "not-an-int")
+    limits = _bounded_proxy_limits()
+    assert limits.max_connections == 20
+    assert limits.max_keepalive_connections == 10


### PR DESCRIPTION
Bounds the Telegram adapter's httpx connection pool when a proxy is configured, so half-closed sockets can no longer accumulate until the process hits its file-descriptor limit.

## What does this PR do?

When the Telegram adapter routes through a local HTTP proxy, half-closed connections accumulate in the httpx general request pool faster than httpx evicts them — httpcore's tunnel-proxy path does not always release the underlying socket on `ConnectError`. With the current unbounded `connection_pool_size` default (512), these dead `CLOSED` sockets pile up over days of flaky-proxy operation until the process exceeds its fd limit and every `send_message` / `set_my_commands` fails with `httpx.ConnectError: All connection attempts failed`.

This implements the reporter's suggested Refs #1: pass a bounded `httpx.Limits` into the proxy `HTTPXRequest` construction. Capping `max_connections`/`max_keepalive_connections` bounds the leak and makes it surface immediately instead of silently wedging the gateway after ~2 days. The caps are env-overridable (`HERMES_TELEGRAM_PROXY_MAX_CONNECTIONS`, `HERMES_TELEGRAM_PROXY_MAX_KEEPALIVE`) for deployments that legitimately need more.

Scoped to the proxy branch only — the non-proxy and fallback-IP paths are unchanged. The issue's other suggested fixes (periodic drain of `_request[1]`, send-path heartbeat, `maxfiles` startup warning) are deliberately deferred, hence `Refs` rather than `Fixes`.

## Related Issue

Refs #31599

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: add `_bounded_proxy_limits()` helper returning an env-overridable `httpx.Limits` (defaults: `max_connections=20`, `max_keepalive_connections=10`); pass it via `httpx_kwargs={"limits": ...}` to the proxy `HTTPXRequest` and `get_updates_request` construction. PTB merges `httpx_kwargs` on top of its `connection_pool_size`-derived limits, so the bounded limits win.
- `tests/gateway/test_telegram_proxy_pool_bound.py`: unit tests for the helper's defaults, env overrides, and invalid-env fallback.

## How to Test

1. `pytest tests/gateway/test_telegram_proxy_pool_bound.py -q` — passes (3 tests).
2. Configure `TELEGRAM_PROXY` (or a system proxy resolved by `resolve_proxy_url`) pointing at a flaky local proxy; start the gateway with Telegram enabled. Over reconnect cycles, `lsof -p <gateway_pid> | wc -l` now plateaus near the bounded pool size instead of climbing past `launchctl limit maxfiles`.
3. Note: the full `pytest tests/gateway/ -k telegram` selection shows 6 pre-existing order-dependent failures (MarkdownV2-escaping / model-picker tests) that reproduce on `main` without this change and pass in isolation; they are unrelated to this proxy fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<!-- autocontrib:worker-id=issue-new-83cfa0b3 kind=pr-open -->