### PR TITLE
fix(gateway): reload system prompt from config before each conversation turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16317,6 +16317,16 @@ class GatewayRunner:
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
             
+            # Re-read .env and config for fresh credentials (gateway is long-lived,
+            # keys may change without restart). Keep config.yaml authoritative for
+            # runtime budget settings bridged into env vars.
+            _reload_runtime_env_preserving_config_authority()
+            # ``agent.system_prompt`` is also runtime-editable (dashboard,
+            # config set, direct YAML edit). Refresh it here so the next
+            # message sees the new prompt and the cached-agent signature
+            # naturally changes with the rebuilt combined prompt.
+            self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
+
             # Combine platform context, per-channel context, and the user-configured
             # ephemeral system prompt.
             combined_ephemeral = context_prompt or ""
@@ -16325,11 +16335,6 @@ class GatewayRunner:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
             if self._ephemeral_system_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
-
-            # Re-read .env and config for fresh credentials (gateway is long-lived,
-            # keys may change without restart). Keep config.yaml authoritative for
-            # runtime budget settings bridged into env vars.
-            _reload_runtime_env_preserving_config_authority()
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -322,6 +322,7 @@ async def test_run_agent_reloads_system_prompt_after_config_edit_and_busts_cache
         session_key=session_key,
         channel_prompt="Channel prompt",
     )
+    assert session_key in runner._agent_cache
 
     config_path.write_text("agent:\n  system_prompt: New prompt\n", encoding="utf-8")
 
@@ -334,9 +335,19 @@ async def test_run_agent_reloads_system_prompt_after_config_edit_and_busts_cache
         session_key=session_key,
         channel_prompt="Channel prompt",
     )
+    third = await runner._run_agent(
+        message="hi once more",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key=session_key,
+        channel_prompt="Channel prompt",
+    )
 
     assert first["final_response"] == "ok"
     assert second["final_response"] == "ok"
+    assert third["final_response"] == "ok"
     assert len(_HotReloadAgent.init_kwargs) == 2
     assert _HotReloadAgent.init_kwargs[0]["ephemeral_system_prompt"] == (
         "Context prompt\n\nChannel prompt\n\nOld prompt"

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -218,7 +218,11 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
-    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"agent": {"system_prompt": "Global prompt"}},
+    )
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,
@@ -256,3 +260,88 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
     assert _CapturingAgent.last_init["ephemeral_system_prompt"] == (
         "Context prompt\n\nChannel prompt\n\nGlobal prompt"
     )
+
+
+@pytest.mark.asyncio
+async def test_run_agent_reloads_system_prompt_after_config_edit_and_busts_cache(
+    monkeypatch, tmp_path
+):
+    class _HotReloadAgent:
+        init_kwargs = []
+
+        def __init__(self, *args, **kwargs):
+            type(self).init_kwargs.append(dict(kwargs))
+            self.tools = []
+
+        def run_conversation(
+            self, user_message, conversation_history=None, task_id=None, persist_user_message=None
+        ):
+            return {
+                "final_response": "ok",
+                "messages": [],
+                "api_calls": 1,
+                "completed": True,
+            }
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _HotReloadAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    runner = _make_runner()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agent:\n  system_prompt: Old prompt\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    runner._ephemeral_system_prompt = gateway_run.GatewayRunner._load_ephemeral_system_prompt()
+
+    session_key = "agent:main:discord:thread:12345"
+    first = await runner._run_agent(
+        message="hi",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key=session_key,
+        channel_prompt="Channel prompt",
+    )
+
+    config_path.write_text("agent:\n  system_prompt: New prompt\n", encoding="utf-8")
+
+    second = await runner._run_agent(
+        message="hi again",
+        context_prompt="Context prompt",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key=session_key,
+        channel_prompt="Channel prompt",
+    )
+
+    assert first["final_response"] == "ok"
+    assert second["final_response"] == "ok"
+    assert len(_HotReloadAgent.init_kwargs) == 2
+    assert _HotReloadAgent.init_kwargs[0]["ephemeral_system_prompt"] == (
+        "Context prompt\n\nChannel prompt\n\nOld prompt"
+    )
+    assert _HotReloadAgent.init_kwargs[1]["ephemeral_system_prompt"] == (
+        "Context prompt\n\nChannel prompt\n\nNew prompt"
+    )
+    assert runner._ephemeral_system_prompt == "New prompt"


### PR DESCRIPTION
## Summary
Fixes a gateway stale-state bug where `agent.system_prompt` edits made while the gateway is already running do not take effect on the next message.

## Problem
The gateway is a long-lived process and is expected to pick up runtime config edits between turns.

Before this change, if `agent.system_prompt` was updated after gateway startup, the next message could still run with the old prompt.

## Root Cause
`GatewayRunner` loaded `_ephemeral_system_prompt` at startup and kept using that in-memory snapshot for later turns.

As a result:
- config was updated successfully
- the user expected the new prompt to apply on the next message
- the gateway continued with stale prompt state

## Fix
Reload `agent.system_prompt` immediately before building the per-turn combined ephemeral prompt in the normal gateway message flow.

This keeps the change narrowly scoped and allows the existing cached-agent signature to invalidate naturally when the prompt changes.

## Why This Approach
- Minimal, targeted fix
- Preserves existing cache behavior
- Makes the next message reflect config edits without requiring a gateway restart
- Avoids broad behavior changes in unrelated runtime settings

## Tests
Added regression coverage for:
- `test_run_agent_reloads_system_prompt_after_config_edit_and_busts_cache`
- `test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt`

Re-verified adjacent hot-reload coverage with:
- `test_reasoning_command_reloads_current_state_from_config`
- `test_handle_reasoning_command_updates_config_and_cache`

## Risk
Low.

This change only affects how the gateway refreshes `agent.system_prompt` between turns. It does not change model routing, tool selection, or transcript persistence.

## Checklist
- [x] Bug reproduced
- [x] Root cause identified
- [x] Fix kept minimal and scoped
- [x] Regression coverage added
- [x] Related hot-reload behavior re-verified