### PR TITLE
Add iputils-ping (ping) to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # hermes process, the dashboard, and per-profile gateways.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    ca-certificates curl python3 python-is-python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
+    ca-certificates curl iputils-ping python3 python-is-python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------- s6-overlay install ----------


### PR DESCRIPTION
### Problem

The official Hermes Agent Docker image does not include `ping` (from `iputils-ping`), a fundamental network diagnostic tool that most sysadmins and developers expect to have available out of the box.

Running `ping` inside the container currently fails with:
```
ping: command not found
```

### Solution

Add `iputils-ping` to the `apt-get install` command in the Dockerfile. This is a one-word, zero-risk change — the package is ~50KB and has no additional dependencies beyond what libc already provides.

### Why upstream?

Per the [contributing guidelines](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing/#should-it-be-a-skill-or-a-tool): *"If a tool is likely to be useful to most Hermes Agent users, consider contributing it upstream rather than carrying it in a private derived image."*

`ping` is orders of magnitude more universally useful than most of the utilities already in the image (and far smaller too). Having it missing means every user who needs basic network diagnostics has to fork the image, which is exactly the overhead the guidelines aim to avoid.

### Changed

- `Dockerfile`: Added `iputils-ping` to the apt package list.