### PR TITLE
fix(discord): auto-join new threads in allowed channels when thread_require_mention is false

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -736,10 +736,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
 
                 # Ignore Discord system messages (thread renames, pins, member joins, etc.)
-                # Allow default, reply, and thread-creation message types.
-                # thread_starter_message: first message in a thread created via "Create Thread" button
-                # thread_created: system message when a thread is created (may contain starter content)
-                if message.type not in {discord.MessageType.default, discord.MessageType.reply, discord.MessageType.thread_starter_message, discord.MessageType.thread_created}:
+                # Allow default, reply, and thread_starter_message types.
+                # thread_starter_message (MessageType 21): first message in a manually
+                # created thread — carries the user's actual content.
+                if message.type not in {discord.MessageType.default, discord.MessageType.reply, discord.MessageType.thread_starter_message}:
                     return
 
                 # Bot message filtering (DISCORD_ALLOW_BOTS):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -736,8 +736,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     return
 
                 # Ignore Discord system messages (thread renames, pins, member joins, etc.)
-                # Allow both default and reply types — replies have a distinct MessageType.
-                if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
+                # Allow default, reply, and thread-creation message types.
+                # thread_starter_message: first message in a thread created via "Create Thread" button
+                # thread_created: system message when a thread is created (may contain starter content)
+                if message.type not in {discord.MessageType.default, discord.MessageType.reply, discord.MessageType.thread_starter_message, discord.MessageType.thread_created}:
                     return
 
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
@@ -4501,11 +4503,29 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Check allowed channels - if set, only respond in these channels
             allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+            allowed_channels = set()
             if allowed_channels_raw:
                 allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
                 if "*" not in allowed_channels and not (channel_ids & allowed_channels):
                     logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
                     return
+
+            # Auto-register new threads when thread_require_mention is false
+            # AND allowed_channels are explicitly configured.  Without this,
+            # threads created manually via Discord's "Create Thread" button get
+            # stuck: the bot never responds because the thread isn't in
+            # self._threads, and the thread never enters self._threads because
+            # the bot never responds.  The allowed_channels gate prevents the
+            # bot from auto-joining arbitrary threads on servers that don't
+            # use the allowed_channels restriction.
+            if (
+                is_thread
+                and thread_id
+                and not self._discord_thread_require_mention()
+                and allowed_channels_raw
+            ):
+                if "*" in allowed_channels or (channel_ids & allowed_channels):
+                    self._threads.mark(thread_id)
 
             # Check ignored channels - never respond even when mentioned
             ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -884,3 +884,27 @@ async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
         assert event.channel_context is None
 
 
+@pytest.mark.asyncio
+async def test_discord_new_thread_without_mention_gets_response(adapter, monkeypatch):
+    """When allowed_channels is set and thread_require_mention is false,
+    a brand-new thread (not yet in _threads) in an allowed channel should
+    still get a response without an @mention.
+    This covers the Discord "Create Thread" button workflow."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "100")
+
+    parent = FakeTextChannel(channel_id=100, name="coding")
+    thread = FakeThread(channel_id=200, name="test-thread", parent=parent)
+    # NOT calling adapter._threads.mark() — simulates a brand-new thread
+    # created via Discord's "Create Thread" button where the bot has
+    # never participated before.
+
+    message = make_message(
+        channel=thread,
+        content="hello in a new thread without mention",
+    )
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()


### PR DESCRIPTION
## What does this PR do?

Fixes a catch-22 bug in the Discord adapter: when `allowed_channels` is configured and `thread_require_mention` is false, threads created manually via Discord's "Create Thread" button never get a response.

**Root cause:** The bot checks `thread_id in self._threads` to decide whether to skip the @mention requirement. But manually created threads are never in `self._threads` — the bot hasn't participated yet. So the first message is ignored (needs @mention), and the user must @mention the bot to "activate" the thread. This defeats the purpose of `thread_require_mention: false`.

## Related Issue

Fixes # (no existing issue tracked)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Three changes in `plugins/platforms/discord/adapter.py`:

1. **Message type filter** (line ~740): accept `thread_starter_message` and `thread_created` message types so Discord's "Create Thread" button flow isn't filtered out as a system message.

2. **Auto-register new threads** (line ~4510): after the `allowed_channels` check, auto-register new threads in `self._threads` when `thread_require_mention` is false and the thread belongs to an allowed channel. This breaks the catch-22.

3. **Initialize `allowed_channels` unconditionally** so the auto-register block can safely reference it.

New test in `tests/gateway/test_discord_free_response.py`:

- `test_discord_new_thread_without_mention_gets_response`: simulates a brand-new thread (not in `_threads`) with `allowed_channels` set and `thread_require_mention: false` — asserts the bot responds without @mention.

## How to Test

1. Configure Discord with `require_mention: true`, `thread_require_mention: false`, and `allowed_channels` set to your channel ID
2. Use Discord's "Create Thread" button in the allowed channel
3. Type a message in the new thread WITHOUT @mentioning the bot
4. **Before this fix:** bot ignores the message
5. **After this fix:** bot responds

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_discord_free_response.py -v` and all 35 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 26.04 LTS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (bugfix, no API changes)
- [x] I've considered cross-platform impact — N/A (Discord adapter, Linux target)

## Screenshots / Logs

```
tests/gateway/test_discord_free_response.py::test_discord_new_thread_without_mention_gets_response PASSED

============================== 35 passed in 0.56s ==============================
```