### PR TITLE
fix(gateway): correct stale-systemd-unit recovery command and surface it as ERROR

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3892,10 +3892,18 @@ class GatewayRunner:
             from gateway.shutdown_forensics import check_systemd_timing_alignment
             _alignment = check_systemd_timing_alignment(self._restart_drain_timeout)
             if _alignment is not None and _alignment.get("mismatch"):
-                logger.warning(
+                # ``hermes gateway service install --replace`` was suggested in
+                # the original message but is not a valid command — the
+                # ``service`` subcommand does not exist and ``--replace`` is a
+                # flag on ``hermes gateway run``. Point users at
+                # ``hermes gateway install --force``, the actual recovery path
+                # verified in #31981. Logged at ERROR so it surfaces in the
+                # default journalctl view before the crash-loop scrolls it
+                # off; users mid-loop otherwise never see the WARNING tier.
+                logger.error(
                     "Stale systemd unit detected: %s has TimeoutStopSec=%.0fs but "
                     "drain_timeout=%.0fs (expected >=%.0fs). systemd may SIGKILL the "
-                    "gateway mid-drain. Run `hermes gateway service install --replace` "
+                    "gateway mid-drain. Run `hermes gateway install --force` "
                     "to regenerate the unit, or shorten agent.restart_drain_timeout.",
                     _alignment.get("unit", "(unknown)"),
                     _alignment["timeout_stop_sec"],

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -248,3 +248,37 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# Stale-systemd-unit warning text (#31981)
+# ---------------------------------------------------------------------------
+
+class TestStaleUnitWarningCommand:
+    """The stale-systemd warning emitted by ``GatewayRunner.start`` must point
+    users at a real recovery command — the original ``hermes gateway service
+    install --replace`` was invalid (``service`` is not a subcommand and
+    ``--replace`` is a flag on ``hermes gateway run``), leaving users in the
+    crash loop described in #31981 with no actionable next step.
+    """
+
+    def _warning_block(self) -> str:
+        run_py = Path(sf.__file__).resolve().parent / "run.py"
+        text = run_py.read_text(encoding="utf-8")
+        idx = text.find("Stale systemd unit detected")
+        assert idx >= 0, "stale-systemd warning block not found in gateway/run.py"
+        return text[idx : idx + 800]
+
+    def test_warning_does_not_suggest_invalid_replace_subcommand(self):
+        block = self._warning_block()
+        assert "service install --replace" not in block, (
+            "stale-systemd warning still suggests `hermes gateway service "
+            "install --replace`, which is not a valid command — see #31981"
+        )
+
+    def test_warning_suggests_valid_install_force_command(self):
+        block = self._warning_block()
+        assert "hermes gateway install --force" in block, (
+            "stale-systemd warning must direct users to "
+            "`hermes gateway install --force` so they can regenerate the unit"
+        )


### PR DESCRIPTION
## What does this PR do?

When the gateway boots under a stale systemd unit (`TimeoutStopSec` smaller than `restart_drain_timeout`), `shutdown_forensics.check_systemd_timing_alignment` detects the mismatch and `GatewayRunner.start()` logs a warning telling the user which command to run. The suggested command was ``hermes gateway service install --replace``, which is invalid on two counts: there is no `service` subcommand, and `--replace` is a flag on `hermes gateway run`, not `install`. Users following the suggestion in #31981 hit `unknown command` and remained stuck in the SIGKILL-mid-drain crash loop the warning was supposed to escape.

Point the message at ``hermes gateway install --force`` — the command the reporter verified actually regenerates the unit with the correct `TimeoutStopSec` — and bump the log level from `WARNING` to `ERROR` so the message surfaces in default `journalctl` views before the crash loop scrolls it off the buffer (a user in an active restart loop never sees the original `WARNING`).

> Mirrors `hermes_cli/gateway.py:_build_systemd_unit_template` — `restart_timeout = max(60, _drain_timeout) + 30` — which is the resolver that produces the regenerated `TimeoutStopSec`. The reporter's fix #1 (auto-align `TimeoutStopSec`) is already correct in this resolver; this PR fixes the user-facing path that points operators at it.

> Audited siblings: `gateway/run.py` is the only emitter of the `Stale systemd unit detected` warning (verified via `rg -n "Stale systemd"`). No widening needed.

## Related Issue

Fixes #31981

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — replace ``hermes gateway service install --replace`` with the valid ``hermes gateway install --force``; bump the log call from `logger.warning` to `logger.error` so the message reaches default `journalctl` views inside a crash-restart loop.
- `tests/gateway/test_shutdown_forensics.py` — add two source-level regression tests asserting the warning block contains the valid command and not the broken one.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_shutdown_forensics.py -v`
2. Both new tests pass; the existing `TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output` failure reproduces on clean `origin/main` and is unrelated to this fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A; warning fires only on Linux systemd
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before:

```
WARNING  Stale systemd unit detected: hermes.service has TimeoutStopSec=90s but drain_timeout=180s (expected >=210s). systemd may SIGKILL the gateway mid-drain. Run `hermes gateway service install --replace` to regenerate the unit, or shorten agent.restart_drain_timeout.
```

After:

```
ERROR    Stale systemd unit detected: hermes.service has TimeoutStopSec=90s but drain_timeout=180s (expected >=210s). systemd may SIGKILL the gateway mid-drain. Run `hermes gateway install --force` to regenerate the unit, or shorten agent.restart_drain_timeout.
```