### PR TITLE
fix(test): mock _YOLO_MODE_FROZEN in test_yolo_overrides_cron_deny

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -239,6 +239,10 @@ class TestCronModeInteractions:
         monkeypatch.setenv("HERMES_YOLO_MODE", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        # _YOLO_MODE_FROZEN is frozen at tools/approval.py import time and
+        # ignores monkeypatch.setenv — it must be patched directly so the
+        # yolo bypass fires before the cron deny path.
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
 
         from unittest.mock import patch as mock_patch
         with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):


### PR DESCRIPTION
## What
Fix `test_yolo_overrides_cron_deny` — the test was broken by the `_YOLO_MODE_FROZEN` security hardening (module-level freeze at import time).

## Root Cause
`_YOLO_MODE_FROZEN` is frozen at `tools/approval.py` module import time and ignores `monkeypatch.setenv('HERMES_YOLO_MODE', '1')`. The test expected the yolo bypass (line 948) to fire before the cron deny path, but the frozen value remained `False` from import time, causing `check_dangerous_command()` to fall through to the cron deny block.

## Fix
`monkeypatch.setattr(approval_module, '_YOLO_MODE_FROZEN', True)` so the yolo check evaluates correctly.

## Verification
All 24 tests in `tests/tools/test_cron_approval_mode.py` pass:
```
24 passed in 0.75s
```

## Related
- CI failure: https://github.com/NousResearch/hermes-agent/actions/runs/26396350667
- Original PR: #31959 (test (5) slice)