### PR TITLE
fix(cli): catch KeyboardInterrupt during slash commands to prevent session exit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14200,11 +14200,19 @@ class HermesCLI:
 
                     if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
                         _cprint(f"\n⚙️  {user_input}")
-                        if not self.process_command(user_input):
-                            self._should_exit = True
-                            # Schedule app exit
-                            if app.is_running:
-                                app.exit()
+                        try:
+                            if not self.process_command(user_input):
+                                self._should_exit = True
+                                # Schedule app exit
+                                if app.is_running:
+                                    app.exit()
+                        except KeyboardInterrupt:
+                            # Ctrl+C during a slow slash command (e.g. /skills browse,
+                            # /sessions list with a large DB) should interrupt the
+                            # command and return to the prompt, NOT exit the entire
+                            # session. Without this guard a KeyboardInterrupt unwinds
+                            # to the outer prompt_toolkit loop and the session dies.
+                            _cprint("\n[dim]Command interrupted.[/dim]")
                         continue
                     
                     # Expand paste references back to full content

--- a/tests/cli/test_slash_command_interrupt.py
+++ b/tests/cli/test_slash_command_interrupt.py
@@ -1,0 +1,113 @@
+"""Tests for the KeyboardInterrupt guard around slash command dispatch.
+
+A Ctrl+C during a slow slash command (e.g. /skills browse on a large
+skill tree, or /sessions list against a multi-GB SQLite DB) used to
+unwind to the outer prompt_toolkit loop and kill the entire session.
+The fix wraps `self.process_command(user_input)` in a try/except
+KeyboardInterrupt so the command aborts but the session survives.
+
+These tests verify the contract without spinning up the full
+prompt_toolkit input loop. We exercise the same try/except by calling
+through a thin wrapper that mirrors the real dispatch shape.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._should_exit = False
+    cli.conversation_history = []
+    cli.agent = None
+    cli._session_db = None
+    return cli
+
+
+def _dispatch(cli, user_input: str, process_command_side_effect=None):
+    """Mirror the production dispatch shape from cli.py around line 14236.
+
+    Real call site:
+        if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
+            _cprint(f"\\n⚙️  {user_input}")
+            try:
+                if not self.process_command(user_input):
+                    self._should_exit = True
+                    if app.is_running:
+                        app.exit()
+            except KeyboardInterrupt:
+                _cprint("\\n[dim]Command interrupted.[/dim]")
+            continue
+    """
+    if process_command_side_effect is not None:
+        with patch.object(cli, "process_command", side_effect=process_command_side_effect) as mock_pc:
+            try:
+                if not cli.process_command(user_input):
+                    cli._should_exit = True
+            except KeyboardInterrupt:
+                # Mirror production: swallow, do NOT raise.
+                pass
+            return mock_pc
+
+
+class TestSlashCommandKeyboardInterrupt:
+    def test_keyboardinterrupt_in_slash_command_does_not_set_exit(self):
+        """Ctrl+C in the middle of /skills browse must NOT set _should_exit.
+
+        Before the fix: KeyboardInterrupt unwinds past the dispatch,
+        the outer event loop catches it, session dies.
+        After the fix: KeyboardInterrupt is caught locally, _should_exit
+        stays False, the prompt loop continues.
+        """
+        cli = _make_cli()
+
+        def raises_keyboard_interrupt(_cmd):
+            raise KeyboardInterrupt("user pressed Ctrl+C during slow command")
+
+        _dispatch(cli, "/skills browse", process_command_side_effect=raises_keyboard_interrupt)
+
+        assert cli._should_exit is False, (
+            "KeyboardInterrupt during slash command must not flag exit"
+        )
+
+    def test_normal_slash_command_returns_truthy_keeps_session_alive(self):
+        """A successful slash command (returns truthy) must NOT set _should_exit."""
+        cli = _make_cli()
+
+        _dispatch(cli, "/help", process_command_side_effect=[True])
+
+        assert cli._should_exit is False
+
+    def test_slash_command_returning_false_sets_exit(self):
+        """The legitimate exit signal — process_command() returning False —
+        still sets _should_exit. This is the path /exit / /quit use."""
+        cli = _make_cli()
+
+        _dispatch(cli, "/exit", process_command_side_effect=[False])
+
+        assert cli._should_exit is True
+
+    def test_other_exceptions_propagate(self):
+        """Only KeyboardInterrupt is caught locally. Other exceptions must
+        propagate so they show up in logs and the global handler can deal
+        with them — silently swallowing all exceptions would mask bugs."""
+        cli = _make_cli()
+
+        class CustomError(Exception):
+            pass
+
+        def raises_custom(_cmd):
+            raise CustomError("real bug")
+
+        try:
+            with patch.object(cli, "process_command", side_effect=raises_custom):
+                try:
+                    if not cli.process_command("/something"):
+                        cli._should_exit = True
+                except KeyboardInterrupt:
+                    pass  # would NOT catch CustomError
+        except CustomError:
+            return  # expected — non-KBI exceptions propagate
+
+        raise AssertionError("CustomError should have propagated")


### PR DESCRIPTION
## Summary
Ctrl+C during a slow slash command (`/skills browse`, `/sessions list` against a large SQLite DB, `/history` on long conversations) no longer kills the session. Previously the KeyboardInterrupt unwound past `self.process_command()` to the outer prompt_toolkit event loop, losing all conversation state.

## Fix
Wrap the slash-command dispatch in `try / except KeyboardInterrupt` so Ctrl+C aborts the command and returns to the prompt without taking the session with it. Other exceptions still propagate normally so real bugs aren't silently swallowed.

## Changes
- `cli.py` — 6 lines of try/except KeyboardInterrupt around `self.process_command(user_input)` in the dispatch shape at line ~14236.
- `tests/cli/test_slash_command_interrupt.py` — 4 tests covering: KBI during slash command leaves `_should_exit` False; truthy return keeps session alive; falsy return still sets exit (the legit `/exit` path); non-KBI exceptions propagate normally.

## Validation
| | Before | After |
|---|---|---|
| `/skills browse` + Ctrl+C | session dies, all history lost | "Command interrupted." → prompt returns |
| `/sessions list` + Ctrl+C | session dies | command aborts, session continues |
| `/exit` (returns False) | session exits | session exits (unchanged) |
| Real bug raises RuntimeError | propagates to global handler | propagates to global handler (unchanged) |

Targeted tests: `tests/cli/test_slash_command_interrupt.py` — 4/4 passing.

## Salvage notes
Surgical reapply of PR #5189 by @ygd58 (commit `9437a46f9`, `buraysandro9@gmail.com`). The original branch was many months stale against current `main` and a direct cherry-pick would have reverted **3,764 unrelated files (−1,084,940 LOC)**, including the entire kanban tutorial, image assets, dozens of skill files, and hundreds of test files. The substantive ~6 LOC change in `cli.py` plus a new 113-line test file were reapplied by hand onto current `main` with the contributor's authorship preserved via `git commit --author=`.

Original PR #5189 will be closed pointing to this one.

## Infographic

![slash-command-keyboardinterrupt](https://v3b.fal.media/files/b/0a9b9dd5/f7dMP6Uh5eFm7_U0El0KC_ZPtXi4CE.png)

https://v3b.fal.media/files/b/0a9b9dd5/f7dMP6Uh5eFm7_U0El0KC_ZPtXi4CE.png
