### PR TITLE
test(approval): patch _YOLO_MODE_FROZEN directly in test_yolo_overrides_cron_deny

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -240,8 +240,18 @@ class TestCronModeInteractions:
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
 
+        # _YOLO_MODE_FROZEN is frozen at module import time (security: prevents
+        # prompt injection from runtime-setting HERMES_YOLO_MODE). When the
+        # test process imports tools.approval BEFORE this test sets the env,
+        # the frozen value is False and yolo-bypass paths don't activate.
+        # Patch the module attribute directly to simulate process-startup
+        # with HERMES_YOLO_MODE=1.
         from unittest.mock import patch as mock_patch
-        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+        import tools.approval
+        with (
+            mock_patch.object(tools.approval, "_YOLO_MODE_FROZEN", True),
+            mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"),
+        ):
             # Use a dangerous-but-not-hardline command — `rm -rf /` is now
             # hardline-blocked regardless of yolo (see test_hardline_blocklist.py).
             result = check_dangerous_command("rm -rf /tmp/stuff", "local")


### PR DESCRIPTION
## Summary
`test_yolo_overrides_cron_deny` now passes deterministically in CI. Pre-existing test-isolation bug exposed by CI's clean-env conftest — blocks every PR routed to the `test (3)` / `test (4)` shard.

## Root cause
`tools.approval._YOLO_MODE_FROZEN` is **intentionally frozen at module import time** to prevent prompt-injection escalation:

```python
# tools/approval.py line 29
# Freeze YOLO mode at module import time. Reading os.environ on every call
# would allow any skill running inside the process to set this variable and
# instantly bypass all approval checks — a prompt-injection escalation path.
_YOLO_MODE_FROZEN: bool = is_truthy_value(os.getenv("HERMES_YOLO_MODE", ""))
```

The test set `HERMES_YOLO_MODE=1` via `monkeypatch.setenv` AFTER the module had already been imported, so the frozen value stayed `False` and the yolo-bypass path never activated. Result: `check_dangerous_command("rm -rf /tmp/stuff", "local")` returned `approved=False`, the test assert failed.

**Why local passes:** the conftest setup leaks a non-empty `HERMES_YOLO_MODE` into the import-time env on developer machines. CI's `env -i HOME=$HOME PATH=$PATH` clean-env path exposes the bug deterministically.

## Fix
Patch the module attribute directly via `mock.patch.object`, simulating process-startup with `HERMES_YOLO_MODE=1` regardless of import order. The behavior under test (yolo bypasses `cron_mode=deny` for non-hardline commands) is unchanged. The security invariant (`_YOLO_MODE_FROZEN` can't be set at runtime by skills) is preserved.

## Changes
- `tests/tools/test_cron_approval_mode.py` — `test_yolo_overrides_cron_deny` adds `mock.patch.object(tools.approval, "_YOLO_MODE_FROZEN", True)` alongside the existing `_get_cron_approval_mode` patch.

## Validation
| | Before | After |
|---|---|---|
| `env -i HOME=$HOME PATH=$PATH pytest tests/tools/test_cron_approval_mode.py` | 1 failed, 23 passed | 24 passed |
| CI test (3) / test (4) shard | fails on every PR | passes |
| Behavior under test | identical | identical |
| Security invariant `_YOLO_MODE_FROZEN` frozen | preserved | preserved |

## Why fix-it-first PR
This is the **second night in a row** a different PR has been blocked by this same test failure (PR #32013 Windows freeze, PR #32017 KBI guard, PR #32018 bracketed-paste timeout all hit it). Per [`references/green-ci-policy.md`](../tree/main/.hermes/skills/github/hermes-agent-dev/references/green-ci-policy.md), pre-existing failures get a separate fix-it PR so the affected PRs can rebase onto a clean main.

Will rebase #32013 / #32017 / #32018 onto this once it lands.

## Infographic

![yolo-frozen-test-isolation](https://v3b.fal.media/files/b/0a9b9e23/O6oTzesAd4CJlfSUJvOMc_C0Mg0cuv.png)

https://v3b.fal.media/files/b/0a9b9e23/O6oTzesAd4CJlfSUJvOMc_C0Mg0cuv.png
