### PR TITLE
chore: ruff auto-fix UP045 — non-pep604-annotation-optional

### DIFF
--- a/acp_adapter/auth.py
+++ b/acp_adapter/auth.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 TERMINAL_SETUP_AUTH_METHOD_ID = "hermes-setup"
 
 
-def detect_provider() -> Optional[str]:
+def detect_provider() -> str | None:
     """Resolve the active Hermes runtime provider, or None if unavailable.
 
     Treats a ``Callable`` ``api_key`` (Azure Foundry Entra ID bearer

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -516,7 +516,7 @@ class HermesACPAgent(acp.Agent):
     def __init__(self, session_manager: SessionManager | None = None):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
-        self._conn: Optional[acp.Client] = None
+        self._conn: acp.Client | None = None
 
     # ---- Connection lifecycle -----------------------------------------------
 

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -228,7 +228,7 @@ class SessionManager:
         logger.info("Created ACP session %s (cwd=%s)", session_id, cwd)
         return state
 
-    def get_session(self, session_id: str) -> Optional[SessionState]:
+    def get_session(self, session_id: str) -> SessionState | None:
         """Return the session for *session_id*, or ``None``.
 
         If the session is not in memory but exists in the database (e.g. after
@@ -250,7 +250,7 @@ class SessionManager:
             _clear_task_cwd(session_id)
         return existed or db_existed
 
-    def fork_session(self, session_id: str, cwd: str = ".") -> Optional[SessionState]:
+    def fork_session(self, session_id: str, cwd: str = ".") -> SessionState | None:
         """Deep-copy a session's history into a new session."""
         import threading
 
@@ -354,7 +354,7 @@ class SessionManager:
         results.sort(key=lambda item: _updated_at_sort_key(item.get("updated_at")), reverse=True)
         return results
 
-    def update_cwd(self, session_id: str, cwd: str) -> Optional[SessionState]:
+    def update_cwd(self, session_id: str, cwd: str) -> SessionState | None:
         """Update the working directory for a session and its tool overrides."""
         cwd = _translate_acp_cwd(cwd)
         state = self.get_session(session_id)  # checks DB too
@@ -473,7 +473,7 @@ class SessionManager:
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
 
-    def _restore(self, session_id: str) -> Optional[SessionState]:
+    def _restore(self, session_id: str) -> SessionState | None:
         """Load a session from the database into memory, recreating the AIAgent."""
         import threading
 

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -184,7 +184,7 @@ def _text(content: str) -> Any:
     return acp.tool_content(acp.text_block(content))
 
 
-def _json_loads_maybe(value: Optional[str]) -> Any:
+def _json_loads_maybe(value: str | None) -> Any:
     if not isinstance(value, str):
         return value
     try:
@@ -202,7 +202,7 @@ def _json_loads_maybe(value: Optional[str]) -> Any:
         return None
 
 
-def _tool_result_failed(result: Optional[str], tool_name: str | None = None) -> bool:
+def _tool_result_failed(result: str | None, tool_name: str | None = None) -> bool:
     """Return True when a structured Hermes tool result clearly failed.
 
     Keep this deliberately conservative. Plain text can contain words like
@@ -253,7 +253,7 @@ def _fenced_text(text: str, language: str = "") -> str:
     return f"{fence}{language}\n{text}\n{fence}"
 
 
-def _format_todo_result(result: Optional[str]) -> Optional[str]:
+def _format_todo_result(result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict) or not isinstance(data.get("todos"), list):
         return None
@@ -285,7 +285,7 @@ def _format_todo_result(result: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _format_read_file_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_read_file_result(result: str | None, args: Dict[str, Any] | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -312,7 +312,7 @@ def _format_read_file_result(result: Optional[str], args: Optional[Dict[str, Any
     return _truncate_text(f"{header}\n\n{_fenced_text(content)}")
 
 
-def _format_search_files_result(result: Optional[str]) -> Optional[str]:
+def _format_search_files_result(result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -371,7 +371,7 @@ def _format_search_files_result(result: Optional[str]) -> Optional[str]:
     return _truncate_text("\n".join(lines), limit=7000)
 
 
-def _format_execute_code_result(result: Optional[str]) -> Optional[str]:
+def _format_execute_code_result(result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -399,7 +399,7 @@ def _extract_markdown_headings(content: str, limit: int = 8) -> list[str]:
     return headings
 
 
-def _format_skill_view_result(result: Optional[str]) -> Optional[str]:
+def _format_skill_view_result(result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -432,7 +432,7 @@ def _format_skill_view_result(result: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _format_skill_manage_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_skill_manage_result(result: str | None, args: Dict[str, Any] | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -462,7 +462,7 @@ def _format_skill_manage_result(result: Optional[str], args: Optional[Dict[str, 
     return "\n".join(lines)
 
 
-def _format_web_search_result(result: Optional[str]) -> Optional[str]:
+def _format_web_search_result(result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -482,7 +482,7 @@ def _format_web_search_result(result: Optional[str]) -> Optional[str]:
     return _truncate_text("\n".join(lines))
 
 
-def _format_web_extract_result(result: Optional[str]) -> Optional[str]:
+def _format_web_extract_result(result: str | None) -> str | None:
     """Return only web_extract errors for ACP; success stays compact via title."""
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
@@ -513,7 +513,7 @@ def _format_web_extract_result(result: Optional[str]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def _format_process_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_process_result(result: str | None, args: Dict[str, Any] | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -560,7 +560,7 @@ def _format_process_result(result: Optional[str], args: Optional[Dict[str, Any]]
     return _truncate_text("\n".join(lines), limit=7000)
 
 
-def _format_delegate_result(result: Optional[str]) -> Optional[str]:
+def _format_delegate_result(result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -606,7 +606,7 @@ def _format_delegate_result(result: Optional[str]) -> Optional[str]:
     return _truncate_text("\n".join(lines), limit=8000)
 
 
-def _format_session_search_result(result: Optional[str]) -> Optional[str]:
+def _format_session_search_result(result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -637,7 +637,7 @@ def _format_session_search_result(result: Optional[str]) -> Optional[str]:
     return _truncate_text("\n".join(lines), limit=7000)
 
 
-def _format_memory_result(result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_memory_result(result: str | None, args: Dict[str, Any] | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return None
@@ -664,7 +664,7 @@ def _format_memory_result(result: Optional[str], args: Optional[Dict[str, Any]])
     return "\n".join(lines)
 
 
-def _format_edit_result(tool_name: str, result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_edit_result(tool_name: str, result: str | None, args: Dict[str, Any] | None) -> str | None:
     data = _json_loads_maybe(result)
     path = str((args or {}).get("path") or "file").strip()
     if isinstance(data, dict):
@@ -687,7 +687,7 @@ def _format_edit_result(tool_name: str, result: Optional[str], args: Optional[Di
     return f"✅ {tool_name} completed" + (f" for `{path}`" if path else "")
 
 
-def _format_browser_result(tool_name: str, result: Optional[str], args: Optional[Dict[str, Any]]) -> Optional[str]:
+def _format_browser_result(tool_name: str, result: str | None, args: Dict[str, Any] | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -713,7 +713,7 @@ def _format_browser_result(tool_name: str, result: Optional[str], args: Optional
     return _truncate_text("\n".join(lines), limit=7000)
 
 
-def _format_media_or_cron_result(tool_name: str, result: Optional[str]) -> Optional[str]:
+def _format_media_or_cron_result(tool_name: str, result: str | None) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, dict):
         return result if isinstance(result, str) and result.strip() else None
@@ -818,10 +818,10 @@ def _format_structured_value(
 
 def _format_generic_structured_result(
     tool_name: str,
-    result: Optional[str],
+    result: str | None,
     *,
     fallback_to_text: bool = True,
-) -> Optional[str]:
+) -> str | None:
     data = _json_loads_maybe(result)
     if not isinstance(data, (dict, list)):
         return result if fallback_to_text and isinstance(result, str) and result.strip() else None
@@ -870,9 +870,9 @@ def _format_generic_structured_result(
 
 def _build_polished_completion_content(
     tool_name: str,
-    result: Optional[str],
-    function_args: Optional[Dict[str, Any]],
-) -> Optional[List[Any]]:
+    result: str | None,
+    function_args: Dict[str, Any] | None,
+) -> List[Any] | None:
     formatter = {
         "todo": lambda: _format_todo_result(result),
         "read_file": lambda: _format_read_file_result(result, function_args),
@@ -986,8 +986,8 @@ def _parse_unified_diff_content(diff_text: str) -> List[Any]:
         return []
 
     content: List[Any] = []
-    current_old_path: Optional[str] = None
-    current_new_path: Optional[str] = None
+    current_old_path: str | None = None
+    current_new_path: str | None = None
     old_lines: list[str] = []
     new_lines: list[str] = []
 
@@ -1041,9 +1041,9 @@ def _parse_unified_diff_content(diff_text: str) -> List[Any]:
 
 def _build_tool_complete_content(
     tool_name: str,
-    result: Optional[str],
+    result: str | None,
     *,
-    function_args: Optional[Dict[str, Any]] = None,
+    function_args: Dict[str, Any] | None = None,
     snapshot: Any = None,
 ) -> List[Any]:
     """Build structured ACP completion content, falling back to plain text."""
@@ -1308,15 +1308,15 @@ def build_tool_start(
     )
 
 
-def _is_structured_json_result(result: Optional[str]) -> bool:
+def _is_structured_json_result(result: str | None) -> bool:
     return isinstance(_json_loads_maybe(result), (dict, list))
 
 
 def build_tool_complete(
     tool_call_id: str,
     tool_name: str,
-    result: Optional[str] = None,
-    function_args: Optional[Dict[str, Any]] = None,
+    result: str | None = None,
+    function_args: Dict[str, Any] | None = None,
     snapshot: Any = None,
 ) -> ToolCallProgress:
     """Create a ToolCallUpdate (progress) event for a completed tool call."""

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -18,9 +18,9 @@ def _utc_now() -> datetime:
 @dataclass(frozen=True)
 class AccountUsageWindow:
     label: str
-    used_percent: Optional[float] = None
-    reset_at: Optional[datetime] = None
-    detail: Optional[str] = None
+    used_percent: float | None = None
+    reset_at: datetime | None = None
+    detail: str | None = None
 
 
 @dataclass(frozen=True)
@@ -29,24 +29,24 @@ class AccountUsageSnapshot:
     source: str
     fetched_at: datetime
     title: str = "Account limits"
-    plan: Optional[str] = None
+    plan: str | None = None
     windows: tuple[AccountUsageWindow, ...] = ()
     details: tuple[str, ...] = ()
-    unavailable_reason: Optional[str] = None
+    unavailable_reason: str | None = None
 
     @property
     def available(self) -> bool:
         return bool(self.windows or self.details) and not self.unavailable_reason
 
 
-def _title_case_slug(value: Optional[str]) -> Optional[str]:
+def _title_case_slug(value: str | None) -> str | None:
     cleaned = str(value or "").strip()
     if not cleaned:
         return None
     return cleaned.replace("_", " ").replace("-", " ").title()
 
 
-def _parse_dt(value: Any) -> Optional[datetime]:
+def _parse_dt(value: Any) -> datetime | None:
     if value in {None, ""}:
         return None
     if isinstance(value, (int, float)):
@@ -65,7 +65,7 @@ def _parse_dt(value: Any) -> Optional[datetime]:
     return None
 
 
-def _format_reset(dt: Optional[datetime]) -> str:
+def _format_reset(dt: datetime | None) -> str:
     if not dt:
         return "unknown"
     local_dt = dt.astimezone()
@@ -85,7 +85,7 @@ def _format_reset(dt: Optional[datetime]) -> str:
     return f"{rel} ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
 
 
-def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False) -> list[str]:
+def render_account_usage_lines(snapshot: AccountUsageSnapshot | None, *, markdown: bool = False) -> list[str]:
     if not snapshot:
         return []
     header = f"📈 {'**' if markdown else ''}{snapshot.title}{'**' if markdown else ''}"
@@ -124,7 +124,7 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
-def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
+def _fetch_codex_account_usage() -> AccountUsageSnapshot | None:
     creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
     token_data = _read_codex_tokens()
     tokens = token_data.get("tokens") or {}
@@ -172,7 +172,7 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
-def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
+def _fetch_anthropic_account_usage() -> AccountUsageSnapshot | None:
     token = (resolve_anthropic_token() or "").strip()
     if not token:
         return None
@@ -233,7 +233,7 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
-def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
+def _fetch_openrouter_account_usage(base_url: str | None, api_key: str | None) -> AccountUsageSnapshot | None:
     runtime = resolve_runtime_provider(
         requested="openrouter",
         explicit_base_url=base_url,
@@ -306,11 +306,11 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
 
 
 def fetch_account_usage(
-    provider: Optional[str],
+    provider: str | None,
     *,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[AccountUsageSnapshot]:
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> AccountUsageSnapshot | None:
     normalized = str(provider or "").strip().lower()
     if normalized in {"", "auto", "custom"}:
         return None

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -90,7 +90,7 @@ def _custom_provider_extra_body_for_agent(
     model: str,
     base_url: str,
     custom_providers: List[Dict[str, Any]],
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any] | None:
     if (provider or "").strip().lower() != "custom":
         return None
 
@@ -98,7 +98,7 @@ def _custom_provider_extra_body_for_agent(
     if not target_url:
         return None
 
-    fallback: Optional[Dict[str, Any]] = None
+    fallback: Dict[str, Any] | None = None
     for entry in custom_providers or []:
         if not isinstance(entry, dict):
             continue
@@ -163,7 +163,7 @@ def init_agent(
     provider_sort: str = None,
     provider_require_parameters: bool = False,
     provider_data_collection: str = None,
-    openrouter_min_coding_score: Optional[float] = None,
+    openrouter_min_coding_score: float | None = None,
     session_id: str = None,
     tool_progress_callback: callable = None,
     tool_start_callback: callable = None,
@@ -423,7 +423,7 @@ def init_agent(
     # last tool result's content so the model sees it on its next
     # iteration. Message-role alternation is preserved (we modify an
     # existing tool message rather than inserting a new user turn).
-    agent._pending_steer: Optional[str] = None
+    agent._pending_steer: str | None = None
     agent._pending_steer_lock = threading.Lock()
 
     # Concurrent-tool worker thread tracking.  `_execute_tool_calls_concurrent`
@@ -506,7 +506,7 @@ def init_agent(
 
     # Rate limit tracking — updated from x-ratelimit-* response headers
     # after each API call.  Accessed by /usage slash command.
-    agent._rate_limit_state: Optional["RateLimitState"] = None
+    agent._rate_limit_state: "RateLimitState" | None = None
 
     # OpenRouter response cache hit counter — incremented when
     # X-OpenRouter-Cache-Status: HIT is seen in streaming response headers.
@@ -1009,7 +1009,7 @@ def init_agent(
     agent._memory_write_context = "foreground"
     
     # Cached system prompt -- built once per session, only rebuilt on compression
-    agent._cached_system_prompt: Optional[str] = None
+    agent._cached_system_prompt: str | None = None
     
     # Filesystem checkpoint manager (transparent — not a tool)
     from tools.checkpoint_manager import CheckpointManager

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -536,10 +536,10 @@ def strip_think_blocks(agent, content: str) -> str:
 def recover_with_credential_pool(
     agent,
     *,
-    status_code: Optional[int],
+    status_code: int | None,
     has_retried_429: bool,
-    classified_reason: Optional[FailoverReason] = None,
-    error_context: Optional[Dict[str, Any]] = None,
+    classified_reason: FailoverReason | None = None,
+    error_context: Dict[str, Any] | None = None,
 ) -> tuple[bool, bool]:
     """Attempt credential recovery via pool rotation.
 
@@ -936,7 +936,7 @@ _TRANSIENT_TRANSPORT_ERRORS = frozenset({
 
 
 
-def extract_reasoning(agent, assistant_message) -> Optional[str]:
+def extract_reasoning(agent, assistant_message) -> str | None:
     """
     Extract reasoning/thinking content from an assistant message.
     
@@ -1023,8 +1023,8 @@ def dump_api_request_debug(
     api_kwargs: Dict[str, Any],
     *,
     reason: str,
-    error: Optional[Exception] = None,
-) -> Optional[Path]:
+    error: Exception | None = None,
+) -> Path | None:
     """
     Dump a debug-friendly HTTP request record for the active inference API.
 
@@ -1102,10 +1102,10 @@ def dump_api_request_debug(
 def anthropic_prompt_cache_policy(
     agent,
     *,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_mode: Optional[str] = None,
-    model: Optional[str] = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    api_mode: str | None = None,
+    model: str | None = None,
 ) -> tuple[bool, bool]:
     """Decide whether to apply Anthropic prompt caching and which layout to use.
 
@@ -1519,7 +1519,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
 
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
-                 tool_call_id: Optional[str] = None, messages: list = None,
+                 tool_call_id: str | None = None, messages: list = None,
                  pre_tool_block_checked: bool = False) -> str:
     """Invoke a single tool and return the result string. No display logic.
 
@@ -1528,7 +1528,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     its own inline invocation for backward-compatible display handling.
     """
     # Check plugin hooks for a block directive before executing anything.
-    block_message: Optional[str] = None
+    block_message: str | None = None
     if not pre_tool_block_checked:
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -148,7 +148,7 @@ def _get_anthropic_max_output(model: str) -> int:
     return best_val
 
 
-def _resolve_positive_anthropic_max_tokens(value) -> Optional[int]:
+def _resolve_positive_anthropic_max_tokens(value) -> int | None:
     """Return ``value`` floored to a positive int, or ``None`` if it is not a
     finite positive number. Ported from openclaw/openclaw#66664.
 
@@ -177,7 +177,7 @@ def _resolve_positive_anthropic_max_tokens(value) -> Optional[int]:
 def _resolve_anthropic_messages_max_tokens(
     requested,
     model: str,
-    context_length: Optional[int] = None,
+    context_length: int | None = None,
 ) -> int:
     """Resolve the ``max_tokens`` budget for an Anthropic Messages call.
 
@@ -285,7 +285,7 @@ _OAUTH_ONLY_BETAS = [
 # The version must stay reasonably current — Anthropic rejects OAuth requests
 # when the spoofed user-agent version is too far behind the actual release.
 _CLAUDE_CODE_VERSION_FALLBACK = "2.1.74"
-_claude_code_version_cache: Optional[str] = None
+_claude_code_version_cache: str | None = None
 
 
 def _detect_claude_code_version() -> str:
@@ -795,7 +795,7 @@ def build_anthropic_bedrock_client(region: str):
     )
 
 
-def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
+def _read_claude_code_credentials_from_keychain() -> Dict[str, Any] | None:
     """Read Claude Code OAuth credentials from the macOS Keychain.
 
     Claude Code >=2.1.114 stores credentials in the macOS Keychain under the
@@ -852,7 +852,7 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     return None
 
 
-def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
+def read_claude_code_credentials() -> Dict[str, Any] | None:
     """Read refreshable Claude Code OAuth credentials.
 
     Checks two sources in order:
@@ -892,7 +892,7 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     return None
 
 
-def read_claude_managed_key() -> Optional[str]:
+def read_claude_managed_key() -> str | None:
     """Read Claude's native managed key from ~/.claude.json for diagnostics only."""
     claude_json = Path.home() / ".claude.json"
     if claude_json.exists():
@@ -985,7 +985,7 @@ def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) 
     raise ValueError("Anthropic token refresh failed")
 
 
-def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
+def _refresh_oauth_token(creds: Dict[str, Any]) -> str | None:
     """Attempt to refresh an expired Claude Code OAuth token."""
     refresh_token = creds.get("refreshToken", "")
     if not refresh_token:
@@ -1011,7 +1011,7 @@ def _write_claude_code_credentials(
     refresh_token: str,
     expires_at_ms: int,
     *,
-    scopes: Optional[list] = None,
+    scopes: list | None = None,
 ) -> None:
     """Write refreshed credentials back to ~/.claude/.credentials.json.
 
@@ -1074,7 +1074,7 @@ def _write_claude_code_credentials(
         logger.debug("Failed to write refreshed credentials: %s", e)
 
 
-def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] = None) -> Optional[str]:
+def _resolve_claude_code_token_from_credentials(creds: Dict[str, Any] | None = None) -> str | None:
     """Resolve a token from Claude Code credential files, refreshing if needed."""
     creds = creds or read_claude_code_credentials()
     if creds and is_claude_code_token_valid(creds):
@@ -1089,7 +1089,7 @@ def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] 
     return None
 
 
-def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[str, Any]]) -> Optional[str]:
+def _prefer_refreshable_claude_code_token(env_token: str, creds: Dict[str, Any] | None) -> str | None:
     """Prefer Claude Code creds when a persisted env OAuth token would shadow refresh.
 
     Hermes historically persisted setup tokens into ANTHROPIC_TOKEN. That makes
@@ -1111,7 +1111,7 @@ def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[s
     return None
 
 
-def resolve_anthropic_token() -> Optional[str]:
+def resolve_anthropic_token() -> str | None:
     """Resolve an Anthropic token from all available sources.
 
     Priority:
@@ -1155,7 +1155,7 @@ def resolve_anthropic_token() -> Optional[str]:
     return None
 
 
-def run_oauth_setup_token() -> Optional[str]:
+def run_oauth_setup_token() -> str | None:
     """Run 'claude setup-token' interactively and return the resulting token.
 
     Checks multiple sources after the subprocess completes:
@@ -1219,7 +1219,7 @@ def _generate_pkce() -> tuple:
     return verifier, challenge
 
 
-def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
+def run_hermes_oauth_login_pure() -> Dict[str, Any] | None:
     """Run Hermes-native OAuth PKCE flow and return credential state."""
     import secrets
     import time
@@ -1324,7 +1324,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
     }
 
 
-def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
+def read_hermes_oauth_credentials() -> Dict[str, Any] | None:
     """Read Hermes-managed OAuth credentials from ~/.hermes/.anthropic_oauth.json."""
     if _HERMES_OAUTH_FILE.exists():
         try:
@@ -1504,7 +1504,7 @@ def _image_source_from_openai_url(url: str) -> Dict[str, str]:
     return {"type": "url", "url": url}
 
 
-def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
+def _convert_content_part_to_anthropic(part: Any) -> Dict[str, Any] | None:
     """Convert a single OpenAI-style content part to Anthropic format."""
     if part is None:
         return None
@@ -1529,7 +1529,7 @@ def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
     return block
 
 
-def _to_plain_data(value: Any, *, _depth: int = 0, _path: Optional[set] = None) -> Any:
+def _to_plain_data(value: Any, *, _depth: int = 0, _path: set | None = None) -> Any:
     """Recursively convert SDK objects to plain Python data structures.
 
     Guards against circular references (``_path`` tracks ``id()`` of objects
@@ -1703,7 +1703,7 @@ def _convert_tool_message_to_result(
     the trailing user message's tool_result list.
     """
     content = m.get("content", "")
-    multimodal_blocks: Optional[List[Dict[str, Any]]] = None
+    multimodal_blocks: List[Dict[str, Any]] | None = None
     if isinstance(content, dict) and content.get("_multimodal"):
         multimodal_blocks = _content_parts_to_anthropic_blocks(
             content.get("content") or []
@@ -1990,7 +1990,7 @@ def convert_messages_to_anthropic(
     messages: List[Dict],
     base_url: str | None = None,
     model: str | None = None,
-) -> Tuple[Optional[Any], List[Dict]]:
+) -> Tuple[Any | None, List[Dict]]:
     """Convert OpenAI-format messages to Anthropic format.
 
     Returns (system_prompt, anthropic_messages).
@@ -2053,13 +2053,13 @@ def convert_messages_to_anthropic(
 def build_anthropic_kwargs(
     model: str,
     messages: List[Dict],
-    tools: Optional[List[Dict]],
-    max_tokens: Optional[int],
-    reasoning_config: Optional[Dict[str, Any]],
-    tool_choice: Optional[str] = None,
+    tools: List[Dict] | None,
+    max_tokens: int | None,
+    reasoning_config: Dict[str, Any] | None,
+    tool_choice: str | None = None,
     is_oauth: bool = False,
     preserve_dots: bool = False,
-    context_length: Optional[int] = None,
+    context_length: int | None = None,
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,

--- a/agent/async_utils.py
+++ b/agent/async_utils.py
@@ -33,12 +33,12 @@ _DEFAULT_LOGGER = logging.getLogger(__name__)
 
 def safe_schedule_threadsafe(
     coro: Coroutine[Any, Any, Any],
-    loop: Optional[asyncio.AbstractEventLoop],
+    loop: asyncio.AbstractEventLoop | None,
     *,
-    logger: Optional[logging.Logger] = None,
+    logger: logging.Logger | None = None,
     log_message: str = "Failed to schedule coroutine on loop",
     log_level: int = logging.DEBUG,
-) -> Optional[Future]:
+) -> Future | None:
     """Schedule ``coro`` on ``loop`` from a sync context, leak-safe.
 
     Returns the :class:`concurrent.futures.Future` on success, or ``None`` if

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -66,7 +66,7 @@ from urllib.parse import urlparse, parse_qs, urlunparse
 if TYPE_CHECKING:
     from openai import OpenAI  # noqa: F401 — type hints only
 
-_OPENAI_CLS_CACHE: Optional[type] = None
+_OPENAI_CLS_CACHE: type | None = None
 
 
 def _load_openai_cls() -> type:
@@ -162,7 +162,7 @@ _PROVIDER_ALIASES = {
 }
 
 
-def _normalize_aux_provider(provider: Optional[str]) -> str:
+def _normalize_aux_provider(provider: str | None) -> str:
     normalized = (provider or "auto").strip().lower()
     if normalized.startswith("custom:"):
         suffix = normalized.split(":", 1)[1].strip()
@@ -190,22 +190,22 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
 OMIT_TEMPERATURE: object = object()
 
 
-def _is_kimi_model(model: Optional[str]) -> bool:
+def _is_kimi_model(model: str | None) -> bool:
     """True for any Kimi / Moonshot model that manages temperature server-side."""
     bare = (model or "").strip().lower().rsplit("/", 1)[-1]
     return bare.startswith("kimi-") or bare == "kimi"
 
 
-def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
+def _is_arcee_trinity_thinking(model: str | None) -> bool:
     """True for Arcee Trinity Large Thinking (direct or via OpenRouter)."""
     bare = (model or "").strip().lower().rsplit("/", 1)[-1]
     return bare == "trinity-large-thinking"
 
 
 def _fixed_temperature_for_model(
-    model: Optional[str],
-    base_url: Optional[str] = None,
-) -> "Optional[float] | object":
+    model: str | None,
+    base_url: str | None = None,
+) -> "float | None | object":
     """Return a temperature directive for models with strict contracts.
 
     Returns:
@@ -224,7 +224,7 @@ def _fixed_temperature_for_model(
     return None
 
 
-def _compression_threshold_for_model(model: Optional[str]) -> Optional[float]:
+def _compression_threshold_for_model(model: str | None) -> float | None:
     """Return a context-compression threshold override for specific models.
 
     The threshold is the fraction of the model's context window that must be
@@ -510,7 +510,7 @@ def _to_openai_base_url(base_url: str) -> str:
     return url
 
 
-def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
+def _select_pool_entry(provider: str) -> Tuple[bool, Any | None]:
     """Return (pool_exists_for_provider, selected_entry)."""
     try:
         pool = load_pool(provider)
@@ -526,7 +526,7 @@ def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
         return True, None
 
 
-def _peek_pool_entry(provider: str) -> Optional[Any]:
+def _peek_pool_entry(provider: str) -> Any | None:
     """Best-effort current/next pool entry without mutating selection order."""
     try:
         pool = load_pool(provider)
@@ -744,7 +744,7 @@ class _CodexCompletionsAdapter:
         total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
         timed_out = threading.Event()
-        timeout_timer: Optional[threading.Timer] = None
+        timeout_timer: threading.Timer | None = None
 
         def _timeout_message() -> str:
             return f"Codex auxiliary Responses stream exceeded {float(total_timeout):.1f}s total timeout"
@@ -1133,7 +1133,7 @@ def _maybe_wrap_anthropic(
     model: str,
     api_key: str,
     base_url: str,
-    api_mode: Optional[str] = None,
+    api_mode: str | None = None,
 ) -> Any:
     """Rewrap a plain OpenAI client in ``AnthropicAuxiliaryClient`` when
     the endpoint actually speaks Anthropic Messages.
@@ -1210,7 +1210,7 @@ def _maybe_wrap_anthropic(
     )
 
 
-def _read_nous_auth() -> Optional[dict]:
+def _read_nous_auth() -> dict | None:
     """Read and validate ~/.hermes/auth.json for an active Nous provider.
 
     Returns the provider state dict if Nous is active with tokens,
@@ -1258,7 +1258,7 @@ def _nous_base_url() -> str:
     return os.getenv("NOUS_INFERENCE_BASE_URL", _NOUS_DEFAULT_BASE_URL)
 
 
-def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[str, str]]:
+def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> tuple[str, str] | None:
     """Return fresh Nous runtime credentials when available.
 
     This mirrors the main agent's 401 recovery path and keeps auxiliary
@@ -1293,7 +1293,7 @@ def _resolve_nous_runtime_api(*, force_refresh: bool = False) -> Optional[tuple[
     return api_key, base_url
 
 
-def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
+def _resolve_xai_oauth_for_aux() -> Tuple[str, str] | None:
     """Resolve a fresh xAI OAuth (api_key, base_url) for auxiliary clients.
 
     Prefer the credential pool, matching the main runtime/provider status
@@ -1348,7 +1348,7 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
     return api_key, base_url
 
 
-def _read_codex_access_token() -> Optional[str]:
+def _read_codex_access_token() -> str | None:
     """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
 
     If a credential pool exists but currently has no selectable runtime entry
@@ -1391,7 +1391,7 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
-def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
+def _resolve_api_key_provider() -> Tuple[OpenAI | None, str | None]:
     """Try each API-key provider in PROVIDER_REGISTRY order.
 
     Returns (client, model) for the first provider with usable runtime
@@ -1500,7 +1500,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 
-def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[OpenAI | None, str | None]:
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
@@ -1534,7 +1534,7 @@ def _describe_openrouter_unavailable() -> str:
     return "no usable OpenRouter credentials found"
 
 
-def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_nous(vision: bool = False) -> Tuple[OpenAI | None, str | None]:
     # Check cross-session rate limit guard before attempting Nous —
     # if another session already recorded a 429, skip Nous entirely
     # to avoid piling more requests onto the tapped RPH bucket.
@@ -1696,7 +1696,7 @@ def clear_runtime_main() -> None:
     _RUNTIME_MAIN_MODEL = ""
 
 
-def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
+def _resolve_custom_runtime() -> Tuple[str | None, str | None, str | None]:
     """Resolve the active custom/main endpoint the same way the main CLI does.
 
     This covers both env-driven OPENAI_BASE_URL setups and config-saved custom
@@ -1798,7 +1798,7 @@ def _validate_base_url(base_url: str) -> None:
         ) from exc
 
 
-def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
+def _try_custom_endpoint() -> Tuple[Any | None, str | None]:
     runtime = _resolve_custom_runtime()
     if len(runtime) == 2:
         custom_base, custom_key = runtime
@@ -1842,7 +1842,7 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     return _fallback_client, model
 
 
-def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_xai_oauth_aux_client(model: str) -> Tuple[Any | None, str | None]:
     """Build a CodexAuxiliaryClient for an xAI Grok OAuth-authenticated session.
 
     xAI's ``/v1/responses`` endpoint speaks the OpenAI Responses API, so we
@@ -1868,7 +1868,7 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     return CodexAuxiliaryClient(real_client, model), model
 
 
-def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
+def _build_codex_client(model: str) -> Tuple[Any | None, str | None]:
     """Build a CodexAuxiliaryClient for an explicitly-requested model.
 
     There is no auto-selection of the Codex model: the ChatGPT-account
@@ -1911,11 +1911,11 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
 
 def _try_azure_foundry(
     *,
-    model: Optional[str] = None,
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
-    api_mode: Optional[str] = None,
-) -> Tuple[Optional[Any], Optional[str]]:
+    model: str | None = None,
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
+    api_mode: str | None = None,
+) -> Tuple[Any | None, str | None]:
     """Resolve an Azure Foundry auxiliary client via the runtime resolver.
 
     Mirrors the ``_try_anthropic`` / ``_try_nous`` shape but delegates to
@@ -2023,7 +2023,7 @@ def _try_azure_foundry(
     return client, final_model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _try_anthropic(explicit_api_key: str = None) -> Tuple[Any | None, str | None]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
     except ImportError:
@@ -2081,7 +2081,7 @@ _AUTO_PROVIDER_LABELS = {
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
 
 
-def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _normalize_main_runtime(main_runtime: Dict[str, Any] | None) -> Dict[str, Any]:
     """Return a sanitized copy of a live main-runtime override.
 
     Most fields are stripped strings. ``api_key`` may legitimately be a
@@ -2177,7 +2177,7 @@ def _normalize_chain_label(provider: str) -> str:
     return _AUX_UNHEALTHY_LABEL_ALIASES.get(p, p)
 
 
-def _mark_provider_unhealthy(provider: str, ttl: Optional[float] = None) -> None:
+def _mark_provider_unhealthy(provider: str, ttl: float | None = None) -> None:
     """Mark ``provider`` as recently-402'd, hidden from chain iteration
     until the TTL expires. Called from the payment-fallback branches in
     ``call_llm`` and ``acall_llm`` after a confirmed payment error.
@@ -2212,7 +2212,7 @@ def _is_provider_unhealthy(label: str) -> bool:
     return True
 
 
-def _log_skip_unhealthy(label: str, task: Optional[str] = None) -> None:
+def _log_skip_unhealthy(label: str, task: str | None = None) -> None:
     """Emit a single info-level log per minute when we skip an unhealthy
     provider. Avoids spamming the log on bursty sessions while still
     giving the user a trail.
@@ -2452,7 +2452,7 @@ def _evict_cached_client_instance(target: Any) -> bool:
 def _pool_cache_hint(
     provider: str,
     *,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Dict[str, Any] | None = None,
 ) -> str:
     """Return a stable cache discriminator for pooled providers."""
     normalized = _normalize_aux_provider(provider)
@@ -2478,7 +2478,7 @@ def _pool_error_context(exc: Exception) -> Dict[str, Any]:
     return payload
 
 
-def _recoverable_pool_provider(resolved_provider: str, client: Any) -> Optional[str]:
+def _recoverable_pool_provider(resolved_provider: str, client: Any) -> str | None:
     """Infer which provider pool can recover the current auxiliary client."""
     normalized = _normalize_aux_provider(resolved_provider)
     if normalized not in {"", "auto", "custom"}:
@@ -2541,18 +2541,18 @@ def _recover_provider_pool(provider: str, exc: Exception) -> bool:
 
 def _retry_same_provider_sync(
     *,
-    task: Optional[str],
+    task: str | None,
     resolved_provider: str,
-    resolved_model: Optional[str],
-    resolved_base_url: Optional[str],
-    resolved_api_key: Optional[str],
-    resolved_api_mode: Optional[str],
-    main_runtime: Optional[Dict[str, Any]],
-    final_model: Optional[str],
+    resolved_model: str | None,
+    resolved_base_url: str | None,
+    resolved_api_key: str | None,
+    resolved_api_mode: str | None,
+    main_runtime: Dict[str, Any] | None,
+    final_model: str | None,
     messages: list,
-    temperature: Optional[float],
-    max_tokens: Optional[int],
-    tools: Optional[list],
+    temperature: float | None,
+    max_tokens: int | None,
+    tools: list | None,
     effective_timeout: float,
     effective_extra_body: dict,
 ) -> Any:
@@ -2599,17 +2599,17 @@ def _retry_same_provider_sync(
 
 async def _retry_same_provider_async(
     *,
-    task: Optional[str],
+    task: str | None,
     resolved_provider: str,
-    resolved_model: Optional[str],
-    resolved_base_url: Optional[str],
-    resolved_api_key: Optional[str],
-    resolved_api_mode: Optional[str],
-    final_model: Optional[str],
+    resolved_model: str | None,
+    resolved_base_url: str | None,
+    resolved_api_key: str | None,
+    resolved_api_mode: str | None,
+    final_model: str | None,
     messages: list,
-    temperature: Optional[float],
-    max_tokens: Optional[int],
-    tools: Optional[list],
+    temperature: float | None,
+    max_tokens: int | None,
+    tools: list | None,
     effective_timeout: float,
     effective_extra_body: dict,
 ) -> Any:
@@ -2702,7 +2702,7 @@ def _try_payment_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "payment error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> Tuple[Any | None, str | None, str]:
     """Try alternative providers after a payment/credit or connection error.
 
     Iterates the standard auto-detection chain, skipping the provider that
@@ -2753,7 +2753,7 @@ def _try_main_agent_model_fallback(
     failed_provider: str,
     task: str = None,
     reason: str = "error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> Tuple[Any | None, str | None, str]:
     """Last-resort fallback to the user's main agent provider + model.
 
     Used after the configured fallback_chain is exhausted (or empty) for
@@ -2802,7 +2802,7 @@ def _try_configured_fallback_chain(
     task: str,
     failed_provider: str,
     reason: str = "error",
-) -> Tuple[Optional[Any], Optional[str], str]:
+) -> Tuple[Any | None, str | None, str]:
     """Try user-configured fallback_chain for a specific auxiliary task.
 
     Reads auxiliary.<task>.fallback_chain from config.yaml and tries each
@@ -2859,10 +2859,10 @@ def _try_configured_fallback_chain(
 
 def _resolve_single_provider(
     provider: str,
-    model: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[Any]:
+    model: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> Any | None:
     """Resolve a single provider entry from fallback_chain to an OpenAI client.
 
     Uses the existing provider resolution infrastructure where possible.
@@ -2876,7 +2876,7 @@ def _resolve_single_provider(
     )
     return client
 
-def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _resolve_auto(main_runtime: Dict[str, Any] | None = None) -> Tuple[OpenAI | None, str | None]:
     """Full auto-detection chain.
 
     Priority:
@@ -3053,7 +3053,7 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     return AsyncOpenAI(**async_kwargs), model
 
 
-def _normalize_resolved_model(model_name: Optional[str], provider: str) -> Optional[str]:
+def _normalize_resolved_model(model_name: str | None, provider: str) -> str | None:
     """Normalize a resolved model for the provider that will receive it."""
     if not model_name:
         return model_name
@@ -3073,9 +3073,9 @@ def resolve_provider_client(
     explicit_base_url: str = None,
     explicit_api_key: str = None,
     api_mode: str = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Dict[str, Any] | None = None,
     is_vision: bool = False,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> Tuple[Any | None, str | None]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.
 
@@ -3683,8 +3683,8 @@ def resolve_provider_client(
 def get_text_auxiliary_client(
     task: str = "",
     *,
-    main_runtime: Optional[Dict[str, Any]] = None,
-) -> Tuple[Optional[OpenAI], Optional[str]]:
+    main_runtime: Dict[str, Any] | None = None,
+) -> Tuple[OpenAI | None, str | None]:
     """Return (client, default_model_slug) for text-only auxiliary tasks.
 
     Args:
@@ -3705,7 +3705,7 @@ def get_text_auxiliary_client(
     )
 
 
-def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Dict[str, Any]] = None):
+def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Dict[str, Any] | None = None):
     """Return (async_client, model_slug) for async consumers.
 
     For standard providers returns (AsyncOpenAI, model). For Codex returns
@@ -3730,7 +3730,7 @@ _VISION_AUTO_PROVIDER_ORDER = (
 )
 
 
-def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
+def _main_model_supports_vision(provider: str, model: str | None) -> bool:
     """Return True when ``provider``/``model`` is known to accept image input.
 
     Used by the vision auto-detect chain to skip the user's main provider
@@ -3761,14 +3761,14 @@ def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     return bool(supports)
 
 
-def _normalize_vision_provider(provider: Optional[str]) -> str:
+def _normalize_vision_provider(provider: str | None) -> str:
     return _normalize_aux_provider(provider)
 
 
 def _resolve_strict_vision_backend(
     provider: str,
-    model: Optional[str] = None,
-) -> Tuple[Optional[Any], Optional[str]]:
+    model: str | None = None,
+) -> Tuple[Any | None, str | None]:
     provider = _normalize_vision_provider(provider)
     if provider == "copilot":
         return resolve_provider_client("copilot", model, is_vision=True)
@@ -3818,13 +3818,13 @@ def get_available_vision_backends() -> List[str]:
 
 
 def resolve_vision_provider_client(
-    provider: Optional[str] = None,
-    model: Optional[str] = None,
+    provider: str | None = None,
+    model: str | None = None,
     *,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
     async_mode: bool = False,
-) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
+) -> Tuple[str | None, Any | None, str | None]:
     """Resolve the client actually used for vision tasks.
 
     Direct endpoint overrides take precedence over provider selection. Explicit
@@ -3837,7 +3837,7 @@ def resolve_vision_provider_client(
     )
     requested = _normalize_vision_provider(requested)
 
-    def _finalize(resolved_provider: str, sync_client: Any, default_model: Optional[str]):
+    def _finalize(resolved_provider: str, sync_client: Any, default_model: str | None):
         if sync_client is None:
             return resolved_provider, None, None
         final_model = resolved_model or default_model
@@ -4039,10 +4039,10 @@ def _client_cache_key(
     provider: str,
     *,
     async_mode: bool,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-    api_mode: Optional[str] = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    api_mode: str | None = None,
+    main_runtime: Dict[str, Any] | None = None,
     is_vision: bool = False,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
@@ -4051,7 +4051,7 @@ def _client_cache_key(
     return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, pool_hint)
 
 
-def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
+def _store_cached_client(cache_key: tuple, client: Any, default_model: str | None, *, bound_loop: Any = None) -> None:
     with _client_cache_lock:
         old_entry = _client_cache.get(cache_key)
         if old_entry is not None and old_entry[0] is not client:
@@ -4068,14 +4068,14 @@ def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[
 def _refresh_nous_auxiliary_client(
     *,
     cache_provider: str,
-    model: Optional[str],
+    model: str | None,
     async_mode: bool,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-    api_mode: Optional[str] = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+    api_mode: str | None = None,
+    main_runtime: Dict[str, Any] | None = None,
     is_vision: bool = False,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> Tuple[Any | None, str | None]:
     """Refresh Nous runtime creds, rebuild the client, and replace the cache entry."""
     runtime = _resolve_nous_runtime_api(force_refresh=True)
     if runtime is None:
@@ -4215,14 +4215,14 @@ def _is_openrouter_client(client: Any) -> bool:
     return False
 
 
-def _cached_client_accepts_slash_models(client: Any, cached_default: Optional[str]) -> bool:
+def _cached_client_accepts_slash_models(client: Any, cached_default: str | None) -> bool:
     """Best-effort check for cached clients that accept ``vendor/model`` IDs."""
     if _is_openrouter_client(client):
         return True
     return bool(cached_default and "/" in cached_default)
 
 
-def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str]) -> Optional[str]:
+def _compat_model(client: Any, model: str | None, cached_default: str | None) -> str | None:
     """Keep slash-bearing model IDs only for cached clients that support them.
 
     Mirrors the guard in resolve_provider_client() which is skipped on cache hits.
@@ -4239,9 +4239,9 @@ def _get_cached_client(
     base_url: str = None,
     api_key: str = None,
     api_mode: str = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Dict[str, Any] | None = None,
     is_vision: bool = False,
-) -> Tuple[Optional[Any], Optional[str]]:
+) -> Tuple[Any | None, str | None]:
     """Get or create a cached client for the given provider.
 
     Async clients (AsyncOpenAI) use httpx.AsyncClient internally, which
@@ -4352,7 +4352,7 @@ def _resolve_task_provider_model(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
-) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
+) -> Tuple[str, str | None, str | None, str | None, str | None]:
     """Determine provider + model for a call.
 
     Priority:
@@ -4388,7 +4388,7 @@ def _resolve_task_provider_model(
     # has already supplied a base_url we keep their endpoint but still rewrite
     # the provider to ``custom`` so resolution doesn't hit the
     # PROVIDER_REGISTRY-only path (which has no ``openai`` entry).
-    def _expand_direct_api_alias(prov: Optional[str], existing_base: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    def _expand_direct_api_alias(prov: str | None, existing_base: str | None) -> Tuple[str | None, str | None]:
         if not prov:
             return prov, existing_base
         target_base = _AUX_DIRECT_API_BASE_URLS.get(prov.strip().lower())
@@ -4567,12 +4567,12 @@ def _build_call_kwargs(
     provider: str,
     model: str,
     messages: list,
-    temperature: Optional[float] = None,
-    max_tokens: Optional[int] = None,
-    tools: Optional[list] = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    tools: list | None = None,
     timeout: float = 30.0,
-    extra_body: Optional[dict] = None,
-    base_url: Optional[str] = None,
+    extra_body: dict | None = None,
+    base_url: str | None = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -4690,7 +4690,7 @@ def call_llm(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
-    main_runtime: Optional[Dict[str, Any]] = None,
+    main_runtime: Dict[str, Any] | None = None,
     messages: list,
     temperature: float = None,
     max_tokens: int = None,

--- a/agent/azure_identity_adapter.py
+++ b/agent/azure_identity_adapter.py
@@ -160,8 +160,8 @@ class EntraIdentityConfig:
         }
 
     @classmethod
-    def from_dict(cls, data: Optional[Dict[str, Any]],
-                  *, default_scope: Optional[str] = None) -> "EntraIdentityConfig":
+    def from_dict(cls, data: Dict[str, Any] | None,
+                  *, default_scope: str | None = None) -> "EntraIdentityConfig":
         data = data or {}
         scope = str(data.get("scope") or "").strip() or default_scope or SCOPE_AI_AZURE_DEFAULT
         exclude_browser = bool(data.get("exclude_interactive_browser", True))
@@ -212,10 +212,10 @@ def build_credential(config: EntraIdentityConfig) -> Any:
     return _build_default_credential(config)
 
 
-def build_token_provider(scope: Optional[str] = None,
+def build_token_provider(scope: str | None = None,
                          *,
-                         config: Optional[EntraIdentityConfig] = None,
-                         base_url: Optional[str] = None,
+                         config: EntraIdentityConfig | None = None,
+                         base_url: str | None = None,
                          exclude_interactive_browser: bool = True,
                          ) -> Callable[[], str]:
     """Return a zero-arg callable that mints a fresh Entra bearer JWT.
@@ -258,9 +258,9 @@ def build_token_provider(scope: Optional[str] = None,
 # ---------------------------------------------------------------------------
 
 
-def has_azure_identity_credentials(scope: Optional[str] = None,
+def has_azure_identity_credentials(scope: str | None = None,
                                    *,
-                                   config: Optional[EntraIdentityConfig] = None,
+                                   config: EntraIdentityConfig | None = None,
                                    timeout_seconds: float = 10.0,
                                    allow_install: bool = True,
                                    **overrides: Any) -> bool:
@@ -312,9 +312,9 @@ def has_azure_identity_credentials(scope: Optional[str] = None,
     return bool(result.get("ok"))
 
 
-def describe_active_credential(config: Optional[EntraIdentityConfig] = None,
+def describe_active_credential(config: EntraIdentityConfig | None = None,
                                *,
-                               scope: Optional[str] = None,
+                               scope: str | None = None,
                                timeout_seconds: float = 10.0,
                                allow_install: bool = True,
                                **overrides: Any) -> Dict[str, Any]:

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -300,10 +300,10 @@ def summarize_background_review_actions(
 def build_memory_write_metadata(
     agent: Any,
     *,
-    write_origin: Optional[str] = None,
-    execution_context: Optional[str] = None,
-    task_id: Optional[str] = None,
-    tool_call_id: Optional[str] = None,
+    write_origin: str | None = None,
+    execution_context: str | None = None,
+    task_id: str | None = None,
+    tool_call_id: str | None = None,
 ) -> Dict[str, Any]:
     """Build provenance metadata for external memory-provider mirrors."""
     metadata: Dict[str, Any] = {

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -228,7 +228,7 @@ _AWS_CREDENTIAL_ENV_VARS = [
 ]
 
 
-def resolve_aws_auth_env_var(env: Optional[Dict[str, str]] = None) -> Optional[str]:
+def resolve_aws_auth_env_var(env: Dict[str, str] | None = None) -> str | None:
     """Return the name of the AWS auth source that is active, or None.
 
     Checks environment variables first, then falls back to boto3's credential
@@ -270,7 +270,7 @@ def resolve_aws_auth_env_var(env: Optional[Dict[str, str]] = None) -> Optional[s
     return None
 
 
-def has_aws_credentials(env: Optional[Dict[str, str]] = None) -> bool:
+def has_aws_credentials(env: Dict[str, str] | None = None) -> bool:
     """Return True if any AWS credential source is detected.
 
     Checks environment variables first (fast, no I/O), then falls back to
@@ -301,7 +301,7 @@ def has_aws_credentials(env: Optional[Dict[str, str]] = None) -> bool:
     return False
 
 
-def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
+def resolve_bedrock_region(env: Dict[str, str] | None = None) -> str:
     """Resolve the AWS region for Bedrock API calls.
 
     Priority:
@@ -332,7 +332,7 @@ def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
     return "us-east-1"
 
 
-def bedrock_model_ids_or_none() -> Optional[List[str]]:
+def bedrock_model_ids_or_none() -> List[str] | None:
     """Live-discover Bedrock model IDs for the active region.
 
     Returns a list of model ID strings if discovery succeeds and yields
@@ -492,7 +492,7 @@ def _convert_content_to_converse(content) -> List[Dict]:
 
 def convert_messages_to_converse(
     messages: List[Dict],
-) -> Tuple[Optional[List[Dict]], List[Dict]]:
+) -> Tuple[List[Dict] | None, List[Dict]]:
     """Convert OpenAI-format messages to Bedrock Converse format.
 
     Returns ``(system_prompt, converse_messages)`` where:
@@ -755,7 +755,7 @@ def stream_converse_with_callbacks(
     text_parts: List[str] = []
     reasoning_parts: List[str] = []
     tool_calls: List[SimpleNamespace] = []
-    current_tool: Optional[Dict] = None
+    current_tool: Dict | None = None
     current_text_buffer: List[str] = []
     has_tool_use = False
     stop_reason = "end_turn"
@@ -876,12 +876,12 @@ def stream_converse_with_callbacks(
 def build_converse_kwargs(
     model: str,
     messages: List[Dict],
-    tools: Optional[List[Dict]] = None,
+    tools: List[Dict] | None = None,
     max_tokens: int = 4096,
-    temperature: Optional[float] = None,
-    top_p: Optional[float] = None,
-    stop_sequences: Optional[List[str]] = None,
-    guardrail_config: Optional[Dict] = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    stop_sequences: List[str] | None = None,
+    guardrail_config: Dict | None = None,
 ) -> Dict[str, Any]:
     """Build kwargs for ``bedrock-runtime.converse()`` or ``converse_stream()``.
 
@@ -935,12 +935,12 @@ def call_converse(
     region: str,
     model: str,
     messages: List[Dict],
-    tools: Optional[List[Dict]] = None,
+    tools: List[Dict] | None = None,
     max_tokens: int = 4096,
-    temperature: Optional[float] = None,
-    top_p: Optional[float] = None,
-    stop_sequences: Optional[List[str]] = None,
-    guardrail_config: Optional[Dict] = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    stop_sequences: List[str] | None = None,
+    guardrail_config: Dict | None = None,
 ) -> SimpleNamespace:
     """Call Bedrock Converse API (non-streaming) and return an OpenAI-compatible response.
 
@@ -976,12 +976,12 @@ def call_converse_stream(
     region: str,
     model: str,
     messages: List[Dict],
-    tools: Optional[List[Dict]] = None,
+    tools: List[Dict] | None = None,
     max_tokens: int = 4096,
-    temperature: Optional[float] = None,
-    top_p: Optional[float] = None,
-    stop_sequences: Optional[List[str]] = None,
-    guardrail_config: Optional[Dict] = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    stop_sequences: List[str] | None = None,
+    guardrail_config: Dict | None = None,
 ) -> SimpleNamespace:
     """Call Bedrock ConverseStream API and return an OpenAI-compatible response.
 
@@ -1029,7 +1029,7 @@ def reset_discovery_cache():
 
 def discover_bedrock_models(
     region: str,
-    provider_filter: Optional[List[str]] = None,
+    provider_filter: List[str] | None = None,
 ) -> List[Dict[str, Any]]:
     """Discover available Bedrock foundation models and inference profiles.
 

--- a/agent/browser_registry.py
+++ b/agent/browser_registry.py
@@ -86,7 +86,7 @@ def list_providers() -> List[BrowserProvider]:
     return sorted(items, key=lambda p: p.name)
 
 
-def get_provider(name: str) -> Optional[BrowserProvider]:
+def get_provider(name: str) -> BrowserProvider | None:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
@@ -110,7 +110,7 @@ _LEGACY_PREFERENCE = (
 )
 
 
-def _resolve(configured: Optional[str]) -> Optional[BrowserProvider]:
+def _resolve(configured: str | None) -> BrowserProvider | None:
     """Resolve the active browser provider.
 
     Resolution rules (in order):
@@ -186,7 +186,7 @@ def _resolve(configured: Optional[str]) -> Optional[BrowserProvider]:
     return None
 
 
-def get_active_browser_provider() -> Optional[BrowserProvider]:
+def get_active_browser_provider() -> BrowserProvider | None:
     """Resolve the currently-active cloud browser provider.
 
     Reads ``browser.cloud_provider`` from config.yaml; falls back per the
@@ -202,7 +202,7 @@ def get_active_browser_provider() -> Optional[BrowserProvider]:
         logger.debug("Could not read browser config: %s", exc)
         browser_cfg = {}
 
-    configured: Optional[str] = None
+    configured: str | None = None
     if isinstance(browser_cfg, dict) and "cloud_provider" in browser_cfg:
         try:
             from tools.tool_backend_helpers import normalize_browser_cloud_provider

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -152,7 +152,7 @@ def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
     return f"call_{digest}"
 
 
-def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]:
+def _split_responses_tool_id(raw_id: Any) -> tuple[str | None, str | None]:
     """Split a stored tool id into (call_id, response_item_id)."""
     if not isinstance(raw_id, str):
         return None, None
@@ -171,7 +171,7 @@ def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]
 
 def _derive_responses_function_call_id(
     call_id: str,
-    response_item_id: Optional[str] = None,
+    response_item_id: str | None = None,
 ) -> str:
     """Build a valid Responses `function_call.id` (must start with `fc_`)."""
     if isinstance(response_item_id, str):
@@ -202,7 +202,7 @@ def _derive_responses_function_call_id(
 # Schema conversion
 # ---------------------------------------------------------------------------
 
-def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
+def _responses_tools(tools: List[Dict[str, Any]] | None = None) -> List[Dict[str, Any]] | None:
     """Convert chat-completions tool schemas to Responses function-tool schemas."""
     if not tools:
         return None

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -581,12 +581,12 @@ class ContextCompressor(ContextEngine):
         self.summary_model = summary_model_override or ""
 
         # Stores the previous compaction summary for iterative updates
-        self._previous_summary: Optional[str] = None
+        self._previous_summary: str | None = None
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
         self._summary_failure_cooldown_until: float = 0.0
-        self._last_summary_error: Optional[str] = None
+        self._last_summary_error: str | None = None
         # When summary generation fails and a static fallback is inserted,
         # record how many turns were unrecoverably dropped so callers
         # (gateway hygiene, /compress) can surface a visible warning.
@@ -602,8 +602,8 @@ class ContextCompressor(ContextEngine):
         # retrying on the main model, record the failure so gateway /
         # CLI callers can still warn the user even though compression
         # succeeded.  Silent recovery would hide the broken config.
-        self._last_aux_model_failure_error: Optional[str] = None
-        self._last_aux_model_failure_model: Optional[str] = None
+        self._last_aux_model_failure_error: str | None = None
+        self._last_aux_model_failure_model: str | None = None
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
@@ -911,7 +911,7 @@ class ContextCompressor(ContextEngine):
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
 
-    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> Optional[str]:
+    def _generate_summary(self, turns_to_summarize: List[Dict[str, Any]], focus_topic: str = None) -> str | None:
         """Generate a structured summary of conversation turns.
 
         Uses a structured template (Goal, Progress, Decisions, Resolved/Pending
@@ -1217,7 +1217,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         messages: List[Dict[str, Any]],
         start: int,
         end: int,
-    ) -> tuple[Optional[int], str]:
+    ) -> tuple[int | None, str]:
         """Find the newest handoff summary inside a compression window."""
         for idx in range(end - 1, start - 1, -1):
             content = messages[idx].get("content")

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -253,9 +253,9 @@ def compress_context(
     messages: list,
     system_message: str,
     *,
-    approx_tokens: Optional[int] = None,
+    approx_tokens: int | None = None,
     task_id: str = "default",
-    focus_topic: Optional[str] = None,
+    focus_topic: str | None = None,
     force: bool = False,
 ) -> Tuple[list, str]:
     """Compress conversation context and split the session in SQLite.
@@ -516,7 +516,7 @@ def try_shrink_image_parts_in_messages(api_messages: list) -> bool:
     target_bytes = 4 * 1024 * 1024
     changed_count = 0
 
-    def _shrink_data_url(url: str) -> Optional[str]:
+    def _shrink_data_url(url: str) -> str | None:
         """Return a smaller data URL, or None if shrink can't help."""
         if not isinstance(url, str) or not url.startswith("data:"):
             return None

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -74,7 +74,7 @@ from utils import base_url_host_matches, env_var_enabled
 logger = logging.getLogger(__name__)
 
 
-def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
+def _ollama_context_limit_error(agent: Any, request_tokens: int) -> str | None:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
         return None
@@ -235,8 +235,8 @@ def run_conversation(
     system_message: str = None,
     conversation_history: List[Dict[str, Any]] = None,
     task_id: str = None,
-    stream_callback: Optional[callable] = None,
-    persist_user_message: Optional[str] = None,
+    stream_callback: callable | None = None,
+    persist_user_message: str | None = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -37,7 +37,7 @@ from hermes_cli.auth import (
 logger = logging.getLogger(__name__)
 
 
-def _load_config_safe() -> Optional[dict]:
+def _load_config_safe() -> dict | None:
     """Load config.yaml, returning None on any error."""
     try:
         from hermes_cli.config import load_config
@@ -99,20 +99,20 @@ class PooledCredential:
     priority: int
     source: str
     access_token: str
-    refresh_token: Optional[str] = None
-    last_status: Optional[str] = None
-    last_status_at: Optional[float] = None
-    last_error_code: Optional[int] = None
-    last_error_reason: Optional[str] = None
-    last_error_message: Optional[str] = None
-    last_error_reset_at: Optional[float] = None
-    base_url: Optional[str] = None
-    expires_at: Optional[str] = None
-    expires_at_ms: Optional[int] = None
-    last_refresh: Optional[str] = None
-    inference_base_url: Optional[str] = None
-    agent_key: Optional[str] = None
-    agent_key_expires_at: Optional[str] = None
+    refresh_token: str | None = None
+    last_status: str | None = None
+    last_status_at: float | None = None
+    last_error_code: int | None = None
+    last_error_reason: str | None = None
+    last_error_message: str | None = None
+    last_error_reset_at: float | None = None
+    base_url: str | None = None
+    expires_at: str | None = None
+    expires_at_ms: int | None = None
+    last_refresh: str | None = None
+    inference_base_url: str | None = None
+    agent_key: str | None = None
+    agent_key_expires_at: str | None = None
     request_count: int = 0
     extra: Dict[str, Any] = None  # type: ignore[assignment]
 
@@ -172,7 +172,7 @@ class PooledCredential:
         return str(self.access_token or "")
 
     @property
-    def runtime_base_url(self) -> Optional[str]:
+    def runtime_base_url(self) -> str | None:
         if self.provider == "nous":
             return self.inference_base_url or self.base_url
         return self.base_url
@@ -196,7 +196,7 @@ def _is_manual_source(source: str) -> bool:
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
 
 
-def _exhausted_ttl(error_code: Optional[int]) -> int:
+def _exhausted_ttl(error_code: int | None) -> int:
     """Return cooldown seconds based on the HTTP status that caused exhaustion."""
     if error_code == 401:
         return EXHAUSTED_TTL_401_SECONDS
@@ -205,7 +205,7 @@ def _exhausted_ttl(error_code: Optional[int]) -> int:
     return EXHAUSTED_TTL_DEFAULT_SECONDS
 
 
-def _parse_absolute_timestamp(value: Any) -> Optional[float]:
+def _parse_absolute_timestamp(value: Any) -> float | None:
     """Best-effort parse for provider reset timestamps.
 
     Accepts epoch seconds, epoch milliseconds, and ISO-8601 strings.
@@ -235,7 +235,7 @@ def _parse_absolute_timestamp(value: Any) -> Optional[float]:
     return None
 
 
-def _extract_retry_delay_seconds(message: str) -> Optional[float]:
+def _extract_retry_delay_seconds(message: str) -> float | None:
     if not message:
         return None
     delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
@@ -248,7 +248,7 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     return None
 
 
-def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _normalize_error_context(error_context: Dict[str, Any] | None) -> Dict[str, Any]:
     if not isinstance(error_context, dict):
         return {}
     normalized: Dict[str, Any] = {}
@@ -273,7 +273,7 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     return normalized
 
 
-def _exhausted_until(entry: PooledCredential) -> Optional[float]:
+def _exhausted_until(entry: PooledCredential) -> float | None:
     if entry.last_status != STATUS_EXHAUSTED:
         return None
     reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
@@ -289,7 +289,7 @@ def _normalize_custom_pool_name(name: str) -> str:
     return name.strip().lower().replace(" ", "-")
 
 
-def _iter_custom_providers(config: Optional[dict] = None):
+def _iter_custom_providers(config: dict | None = None):
     """Yield (normalized_name, entry_dict) for each valid custom_providers entry."""
     if config is None:
         config = _load_config_safe()
@@ -315,7 +315,7 @@ def _iter_custom_providers(config: Optional[dict] = None):
         yield _normalize_custom_pool_name(name), entry
 
 
-def get_custom_provider_pool_key(base_url: str, provider_name: Optional[str] = None) -> Optional[str]:
+def get_custom_provider_pool_key(base_url: str, provider_name: str | None = None) -> str | None:
     """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching base_url.
 
     When provider_name is given, prefer matching by name first (solving the case where
@@ -356,7 +356,7 @@ def list_custom_pool_providers() -> List[str]:
     )
 
 
-def _get_custom_provider_config(pool_key: str) -> Optional[Dict[str, Any]]:
+def _get_custom_provider_config(pool_key: str) -> Dict[str, Any] | None:
     """Return the custom_providers config entry matching a pool key like 'custom:together.ai'."""
     if not pool_key.startswith(CUSTOM_POOL_PREFIX):
         return None
@@ -390,7 +390,7 @@ class CredentialPool:
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
-        self._current_id: Optional[str] = None
+        self._current_id: str | None = None
         self._strategy = get_pool_strategy(provider)
         self._lock = threading.Lock()
         self._active_leases: Dict[str, int] = {}
@@ -406,7 +406,7 @@ class CredentialPool:
     def entries(self) -> List[PooledCredential]:
         return list(self._entries)
 
-    def current(self) -> Optional[PooledCredential]:
+    def current(self) -> PooledCredential | None:
         if not self._current_id:
             return None
         return next((entry for entry in self._entries if entry.id == self._current_id), None)
@@ -427,8 +427,8 @@ class CredentialPool:
     def _mark_exhausted(
         self,
         entry: PooledCredential,
-        status_code: Optional[int],
-        error_context: Optional[Dict[str, Any]] = None,
+        status_code: int | None,
+        error_context: Dict[str, Any] | None = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
         updated = replace(
@@ -763,7 +763,7 @@ class CredentialPool:
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
-    def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+    def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> PooledCredential | None:
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
@@ -1131,7 +1131,7 @@ class CredentialPool:
             return False
         return False
 
-    def select(self) -> Optional[PooledCredential]:
+    def select(self) -> PooledCredential | None:
         with self._lock:
             return self._select_unlocked()
 
@@ -1216,7 +1216,7 @@ class CredentialPool:
             self._persist()
         return available
 
-    def _select_unlocked(self) -> Optional[PooledCredential]:
+    def _select_unlocked(self) -> PooledCredential | None:
         available = self._available_entries(clear_expired=True, refresh=True)
         if not available:
             self._current_id = None
@@ -1249,7 +1249,7 @@ class CredentialPool:
         self._current_id = entry.id
         return entry
 
-    def peek(self) -> Optional[PooledCredential]:
+    def peek(self) -> PooledCredential | None:
         current = self.current()
         if current is not None:
             return current
@@ -1259,9 +1259,9 @@ class CredentialPool:
     def mark_exhausted_and_rotate(
         self,
         *,
-        status_code: Optional[int],
-        error_context: Optional[Dict[str, Any]] = None,
-    ) -> Optional[PooledCredential]:
+        status_code: int | None,
+        error_context: Dict[str, Any] | None = None,
+    ) -> PooledCredential | None:
         with self._lock:
             entry = self.current() or self._select_unlocked()
             if entry is None:
@@ -1279,7 +1279,7 @@ class CredentialPool:
                 logger.info("credential pool: rotated to %s", _next_label)
             return next_entry
 
-    def acquire_lease(self, credential_id: Optional[str] = None) -> Optional[str]:
+    def acquire_lease(self, credential_id: str | None = None) -> str | None:
         """Acquire a soft lease on a credential.
 
         If a specific credential_id is provided, lease that entry directly.
@@ -1319,11 +1319,11 @@ class CredentialPool:
             else:
                 self._active_leases[credential_id] = count - 1
 
-    def try_refresh_current(self) -> Optional[PooledCredential]:
+    def try_refresh_current(self) -> PooledCredential | None:
         with self._lock:
             return self._try_refresh_current_unlocked()
 
-    def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
+    def _try_refresh_current_unlocked(self) -> PooledCredential | None:
         entry = self.current()
         if entry is None:
             return None
@@ -1356,7 +1356,7 @@ class CredentialPool:
             self._persist()
         return count
 
-    def remove_index(self, index: int) -> Optional[PooledCredential]:
+    def remove_index(self, index: int) -> PooledCredential | None:
         if index < 1 or index > len(self._entries):
             return None
         removed = self._entries.pop(index - 1)
@@ -1369,7 +1369,7 @@ class CredentialPool:
             self._current_id = None
         return removed
 
-    def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
+    def resolve_target(self, target: Any) -> Tuple[int | None, PooledCredential | None, str | None]:
         raw = str(target or "").strip()
         if not raw:
             return None, None, "No credential target provided."

--- a/agent/credential_sources.py
+++ b/agent/credential_sources.py
@@ -98,7 +98,7 @@ class RemovalStep:
     provider: str
     source_id: str
     remove_fn: Callable[..., RemovalResult]
-    match_fn: Optional[Callable[[str], bool]] = None
+    match_fn: Callable[[str], bool] | None = None
     description: str = ""
 
     def matches(self, provider: str, source: str) -> bool:
@@ -117,7 +117,7 @@ def register(step: RemovalStep) -> RemovalStep:
     return step
 
 
-def find_removal_step(provider: str, source: str) -> Optional[RemovalStep]:
+def find_removal_step(provider: str, source: str) -> RemovalStep | None:
     """Return the first matching RemovalStep, or None if unregistered.
 
     Unregistered sources fall through to the default remove path in

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -37,7 +37,7 @@ from tools import skill_usage
 logger = logging.getLogger(__name__)
 
 
-def _strip_aux_credential(value: Any) -> Optional[str]:
+def _strip_aux_credential(value: Any) -> str | None:
     if value is None:
         return None
     text = str(value).strip()
@@ -49,8 +49,8 @@ class _ReviewRuntimeBinding(NamedTuple):
 
     provider: str
     model: str
-    explicit_api_key: Optional[str]
-    explicit_base_url: Optional[str]
+    explicit_api_key: str | None
+    explicit_base_url: str | None
 
 
 DEFAULT_INTERVAL_HOURS = 24 * 7  # 7 days
@@ -187,7 +187,7 @@ def get_archive_after_days() -> int:
 # Idle / interval check
 # ---------------------------------------------------------------------------
 
-def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
+def _parse_iso(ts: str | None) -> datetime | None:
     if not ts:
         return None
     try:
@@ -196,7 +196,7 @@ def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
         return None
 
 
-def should_run_now(now: Optional[datetime] = None) -> bool:
+def should_run_now(now: datetime | None = None) -> bool:
     """Return True if the curator should run immediately.
 
     Gates:
@@ -253,7 +253,7 @@ def should_run_now(now: Optional[datetime] = None) -> bool:
 # Automatic state transitions (pure function, no LLM)
 # ---------------------------------------------------------------------------
 
-def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int]:
+def apply_automatic_transitions(now: datetime | None = None) -> Dict[str, int]:
     """Walk every agent-created skill and move active/stale/archived based on
     the latest real activity timestamp. Pinned skills are never touched.
     Returns a counter dict describing what changed."""
@@ -547,8 +547,8 @@ def _classify_removed_skills(
     for name in removed:
         if not name:
             continue
-        into: Optional[str] = None
-        evidence: Optional[str] = None
+        into: str | None = None
+        evidence: str | None = None
 
         # Normalise name variants we'll search for in path/content strings.
         needles = {name, name.replace("-", "_"), name.replace("_", "-")}
@@ -751,7 +751,7 @@ def _reconcile_classification(
     heuristic: Dict[str, List[Dict[str, Any]]],
     model_block: Dict[str, List[Dict[str, str]]],
     destinations: Set[str],
-    absorbed_declarations: Optional[Dict[str, Dict[str, Any]]] = None,
+    absorbed_declarations: Dict[str, Dict[str, Any]] | None = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """Merge heuristic (tool-call evidence) with the model's structured block.
 
@@ -977,7 +977,7 @@ def _write_run_report(
     before_names: Set[str],
     after_report: List[Dict[str, Any]],
     llm_meta: Dict[str, Any],
-) -> Optional[Path]:
+) -> Path | None:
     """Write run.json + REPORT.md under logs/curator/{YYYYMMDD-HHMMSS}/.
 
     Returns the report directory path on success, None if the write
@@ -1367,7 +1367,7 @@ def _render_candidate_list() -> str:
 
 
 def run_curator_review(
-    on_summary: Optional[Callable[[str], None]] = None,
+    on_summary: Callable[[str], None] | None = None,
     synchronous: bool = False,
     dry_run: bool = False,
 ) -> Dict[str, Any]:
@@ -1762,9 +1762,9 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
 
 def maybe_run_curator(
     *,
-    idle_for_seconds: Optional[float] = None,
-    on_summary: Optional[Callable[[str], None]] = None,
-) -> Optional[Dict[str, Any]]:
+    idle_for_seconds: float | None = None,
+    on_summary: Callable[[str], None] | None = None,
+) -> Dict[str, Any] | None:
     """Best-effort: run a curator pass if all gates pass. Returns the result
     dict if a pass was started, else None. Never raises."""
     try:

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -130,7 +130,7 @@ def _backup_cron_jobs_into(dest: Path) -> Dict[str, Any]:
     return info
 
 
-def _utc_id(now: Optional[datetime] = None) -> str:
+def _utc_id(now: datetime | None = None) -> str:
     """UTC ISO-ish filesystem-safe timestamp: ``2026-05-01T13-05-42Z``."""
     if now is None:
         now = datetime.now(timezone.utc)
@@ -186,7 +186,7 @@ def _count_skill_files(base: Path) -> int:
 
 def _write_manifest(dest: Path, reason: str, archive_path: Path,
                     skills_counted: int,
-                    cron_info: Optional[Dict[str, Any]] = None) -> None:
+                    cron_info: Dict[str, Any] | None = None) -> None:
     manifest = {
         "id": dest.name,
         "reason": reason,
@@ -209,7 +209,7 @@ def _write_manifest(dest: Path, reason: str, archive_path: Path,
     )
 
 
-def snapshot_skills(reason: str = "manual") -> Optional[Path]:
+def snapshot_skills(reason: str = "manual") -> Path | None:
     """Create a tar.gz snapshot of ``~/.hermes/skills/`` and prune old ones.
 
     Returns the snapshot directory path, or ``None`` if the snapshot was
@@ -362,7 +362,7 @@ def list_backups() -> List[Dict[str, Any]]:
     return out
 
 
-def _resolve_backup(backup_id: Optional[str]) -> Optional[Path]:
+def _resolve_backup(backup_id: str | None) -> Path | None:
     """Return the path of the requested backup, or the newest one if
     *backup_id* is None. Returns None if no match."""
     backups = _backups_dir()
@@ -527,7 +527,7 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 
-def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]]:
+def rollback(backup_id: str | None = None) -> Tuple[bool, str, Path | None]:
     """Restore ``~/.hermes/skills/`` from a snapshot.
 
     Strategy:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -69,9 +69,9 @@ class ClassifiedError:
     """Structured classification of an API error with recovery hints."""
 
     reason: FailoverReason
-    status_code: Optional[int] = None
-    provider: Optional[str] = None
-    model: Optional[str] = None
+    status_code: int | None = None
+    provider: str | None = None
+    model: str | None = None
     message: str = ""
     error_context: Dict[str, Any] = field(default_factory=dict)
 
@@ -672,7 +672,7 @@ def _classify_by_status(
     context_length: int,
     num_messages: int = 0,
     result_fn,
-) -> Optional[ClassifiedError]:
+) -> ClassifiedError | None:
     """Classify based on HTTP status code with message-aware refinement."""
 
     if status_code == 401:
@@ -941,7 +941,7 @@ def _classify_400(
 
 def _classify_by_error_code(
     error_code: str, error_msg: str, result_fn,
-) -> Optional[ClassifiedError]:
+) -> ClassifiedError | None:
     """Classify by structured error codes from the response body."""
     code_lower = error_code.lower()
 
@@ -986,7 +986,7 @@ def _classify_by_message(
     approx_tokens: int,
     context_length: int,
     result_fn,
-) -> Optional[ClassifiedError]:
+) -> ClassifiedError | None:
     """Classify based on error message patterns when no status code is available."""
 
     # Payload-too-large patterns (from message text when no status_code)
@@ -1101,7 +1101,7 @@ def _classify_by_message(
 
 # ── Helpers ─────────────────────────────────────────────────────────────
 
-def _extract_status_code(error: Exception) -> Optional[int]:
+def _extract_status_code(error: Exception) -> int | None:
     """Walk the error and its cause chain to find an HTTP status code."""
     current = error
     for _ in range(5):  # Max depth to prevent infinite loops

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -82,7 +82,7 @@ def build_write_denied_prefixes(home: str) -> list[str]:
     ]
 
 
-def get_safe_write_root() -> Optional[str]:
+def get_safe_write_root() -> str | None:
     """Return the resolved HERMES_WRITE_SAFE_ROOT path, or None if unset."""
     root = os.getenv("HERMES_WRITE_SAFE_ROOT", "")
     if not root:
@@ -148,7 +148,7 @@ def is_write_denied(path: str) -> bool:
     return False
 
 
-def get_read_block_error(path: str) -> Optional[str]:
+def get_read_block_error(path: str) -> str | None:
     """Return an error message when a read targets a denied Hermes path.
 
     Two categories are blocked:
@@ -323,7 +323,7 @@ def _resolve_active_profile_name() -> str:
     return "default"
 
 
-def classify_cross_profile_target(path: str) -> Optional[dict]:
+def classify_cross_profile_target(path: str) -> dict | None:
     """Classify a write target as cross-profile if it lands in another
     profile's scoped area (skills/plugins/cron/memories).
 
@@ -346,8 +346,8 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
     except (OSError, RuntimeError):
         return None
 
-    target_profile: Optional[str] = None
-    area: Optional[str] = None
+    target_profile: str | None = None
+    area: str | None = None
 
     try:
         rel = target.relative_to(root_real)
@@ -386,7 +386,7 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
     }
 
 
-def get_cross_profile_warning(path: str) -> Optional[str]:
+def get_cross_profile_warning(path: str) -> str | None:
     """Return a model-facing warning string when ``path`` is cross-profile.
 
     Returns ``None`` when the write is in-scope (same profile) or outside

--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -132,7 +132,7 @@ def _translate_tool_result_to_gemini(message: Dict[str, Any]) -> Dict[str, Any]:
 
 def _build_gemini_contents(
     messages: List[Dict[str, Any]],
-) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+) -> tuple[List[Dict[str, Any]], Dict[str, Any] | None]:
     """Convert OpenAI messages[] to Gemini contents[] + systemInstruction."""
     system_text_parts: List[str] = []
     contents: List[Dict[str, Any]] = []
@@ -174,7 +174,7 @@ def _build_gemini_contents(
 
         contents.append({"role": gemini_role, "parts": parts})
 
-    system_instruction: Optional[Dict[str, Any]] = None
+    system_instruction: Dict[str, Any] | None = None
     joined_system = "\n".join(p for p in system_text_parts if p).strip()
     if joined_system:
         system_instruction = {
@@ -211,7 +211,7 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
     return [{"functionDeclarations": declarations}]
 
 
-def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any]]:
+def _translate_tool_choice_to_gemini(tool_choice: Any) -> Dict[str, Any] | None:
     """OpenAI tool_choice -> Gemini toolConfig.functionCallingConfig."""
     if tool_choice is None:
         return None
@@ -235,7 +235,7 @@ def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any
     return None
 
 
-def _normalize_thinking_config(config: Any) -> Optional[Dict[str, Any]]:
+def _normalize_thinking_config(config: Any) -> Dict[str, Any] | None:
     """Accept thinkingBudget / thinkingLevel / includeThoughts (+ snake_case)."""
     if not isinstance(config, dict) or not config:
         return None
@@ -257,9 +257,9 @@ def build_gemini_request(
     messages: List[Dict[str, Any]],
     tools: Any = None,
     tool_choice: Any = None,
-    temperature: Optional[float] = None,
-    max_tokens: Optional[int] = None,
-    top_p: Optional[float] = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    top_p: float | None = None,
     stop: Any = None,
     thinking_config: Any = None,
 ) -> Dict[str, Any]:
@@ -302,7 +302,7 @@ def wrap_code_assist_request(
     project_id: str,
     model: str,
     inner_request: Dict[str, Any],
-    user_prompt_id: Optional[str] = None,
+    user_prompt_id: str | None = None,
 ) -> Dict[str, Any]:
     """Wrap the inner Gemini request in the Code Assist envelope."""
     return {
@@ -446,8 +446,8 @@ def _make_stream_chunk(
     *,
     model: str,
     content: str = "",
-    tool_call_delta: Optional[Dict[str, Any]] = None,
-    finish_reason: Optional[str] = None,
+    tool_call_delta: Dict[str, Any] | None = None,
+    finish_reason: str | None = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
     delta_kwargs: Dict[str, Any] = {
@@ -594,9 +594,9 @@ class GeminiCloudCodeClient:
     def __init__(
         self,
         *,
-        api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
-        default_headers: Optional[Dict[str, str]] = None,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: Dict[str, str] | None = None,
         project_id: str = "",
         **_: Any,
     ):
@@ -607,7 +607,7 @@ class GeminiCloudCodeClient:
         self.base_url = base_url or MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._configured_project_id = project_id
-        self._project_context: Optional[ProjectContext] = None
+        self._project_context: ProjectContext | None = None
         self._project_context_lock = False  # simple single-thread guard
         self.chat = _GeminiChatNamespace(self)
         self.is_closed = False
@@ -666,15 +666,15 @@ class GeminiCloudCodeClient:
         self,
         *,
         model: str = "gemini-2.5-flash",
-        messages: Optional[List[Dict[str, Any]]] = None,
+        messages: List[Dict[str, Any]] | None = None,
         stream: bool = False,
         tools: Any = None,
         tool_choice: Any = None,
-        temperature: Optional[float] = None,
-        max_tokens: Optional[int] = None,
-        top_p: Optional[float] = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
         stop: Any = None,
-        extra_body: Optional[Dict[str, Any]] = None,
+        extra_body: Dict[str, Any] | None = None,
         timeout: Any = None,
         **_: Any,
     ) -> Any:
@@ -810,7 +810,7 @@ def _gemini_http_error(response: httpx.Response) -> CodeAssistError:
     # than one ErrorInfo (rare), so we pick the first one with a reason.
     error_reason = ""
     error_metadata: Dict[str, Any] = {}
-    retry_delay_seconds: Optional[float] = None
+    retry_delay_seconds: float | None = None
     for detail in err_details_list:
         if not isinstance(detail, dict):
             continue

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -143,10 +143,10 @@ class GeminiAPIError(Exception):
         message: str,
         *,
         code: str = "gemini_api_error",
-        status_code: Optional[int] = None,
-        response: Optional[httpx.Response] = None,
-        retry_after: Optional[float] = None,
-        details: Optional[Dict[str, Any]] = None,
+        status_code: int | None = None,
+        response: httpx.Response | None = None,
+        retry_after: float | None = None,
+        details: Dict[str, Any] | None = None,
     ) -> None:
         super().__init__(message)
         self.code = code
@@ -212,7 +212,7 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
     return parts
 
 
-def _tool_call_extra_signature(tool_call: Dict[str, Any]) -> Optional[str]:
+def _tool_call_extra_signature(tool_call: Dict[str, Any]) -> str | None:
     extra = tool_call.get("extra_content") or {}
     if not isinstance(extra, dict):
         return None
@@ -249,7 +249,7 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
 
 def _translate_tool_result_to_gemini(
     message: Dict[str, Any],
-    tool_name_by_call_id: Optional[Dict[str, str]] = None,
+    tool_name_by_call_id: Dict[str, str] | None = None,
 ) -> Dict[str, Any]:
     tool_name_by_call_id = tool_name_by_call_id or {}
     tool_call_id = str(message.get("tool_call_id") or "")
@@ -273,7 +273,7 @@ def _translate_tool_result_to_gemini(
     }
 
 
-def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], Dict[str, Any] | None]:
     system_text_parts: List[str] = []
     contents: List[Dict[str, Any]] = []
     tool_name_by_call_id: Dict[str, str] = {}
@@ -351,7 +351,7 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
     return [{"functionDeclarations": declarations}] if declarations else []
 
 
-def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any]]:
+def _translate_tool_choice_to_gemini(tool_choice: Any) -> Dict[str, Any] | None:
     if tool_choice is None:
         return None
     if isinstance(tool_choice, str):
@@ -369,7 +369,7 @@ def _translate_tool_choice_to_gemini(tool_choice: Any) -> Optional[Dict[str, Any
     return None
 
 
-def _normalize_thinking_config(config: Any) -> Optional[Dict[str, Any]]:
+def _normalize_thinking_config(config: Any) -> Dict[str, Any] | None:
     if not isinstance(config, dict) or not config:
         return None
     budget = config.get("thinkingBudget", config.get("thinking_budget"))
@@ -390,9 +390,9 @@ def build_gemini_request(
     messages: List[Dict[str, Any]],
     tools: Any = None,
     tool_choice: Any = None,
-    temperature: Optional[float] = None,
-    max_tokens: Optional[int] = None,
-    top_p: Optional[float] = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    top_p: float | None = None,
     stop: Any = None,
     thinking_config: Any = None,
 ) -> Dict[str, Any]:
@@ -438,7 +438,7 @@ def _map_gemini_finish_reason(reason: str) -> str:
     return mapping.get(str(reason or "").upper(), "stop")
 
 
-def _tool_call_extra_from_part(part: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _tool_call_extra_from_part(part: Dict[str, Any]) -> Dict[str, Any] | None:
     sig = part.get("thoughtSignature")
     if isinstance(sig, str) and sig:
         return {"google": {"thought_signature": sig}}
@@ -548,8 +548,8 @@ def _make_stream_chunk(
     *,
     model: str,
     content: str = "",
-    tool_call_delta: Optional[Dict[str, Any]] = None,
-    finish_reason: Optional[str] = None,
+    tool_call_delta: Dict[str, Any] | None = None,
+    finish_reason: str | None = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
     delta_kwargs: Dict[str, Any] = {
@@ -722,7 +722,7 @@ def gemini_http_error(response: httpx.Response) -> GeminiAPIError:
     details_list = _raw_details if isinstance(_raw_details, list) else []
 
     reason = ""
-    retry_after: Optional[float] = None
+    retry_after: float | None = None
     metadata: Dict[str, Any] = {}
     for detail in details_list:
         if not isinstance(detail, dict):
@@ -809,10 +809,10 @@ class GeminiNativeClient:
         self,
         *,
         api_key: str,
-        base_url: Optional[str] = None,
-        default_headers: Optional[Dict[str, str]] = None,
+        base_url: str | None = None,
+        default_headers: Dict[str, str] | None = None,
         timeout: Any = None,
-        http_client: Optional[httpx.Client] = None,
+        http_client: httpx.Client | None = None,
         **_: Any,
     ) -> None:
         if not (api_key or "").strip():
@@ -858,7 +858,7 @@ class GeminiNativeClient:
         return headers
 
     @staticmethod
-    def _advance_stream_iterator(iterator: Iterator[_GeminiStreamChunk]) -> tuple[bool, Optional[_GeminiStreamChunk]]:
+    def _advance_stream_iterator(iterator: Iterator[_GeminiStreamChunk]) -> tuple[bool, _GeminiStreamChunk | None]:
         try:
             return False, next(iterator)
         except StopIteration:
@@ -868,15 +868,15 @@ class GeminiNativeClient:
         self,
         *,
         model: str = "gemini-2.5-flash",
-        messages: Optional[List[Dict[str, Any]]] = None,
+        messages: List[Dict[str, Any]] | None = None,
         stream: bool = False,
         tools: Any = None,
         tool_choice: Any = None,
-        temperature: Optional[float] = None,
-        max_tokens: Optional[int] = None,
-        top_p: Optional[float] = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
         stop: Any = None,
-        extra_body: Optional[Dict[str, Any]] = None,
+        extra_body: Dict[str, Any] | None = None,
         timeout: Any = None,
         **_: Any,
     ) -> Any:

--- a/agent/google_code_assist.py
+++ b/agent/google_code_assist.py
@@ -81,10 +81,10 @@ class CodeAssistError(RuntimeError):
         message: str,
         *,
         code: str = "code_assist_error",
-        status_code: Optional[int] = None,
+        status_code: int | None = None,
         response: Any = None,
-        retry_after: Optional[float] = None,
-        details: Optional[Dict[str, Any]] = None,
+        retry_after: float | None = None,
+        details: Dict[str, Any] | None = None,
     ) -> None:
         super().__init__(message)
         self.code = code
@@ -237,7 +237,7 @@ def load_code_assist(
         body["cloudaicompanionProject"] = project_id
 
     endpoints = [CODE_ASSIST_ENDPOINT] + FALLBACK_ENDPOINTS
-    last_err: Optional[Exception] = None
+    last_err: Exception | None = None
     for endpoint in endpoints:
         url = f"{endpoint}/v1internal:loadCodeAssist"
         try:

--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -249,7 +249,7 @@ def _credentials_lock(timeout_seconds: float = LOCK_TIMEOUT_SECONDS):
 _scraped_creds_cache: Dict[str, str] = {}
 
 
-def _locate_gemini_cli_oauth_js() -> Optional[Path]:
+def _locate_gemini_cli_oauth_js() -> Path | None:
     """Walk the user's gemini binary install to find its oauth2.js.
 
     Returns None if gemini isn't installed. Supports both the npm install
@@ -465,7 +465,7 @@ class GoogleCredentials:
 # Credential I/O (atomic + locked)
 # =============================================================================
 
-def load_credentials() -> Optional[GoogleCredentials]:
+def load_credentials() -> GoogleCredentials | None:
     """Load credentials from disk. Returns None if missing or corrupt."""
     path = _credentials_path()
     if not path.exists():
@@ -578,8 +578,8 @@ def exchange_code(
     verifier: str,
     redirect_uri: str,
     *,
-    client_id: Optional[str] = None,
-    client_secret: Optional[str] = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
     timeout: float = TOKEN_REQUEST_TIMEOUT_SECONDS,
 ) -> Dict[str, Any]:
     """Exchange authorization code for access + refresh tokens."""
@@ -600,8 +600,8 @@ def exchange_code(
 def refresh_access_token(
     refresh_token: str,
     *,
-    client_id: Optional[str] = None,
-    client_secret: Optional[str] = None,
+    client_id: str | None = None,
+    client_secret: str | None = None,
     timeout: float = TOKEN_REQUEST_TIMEOUT_SECONDS,
 ) -> Dict[str, Any]:
     """Refresh the access token."""
@@ -739,9 +739,9 @@ def update_project_ids(project_id: str = "", managed_project_id: str = "") -> No
 
 class _OAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
     expected_state: str = ""
-    captured_code: Optional[str] = None
-    captured_error: Optional[str] = None
-    ready: Optional[threading.Event] = None
+    captured_code: str | None = None
+    captured_error: str | None = None
+    ready: threading.Event | None = None
 
     def log_message(self, format: str, *args: Any) -> None:  # noqa: A002, N802
         logger.debug("OAuth callback: " + format, *args)
@@ -903,7 +903,7 @@ def start_oauth_flow(
         except Exception as exc:
             logger.debug("webbrowser.open failed: %s", exc)
 
-    code: Optional[str] = None
+    code: str | None = None
     try:
         if ready.wait(timeout=callback_wait_seconds):
             code = _OAuthCallbackHandler.captured_code
@@ -983,7 +983,7 @@ def _paste_mode_login(
     return _persist_token_response(token_resp, project_id=project_id)
 
 
-def _prompt_paste_fallback() -> Optional[str]:
+def _prompt_paste_fallback() -> str | None:
     print()
     print("Paste the full redirect URL Google showed you, OR just the 'code=' parameter value.")
     raw = input("Callback URL or code: ").strip()

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -120,7 +120,7 @@ class ImageGenProvider(abc.ABC):
             "env_vars": [],
         }
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         """Return the default model id, or None if not applicable."""
         models = self.list_models()
         if models:
@@ -148,7 +148,7 @@ class ImageGenProvider(abc.ABC):
 # ---------------------------------------------------------------------------
 
 
-def resolve_aspect_ratio(value: Optional[str]) -> str:
+def resolve_aspect_ratio(value: str | None) -> str:
     """Clamp an aspect_ratio value to the valid set, defaulting to landscape.
 
     Invalid values are coerced rather than rejected so the tool surface is
@@ -280,7 +280,7 @@ def success_response(
     prompt: str,
     aspect_ratio: str,
     provider: str,
-    extra: Optional[Dict[str, Any]] = None,
+    extra: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Build a uniform success response dict.
 

--- a/agent/image_gen_registry.py
+++ b/agent/image_gen_registry.py
@@ -64,7 +64,7 @@ def list_providers() -> List[ImageGenProvider]:
     return sorted(items, key=lambda p: p.name)
 
 
-def get_provider(name: str) -> Optional[ImageGenProvider]:
+def get_provider(name: str) -> ImageGenProvider | None:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
@@ -72,7 +72,7 @@ def get_provider(name: str) -> Optional[ImageGenProvider]:
         return _providers.get(name.strip())
 
 
-def get_active_provider() -> Optional[ImageGenProvider]:
+def get_active_provider() -> ImageGenProvider | None:
     """Resolve the currently-active provider.
 
     Reads ``image_gen.provider`` from config.yaml; falls back per the
@@ -89,7 +89,7 @@ def get_active_provider() -> Optional[ImageGenProvider]:
       ``is_available()`` so we don't pick a provider the user has no
       credentials for.
     """
-    configured: Optional[str] = None
+    configured: str | None = None
     try:
         from hermes_cli.config import load_config
 

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -58,7 +58,7 @@ _TRUE_TOKENS = frozenset({"true", "yes", "on", "1"})
 _FALSE_TOKENS = frozenset({"false", "no", "off", "0"})
 
 
-def _coerce_capability_bool(raw: Any) -> Optional[bool]:
+def _coerce_capability_bool(raw: Any) -> bool | None:
     """Return True/False for recognised boolean values, None otherwise."""
     if isinstance(raw, bool):
         return raw
@@ -76,10 +76,10 @@ def _coerce_capability_bool(raw: Any) -> Optional[bool]:
 
 
 def _supports_vision_override(
-    cfg: Optional[Dict[str, Any]],
+    cfg: Dict[str, Any] | None,
     provider: str,
     model: str,
-) -> Optional[bool]:
+) -> bool | None:
     """Resolve user-declared vision capability from config.yaml.
 
     Resolution order, first hit wins:
@@ -134,7 +134,7 @@ def _coerce_mode(raw: Any) -> str:
     return "auto"
 
 
-def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
+def _explicit_aux_vision_override(cfg: Dict[str, Any] | None) -> bool:
     """True when the user configured a specific auxiliary vision backend.
 
     An explicit override means the user *wants* the text pipeline (they're
@@ -162,8 +162,8 @@ def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
 def _lookup_supports_vision(
     provider: str,
     model: str,
-    cfg: Optional[Dict[str, Any]] = None,
-) -> Optional[bool]:
+    cfg: Dict[str, Any] | None = None,
+) -> bool | None:
     """Return True/False if we can resolve caps, None if unknown.
 
     Consults the user's ``supports_vision`` override in config.yaml first
@@ -189,7 +189,7 @@ def _lookup_supports_vision(
 def decide_image_input_mode(
     provider: str,
     model: str,
-    cfg: Optional[Dict[str, Any]],
+    cfg: Dict[str, Any] | None,
 ) -> str:
     """Return ``"native"`` or ``"text"`` for the given turn.
 
@@ -234,7 +234,7 @@ def decide_image_input_mode(
 # it fires, which is cheaper than permanent quality loss.
 
 
-def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
+def _sniff_mime_from_bytes(raw: bytes) -> str | None:
     """Detect image MIME from magic bytes. Returns None if unrecognised.
 
     Filename-based detection (``mimetypes.guess_type``) is unreliable when
@@ -269,7 +269,7 @@ def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     return None
 
 
-def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
+def _guess_mime(path: Path, raw: bytes | None = None) -> str:
     """Return image MIME type for *path*.
 
     If *raw* bytes are provided, magic-byte sniffing wins (authoritative).
@@ -295,7 +295,7 @@ def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
     }.get(suffix, "image/jpeg")
 
 
-def _file_to_data_url(path: Path) -> Optional[str]:
+def _file_to_data_url(path: Path) -> str | None:
     """Encode a local image as a base64 data URL at its native size.
 
     Size limits are NOT enforced here — the agent retry loop

--- a/agent/lmstudio_reasoning.py
+++ b/agent/lmstudio_reasoning.py
@@ -22,9 +22,9 @@ _LM_EFFORT_ALIASES = {"off": "none", "on": "medium"}
 
 
 def resolve_lmstudio_effort(
-    reasoning_config: Optional[dict],
-    allowed_options: Optional[List[str]],
-) -> Optional[str]:
+    reasoning_config: dict | None,
+    allowed_options: List[str] | None,
+) -> str | None:
     """Return the ``reasoning_effort`` string to send to LM Studio, or ``None``.
 
     ``None`` means "omit the field": the user picked a level the model can't

--- a/agent/lsp/__init__.py
+++ b/agent/lsp/__init__.py
@@ -37,12 +37,12 @@ from agent.lsp.manager import LSPService
 
 logger = logging.getLogger("agent.lsp")
 
-_service: Optional[LSPService] = None
+_service: LSPService | None = None
 _atexit_registered = False
 _service_lock = threading.Lock()
 
 
-def get_service() -> Optional[LSPService]:
+def get_service() -> LSPService | None:
     """Return the process-wide LSP service singleton, or None when disabled.
 
     The service is created lazily on first call.  ``None`` is returned

--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -146,9 +146,9 @@ class LSPClient:
         server_id: str,
         workspace_root: str,
         command: List[str],
-        env: Optional[Dict[str, str]] = None,
-        cwd: Optional[str] = None,
-        initialization_options: Optional[Dict[str, Any]] = None,
+        env: Dict[str, str] | None = None,
+        cwd: str | None = None,
+        initialization_options: Dict[str, Any] | None = None,
         seed_diagnostics_on_first_push: bool = False,
     ) -> None:
         self.server_id = server_id
@@ -160,9 +160,9 @@ class LSPClient:
         self._seed_first_push = seed_diagnostics_on_first_push
 
         # Process + streams
-        self._proc: Optional[asyncio.subprocess.Process] = None
-        self._stderr_task: Optional[asyncio.Task] = None
-        self._reader_task: Optional[asyncio.Task] = None
+        self._proc: asyncio.subprocess.Process | None = None
+        self._stderr_task: asyncio.Task | None = None
+        self._reader_task: asyncio.Task | None = None
 
         # Request/response correlation
         self._next_id: int = 0
@@ -202,7 +202,7 @@ class LSPClient:
 
         # State machine
         self._state: str = "stopped"
-        self._initialize_result: Optional[Dict[str, Any]] = None
+        self._initialize_result: Dict[str, Any] | None = None
         self._sync_kind: int = 1  # 1=Full, 2=Incremental
         self._stopping: bool = False
 

--- a/agent/lsp/install.py
+++ b/agent/lsp/install.py
@@ -106,7 +106,7 @@ INSTALL_RECIPES: Dict[str, Dict[str, Any]] = {
 
 
 _install_locks: Dict[str, threading.Lock] = {}
-_install_results: Dict[str, Optional[str]] = {}
+_install_results: Dict[str, str | None] = {}
 _install_lock_meta = threading.Lock()
 
 
@@ -120,7 +120,7 @@ def hermes_lsp_bin_dir() -> Path:
     return p
 
 
-def _existing_binary(name: str) -> Optional[str]:
+def _existing_binary(name: str) -> str | None:
     """Probe the staging dir + PATH for a binary named ``name``."""
     staged = hermes_lsp_bin_dir() / name
     if staged.exists() and os.access(staged, os.X_OK):
@@ -140,7 +140,7 @@ def _get_lock(pkg: str) -> threading.Lock:
         return lock
 
 
-def try_install(pkg: str, strategy: str = "auto") -> Optional[str]:
+def try_install(pkg: str, strategy: str = "auto") -> str | None:
     """Try to install ``pkg`` and return the binary path if successful.
 
     ``strategy`` is ``"auto"``, ``"manual"``, or ``"off"``.  In
@@ -171,7 +171,7 @@ def try_install(pkg: str, strategy: str = "auto") -> Optional[str]:
         return result
 
 
-def _do_install(pkg: str) -> Optional[str]:
+def _do_install(pkg: str) -> str | None:
     recipe = INSTALL_RECIPES.get(pkg)
     if recipe is None:
         # Not in our registry — best-effort: just probe PATH.
@@ -207,8 +207,8 @@ def _do_install(pkg: str) -> Optional[str]:
 def _install_npm(
     pkg: str,
     bin_name: str,
-    extra_pkgs: Optional[list] = None,
-) -> Optional[str]:
+    extra_pkgs: list | None = None,
+) -> str | None:
     """Install an npm package into our staging dir.
 
     Uses ``npm install --prefix`` so the binaries land in
@@ -273,7 +273,7 @@ def _install_npm(
     return None
 
 
-def _install_go(pkg: str, bin_name: str) -> Optional[str]:
+def _install_go(pkg: str, bin_name: str) -> str | None:
     """Install a Go module to GOBIN=<staging>."""
     go = shutil.which("go")
     if go is None:
@@ -309,7 +309,7 @@ def _install_go(pkg: str, bin_name: str) -> Optional[str]:
     return None
 
 
-def _install_pip(pkg: str, bin_name: str) -> Optional[str]:
+def _install_pip(pkg: str, bin_name: str) -> str | None:
     """Install a Python package into a hermes-owned target dir.
 
     We avoid polluting the user's site-packages by using

--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -74,8 +74,8 @@ class _BackgroundLoop:
     """
 
     def __init__(self) -> None:
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._thread: Optional[threading.Thread] = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
         self._ready = threading.Event()
 
     def start(self) -> None:
@@ -102,7 +102,7 @@ class _BackgroundLoop:
             except Exception:  # noqa: BLE001
                 pass
 
-    def run(self, coro, *, timeout: Optional[float] = None) -> Any:
+    def run(self, coro, *, timeout: float | None = None) -> Any:
         """Submit a coroutine to the loop and block until done.
 
         Returns the coroutine's result, or raises its exception.
@@ -155,10 +155,10 @@ class LSPService:
         wait_mode: str,
         wait_timeout: float,
         install_strategy: str,
-        binary_overrides: Optional[Dict[str, List[str]]] = None,
-        env_overrides: Optional[Dict[str, Dict[str, str]]] = None,
-        init_overrides: Optional[Dict[str, Dict[str, Any]]] = None,
-        disabled_servers: Optional[List[str]] = None,
+        binary_overrides: Dict[str, List[str]] | None = None,
+        env_overrides: Dict[str, Dict[str, str]] | None = None,
+        init_overrides: Dict[str, Dict[str, Any]] | None = None,
+        disabled_servers: List[str] | None = None,
         idle_timeout: float = DEFAULT_IDLE_TIMEOUT,
     ) -> None:
         self._enabled = enabled
@@ -189,7 +189,7 @@ class LSPService:
         self._delta_baseline: Dict[str, List[Dict[str, Any]]] = {}
 
     @classmethod
-    def create_from_config(cls) -> Optional["LSPService"]:
+    def create_from_config(cls) -> "LSPService" | None:
         """Build a service from ``hermes_cli.config`` settings.
 
         Returns ``None`` if the config can't be loaded.  The service
@@ -309,8 +309,8 @@ class LSPService:
         file_path: str,
         *,
         delta: bool = True,
-        timeout: Optional[float] = None,
-        line_shift: Optional[Callable[[int], Optional[int]]] = None,
+        timeout: float | None = None,
+        line_shift: Callable[[int], int | None] | None = None,
     ) -> List[Dict[str, Any]]:
         """Synchronously open ``file_path`` in the right server, wait for
         diagnostics, return them.
@@ -489,7 +489,7 @@ class LSPService:
             return []
         return list(client.diagnostics_for(file_path))
 
-    async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:
+    async def _get_or_spawn(self, file_path: str) -> LSPClient | None:
         srv = find_server_for_file(file_path)
         if srv is None:
             return None

--- a/agent/lsp/protocol.py
+++ b/agent/lsp/protocol.py
@@ -63,7 +63,7 @@ def encode_message(obj: dict) -> bytes:
     return header + body
 
 
-async def read_message(reader: asyncio.StreamReader) -> Optional[dict]:
+async def read_message(reader: asyncio.StreamReader) -> dict | None:
     """Read one Content-Length framed JSON-RPC message from the stream.
 
     Returns ``None`` on clean EOF (server closed stdout cleanly between

--- a/agent/lsp/range_shift.py
+++ b/agent/lsp/range_shift.py
@@ -30,7 +30,7 @@ import difflib
 from typing import Any, Callable, Dict, List, Optional
 
 
-def build_line_shift(pre_text: str, post_text: str) -> Callable[[int], Optional[int]]:
+def build_line_shift(pre_text: str, post_text: str) -> Callable[[int], int | None]:
     """Build a function mapping pre-edit line numbers to post-edit line numbers.
 
     Lines are 0-indexed to match the LSP wire format
@@ -61,7 +61,7 @@ def build_line_shift(pre_text: str, post_text: str) -> Callable[[int], Optional[
     sm = difflib.SequenceMatcher(a=pre_lines, b=post_lines, autojunk=False)
     opcodes = sm.get_opcodes()
 
-    def shift(line: int) -> Optional[int]:
+    def shift(line: int) -> int | None:
         # Find the opcode region whose i1 <= line < i2.
         # Linear scan is fine — typical opcode count is small (single
         # digits for a typical patch-tool edit).
@@ -89,7 +89,7 @@ def build_line_shift(pre_text: str, post_text: str) -> Callable[[int], Optional[
 
 
 def shift_diagnostic_range(diag: Dict[str, Any],
-                           shift: Callable[[int], Optional[int]]) -> Optional[Dict[str, Any]]:
+                           shift: Callable[[int], int | None]) -> Dict[str, Any] | None:
     """Return a copy of ``diag`` with its line range remapped through ``shift``.
 
     Returns ``None`` if the diagnostic's start line maps to ``None``
@@ -134,7 +134,7 @@ def shift_diagnostic_range(diag: Dict[str, Any],
 
 
 def shift_baseline(baseline: List[Dict[str, Any]],
-                   shift: Callable[[int], Optional[int]]) -> List[Dict[str, Any]]:
+                   shift: Callable[[int], int | None]) -> List[Dict[str, Any]]:
     """Apply ``shift`` to every diagnostic in ``baseline``, dropping deleted entries."""
     out: List[Dict[str, Any]] = []
     for d in baseline:

--- a/agent/lsp/servers.py
+++ b/agent/lsp/servers.py
@@ -139,8 +139,8 @@ class ServerDef:
 
     server_id: str
     extensions: Tuple[str, ...]
-    resolve_root: Callable[[str, str], Optional[str]]
-    build_spawn: Callable[[str, "ServerContext"], Optional[SpawnSpec]]
+    resolve_root: Callable[[str, str], str | None]
+    build_spawn: Callable[[str, "ServerContext"], SpawnSpec | None]
     seed_first_push: bool = False
     description: str = ""
 
@@ -185,7 +185,7 @@ def _file_ext_or_basename(path: str) -> str:
     return base
 
 
-def _which(*names: str) -> Optional[str]:
+def _which(*names: str) -> str | None:
     """Return the full path of the first command found on PATH."""
     for n in names:
         path = shutil.which(n)
@@ -194,7 +194,7 @@ def _which(*names: str) -> Optional[str]:
     return None
 
 
-def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], excludes: Sequence[str] = ()) -> Optional[str]:
+def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], excludes: Sequence[str] = ()) -> str | None:
     """Common pattern: try ``nearest_root``, fall back to workspace root.
 
     Returns ``None`` if an exclude marker matches first (server gated off).
@@ -226,7 +226,7 @@ def _root_or_workspace(file_path: str, workspace: str, markers: Sequence[str], e
 # ---------------------------------------------------------------------------
 
 
-def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_pyright(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "pyright") or _which(
         "pyright-langserver", "pyright"
     )
@@ -258,7 +258,7 @@ def _spawn_pyright(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _detect_python(root: str) -> Optional[str]:
+def _detect_python(root: str) -> str | None:
     candidates = []
     if os.environ.get("VIRTUAL_ENV"):
         candidates.append(os.environ["VIRTUAL_ENV"])
@@ -271,7 +271,7 @@ def _detect_python(root: str) -> Optional[str]:
     return None
 
 
-def _spawn_typescript(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_typescript(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "typescript") or _which("typescript-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -288,7 +288,7 @@ def _spawn_typescript(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_gopls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_gopls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "gopls") or _which("gopls")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -304,7 +304,7 @@ def _spawn_gopls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_rust_analyzer(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_rust_analyzer(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "rust-analyzer") or _which("rust-analyzer")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -320,7 +320,7 @@ def _spawn_rust_analyzer(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_clangd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_clangd(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "clangd") or _which("clangd")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -339,7 +339,7 @@ def _spawn_clangd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
 _BASH_SHELLCHECK_WARNED = False
 
 
-def _spawn_bash_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_bash_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "bash-language-server") or _which("bash-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -367,7 +367,7 @@ def _spawn_bash_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_yaml_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_yaml_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "yaml-language-server") or _which("yaml-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -383,7 +383,7 @@ def _spawn_yaml_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_lua_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_lua_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "lua-language-server") or _which("lua-language-server")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -399,7 +399,7 @@ def _spawn_lua_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_intelephense(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "intelephense") or _which("intelephense")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -417,7 +417,7 @@ def _spawn_intelephense(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_ocamllsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_ocamllsp(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "ocaml-lsp") or _which("ocamllsp")
     if bin_path is None:
         return None
@@ -430,7 +430,7 @@ def _spawn_ocamllsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_dockerfile_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_dockerfile_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "dockerfile-ls") or _which("docker-langserver")
     if bin_path is None:
         from agent.lsp.install import try_install
@@ -446,7 +446,7 @@ def _spawn_dockerfile_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_terraform_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_terraform_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "terraform-ls") or _which("terraform-ls")
     if bin_path is None:
         return None  # terraform-ls is heavy to auto-install; require user
@@ -466,7 +466,7 @@ def _spawn_terraform_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_dart(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_dart(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "dart") or _which("dart")
     if bin_path is None:
         return None
@@ -479,7 +479,7 @@ def _spawn_dart(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_haskell_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_haskell_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "haskell-language-server") or _which(
         "haskell-language-server-wrapper", "haskell-language-server"
     )
@@ -494,7 +494,7 @@ def _spawn_haskell_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_julia(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_julia(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "julia") or _which("julia")
     if bin_path is None:
         return None
@@ -513,7 +513,7 @@ def _spawn_julia(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_clojure_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_clojure_lsp(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "clojure-lsp") or _which("clojure-lsp")
     if bin_path is None:
         return None
@@ -526,7 +526,7 @@ def _spawn_clojure_lsp(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_nixd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_nixd(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "nixd") or _which("nixd")
     if bin_path is None:
         return None
@@ -539,7 +539,7 @@ def _spawn_nixd(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_zls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_zls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "zls") or _which("zls")
     if bin_path is None:
         return None
@@ -552,7 +552,7 @@ def _spawn_zls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_gleam(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_gleam(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "gleam") or _which("gleam")
     if bin_path is None:
         return None
@@ -565,7 +565,7 @@ def _spawn_gleam(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_elixir_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_elixir_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "elixir-ls") or _which("elixir-ls", "language_server.sh")
     if bin_path is None:
         return None
@@ -578,7 +578,7 @@ def _spawn_elixir_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_prisma(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_prisma(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "prisma") or _which("prisma")
     if bin_path is None:
         return None
@@ -591,7 +591,7 @@ def _spawn_prisma(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_kotlin_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_kotlin_ls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "kotlin-language-server") or _which(
         "kotlin-language-server"
     )
@@ -606,7 +606,7 @@ def _spawn_kotlin_ls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_jdtls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_jdtls(root: str, ctx: ServerContext) -> SpawnSpec | None:
     # jdtls has a complex install flow.  We require a manual install
     # for now and look for the wrapper script that the jdtls install
     # produces.
@@ -622,7 +622,7 @@ def _spawn_jdtls(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_vue(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_vue(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "vue-language-server") or _which(
         "vue-language-server"
     )
@@ -640,7 +640,7 @@ def _spawn_vue(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_svelte(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_svelte(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "svelte-language-server") or _which(
         "svelteserver", "svelte-language-server"
     )
@@ -658,7 +658,7 @@ def _spawn_svelte(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _spawn_astro(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
+def _spawn_astro(root: str, ctx: ServerContext) -> SpawnSpec | None:
     bin_path = _resolve_override(ctx, "astro-language-server") or _which(
         "astro-ls", "astro-language-server"
     )
@@ -676,7 +676,7 @@ def _spawn_astro(root: str, ctx: ServerContext) -> Optional[SpawnSpec]:
     )
 
 
-def _resolve_override(ctx: ServerContext, server_id: str) -> Optional[str]:
+def _resolve_override(ctx: ServerContext, server_id: str) -> str | None:
     """User can pin a binary path in config."""
     override = ctx.binary_overrides.get(server_id)
     if override and override[0] and os.path.exists(override[0]):
@@ -689,7 +689,7 @@ def _resolve_override(ctx: ServerContext, server_id: str) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
-def _root_python(file_path: str, workspace: str) -> Optional[str]:
+def _root_python(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path,
         workspace,
@@ -697,7 +697,7 @@ def _root_python(file_path: str, workspace: str) -> Optional[str]:
     )
 
 
-def _root_typescript(file_path: str, workspace: str) -> Optional[str]:
+def _root_typescript(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path,
         workspace,
@@ -714,7 +714,7 @@ def _root_typescript(file_path: str, workspace: str) -> Optional[str]:
     )
 
 
-def _root_go(file_path: str, workspace: str) -> Optional[str]:
+def _root_go(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path,
         workspace,
@@ -722,15 +722,15 @@ def _root_go(file_path: str, workspace: str) -> Optional[str]:
     )
 
 
-def _root_rust(file_path: str, workspace: str) -> Optional[str]:
+def _root_rust(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["Cargo.toml", "Cargo.lock"])
 
 
-def _root_ruby(file_path: str, workspace: str) -> Optional[str]:
+def _root_ruby(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["Gemfile"])
 
 
-def _root_clangd(file_path: str, workspace: str) -> Optional[str]:
+def _root_clangd(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path,
         workspace,
@@ -746,7 +746,7 @@ def _root_yaml(file_path: str, workspace: str) -> str:
     return workspace
 
 
-def _root_lua(file_path: str, workspace: str) -> Optional[str]:
+def _root_lua(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path,
         workspace,
@@ -754,11 +754,11 @@ def _root_lua(file_path: str, workspace: str) -> Optional[str]:
     )
 
 
-def _root_php(file_path: str, workspace: str) -> Optional[str]:
+def _root_php(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["composer.json", "composer.lock", ".php-version"])
 
 
-def _root_ocaml(file_path: str, workspace: str) -> Optional[str]:
+def _root_ocaml(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["dune-project", "dune-workspace", ".merlin", "opam"])
 
 
@@ -766,23 +766,23 @@ def _root_docker(file_path: str, workspace: str) -> str:
     return workspace
 
 
-def _root_terraform(file_path: str, workspace: str) -> Optional[str]:
+def _root_terraform(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, [".terraform.lock.hcl", "terraform.tfstate"])
 
 
-def _root_dart(file_path: str, workspace: str) -> Optional[str]:
+def _root_dart(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["pubspec.yaml", "analysis_options.yaml"])
 
 
-def _root_haskell(file_path: str, workspace: str) -> Optional[str]:
+def _root_haskell(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["stack.yaml", "cabal.project", "hie.yaml"])
 
 
-def _root_julia(file_path: str, workspace: str) -> Optional[str]:
+def _root_julia(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["Project.toml", "Manifest.toml"])
 
 
-def _root_clojure(file_path: str, workspace: str) -> Optional[str]:
+def _root_clojure(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path, workspace, ["deps.edn", "project.clj", "shadow-cljs.edn", "bb.edn", "build.boot"]
     )
@@ -793,21 +793,21 @@ def _root_nix(file_path: str, workspace: str) -> str:
     return found or workspace
 
 
-def _root_zig(file_path: str, workspace: str) -> Optional[str]:
+def _root_zig(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["build.zig"])
 
 
-def _root_elixir(file_path: str, workspace: str) -> Optional[str]:
+def _root_elixir(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(file_path, workspace, ["mix.exs", "mix.lock"])
 
 
-def _root_prisma(file_path: str, workspace: str) -> Optional[str]:
+def _root_prisma(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path, workspace, ["schema.prisma", "prisma/schema.prisma"]
     )
 
 
-def _root_kotlin(file_path: str, workspace: str) -> Optional[str]:
+def _root_kotlin(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path,
         workspace,
@@ -815,7 +815,7 @@ def _root_kotlin(file_path: str, workspace: str) -> Optional[str]:
     )
 
 
-def _root_java(file_path: str, workspace: str) -> Optional[str]:
+def _root_java(file_path: str, workspace: str) -> str | None:
     return _root_or_workspace(
         file_path,
         workspace,
@@ -1015,7 +1015,7 @@ SERVERS: List[ServerDef] = [
 ]
 
 
-def find_server_for_file(file_path: str) -> Optional[ServerDef]:
+def find_server_for_file(file_path: str) -> ServerDef | None:
     """Return the registry entry that handles ``file_path``, or None."""
     for srv in SERVERS:
         if srv.matches(file_path):

--- a/agent/lsp/workspace.py
+++ b/agent/lsp/workspace.py
@@ -41,7 +41,7 @@ def normalize_path(path: str) -> str:
     return os.path.abspath(os.path.expanduser(path))
 
 
-def find_git_worktree(start: str) -> Optional[str]:
+def find_git_worktree(start: str) -> str | None:
     """Walk up from ``start`` looking for a ``.git`` entry (file or dir).
 
     Returns the directory containing ``.git``, or ``None`` if no git
@@ -114,9 +114,9 @@ def nearest_root(
     start: str,
     markers: Iterable[str],
     *,
-    excludes: Optional[Iterable[str]] = None,
-    ceiling: Optional[str] = None,
-) -> Optional[str]:
+    excludes: Iterable[str] | None = None,
+    ceiling: str | None = None,
+) -> str | None:
     """Walk up from ``start`` looking for any of the given marker files.
 
     Returns the **directory containing** the first matched marker, or
@@ -173,8 +173,8 @@ def nearest_root(
 def resolve_workspace_for_file(
     file_path: str,
     *,
-    cwd: Optional[str] = None,
-) -> Tuple[Optional[str], bool]:
+    cwd: str | None = None,
+) -> Tuple[str | None, bool]:
     """Resolve the workspace root for a file.
 
     Returns ``(workspace_root, gated_in)`` where ``gated_in`` is True

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -306,7 +306,7 @@ class MemoryManager:
         """All registered providers in order."""
         return list(self._providers)
 
-    def get_provider(self, name: str) -> Optional[MemoryProvider]:
+    def get_provider(self, name: str) -> MemoryProvider | None:
         """Get a provider by name, or None if not registered."""
         for p in self._providers:
             if p.name == name:
@@ -539,7 +539,7 @@ class MemoryManager:
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> None:
         """Notify external providers when the built-in memory tool writes.
 

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -264,7 +264,7 @@ class MemoryProvider(ABC):
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> None:
         """Called when the built-in memory tool writes an entry.
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -390,7 +390,7 @@ except Exception:
     pass
 
 
-def _infer_provider_from_url(base_url: str) -> Optional[str]:
+def _infer_provider_from_url(base_url: str) -> str | None:
     """Infer the models.dev provider name from a base URL.
 
     This allows context length resolution via models.dev for custom endpoints
@@ -464,7 +464,7 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
-def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
+def detect_local_server_type(base_url: str, api_key: str = "") -> str | None:
     """Detect which local server is running at base_url by probing known endpoints.
 
     Returns one of: "ollama", "lm-studio", "vllm", "llamacpp", or None.
@@ -535,7 +535,7 @@ def _iter_nested_dicts(value: Any):
             yield from _iter_nested_dicts(item)
 
 
-def _coerce_reasonable_int(value: Any, minimum: int = 1024, maximum: int = 10_000_000) -> Optional[int]:
+def _coerce_reasonable_int(value: Any, minimum: int = 1024, maximum: int = 10_000_000) -> int | None:
     try:
         if isinstance(value, bool):
             return None
@@ -549,7 +549,7 @@ def _coerce_reasonable_int(value: Any, minimum: int = 1024, maximum: int = 10_00
     return None
 
 
-def _extract_first_int(payload: Dict[str, Any], keys: tuple[str, ...]) -> Optional[int]:
+def _extract_first_int(payload: Dict[str, Any], keys: tuple[str, ...]) -> int | None:
     keyset = {key.lower() for key in keys}
     for mapping in _iter_nested_dicts(payload):
         for key, value in mapping.items():
@@ -561,11 +561,11 @@ def _extract_first_int(payload: Dict[str, Any], keys: tuple[str, ...]) -> Option
     return None
 
 
-def _extract_context_length(payload: Dict[str, Any]) -> Optional[int]:
+def _extract_context_length(payload: Dict[str, Any]) -> int | None:
     return _extract_first_int(payload, _CONTEXT_LENGTH_KEYS)
 
 
-def _extract_max_completion_tokens(payload: Dict[str, Any]) -> Optional[int]:
+def _extract_max_completion_tokens(payload: Dict[str, Any]) -> int | None:
     return _extract_first_int(payload, _MAX_COMPLETION_KEYS)
 
 
@@ -674,7 +674,7 @@ def fetch_endpoint_model_metadata(
         candidates.append(alternate)
 
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
-    last_error: Optional[Exception] = None
+    last_error: Exception | None = None
 
     if is_local_endpoint(normalized):
         try:
@@ -793,7 +793,7 @@ def _resolve_endpoint_context_length(
     model: str,
     base_url: str,
     api_key: str = "",
-) -> Optional[int]:
+) -> int | None:
     """Resolve context length from an endpoint's live ``/models`` metadata."""
     endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
     matched = endpoint_metadata.get(model)
@@ -853,7 +853,7 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
         logger.debug("Failed to save context length cache: %s", e)
 
 
-def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
+def get_cached_context_length(model: str, base_url: str) -> int | None:
     """Look up a previously discovered context length for model+provider."""
     key = f"{model}@{base_url}"
     cache = _load_context_cache()
@@ -876,7 +876,7 @@ def _invalidate_cached_context_length(model: str, base_url: str) -> None:
         logger.debug("Failed to invalidate context length cache entry %s: %s", key, e)
 
 
-def get_next_probe_tier(current_length: int) -> Optional[int]:
+def get_next_probe_tier(current_length: int) -> int | None:
     """Return the next lower probe tier, or None if already at minimum."""
     for tier in CONTEXT_PROBE_TIERS:
         if tier < current_length:
@@ -884,7 +884,7 @@ def get_next_probe_tier(current_length: int) -> Optional[int]:
     return None
 
 
-def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
+def parse_context_limit_from_error(error_msg: str) -> int | None:
     """Try to extract the actual context limit from an API error message.
 
     Many providers include the limit in their error text, e.g.:
@@ -912,7 +912,7 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     return None
 
 
-def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
+def parse_available_output_tokens_from_error(error_msg: str) -> int | None:
     """Detect an "output cap too large" error and return how many output tokens are available.
 
     Background — two distinct context errors exist:
@@ -974,7 +974,7 @@ def _model_id_matches(candidate_id: str, lookup_model: str) -> bool:
     return False
 
 
-def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Optional[int]:
+def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> int | None:
     """Query an Ollama server for the model's context length.
 
     Returns the model's maximum context from GGUF metadata via ``/api/show``,
@@ -1029,7 +1029,7 @@ def query_ollama_num_ctx(model: str, base_url: str, api_key: str = "") -> Option
     return None
 
 
-def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> Optional[int]:
+def _query_ollama_api_show(model: str, base_url: str, api_key: str = "") -> int | None:
     """Query an Ollama server's native ``/api/show`` for context length.
 
     Provider-agnostic: works against ANY Ollama-compatible server regardless
@@ -1102,7 +1102,7 @@ def _model_name_suggests_kimi(model: str) -> bool:
     return lower.startswith("kimi") or "moonshot" in lower
 
 
-def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> Optional[int]:
+def _query_local_context_length(model: str, base_url: str, api_key: str = "") -> int | None:
     """Query a local server for the model's context length."""
     import httpx
 
@@ -1206,7 +1206,7 @@ def _normalize_model_version(model: str) -> str:
     return model.replace(".", "-")
 
 
-def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> Optional[int]:
+def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> int | None:
     """Query Anthropic's /v1/models endpoint for context length.
 
     Only works with regular ANTHROPIC_API_KEY (sk-ant-api*).
@@ -1322,7 +1322,7 @@ def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
 
 def _resolve_codex_oauth_context_length(
     model: str, access_token: str = ""
-) -> Optional[int]:
+) -> int | None:
     """Resolve a Codex OAuth model's real context window.
 
     Prefers a live probe of chatgpt.com/backend-api/codex/models (when we
@@ -1357,7 +1357,7 @@ def _resolve_nous_context_length(
     model: str,
     base_url: str = "",
     api_key: str = "",
-) -> Tuple[Optional[int], str]:
+) -> Tuple[int | None, str]:
     """Resolve Nous Portal model context length.
 
     Tries the live Nous inference endpoint first (authoritative), then falls
@@ -1386,7 +1386,7 @@ def _resolve_nous_context_length(
 
     metadata = fetch_model_metadata()
 
-    def _safe_ctx(or_id: str, entry: dict) -> Optional[int]:
+    def _safe_ctx(or_id: str, entry: dict) -> int | None:
         ctx = entry.get("context_length")
         if ctx is None:
             return None
@@ -1808,7 +1808,7 @@ def estimate_request_tokens_rough(
     messages: List[Dict[str, Any]],
     *,
     system_prompt: str = "",
-    tools: Optional[List[Dict[str, Any]]] = None,
+    tools: List[Dict[str, Any]] | None = None,
 ) -> int:
     """Rough token estimate for a full chat-completions request.
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -67,13 +67,13 @@ class ModelInfo:
     # Limits
     context_window: int = 0
     max_output: int = 0
-    max_input: Optional[int] = None
+    max_input: int | None = None
 
     # Cost (per million tokens, USD)
     cost_input: float = 0.0
     cost_output: float = 0.0
-    cost_cache_read: Optional[float] = None
-    cost_cache_write: Optional[float] = None
+    cost_cache_read: float | None = None
+    cost_cache_write: float | None = None
 
     # Metadata
     knowledge_cutoff: str = ""
@@ -181,7 +181,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
 }
 
 # Reverse mapping: models.dev → Hermes (built lazily)
-_MODELS_DEV_TO_PROVIDER: Optional[Dict[str, str]] = None
+_MODELS_DEV_TO_PROVIDER: Dict[str, str] | None = None
 
 
 
@@ -203,7 +203,7 @@ def _load_disk_cache() -> Dict[str, Any]:
     return {}
 
 
-def _disk_cache_age_seconds() -> Optional[float]:
+def _disk_cache_age_seconds() -> float | None:
     """Return age (in seconds) of the disk cache file, or None if missing.
 
     Used by ``fetch_models_dev`` to short-circuit the network probe when
@@ -319,7 +319,7 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
     return _models_dev_cache
 
 
-def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
+def lookup_models_dev_context(provider: str, model: str) -> int | None:
     """Look up context_length for a provider+model combo in models.dev.
 
     Returns the context window in tokens, or None if not found.
@@ -378,7 +378,7 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     return None
 
 
-def _extract_context(entry: Dict[str, Any]) -> Optional[int]:
+def _extract_context(entry: Dict[str, Any]) -> int | None:
     """Extract context_length from a models.dev model entry.
 
     Returns None for invalid/zero values (some audio/image models have context=0).
@@ -411,7 +411,7 @@ class ModelCapabilities:
     model_family: str = ""
 
 
-def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
+def _get_provider_models(provider: str) -> Dict[str, Any] | None:
     """Resolve a Hermes provider ID to its models dict from models.dev.
 
     Returns the models dict or None if the provider is unknown or has no data.
@@ -432,7 +432,7 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
     return models
 
 
-def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
+def _find_model_entry(models: Dict[str, Any], model: str) -> Dict[str, Any] | None:
     """Find a model entry by exact match, then case-insensitive fallback."""
     # Exact match
     entry = models.get(model)
@@ -448,7 +448,7 @@ def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, 
     return None
 
 
-def get_model_capabilities(provider: str, model: str) -> Optional[ModelCapabilities]:
+def get_model_capabilities(provider: str, model: str) -> ModelCapabilities | None:
     """Look up full capability metadata from models.dev cache.
 
     Uses the existing fetch_models_dev() and PROVIDER_TO_MODELS_DEV mapping.
@@ -672,7 +672,7 @@ def _parse_provider_info(provider_id: str, raw: Dict[str, Any]) -> ProviderInfo:
 # Provider-level queries
 # ---------------------------------------------------------------------------
 
-def get_provider_info(provider_id: str) -> Optional[ProviderInfo]:
+def get_provider_info(provider_id: str) -> ProviderInfo | None:
     """Get full provider metadata from models.dev.
 
     Accepts either a Hermes provider ID (e.g. "kilocode") or a models.dev
@@ -695,7 +695,7 @@ def get_provider_info(provider_id: str) -> Optional[ProviderInfo]:
 
 def get_model_info(
     provider_id: str, model_id: str
-) -> Optional[ModelInfo]:
+) -> ModelInfo | None:
     """Get full model metadata from models.dev.
 
     Accepts Hermes or models.dev provider ID.  Tries exact match then

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -36,7 +36,7 @@ def _state_path() -> str:
     return os.path.join(base, _STATE_SUBDIR, _STATE_FILENAME)
 
 
-def _parse_reset_seconds(headers: Optional[Mapping[str, str]]) -> Optional[float]:
+def _parse_reset_seconds(headers: Mapping[str, str] | None) -> float | None:
     """Extract the best available reset-time estimate from response headers.
 
     Priority:
@@ -70,8 +70,8 @@ def _parse_reset_seconds(headers: Optional[Mapping[str, str]]) -> Optional[float
 
 def record_nous_rate_limit(
     *,
-    headers: Optional[Mapping[str, str]] = None,
-    error_context: Optional[dict[str, Any]] = None,
+    headers: Mapping[str, str] | None = None,
+    error_context: dict[str, Any] | None = None,
     default_cooldown: float = 300.0,
 ) -> None:
     """Record that Nous Portal is rate-limited.
@@ -136,7 +136,7 @@ def record_nous_rate_limit(
         logger.debug("Failed to write Nous rate limit state: %s", exc)
 
 
-def nous_rate_limit_remaining() -> Optional[float]:
+def nous_rate_limit_remaining() -> float | None:
     """Check if Nous Portal is currently rate-limited.
 
     Returns:
@@ -191,8 +191,8 @@ _MIN_RESET_FOR_BREAKER_SECONDS = 60.0
 
 def is_genuine_nous_rate_limit(
     *,
-    headers: Optional[Mapping[str, str]] = None,
-    last_known_state: Optional[Any] = None,
+    headers: Mapping[str, str] | None = None,
+    last_known_state: Any | None = None,
 ) -> bool:
     """Decide whether a 429 from Nous Portal is a real account rate limit.
 
@@ -245,8 +245,8 @@ def is_genuine_nous_rate_limit(
 
 
 def _parse_buckets_from_headers(
-    headers: Optional[Mapping[str, str]],
-) -> dict[str, tuple[Optional[int], Optional[float]]]:
+    headers: Mapping[str, str] | None,
+) -> dict[str, tuple[int | None, float | None]]:
     """Extract (remaining, reset_seconds) per bucket from x-ratelimit-* headers.
 
     Returns empty dict when no rate-limit headers are present.
@@ -258,7 +258,7 @@ def _parse_buckets_from_headers(
     if not any(k.startswith("x-ratelimit-") for k in lowered):
         return {}
 
-    def _maybe_int(raw: Optional[str]) -> Optional[int]:
+    def _maybe_int(raw: str | None) -> int | None:
         if raw is None:
             return None
         try:
@@ -266,7 +266,7 @@ def _parse_buckets_from_headers(
         except (TypeError, ValueError):
             return None
 
-    def _maybe_float(raw: Optional[str]) -> Optional[float]:
+    def _maybe_float(raw: str | None) -> float | None:
         if raw is None:
             return None
         try:
@@ -274,7 +274,7 @@ def _parse_buckets_from_headers(
         except (TypeError, ValueError):
             return None
 
-    result: dict[str, tuple[Optional[int], Optional[float]]] = {}
+    result: dict[str, tuple[int | None, float | None]] = {}
     for tag in ("requests", "requests-1h", "tokens", "tokens-1h"):
         remaining = _maybe_int(lowered.get(f"x-ratelimit-remaining-{tag}"))
         reset = _maybe_float(lowered.get(f"x-ratelimit-reset-{tag}"))
@@ -284,7 +284,7 @@ def _parse_buckets_from_headers(
 
 
 def _has_exhausted_bucket(
-    buckets: Mapping[str, tuple[Optional[int], Optional[float]]],
+    buckets: Mapping[str, tuple[int | None, float | None]],
 ) -> bool:
     """Return True when any bucket has remaining == 0 AND a meaningful reset window."""
     for remaining, reset in buckets.values():

--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -114,7 +114,7 @@ def openclaw_residue_hint_cli() -> str:
     )
 
 
-def detect_openclaw_residue(home: Optional[Path] = None) -> bool:
+def detect_openclaw_residue(home: Path | None = None) -> bool:
     """Return True if an OpenClaw workspace directory is present in ``$HOME``.
 
     Pure filesystem check — no side effects. ``home`` override exists for tests.

--- a/agent/plugin_llm.py
+++ b/agent/plugin_llm.py
@@ -92,8 +92,8 @@ class PluginLlmImageInput:
     providers.
     """
 
-    data: Optional[bytes] = None
-    url: Optional[str] = None
+    data: bytes | None = None
+    url: str | None = None
     mime_type: str = "image/png"
     file_name: str = ""
     type: str = "image"
@@ -121,7 +121,7 @@ class PluginLlmUsage:
     total_tokens: int = 0
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
-    cost_usd: Optional[float] = None
+    cost_usd: float | None = None
 
 
 @dataclass
@@ -150,7 +150,7 @@ class PluginLlmStructuredResult:
     model: str
     agent_id: str
     usage: PluginLlmUsage = field(default_factory=PluginLlmUsage)
-    parsed: Optional[Any] = None
+    parsed: Any | None = None
     content_type: str = "text"
     audit: Dict[str, Any] = field(default_factory=dict)
 
@@ -166,10 +166,10 @@ class _TrustPolicy:
 
     plugin_id: str
     allow_provider_override: bool = False
-    allowed_providers: Optional[frozenset] = None  # None = no allowlist
+    allowed_providers: frozenset | None = None  # None = no allowlist
     allow_any_provider: bool = False  # True when allowed_providers == ["*"]
     allow_model_override: bool = False
-    allowed_models: Optional[frozenset] = None  # None = no allowlist
+    allowed_models: frozenset | None = None  # None = no allowlist
     allow_any_model: bool = False  # True when allowed_models == ["*"]
     allow_agent_id_override: bool = False
     allow_profile_override: bool = False
@@ -180,7 +180,7 @@ def _normalize_ref(raw: str) -> str:
     return (raw or "").strip().lower()
 
 
-def _coerce_allowlist(raw: Any) -> tuple[Optional[frozenset], bool]:
+def _coerce_allowlist(raw: Any) -> tuple[frozenset | None, bool]:
     """Coerce a YAML list into ``(frozenset_or_None, allow_any)``.
 
     ``["*"]`` (or any list containing ``"*"``) → ``(frozenset(), True)``.
@@ -253,11 +253,11 @@ class PluginLlmTrustError(PermissionError):
 def _check_overrides(
     policy: _TrustPolicy,
     *,
-    requested_provider: Optional[str],
-    requested_model: Optional[str],
-    requested_agent_id: Optional[str],
-    requested_profile: Optional[str],
-) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    requested_provider: str | None,
+    requested_model: str | None,
+    requested_agent_id: str | None,
+    requested_profile: str | None,
+) -> tuple[str | None, str | None, str | None, str | None]:
     """Apply the trust gate. Returns the validated overrides as
     ``(provider, model, agent_id, profile)`` or raises
     :class:`PluginLlmTrustError`.
@@ -266,9 +266,9 @@ def _check_overrides(
     is independently gated. ``provider`` and ``model`` each have an
     optional allowlist via ``allowed_providers`` / ``allowed_models``.
     """
-    final_provider: Optional[str] = None
-    final_model: Optional[str] = None
-    final_profile: Optional[str] = None
+    final_provider: str | None = None
+    final_model: str | None = None
+    final_profile: str | None = None
 
     if requested_provider:
         if not policy.allow_provider_override:
@@ -376,9 +376,9 @@ def _build_structured_messages(
     instructions: str,
     inputs: Sequence[PluginLlmInput],
     json_mode: bool,
-    json_schema: Optional[Any],
-    schema_name: Optional[str],
-    system_prompt: Optional[str],
+    json_schema: Any | None,
+    schema_name: str | None,
+    system_prompt: str | None,
 ) -> List[Dict[str, Any]]:
     """Build the OpenAI-style messages list for a structured call.
 
@@ -454,8 +454,8 @@ def _strip_code_fences(text: str) -> str:
 
 
 def _parse_structured_text(
-    *, text: str, json_mode: bool, json_schema: Optional[Any]
-) -> tuple[Optional[Any], str]:
+    *, text: str, json_mode: bool, json_schema: Any | None
+) -> tuple[Any | None, str]:
     """Return ``(parsed, content_type)``. ``content_type`` is ``"json"``
     when parsing succeeded and (when a schema was given) validation
     passed; ``"text"`` otherwise."""
@@ -542,8 +542,8 @@ def _extract_text(response: Any) -> str:
 
 def _resolve_attribution(
     *,
-    provider_override: Optional[str],
-    model_override: Optional[str],
+    provider_override: str | None,
+    model_override: str | None,
     response: Any,
 ) -> tuple[str, str]:
     """Decide what to record as ``result.provider`` / ``result.model``.
@@ -608,9 +608,9 @@ class PluginLlm:
         self,
         *,
         plugin_id: str,
-        policy_loader: Optional[Callable[[str], _TrustPolicy]] = None,
-        sync_caller: Optional[Callable[..., Any]] = None,
-        async_caller: Optional[Callable[..., Awaitable[Any]]] = None,
+        policy_loader: Callable[[str], _TrustPolicy] | None = None,
+        sync_caller: Callable[..., Any] | None = None,
+        async_caller: Callable[..., Awaitable[Any]] | None = None,
     ) -> None:
         self._plugin_id = plugin_id
         self._policy_loader = policy_loader or _resolve_trust_policy
@@ -623,14 +623,14 @@ class PluginLlm:
         self,
         messages: List[Dict[str, Any]],
         *,
-        provider: Optional[str] = None,
-        model: Optional[str] = None,
-        temperature: Optional[float] = None,
-        max_tokens: Optional[int] = None,
-        timeout: Optional[float] = None,
-        agent_id: Optional[str] = None,
-        profile: Optional[str] = None,
-        purpose: Optional[str] = None,
+        provider: str | None = None,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+        agent_id: str | None = None,
+        profile: str | None = None,
+        purpose: str | None = None,
     ) -> PluginLlmCompleteResult:
         """Run a host-owned chat completion against the user's active model.
 
@@ -685,18 +685,18 @@ class PluginLlm:
         *,
         instructions: str,
         input: Sequence[PluginLlmInput],
-        json_schema: Optional[Any] = None,
+        json_schema: Any | None = None,
         json_mode: bool = False,
-        schema_name: Optional[str] = None,
-        system_prompt: Optional[str] = None,
-        provider: Optional[str] = None,
-        model: Optional[str] = None,
-        temperature: Optional[float] = None,
-        max_tokens: Optional[int] = None,
-        timeout: Optional[float] = None,
-        agent_id: Optional[str] = None,
-        profile: Optional[str] = None,
-        purpose: Optional[str] = None,
+        schema_name: str | None = None,
+        system_prompt: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+        agent_id: str | None = None,
+        profile: str | None = None,
+        purpose: str | None = None,
     ) -> PluginLlmStructuredResult:
         """Run a bounded host-owned structured completion.
 
@@ -778,14 +778,14 @@ class PluginLlm:
         self,
         messages: List[Dict[str, Any]],
         *,
-        provider: Optional[str] = None,
-        model: Optional[str] = None,
-        temperature: Optional[float] = None,
-        max_tokens: Optional[int] = None,
-        timeout: Optional[float] = None,
-        agent_id: Optional[str] = None,
-        profile: Optional[str] = None,
-        purpose: Optional[str] = None,
+        provider: str | None = None,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+        agent_id: str | None = None,
+        profile: str | None = None,
+        purpose: str | None = None,
     ) -> PluginLlmCompleteResult:
         """Async sibling of :meth:`complete`."""
         policy = self._policy_loader(self._plugin_id)
@@ -825,18 +825,18 @@ class PluginLlm:
         *,
         instructions: str,
         input: Sequence[PluginLlmInput],
-        json_schema: Optional[Any] = None,
+        json_schema: Any | None = None,
         json_mode: bool = False,
-        schema_name: Optional[str] = None,
-        system_prompt: Optional[str] = None,
-        provider: Optional[str] = None,
-        model: Optional[str] = None,
-        temperature: Optional[float] = None,
-        max_tokens: Optional[int] = None,
-        timeout: Optional[float] = None,
-        agent_id: Optional[str] = None,
-        profile: Optional[str] = None,
-        purpose: Optional[str] = None,
+        schema_name: str | None = None,
+        system_prompt: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        timeout: float | None = None,
+        agent_id: str | None = None,
+        profile: str | None = None,
+        purpose: str | None = None,
     ) -> PluginLlmStructuredResult:
         """Async sibling of :meth:`complete_structured`."""
         if not instructions or not instructions.strip():
@@ -896,8 +896,8 @@ class PluginLlm:
 
     @staticmethod
     def _json_response_format(
-        *, json_mode: bool, json_schema: Optional[Any]
-    ) -> Optional[Dict[str, Any]]:
+        *, json_mode: bool, json_schema: Any | None
+    ) -> Dict[str, Any] | None:
         """Build the ``extra_body.response_format`` payload for the
         provider request. Falls back to ``json_object`` when no schema
         is given so providers that ignore json_schema still get a hint."""
@@ -920,13 +920,13 @@ class PluginLlm:
         self,
         *,
         messages: List[Dict[str, Any]],
-        provider_override: Optional[str],
-        model_override: Optional[str],
-        profile_override: Optional[str],
-        temperature: Optional[float],
-        max_tokens: Optional[int],
-        timeout: Optional[float],
-        extra_body: Optional[Dict[str, Any]] = None,
+        provider_override: str | None,
+        model_override: str | None,
+        profile_override: str | None,
+        temperature: float | None,
+        max_tokens: int | None,
+        timeout: float | None,
+        extra_body: Dict[str, Any] | None = None,
     ) -> tuple[str, str, Any]:
         """Invoke the host's ``call_llm``. Lazy-imports
         ``agent.auxiliary_client`` to avoid circular deps at plugin
@@ -967,13 +967,13 @@ class PluginLlm:
         self,
         *,
         messages: List[Dict[str, Any]],
-        provider_override: Optional[str],
-        model_override: Optional[str],
-        profile_override: Optional[str],
-        temperature: Optional[float],
-        max_tokens: Optional[int],
-        timeout: Optional[float],
-        extra_body: Optional[Dict[str, Any]] = None,
+        provider_override: str | None,
+        model_override: str | None,
+        profile_override: str | None,
+        temperature: float | None,
+        max_tokens: int | None,
+        timeout: float | None,
+        extra_body: Dict[str, Any] | None = None,
     ) -> tuple[str, str, Any]:
         if self._async_caller is not None:
             return await self._async_caller(
@@ -1017,8 +1017,8 @@ def make_plugin_llm_for_test(
     *,
     plugin_id: str,
     policy: _TrustPolicy,
-    sync_caller: Optional[Callable[..., Any]] = None,
-    async_caller: Optional[Callable[..., Awaitable[Any]]] = None,
+    sync_caller: Callable[..., Any] | None = None,
+    async_caller: Callable[..., Awaitable[Any]] | None = None,
 ) -> PluginLlm:
     """Construct a :class:`PluginLlm` with an injected policy and caller.
 

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -109,7 +109,7 @@ class _SafeWriter:
         return getattr(self._inner, name)
 
 
-def _get_proxy_from_env() -> Optional[str]:
+def _get_proxy_from_env() -> str | None:
     """Read proxy URL from environment variables.
 
     Checks HTTPS_PROXY, HTTP_PROXY, ALL_PROXY (and lowercase variants) in order.
@@ -123,7 +123,7 @@ def _get_proxy_from_env() -> Optional[str]:
     return None
 
 
-def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
+def _get_proxy_for_base_url(base_url: str | None) -> str | None:
     """Return an env-configured proxy unless NO_PROXY excludes this base URL."""
     proxy = _get_proxy_from_env()
     if not proxy or not base_url:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -73,7 +73,7 @@ def _scan_context_content(content: str, filename: str) -> str:
     return content
 
 
-def _find_git_root(start: Path) -> Optional[Path]:
+def _find_git_root(start: Path) -> Path | None:
     """Walk *start* and its parents looking for a ``.git`` directory.
 
     Returns the directory containing ``.git``, or ``None`` if we hit the
@@ -89,7 +89,7 @@ def _find_git_root(start: Path) -> Optional[Path]:
 _HERMES_MD_NAMES = (".hermes.md", "HERMES.md")
 
 
-def _find_hermes_md(cwd: Path) -> Optional[Path]:
+def _find_hermes_md(cwd: Path) -> Path | None:
     """Discover the nearest ``.hermes.md`` or ``HERMES.md``.
 
     Search order: *cwd* first, then each parent directory up to (and
@@ -873,7 +873,7 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _load_skills_snapshot(skills_dir: Path) -> dict | None:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -1310,7 +1310,7 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
     return head + marker + tail
 
 
-def load_soul_md() -> Optional[str]:
+def load_soul_md() -> str | None:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 
     Used as the agent identity (slot #1 in the system prompt).  When this
@@ -1423,7 +1423,7 @@ def _load_cursorrules(cwd_path: Path) -> str:
     return _truncate_content(cursorrules_content, ".cursorrules")
 
 
-def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
+def build_context_files_prompt(cwd: str | None = None, skip_soul: bool = False) -> str:
     """Discover and load context files for the system prompt.
 
     Priority (first found wins — only ONE project context type is loaded):

--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -92,7 +92,7 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
 def parse_rate_limit_headers(
     headers: Mapping[str, str],
     provider: str = "",
-) -> Optional[RateLimitState]:
+) -> RateLimitState | None:
     """Parse x-ratelimit-* headers into a RateLimitState.
 
     Returns None if no rate limit headers are present.

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -98,8 +98,8 @@ class FetchResult:
     applied: List[str] = field(default_factory=list)   # set into os.environ
     skipped: List[str] = field(default_factory=list)   # already set, not overridden
     warnings: List[str] = field(default_factory=list)  # non-fatal issues
-    error: Optional[str] = None                        # fatal: nothing was fetched
-    binary_path: Optional[Path] = None
+    error: str | None = None                        # fatal: nothing was fetched
+    binary_path: Path | None = None
 
     @property
     def ok(self) -> bool:
@@ -118,7 +118,7 @@ def _hermes_bin_dir() -> Path:
     return get_hermes_home() / "bin"
 
 
-def find_bws(*, install_if_missing: bool = False) -> Optional[Path]:
+def find_bws(*, install_if_missing: bool = False) -> Path | None:
     """Return a path to a usable ``bws`` binary, or None.
 
     Resolution order:
@@ -314,7 +314,7 @@ def fetch_bitwarden_secrets(
     *,
     access_token: str,
     project_id: str,
-    binary: Optional[Path] = None,
+    binary: Path | None = None,
     cache_ttl_seconds: float = 300,
     use_cache: bool = True,
     server_url: str = "",

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -91,7 +91,7 @@ _DEFAULT_BLOCK_MESSAGE = "Blocked by shell hook."
 # the same event (e.g. one entry per tool the user wants to gate).
 # Second registration attempts for the exact same triple become no-ops
 # so the CLI and gateway can both call register_from_config() safely.
-_registered: Set[Tuple[str, Optional[str], str]] = set()
+_registered: Set[Tuple[str, str | None, str]] = set()
 _registered_lock = threading.Lock()
 
 # Intra-process lock for allowlist read-modify-write on platforms that
@@ -109,9 +109,9 @@ class ShellHookSpec:
 
     event: str
     command: str
-    matcher: Optional[str] = None
+    matcher: str | None = None
     timeout: int = DEFAULT_TIMEOUT_SECONDS
-    compiled_matcher: Optional[re.Pattern] = field(default=None, repr=False)
+    compiled_matcher: re.Pattern | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         # Strip whitespace introduced by YAML quirks (e.g. multi-line string
@@ -130,7 +130,7 @@ class ShellHookSpec:
                 )
                 self.compiled_matcher = None
 
-    def matches_tool(self, tool_name: Optional[str]) -> bool:
+    def matches_tool(self, tool_name: str | None) -> bool:
         if not self.matcher:
             return True
         if tool_name is None:
@@ -147,7 +147,7 @@ class ShellHookSpec:
 # ---------------------------------------------------------------------------
 
 def register_from_config(
-    cfg: Optional[Dict[str, Any]],
+    cfg: Dict[str, Any] | None,
     *,
     accept_hooks: bool = False,
 ) -> List[ShellHookSpec]:
@@ -221,7 +221,7 @@ def register_from_config(
     return registered
 
 
-def iter_configured_hooks(cfg: Optional[Dict[str, Any]]) -> List[ShellHookSpec]:
+def iter_configured_hooks(cfg: Dict[str, Any] | None) -> List[ShellHookSpec]:
     """Return the parsed ``ShellHookSpec`` entries from config without
     registering anything.  Used by ``hermes hooks list`` and ``doctor``."""
     if not isinstance(cfg, dict):
@@ -289,7 +289,7 @@ def _parse_hooks_block(hooks_cfg: Any) -> List[ShellHookSpec]:
 
 def _parse_single_entry(
     event: str, index: int, raw: Any,
-) -> Optional[ShellHookSpec]:
+) -> ShellHookSpec | None:
     if not isinstance(raw, dict):
         logger.warning(
             "hooks.%s[%d] must be a mapping with a 'command' key; got %s",
@@ -419,10 +419,10 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     return result
 
 
-def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]]]:
+def _make_callback(spec: ShellHookSpec) -> Callable[..., Dict[str, Any] | None]:
     """Build the closure that ``invoke_hook()`` will call per firing."""
 
-    def _callback(**kwargs: Any) -> Optional[Dict[str, Any]]:
+    def _callback(**kwargs: Any) -> Dict[str, Any] | None:
         # Matcher gate — only meaningful for tool-scoped events.
         if spec.event in {"pre_tool_call", "post_tool_call"}:
             if not spec.matches_tool(kwargs.get("tool_name")):
@@ -493,7 +493,7 @@ def _block_message(primary: Any, secondary: Any) -> str:
     return raw if isinstance(raw, str) and raw else _DEFAULT_BLOCK_MESSAGE
 
 
-def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
+def _parse_response(event: str, stdout: str) -> Dict[str, Any] | None:
     """Translate stdout JSON into a Hermes wire-shape dict.
 
     For ``pre_tool_call`` the Claude-Code-style ``{"decision": "block",
@@ -777,7 +777,7 @@ def _resolve_effective_accept(
 # Introspection (used by `hermes hooks` CLI)
 # ---------------------------------------------------------------------------
 
-def allowlist_entry_for(event: str, command: str) -> Optional[Dict[str, Any]]:
+def allowlist_entry_for(event: str, command: str) -> Dict[str, Any] | None:
     """Return the allowlist record for this pair, if any."""
     for e in load_allowlist().get("approvals", []):
         if (
@@ -789,7 +789,7 @@ def allowlist_entry_for(event: str, command: str) -> Optional[Dict[str, Any]]:
     return None
 
 
-def script_mtime_iso(command: str) -> Optional[str]:
+def script_mtime_iso(command: str) -> str | None:
     """ISO-8601 mtime of the resolved script path, or ``None`` if the
     script is missing."""
     path = _command_script_path(command)

--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -60,7 +60,7 @@ _BUNDLE_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _BUNDLE_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 _bundles_cache: Dict[str, Dict[str, Any]] = {}
-_bundles_cache_mtime: Optional[float] = None
+_bundles_cache_mtime: float | None = None
 
 
 def _bundles_dir() -> Path:
@@ -113,7 +113,7 @@ def _max_mtime(files: List[Path]) -> float:
     return max(mtimes) if mtimes else 0.0
 
 
-def _load_bundle_file(path: Path) -> Optional[Dict[str, Any]]:
+def _load_bundle_file(path: Path) -> Dict[str, Any] | None:
     """Parse a single bundle YAML file. Returns ``None`` on any error.
 
     Errors are logged at WARNING level. We don't raise — a broken bundle
@@ -205,7 +205,7 @@ def get_skill_bundles() -> Dict[str, Dict[str, Any]]:
     return _bundles_cache
 
 
-def resolve_bundle_command_key(command: str) -> Optional[str]:
+def resolve_bundle_command_key(command: str) -> str | None:
     """Resolve a user-typed command to its canonical bundle slash key.
 
     Hyphens and underscores are treated interchangeably to mirror the
@@ -254,7 +254,7 @@ def build_bundle_invocation_message(
     cmd_key: str,
     user_instruction: str = "",
     task_id: str | None = None,
-) -> Optional[Tuple[str, List[str], List[str]]]:
+) -> Tuple[str, List[str], List[str]] | None:
     """Build the user message content for a bundle slash command invocation.
 
     Returns ``(message, loaded_skill_names, missing_skill_names)`` or
@@ -404,7 +404,7 @@ def delete_bundle(name: str) -> Path:
     return path
 
 
-def get_bundle(name: str) -> Optional[Dict[str, Any]]:
+def get_bundle(name: str) -> Dict[str, Any] | None:
     """Look up a bundle by name (slug-normalized)."""
     slug = _slugify(name)
     return get_skill_bundles().get(f"/{slug}")

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -21,13 +21,13 @@ from agent.skill_preprocessing import (
 logger = logging.getLogger(__name__)
 
 _skill_commands: Dict[str, Dict[str, Any]] = {}
-_skill_commands_platform: Optional[str] = None
+_skill_commands_platform: str | None = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 
-def _resolve_skill_commands_platform() -> Optional[str]:
+def _resolve_skill_commands_platform() -> str | None:
     """Return the current platform scope used for disabled-skill filtering.
 
     Used to detect when the active platform has shifted so
@@ -406,7 +406,7 @@ def reload_skills() -> Dict[str, Any]:
     }
 
 
-def resolve_skill_command_key(command: str) -> Optional[str]:
+def resolve_skill_command_key(command: str) -> str | None:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
     Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
@@ -430,7 +430,7 @@ def build_skill_invocation_message(
     user_instruction: str = "",
     task_id: str | None = None,
     runtime_note: str = "",
-) -> Optional[str]:
+) -> str | None:
     """Build the user message content for a skill slash command invocation.
 
     Args:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -549,7 +549,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
 _NAMESPACE_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
-def parse_qualified_name(name: str) -> Tuple[Optional[str], str]:
+def parse_qualified_name(name: str) -> Tuple[str | None, str]:
     """Split ``'namespace:skill-name'`` into ``(namespace, bare_name)``.
 
     Returns ``(None, name)`` when there is no ``':'``.
@@ -559,7 +559,7 @@ def parse_qualified_name(name: str) -> Tuple[Optional[str], str]:
     return tuple(name.split(":", 1))  # type: ignore[return-value]
 
 
-def is_valid_namespace(candidate: Optional[str]) -> bool:
+def is_valid_namespace(candidate: str | None) -> bool:
     """Check whether *candidate* is a valid namespace (``[a-zA-Z0-9_-]+``)."""
     if not candidate:
         return False

--- a/agent/stream_diag.py
+++ b/agent/stream_diag.py
@@ -97,7 +97,7 @@ def flatten_exception_chain(error: BaseException) -> str:
     deep) to surface the chain in one line.
     """
     seen: List[BaseException] = []
-    link: Optional[BaseException] = error
+    link: BaseException | None = error
     while link is not None and len(seen) < 4:
         if link in seen:
             break
@@ -125,7 +125,7 @@ def log_stream_retry(
     attempt: int,
     max_attempts: int,
     mid_tool_call: bool,
-    diag: Optional[Dict[str, Any]] = None,
+    diag: Dict[str, Any] | None = None,
 ) -> None:
     """Record a transient stream-drop and retry to ``agent.log``.
 
@@ -218,7 +218,7 @@ def emit_stream_drop(
     attempt: int,
     max_attempts: int,
     mid_tool_call: bool,
-    diag: Optional[Dict[str, Any]] = None,
+    diag: Dict[str, Any] | None = None,
 ) -> None:
     """Emit a single user-visible line for a stream drop+retry.
 

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -58,7 +58,7 @@ class SubdirectoryHintTracker:
             tool_result += hints  # append to the tool result string
     """
 
-    def __init__(self, working_dir: Optional[str] = None):
+    def __init__(self, working_dir: str | None = None):
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
         self._loaded_dirs: Set[Path] = set()
         # Pre-mark the working dir as loaded (startup context handles it)
@@ -68,7 +68,7 @@ class SubdirectoryHintTracker:
         self,
         tool_name: str,
         tool_args: Dict[str, Any],
-    ) -> Optional[str]:
+    ) -> str | None:
         """Check tool call arguments for new directories and load any hint files.
 
         Returns formatted hint text to append to the tool result, or None.
@@ -168,7 +168,7 @@ class SubdirectoryHintTracker:
             return False
         return True
 
-    def _load_hints_for_directory(self, directory: Path) -> Optional[str]:
+    def _load_hints_for_directory(self, directory: Path) -> str | None:
         """Load hint files from a directory. Returns formatted text or None."""
         self._loaded_dirs.add(directory)
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -57,7 +57,7 @@ def _ra():
     return run_agent
 
 
-def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
+def build_system_prompt_parts(agent: Any, system_message: str | None = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered parts.
 
     Returns a dict with three keys:
@@ -318,7 +318,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     }
 
 
-def build_system_prompt(agent: Any, system_message: Optional[str] = None) -> str:
+def build_system_prompt(agent: Any, system_message: str | None = None) -> str:
     """Assemble the full system prompt from all layers.
 
     Called once per session (cached on ``agent._cached_system_prompt``) and

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -30,9 +30,9 @@ def generate_title(
     user_message: str,
     assistant_response: str,
     timeout: float = 30.0,
-    failure_callback: Optional[FailureCallback] = None,
+    failure_callback: FailureCallback | None = None,
     main_runtime: dict = None,
-) -> Optional[str]:
+) -> str | None:
     """Generate a session title from the first exchange.
 
     Uses the main runtime's model when available, falling back to the
@@ -89,9 +89,9 @@ def auto_title_session(
     session_id: str,
     user_message: str,
     assistant_response: str,
-    failure_callback: Optional[FailureCallback] = None,
+    failure_callback: FailureCallback | None = None,
     main_runtime: dict = None,
-    title_callback: Optional[TitleCallback] = None,
+    title_callback: TitleCallback | None = None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -136,9 +136,9 @@ def maybe_auto_title(
     user_message: str,
     assistant_response: str,
     conversation_history: list,
-    failure_callback: Optional[FailureCallback] = None,
+    failure_callback: FailureCallback | None = None,
     main_runtime: dict = None,
-    title_callback: Optional[TitleCallback] = None,
+    title_callback: TitleCallback | None = None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -146,7 +146,7 @@ def _should_parallelize_tool_batch(tool_calls) -> bool:
     return True
 
 
-def _extract_parallel_scope_path(tool_name: str, function_args: dict) -> Optional[Path]:
+def _extract_parallel_scope_path(tool_name: str, function_args: dict) -> Path | None:
     """Return the normalized file target for path-scoped tools."""
     if tool_name not in _PATH_SCOPED_TOOLS:
         return None

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -498,7 +498,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             function_args = {}
 
         # Check plugin hooks for a block directive before executing.
-        _block_msg: Optional[str] = None
+        _block_msg: str | None = None
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
             _block_msg = get_pre_tool_call_block_message(

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -42,7 +42,7 @@ class AnthropicTransport(ProviderTransport):
         self,
         model: str,
         messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        tools: List[Dict[str, Any]] | None = None,
         **params,
     ) -> Dict[str, Any]:
         """Build Anthropic messages.create() kwargs.
@@ -157,7 +157,7 @@ class AnthropicTransport(ProviderTransport):
             return getattr(response, "stop_reason", None) == "end_turn"
         return True
 
-    def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
+    def extract_cache_stats(self, response: Any) -> Dict[str, int] | None:
         """Extract Anthropic cache_read and cache_creation token counts."""
         usage = getattr(response, "usage", None)
         if usage is None:

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -44,7 +44,7 @@ class ProviderTransport(ABC):
         self,
         model: str,
         messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        tools: List[Dict[str, Any]] | None = None,
         **params,
     ) -> Dict[str, Any]:
         """Build the complete API call kwargs dict.
@@ -72,7 +72,7 @@ class ProviderTransport(ABC):
         """
         return True
 
-    def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
+    def extract_cache_stats(self, response: Any) -> Dict[str, int] | None:
         """Optional: extract provider-specific cache hit/creation stats.
 
         Returns dict with 'cached_tokens' and 'creation_tokens', or None.

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -33,7 +33,7 @@ class BedrockTransport(ProviderTransport):
         self,
         model: str,
         messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        tools: List[Dict[str, Any]] | None = None,
         **params,
     ) -> Dict[str, Any]:
         """Build Bedrock converse() kwargs.

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -38,7 +38,7 @@ class ResponsesApiTransport(ProviderTransport):
         self,
         model: str,
         messages: List[Dict[str, Any]],
-        tools: Optional[List[Dict[str, Any]]] = None,
+        tools: List[Dict[str, Any]] | None = None,
         **params,
     ) -> Dict[str, Any]:
         """Build Responses API kwargs.

--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -36,7 +36,7 @@ class CodexAppServerError(RuntimeError):
 
     code: int
     message: str
-    data: Optional[Any] = None
+    data: Any | None = None
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return f"codex app-server error {self.code}: {self.message}"
@@ -69,9 +69,9 @@ class CodexAppServerClient:
     def __init__(
         self,
         codex_bin: str = "codex",
-        codex_home: Optional[str] = None,
-        extra_args: Optional[list[str]] = None,
-        env: Optional[dict[str, str]] = None,
+        codex_home: str | None = None,
+        extra_args: list[str] | None = None,
+        env: dict[str, str] | None = None,
     ) -> None:
         self._codex_bin = codex_bin
         spawn_env = os.environ.copy()
@@ -144,7 +144,7 @@ class CodexAppServerClient:
         client_name: str = "hermes",
         client_title: str = "Hermes Agent",
         client_version: str = "0.1",
-        capabilities: Optional[dict] = None,
+        capabilities: dict | None = None,
         timeout: float = 10.0,
     ) -> dict:
         """Send `initialize` + `initialized` handshake. Returns the server's
@@ -195,7 +195,7 @@ class CodexAppServerClient:
     def request(
         self,
         method: str,
-        params: Optional[dict] = None,
+        params: dict | None = None,
         timeout: float = 30.0,
     ) -> dict:
         """Send a JSON-RPC request and block on the response. Returns `result`,
@@ -222,7 +222,7 @@ class CodexAppServerClient:
             )
         return msg.get("result", {})
 
-    def notify(self, method: str, params: Optional[dict] = None) -> None:
+    def notify(self, method: str, params: dict | None = None) -> None:
         """Send a JSON-RPC notification (no id, no response expected)."""
         self._send({"method": method, "params": params or {}})
 
@@ -231,7 +231,7 @@ class CodexAppServerClient:
         self._send({"id": request_id, "result": result})
 
     def respond_error(
-        self, request_id: Any, code: int, message: str, data: Optional[Any] = None
+        self, request_id: Any, code: int, message: str, data: Any | None = None
     ) -> None:
         """Reply to a server-initiated request with an error."""
         err: dict[str, Any] = {"code": code, "message": message}
@@ -239,7 +239,7 @@ class CodexAppServerClient:
             err["data"] = data
         self._send({"id": request_id, "error": err})
 
-    def take_notification(self, timeout: float = 0.0) -> Optional[dict]:
+    def take_notification(self, timeout: float = 0.0) -> dict | None:
         """Pop the next streaming notification, or return None on timeout.
 
         timeout=0.0 means non-blocking. Use small positive timeouts inside the
@@ -251,7 +251,7 @@ class CodexAppServerClient:
         except queue.Empty:
             return None
 
-    def take_server_request(self, timeout: float = 0.0) -> Optional[dict]:
+    def take_server_request(self, timeout: float = 0.0) -> dict | None:
         """Pop the next server-initiated request (e.g. exec/applyPatch approval)."""
         try:
             if timeout <= 0:
@@ -355,7 +355,7 @@ class CodexAppServerClient:
             pass
 
 
-def parse_codex_version(output: str) -> Optional[tuple[int, int, int]]:
+def parse_codex_version(output: str) -> tuple[int, int, int] | None:
     """Parse `codex --version` output. Returns (major, minor, patch) or None."""
     # Output format: "codex-cli 0.130.0" possibly followed by metadata.
     import re

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -68,9 +68,9 @@ class TurnResult:
     projected_messages: list[dict] = field(default_factory=list)
     tool_iterations: int = 0
     interrupted: bool = False
-    error: Optional[str] = None  # Set if turn ended in a non-recoverable error
-    turn_id: Optional[str] = None
-    thread_id: Optional[str] = None
+    error: str | None = None  # Set if turn ended in a non-recoverable error
+    turn_id: str | None = None
+    thread_id: str | None = None
     # Hint to the caller that the underlying codex subprocess is likely
     # wedged (turn-level timeout fired, post-tool watchdog tripped, or
     # token-refresh failure killed the child). The caller should retire
@@ -150,7 +150,7 @@ _OAUTH_REFRESH_FAILURE_HINTS = (
 )
 
 
-def _classify_oauth_failure(*parts: str) -> Optional[str]:
+def _classify_oauth_failure(*parts: str) -> str | None:
     """Return a user-friendly re-auth hint if any of the provided strings
     look like a codex OAuth/token-refresh failure; otherwise None.
 
@@ -196,14 +196,14 @@ class CodexAppServerSession:
     def __init__(
         self,
         *,
-        cwd: Optional[str] = None,
+        cwd: str | None = None,
         codex_bin: str = "codex",
-        codex_home: Optional[str] = None,
-        permission_profile: Optional[str] = None,
-        approval_callback: Optional[Callable[..., str]] = None,
-        on_event: Optional[Callable[[dict], None]] = None,
-        request_routing: Optional[_ServerRequestRouting] = None,
-        client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        codex_home: str | None = None,
+        permission_profile: str | None = None,
+        approval_callback: Callable[..., str] | None = None,
+        on_event: Callable[[dict], None] | None = None,
+        request_routing: _ServerRequestRouting | None = None,
+        client_factory: Callable[..., CodexAppServerClient] | None = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
@@ -219,8 +219,8 @@ class CodexAppServerSession:
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
 
-        self._client: Optional[CodexAppServerClient] = None
-        self._thread_id: Optional[str] = None
+        self._client: CodexAppServerClient | None = None
+        self._thread_id: str | None = None
         self._interrupt_event = threading.Event()
         # Pending file-change items, keyed by item id. Populated on
         # item/started for fileChange items; consumed by the approval
@@ -445,7 +445,7 @@ class CodexAppServerSession:
         # a tool-shaped item completes; if no further notification arrives
         # within post_tool_quiet_timeout and the turn hasn't completed, we
         # fast-fail and retire the session.
-        last_tool_completion_at: Optional[float] = None
+        last_tool_completion_at: float | None = None
 
         while time.monotonic() < deadline and not turn_complete:
             if self._interrupt_event.is_set():
@@ -614,7 +614,7 @@ class CodexAppServerSession:
 
     # ---------- internals ----------
 
-    def _issue_interrupt(self, turn_id: Optional[str]) -> None:
+    def _issue_interrupt(self, turn_id: str | None) -> None:
         if self._client is None or self._thread_id is None or turn_id is None:
             return
         try:
@@ -788,7 +788,7 @@ class CodexAppServerSession:
         elif method == "item/completed":
             self._pending_file_changes.pop(item_id, None)
 
-    def _lookup_pending_file_change(self, item_id: str) -> Optional[str]:
+    def _lookup_pending_file_change(self, item_id: str) -> str | None:
         """Look up an in-progress fileChange item by id and summarize its
         changes for the approval prompt. Returns None when we don't have
         the item cached (e.g. approval arrived before item/started, or

--- a/agent/transports/codex_event_projector.py
+++ b/agent/transports/codex_event_projector.py
@@ -63,7 +63,7 @@ class ProjectionResult:
 
     messages: list[dict] = field(default_factory=list)
     is_tool_iteration: bool = False
-    final_text: Optional[str] = None  # Set when an agentMessage completes
+    final_text: str | None = None  # Set when an agentMessage completes
 
 
 class CodexEventProjector:

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -194,7 +194,7 @@ def _build_server() -> Any:
     return mcp
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     """Entry point for `python -m agent.transports.hermes_tools_mcp_server`."""
     argv = argv or sys.argv[1:]
     verbose = "--verbose" in argv or "-v" in argv

--- a/agent/tts_provider.py
+++ b/agent/tts_provider.py
@@ -163,14 +163,14 @@ class TTSProvider(abc.ABC):
             "env_vars": [],
         }
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         """Return the default model id, or None if not applicable."""
         models = self.list_models()
         if models:
             return models[0].get("id")
         return None
 
-    def default_voice(self) -> Optional[str]:
+    def default_voice(self) -> str | None:
         """Return the default voice id, or None if not applicable."""
         voices = self.list_voices()
         if voices:
@@ -183,9 +183,9 @@ class TTSProvider(abc.ABC):
         text: str,
         output_path: str,
         *,
-        voice: Optional[str] = None,
-        model: Optional[str] = None,
-        speed: Optional[float] = None,
+        voice: str | None = None,
+        model: str | None = None,
+        speed: float | None = None,
         format: str = DEFAULT_OUTPUT_FORMAT,
         **extra: Any,
     ) -> str:
@@ -220,8 +220,8 @@ class TTSProvider(abc.ABC):
         self,
         text: str,
         *,
-        voice: Optional[str] = None,
-        model: Optional[str] = None,
+        voice: str | None = None,
+        model: str | None = None,
         format: str = "opus",
         **extra: Any,
     ) -> Iterator[bytes]:
@@ -260,7 +260,7 @@ class TTSProvider(abc.ABC):
 # ---------------------------------------------------------------------------
 
 
-def resolve_output_format(value: Optional[str]) -> str:
+def resolve_output_format(value: str | None) -> str:
     """Clamp an output_format value to the valid set.
 
     Invalid values are coerced to :data:`DEFAULT_OUTPUT_FORMAT` rather

--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -115,7 +115,7 @@ def list_providers() -> List[TTSProvider]:
     return sorted(items, key=lambda p: p.name)
 
 
-def get_provider(name: str) -> Optional[TTSProvider]:
+def get_provider(name: str) -> TTSProvider | None:
     """Return the provider registered under *name*, or None.
 
     Name matching is case-insensitive and whitespace-tolerant — mirrors

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -34,7 +34,7 @@ class CanonicalUsage:
     cache_write_tokens: int = 0
     reasoning_tokens: int = 0
     request_count: int = 1
-    raw_usage: Optional[dict[str, Any]] = None
+    raw_usage: dict[str, Any] | None = None
 
     @property
     def prompt_tokens(self) -> int:
@@ -55,25 +55,25 @@ class BillingRoute:
 
 @dataclass(frozen=True)
 class PricingEntry:
-    input_cost_per_million: Optional[Decimal] = None
-    output_cost_per_million: Optional[Decimal] = None
-    cache_read_cost_per_million: Optional[Decimal] = None
-    cache_write_cost_per_million: Optional[Decimal] = None
-    request_cost: Optional[Decimal] = None
+    input_cost_per_million: Decimal | None = None
+    output_cost_per_million: Decimal | None = None
+    cache_read_cost_per_million: Decimal | None = None
+    cache_write_cost_per_million: Decimal | None = None
+    request_cost: Decimal | None = None
     source: CostSource = "none"
-    source_url: Optional[str] = None
-    pricing_version: Optional[str] = None
-    fetched_at: Optional[datetime] = None
+    source_url: str | None = None
+    pricing_version: str | None = None
+    fetched_at: datetime | None = None
 
 
 @dataclass(frozen=True)
 class CostResult:
-    amount_usd: Optional[Decimal]
+    amount_usd: Decimal | None
     status: CostStatus
     source: CostSource
     label: str
-    fetched_at: Optional[datetime] = None
-    pricing_version: Optional[str] = None
+    fetched_at: datetime | None = None
+    pricing_version: str | None = None
     notes: tuple[str, ...] = ()
 
 
@@ -508,7 +508,7 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
 }
 
 
-def _to_decimal(value: Any) -> Optional[Decimal]:
+def _to_decimal(value: Any) -> Decimal | None:
     if value is None:
         return None
     try:
@@ -526,8 +526,8 @@ def _to_int(value: Any) -> int:
 
 def resolve_billing_route(
     model_name: str,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
+    provider: str | None = None,
+    base_url: str | None = None,
 ) -> BillingRoute:
     provider_name = (provider or "").strip().lower()
     base = (base_url or "").strip().lower()
@@ -570,7 +570,7 @@ def _normalize_anthropic_model_name(model: str) -> str:
     return name
 
 
-def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
+def _lookup_official_docs_pricing(route: BillingRoute) -> PricingEntry | None:
     model = route.model.lower()
     # Direct lookup first
     entry = _OFFICIAL_DOCS_PRICING.get((route.provider, model))
@@ -586,7 +586,7 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
     return None
 
 
-def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
+def _openrouter_pricing_entry(route: BillingRoute) -> PricingEntry | None:
     return _pricing_entry_from_metadata(
         fetch_model_metadata(),
         route.model,
@@ -601,7 +601,7 @@ def _pricing_entry_from_metadata(
     *,
     source_url: str,
     pricing_version: str,
-) -> Optional[PricingEntry]:
+) -> PricingEntry | None:
     if model_id not in metadata:
         return None
     pricing = metadata[model_id].get("pricing") or {}
@@ -621,7 +621,7 @@ def _pricing_entry_from_metadata(
     if prompt is None and completion is None and request is None:
         return None
 
-    def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
+    def _per_token_to_per_million(value: Decimal | None) -> Decimal | None:
         if value is None:
             return None
         return value * _ONE_MILLION
@@ -641,10 +641,10 @@ def _pricing_entry_from_metadata(
 
 def get_pricing_entry(
     model_name: str,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[PricingEntry]:
+    provider: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> PricingEntry | None:
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return PricingEntry(
@@ -672,8 +672,8 @@ def get_pricing_entry(
 def normalize_usage(
     response_usage: Any,
     *,
-    provider: Optional[str] = None,
-    api_mode: Optional[str] = None,
+    provider: str | None = None,
+    api_mode: str | None = None,
 ) -> CanonicalUsage:
     """Normalize raw API response usage into canonical token buckets.
 
@@ -746,9 +746,9 @@ def estimate_usage_cost(
     model_name: str,
     usage: CanonicalUsage,
     *,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> CostResult:
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
@@ -823,9 +823,9 @@ def estimate_usage_cost(
 
 def has_known_pricing(
     model_name: str,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
 ) -> bool:
     """Check whether we have pricing data for this model+route.
 

--- a/agent/video_gen_provider.py
+++ b/agent/video_gen_provider.py
@@ -128,7 +128,7 @@ class VideoGenProvider(abc.ABC):
             "env_vars": [],
         }
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         """Return the default model id, or None if not applicable."""
         models = self.list_models()
         if models:
@@ -170,15 +170,15 @@ class VideoGenProvider(abc.ABC):
         self,
         prompt: str,
         *,
-        model: Optional[str] = None,
-        image_url: Optional[str] = None,
-        reference_image_urls: Optional[List[str]] = None,
-        duration: Optional[int] = None,
+        model: str | None = None,
+        image_url: str | None = None,
+        reference_image_urls: List[str] | None = None,
+        duration: int | None = None,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         resolution: str = DEFAULT_RESOLUTION,
-        negative_prompt: Optional[str] = None,
-        audio: Optional[bool] = None,
-        seed: Optional[int] = None,
+        negative_prompt: str | None = None,
+        audio: bool | None = None,
+        seed: int | None = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Generate a video from a prompt (text-to-video) or animate an image
@@ -253,7 +253,7 @@ def success_response(
     aspect_ratio: str = "",
     duration: int = 0,
     provider: str,
-    extra: Optional[Dict[str, Any]] = None,
+    extra: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Build a uniform success response dict.
 

--- a/agent/video_gen_registry.py
+++ b/agent/video_gen_registry.py
@@ -65,7 +65,7 @@ def list_providers() -> List[VideoGenProvider]:
     return sorted(items, key=lambda p: p.name)
 
 
-def get_provider(name: str) -> Optional[VideoGenProvider]:
+def get_provider(name: str) -> VideoGenProvider | None:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
@@ -73,13 +73,13 @@ def get_provider(name: str) -> Optional[VideoGenProvider]:
         return _providers.get(name.strip())
 
 
-def get_active_provider() -> Optional[VideoGenProvider]:
+def get_active_provider() -> VideoGenProvider | None:
     """Resolve the currently-active provider.
 
     Reads ``video_gen.provider`` from config.yaml; falls back per the
     module docstring.
     """
-    configured: Optional[str] = None
+    configured: str | None = None
     try:
         from hermes_cli.config import load_config
 

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -82,7 +82,7 @@ def list_providers() -> List[WebSearchProvider]:
     return sorted(items, key=lambda p: p.name)
 
 
-def get_provider(name: str) -> Optional[WebSearchProvider]:
+def get_provider(name: str) -> WebSearchProvider | None:
     """Return the provider registered under *name*, or None."""
     if not isinstance(name, str):
         return None
@@ -95,7 +95,7 @@ def get_provider(name: str) -> Optional[WebSearchProvider]:
 # ---------------------------------------------------------------------------
 
 
-def _read_config_key(*path: str) -> Optional[str]:
+def _read_config_key(*path: str) -> str | None:
     """Resolve a dotted config key from ``config.yaml``. Returns None on miss."""
     try:
         from hermes_cli.config import load_config
@@ -130,7 +130,7 @@ _LEGACY_PREFERENCE = (
 )
 
 
-def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearchProvider]:
+def _resolve(configured: str | None, *, capability: str) -> WebSearchProvider | None:
     """Resolve the active provider for a capability ("search" | "extract" | "crawl").
 
     Resolution rules (in order):
@@ -221,7 +221,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
     return None
 
 
-def get_active_search_provider() -> Optional[WebSearchProvider]:
+def get_active_search_provider() -> WebSearchProvider | None:
     """Resolve the currently-active web search provider.
 
     Reads ``web.search_backend`` (preferred) or ``web.backend`` (shared
@@ -231,7 +231,7 @@ def get_active_search_provider() -> Optional[WebSearchProvider]:
     return _resolve(explicit, capability="search")
 
 
-def get_active_extract_provider() -> Optional[WebSearchProvider]:
+def get_active_extract_provider() -> WebSearchProvider | None:
     """Resolve the currently-active web extract provider.
 
     Reads ``web.extract_backend`` (preferred) or ``web.backend`` (shared
@@ -241,7 +241,7 @@ def get_active_extract_provider() -> Optional[WebSearchProvider]:
     return _resolve(explicit, capability="extract")
 
 
-def get_active_crawl_provider() -> Optional[WebSearchProvider]:
+def get_active_crawl_provider() -> WebSearchProvider | None:
     """Resolve the currently-active web crawl provider.
 
     Reads ``web.crawl_backend`` (preferred) or ``web.backend`` (shared

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -547,7 +547,7 @@ class BatchRunner:
         providers_ignored: List[str] = None,
         providers_order: List[str] = None,
         provider_sort: str = None,
-        openrouter_min_coding_score: Optional[float] = None,
+        openrouter_min_coding_score: float | None = None,
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
@@ -712,7 +712,7 @@ class BatchRunner:
                 "last_updated": None
             }
     
-    def _save_checkpoint(self, checkpoint_data: Dict[str, Any], lock: Optional[Lock] = None):
+    def _save_checkpoint(self, checkpoint_data: Dict[str, Any], lock: Lock | None = None):
         """
         Save checkpoint data.
         

--- a/cli.py
+++ b/cli.py
@@ -962,10 +962,10 @@ def _run_cleanup():
 # =============================================================================
 
 # Tracks the active worktree for cleanup on exit
-_active_worktree: Optional[Dict[str, str]] = None
+_active_worktree: Dict[str, str] | None = None
 
 
-def _normalize_git_bash_path(p: Optional[str]) -> Optional[str]:
+def _normalize_git_bash_path(p: str | None) -> str | None:
     """Translate a Git Bash-style path (``/c/Users/...``) to the native
     Windows form (``C:\\Users\\...``) that Python's ``subprocess.Popen``
     and ``pathlib.Path`` accept.
@@ -994,7 +994,7 @@ def _normalize_git_bash_path(p: Optional[str]) -> Optional[str]:
     return p
 
 
-def _git_repo_root() -> Optional[str]:
+def _git_repo_root() -> str | None:
     """Return the git repo root for CWD, or None if not in a repo.
 
     Runs through :func:`_normalize_git_bash_path` so callers can pass
@@ -1024,7 +1024,7 @@ def _path_is_within_root(path: Path, root: Path) -> bool:
         return False
 
 
-def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
+def _setup_worktree(repo_root: str = None) -> Dict[str, str] | None:
     """Create an isolated git worktree for this CLI session.
 
     Returns a dict with worktree metadata on success, None on failure.
@@ -2812,7 +2812,7 @@ class HermesCLI:
         api_key: str = None,
         base_url: str = None,
         max_turns: int = None,
-        verbose: Optional[bool] = None,
+        verbose: bool | None = None,
         compact: bool = False,
         resume: str = None,
         checkpoints: bool = False,
@@ -2950,10 +2950,10 @@ class HermesCLI:
             or os.getenv("HERMES_INFERENCE_PROVIDER")
             or "auto"
         )
-        self._provider_source: Optional[str] = None
+        self._provider_source: str | None = None
         self.provider = self.requested_provider
         self.api_mode = "chat_completions"
-        self.acp_command: Optional[str] = None
+        self.acp_command: str | None = None
         self.acp_args: list[str] = []
         self.base_url = (
             base_url
@@ -3044,7 +3044,7 @@ class HermesCLI:
         # Empty string / None / out-of-range = unset (let OR pick strongest coder).
         _or_cfg = CLI_CONFIG.get("openrouter", {}) or {}
         _raw_score = _or_cfg.get("min_coding_score")
-        self._openrouter_min_coding_score: Optional[float] = None
+        self._openrouter_min_coding_score: float | None = None
         if _raw_score not in {None, ""}:
             try:
                 _f = float(_raw_score)
@@ -3064,7 +3064,7 @@ class HermesCLI:
         self._active_agent_route_signature = None
 
         # Agent will be initialized on first use
-        self.agent: Optional[Any] = None
+        self.agent: Any | None = None
         self._tool_callbacks_installed = False
         self._tirith_security_checked = False
         self._app = None  # prompt_toolkit Application (set in run())
@@ -3075,7 +3075,7 @@ class HermesCLI:
         self._resumed = False
         # Per-prompt elapsed timer — started at the beginning of each chat turn,
         # frozen when the agent thread completes, displayed in the status bar.
-        self._prompt_start_time: Optional[float] = None  # time.time() when turn started
+        self._prompt_start_time: float | None = None  # time.time() when turn started
         self._prompt_duration: float = 0.0  # frozen duration of last completed turn
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
@@ -3097,7 +3097,7 @@ class HermesCLI:
         _run_checkpoint_auto_maintenance()
 
         # Deferred title: stored in memory until the session is created in the DB
-        self._pending_title: Optional[str] = None
+        self._pending_title: str | None = None
         
         # Session ID: reuse existing one when resuming, otherwise generate fresh
         if resume:
@@ -3321,7 +3321,7 @@ class HermesCLI:
             self._resize_recovery_pending = False
             self._recover_after_resize(app, original_on_resize)
 
-    def _status_bar_context_style(self, percent_used: Optional[int]) -> str:
+    def _status_bar_context_style(self, percent_used: int | None) -> str:
         if percent_used is None:
             return "class:status-bar-dim"
         if percent_used >= 95:
@@ -3341,13 +3341,13 @@ class HermesCLI:
             return "class:status-bar-warn"
         return "class:status-bar-dim"
 
-    def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
+    def _build_context_bar(self, percent_used: int | None, width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
         return f"[{('█' * filled) + ('░' * max(0, width - filled))}]"
 
     @staticmethod
-    def _format_prompt_elapsed(prompt_start_time: Optional[float], prompt_duration: float, live: bool = False) -> str:
+    def _format_prompt_elapsed(prompt_start_time: float | None, prompt_duration: float, live: bool = False) -> str:
         """Format per-prompt elapsed time for the status bar.
 
         Always returns a string — shows 0s on fresh start before first turn.
@@ -3513,14 +3513,14 @@ class HermesCLI:
         except Exception:
             return shutil.get_terminal_size(default).columns
 
-    def _use_minimal_tui_chrome(self, width: Optional[int] = None) -> bool:
+    def _use_minimal_tui_chrome(self, width: int | None = None) -> bool:
         """Hide low-value chrome on narrow/mobile terminals to preserve rows."""
         if width is None:
             width = self._get_tui_terminal_width()
         return width < 64
 
     @staticmethod
-    def _scrollback_box_width(width: Optional[int] = None) -> int:
+    def _scrollback_box_width(width: int | None = None) -> int:
         """Return the full viewport width for printed scrollback box rules.
 
         Previously this clamped to ``max(32, min(width, 56))`` as a defense
@@ -3543,7 +3543,7 @@ class HermesCLI:
                 width = 80
         return max(32, int(width or 80))
 
-    def _tui_input_rule_height(self, position: str, width: Optional[int] = None) -> int:
+    def _tui_input_rule_height(self, position: str, width: int | None = None) -> int:
         """Return the visible height for the top/bottom input separator rules."""
         if position not in {"top", "bottom"}:
             raise ValueError(f"Unknown input rule position: {position}")
@@ -3553,13 +3553,13 @@ class HermesCLI:
             return 1
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
 
-    def _agent_spacer_height(self, width: Optional[int] = None) -> int:
+    def _agent_spacer_height(self, width: int | None = None) -> int:
         """Return the spacer height shown above the status bar while the agent runs."""
         if not getattr(self, "_agent_running", False):
             return 0
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
 
-    def _spinner_widget_height(self, width: Optional[int] = None) -> int:
+    def _spinner_widget_height(self, width: int | None = None) -> int:
         """Return the visible height for the spinner/status text line above the status bar."""
         spinner_line = self._render_spinner_text()
         if not spinner_line:
@@ -3627,7 +3627,7 @@ class HermesCLI:
         except Exception:
             self._voice_record_key_display_cache = "Ctrl+B"
 
-    def _get_voice_status_fragments(self, width: Optional[int] = None):
+    def _get_voice_status_fragments(self, width: int | None = None):
         """Return the voice status bar fragments for the interactive TUI."""
         width = width or self._get_tui_terminal_width()
         compact = self._use_minimal_tui_chrome(width=width)
@@ -3646,7 +3646,7 @@ class HermesCLI:
         cont = " | Continuous" if self._voice_continuous else ""
         return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  {label} to record ")]
 
-    def _build_status_bar_text(self, width: Optional[int] = None) -> str:
+    def _build_status_bar_text(self, width: int | None = None) -> str:
         """Return a compact one-line session status string for the TUI footer."""
         try:
             snapshot = self._get_status_bar_snapshot()
@@ -9946,7 +9946,7 @@ class HermesCLI:
     _DESTRUCTIVE_SKIP_TOKENS = frozenset({"now", "--yes", "-y"})
 
     @classmethod
-    def _split_destructive_skip(cls, cmd_text: Optional[str]) -> tuple[str, bool]:
+    def _split_destructive_skip(cls, cmd_text: str | None) -> tuple[str, bool]:
         """Split inline-skip tokens out of a destructive slash command.
 
         Returns ``(remainder, skip)`` where ``remainder`` is the original
@@ -9980,8 +9980,8 @@ class HermesCLI:
         self,
         command: str,
         detail: str,
-        cmd_original: Optional[str] = None,
-    ) -> Optional[str]:
+        cmd_original: str | None = None,
+    ) -> str | None:
         """Prompt the user to confirm a destructive session slash command.
 
         Used by ``/clear``, ``/new``/``/reset``, and ``/undo`` before they
@@ -11312,7 +11312,7 @@ class HermesCLI:
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None) -> Optional[str]:
+    def chat(self, message, images: list = None) -> str | None:
         """
         Send a message to the agent and get a response.
         
@@ -14522,7 +14522,7 @@ def main(
     api_key: str = None,
     base_url: str = None,
     max_turns: int = None,
-    verbose: Optional[bool] = None,
+    verbose: bool | None = None,
     quiet: bool = False,
     compact: bool = False,
     list_tools: bool = False,

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -46,7 +46,7 @@ OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
 
-def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
+def _normalize_skill_list(skill: str | None = None, skills: Any | None = None) -> List[str]:
     """Normalize legacy/single-skill and multi-skill inputs into a unique ordered list."""
     if skills is None:
         raw_items = [skill] if skill else []
@@ -296,8 +296,8 @@ def _recoverable_oneshot_run_at(
     schedule: Dict[str, Any],
     now: datetime,
     *,
-    last_run_at: Optional[str] = None,
-) -> Optional[str]:
+    last_run_at: str | None = None,
+) -> str | None:
     """Return a one-shot run time if it is still eligible to fire.
 
     One-shot jobs get a small grace window so jobs created a few seconds after
@@ -351,7 +351,7 @@ def _compute_grace_seconds(schedule: dict) -> int:
     return MIN_GRACE
 
 
-def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None) -> Optional[str]:
+def compute_next_run(schedule: Dict[str, Any], last_run_at: str | None = None) -> str | None:
     """
     Compute the next run time for a schedule.
 
@@ -449,7 +449,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
         raise
 
 
-def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
+def _normalize_workdir(workdir: str | None) -> str | None:
     """Normalize and validate a cron job workdir.
 
     Rules:
@@ -482,7 +482,7 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     return str(resolved)
 
 
-def _normalize_profile(profile: Optional[str]) -> Optional[str]:
+def _normalize_profile(profile: str | None) -> str | None:
     """Normalize and validate an optional cron job profile name.
 
     Empty / None disables per-job profile selection. Otherwise the profile name
@@ -507,22 +507,22 @@ def _normalize_profile(profile: Optional[str]) -> Optional[str]:
 
 
 def create_job(
-    prompt: Optional[str],
+    prompt: str | None,
     schedule: str,
-    name: Optional[str] = None,
-    repeat: Optional[int] = None,
-    deliver: Optional[str] = None,
-    origin: Optional[Dict[str, Any]] = None,
-    skill: Optional[str] = None,
-    skills: Optional[List[str]] = None,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
-    script: Optional[str] = None,
-    context_from: Optional[Union[str, List[str]]] = None,
-    enabled_toolsets: Optional[List[str]] = None,
-    workdir: Optional[str] = None,
-    profile: Optional[str] = None,
+    name: str | None = None,
+    repeat: int | None = None,
+    deliver: str | None = None,
+    origin: Dict[str, Any] | None = None,
+    skill: str | None = None,
+    skills: List[str] | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    script: str | None = None,
+    context_from: Union[str, List[str]] | None = None,
+    enabled_toolsets: List[str] | None = None,
+    workdir: str | None = None,
+    profile: str | None = None,
     no_agent: bool = False,
 ) -> Dict[str, Any]:
     """
@@ -671,7 +671,7 @@ def create_job(
     return job
 
 
-def get_job(job_id: str) -> Optional[Dict[str, Any]]:
+def get_job(job_id: str) -> Dict[str, Any] | None:
     """Get a job by ID."""
     jobs = load_jobs()
     for job in jobs:
@@ -693,7 +693,7 @@ class AmbiguousJobReference(LookupError):
         )
 
 
-def resolve_job_ref(ref: str) -> Optional[Dict[str, Any]]:
+def resolve_job_ref(ref: str) -> Dict[str, Any] | None:
     """Resolve a job reference (ID or name) to a job record.
 
     - Exact ID match wins (works even if a different job's name equals this ID).
@@ -726,7 +726,7 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
     return jobs
 
 
-def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def update_job(job_id: str, updates: Dict[str, Any]) -> Dict[str, Any] | None:
     """Update a job by ID, refreshing derived schedule fields when needed."""
     jobs = load_jobs()
     for i, job in enumerate(jobs):
@@ -783,7 +783,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
     return None
 
 
-def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
+def pause_job(job_id: str, reason: str | None = None) -> Dict[str, Any] | None:
     """Pause a job without deleting it. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
@@ -799,7 +799,7 @@ def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, A
     )
 
 
-def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
+def resume_job(job_id: str) -> Dict[str, Any] | None:
     """Resume a paused job and compute the next future run from now. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
@@ -818,7 +818,7 @@ def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
     )
 
 
-def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
+def trigger_job(job_id: str) -> Dict[str, Any] | None:
     """Schedule a job to run on the next scheduler tick. Accepts a job ID or name."""
     job = resolve_job_ref(job_id)
     if not job:
@@ -854,8 +854,8 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
-def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+def mark_job_run(job_id: str, success: bool, error: str | None = None,
+                 delivery_error: str | None = None):
     """
     Mark a job as having been run.
     
@@ -1091,8 +1091,8 @@ def save_job_output(job_id: str, output: str):
 # =============================================================================
 
 def rewrite_skill_refs(
-    consolidated: Optional[Dict[str, str]] = None,
-    pruned: Optional[List[str]] = None,
+    consolidated: Dict[str, str] | None = None,
+    pruned: List[str] | None = None,
 ) -> Dict[str, Any]:
     """Rewrite cron job skill references after a curator consolidation pass.
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -148,7 +148,7 @@ def _get_lock_paths() -> tuple[Path, Path]:
 
 
 @contextmanager
-def _job_profile_context(job_id: str, profile: Optional[str]):
+def _job_profile_context(job_id: str, profile: str | None):
     """Temporarily run a job under a specific Hermes profile.
 
     Cron jobs are stored and scheduled by the profile running the scheduler, but
@@ -212,7 +212,7 @@ def _job_profile_context(job_id: str, profile: Optional[str]):
                 os.environ[k] = v
 
 
-def _resolve_origin(job: dict) -> Optional[dict]:
+def _resolve_origin(job: dict) -> dict | None:
     """Extract origin info from a job, preserving any extra routing metadata.
 
     Treats non-dict origins (free-form provenance strings, ints, lists from
@@ -292,7 +292,7 @@ def _get_home_target_chat_id(platform_name: str) -> str:
     return value
 
 
-def _get_home_target_thread_id(platform_name: str) -> Optional[str]:
+def _get_home_target_thread_id(platform_name: str) -> str | None:
     """Return the optional thread/topic ID for a platform home target.
 
     Telegram-only override: ``TELEGRAM_CRON_THREAD_ID`` takes precedence over
@@ -336,7 +336,7 @@ def _iter_home_target_platforms():
         pass
 
 
-def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
+def _resolve_single_delivery_target(job: dict, deliver_value: str) -> dict | None:
     """Resolve one concrete auto-delivery target for a cron job."""
 
     origin = _resolve_origin(job)
@@ -500,7 +500,7 @@ def _resolve_delivery_targets(job: dict) -> List[dict]:
     return targets
 
 
-def _resolve_delivery_target(job: dict) -> Optional[dict]:
+def _resolve_delivery_target(job: dict) -> dict | None:
     """Resolve the concrete auto-delivery target for a cron job, if any."""
     targets = _resolve_delivery_targets(job)
     return targets[0] if targets else None
@@ -568,7 +568,7 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> str | None:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -954,7 +954,7 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
-def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
+def _build_job_prompt(job: dict, prerun_script: tuple | None = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
     Args:
@@ -1134,14 +1134,14 @@ def _scan_assembled_cron_prompt(assembled: str, job: dict) -> str:
     return assembled
 
 
-def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def run_job(job: dict) -> tuple[bool, str, str, str | None]:
     """Execute a single cron job, applying any per-job profile override."""
     job_id = job["id"]
     with _job_profile_context(job_id, job.get("profile")):
         return _run_job_impl(job)
 
 
-def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
+def _run_job_impl(job: dict) -> tuple[bool, str, str, str | None]:
     """
     Execute a single cron job.
     
@@ -1836,7 +1836,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
-        _max_workers: Optional[int] = None
+        _max_workers: int | None = None
         try:
             _env_par = os.getenv("HERMES_CRON_MAX_PARALLEL", "").strip()
             if _env_par:

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -33,7 +33,7 @@ def _channel_target_name(platform_name: str, channel: Dict[str, Any]) -> str:
     return name
 
 
-def _session_entry_id(origin: Dict[str, Any]) -> Optional[str]:
+def _session_entry_id(origin: Dict[str, Any]) -> str | None:
     chat_id = origin.get("chat_id")
     if not chat_id:
         return None
@@ -163,7 +163,7 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
 
     for team_id, client in team_clients.items():
         try:
-            cursor: Optional[str] = None
+            cursor: str | None = None
             for _page in range(20):  # safety cap on pagination
                 response = await client.users_conversations(
                     types="public_channel,private_channel",
@@ -255,7 +255,7 @@ def load_directory() -> Dict[str, Any]:
         return {"updated_at": None, "platforms": {}}
 
 
-def lookup_channel_type(platform_name: str, chat_id: str) -> Optional[str]:
+def lookup_channel_type(platform_name: str, chat_id: str) -> str | None:
     """Return the channel ``type`` string (e.g. ``"channel"``, ``"forum"``) for *chat_id*, or *None* if unknown."""
     directory = load_directory()
     for ch in directory.get("platforms", {}).get(platform_name, []):
@@ -264,7 +264,7 @@ def lookup_channel_type(platform_name: str, chat_id: str) -> Optional[str]:
     return None
 
 
-def resolve_channel_name(platform_name: str, name: str) -> Optional[str]:
+def resolve_channel_name(platform_name: str, name: str) -> str | None:
     """
     Resolve a human-friendly channel name to a numeric ID.
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -94,7 +94,7 @@ def _ensure_platform_extra_dict(platforms_data: dict, name: str) -> tuple[dict, 
 
 # Module-level cache for bundled platform plugin names (lives outside the
 # enum so it doesn't become an accidental enum member).
-_Platform__bundled_plugin_names: Optional[set] = None
+_Platform__bundled_plugin_names: set | None = None
 
 
 class Platform(Enum):
@@ -212,7 +212,7 @@ class HomeChannel:
     platform: Platform
     chat_id: str
     name: str  # Human-readable name for display
-    thread_id: Optional[str] = None
+    thread_id: str | None = None
     
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -281,9 +281,9 @@ class SessionResetPolicy:
 class PlatformConfig:
     """Configuration for a single messaging platform."""
     enabled: bool = False
-    token: Optional[str] = None  # Bot token (Telegram, Discord)
-    api_key: Optional[str] = None  # API key if different from token
-    home_channel: Optional[HomeChannel] = None
+    token: str | None = None  # Bot token (Telegram, Discord)
+    api_key: str | None = None  # API key if different from token
+    home_channel: HomeChannel | None = None
     
     # Reply threading mode (Telegram/Slack)
     # - "off": Never thread replies to original message
@@ -539,7 +539,7 @@ class GatewayConfig:
 
         return False
     
-    def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
+    def get_home_channel(self, platform: Platform) -> HomeChannel | None:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
         if config:
@@ -548,8 +548,8 @@ class GatewayConfig:
     
     def get_reset_policy(
         self, 
-        platform: Optional[Platform] = None,
-        session_type: Optional[str] = None
+        platform: Platform | None = None,
+        session_type: str | None = None
     ) -> SessionResetPolicy:
         """
         Get the appropriate reset policy for a session.
@@ -658,7 +658,7 @@ class GatewayConfig:
             session_store_max_age_days=session_store_max_age_days,
         )
 
-    def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
+    def get_unauthorized_dm_behavior(self, platform: Platform | None = None) -> str:
         """Return the effective unauthorized-DM behavior for a platform."""
         if platform:
             platform_cfg = self.platforms.get(platform)
@@ -669,7 +669,7 @@ class GatewayConfig:
                 )
         return self.unauthorized_dm_behavior
 
-    def get_notice_delivery(self, platform: Optional[Platform] = None) -> str:
+    def get_notice_delivery(self, platform: Platform | None = None) -> str:
         """Return the effective notice-delivery mode for a platform."""
         if platform:
             platform_cfg = self.platforms.get(platform)

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -37,13 +37,13 @@ class DeliveryTarget:
     - "telegram:123456" → specific Telegram chat
     """
     platform: Platform
-    chat_id: Optional[str] = None  # None means use home channel
-    thread_id: Optional[str] = None
+    chat_id: str | None = None  # None means use home channel
+    thread_id: str | None = None
     is_origin: bool = False
     is_explicit: bool = False  # True if chat_id was explicitly specified
     
     @classmethod
-    def parse(cls, target: str, origin: Optional[SessionSource] = None) -> "DeliveryTarget":
+    def parse(cls, target: str, origin: SessionSource | None = None) -> "DeliveryTarget":
         """
         Parse a delivery target string.
         
@@ -130,9 +130,9 @@ class DeliveryRouter:
         self,
         content: str,
         targets: List[DeliveryTarget],
-        job_id: Optional[str] = None,
-        job_name: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        job_id: str | None = None,
+        job_name: str | None = None,
+        metadata: Dict[str, Any] | None = None
     ) -> Dict[str, Any]:
         """
         Deliver content to all specified targets.
@@ -171,9 +171,9 @@ class DeliveryRouter:
     def _deliver_local(
         self,
         content: str,
-        job_id: Optional[str],
-        job_name: Optional[str],
-        metadata: Optional[Dict[str, Any]]
+        job_id: str | None,
+        job_name: str | None,
+        metadata: Dict[str, Any] | None
     ) -> Dict[str, Any]:
         """Save content to local files."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -227,7 +227,7 @@ class DeliveryRouter:
         self,
         target: DeliveryTarget,
         content: str,
-        metadata: Optional[Dict[str, Any]]
+        metadata: Dict[str, Any] | None
     ) -> Dict[str, Any]:
         """Deliver content to a messaging platform."""
         adapter = self.adapters.get(target.platform)

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -155,7 +155,7 @@ class HookRegistry:
             handlers.extend(self._handlers.get(wildcard_key, []))
         return handlers
 
-    async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
+    async def emit(self, event_type: str, context: Dict[str, Any] | None = None) -> None:
         """
         Fire all handlers registered for an event, discarding return values.
 
@@ -183,7 +183,7 @@ class HookRegistry:
     async def emit_collect(
         self,
         event_type: str,
-        context: Optional[Dict[str, Any]] = None,
+        context: Dict[str, Any] | None = None,
     ) -> List[Any]:
         """Fire handlers and return their non-None return values in order.
 

--- a/gateway/memory_monitor.py
+++ b/gateway/memory_monitor.py
@@ -42,14 +42,14 @@ logger = logging.getLogger(__name__)
 
 _BYTES_TO_MB = 1024 * 1024
 
-_monitor_thread: Optional[threading.Thread] = None
-_stop_event: Optional[threading.Event] = None
-_start_time: Optional[float] = None
+_monitor_thread: threading.Thread | None = None
+_stop_event: threading.Event | None = None
+_start_time: float | None = None
 _interval_seconds: float = 300.0  # 5 minutes
 _lock = threading.Lock()
 
 
-def _get_rss_mb() -> Optional[int]:
+def _get_rss_mb() -> int | None:
     """Return current process resident set size in MB, or None if unavailable.
 
     Tries ``resource.getrusage`` first (Linux/macOS, no extra deps), then

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -27,8 +27,8 @@ def mirror_to_session(
     chat_id: str,
     message_text: str,
     source_label: str = "cli",
-    thread_id: Optional[str] = None,
-    user_id: Optional[str] = None,
+    thread_id: str | None = None,
+    user_id: str | None = None,
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
@@ -84,9 +84,9 @@ def mirror_to_session(
 def _find_session_id(
     platform: str,
     chat_id: str,
-    thread_id: Optional[str] = None,
-    user_id: Optional[str] = None,
-) -> Optional[str]:
+    thread_id: str | None = None,
+    user_id: str | None = None,
+) -> str | None:
     """
     Find the active session_id for a platform + chat_id pair.
 

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -203,7 +203,7 @@ class PairingStore:
 
     def generate_code(
         self, platform: str, user_id: str, user_name: str = ""
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Generate a pairing code for a new user.
 
@@ -257,7 +257,7 @@ class PairingStore:
 
             return code
 
-    def approve_code(self, platform: str, code: str) -> Optional[dict]:
+    def approve_code(self, platform: str, code: str) -> dict | None:
         """
         Approve a pairing code. Adds the user to the approved list.
 

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -56,12 +56,12 @@ class PlatformEntry:
     # Optional: given a PlatformConfig, is it properly configured?
     # If None, the registry skips config validation and lets the adapter
     # fail at connect() time with a descriptive error.
-    validate_config: Optional[Callable[[Any], bool]] = None
+    validate_config: Callable[[Any], bool] | None = None
 
     # Optional: given a PlatformConfig, is the platform connected/enabled?
     # Used by ``GatewayConfig.get_connected_platforms()`` and setup UI status.
     # If None, falls back to ``validate_config`` or ``check_fn``.
-    is_connected: Optional[Callable[[Any], bool]] = None
+    is_connected: Callable[[Any], bool] | None = None
 
     # Env vars this platform needs (for ``hermes setup`` display).
     required_env: list = field(default_factory=list)
@@ -73,7 +73,7 @@ class PlatformEntry:
     # Signature: () -> None (prompts user, saves env vars).
     # If None, falls back to _setup_standard_platform (needs token_var + vars)
     # or a generic "set these env vars" display.
-    setup_fn: Optional[Callable[[], None]] = None
+    setup_fn: Callable[[], None] | None = None
 
     # "builtin" or "plugin"
     source: str = "plugin"
@@ -117,7 +117,7 @@ class PlatformEntry:
     # ``gateway status`` etc. can reflect env-only configuration without
     # instantiating the adapter.  Return ``None`` (or an empty dict) to skip.
     # Signature: () -> Optional[dict[str, Any]]
-    env_enablement_fn: Optional[Callable[[], Optional[dict]]] = None
+    env_enablement_fn: Callable[[], dict | None] | None = None
 
     # ── YAML→env config bridge ──
     # Optional: translate this platform's ``config.yaml`` keys into env vars
@@ -133,7 +133,7 @@ class PlatformEntry:
     # are caught and logged at debug level.
     # See website/docs/developer-guide/adding-platform-adapters.md for the
     # full contract and a worked example.
-    apply_yaml_config_fn: Optional[Callable[[dict, dict], Optional[dict]]] = None
+    apply_yaml_config_fn: Callable[[dict, dict], dict | None] | None = None
 
     # Optional: home-channel env var name for cron/notification delivery
     # (e.g. ``"IRC_HOME_CHANNEL"``).  When set, ``cron.scheduler`` treats this
@@ -156,7 +156,7 @@ class PlatformEntry:
     # ephemeral connection / acquire a fresh OAuth token, send, and close.
     # Without this hook, plugin platforms cannot serve as cron ``deliver=``
     # targets when the gateway is not co-resident with the cron process.
-    standalone_sender_fn: Optional[Callable[..., Awaitable[dict]]] = None
+    standalone_sender_fn: Callable[..., Awaitable[dict]] | None = None
 
 
 class PlatformRegistry:
@@ -190,7 +190,7 @@ class PlatformRegistry:
         """Remove a platform entry.  Returns True if it existed."""
         return self._entries.pop(name, None) is not None
 
-    def get(self, name: str) -> Optional[PlatformEntry]:
+    def get(self, name: str) -> PlatformEntry | None:
         """Look up a platform entry by name."""
         return self._entries.get(name)
 
@@ -205,7 +205,7 @@ class PlatformRegistry:
     def is_registered(self, name: str) -> bool:
         return name in self._entries
 
-    def create_adapter(self, name: str, config: Any) -> Optional[Any]:
+    def create_adapter(self, name: str, config: Any) -> Any | None:
         """Create an adapter instance for the given platform name.
 
         Returns None if:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -338,7 +338,7 @@ class ResponseStore:
                 db_path = str(get_hermes_home() / "response_store.db")
             except Exception:
                 db_path = ":memory:"
-        self._db_path: Optional[str] = db_path if db_path != ":memory:" else None
+        self._db_path: str | None = db_path if db_path != ":memory:" else None
         try:
             self._conn = sqlite3.connect(db_path, check_same_thread=False)
         except Exception:
@@ -390,7 +390,7 @@ class ResponseStore:
                     exc_info=True,
                 )
 
-    def get(self, response_id: str) -> Optional[Dict[str, Any]]:
+    def get(self, response_id: str) -> Dict[str, Any] | None:
         """Retrieve a stored response by ID (updates access time for LRU)."""
         row = self._conn.execute(
             "SELECT data FROM responses WHERE response_id = ?", (response_id,)
@@ -447,7 +447,7 @@ class ResponseStore:
         self._conn.commit()
         return cursor.rowcount > 0
 
-    def get_conversation(self, name: str) -> Optional[str]:
+    def get_conversation(self, name: str) -> str | None:
         """Get the latest response_id for a conversation name."""
         row = self._conn.execute(
             "SELECT response_id FROM conversations WHERE name = ?", (name,)
@@ -615,7 +615,7 @@ def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
 
 
 def _derive_chat_session_id(
-    system_prompt: Optional[str],
+    system_prompt: str | None,
     first_user_message: str,
 ) -> str:
     """Derive a stable session ID from the conversation's first user message.
@@ -679,12 +679,12 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
-        self._app: Optional["web.Application"] = None
-        self._runner: Optional["web.AppRunner"] = None
-        self._site: Optional["web.TCPSite"] = None
+        self._app: "web.Application" | None = None
+        self._runner: "web.AppRunner" | None = None
+        self._site: "web.TCPSite" | None = None
         self._response_store = ResponseStore()
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
-        self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
+        self._run_streams: Dict[str, "asyncio.Queue[Dict | None]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
         self._run_streams_created: Dict[str, float] = {}
         # Active run agent/task references for stop support
@@ -696,7 +696,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
-        self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._session_db: Any | None = None  # Lazy-init SessionDB for session continuity
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -733,7 +733,7 @@ class APIServerAdapter(BasePlatformAdapter):
             pass
         return "hermes-agent"
 
-    def _cors_headers_for_origin(self, origin: str) -> Optional[Dict[str, str]]:
+    def _cors_headers_for_origin(self, origin: str) -> Dict[str, str] | None:
         """Return CORS headers for an allowed browser origin."""
         if not origin or not self._cors_origins:
             return None
@@ -804,7 +804,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _parse_session_key_header(
         self, request: "web.Request"
-    ) -> tuple[Optional[str], Optional["web.Response"]]:
+    ) -> tuple[str | None, Optional["web.Response"]]:
         """Extract and validate the ``X-Hermes-Session-Key`` header.
 
         The session key is a stable per-channel identifier that scopes
@@ -878,13 +878,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _create_agent(
         self,
-        ephemeral_system_prompt: Optional[str] = None,
-        session_id: Optional[str] = None,
+        ephemeral_system_prompt: str | None = None,
+        session_id: str | None = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
-        gateway_session_key: Optional[str] = None,
+        gateway_session_key: str | None = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -1532,11 +1532,11 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_ref,
         conversation_history: List[Dict[str, str]],
         user_message: str,
-        instructions: Optional[str],
-        conversation: Optional[str],
+        instructions: str | None,
+        conversation: str | None,
         store: bool,
         session_id: str,
-        gateway_session_key: Optional[str] = None,
+        gateway_session_key: str | None = None,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -1604,7 +1604,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Track the assistant message item id + content index for text
         # delta events — the spec ties deltas to a specific item.
         message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
-        message_output_index: Optional[int] = None
+        message_output_index: int | None = None
         message_opened = False
 
         async def _write_event(event_type: str, data: Dict[str, Any]) -> None:
@@ -1626,14 +1626,14 @@ class APIServerAdapter(BasePlatformAdapter):
             return env
 
         final_response_text = ""
-        agent_error: Optional[str] = None
+        agent_error: str | None = None
         usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
 
         def _persist_response_snapshot(
             response_env: Dict[str, Any],
             *,
-            conversation_history_snapshot: Optional[List[Dict[str, Any]]] = None,
+            conversation_history_snapshot: List[Dict[str, Any]] | None = None,
         ) -> None:
             if not store:
                 return
@@ -1863,7 +1863,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # ── Batching state ──
             _batch_buf: List[str] = []
-            _batch_timer: Optional[asyncio.Task] = None
+            _batch_timer: asyncio.Task | None = None
             _batch_lock = asyncio.Lock()
 
             async def _batch_flush_after(delay: float) -> None:
@@ -2763,14 +2763,14 @@ class APIServerAdapter(BasePlatformAdapter):
         self,
         user_message: str,
         conversation_history: List[Dict[str, str]],
-        ephemeral_system_prompt: Optional[str] = None,
-        session_id: Optional[str] = None,
+        ephemeral_system_prompt: str | None = None,
+        session_id: str | None = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
-        agent_ref: Optional[list] = None,
-        gateway_session_key: Optional[str] = None,
+        agent_ref: list | None = None,
+        gateway_session_key: str | None = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2970,7 +2970,7 @@ class APIServerAdapter(BasePlatformAdapter):
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
-        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
+        q: "asyncio.Queue[Dict | None]" = asyncio.Queue()
         created_at = time.time()
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = created_at
@@ -2979,7 +2979,7 @@ class APIServerAdapter(BasePlatformAdapter):
         event_cb = self._make_run_event_callback(run_id, loop)
 
         # Also wire stream_delta_callback so message.delta events flow through.
-        def _text_cb(delta: Optional[str]) -> None:
+        def _text_cb(delta: str | None) -> None:
             if delta is None:
                 return
             try:
@@ -3534,8 +3534,8 @@ class APIServerAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """
         Not used — HTTP request/response cycle handles delivery directly.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -864,7 +864,7 @@ def _path_is_within(path: Path, root: Path) -> bool:
         return False
 
 
-def validate_media_delivery_path(path: str) -> Optional[str]:
+def validate_media_delivery_path(path: str) -> str | None:
     """Return a safe absolute file path for native media delivery, else None.
 
     MEDIA tags and bare local paths in model output are untrusted text. Only
@@ -1044,7 +1044,7 @@ class MessageEvent:
     
     # Original platform data
     raw_message: Any = None
-    message_id: Optional[str] = None
+    message_id: str | None = None
 
     # Platform-specific update identifier.  For Telegram this is the
     # ``update_id`` from the PTB Update wrapper; other platforms currently
@@ -1053,7 +1053,7 @@ class MessageEvent:
     # the same ``/restart`` twice if PTB's graceful-shutdown ACK times out
     # ("Error while calling `get_updates` one more time to mark all fetched
     # updates" in gateway.log).
-    platform_update_id: Optional[int] = None
+    platform_update_id: int | None = None
     
     # Media attachments
     # media_urls: local file paths (for vision tool access)
@@ -1061,22 +1061,22 @@ class MessageEvent:
     media_types: List[str] = field(default_factory=list)
     
     # Reply context
-    reply_to_message_id: Optional[str] = None
-    reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
+    reply_to_message_id: str | None = None
+    reply_to_text: str | None = None  # Text of the replied-to message (for context injection)
     
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.
-    auto_skill: Optional[str | list[str]] = None
+    auto_skill: str | list[str] | None = None
 
     # Per-channel ephemeral system prompt (e.g. Discord channel_prompts).
     # Applied at API call time and never persisted to transcript history.
-    channel_prompt: Optional[str] = None
+    channel_prompt: str | None = None
 
     # Channel context recovered by history backfill (e.g. messages between
     # bot turns that were missed due to require_mention).  Kept separate
     # from ``text`` so the sender-prefix logic in run.py can operate on the
     # trigger message alone, then prepend this context afterward.
-    channel_context: Optional[str] = None
+    channel_context: str | None = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
@@ -1089,7 +1089,7 @@ class MessageEvent:
         """Check if this is a command message (e.g., /new, /reset)."""
         return self.text.startswith("/")
     
-    def get_command(self) -> Optional[str]:
+    def get_command(self) -> str | None:
         """Extract command name if this is a command message."""
         if not self.is_command():
             return None
@@ -1161,8 +1161,8 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
 class SendResult:
     """Result of sending a message."""
     success: bool
-    message_id: Optional[str] = None
-    error: Optional[str] = None
+    message_id: str | None = None
+    error: str | None = None
     raw_response: Any = None
     retryable: bool = False  # True for transient connection errors — base will retry automatically
     # When the adapter had to split an oversized payload across multiple
@@ -1195,9 +1195,9 @@ class EphemeralReply(str):
     disables auto-deletion globally, preserving prior behavior.
     """
 
-    ttl_seconds: Optional[int]
+    ttl_seconds: int | None
 
-    def __new__(cls, text: str, ttl_seconds: Optional[int] = None):
+    def __new__(cls, text: str, ttl_seconds: int | None = None):
         instance = super().__new__(cls, text)
         instance.ttl_seconds = ttl_seconds
         return instance
@@ -1298,7 +1298,7 @@ _RETRYABLE_ERROR_PATTERNS = (
 # Type for message handlers.  Handlers may return a plain string (normal
 # reply), an ``EphemeralReply`` to opt the reply into auto-deletion, or
 # ``None`` when the response was already delivered (e.g. via streaming).
-MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+MessageHandler = Callable[[MessageEvent], Awaitable[Union[str, "EphemeralReply"] | None]]
 
 
 def resolve_channel_prompt(
@@ -1400,12 +1400,12 @@ class BasePlatformAdapter(ABC):
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform
-        self._message_handler: Optional[MessageHandler] = None
+        self._message_handler: MessageHandler | None = None
         self._running = False
-        self._fatal_error_code: Optional[str] = None
-        self._fatal_error_message: Optional[str] = None
+        self._fatal_error_code: str | None = None
+        self._fatal_error_message: str | None = None
         self._fatal_error_retryable = True
-        self._fatal_error_handler: Optional[Callable[["BasePlatformAdapter"], Awaitable[None] | None]] = None
+        self._fatal_error_handler: Callable[["BasePlatformAdapter"], Awaitable[None] | None] | None = None
         
         # Track active message handlers per session for interrupt support.
         # _active_sessions stores the per-session interrupt Event; _session_tasks
@@ -1439,7 +1439,7 @@ class BasePlatformAdapter(ABC):
         # registered by a fresher run for the same session.
         self._post_delivery_callbacks: Dict[str, Any] = {}
         self._expected_cancelled_tasks: set[asyncio.Task] = set()
-        self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
+        self._busy_session_handler: Callable[[MessageEvent, str], Awaitable[bool]] | None = None
         # Auto-TTS on voice input: ``_auto_tts_default`` is the global default
         # (``voice.auto_tts`` in config.yaml, pushed by GatewayRunner on connect).
         # Per-chat overrides live in two sets populated from ``_voice_mode``:
@@ -1470,8 +1470,8 @@ class BasePlatformAdapter(ABC):
 
     def supports_draft_streaming(
         self,
-        chat_type: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        chat_type: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> bool:
         """Whether this adapter supports native streaming-draft updates.
 
@@ -1492,7 +1492,7 @@ class BasePlatformAdapter(ABC):
         chat_id: str,
         draft_id: int,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send or update an animated streaming-draft preview.
 
@@ -1519,11 +1519,11 @@ class BasePlatformAdapter(ABC):
         return self._fatal_error_message is not None
 
     @property
-    def fatal_error_message(self) -> Optional[str]:
+    def fatal_error_message(self) -> str | None:
         return self._fatal_error_message
 
     @property
-    def fatal_error_code(self) -> Optional[str]:
+    def fatal_error_code(self) -> str | None:
         return self._fatal_error_code
 
     @property
@@ -1656,7 +1656,7 @@ class BasePlatformAdapter(ABC):
         """
         self._message_handler = handler
 
-    def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
+    def set_busy_session_handler(self, handler: Callable[[MessageEvent, str], Awaitable[bool]] | None) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
     
@@ -1689,8 +1689,8 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None
     ) -> SendResult:
         """
         Send a message to a chat.
@@ -1718,7 +1718,7 @@ class BasePlatformAdapter(ABC):
         self,
         parent_chat_id: str,
         name: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Create a fresh thread under ``parent_chat_id`` for a session handoff.
 
         Used by the gateway's handoff watcher when transferring a CLI
@@ -1856,7 +1856,7 @@ class BasePlatformAdapter(ABC):
         message: str,
         session_key: str,
         confirm_id: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a three-option slash-command confirmation prompt.
 
@@ -1888,10 +1888,10 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         question: str,
-        choices: Optional[list],
+        choices: list | None,
         clarify_id: str,
         session_key: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a clarify prompt to the user.
 
@@ -1944,10 +1944,10 @@ class BasePlatformAdapter(ABC):
     async def send_private_notice(
         self,
         chat_id: str,
-        user_id: Optional[str],
+        user_id: str | None,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a notice privately when the platform supports it.
 
@@ -1982,7 +1982,7 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images.
@@ -2039,9 +2039,9 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """
         Send an image natively via the platform API.
@@ -2058,9 +2058,9 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         animation_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """
         Send an animated GIF natively via the platform API.
@@ -2129,9 +2129,9 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2171,9 +2171,9 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2191,10 +2191,10 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2212,9 +2212,9 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """
@@ -2230,7 +2230,7 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 
     @staticmethod
-    def validate_media_delivery_path(path: str) -> Optional[str]:
+    def validate_media_delivery_path(path: str) -> str | None:
         """Return a resolved path if it is safe for native attachment upload."""
         return validate_media_delivery_path(path)
 
@@ -2616,7 +2616,7 @@ class BasePlatformAdapter(ABC):
             logger.warning("[%s] %s hook failed: %s", self.name, hook_name, e)
 
     @staticmethod
-    def _is_retryable_error(error: Optional[str]) -> bool:
+    def _is_retryable_error(error: str | None) -> bool:
         """Return True if the error string looks like a transient network failure."""
         if not error:
             return False
@@ -2624,7 +2624,7 @@ class BasePlatformAdapter(ABC):
         return any(pat in lowered for pat in _RETRYABLE_ERROR_PATTERNS)
 
     @staticmethod
-    def _is_timeout_error(error: Optional[str]) -> bool:
+    def _is_timeout_error(error: str | None) -> bool:
         """Return True if the error string indicates a read/write timeout.
 
         Timeout errors are NOT retryable and should NOT trigger plain-text
@@ -2635,7 +2635,7 @@ class BasePlatformAdapter(ABC):
         lowered = error.lower()
         return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
 
-    def _unwrap_ephemeral(self, response: Any) -> Tuple[Optional[str], int]:
+    def _unwrap_ephemeral(self, response: Any) -> Tuple[str | None, int]:
         """Unwrap a handler response into (text, ttl_seconds).
 
         Accepts a plain string, ``None``, or an :class:`EphemeralReply`.
@@ -2661,7 +2661,7 @@ class BasePlatformAdapter(ABC):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
+        reply_to: str | None = None,
         metadata: Any = None,
         max_retries: int = 2,
         base_delay: float = 2.0,
@@ -2740,7 +2740,7 @@ class BasePlatformAdapter(ABC):
         return fallback_result
 
     @staticmethod
-    def _merge_caption(existing_text: Optional[str], new_text: str) -> str:
+    def _merge_caption(existing_text: str | None, new_text: str) -> str:
         """Merge a new caption into existing text, avoiding duplicates.
 
         Uses line-by-line exact match (not substring) to prevent false positives
@@ -2922,7 +2922,7 @@ class BasePlatformAdapter(ABC):
         self,
         session_key: str,
         *,
-        guard: Optional[asyncio.Event] = None,
+        guard: asyncio.Event | None = None,
     ) -> None:
         """Release the adapter-level guard for a session.
 
@@ -2987,7 +2987,7 @@ class BasePlatformAdapter(ABC):
         event: MessageEvent,
         session_key: str,
         *,
-        interrupt_event: Optional[asyncio.Event] = None,
+        interrupt_event: asyncio.Event | None = None,
     ) -> bool:
         """Spawn a background processing task under the given session guard.
 
@@ -3930,25 +3930,25 @@ class BasePlatformAdapter(ABC):
         """Check if there's a pending interrupt for a session."""
         return session_key in self._active_sessions and self._active_sessions[session_key].is_set()
     
-    def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
+    def get_pending_message(self, session_key: str) -> MessageEvent | None:
         """Get and clear any pending message for a session."""
         return self._pending_messages.pop(session_key, None)
     
     def build_source(
         self,
         chat_id: str,
-        chat_name: Optional[str] = None,
+        chat_name: str | None = None,
         chat_type: str = "dm",
-        user_id: Optional[str] = None,
-        user_name: Optional[str] = None,
-        thread_id: Optional[str] = None,
-        chat_topic: Optional[str] = None,
-        user_id_alt: Optional[str] = None,
-        chat_id_alt: Optional[str] = None,
+        user_id: str | None = None,
+        user_name: str | None = None,
+        thread_id: str | None = None,
+        chat_topic: str | None = None,
+        user_id_alt: str | None = None,
+        chat_id_alt: str | None = None,
         is_bot: bool = False,
-        guild_id: Optional[str] = None,
-        parent_chat_id: Optional[str] = None,
-        message_id: Optional[str] = None,
+        guild_id: str | None = None,
+        parent_chat_id: str | None = None,
+        message_id: str | None = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -4029,7 +4029,7 @@ class BasePlatformAdapter(ABC):
         remaining = content
         # When the previous chunk ended mid-code-block, this holds the
         # language tag (possibly "") so we can reopen the fence.
-        carry_lang: Optional[str] = None
+        carry_lang: str | None = None
 
         while remaining:
             # If we're continuing a code block from the previous chunk,

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -124,9 +124,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
-        self.client: Optional[httpx.AsyncClient] = None
+        self.client: httpx.AsyncClient | None = None
         self._runner = None
-        self._private_api_enabled: Optional[bool] = None
+        self._private_api_enabled: bool | None = None
         self._helper_connected: bool = False
         self._guid_cache: Dict[str, str] = {}
 
@@ -350,7 +350,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Chat GUID resolution
     # ------------------------------------------------------------------
 
-    async def _resolve_chat_guid(self, target: str) -> Optional[str]:
+    async def _resolve_chat_guid(self, target: str) -> str | None:
         """Resolve an email/phone to a BlueBubbles chat GUID.
 
         If *target* already contains a semicolon (raw GUID format like
@@ -418,8 +418,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         text = self.format_message(content)
         if not text:
@@ -475,8 +475,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        filename: Optional[str] = None,
-        caption: Optional[str] = None,
+        filename: str | None = None,
+        caption: str | None = None,
         is_audio_message: bool = False,
     ) -> SendResult:
         """Send a file attachment via BlueBubbles multipart upload."""
@@ -529,9 +529,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         try:
             from gateway.platforms.base import cache_image_from_url
@@ -545,8 +545,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         return await self._send_attachment(chat_id, image_path, caption=caption)
@@ -555,8 +555,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         return await self._send_attachment(
@@ -567,8 +567,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         return await self._send_attachment(chat_id, video_path, caption=caption)
@@ -577,9 +577,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         return await self._send_attachment(
@@ -590,9 +590,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         animation_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         return await self.send_image(
             chat_id, animation_url, caption, reply_to, metadata
@@ -695,7 +695,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     async def _download_attachment(
         self, att_guid: str, att_meta: Dict[str, Any]
-    ) -> Optional[str]:
+    ) -> str | None:
         """Download an attachment from BlueBubbles and cache it locally.
 
         Returns the local file path on success, None on failure.
@@ -759,7 +759,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     def _extract_payload_record(
         self, payload: Dict[str, Any]
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any] | None:
         data = payload.get("data")
         if isinstance(data, dict):
             return data
@@ -772,7 +772,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return payload if isinstance(payload, dict) else None
 
     @staticmethod
-    def _value(*candidates: Any) -> Optional[str]:
+    def _value(*candidates: Any) -> str | None:
         for candidate in candidates:
             if isinstance(candidate, str) and candidate.strip():
                 return candidate.strip()

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -197,10 +197,10 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._allowed_users: Set[str] = self._load_allowed_users()
 
         self._stream_client: Any = None
-        self._stream_task: Optional[asyncio.Task] = None
-        self._http_client: Optional["httpx.AsyncClient"] = None
-        self._card_sdk: Optional[Any] = None
-        self._robot_sdk: Optional[Any] = None
+        self._stream_task: asyncio.Task | None = None
+        self._http_client: "httpx.AsyncClient" | None = None
+        self._card_sdk: Any | None = None
+        self._robot_sdk: Any | None = None
         self._robot_code: str = extra.get("robot_code") or self._client_id
 
         # Message deduplication
@@ -211,7 +211,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         # of a single class attribute to avoid cross-message clobbering when
         # multiple conversations run concurrently.
         self._message_contexts: Dict[str, Any] = {}
-        self._card_template_id: Optional[str] = extra.get("card_template_id")
+        self._card_template_id: str | None = extra.get("card_template_id")
 
         # Chats for which we've already fired the Done reaction — prevents
         # double-firing across segment boundaries or parallel flows
@@ -822,8 +822,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a markdown reply via DingTalk session webhook."""
         metadata = metadata or {}
@@ -934,9 +934,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an image via DingTalk markdown.
 
@@ -958,9 +958,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """DingTalk webhook replies cannot send local image files directly."""
@@ -976,10 +976,10 @@ class DingTalkAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """DingTalk webhook replies cannot send local file attachments directly."""
@@ -998,7 +998,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             "type": "group" if "group" in chat_id.lower() else "dm",
         }
 
-    def _get_valid_webhook(self, chat_id: str) -> Optional[tuple[str, int]]:
+    def _get_valid_webhook(self, chat_id: str) -> tuple[str, int] | None:
         """Get a valid (non-expired) session webhook for the given chat_id."""
         info = self._session_webhooks.get(chat_id)
         if not info:
@@ -1021,7 +1021,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = True,
-    ) -> Optional[SendResult]:
+    ) -> SendResult | None:
         """Create an AI Card, deliver it to the conversation, and stream initial content.
 
         Always called with ``finalize=True`` from ``send()`` (closed state).
@@ -1208,7 +1208,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             stream_request, stream_headers, runtime
         )
 
-    async def _get_access_token(self) -> Optional[str]:
+    async def _get_access_token(self) -> str | None:
         """Get access token using SDK's cached token."""
         if not self._stream_client:
             return None
@@ -1409,7 +1409,7 @@ class _IncomingHandler(
     CallbackMessage.data dict into a ChatbotMessage before forwarding.
     """
 
-    def __init__(self, adapter: DingTalkAdapter, loop: Optional[asyncio.AbstractEventLoop] = None):
+    def __init__(self, adapter: DingTalkAdapter, loop: asyncio.AbstractEventLoop | None = None):
         if DINGTALK_STREAM_AVAILABLE:
             super().__init__()
         self._adapter = adapter

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -266,7 +266,7 @@ class EmailAdapter(BasePlatformAdapter):
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
-        self._poll_task: Optional[asyncio.Task] = None
+        self._poll_task: asyncio.Task | None = None
 
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
@@ -504,8 +504,8 @@ class EmailAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
         try:
@@ -522,7 +522,7 @@ class EmailAdapter(BasePlatformAdapter):
         self,
         to_addr: str,
         body: str,
-        reply_to_msg_id: Optional[str] = None,
+        reply_to_msg_id: str | None = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
@@ -562,15 +562,15 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Dict[str, Any] | None = None) -> None:
         """Email has no typing indicator — no-op."""
 
     async def send_image(
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
     ) -> SendResult:
         """Send an image URL as part of an email body."""
         text = caption or ""
@@ -581,7 +581,7 @@ class EmailAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single email with multiple MIME attachments.
@@ -688,9 +688,9 @@ class EmailAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
@@ -714,7 +714,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_path: str,
-        file_name: Optional[str] = None,
+        file_name: str | None = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -386,8 +386,8 @@ class FeishuAdapterSettings:
     webhook_path: str
     ws_reconnect_nonce: int = 30
     ws_reconnect_interval: int = 120
-    ws_ping_interval: Optional[int] = None
-    ws_ping_timeout: Optional[int] = None
+    ws_ping_interval: int | None = None
+    ws_ping_timeout: int | None = None
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
@@ -402,7 +402,7 @@ class FeishuGroupRule:
     policy: str  # "open" | "allowlist" | "blacklist" | "admin_only" | "disabled"
     allowlist: set[str] = field(default_factory=set)
     blacklist: set[str] = field(default_factory=set)
-    require_mention: Optional[bool] = None  # None = inherit global
+    require_mention: bool | None = None  # None = inherit global
 
 
 @dataclass
@@ -527,7 +527,7 @@ def _strip_markdown_to_plain_text(text: str) -> str:
     return plain
 
 
-def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -> Optional[int]:
+def _coerce_int(value: Any, default: int | None = None, min_value: int = 0) -> int | None:
     """Coerce value to int with optional default and minimum constraint."""
     try:
         parsed = int(value)
@@ -610,7 +610,7 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
 def parse_feishu_post_payload(
     payload: Any,
     *,
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    mentions_map: Dict[str, FeishuMentionRef] | None = None,
 ) -> FeishuPostParseResult:
     resolved = _resolve_post_payload(payload)
     if not resolved:
@@ -691,7 +691,7 @@ def _render_post_element(
     element: Any,
     image_keys: List[str],
     media_refs: List[FeishuPostMediaRef],
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    mentions_map: Dict[str, FeishuMentionRef] | None = None,
 ) -> str:
     if isinstance(element, str):
         return element
@@ -771,7 +771,7 @@ def _render_nested_post(
     value: Any,
     image_keys: List[str],
     media_refs: List[FeishuPostMediaRef],
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    mentions_map: Dict[str, FeishuMentionRef] | None = None,
 ) -> str:
     if isinstance(value, str):
         return _escape_markdown_text(value)
@@ -804,7 +804,7 @@ def normalize_feishu_message(
     *,
     message_type: str,
     raw_content: str,
-    mentions: Optional[Sequence[Any]] = None,
+    mentions: Sequence[Any] | None = None,
     bot: _FeishuBotIdentity = _FeishuBotIdentity(),
 ) -> FeishuNormalizedMessage:
     normalized_type = str(message_type or "").strip().lower()
@@ -1138,7 +1138,7 @@ def _first_non_empty_text(*values: Any) -> str:
 
 def _normalize_feishu_text(
     text: str,
-    mentions_map: Optional[Dict[str, FeishuMentionRef]] = None,
+    mentions_map: Dict[str, FeishuMentionRef] | None = None,
 ) -> str:
     def _sub(match: "re.Match[str]") -> str:
         key = match.group(0)
@@ -1194,7 +1194,7 @@ def _extract_mention_ids(mention: Any) -> tuple[str, str]:
 
 
 def _build_mentions_map(
-    mentions: Optional[Sequence[Any]],
+    mentions: Sequence[Any] | None,
     bot: _FeishuBotIdentity,
 ) -> Dict[str, FeishuMentionRef]:
     result: Dict[str, FeishuMentionRef] = {}
@@ -1422,14 +1422,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
         self._settings = self._load_settings(config.extra or {})
         self._apply_settings(self._settings)
-        self._client: Optional[Any] = None
-        self._ws_client: Optional[Any] = None
-        self._ws_future: Optional[asyncio.Future] = None
-        self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._webhook_runner: Optional[Any] = None
-        self._webhook_site: Optional[Any] = None
-        self._event_handler: Optional[Any] = None
+        self._client: Any | None = None
+        self._ws_client: Any | None = None
+        self._ws_future: asyncio.Future | None = None
+        self._ws_thread_loop: asyncio.AbstractEventLoop | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._webhook_runner: Any | None = None
+        self._webhook_site: Any | None = None
+        self._event_handler: Any | None = None
         self._seen_message_ids: Dict[str, float] = {}  # message_id → seen_at (time.time())
         self._seen_message_order: List[str] = []
         self._dedup_state_path = get_hermes_home() / "feishu_seen_message_ids.json"
@@ -1449,8 +1449,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
-        self._message_text_cache: Dict[str, Optional[str]] = {}
-        self._app_lock_identity: Optional[str] = None
+        self._message_text_cache: Dict[str, str | None] = {}
+        self._app_lock_identity: str | None = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
         self._pending_text_batch_tasks = self._text_batch_state.tasks
@@ -1480,7 +1480,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     continue
                 # Only override when the key is explicitly set — missing vs false
                 # must not collapse.
-                per_chat_require_mention: Optional[bool] = None
+                per_chat_require_mention: bool | None = None
                 if "require_mention" in rule_cfg:
                     per_chat_require_mention = _to_boolean(rule_cfg.get("require_mention"))
                 group_rules[str(chat_id)] = FeishuGroupRule(
@@ -1765,8 +1765,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a Feishu message."""
         if not self._client:
@@ -1856,7 +1856,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an interactive card with approval buttons.
 
@@ -1959,7 +1959,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an interactive update prompt with Yes/No buttons."""
         if not self._client:
@@ -2036,9 +2036,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send audio to Feishu as a file attachment plus optional caption."""
@@ -2055,10 +2055,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file attachment to Feishu."""
@@ -2075,9 +2075,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a video file to Feishu."""
@@ -2094,9 +2094,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a local image file to Feishu."""
@@ -2159,9 +2159,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Download a remote image then send it through the native Feishu image flow."""
         try:
@@ -2187,9 +2187,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         animation_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Feishu has no native GIF bubble; degrade to a downloadable file."""
         try:
@@ -2861,7 +2861,7 @@ class FeishuAdapter(BasePlatformAdapter):
     def _reactions_enabled(self) -> bool:
         return os.getenv("FEISHU_REACTIONS", "true").strip().lower() not in {"false", "0", "no"}
 
-    async def _add_reaction(self, message_id: str, emoji_type: str) -> Optional[str]:
+    async def _add_reaction(self, message_id: str, emoji_type: str) -> str | None:
         """Return the reaction_id on success, else None. The id is needed later for deletion."""
         if not self._client or not message_id or not emoji_type:
             return None
@@ -2938,7 +2938,7 @@ class FeishuAdapter(BasePlatformAdapter):
         while len(cache) > _FEISHU_PROCESSING_REACTION_CACHE_SIZE:
             cache.popitem(last=False)
 
-    def _pop_processing_reaction(self, message_id: str) -> Optional[str]:
+    def _pop_processing_reaction(self, message_id: str) -> str | None:
         return self._pending_processing_reactions.pop(message_id, None)
 
     async def on_processing_start(self, event: MessageEvent) -> None:
@@ -3810,7 +3810,7 @@ class FeishuAdapter(BasePlatformAdapter):
         sender_id: Any,
         *,
         is_bot: bool = False,
-    ) -> Dict[str, Optional[str]]:
+    ) -> Dict[str, str | None]:
         """Map Feishu's three-tier user IDs onto Hermes' SessionSource fields.
 
         Preference order for the primary ``user_id`` field:
@@ -3838,7 +3838,7 @@ class FeishuAdapter(BasePlatformAdapter):
             "user_id_alt": union_id,
         }
 
-    def _get_cached_sender_name(self, sender_id: Optional[str]) -> Optional[str]:
+    def _get_cached_sender_name(self, sender_id: str | None) -> str | None:
         """Return a cached sender name only while its TTL is still valid."""
         if not sender_id:
             return None
@@ -3853,10 +3853,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def _resolve_sender_name_from_api(
         self,
-        sender_id: Optional[str],
+        sender_id: str | None,
         *,
         is_bot: bool = False,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Bots divert to bot/basic_batch — contact API doesn't return bot names.
         Failures are silent so the pipeline never blocks on name resolution.
         """
@@ -3906,7 +3906,7 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Failed to resolve sender name for %s", sender_id, exc_info=True)
         return None
 
-    async def _fetch_bot_names(self, bot_ids: List[str]) -> Optional[Dict[str, str]]:
+    async def _fetch_bot_names(self, bot_ids: List[str]) -> Dict[str, str] | None:
         if not self._client or not bot_ids:
             return None
         try:
@@ -3935,7 +3935,7 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Failed to fetch bot names for %s", bot_ids, exc_info=True)
             return None
 
-    async def _fetch_message_text(self, message_id: str) -> Optional[str]:
+    async def _fetch_message_text(self, message_id: str) -> str | None:
         if not self._client or not message_id:
             return None
         if message_id in self._message_text_cache:
@@ -3970,8 +3970,8 @@ class FeishuAdapter(BasePlatformAdapter):
         *,
         msg_type: str,
         raw_content: str,
-        mentions: Optional[Sequence[Any]] = None,
-    ) -> Optional[str]:
+        mentions: Sequence[Any] | None = None,
+    ) -> str | None:
         normalized = normalize_feishu_message(
             message_type=msg_type,
             raw_content=raw_content,
@@ -4001,7 +4001,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # Inbound admission
     # =========================================================================
 
-    def _admit(self, sender: Any, message: Any) -> Optional[RejectReason]:
+    def _admit(self, sender: Any, message: Any) -> RejectReason | None:
         sender_ids = _sender_identity(sender)
         self_ids = frozenset(v for v in (self._bot_open_id, self._bot_user_id) if v)
         is_bot = _is_bot_sender(sender)
@@ -4300,10 +4300,10 @@ class FeishuAdapter(BasePlatformAdapter):
         *,
         chat_id: str,
         file_path: str,
-        reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
+        reply_to: str | None,
+        metadata: Dict[str, Any] | None,
+        caption: str | None = None,
+        file_name: str | None = None,
         outbound_message_type: str = "file",
     ) -> SendResult:
         if not self._client:
@@ -4365,8 +4365,8 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id: str,
         msg_type: str,
         payload: str,
-        reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
+        reply_to: str | None,
+        metadata: Dict[str, Any] | None,
     ) -> Any:
         effective_reply_to = reply_to
         if not effective_reply_to and metadata and metadata.get("thread_id"):
@@ -4425,7 +4425,7 @@ class FeishuAdapter(BasePlatformAdapter):
         response: Any,
         *,
         default_message: str,
-        override_error: Optional[str] = None,
+        override_error: str | None = None,
     ) -> SendResult:
         if override_error:
             return SendResult(success=False, error=override_error, raw_response=response)
@@ -4529,10 +4529,10 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id: str,
         msg_type: str,
         payload: str,
-        reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
+        reply_to: str | None,
+        metadata: Dict[str, Any] | None,
     ) -> Any:
-        last_error: Optional[Exception] = None
+        last_error: Exception | None = None
         active_reply_to = reply_to
         for attempt in range(_FEISHU_SEND_ATTEMPTS):
             try:
@@ -4874,7 +4874,7 @@ def _poll_registration(
     interval: int,
     expire_in: int,
     domain: str = "feishu",
-) -> Optional[dict]:
+) -> dict | None:
     """Poll until the user scans the QR code, or timeout/denial.
 
     Returns dict with app_id, app_secret, domain, open_id on success.
@@ -4959,7 +4959,7 @@ def _render_qr(url: str) -> bool:
         return False
 
 
-def probe_bot(app_id: str, app_secret: str, domain: str) -> Optional[dict]:
+def probe_bot(app_id: str, app_secret: str, domain: str) -> dict | None:
     """Verify bot connectivity via /open-apis/bot/v3/info.
 
     Uses lark_oapi SDK when available, falls back to raw HTTP otherwise.
@@ -4986,7 +4986,7 @@ def _build_onboard_client(app_id: str, app_secret: str, domain: str) -> Any:
     )
 
 
-def _parse_bot_response(data: dict) -> Optional[dict]:
+def _parse_bot_response(data: dict) -> dict | None:
     # /bot/v3/info returns bot.app_name; legacy paths used bot_name — accept both.
     if data.get("code") != 0:
         return None
@@ -4997,7 +4997,7 @@ def _parse_bot_response(data: dict) -> Optional[dict]:
     }
 
 
-def _probe_bot_sdk(app_id: str, app_secret: str, domain: str) -> Optional[dict]:
+def _probe_bot_sdk(app_id: str, app_secret: str, domain: str) -> dict | None:
     """Probe bot info using lark_oapi SDK."""
     try:
         client = _build_onboard_client(app_id, app_secret, domain)
@@ -5018,7 +5018,7 @@ def _probe_bot_sdk(app_id: str, app_secret: str, domain: str) -> Optional[dict]:
         return None
 
 
-def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> Optional[dict]:
+def _probe_bot_http(app_id: str, app_secret: str, domain: str) -> dict | None:
     """Fallback probe using raw HTTP (when lark_oapi is not installed)."""
     base_url = _onboard_open_base_url(domain)
     try:
@@ -5055,7 +5055,7 @@ def qr_register(
     *,
     initial_domain: str = "feishu",
     timeout_seconds: int = 600,
-) -> Optional[dict]:
+) -> dict | None:
     """Run the Feishu / Lark scan-to-create QR registration flow.
 
     Returns on success::
@@ -5083,7 +5083,7 @@ def _qr_register_inner(
     *,
     initial_domain: str,
     timeout_seconds: int,
-) -> Optional[dict]:
+) -> dict | None:
     """Run init → begin → poll → probe. Raises on network/protocol errors."""
     print("  Connecting to Feishu / Lark...", end="", flush=True)
     _init_registration(initial_domain)

--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -100,7 +100,7 @@ async def _exec_request(client, method, uri, paths=None, queries=None, body=None
 # ---------------------------------------------------------------------------
 
 
-def parse_drive_comment_event(data: Any) -> Optional[Dict[str, Any]]:
+def parse_drive_comment_event(data: Any) -> Dict[str, Any] | None:
     """Extract structured fields from a ``drive.notice.comment_add_v1`` payload.
 
     *data* may be a ``CustomizedEvent`` (WebSocket) whose ``.event`` is a dict,
@@ -710,7 +710,7 @@ def _extract_docs_links(replies: List[Dict[str, Any]]) -> List[Dict[str, str]]:
 
 async def _reverse_lookup_wiki_token(
     client: Any, obj_type: str, obj_token: str,
-) -> Optional[str]:
+) -> str | None:
     """Reverse-lookup: given an obj_token, find its wiki node_token.
 
     Returns the wiki_token if the document belongs to a wiki space,

--- a/gateway/platforms/feishu_comment_rules.py
+++ b/gateway/platforms/feishu_comment_rules.py
@@ -42,9 +42,9 @@ _VALID_POLICIES = ("allowlist", "pairing")
 @dataclass(frozen=True)
 class CommentDocumentRule:
     """Per-document rule.  ``None`` means 'inherit from lower tier'."""
-    enabled: Optional[bool] = None
-    policy: Optional[str] = None
-    allow_from: Optional[frozenset] = None
+    enabled: bool | None = None
+    policy: str | None = None
+    allow_from: frozenset | None = None
 
 
 @dataclass(frozen=True)
@@ -75,7 +75,7 @@ class _MtimeCache:
     def __init__(self, path: Path):
         self._path = path
         self._mtime: float = 0.0
-        self._data: Optional[dict] = None
+        self._data: dict | None = None
 
     def load(self) -> dict:
         try:
@@ -111,7 +111,7 @@ _pairing_cache = _MtimeCache(PAIRING_FILE)
 # Config parsing
 # ---------------------------------------------------------------------------
 
-def _parse_frozenset(raw: Any) -> Optional[frozenset]:
+def _parse_frozenset(raw: Any) -> frozenset | None:
     """Parse a list of strings into a frozenset; return None if key absent."""
     if raw is None:
         return None

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -66,10 +66,10 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.HOMEASSISTANT)
 
         # Connection state
-        self._session: Optional["aiohttp.ClientSession"] = None
-        self._ws: Optional["aiohttp.ClientWebSocketResponse"] = None
-        self._rest_session: Optional["aiohttp.ClientSession"] = None
-        self._listen_task: Optional[asyncio.Task] = None
+        self._session: "aiohttp.ClientSession" | None = None
+        self._ws: "aiohttp.ClientWebSocketResponse" | None = None
+        self._rest_session: "aiohttp.ClientSession" | None = None
+        self._listen_task: asyncio.Task | None = None
         self._msg_id: int = 0
 
         # Configuration from extra
@@ -322,7 +322,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         entity_id: str,
         old_state: Dict[str, Any],
         new_state: Dict[str, Any],
-    ) -> Optional[str]:
+    ) -> str | None:
         """Convert a state_changed event into a human-readable description."""
         if not new_state:
             return None
@@ -387,8 +387,8 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a notification via HA REST API (persistent_notification.create).
 

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -379,7 +379,7 @@ class MatrixAdapter(BasePlatformAdapter):
 
         self._client: Any = None  # mautrix.client.Client
         self._crypto_db: Any = None  # mautrix.util.async_db.Database
-        self._sync_task: Optional[asyncio.Task] = None
+        self._sync_task: asyncio.Task | None = None
         self._closing = False
         self._startup_ts: float = 0.0
         # Clock-skew detection: count grace-check drops that happen well
@@ -529,7 +529,7 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_server_ed25519(device_keys_obj: Any) -> Optional[str]:
+    def _extract_server_ed25519(device_keys_obj: Any) -> str | None:
         """Extract the ed25519 identity key from a DeviceKeys object."""
         for kid, kval in (getattr(device_keys_obj, "keys", {}) or {}).items():
             if str(kid).startswith("ed25519:"):
@@ -1002,8 +1002,8 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a message to a Matrix room."""
 
@@ -1098,7 +1098,7 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(
-        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+        self, chat_id: str, metadata: Dict[str, Any] | None = None
     ) -> None:
         """Send a typing indicator."""
         if self._client:
@@ -1152,9 +1152,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Download an image URL and upload it to Matrix."""
         from tools.url_safety import is_safe_url
@@ -1207,9 +1207,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload a local image file to Matrix."""
         return await self._send_local_file(
@@ -1220,10 +1220,10 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
@@ -1234,9 +1234,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload an audio file as a voice message (MSC3245 native voice)."""
         return await self._send_local_file(
@@ -1253,9 +1253,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
@@ -1268,7 +1268,7 @@ class MatrixAdapter(BasePlatformAdapter):
         command: str,
         session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[dict] = None,
+        metadata: dict | None = None,
     ) -> SendResult:
         """Send a reaction-based exec approval prompt for Matrix."""
         if not self._client:
@@ -1329,9 +1329,9 @@ class MatrixAdapter(BasePlatformAdapter):
         filename: str,
         content_type: str,
         msgtype: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         is_voice: bool = False,
     ) -> SendResult:
         """Upload bytes to Matrix and send as a media message."""
@@ -1411,10 +1411,10 @@ class MatrixAdapter(BasePlatformAdapter):
         room_id: str,
         file_path: str,
         msgtype: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        file_name: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        file_name: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         is_voice: bool = False,
     ) -> SendResult:
         """Read a local file and upload it."""
@@ -1710,7 +1710,7 @@ class MatrixAdapter(BasePlatformAdapter):
         body: str,
         source_content: dict,
         relates_to: dict,
-    ) -> Optional[tuple]:
+    ) -> tuple | None:
         """Shared mention/thread/DM gating for text and media handlers.
 
         Returns (body, is_dm, chat_type, thread_id, display_name, source)
@@ -2095,7 +2095,7 @@ class MatrixAdapter(BasePlatformAdapter):
         room_id: str,
         event_id: str,
         emoji: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Send an emoji reaction to a message in a room.
         Returns the reaction event_id on success, None on failure.
         """
@@ -2414,10 +2414,10 @@ class MatrixAdapter(BasePlatformAdapter):
         self,
         name: str = "",
         topic: str = "",
-        invite: Optional[list] = None,
+        invite: list | None = None,
         is_direct: bool = False,
         preset: str = "private_chat",
-    ) -> Optional[str]:
+    ) -> str | None:
         """Create a new Matrix room."""
         if not self._client:
             return None
@@ -2536,7 +2536,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return
 
-        dm_data: Optional[Dict] = None
+        dm_data: Dict | None = None
 
         try:
             resp = await self._client.get_account_data("m.direct")
@@ -2635,8 +2635,8 @@ class MatrixAdapter(BasePlatformAdapter):
     def _is_bot_mentioned(
         self,
         body: str,
-        formatted_body: Optional[str] = None,
-        mention_user_ids: Optional[list] = None,
+        formatted_body: str | None = None,
+        mention_user_ids: list | None = None,
     ) -> bool:
         """Return True if the bot is mentioned in the message.
 

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -58,7 +58,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             for value in (extra.get("accepted_resources") or [])
             if str(value).strip()
         ]
-        self._client_state: Optional[str] = self._string_or_none(extra.get("client_state"))
+        self._client_state: str | None = self._string_or_none(extra.get("client_state"))
         self._max_seen_receipts = max(
             1, int(extra.get("max_seen_receipts", DEFAULT_MAX_SEEN_RECEIPTS))
         )
@@ -66,14 +66,14 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             self._parse_allowed_source_cidrs(extra.get("allowed_source_cidrs"))
         )
         self._runner = None
-        self._notification_scheduler: Optional[NotificationScheduler] = None
+        self._notification_scheduler: NotificationScheduler | None = None
         self._seen_receipts: set[str] = set()
         self._seen_receipt_order: deque[str] = deque()
         self._accepted_count = 0
         self._duplicate_count = 0
 
     @staticmethod
-    def _string_or_none(value: Any) -> Optional[str]:
+    def _string_or_none(value: Any) -> str | None:
         if value is None:
             return None
         text = str(value).strip()
@@ -85,7 +85,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         return raw if raw.startswith("/") else f"/{raw}"
 
     @staticmethod
-    def _build_receipt_key(notification: Dict[str, Any]) -> Optional[str]:
+    def _build_receipt_key(notification: Dict[str, Any]) -> str | None:
         explicit_id = str(notification.get("id") or "").strip()
         if explicit_id:
             return f"id:{explicit_id}"
@@ -129,7 +129,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
                 )
         return networks
 
-    def set_notification_scheduler(self, scheduler: Optional[NotificationScheduler]) -> None:
+    def set_notification_scheduler(self, scheduler: NotificationScheduler | None) -> None:
         self._notification_scheduler = scheduler
 
     async def connect(self) -> bool:
@@ -167,8 +167,8 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         logger.info("[msgraph_webhook] Response for %s: %s", chat_id, content[:200])
         return SendResult(success=True)
@@ -335,7 +335,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
     def _build_message_event(
         self,
         notification: Dict[str, Any],
-        receipt_key: Optional[str],
+        receipt_key: str | None,
     ) -> MessageEvent:
         message_id = receipt_key or f"sha1:{sha1(json.dumps(notification, sort_keys=True).encode('utf-8')).hexdigest()}"
         source = self.build_source(

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -219,14 +219,14 @@ class QQAdapter(BasePlatformAdapter):
         )
 
         # Connection state
-        self._session: Optional[aiohttp.ClientSession] = None
-        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
-        self._http_client: Optional[httpx.AsyncClient] = None
-        self._listen_task: Optional[asyncio.Task] = None
-        self._heartbeat_task: Optional[asyncio.Task] = None
+        self._session: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._http_client: httpx.AsyncClient | None = None
+        self._listen_task: asyncio.Task | None = None
+        self._heartbeat_task: asyncio.Task | None = None
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
-        self._session_id: Optional[str] = None
-        self._last_seq: Optional[int] = None
+        self._session_id: str | None = None
+        self._last_seq: int | None = None
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
 
         # Request/response correlation
@@ -239,7 +239,7 @@ class QQAdapter(BasePlatformAdapter):
         self._typing_sent_at: Dict[str, float] = {}
 
         # Token cache
-        self._access_token: Optional[str] = None
+        self._access_token: str | None = None
         self._token_expires_at: float = 0.0
         self._token_lock = asyncio.Lock()
 
@@ -250,9 +250,7 @@ class QQAdapter(BasePlatformAdapter):
         # for every INTERACTION_CREATE event after the adapter has already
         # ACKed it. Callers (gateway wiring for approvals / update prompts)
         # register via set_interaction_callback().
-        self._interaction_callback: Optional[
-            Callable[[InteractionEvent], Awaitable[None]]
-        ] = None
+        self._interaction_callback: Callable[[InteractionEvent], Awaitable[None]] | None = None
 
         # Default interaction dispatcher: routes approval-button clicks to
         # tools.approval.resolve_gateway_approval() and update-prompt clicks
@@ -886,7 +884,7 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _parse_json(raw: Any) -> Optional[Dict[str, Any]]:
+    def _parse_json(raw: Any) -> Dict[str, Any] | None:
         try:
             payload = json.loads(raw)
         except Exception:
@@ -944,7 +942,7 @@ class QQAdapter(BasePlatformAdapter):
 
     def set_interaction_callback(
         self,
-        callback: Optional[Callable[[InteractionEvent], Awaitable[None]]],
+        callback: Callable[[InteractionEvent], Awaitable[None]] | None,
     ) -> None:
         """Register (or clear) the interaction callback.
 
@@ -1055,7 +1053,7 @@ class QQAdapter(BasePlatformAdapter):
     }
 
     @staticmethod
-    def _parse_gateway_session_key(session_key: str) -> Optional[Dict[str, str]]:
+    def _parse_gateway_session_key(session_key: str) -> Dict[str, str] | None:
         """Parse ``agent:main:<platform>:<chat_type>:<chat_id>[:<user_id>]``."""
         parts = str(session_key or "").split(":")
         if len(parts) < 5 or parts[0] != "agent" or parts[1] != "main":
@@ -1743,7 +1741,7 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _download_and_cache(
             self, url: str, content_type: str, original_name: str = "",
-    ) -> Optional[str]:
+    ) -> str | None:
         """Download a URL and cache it locally.
 
         :param original_name: Preferred filename from attachment metadata.
@@ -1825,9 +1823,9 @@ class QQAdapter(BasePlatformAdapter):
             content_type: str,
             filename: str,
             *,
-            asr_refer_text: Optional[str] = None,
-            voice_wav_url: Optional[str] = None,
-    ) -> Optional[str]:
+            asr_refer_text: str | None = None,
+            voice_wav_url: str | None = None,
+    ) -> str | None:
         """Download a voice attachment, convert to wav, and transcribe.
 
         Priority:
@@ -1945,7 +1943,7 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _convert_audio_to_wav_file(
             self, audio_data: bytes, filename: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """Convert audio bytes to a temp .wav file using pilk (SILK) or ffmpeg.
 
         QQ voice messages are typically SILK format which ffmpeg cannot decode.
@@ -2018,7 +2016,7 @@ class QQAdapter(BasePlatformAdapter):
         """Check if bytes look like a SILK audio file."""
         return data[:6] == b"#!SILK" or data[:2] == b"\x02!" or data[:9] == b"#!SILK_V3"
 
-    async def _convert_silk_to_wav(self, src_path: str, wav_path: str) -> Optional[str]:
+    async def _convert_silk_to_wav(self, src_path: str, wav_path: str) -> str | None:
         """Convert audio file to WAV using the pilk library.
 
         Tries the file as-is first, then as .silk if the extension differs.
@@ -2072,7 +2070,7 @@ class QQAdapter(BasePlatformAdapter):
 
         return None
 
-    async def _convert_raw_to_wav(self, audio_data: bytes, wav_path: str) -> Optional[str]:
+    async def _convert_raw_to_wav(self, audio_data: bytes, wav_path: str) -> str | None:
         """Last resort: try writing audio data as raw PCM 16-bit mono 16kHz WAV.
 
         This will produce garbage if the data isn't raw PCM, but at least
@@ -2091,7 +2089,7 @@ class QQAdapter(BasePlatformAdapter):
             logger.debug("[%s] raw PCM fallback failed: %s", self._log_tag, exc)
             return None
 
-    async def _convert_ffmpeg_to_wav(self, src_path: str, wav_path: str) -> Optional[str]:
+    async def _convert_ffmpeg_to_wav(self, src_path: str, wav_path: str) -> str | None:
         """Convert audio file to WAV using ffmpeg."""
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -2136,7 +2134,7 @@ class QQAdapter(BasePlatformAdapter):
         )
         return wav_path
 
-    def _resolve_stt_config(self) -> Optional[Dict[str, str]]:
+    def _resolve_stt_config(self) -> Dict[str, str] | None:
         """Resolve STT backend configuration from config/environment.
 
         Priority:
@@ -2192,7 +2190,7 @@ class QQAdapter(BasePlatformAdapter):
 
         return None
 
-    async def _call_stt(self, wav_path: str) -> Optional[str]:
+    async def _call_stt(self, wav_path: str) -> str | None:
         """Call an OpenAI-compatible STT API to transcribe a wav file.
 
         Uses the provider configured in ``channels.qqbot.stt`` config,
@@ -2245,7 +2243,7 @@ class QQAdapter(BasePlatformAdapter):
 
     async def _convert_audio_to_wav(
             self, audio_data: bytes, source_url: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """Convert audio bytes to .wav using pilk (SILK) or ffmpeg, caching the result."""
         import tempfile
 
@@ -2312,7 +2310,7 @@ class QQAdapter(BasePlatformAdapter):
             self,
             method: str,
             path: str,
-            body: Optional[Dict[str, Any]] = None,
+            body: Dict[str, Any] | None = None,
             timeout: float = DEFAULT_API_TIMEOUT,
     ) -> Dict[str, Any]:
         """Make an authenticated REST API request to QQ Bot API."""
@@ -2349,10 +2347,10 @@ class QQAdapter(BasePlatformAdapter):
             target_type: str,
             target_id: str,
             file_type: int,
-            url: Optional[str] = None,
-            file_data: Optional[str] = None,
+            url: str | None = None,
+            file_data: str | None = None,
             srv_send_msg: bool = False,
-            file_name: Optional[str] = None,
+            file_name: str | None = None,
     ) -> Dict[str, Any]:
         """Upload media and return file_info."""
         path = (
@@ -2421,8 +2419,8 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             content: str,
-            reply_to: Optional[str] = None,
-            metadata: Optional[Dict[str, Any]] = None,
+            reply_to: str | None = None,
+            metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a text or markdown message to a QQ user or group.
 
@@ -2454,10 +2452,10 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             content: str,
-            reply_to: Optional[str] = None,
+            reply_to: str | None = None,
     ) -> SendResult:
         """Send a single chunk with retry + exponential backoff."""
-        last_exc: Optional[Exception] = None
+        last_exc: Exception | None = None
         chat_type = self._guess_chat_type(chat_id)
 
         for attempt in range(3):
@@ -2504,8 +2502,8 @@ class QQAdapter(BasePlatformAdapter):
             self,
             openid: str,
             content: str,
-            reply_to: Optional[str] = None,
-            keyboard: Optional[InlineKeyboard] = None,
+            reply_to: str | None = None,
+            keyboard: InlineKeyboard | None = None,
     ) -> SendResult:
         """Send text to a C2C user via REST API.
 
@@ -2526,8 +2524,8 @@ class QQAdapter(BasePlatformAdapter):
             self,
             group_openid: str,
             content: str,
-            reply_to: Optional[str] = None,
-            keyboard: Optional[InlineKeyboard] = None,
+            reply_to: str | None = None,
+            keyboard: InlineKeyboard | None = None,
     ) -> SendResult:
         """Send text to a group via REST API.
 
@@ -2547,7 +2545,7 @@ class QQAdapter(BasePlatformAdapter):
         return SendResult(success=True, message_id=msg_id, raw_response=data)
 
     async def _send_guild_text(
-            self, channel_id: str, content: str, reply_to: Optional[str] = None
+            self, channel_id: str, content: str, reply_to: str | None = None
     ) -> SendResult:
         """Send text to a guild channel via REST API."""
         body: Dict[str, Any] = {"content": content[: self.MAX_MESSAGE_LENGTH]}
@@ -2567,7 +2565,7 @@ class QQAdapter(BasePlatformAdapter):
             chat_id: str,
             content: str,
             keyboard: InlineKeyboard,
-            reply_to: Optional[str] = None,
+            reply_to: str | None = None,
     ) -> SendResult:
         """Send a single text message with an inline keyboard attached.
 
@@ -2615,7 +2613,7 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             req: ApprovalRequest,
-            reply_to: Optional[str] = None,
+            reply_to: str | None = None,
     ) -> SendResult:
         """Send a 3-button approval request (``allow-once / allow-always / deny``).
 
@@ -2649,7 +2647,7 @@ class QQAdapter(BasePlatformAdapter):
             command: str,
             session_key: str,
             description: str = "dangerous command",
-            metadata: Optional[Dict[str, Any]] = None,
+            metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a button-based exec-approval prompt for a dangerous command.
 
@@ -2684,7 +2682,7 @@ class QQAdapter(BasePlatformAdapter):
             prompt: str,
             default: str = "",
             session_key: str = "",
-            metadata: Optional[Dict[str, Any]] = None,
+            metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a Yes/No update-confirmation prompt with inline buttons.
 
@@ -2709,7 +2707,7 @@ class QQAdapter(BasePlatformAdapter):
         )
 
     def _build_text_body(
-            self, content: str, reply_to: Optional[str] = None
+            self, content: str, reply_to: str | None = None
     ) -> Dict[str, Any]:
         """Build the message body for C2C/group text sending."""
         msg_seq = self._next_msg_seq(reply_to or "default")
@@ -2742,9 +2740,9 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             image_url: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            metadata: Optional[Dict[str, Any]] = None,
+            caption: str | None = None,
+            reply_to: str | None = None,
+            metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an image natively via QQ Bot API upload."""
         del metadata
@@ -2768,8 +2766,8 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             image_path: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
+            caption: str | None = None,
+            reply_to: str | None = None,
             **kwargs,
     ) -> SendResult:
         """Send a local image file natively."""
@@ -2782,8 +2780,8 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             audio_path: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
+            caption: str | None = None,
+            reply_to: str | None = None,
             **kwargs,
     ) -> SendResult:
         """Send a voice message natively."""
@@ -2796,8 +2794,8 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             video_path: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
+            caption: str | None = None,
+            reply_to: str | None = None,
             **kwargs,
     ) -> SendResult:
         """Send a video natively."""
@@ -2810,9 +2808,9 @@ class QQAdapter(BasePlatformAdapter):
             self,
             chat_id: str,
             file_path: str,
-            caption: Optional[str] = None,
-            file_name: Optional[str] = None,
-            reply_to: Optional[str] = None,
+            caption: str | None = None,
+            file_name: str | None = None,
+            reply_to: str | None = None,
             **kwargs,
     ) -> SendResult:
         """Send a file/document natively."""
@@ -2833,9 +2831,9 @@ class QQAdapter(BasePlatformAdapter):
             media_source: str,
             file_type: int,
             kind: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            file_name: Optional[str] = None,
+            caption: str | None = None,
+            reply_to: str | None = None,
+            file_name: str | None = None,
     ) -> SendResult:
         """Upload media and send as a native message.
 
@@ -2959,7 +2957,7 @@ class QQAdapter(BasePlatformAdapter):
             chat_id: str,
             media_source: str,
             file_type: int,
-            file_name: Optional[str],
+            file_name: str | None,
     ) -> Tuple[str, Dict[str, Any]]:
         """Chunked-upload a local file and return ``(resolved_name, complete_response)``.
 
@@ -3002,7 +3000,7 @@ class QQAdapter(BasePlatformAdapter):
         return resolved_name, complete
 
     async def _load_media(
-            self, source: str, file_name: Optional[str] = None
+            self, source: str, file_name: str | None = None
     ) -> Tuple[str, str, str]:
         """Load media from URL or local path. Returns (base64_or_url, content_type, filename)."""
         source = str(source).strip()

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -398,7 +398,7 @@ class ChunkedUploader:
         total_parts: int,
     ) -> None:
         """PUT part data to a pre-signed COS URL with retry."""
-        last_exc: Optional[Exception] = None
+        last_exc: Exception | None = None
         for attempt in range(_PART_UPLOAD_MAX_RETRIES + 1):
             try:
                 resp = await asyncio.wait_for(
@@ -506,7 +506,7 @@ class ChunkedUploader:
         path = f"{base}/{target_id}/files"
         body = {"upload_id": upload_id}
 
-        last_exc: Optional[Exception] = None
+        last_exc: Exception | None = None
         for attempt in range(_COMPLETE_UPLOAD_MAX_RETRIES + 1):
             try:
                 return await self._api_request(

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -158,7 +158,7 @@ class InlineKeyboard:
 
 # ── INTERACTION_CREATE parsing ───────────────────────────────────────
 
-def parse_approval_button_data(button_data: str) -> Optional[tuple[str, str]]:
+def parse_approval_button_data(button_data: str) -> tuple[str, str] | None:
     """Parse approval ``button_data`` into ``(session_key, decision)``.
 
     :param button_data: Raw ``data.resolved.button_data`` from
@@ -171,7 +171,7 @@ def parse_approval_button_data(button_data: str) -> Optional[tuple[str, str]]:
     return m.group(1), m.group(2)
 
 
-def parse_update_prompt_button_data(button_data: str) -> Optional[str]:
+def parse_update_prompt_button_data(button_data: str) -> str | None:
     """Parse update-prompt ``button_data`` into ``'y'`` or ``'n'``."""
     m = _UPDATE_PROMPT_RE.match(button_data or "")
     if not m:
@@ -369,7 +369,7 @@ class ApprovalSender:
         chat_type: str,
         chat_id: str,
         req: ApprovalRequest,
-        msg_id: Optional[str] = None,
+        msg_id: str | None = None,
     ) -> bool:
         """Send an approval message to *chat_id*.
 

--- a/gateway/platforms/qqbot/onboard.py
+++ b/gateway/platforms/qqbot/onboard.py
@@ -153,7 +153,7 @@ def build_connect_url(task_id: str) -> str:
 _MAX_REFRESHES = 3
 
 
-def qr_register(timeout_seconds: int = 600) -> Optional[dict]:
+def qr_register(timeout_seconds: int = 600) -> dict | None:
     """Run the QQBot scan-to-configure QR registration flow.
 
     Mirrors ``feishu.qr_register()``: handles create → display → poll →

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -210,11 +210,11 @@ class SignalAdapter(BasePlatformAdapter):
         self.dm_allow_from = set(_parse_comma_list(dm_allowed_str))
 
         # HTTP client
-        self.client: Optional[httpx.AsyncClient] = None
+        self.client: httpx.AsyncClient | None = None
 
         # Background tasks
-        self._sse_task: Optional[asyncio.Task] = None
-        self._health_monitor_task: Optional[asyncio.Task] = None
+        self._sse_task: asyncio.Task | None = None
+        self._health_monitor_task: asyncio.Task | None = None
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         # Per-chat typing-indicator backoff. When signal-cli reports
         # NETWORK_FAILURE (recipient offline / unroutable), base.py's
@@ -226,7 +226,7 @@ class SignalAdapter(BasePlatformAdapter):
         self._typing_skip_until: Dict[str, float] = {}
         self._running = False
         self._last_sse_activity = 0.0
-        self._sse_response: Optional[httpx.Response] = None
+        self._sse_response: httpx.Response | None = None
 
         # Normalize account for self-message filtering
         self._account_normalized = self.account.strip()
@@ -643,14 +643,14 @@ class SignalAdapter(BasePlatformAdapter):
 
         await self.handle_message(event)
 
-    def _remember_recipient_identifiers(self, number: Optional[str], service_id: Optional[str]) -> None:
+    def _remember_recipient_identifiers(self, number: str | None, service_id: str | None) -> None:
         """Cache any number↔UUID mapping observed from Signal envelopes."""
         if not number or not service_id or not _is_signal_service_id(service_id):
             return
         self._recipient_uuid_by_number[number] = service_id
         self._recipient_number_by_uuid[service_id] = number
 
-    def _extract_contact_uuid(self, contact: Any, phone_number: str) -> Optional[str]:
+    def _extract_contact_uuid(self, contact: Any, phone_number: str) -> str | None:
         """Best-effort extraction of a Signal service ID from listContacts output."""
         if not isinstance(contact, dict):
             return None
@@ -970,8 +970,8 @@ class SignalAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a text message with native Signal formatting."""
         await self._stop_typing_indicator(chat_id)
@@ -1069,7 +1069,7 @@ class SignalAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images via chunked Signal RPC calls.
@@ -1241,7 +1241,7 @@ class SignalAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
+        caption: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send an image. Supports http(s):// and file:// URLs."""
@@ -1288,7 +1288,7 @@ class SignalAdapter(BasePlatformAdapter):
         chat_id: str,
         file_path: str,
         media_label: str,
-        caption: Optional[str] = None,
+        caption: str | None = None,
     ) -> SendResult:
         """Send any file as a Signal attachment via RPC.
 
@@ -1326,8 +1326,8 @@ class SignalAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        filename: Optional[str] = None,
+        caption: str | None = None,
+        filename: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file attachment."""
@@ -1337,8 +1337,8 @@ class SignalAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a local image file as a native Signal attachment.
@@ -1352,8 +1352,8 @@ class SignalAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send an audio file as a Signal attachment.
@@ -1367,8 +1367,8 @@ class SignalAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a video file as a Signal attachment."""
@@ -1461,7 +1461,7 @@ class SignalAdapter(BasePlatformAdapter):
     # Processing Lifecycle Hooks (reactions as progress indicators)
     # ------------------------------------------------------------------
 
-    def _extract_reaction_target(self, event: MessageEvent) -> Optional[tuple]:
+    def _extract_reaction_target(self, event: MessageEvent) -> tuple | None:
         """Extract (target_author, target_timestamp) from a MessageEvent.
 
         Returns None if the event doesn't carry the raw Signal envelope data

--- a/gateway/platforms/signal_rate_limit.py
+++ b/gateway/platforms/signal_rate_limit.py
@@ -50,7 +50,7 @@ class SignalRateLimitError(Exception):
     ``retry_after`` is None when the version doesn't expose it.
     """
 
-    def __init__(self, message: str, retry_after: Optional[float] = None) -> None:
+    def __init__(self, message: str, retry_after: float | None = None) -> None:
         super().__init__(message)
         self.retry_after = retry_after
 
@@ -71,7 +71,7 @@ class SignalSchedulerError(Exception):
 _RETRY_AFTER_RE = re.compile(r"Retry after (\d+(?:\.\d+)?)\s*second", re.IGNORECASE)
 
 
-def _extract_retry_after_seconds(err: Any) -> Optional[float]:
+def _extract_retry_after_seconds(err: Any) -> float | None:
     """Pull the per-token Retry-After window from a signal-cli rate-limit error.
 
     Tries two sources, in order:
@@ -300,7 +300,7 @@ class SignalAttachmentScheduler:
             n_attachments, self.refill_rate,
         )
 
-    def feedback(self, retry_after: Optional[float], n_attempted: int) -> None:
+    def feedback(self, retry_after: float | None, n_attempted: int) -> None:
         """Apply server feedback after a 429.
 
         ``retry_after`` is the per-*token* refill window the server
@@ -345,7 +345,7 @@ class SignalAttachmentScheduler:
 # Process-wide singleton
 # ---------------------------------------------------------------------------
 
-_scheduler: Optional[SignalAttachmentScheduler] = None
+_scheduler: SignalAttachmentScheduler | None = None
 
 
 def get_scheduler() -> SignalAttachmentScheduler:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 # channel concurrently.  ContextVars propagate to child asyncio.Tasks
 # (Python 3.7+), so the value set in _handle_slash_command's task is
 # visible in _process_message_background's child task.
-_slash_user_id: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+_slash_user_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "_slash_user_id", default=None,
 )
 
@@ -252,7 +252,7 @@ def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> st
     return f"[Slack Block Kit payload for this message]\n```json\n{payload}\n```"
 
 
-def _apply_slack_proxy(client: Any, proxy_url: Optional[str]) -> None:
+def _apply_slack_proxy(client: Any, proxy_url: str | None) -> None:
     """Apply a resolved proxy to a Slack SDK client or clear it explicitly."""
     if hasattr(client, "proxy"):
         client.proxy = proxy_url
@@ -265,7 +265,7 @@ _SLACK_PROXY_HOSTS = (
 )
 
 
-def _resolve_slack_proxy_url() -> Optional[str]:
+def _resolve_slack_proxy_url() -> str | None:
     """Resolve a proxy URL that Slack SDK clients can safely use."""
     proxy_url = resolve_proxy_url()
     if not proxy_url:
@@ -306,11 +306,11 @@ class SlackAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SLACK)
-        self._app: Optional[Any] = None
-        self._handler: Optional[Any] = None
-        self._bot_user_id: Optional[str] = None
+        self._app: Any | None = None
+        self._handler: Any | None = None
+        self._bot_user_id: str | None = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
-        self._socket_mode_task: Optional[asyncio.Task] = None
+        self._socket_mode_task: asyncio.Task | None = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}   # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}          # team_id → bot_user_id
@@ -349,7 +349,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
-    def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    def _describe_slack_api_error(self, response: Any, *, file_obj: Dict[str, Any] | None = None) -> str | None:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
         if response is None or not hasattr(response, "get"):
             return None
@@ -375,7 +375,7 @@ class SlackAdapter(BasePlatformAdapter):
             return f"Slack attachment access failed for {file_label} because the bot does not have permission ({error}). Check workspace permissions/scopes and reinstall if needed."
         return None
 
-    def _describe_slack_download_failure(self, exc: Exception, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    def _describe_slack_download_failure(self, exc: Exception, *, file_obj: Dict[str, Any] | None = None) -> str | None:
         """Translate Slack download exceptions into user-facing attachment diagnostics."""
         file_label = str((file_obj or {}).get("name") or (file_obj or {}).get("id") or "this attachment")
 
@@ -416,7 +416,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     def _pop_slash_context(
         self, chat_id: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any] | None:
         """Return and remove the slash-command context for *chat_id*, if fresh.
 
         Contexts older than ``_SLASH_CTX_TTL`` seconds are silently discarded.
@@ -704,7 +704,7 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Create a Slack thread anchor for a session handoff.
 
         Slack threads are anchored to a parent message (``thread_ts``), not
@@ -759,8 +759,8 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a message to a Slack channel or DM."""
         if not self._app:
@@ -837,8 +837,8 @@ class SlackAdapter(BasePlatformAdapter):
         chat_id: str,
         user_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a Slack ephemeral message visible only to one user."""
         if not self._app:
@@ -960,9 +960,9 @@ class SlackAdapter(BasePlatformAdapter):
 
     def _resolve_thread_ts(
         self,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> Optional[str]:
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
+    ) -> str | None:
         """Resolve the correct thread_ts for a Slack API call.
 
         Prefers metadata thread_id (the thread parent's ts, set by the
@@ -1000,9 +1000,9 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload a local file to Slack."""
         if not self._app:
@@ -1042,7 +1042,7 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single Slack message with multiple file uploads.
@@ -1143,7 +1143,7 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 await super().send_multiple_images(chat_id, chunk, metadata, human_delay=human_delay)
 
-    def _record_uploaded_file_thread(self, chat_id: str, thread_ts: Optional[str]) -> None:
+    def _record_uploaded_file_thread(self, chat_id: str, thread_ts: str | None) -> None:
         """Treat successful file uploads as bot participation in a thread."""
         if not thread_ts:
             return
@@ -1387,9 +1387,9 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a local image file to Slack by uploading it."""
         try:
@@ -1413,9 +1413,9 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an image to Slack by uploading the URL as a file."""
         if not self._app:
@@ -1477,9 +1477,9 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send an audio file to Slack."""
@@ -1500,9 +1500,9 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a video file to Slack."""
         if not self._app:
@@ -1556,10 +1556,10 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a document/file attachment to Slack."""
         if not self._app:
@@ -1635,7 +1635,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Internal handlers -----
 
-    def _assistant_thread_key(self, channel_id: str, thread_ts: str) -> Optional[Tuple[str, str]]:
+    def _assistant_thread_key(self, channel_id: str, thread_ts: str) -> Tuple[str, str] | None:
         """Return a stable cache key for Slack assistant thread metadata."""
         if not channel_id or not thread_ts:
             return None
@@ -2242,7 +2242,7 @@ class SlackAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a Block Kit approval prompt with interactive buttons.
 
@@ -2321,7 +2321,7 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
-        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+        confirm_id: str, metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a Block Kit three-option slash-command confirmation prompt."""
         if not self._app:

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -74,7 +74,7 @@ class SmsAdapter(BasePlatformAdapter):
         self._webhook_host: str = os.getenv("SMS_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
         self._webhook_url: str = os.getenv("SMS_WEBHOOK_URL", "").strip()
         self._runner = None
-        self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._http_session: "aiohttp.ClientSession" | None = None
 
     def _basic_auth_header(self) -> str:
         """Build HTTP Basic auth header value for Twilio."""
@@ -154,8 +154,8 @@ class SmsAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         import aiohttp
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -361,8 +361,8 @@ class TelegramAdapter(BasePlatformAdapter):
         name: str,
         default: float,
         *,
-        min_value: Optional[float] = None,
-        max_value: Optional[float] = None,
+        min_value: float | None = None,
+        max_value: float | None = None,
     ) -> float:
         """Read a float env var, reject non-finite values, and clamp to bounds.
 
@@ -391,8 +391,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
-        self._app: Optional[Application] = None
-        self._bot: Optional[Bot] = None
+        self._app: Application | None = None
+        self._bot: Bot | None = None
         self._webhook_mode: bool = False
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -425,7 +425,7 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
-        self._polling_error_task: Optional[asyncio.Task] = None
+        self._polling_error_task: asyncio.Task | None = None
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
@@ -481,7 +481,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._status_message_ids: Dict[tuple, str] = {}
 
     def _notification_kwargs(
-        self, metadata: Optional[Dict[str, Any]]
+        self, metadata: Dict[str, Any] | None
     ) -> Dict[str, Any]:
         """Return disable_notification kwargs when the adapter is in silent mode.
 
@@ -499,10 +499,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         user_id: str,
         *,
-        chat_id: Optional[str] = None,
-        chat_type: Optional[str] = None,
-        thread_id: Optional[str] = None,
-        user_name: Optional[str] = None,
+        chat_id: str | None = None,
+        chat_type: str | None = None,
+        thread_id: str | None = None,
+        user_name: str | None = None,
     ) -> bool:
         """Return whether a Telegram inline-button caller may perform gated actions."""
         normalized_user_id = str(user_id or "").strip()
@@ -548,21 +548,21 @@ class TelegramAdapter(BasePlatformAdapter):
         return "*" in allowed_ids or normalized_user_id in allowed_ids
 
     @classmethod
-    def _metadata_thread_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    def _metadata_thread_id(cls, metadata: Dict[str, Any] | None) -> str | None:
         if not metadata:
             return None
         thread_id = metadata.get("thread_id") or metadata.get("message_thread_id")
         return str(thread_id) if thread_id is not None else None
 
     @classmethod
-    def _metadata_direct_messages_topic_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    def _metadata_direct_messages_topic_id(cls, metadata: Dict[str, Any] | None) -> str | None:
         if not metadata:
             return None
         topic_id = metadata.get("direct_messages_topic_id") or metadata.get("telegram_direct_messages_topic_id")
         return str(topic_id) if topic_id is not None else None
 
     @classmethod
-    def _metadata_reply_to_message_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[int]:
+    def _metadata_reply_to_message_id(cls, metadata: Dict[str, Any] | None) -> int | None:
         if not metadata:
             return None
         reply_to = metadata.get("telegram_reply_to_message_id")
@@ -571,10 +571,10 @@ class TelegramAdapter(BasePlatformAdapter):
     @classmethod
     def _reply_to_message_id_for_send(
         cls,
-        reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]] = None,
-        reply_to_mode: Optional[str] = None,
-    ) -> Optional[int]:
+        reply_to: str | None,
+        metadata: Dict[str, Any] | None = None,
+        reply_to_mode: str | None = None,
+    ) -> int | None:
         if reply_to:
             return int(reply_to)
         if metadata and metadata.get("telegram_dm_topic_reply_fallback"):
@@ -587,10 +587,10 @@ class TelegramAdapter(BasePlatformAdapter):
     def _thread_kwargs_for_send(
         cls,
         chat_id: str,
-        thread_id: Optional[str],
-        metadata: Optional[Dict[str, Any]] = None,
-        reply_to_message_id: Optional[int] = None,
-        reply_to_mode: Optional[str] = None,
+        thread_id: str | None,
+        metadata: Dict[str, Any] | None = None,
+        reply_to_message_id: int | None = None,
+        reply_to_mode: str | None = None,
     ) -> Dict[str, Any]:
         """Return Telegram send kwargs for forum and direct-message topic routing.
 
@@ -629,13 +629,13 @@ class TelegramAdapter(BasePlatformAdapter):
         return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}
 
     @classmethod
-    def _message_thread_id_for_send(cls, thread_id: Optional[str]) -> Optional[int]:
+    def _message_thread_id_for_send(cls, thread_id: str | None) -> int | None:
         if not thread_id or str(thread_id) == cls._GENERAL_TOPIC_THREAD_ID:
             return None
         return int(thread_id)
 
     @classmethod
-    def _message_thread_id_for_typing(cls, thread_id: Optional[str]) -> Optional[int]:
+    def _message_thread_id_for_typing(cls, thread_id: str | None) -> int | None:
         # Asymmetric with _message_thread_id_for_send on purpose. Telegram's
         # sendMessage and sendChatAction treat thread id "1" (the forum General
         # topic) differently: sends reject message_thread_id=1 and must omit it,
@@ -666,8 +666,8 @@ class TelegramAdapter(BasePlatformAdapter):
     def _should_retry_without_dm_topic_reply_anchor(
         cls,
         error: Exception,
-        metadata: Optional[Dict[str, Any]],
-        reply_to_message_id: Optional[int],
+        metadata: Dict[str, Any] | None,
+        reply_to_message_id: int | None,
     ) -> bool:
         """True when a DM-topic send should be retried with routing stripped.
 
@@ -710,10 +710,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         send_fn: Any,
         send_kwargs: Dict[str, Any],
-        metadata: Optional[Dict[str, Any]],
-        reply_to_message_id: Optional[int],
+        metadata: Dict[str, Any] | None,
+        reply_to_message_id: int | None,
         media_label: str,
-        reset_media: Optional[Any] = None,
+        reset_media: Any | None = None,
     ) -> Any:
         """Retry stale private-topic media replies once without the topic anchor."""
         try:
@@ -1097,9 +1097,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: int,
         name: str,
-        icon_color: Optional[int] = None,
-        icon_custom_emoji_id: Optional[str] = None,
-    ) -> Optional[int]:
+        icon_color: int | None = None,
+        icon_custom_emoji_id: str | None = None,
+    ) -> int | None:
         """Create a forum topic in a private (DM) chat.
 
         Uses Bot API 9.4's createForumTopic which now works for 1-on-1 chats.
@@ -1148,7 +1148,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Create a forum topic for a session handoff.
 
         Works for DM topics (Bot API 9.4+, requires user to enable Topics
@@ -1662,7 +1662,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._bot = None
         logger.info("[%s] Disconnected from Telegram", self.name)
 
-    def _should_thread_reply(self, reply_to: Optional[str], chunk_index: int) -> bool:
+    def _should_thread_reply(self, reply_to: str | None, chunk_index: int) -> bool:
         """Determine if this message chunk should thread to the original message.
 
         Args:
@@ -1686,8 +1686,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None
     ) -> SendResult:
         """Send a message to a Telegram chat."""
         if not self._bot:
@@ -1931,7 +1931,7 @@ class TelegramAdapter(BasePlatformAdapter):
         status_key: str,
         content: str,
         *,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a status message, or edit the previous one with the same key.
 
@@ -1966,7 +1966,7 @@ class TelegramAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Edit a previously sent Telegram message.
 
@@ -2101,7 +2101,7 @@ class TelegramAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Split an oversized edit across the existing message + continuations.
 
@@ -2286,8 +2286,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def supports_draft_streaming(
         self,
-        chat_type: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        chat_type: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> bool:
         """Telegram supports sendMessageDraft for private chats only.
 
@@ -2308,7 +2308,7 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: str,
         draft_id: int,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Stream a partial message via Telegram's native sendMessageDraft.
 
@@ -2390,7 +2390,7 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an inline-keyboard update prompt (Yes / No buttons).
 
@@ -2433,7 +2433,7 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
 
@@ -2504,7 +2504,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
-        confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+        confirm_id: str, metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Render a three-button slash-command confirmation prompt."""
         if not self._bot:
@@ -2554,10 +2554,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         question: str,
-        choices: Optional[list],
+        choices: list | None,
         clarify_id: str,
         session_key: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Render a clarify prompt with one inline button per choice.
 
@@ -2640,7 +2640,7 @@ class TelegramAdapter(BasePlatformAdapter):
         current_provider: str,
         session_key: str,
         on_model_selected,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an interactive inline-keyboard model picker.
 
@@ -3208,7 +3208,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Look up the choice text from the entry registered in the
                 # clarify primitive.  Fall back to the index if the entry
                 # has been cleaned up (race with timeout / session reset).
-                resolved_text: Optional[str] = None
+                resolved_text: str | None = None
                 try:
                     from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
                     entry = _clarify_entries.get(clarify_id)
@@ -3425,9 +3425,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send audio as a native Telegram voice message or audio file."""
@@ -3516,7 +3516,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         images: List[tuple],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images natively via Telegram's media group API.
@@ -3651,9 +3651,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a local image file natively as a Telegram photo."""
@@ -3744,10 +3744,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file natively as a Telegram file attachment."""
@@ -3795,9 +3795,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a video natively as a Telegram video message."""
@@ -3842,9 +3842,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an image natively as a Telegram photo.
         
@@ -3936,9 +3936,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         animation_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Telegram animation (auto-plays inline)."""
         if not self._bot:
@@ -3979,11 +3979,11 @@ class TelegramAdapter(BasePlatformAdapter):
             # Fallback: try as a regular photo
             return await self.send_image(chat_id, animation_url, caption, reply_to, metadata=metadata)
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Dict[str, Any] | None = None) -> None:
         """Send typing indicator."""
         if self._bot:
             _is_dm_topic: bool = False
-            message_thread_id: Optional[int] = None
+            message_thread_id: int | None = None
             try:
                 _typing_thread = self._metadata_thread_id(metadata)
                 _is_dm_topic = bool(metadata and metadata.get("telegram_dm_topic_reply_fallback"))
@@ -4553,7 +4553,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return self._telegram_guest_mode() and self._message_mentions_bot(message)
 
-    def _clean_bot_trigger_text(self, text: Optional[str]) -> Optional[str]:
+    def _clean_bot_trigger_text(self, text: str | None) -> str | None:
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
         username = re.escape(self._bot.username)
@@ -4657,7 +4657,7 @@ class TelegramAdapter(BasePlatformAdapter):
             channel_prompt=channel_prompt,
         )
 
-    def _observe_unmentioned_group_message(self, message: Message, msg_type: MessageType, update_id: Optional[int] = None) -> None:
+    def _observe_unmentioned_group_message(self, message: Message, msg_type: MessageType, update_id: int | None = None) -> None:
         """Append skipped group chatter to the target session without dispatching."""
         store = getattr(self, "_session_store", None)
         if not store:
@@ -4789,7 +4789,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[%s] Forum command lazy-registration failed: %s", self.name, e)
 
-    def _effective_update_message(self, update: Update) -> Optional[Message]:
+    def _effective_update_message(self, update: Update) -> Message | None:
         """Return the message-like payload for normal messages and channel posts.
 
         Telegram exposes channel broadcasts as ``update.channel_post`` rather
@@ -5435,7 +5435,7 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[%s] Failed to reload dm_topics from config: %s", self.name, e)
 
-    def _get_dm_topic_info(self, chat_id: str, thread_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    def _get_dm_topic_info(self, chat_id: str, thread_id: str | None) -> Dict[str, Any] | None:
         """Look up DM topic config by chat_id and thread_id.
 
         Returns the topic config dict (name, skill, etc.) if this thread_id
@@ -5488,7 +5488,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self,
         message: Message,
         msg_type: MessageType,
-        update_id: Optional[int] = None,
+        update_id: int | None = None,
     ) -> MessageEvent:
         """Build a MessageEvent from a Telegram message.
 

--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -67,7 +67,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         self._fallbacks = {
             ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips
         }
-        self._sticky_ip: Optional[str] = None
+        self._sticky_ip: str | None = None
         self._sticky_lock = asyncio.Lock()
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
@@ -75,7 +75,7 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
             return await self._primary.handle_async_request(request)
 
         sticky_ip = self._sticky_ip
-        attempt_order: list[Optional[str]] = [sticky_ip] if sticky_ip else [None]
+        attempt_order: list[str | None] = [sticky_ip] if sticky_ip else [None]
         if sticky_ip:
             attempt_order.append(None)  # retry primary DNS after sticky failure
         for ip in self._fallback_ips:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -223,8 +223,8 @@ class WebhookAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Deliver the agent's response to the configured destination.
 

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -167,11 +167,11 @@ class WeComAdapter(BasePlatformAdapter):
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))
         self._groups = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
 
-        self._session: Optional["aiohttp.ClientSession"] = None
-        self._ws: Optional["aiohttp.ClientWebSocketResponse"] = None
-        self._http_client: Optional["httpx.AsyncClient"] = None
-        self._listen_task: Optional[asyncio.Task] = None
-        self._heartbeat_task: Optional[asyncio.Task] = None
+        self._session: "aiohttp.ClientSession" | None = None
+        self._ws: "aiohttp.ClientWebSocketResponse" | None = None
+        self._http_client: "httpx.AsyncClient" | None = None
+        self._listen_task: asyncio.Task | None = None
+        self._heartbeat_task: asyncio.Task | None = None
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._dedup = MessageDeduplicator(max_size=DEDUP_MAX_SIZE)
         self._reply_req_ids: Dict[str, str] = {}
@@ -469,7 +469,7 @@ class WeComAdapter(BasePlatformAdapter):
         return ""
 
     @staticmethod
-    def _parse_json(raw: Any) -> Optional[Dict[str, Any]]:
+    def _parse_json(raw: Any) -> Dict[str, Any] | None:
         try:
             payload = json.loads(raw)
         except Exception:
@@ -641,10 +641,10 @@ class WeComAdapter(BasePlatformAdapter):
                 self._pending_text_batch_tasks.pop(key, None)
 
     @staticmethod
-    def _extract_text(body: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+    def _extract_text(body: Dict[str, Any]) -> Tuple[str, str | None]:
         """Extract plain text and quoted text from a callback payload."""
         text_parts: List[str] = []
-        reply_text: Optional[str] = None
+        reply_text: str | None = None
         msgtype = str(body.get("msgtype") or "").lower()
 
         if msgtype == "mixed":
@@ -738,7 +738,7 @@ class WeComAdapter(BasePlatformAdapter):
 
         return media_paths, media_types
 
-    async def _cache_media(self, kind: str, media: Dict[str, Any]) -> Optional[Tuple[str, str]]:
+    async def _cache_media(self, kind: str, media: Dict[str, Any]) -> Tuple[str, str] | None:
         """Cache an inbound image/file/media reference to local storage."""
         if "base64" in media and media.get("base64"):
             try:
@@ -820,7 +820,7 @@ class WeComAdapter(BasePlatformAdapter):
         return fallback
 
     @staticmethod
-    def _guess_filename(url: str, content_disposition: Optional[str], content_type: str) -> str:
+    def _guess_filename(url: str, content_disposition: str | None, content_type: str) -> str:
         if content_disposition:
             match = re.search(r'filename="?([^";]+)"?', content_disposition)
             if match:
@@ -904,7 +904,7 @@ class WeComAdapter(BasePlatformAdapter):
         while len(self._last_chat_req_ids) > DEDUP_MAX_SIZE:
             self._last_chat_req_ids.pop(next(iter(self._last_chat_req_ids)))
 
-    def _reply_req_id_for_message(self, reply_to: Optional[str]) -> Optional[str]:
+    def _reply_req_id_for_message(self, reply_to: str | None) -> str | None:
         normalized = str(reply_to or "").strip()
         if not normalized or normalized.startswith("quote:"):
             return None
@@ -945,7 +945,7 @@ class WeComAdapter(BasePlatformAdapter):
         return "file"
 
     @staticmethod
-    def _apply_file_size_limits(file_size: int, detected_type: str, content_type: Optional[str] = None) -> Dict[str, Any]:
+    def _apply_file_size_limits(file_size: int, detected_type: str, content_type: str | None = None) -> Dict[str, Any]:
         file_size_mb = file_size / (1024 * 1024)
         normalized_type = str(detected_type or "file").lower()
         normalized_content_type = str(content_type or "").strip().lower()
@@ -1009,7 +1009,7 @@ class WeComAdapter(BasePlatformAdapter):
         }
 
     @staticmethod
-    def _response_error(response: Dict[str, Any]) -> Optional[str]:
+    def _response_error(response: Dict[str, Any]) -> str | None:
         errcode = response.get("errcode", 0)
         if errcode in {0, None}:
             return None
@@ -1104,7 +1104,7 @@ class WeComAdapter(BasePlatformAdapter):
     async def _load_outbound_media(
         self,
         media_source: str,
-        file_name: Optional[str] = None,
+        file_name: str | None = None,
     ) -> Tuple[bytes, str, str]:
         source = str(media_source or "").strip()
         if not source:
@@ -1139,7 +1139,7 @@ class WeComAdapter(BasePlatformAdapter):
     async def _prepare_outbound_media(
         self,
         media_source: str,
-        file_name: Optional[str] = None,
+        file_name: str | None = None,
     ) -> Dict[str, Any]:
         data, content_type, resolved_name = await self._load_outbound_media(media_source, file_name=file_name)
         detected_type = self._detect_wecom_media_type(content_type)
@@ -1253,8 +1253,8 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-    ) -> Optional[SendResult]:
+        reply_to: str | None = None,
+    ) -> SendResult | None:
         if not content:
             return None
         result = await self.send(chat_id=chat_id, content=content, reply_to=reply_to)
@@ -1266,9 +1266,9 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         media_source: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
     ) -> SendResult:
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
@@ -1349,8 +1349,8 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send markdown to a WeCom chat via proactive ``aibot_send_msg``."""
         del metadata
@@ -1395,9 +1395,9 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         del metadata
 
@@ -1418,8 +1418,8 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         del kwargs
@@ -1434,9 +1434,9 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         del kwargs
@@ -1452,8 +1452,8 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         del kwargs
@@ -1468,8 +1468,8 @@ class WeComAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         del kwargs
@@ -1506,7 +1506,7 @@ _QR_POLL_TIMEOUT = 300  # 5 minutes
 def qr_scan_for_bot_info(
     *,
     timeout_seconds: int = _QR_POLL_TIMEOUT,
-) -> Optional[Dict[str, str]]:
+) -> Dict[str, str] | None:
     """Run the WeCom QR scan flow to obtain bot_id and secret.
 
     Fetches a QR code from WeCom, renders it in the terminal, and polls

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -60,12 +60,12 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         self._port = int(extra.get("port") or DEFAULT_PORT)
         self._path = str(extra.get("path") or DEFAULT_PATH)
         self._apps: List[Dict[str, Any]] = self._normalize_apps(extra)
-        self._runner: Optional[web.AppRunner] = None
-        self._site: Optional[web.TCPSite] = None
-        self._app: Optional[web.Application] = None
-        self._http_client: Optional[httpx.AsyncClient] = None
+        self._runner: web.AppRunner | None = None
+        self._site: web.TCPSite | None = None
+        self._app: web.Application | None = None
+        self._http_client: httpx.AsyncClient | None = None
         self._message_queue: asyncio.Queue[MessageEvent] = asyncio.Queue()
-        self._poll_task: Optional[asyncio.Task] = None
+        self._poll_task: asyncio.Task | None = None
         self._seen_messages: Dict[str, float] = {}
         self._user_app_map: Dict[str, str] = {}
         self._access_tokens: Dict[str, Dict[str, Any]] = {}
@@ -181,8 +181,8 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         app = self._resolve_app_for_chat(chat_id)
         touser = chat_id.split(":", 1)[1] if ":" in chat_id else chat_id
@@ -327,7 +327,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         crypt = self._crypt_for_app(app)
         return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")
 
-    def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
+    def _build_event(self, app: Dict[str, Any], xml_text: str) -> MessageEvent | None:
         root = ET.fromstring(xml_text)
         msg_type = (root.findtext("MsgType") or "").lower()
         # Silently acknowledge lifecycle events.
@@ -370,7 +370,7 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             receive_id=str(app.get("corp_id") or ""),
         )
 
-    def _get_app_by_name(self, name: Optional[str]) -> Optional[Dict[str, Any]]:
+    def _get_app_by_name(self, name: str | None) -> Dict[str, Any] | None:
         if not name:
             return None
         for app in self._apps:

--- a/gateway/platforms/wecom_crypto.py
+++ b/gateway/platforms/wecom_crypto.py
@@ -111,7 +111,7 @@ class WXBizMsgCrypt:
             raise DecryptError("receive_id mismatch")
         return xml_content
 
-    def encrypt(self, plaintext: str, nonce: Optional[str] = None, timestamp: Optional[str] = None) -> str:
+    def encrypt(self, plaintext: str, nonce: str | None = None, timestamp: str | None = None) -> str:
         nonce = nonce or self._random_nonce()
         timestamp = timestamp or str(int(__import__("time").time()))
         encrypt = self._encrypt_bytes(plaintext.encode("utf-8"))

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -97,7 +97,7 @@ MESSAGE_DEDUP_TTL_SECONDS = 300
 
 
 def _is_stale_session_ret(
-    ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
+    ret: "int | None", errcode: "int | None", errmsg: "str | None",
 ) -> bool:
     """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
     which is a stale-session signal (same as errcode=-14) rather than
@@ -115,7 +115,7 @@ MEDIA_VOICE = 4
 _LIVE_ADAPTERS: Dict[str, Any] = {}
 
 
-def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
+def _make_ssl_connector() -> "aiohttp.TCPConnector" | None:
     """Return a TCPConnector with a certifi CA bundle, or None if certifi is unavailable.
 
     Tencent's iLink server (``ilinkai.weixin.qq.com``) is not verifiable against
@@ -158,7 +158,7 @@ def check_weixin_requirements() -> bool:
     return AIOHTTP_AVAILABLE and CRYPTO_AVAILABLE
 
 
-def _safe_id(value: Optional[str], keep: int = 8) -> str:
+def _safe_id(value: str | None, keep: int = 8) -> str:
     raw = str(value or "").strip()
     if not raw:
         return "?"
@@ -207,7 +207,7 @@ def _base_info() -> Dict[str, Any]:
     return {"channel_version": CHANNEL_VERSION}
 
 
-def _headers(token: Optional[str], body: str) -> Dict[str, str]:
+def _headers(token: str | None, body: str) -> Dict[str, str]:
     headers = {
         "Content-Type": "application/json",
         "AuthorizationType": "ilink_bot_token",
@@ -254,7 +254,7 @@ def save_weixin_account(
         pass
 
 
-def load_weixin_account(hermes_home: str, account_id: str) -> Optional[Dict[str, Any]]:
+def load_weixin_account(hermes_home: str, account_id: str) -> Dict[str, Any] | None:
     """Load persisted account credentials."""
     path = _account_file(hermes_home, account_id)
     if not path.exists():
@@ -295,7 +295,7 @@ class ContextTokenStore:
         if restored:
             logger.info("weixin: restored %d context token(s) for %s", restored, _safe_id(account_id))
 
-    def get(self, account_id: str, user_id: str) -> Optional[str]:
+    def get(self, account_id: str, user_id: str) -> str | None:
         return self._cache.get(self._key(account_id, user_id))
 
     def set(self, account_id: str, user_id: str, token: str) -> None:
@@ -322,7 +322,7 @@ class TypingTicketCache:
         self._ttl_seconds = ttl_seconds
         self._cache: Dict[str, Tuple[str, float]] = {}
 
-    def get(self, user_id: str) -> Optional[str]:
+    def get(self, user_id: str) -> str | None:
         entry = self._cache.get(user_id)
         if not entry:
             return None
@@ -373,7 +373,7 @@ async def _api_post(
     base_url: str,
     endpoint: str,
     payload: Dict[str, Any],
-    token: Optional[str],
+    token: str | None,
     timeout_ms: int,
 ) -> Dict[str, Any]:
     body = _json_dumps({**payload, "base_info": _base_info()})
@@ -434,7 +434,7 @@ async def _send_message(
     token: str,
     to: str,
     text: str,
-    context_token: Optional[str],
+    context_token: str | None,
     client_id: str,
 ) -> Dict[str, Any]:
     """Send a text message via iLink sendmessage API.
@@ -493,7 +493,7 @@ async def _get_config(
     base_url: str,
     token: str,
     user_id: str,
-    context_token: Optional[str],
+    context_token: str | None,
 ) -> Dict[str, Any]:
     payload: Dict[str, Any] = {"ilink_user_id": user_id}
     if context_token:
@@ -624,9 +624,9 @@ async def _download_and_decrypt_media(
     session: "aiohttp.ClientSession",
     *,
     cdn_base_url: str,
-    encrypted_query_param: Optional[str],
-    aes_key_b64: Optional[str],
-    full_url: Optional[str],
+    encrypted_query_param: str | None,
+    aes_key_b64: str | None,
+    full_url: str | None,
     timeout_seconds: float,
 ) -> bytes:
     if encrypted_query_param:
@@ -1043,7 +1043,7 @@ async def qr_login(
     *,
     bot_type: str = "3",
     timeout_seconds: int = 480,
-) -> Optional[Dict[str, str]]:
+) -> Dict[str, str] | None:
     """
     Run the interactive iLink QR login flow.
 
@@ -1189,9 +1189,9 @@ class WeixinAdapter(BasePlatformAdapter):
         self._hermes_home = hermes_home
         self._token_store = ContextTokenStore(hermes_home)
         self._typing_cache = TypingTicketCache()
-        self._poll_session: Optional[aiohttp.ClientSession] = None
-        self._send_session: Optional[aiohttp.ClientSession] = None
-        self._poll_task: Optional[asyncio.Task] = None
+        self._poll_session: aiohttp.ClientSession | None = None
+        self._send_session: aiohttp.ClientSession | None = None
+        self._poll_task: asyncio.Task | None = None
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
         self._account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
@@ -1473,7 +1473,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 media_paths.append(voice_path)
                 media_types.append("audio/silk")
 
-    async def _download_image(self, item: Dict[str, Any]) -> Optional[str]:
+    async def _download_image(self, item: Dict[str, Any]) -> str | None:
         media = _media_reference(item, "image_item")
         try:
             data = await _download_and_decrypt_media(
@@ -1491,7 +1491,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] image download failed: %s", self.name, exc)
             return None
 
-    async def _download_video(self, item: Dict[str, Any]) -> Optional[str]:
+    async def _download_video(self, item: Dict[str, Any]) -> str | None:
         media = _media_reference(item, "video_item")
         try:
             data = await _download_and_decrypt_media(
@@ -1507,7 +1507,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] video download failed: %s", self.name, exc)
             return None
 
-    async def _download_file(self, item: Dict[str, Any]) -> Tuple[Optional[str], str]:
+    async def _download_file(self, item: Dict[str, Any]) -> Tuple[str | None, str]:
         file_item = item.get("file_item") or {}
         media = file_item.get("media") or {}
         filename = str(file_item.get("file_name") or "document.bin")
@@ -1526,7 +1526,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] file download failed: %s", self.name, exc)
             return None, mime
 
-    async def _download_voice(self, item: Dict[str, Any]) -> Optional[str]:
+    async def _download_voice(self, item: Dict[str, Any]) -> str | None:
         voice_item = item.get("voice_item") or {}
         media = voice_item.get("media") or {}
         if voice_item.get("text"):
@@ -1545,7 +1545,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.warning("[%s] voice download failed: %s", self.name, exc)
             return None
 
-    async def _maybe_fetch_typing_ticket(self, user_id: str, context_token: Optional[str]) -> None:
+    async def _maybe_fetch_typing_ticket(self, user_id: str, context_token: str | None) -> None:
         if not self._poll_session or not self._token:
             return
         if self._typing_cache.get(user_id):
@@ -1574,7 +1574,7 @@ class WeixinAdapter(BasePlatformAdapter):
         *,
         chat_id: str,
         chunk: str,
-        context_token: Optional[str],
+        context_token: str | None,
         client_id: str,
     ) -> None:
         """Send a single text chunk with per-chunk retry and backoff.
@@ -1584,7 +1584,7 @@ class WeixinAdapter(BasePlatformAdapter):
         degraded fallback, which keeps cron-initiated push messages working
         even when no user message has refreshed the session recently.
         """
-        last_error: Optional[Exception] = None
+        last_error: Exception | None = None
         retried_without_token = False
         for attempt in range(self._send_chunk_retries + 1):
             try:
@@ -1669,13 +1669,13 @@ class WeixinAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
         context_token = self._token_store.get(self._account_id, chat_id)
-        last_message_id: Optional[str] = None
+        last_message_id: str | None = None
 
         # Extract MEDIA: tags and bare local file paths before text delivery.
         media_files, cleaned_content = self.extract_media(content)
@@ -1732,7 +1732,7 @@ class WeixinAdapter(BasePlatformAdapter):
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)
             return SendResult(success=False, error=str(exc))
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Dict[str, Any] | None = None) -> None:
         if not self._send_session or not self._token:
             return
         typing_ticket = self._typing_cache.get(chat_id)
@@ -1773,8 +1773,8 @@ class WeixinAdapter(BasePlatformAdapter):
         chat_id: str,
         image_url: str,
         caption: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         if image_url.startswith(("http://", "https://")):
             file_path = await self._download_remote_media(image_url)
@@ -1797,9 +1797,9 @@ class WeixinAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         del reply_to, kwargs
@@ -1814,10 +1814,10 @@ class WeixinAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         del file_name, reply_to, metadata, kwargs
@@ -1834,9 +1834,9 @@ class WeixinAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
@@ -1851,9 +1851,9 @@ class WeixinAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
@@ -2064,7 +2064,7 @@ class WeixinAdapter(BasePlatformAdapter):
         chat_type = "group" if chat_id.endswith("@chatroom") else "dm"
         return {"name": chat_id, "type": chat_type, "chat_id": chat_id}
 
-    def format_message(self, content: Optional[str]) -> str:
+    def format_message(self, content: str | None) -> str:
         if content is None:
             return ""
         return _wrap_copy_friendly_lines_for_weixin(_normalize_markdown_blocks(content))
@@ -2073,10 +2073,10 @@ class WeixinAdapter(BasePlatformAdapter):
 async def send_weixin_direct(
     *,
     extra: Dict[str, Any],
-    token: Optional[str],
+    token: str | None,
     chat_id: str,
     message: str,
-    media_files: Optional[List[Tuple[str, bool]]] = None,
+    media_files: List[Tuple[str, bool]] | None = None,
 ) -> Dict[str, Any]:
     """
     One-shot send helper for ``send_message`` and cron delivery.
@@ -2101,7 +2101,7 @@ async def send_weixin_direct(
     if (live_adapter is not None and send_session is not None
             and not send_session.closed
             and send_session._loop is asyncio.get_running_loop()):
-        last_result: Optional[SendResult] = None
+        last_result: SendResult | None = None
         cleaned = live_adapter.format_message(message)
         if cleaned:
             last_result = await live_adapter.send(chat_id, cleaned)
@@ -2146,7 +2146,7 @@ async def send_weixin_direct(
         adapter._cdn_base_url = cdn_base_url
         adapter._token_store = token_store
 
-        last_result: Optional[SendResult] = None
+        last_result: SendResult | None = None
         cleaned = adapter.format_message(message)
         if cleaned:
             last_result = await adapter.send(chat_id, cleaned)

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -249,9 +249,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WHATSAPP)
-        self._bridge_process: Optional[subprocess.Popen] = None
+        self._bridge_process: subprocess.Popen | None = None
         self._bridge_port: int = config.extra.get("bridge_port", 3000)
-        self._bridge_script: Optional[str] = config.extra.get(
+        self._bridge_script: str | None = config.extra.get(
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
         )
@@ -259,7 +259,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             "session_path",
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
-        self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
+        self._reply_prefix: str | None = config.extra.get("reply_prefix")
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "open")).strip().lower()
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
@@ -267,9 +267,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
-        self._bridge_log: Optional[Path] = None
-        self._poll_task: Optional[asyncio.Task] = None
-        self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._bridge_log: Path | None = None
+        self._poll_task: asyncio.Task | None = None
+        self._http_session: "aiohttp.ClientSession" | None = None
         # Set to True by disconnect() before we SIGTERM our child bridge so
         # _check_managed_bridge_exit() can distinguish an intentional
         # shutdown-time exit (returncode -15 / -2 / 0) from a real crash.
@@ -392,7 +392,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         return compiled
 
     @staticmethod
-    def _normalize_whatsapp_id(value: Optional[str]) -> str:
+    def _normalize_whatsapp_id(value: str | None) -> str:
         if not value:
             return ""
         normalized = str(value).strip()
@@ -725,7 +725,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 pass
             self._bridge_log_fh = None
 
-    async def _check_managed_bridge_exit(self) -> Optional[str]:
+    async def _check_managed_bridge_exit(self) -> str | None:
         """Return a fatal error message if the managed bridge child exited."""
         if self._bridge_process is None:
             return None
@@ -869,8 +869,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None
     ) -> SendResult:
         """Send a message via the WhatsApp bridge.
 
@@ -964,8 +964,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         chat_id: str,
         file_path: str,
         media_type: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
     ) -> SendResult:
         """Send any media file via bridge /send-media endpoint."""
         if not self._running or not self._http_session:
@@ -1012,8 +1012,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
     ) -> SendResult:
         """Download image URL to cache, send natively via bridge."""
         try:
@@ -1026,8 +1026,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a local image file natively via bridge."""
@@ -1037,8 +1037,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a video natively via bridge — plays inline in WhatsApp."""
@@ -1048,8 +1048,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send an audio file as a WhatsApp voice message via bridge."""
@@ -1059,9 +1059,9 @@ class WhatsAppAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file as a downloadable attachment via bridge."""
@@ -1152,7 +1152,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             
             await asyncio.sleep(1)  # Poll interval
     
-    async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
+    async def _build_message_event(self, data: Dict[str, Any]) -> MessageEvent | None:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
             if not self._should_process_message(data):

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -217,7 +217,7 @@ class MarkdownProcessor:
     def split_at_paragraph_boundary(
         text: str,
         max_chars: int,
-        len_fn: Optional[Callable[[str], int]] = None,
+        len_fn: Callable[[str], int] | None = None,
     ) -> tuple[str, str]:
         """
         Find the nearest paragraph boundary split point within max_chars, return (head, tail).
@@ -356,7 +356,7 @@ class MarkdownProcessor:
         cls,
         text: str,
         max_chars: int = 4000,
-        len_fn: Optional[Callable[[str], int]] = None,
+        len_fn: Callable[[str], int] | None = None,
     ) -> list[str]:
         """
         Split Markdown text into multiple chunks by max_chars.
@@ -895,7 +895,7 @@ class InboundContext:
     raw_frames: list = dc_field(default_factory=list)  # Raw bytes frames (debounce-aggregated)
 
     # Populated by DecodeMiddleware
-    push: Optional[dict] = None
+    push: dict | None = None
     decoded_via: str = ""  # "json" | "protobuf"
 
     # Extracted from push by FieldExtractMiddleware
@@ -917,17 +917,17 @@ class InboundContext:
     media_refs: list = dc_field(default_factory=list)
 
     # Owner command detection
-    owner_command: Optional[str] = None
+    owner_command: str | None = None
 
     # Source built by BuildSourceMiddleware
-    source: Optional[Any] = None  # SessionSource
+    source: Any | None = None  # SessionSource
 
     # Populated by ClassifyMessageTypeMiddleware
-    msg_type: Optional[Any] = None  # MessageType
+    msg_type: Any | None = None  # MessageType
 
     # Populated by QuoteContextMiddleware
-    reply_to_message_id: Optional[str] = None
-    reply_to_text: Optional[str] = None
+    reply_to_message_id: str | None = None
+    reply_to_text: str | None = None
     quote_media_refs: list = dc_field(default_factory=list)  # List of (rid, kind, filename)
 
     # Populated by MediaResolveMiddleware
@@ -938,7 +938,7 @@ class InboundContext:
     link_urls: list = dc_field(default_factory=list)
 
     # Populated by GroupAttributionMiddleware
-    channel_prompt: Optional[str] = None
+    channel_prompt: str | None = None
 
 
 class InboundMiddleware(ABC):
@@ -1316,7 +1316,7 @@ class RecallGuardMiddleware(InboundMiddleware):
     # -- Branch C: interrupt currently-processing message ---------------
 
     @staticmethod
-    def _find_processing_session(adapter, recalled_id: str) -> Optional[str]:
+    def _find_processing_session(adapter, recalled_id: str) -> str | None:
         for sk, mid in adapter._processing_msg_ids.items():
             if mid == recalled_id and sk in adapter._active_sessions:
                 return sk
@@ -1400,7 +1400,7 @@ class RecallGuardMiddleware(InboundMiddleware):
 
     @classmethod
     def _patch_transcript(cls, adapter, recalled_id: str, group_code: str,
-                          from_account: str, recalled_content: Optional[str] = None) -> None:
+                          from_account: str, recalled_content: str | None = None) -> None:
         store = getattr(adapter, "_session_store", None)
         if not store:
             return
@@ -1466,7 +1466,7 @@ class SkipSelfMiddleware(InboundMiddleware):
     name = "skip-self"
 
     @staticmethod
-    def _is_self_reference(from_account: str, bot_id: Optional[str]) -> bool:
+    def _is_self_reference(from_account: str, bot_id: str | None) -> bool:
         """Detect whether the message is from the bot itself."""
         if not from_account or not bot_id:
             return False
@@ -1637,7 +1637,7 @@ class ExtractContentMiddleware(InboundMiddleware):
         return "\n".join(lines)
 
     @staticmethod
-    def _format_link_understanding(custom: dict) -> Optional[str]:
+    def _format_link_understanding(custom: dict) -> str | None:
         """Format elem_type 1007 (link understanding card) into bracket-placeholder text."""
         content = custom.get("content")
         if not content:
@@ -1915,7 +1915,7 @@ class OwnerCommandMiddleware(InboundMiddleware):
         msg_body: list,
         chat_type: str,
         from_account: str,
-    ) -> Tuple[Optional[str], Optional[str], bool]:
+    ) -> Tuple[str | None, str | None, bool]:
         """Identify allowlisted slash commands and determine sender identity.
 
         Returns (cmd, cmd_line, is_owner):
@@ -2007,7 +2007,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
     name = "group-at-guard"
 
     @staticmethod
-    def _is_at_bot(msg_body: list, bot_id: Optional[str]) -> bool:
+    def _is_at_bot(msg_body: list, bot_id: str | None) -> bool:
         """Detect whether the message @Bot.
 
         AT element format: TIMCustomElem, msg_content.data is a JSON string:
@@ -2031,7 +2031,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
         return False
 
     @staticmethod
-    def _extract_bot_mention_text(msg_body: list, bot_id: Optional[str]) -> str:
+    def _extract_bot_mention_text(msg_body: list, bot_id: str | None) -> str:
         """Extract the display text used to @-mention this bot (e.g. ``@yuanbao-bot``)."""
         if not bot_id:
             return ""
@@ -2052,7 +2052,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
         return ""
 
     @staticmethod
-    def _build_group_channel_prompt(msg_body: list, bot_id: Optional[str]) -> str:
+    def _build_group_channel_prompt(msg_body: list, bot_id: str | None) -> str:
         """Build a per-turn group-chat prompt that highlights which message to respond to."""
         bid = str(bot_id or "unknown")
         bot_mention = GroupAtGuardMiddleware._extract_bot_mention_text(msg_body, bot_id) or "unknown"
@@ -2068,7 +2068,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
     @staticmethod
     def _observe_group_message(
         adapter, source, sender_display: str, text: str,
-        *, msg_id: Optional[str] = None,
+        *, msg_id: str | None = None,
     ) -> None:
         """Write a group message into the session transcript without triggering the agent.
 
@@ -2178,7 +2178,7 @@ class QuoteContextMiddleware(InboundMiddleware):
     name = "quote-context"
 
     @staticmethod
-    def _extract_quote_context(cloud_custom_data: str) -> Tuple[Optional[str], Optional[str], list]:
+    def _extract_quote_context(cloud_custom_data: str) -> Tuple[str | None, str | None, list]:
         """Extract quote context, mapping to MessageEvent.reply_to_*.
 
         Returns:
@@ -2326,8 +2326,8 @@ class MediaResolveMiddleware(InboundMiddleware):
     @classmethod
     async def _download_and_cache(
         cls, adapter, *, fetch_url: str, kind: str,
-        file_name: Optional[str] = None, log_tag: str = "",
-    ) -> Optional[Tuple[str, str]]:
+        file_name: str | None = None, log_tag: str = "",
+    ) -> Tuple[str, str] | None:
         """Download a Yuanbao resource and cache locally. Returns ``(local_path, mime)`` or ``None``."""
         try:
             file_bytes, content_type = await media_download_url(
@@ -2748,11 +2748,11 @@ class ConnectionManager:
     def __init__(self, adapter: "YuanbaoAdapter") -> None:
         self._adapter = adapter
         self._ws = None  # websockets connection
-        self._connect_id: Optional[str] = None
-        self._heartbeat_task: Optional[asyncio.Task] = None
-        self._recv_task: Optional[asyncio.Task] = None
+        self._connect_id: str | None = None
+        self._heartbeat_task: asyncio.Task | None = None
+        self._recv_task: asyncio.Task | None = None
         self._pending_acks: Dict[str, asyncio.Future] = {}
-        self._pending_pong: Optional[asyncio.Future] = None
+        self._pending_pong: asyncio.Future | None = None
         self._consecutive_hb_timeouts: int = 0
         self._reconnect_attempts: int = 0
         self._reconnecting: bool = False
@@ -2767,7 +2767,7 @@ class ConnectionManager:
         return self._ws
 
     @property
-    def connect_id(self) -> Optional[str]:
+    def connect_id(self) -> str | None:
         return self._connect_id
 
     @property
@@ -2990,7 +2990,7 @@ class ConnectionManager:
             logger.error("[%s] AUTH_BIND error: %s", adapter.name, exc, exc_info=True)
             return False
 
-    def _extract_connect_id(self, decoded_msg: dict) -> Optional[str]:
+    def _extract_connect_id(self, decoded_msg: dict) -> str | None:
         """Extract connectId from decoded BIND_ACK message."""
         data: bytes = decoded_msg.get("data", b"")
         if not data:
@@ -3425,8 +3425,8 @@ class MediaSendHandler(ABC):
         self,
         adapter: "YuanbaoAdapter",
         chat_id: str,
-        reply_to: Optional[str] = None,
-        caption: Optional[str] = None,
+        reply_to: str | None = None,
+        caption: str | None = None,
         **kwargs: Any,
     ) -> "SendResult":
         """Template method: shared media send flow."""
@@ -3671,7 +3671,7 @@ class GroupQueryService:
     # Low-level WS query methods
     # ------------------------------------------------------------------
 
-    async def query_group_info_raw(self, group_code: str) -> Optional[dict]:
+    async def query_group_info_raw(self, group_code: str) -> dict | None:
         """Query group info via WS (group name, owner, member count, etc.).
 
         Returns:
@@ -3704,7 +3704,7 @@ class GroupQueryService:
 
     async def get_group_member_list_raw(
         self, group_code: str, offset: int = 0, limit: int = 200
-    ) -> Optional[dict]:
+    ) -> dict | None:
         """Query group member list via WS.
 
         Returns:
@@ -3761,7 +3761,7 @@ class GroupQueryService:
         self,
         chat_id: str,
         action: str = "list_all",
-        name: Optional[str] = None,
+        name: str | None = None,
     ) -> dict:
         """AI tool: Query group member list.
 
@@ -3997,8 +3997,8 @@ class MessageSender:
         self._chat_locks: collections.OrderedDict[str, asyncio.Lock] = collections.OrderedDict()
 
         # Optional hooks injected by OutboundManager for coordination
-        self._on_send_start: Optional[Callable[[str], Any]] = None   # cancel slow-notifier
-        self._on_send_finish: Optional[Callable[[str], Any]] = None  # send FINISH heartbeat
+        self._on_send_start: Callable[[str], Any] | None = None   # cancel slow-notifier
+        self._on_send_finish: Callable[[str], Any] | None = None  # send FINISH heartbeat
 
         # Media send handlers (strategy pattern)
         self._media_handlers: Dict[str, MediaSendHandler] = {
@@ -4040,7 +4040,7 @@ class MessageSender:
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
+        reply_to: str | None = None,
         group_code: str = "",
     ) -> "SendResult":
         """Send text message with auto-chunking and per-chat-id ordering guarantee."""
@@ -4079,8 +4079,8 @@ class MessageSender:
         self,
         chat_id: str,
         handler_name: str,
-        reply_to: Optional[str] = None,
-        caption: Optional[str] = None,
+        reply_to: str | None = None,
+        caption: str | None = None,
         **kwargs: Any,
     ) -> "SendResult":
         """Dispatch media send to the named handler strategy."""
@@ -4101,7 +4101,7 @@ class MessageSender:
         self,
         chat_id: str,
         message: str,
-        media_files: Optional[List[Tuple[str, bool]]] = None,
+        media_files: List[Tuple[str, bool]] | None = None,
     ) -> Dict[str, Any]:
         """Send text + media via Yuanbao (used by the ``send_message`` tool).
 
@@ -4111,7 +4111,7 @@ class MessageSender:
         extension.
         """
         adapter = self._adapter
-        last_result: Optional["SendResult"] = None
+        last_result: "SendResult" | None = None
 
         # 1. Send text
         if message.strip():
@@ -4144,7 +4144,7 @@ class MessageSender:
         self,
         chat_id: str,
         msg_body: list,
-        reply_to: Optional[str] = None,
+        reply_to: str | None = None,
         group_code: str = "",
     ) -> "SendResult":
         """Lock + dispatch an arbitrary MsgBody to C2C or group."""
@@ -4165,7 +4165,7 @@ class MessageSender:
         self,
         chat_id: str,
         text: str,
-        reply_to: Optional[str] = None,
+        reply_to: str | None = None,
         retry: int = 3,
         group_code: str = "",
     ) -> "SendResult":
@@ -4216,7 +4216,7 @@ class MessageSender:
         self,
         group_code: str,
         text: str,
-        reply_to: Optional[str] = None,
+        reply_to: str | None = None,
     ) -> dict:
         """Send group text message, auto-converting @nickname to TIMCustomElem."""
         msg_body = self._build_msg_body_with_mentions(text, group_code)
@@ -4294,7 +4294,7 @@ class MessageSender:
         self,
         group_code: str,
         msg_body: list,
-        reply_to: Optional[str] = None,
+        reply_to: str | None = None,
     ) -> dict:
         """Send group message with arbitrary MsgBody."""
         adapter = self._adapter
@@ -4327,8 +4327,8 @@ class MessageSender:
 
     @staticmethod
     def validate_media(
-        file_bytes: Optional[bytes], filename: str, max_size_mb: int = 20
-    ) -> Optional[str]:
+        file_bytes: bytes | None, filename: str, max_size_mb: int = 20
+    ) -> str | None:
         """Media pre-validation: check file validity before sending/uploading.
 
         Returns:
@@ -4348,7 +4348,7 @@ class MessageSender:
     def truncate_message(
         content: str,
         max_length: int = 4000,
-        len_fn: Optional[Callable[[str], int]] = None,
+        len_fn: Callable[[str], int] | None = None,
     ) -> List[str]:
         """
         Split a long message into chunks with table-awareness.
@@ -4441,7 +4441,7 @@ class OutboundManager:
     # -- Delegated public API (used by YuanbaoAdapter) ---------------------
 
     async def send_text(
-        self, chat_id: str, content: str, reply_to: Optional[str] = None,
+        self, chat_id: str, content: str, reply_to: str | None = None,
         group_code: str = "",
     ) -> "SendResult":
         """Send text message with auto-chunking."""
@@ -4455,7 +4455,7 @@ class OutboundManager:
 
     async def send_direct(
         self, chat_id: str, message: str,
-        media_files: Optional[List[Tuple[str, bool]]] = None,
+        media_files: List[Tuple[str, bool]] | None = None,
     ) -> Dict[str, Any]:
         """Send text + media (used by send_message tool)."""
         return await self.sender.send_direct(chat_id, message, media_files)
@@ -4487,8 +4487,8 @@ class OutboundManager:
 
     @staticmethod
     def validate_media(
-        file_bytes: Optional[bytes], filename: str, max_size_mb: int = 20,
-    ) -> Optional[str]:
+        file_bytes: bytes | None, filename: str, max_size_mb: int = 20,
+    ) -> str | None:
         """Proxy to MessageSender.validate_media."""
         return MessageSender.validate_media(file_bytes, filename, max_size_mb)
 
@@ -4509,15 +4509,15 @@ class YuanbaoAdapter(BasePlatformAdapter):
 
     # -- Active instance registry (class-level singleton) -------------------
 
-    _active_instance: ClassVar[Optional["YuanbaoAdapter"]] = None
+    _active_instance: ClassVar["YuanbaoAdapter" | None] = None
 
     @classmethod
-    def get_active(cls) -> Optional["YuanbaoAdapter"]:
+    def get_active(cls) -> "YuanbaoAdapter" | None:
         """Return the currently connected YuanbaoAdapter, or None."""
         return cls._active_instance
 
     @classmethod
-    def set_active(cls, adapter: Optional["YuanbaoAdapter"]) -> None:
+    def set_active(cls, adapter: "YuanbaoAdapter" | None) -> None:
         """Register (or clear) the active adapter instance."""
         cls._active_instance = adapter
 
@@ -4528,7 +4528,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
         _extra = config.extra or {}
         self._app_key: str = (_extra.get("app_id") or "").strip()
         self._app_secret: str = (_extra.get("app_secret") or "").strip()
-        self._bot_id: Optional[str] = _extra.get("bot_id") or None
+        self._bot_id: str | None = _extra.get("bot_id") or None
         self._ws_url: str = (_extra.get("ws_url") or DEFAULT_WS_GATEWAY_URL).strip()
         self._api_domain: str = (_extra.get("api_domain") or DEFAULT_API_DOMAIN).rstrip("/")
         self._route_env: str = (_extra.get("route_env") or "").strip()
@@ -4663,8 +4663,8 @@ class YuanbaoAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         group_code: str = "",
     ) -> SendResult:
         """Send text message with auto-chunking. Delegates to OutboundManager."""
@@ -4683,7 +4683,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
             return {"name": chat_id, "type": "group"}
         return {"name": chat_id, "type": "dm"}
 
-    async def send_typing(self, chat_id: str, metadata: Optional[dict] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: dict | None = None) -> None:
         """Send "typing" status heartbeat (RUNNING). Delegates to OutboundManager."""
         try:
             await self._outbound.start_typing(chat_id)
@@ -4714,13 +4714,13 @@ class YuanbaoAdapter(BasePlatformAdapter):
     # Group query (delegate to GroupQueryService)
     # ------------------------------------------------------------------
 
-    async def query_group_info(self, group_code: str) -> Optional[dict]:
+    async def query_group_info(self, group_code: str) -> dict | None:
         """Query group info (delegates to GroupQueryService)."""
         return await self._group_query.query_group_info_raw(group_code)
 
     async def get_group_member_list(
         self, group_code: str, offset: int = 0, limit: int = 200
-    ) -> Optional[dict]:
+    ) -> dict | None:
         """Query group member list (delegates to GroupQueryService)."""
         return await self._group_query.get_group_member_list_raw(group_code, offset=offset, limit=limit)
 
@@ -4757,9 +4757,9 @@ class YuanbaoAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[dict] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
         **kwargs: Any,
     ) -> SendResult:
         """Send image message (URL). Delegates to OutboundManager via ImageUrlHandler."""
@@ -4773,9 +4773,9 @@ class YuanbaoAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[dict] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
         **kwargs: Any,
     ) -> SendResult:
         """Send local image file. Delegates to OutboundManager via ImageFileHandler."""
@@ -4789,9 +4789,9 @@ class YuanbaoAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_url: str,
-        filename: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[dict] = None,
+        filename: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
         **kwargs: Any,
     ) -> SendResult:
         """Send file message (URL). Delegates to OutboundManager via FileUrlHandler."""
@@ -4804,9 +4804,9 @@ class YuanbaoAdapter(BasePlatformAdapter):
     async def send_sticker(
         self,
         chat_id: str,
-        sticker_name: Optional[str] = None,
-        face_index: Optional[int] = None,
-        reply_to: Optional[str] = None,
+        sticker_name: str | None = None,
+        face_index: int | None = None,
+        reply_to: str | None = None,
         **kwargs: Any,
     ) -> SendResult:
         """Send sticker/emoji. Delegates to OutboundManager via StickerHandler."""
@@ -4821,10 +4821,10 @@ class YuanbaoAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        filename: Optional[str] = None,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[dict] = None,
+        filename: str | None = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict | None = None,
         **kwargs: Any,
     ) -> SendResult:
         """Send local file (document). Delegates to OutboundManager via DocumentHandler."""
@@ -4859,7 +4859,7 @@ class YuanbaoAdapter(BasePlatformAdapter):
 # ---------------------------------------------------------------------------
 
 
-def get_active_adapter() -> Optional["YuanbaoAdapter"]:
+def get_active_adapter() -> "YuanbaoAdapter" | None:
     """Delegate to ``YuanbaoAdapter.get_active()``."""
     return YuanbaoAdapter.get_active()
 
@@ -4868,7 +4868,7 @@ async def send_yuanbao_direct(
     adapter: "YuanbaoAdapter",
     chat_id: str,
     message: str,
-    media_files: Optional[List[Tuple[str, bool]]] = None,
+    media_files: List[Tuple[str, bool]] | None = None,
 ) -> Dict[str, Any]:
     """Delegate to ``OutboundManager.send_direct``."""
     return await adapter._outbound.send_direct(chat_id, message, media_files)

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -118,7 +118,7 @@ def generate_file_id() -> str:
 
 # ============ 图片尺寸解析（纯 Python，无需 Pillow） ============
 
-def parse_image_size(data: bytes) -> Optional[dict[str, int]]:
+def parse_image_size(data: bytes) -> dict[str, int] | None:
     """
     解析图片宽高（支持 JPEG/PNG/GIF/WebP），无需第三方依赖。
     返回 {"width": w, "height": h} 或 None（无法识别）。
@@ -131,7 +131,7 @@ def parse_image_size(data: bytes) -> Optional[dict[str, int]]:
     )
 
 
-def _parse_png_size(buf: bytes) -> Optional[dict[str, int]]:
+def _parse_png_size(buf: bytes) -> dict[str, int] | None:
     if len(buf) < 24:
         return None
     if buf[:4] != b"\x89PNG":
@@ -141,7 +141,7 @@ def _parse_png_size(buf: bytes) -> Optional[dict[str, int]]:
     return {"width": w, "height": h}
 
 
-def _parse_jpeg_size(buf: bytes) -> Optional[dict[str, int]]:
+def _parse_jpeg_size(buf: bytes) -> dict[str, int] | None:
     if len(buf) < 4 or buf[0] != 0xFF or buf[1] != 0xD8:
         return None
     i = 2
@@ -161,7 +161,7 @@ def _parse_jpeg_size(buf: bytes) -> Optional[dict[str, int]]:
     return None
 
 
-def _parse_gif_size(buf: bytes) -> Optional[dict[str, int]]:
+def _parse_gif_size(buf: bytes) -> dict[str, int] | None:
     if len(buf) < 10:
         return None
     sig = buf[:6].decode("ascii", errors="replace")
@@ -172,7 +172,7 @@ def _parse_gif_size(buf: bytes) -> Optional[dict[str, int]]:
     return {"width": w, "height": h}
 
 
-def _parse_webp_size(buf: bytes) -> Optional[dict[str, int]]:
+def _parse_webp_size(buf: bytes) -> dict[str, int] | None:
     if len(buf) < 16:
         return None
     if buf[:4] != b"RIFF" or buf[8:12] != b"WEBP":
@@ -259,7 +259,7 @@ def _cos_sign(
     headers: dict[str, str],
     secret_id: str,
     secret_key: str,
-    start_time: Optional[int] = None,
+    start_time: int | None = None,
     expire_seconds: int = 3600,
 ) -> str:
     """
@@ -341,7 +341,7 @@ async def get_cos_credentials(
     api_domain: str,
     token: str,
     filename: str = "file",
-    file_id: Optional[str] = None,
+    file_id: str | None = None,
     bot_id: str = "",
     route_env: str = "",
 ) -> dict:
@@ -458,8 +458,8 @@ async def upload_to_cos(
     session_token: str = credentials.get("encryptToken", "")
     cos_key: str = credentials.get("location", "")
     resource_url: str = credentials.get("resourceUrl", "")
-    start_time: Optional[int] = credentials.get("startTime")
-    expired_time: Optional[int] = credentials.get("expiredTime")
+    start_time: int | None = credentials.get("startTime")
+    expired_time: int | None = credentials.get("expiredTime")
 
     if not secret_id or not secret_key or not cos_key:
         raise RuntimeError(
@@ -554,8 +554,8 @@ async def upload_to_cos(
 
 def build_image_msg_body(
     url: str,
-    uuid: Optional[str] = None,
-    filename: Optional[str] = None,
+    uuid: str | None = None,
+    filename: str | None = None,
     size: int = 0,
     width: int = 0,
     height: int = 0,
@@ -603,7 +603,7 @@ def build_image_msg_body(
 def build_file_msg_body(
     url: str,
     filename: str,
-    uuid: Optional[str] = None,
+    uuid: str | None = None,
     size: int = 0,
 ) -> list[dict]:
     """

--- a/gateway/platforms/yuanbao_proto.py
+++ b/gateway/platforms/yuanbao_proto.py
@@ -634,7 +634,7 @@ def _decode_log_ext(data: bytes) -> dict:
 #   20: log_ext (message LogInfoExt)
 
 
-def decode_inbound_push(data: bytes) -> Optional[dict]:
+def decode_inbound_push(data: bytes) -> dict | None:
     """
     解析入站消息推送的 biz payload（InboundMessagePush proto bytes）。
 
@@ -719,7 +719,7 @@ def _encode_send_c2c_req(
     msg_body: list,
     msg_id: str = "",
     msg_random: int = 0,
-    msg_seq: Optional[int] = None,
+    msg_seq: int | None = None,
     group_code: str = "",
     trace_id: str = "",
 ) -> bytes:
@@ -764,7 +764,7 @@ def _encode_send_group_req(
     msg_id: str = "",
     to_account: str = "",
     random: str = "",
-    msg_seq: Optional[int] = None,
+    msg_seq: int | None = None,
     ref_msg_id: str = "",
     trace_id: str = "",
 ) -> bytes:
@@ -811,7 +811,7 @@ def encode_send_c2c_message(
     from_account: str,
     msg_id: str = "",
     msg_random: int = 0,
-    msg_seq: Optional[int] = None,
+    msg_seq: int | None = None,
     group_code: str = "",
     trace_id: str = "",
 ) -> bytes:
@@ -861,7 +861,7 @@ def encode_send_group_message(
     msg_id: str = "",
     to_account: str = "",
     random: str = "",
-    msg_seq: Optional[int] = None,
+    msg_seq: int | None = None,
     ref_msg_id: str = "",
     trace_id: str = "",
 ) -> bytes:
@@ -1073,7 +1073,7 @@ def encode_query_group_info(group_code: str) -> bytes:
     )
 
 
-def decode_query_group_info_rsp(data: bytes) -> Optional[dict]:
+def decode_query_group_info_rsp(data: bytes) -> dict | None:
     """
     解码 QueryGroupInfoRsp biz payload。
 
@@ -1154,7 +1154,7 @@ def encode_get_group_member_list(
     )
 
 
-def decode_get_group_member_list_rsp(data: bytes) -> Optional[dict]:
+def decode_get_group_member_list_rsp(data: bytes) -> dict | None:
     """
     解码 GetGroupMemberListRsp biz payload。
 

--- a/gateway/platforms/yuanbao_sticker.py
+++ b/gateway/platforms/yuanbao_sticker.py
@@ -328,7 +328,7 @@ STICKER_MAP: dict[str, dict] = {
 }
 
 
-def get_sticker_by_name(name: str) -> Optional[dict]:
+def get_sticker_by_name(name: str) -> dict | None:
     """
     按名称查找贴纸，支持模糊匹配。
 
@@ -378,7 +378,7 @@ def get_random_sticker(category: str = None) -> dict:
     return random.choice(list(STICKER_MAP.values()))
 
 
-def get_sticker_by_id(sticker_id: str) -> Optional[dict]:
+def get_sticker_by_id(sticker_id: str) -> dict | None:
     """按 sticker_id 精确查找贴纸。"""
     if not sticker_id:
         return None
@@ -511,7 +511,7 @@ def search_stickers(query: str, limit: int = 10) -> list[dict]:
 def build_face_msg_body(
     face_index: int,
     face_type: int = 1,
-    data: Optional[str] = None,
+    data: str | None = None,
 ) -> list:
     """
     构造 TIMFaceElem 消息体。

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -153,7 +153,7 @@ def _is_transient_network_error(exc: BaseException) -> bool:
     classified. The chain is bounded to avoid pathological cycles.
     """
     seen: set[int] = set()
-    cur: Optional[BaseException] = exc
+    cur: BaseException | None = exc
     depth = 0
     transient_class_names = {
         "TimedOut",
@@ -302,7 +302,7 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> str | None:
     """Filter/sanitize agent status callbacks before platform delivery."""
     text = str(message or "").strip()
     if not text:
@@ -372,7 +372,7 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
 
 
-def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
+def _coerce_gateway_timestamp(value: Any) -> float | None:
     """Best-effort conversion of stored gateway timestamps to epoch seconds.
 
     Missing/unparseable timestamps return None so legacy transcripts keep the
@@ -443,8 +443,8 @@ def _float_env(name: str, default: float) -> float:
 def _is_fresh_gateway_interruption(
     value: Any,
     *,
-    now: Optional[float] = None,
-    window_secs: Optional[float] = None,
+    now: float | None = None,
+    window_secs: float | None = None,
 ) -> bool:
     """Return True when an interruption marker is fresh enough to auto-continue.
 
@@ -545,7 +545,7 @@ _OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context onl
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
 
 
-def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
+def _uses_telegram_observed_group_context(channel_prompt: str | None) -> bool:
     """Return True for Telegram group turns that may include observed chatter.
 
     Telegram's observe-unmentioned mode persists skipped group chatter so a
@@ -562,8 +562,8 @@ def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool
 def _build_gateway_agent_history(
     history: List[Dict[str, Any]],
     *,
-    channel_prompt: Optional[str] = None,
-) -> tuple[List[Dict[str, Any]], Optional[str]]:
+    channel_prompt: str | None = None,
+) -> tuple[List[Dict[str, Any]], str | None]:
     """Convert stored gateway transcript rows into agent replay messages.
 
     Observed Telegram group rows are returned as API-only context for the
@@ -617,7 +617,7 @@ def _build_gateway_agent_history(
     return agent_history, observed_context
 
 
-def _wrap_current_message_with_observed_context(message: Any, observed_context: Optional[str]) -> Any:
+def _wrap_current_message_with_observed_context(message: Any, observed_context: str | None) -> Any:
     """Prepend observed Telegram context to the API-only current user turn."""
 
     if not observed_context:
@@ -643,7 +643,7 @@ def _wrap_current_message_with_observed_context(message: Any, observed_context: 
     return message
 
 
-def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
+def _last_transcript_timestamp(history: List[Dict[str, Any]] | None) -> Any:
     """Return the ``timestamp`` of the last usable transcript row, if any.
 
     Skips metadata-only rows (``session_meta``, system injections) that are
@@ -1166,7 +1166,7 @@ def _format_duration(seconds: float) -> str:
     return f"{minutes}:{secs:02d}"
 
 
-async def _probe_audio_duration(path: str) -> Optional[str]:
+async def _probe_audio_duration(path: str) -> str | None:
     """Best-effort duration probe. Returns formatted MM:SS / HH:MM:SS, or None on failure."""
     ext = os.path.splitext(path)[1].lower()
 
@@ -1237,7 +1237,7 @@ _CONTROL_INTERRUPT_MESSAGES = frozenset(
 )
 
 
-def _is_control_interrupt_message(message: Optional[str]) -> bool:
+def _is_control_interrupt_message(message: str | None) -> bool:
     """Return True when an interrupt message is internal control flow."""
     if not message:
         return False
@@ -1438,7 +1438,7 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
-def _resolve_hermes_bin() -> Optional[list[str]]:
+def _resolve_hermes_bin() -> list[str] | None:
     """Resolve the Hermes update command as argv parts.
 
     Tries in order:
@@ -1637,17 +1637,17 @@ class GatewayRunner:
     _busy_input_mode: str = "interrupt"
     _busy_text_mode: str = "interrupt"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
-    _exit_code: Optional[int] = None
+    _exit_code: int | None = None
     _draining: bool = False
     _restart_requested: bool = False
     _restart_task_started: bool = False
     _restart_detached: bool = False
     _restart_via_service: bool = False
-    _stop_task: Optional[asyncio.Task] = None
+    _stop_task: asyncio.Task | None = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
 
-    def __init__(self, config: Optional[GatewayConfig] = None):
+    def __init__(self, config: GatewayConfig | None = None):
         global _gateway_runner_ref
         self.config = config or load_gateway_config()
         self.adapters: Dict[Platform, BasePlatformAdapter] = {}
@@ -1675,18 +1675,18 @@ class GatewayRunner:
         )
         self.delivery_router = DeliveryRouter(self.config)
         self._running = False
-        self._gateway_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._gateway_loop: asyncio.AbstractEventLoop | None = None
         self._shutdown_event = asyncio.Event()
         self._exit_cleanly = False
         self._exit_with_failure = False
-        self._exit_reason: Optional[str] = None
-        self._exit_code: Optional[int] = None
+        self._exit_reason: str | None = None
+        self._exit_code: int | None = None
         self._draining = False
         self._restart_requested = False
         self._restart_task_started = False
         self._restart_detached = False
         self._restart_via_service = False
-        self._stop_task: Optional[asyncio.Task] = None
+        self._stop_task: asyncio.Task | None = None
         
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
@@ -1737,7 +1737,7 @@ class GatewayRunner:
         self._kanban_notifier_profile = self._active_profile_name()
         # Teams meeting pipeline runtime (bound later when msgraph_webhook adapter exists).
         self._teams_pipeline_runtime = None
-        self._teams_pipeline_runtime_error: Optional[str] = None
+        self._teams_pipeline_runtime_error: str | None = None
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
@@ -2131,11 +2131,11 @@ class GatewayRunner:
         return self._exit_with_failure
 
     @property
-    def exit_reason(self) -> Optional[str]:
+    def exit_reason(self) -> str | None:
         return self._exit_reason
 
     @property
-    def exit_code(self) -> Optional[int]:
+    def exit_code(self) -> int | None:
         return self._exit_code
 
     def _session_key_for_source(self, source: SessionSource) -> str:
@@ -2239,7 +2239,7 @@ class GatewayRunner:
             "existing topic only if you want to replace that topic's current session."
         )
 
-    def _telegram_topic_new_header(self, source: SessionSource) -> Optional[str]:
+    def _telegram_topic_new_header(self, source: SessionSource) -> str | None:
         if not self._is_telegram_topic_lane(source):
             return None
         return (
@@ -2269,7 +2269,7 @@ class GatewayRunner:
     def _recover_telegram_topic_thread_id(
         self,
         source: SessionSource,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Pin DM-topic routing to the user's last-active topic.
 
         Telegram can omit ``message_thread_id`` or surface General (``1``)
@@ -2321,9 +2321,9 @@ class GatewayRunner:
     def _resolve_session_agent_runtime(
         self,
         *,
-        source: Optional[SessionSource] = None,
-        session_key: Optional[str] = None,
-        user_config: Optional[dict] = None,
+        source: SessionSource | None = None,
+        session_key: str | None = None,
+        user_config: dict | None = None,
     ) -> tuple[str, dict]:
         """Resolve model/runtime for a session, honoring session-scoped /model overrides.
 
@@ -2654,7 +2654,7 @@ class GatewayRunner:
             logger.debug("goal continuation: active-state recheck failed: %s", exc)
             return False
 
-    def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
+    def _update_runtime_status(self, gateway_state: str | None = None, exit_reason: str | None = None) -> None:
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(
@@ -2670,9 +2670,9 @@ class GatewayRunner:
         self,
         platform: str,
         *,
-        platform_state: Optional[str] = None,
-        error_code: Optional[str] = None,
-        error_message: Optional[str] = None,
+        platform_state: str | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
     ) -> None:
         try:
             from gateway.status import write_runtime_status
@@ -2841,8 +2841,8 @@ class GatewayRunner:
     def _resolve_session_reasoning_config(
         self,
         *,
-        source: Optional[SessionSource] = None,
-        session_key: Optional[str] = None,
+        source: SessionSource | None = None,
+        session_key: str | None = None,
     ) -> dict | None:
         """Resolve reasoning effort for a session, honoring session overrides."""
         resolved_session_key = session_key
@@ -2860,7 +2860,7 @@ class GatewayRunner:
     def _set_session_reasoning_override(
         self,
         session_key: str,
-        reasoning_config: Optional[dict],
+        reasoning_config: dict | None,
     ) -> None:
         """Set or clear the session-scoped reasoning override."""
         if not session_key:
@@ -3287,7 +3287,7 @@ class GatewayRunner:
         )
         msg = f"⚠️ Gateway {action} — {hint}"
 
-        notified: set[tuple[str, str, Optional[str]]] = set()
+        notified: set[tuple[str, str, str | None]] = set()
         for session_key in active:
             source = None
             try:
@@ -5026,7 +5026,7 @@ class GatewayRunner:
                 await asyncio.sleep(1)
 
     def _kanban_advance(
-        self, sub: dict, cursor: int, board: Optional[str] = None,
+        self, sub: dict, cursor: int, board: str | None = None,
     ) -> None:
         """Sync helper: advance a subscription's cursor. Runs in to_thread.
 
@@ -5047,7 +5047,7 @@ class GatewayRunner:
         finally:
             conn.close()
 
-    def _kanban_unsub(self, sub: dict, board: Optional[str] = None) -> None:
+    def _kanban_unsub(self, sub: dict, board: str | None = None) -> None:
         from hermes_cli import kanban_db as _kb
         conn = _kb.connect(board=board)
         try:
@@ -5066,7 +5066,7 @@ class GatewayRunner:
         sub: dict,
         claimed_cursor: int,
         old_cursor: int,
-        board: Optional[str] = None,
+        board: str | None = None,
     ) -> None:
         """Sync helper: undo a claimed notification cursor after send failure."""
         from hermes_cli import kanban_db as _kb
@@ -5090,7 +5090,7 @@ class GatewayRunner:
         adapter,
         chat_id: str,
         metadata: dict,
-        event_payload: Optional[dict],
+        event_payload: dict | None,
         task,
     ) -> None:
         """Upload artifact files referenced by a completed kanban task.
@@ -5340,7 +5340,7 @@ class GatewayRunner:
                 or "database disk image is malformed" in msg
             )
 
-        def _tick_once_for_board(slug: str) -> "Optional[object]":
+        def _tick_once_for_board(slug: str) -> "object | None":
             """Run one dispatch_once for a specific board.
 
             Runs in a worker thread via `asyncio.to_thread`. `board=slug`
@@ -5401,7 +5401,7 @@ class GatewayRunner:
                     except Exception:
                         pass
 
-        def _tick_once() -> "list[tuple[str, Optional[object]]]":
+        def _tick_once() -> "list[tuple[str, object | None]]":
             """Run one dispatch_once per board. Returns (slug, result) pairs.
 
             Enumerating boards on every tick keeps the dispatcher honest
@@ -5412,7 +5412,7 @@ class GatewayRunner:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            out: list[tuple[str, "Optional[object]"]] = []
+            out: list[tuple[str, "object | None"]] = []
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 out.append((slug, _tick_once_for_board(slug)))
@@ -6076,7 +6076,7 @@ class GatewayRunner:
         self, 
         platform: Platform, 
         config: Any
-    ) -> Optional[BasePlatformAdapter]:
+    ) -> BasePlatformAdapter | None:
         """Create the appropriate adapter for a platform.
 
         Checks the platform_registry first (plugin adapters), then falls
@@ -6499,7 +6499,7 @@ class GatewayRunner:
 
         return bool(check_ids & allowed_ids)
 
-    def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
+    def _get_unauthorized_dm_behavior(self, platform: Platform | None) -> str:
         """Return how unauthorized DMs should be handled for a platform.
 
         Resolution order:
@@ -6598,7 +6598,7 @@ class GatewayRunner:
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
-    async def _handle_message(self, event: MessageEvent) -> Optional[str]:
+    async def _handle_message(self, event: MessageEvent) -> str | None:
         """
         Handle an incoming message from any platform.
         
@@ -7730,7 +7730,7 @@ class GatewayRunner:
         event: MessageEvent,
         source: SessionSource,
         history: List[Dict[str, Any]],
-    ) -> Optional[str]:
+    ) -> str | None:
         """Prepare inbound event text for the agent.
 
         Keep the normal inbound path and the queued follow-up path on the same
@@ -9332,7 +9332,7 @@ class GatewayRunner:
 
     def _check_slash_access(
         self, source: SessionSource, canonical_cmd: str
-    ) -> Optional[str]:
+    ) -> str | None:
         """Return a denial message if ``source`` cannot run ``canonical_cmd``,
         else None. Used by both the cold and running-agent dispatch paths
         in ``_handle_message`` so admin/user gating can't be bypassed by
@@ -10038,7 +10038,7 @@ class GatewayRunner:
             getattr(getattr(event, "source", None), "platform", None),
         )
 
-    async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
+    async def _handle_model_command(self, event: MessageEvent) -> str | None:
         """Handle /model command — switch model for this session.
 
         Supports:
@@ -10916,7 +10916,7 @@ class GatewayRunner:
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)
 
     @staticmethod
-    def _get_guild_id(event: MessageEvent) -> Optional[int]:
+    def _get_guild_id(event: MessageEvent) -> int | None:
         """Extract Discord guild_id from the raw message object."""
         raw = getattr(event, "raw_message", None)
         if raw is None:
@@ -11536,9 +11536,9 @@ class GatewayRunner:
         prompt: str,
         source: "SessionSource",
         task_id: str,
-        event_message_id: Optional[str] = None,
-        media_urls: Optional[List[str]] = None,
-        media_types: Optional[List[str]] = None,
+        event_message_id: str | None = None,
+        media_urls: List[str] | None = None,
+        media_types: List[str] | None = None,
     ) -> None:
         """Execute a background agent task and deliver the result to the chat."""
         from run_agent import AIAgent
@@ -13101,7 +13101,7 @@ class GatewayRunner:
             logger.error("Insights command error: %s", e, exc_info=True)
             return t("gateway.insights.error", error=e)
 
-    async def _handle_reload_mcp_command(self, event: MessageEvent) -> Optional[str]:
+    async def _handle_reload_mcp_command(self, event: MessageEvent) -> str | None:
         """Handle /reload-mcp — reconnect MCP servers and rebuild the cached agent.
 
         Reloading MCP tools invalidates the provider prompt cache for the
@@ -13135,7 +13135,7 @@ class GatewayRunner:
         # stores the resume handler; the button/text response triggers
         # ``_resolve_slash_confirm`` which invokes the handler with the
         # chosen outcome.
-        async def _on_confirm(choice: str) -> Optional[str]:
+        async def _on_confirm(choice: str) -> str | None:
             if choice == "cancel":
                 return t("gateway.reload_mcp.cancelled")
             if choice == "always":
@@ -13482,7 +13482,7 @@ class GatewayRunner:
         title: str,
         message: str,
         handler,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Ask the user to confirm an expensive slash command.
 
         ``handler`` is an async callable ``handler(choice: str) -> str``
@@ -13558,8 +13558,8 @@ class GatewayRunner:
     def _thread_metadata_for_source(
         self,
         source,
-        reply_to_message_id: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
+        reply_to_message_id: str | None = None,
+    ) -> Dict[str, Any] | None:
         """Build the metadata dict platforms need for thread-aware replies."""
         thread_id = getattr(source, "thread_id", None)
         if thread_id is None:
@@ -13582,7 +13582,7 @@ class GatewayRunner:
         return metadata
 
     @staticmethod
-    def _reply_anchor_for_event(event: MessageEvent) -> Optional[str]:
+    def _reply_anchor_for_event(event: MessageEvent) -> str | None:
         """Return the platform-specific reply anchor for GatewayRunner sends."""
         return _reply_anchor_for_event(event)
 
@@ -13593,7 +13593,7 @@ class GatewayRunner:
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # 5 minutes
 
-    async def _handle_approve_command(self, event: MessageEvent) -> Optional[str]:
+    async def _handle_approve_command(self, event: MessageEvent) -> str | None:
         """Handle /approve command — unblock waiting agent thread(s).
 
         The agent thread(s) are blocked inside tools/approval.py waiting for
@@ -14202,7 +14202,7 @@ class GatewayRunner:
 
         return True
 
-    async def _send_restart_notification(self) -> Optional[tuple[str, str, Optional[str]]]:
+    async def _send_restart_notification(self) -> tuple[str, str, str | None] | None:
         """Notify the chat that initiated /restart that the gateway is back."""
         notify_path = _hermes_home / ".restart_notify.json"
         if not notify_path.exists():
@@ -14268,15 +14268,15 @@ class GatewayRunner:
     async def _send_home_channel_startup_notifications(
         self,
         *,
-        skip_targets: Optional[set[tuple[str, str, Optional[str]]]] = None,
-    ) -> set[tuple[str, str, Optional[str]]]:
+        skip_targets: set[tuple[str, str, str | None]] | None = None,
+    ) -> set[tuple[str, str, str | None]]:
         """Notify configured home channels that the gateway is back online.
 
         The notification is best-effort and sent once per connected platform
         home channel. ``skip_targets`` lets startup avoid duplicate messages
         when a more specific restart notification is queued for the same chat.
         """
-        delivered: set[tuple[str, str, Optional[str]]] = set()
+        delivered: set[tuple[str, str, str | None]] = set()
         skipped = skip_targets or set()
         message = "♻️ Gateway online — Hermes is back and ready."
 
@@ -14953,7 +14953,7 @@ class GatewayRunner:
         self,
         session_key: str,
         *,
-        run_generation: Optional[int] = None,
+        run_generation: int | None = None,
     ) -> bool:
         """Pop ALL per-running-agent state entries for ``session_key``.
 
@@ -15292,7 +15292,7 @@ class GatewayRunner:
     # Proxy mode: forward messages to a remote Hermes API server
     # ------------------------------------------------------------------
 
-    def _get_proxy_url(self) -> Optional[str]:
+    def _get_proxy_url(self) -> str | None:
         """Return the proxy URL if proxy mode is configured, else None.
 
         Checks GATEWAY_PROXY_URL env var first (convenient for Docker),
@@ -15315,8 +15315,8 @@ class GatewayRunner:
         source: "SessionSource",
         session_id: str,
         session_key: str = None,
-        run_generation: Optional[int] = None,
-        event_message_id: Optional[str] = None,
+        run_generation: int | None = None,
+        event_message_id: str | None = None,
     ) -> Dict[str, Any]:
         """Forward the message to a remote Hermes API server instead of
         running a local AIAgent.
@@ -15412,7 +15412,7 @@ class GatewayRunner:
             else bool(_plat_streaming)
         )
 
-        _thread_metadata: Optional[Dict[str, Any]] = self._thread_metadata_for_source(source, event_message_id)
+        _thread_metadata: Dict[str, Any] | None = self._thread_metadata_for_source(source, event_message_id)
 
         if _streaming_enabled:
             try:
@@ -15601,10 +15601,10 @@ class GatewayRunner:
         source: SessionSource,
         session_id: str,
         session_key: str = None,
-        run_generation: Optional[int] = None,
+        run_generation: int | None = None,
         _interrupt_depth: int = 0,
-        event_message_id: Optional[str] = None,
-        channel_prompt: Optional[str] = None,
+        event_message_id: str | None = None,
+        channel_prompt: str | None = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -16238,7 +16238,7 @@ class GatewayRunner:
             # sent via the reply API with reply_in_thread=true. Status/interim,
             # approval, and stream-consumer paths usually only receive metadata,
             # so carry the triggering message id as a Feishu-specific fallback.
-            _status_thread_metadata: Optional[Dict[str, Any]] = {
+            _status_thread_metadata: Dict[str, Any] | None = {
                 "thread_id": _progress_thread_id,
                 "reply_to_message_id": event_message_id,
             }
@@ -17949,7 +17949,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker stopped")
 
 
-async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
+async def start_gateway(config: GatewayConfig | None = None, replace: bool = False, verbosity: int | None = 0) -> bool:
     """
     Start the gateway and run until interrupted.
     

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -47,7 +47,7 @@ def _home_relative_cwd(cwd: str) -> str:
         return cwd
 
 
-def _model_short(model: Optional[str]) -> str:
+def _model_short(model: str | None) -> str:
     """Drop ``vendor/`` prefix for readability (``openai/gpt-5.4`` → ``gpt-5.4``)."""
     if not model:
         return ""
@@ -91,10 +91,10 @@ def resolve_footer_config(
 
 def format_runtime_footer(
     *,
-    model: Optional[str],
+    model: str | None,
     context_tokens: int,
-    context_length: Optional[int],
-    cwd: Optional[str] = None,
+    context_length: int | None,
+    cwd: str | None = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -127,10 +127,10 @@ def build_footer_line(
     *,
     user_config: dict[str, Any] | None,
     platform_key: str | None,
-    model: Optional[str],
+    model: str | None,
     context_tokens: int,
-    context_length: Optional[int],
-    cwd: Optional[str] = None,
+    context_length: int | None,
+    cwd: str | None = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -79,18 +79,18 @@ class SessionSource:
     """
     platform: Platform
     chat_id: str
-    chat_name: Optional[str] = None
+    chat_name: str | None = None
     chat_type: str = "dm"  # "dm", "group", "channel", "thread"
-    user_id: Optional[str] = None
-    user_name: Optional[str] = None
-    thread_id: Optional[str] = None  # For forum topics, Discord threads, etc.
-    chat_topic: Optional[str] = None  # Channel topic/description (Discord, Slack)
-    user_id_alt: Optional[str] = None  # Platform-specific stable alt ID (Signal UUID, Feishu union_id)
-    chat_id_alt: Optional[str] = None  # Signal group internal ID
+    user_id: str | None = None
+    user_name: str | None = None
+    thread_id: str | None = None  # For forum topics, Discord threads, etc.
+    chat_topic: str | None = None  # Channel topic/description (Discord, Slack)
+    user_id_alt: str | None = None  # Platform-specific stable alt ID (Signal UUID, Feishu union_id)
+    chat_id_alt: str | None = None  # Signal group internal ID
     is_bot: bool = False  # True when the message author is a bot/webhook (Discord)
-    guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
-    parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
-    message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    guild_id: str | None = None  # Discord guild / Slack workspace / Matrix server scope
+    parent_chat_id: str | None = None  # Parent channel when chat_id refers to a thread
+    message_id: str | None = None  # ID of the triggering message (for pin/reply/react)
     
     @property
     def description(self) -> str:
@@ -174,8 +174,8 @@ class SessionContext:
     # Session metadata
     session_key: str = ""
     session_id: str = ""
-    created_at: Optional[datetime] = None
-    updated_at: Optional[datetime] = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
     
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -434,11 +434,11 @@ class SessionEntry:
     updated_at: datetime
     
     # Origin metadata for delivery routing
-    origin: Optional[SessionSource] = None
+    origin: SessionSource | None = None
     
     # Display metadata
-    display_name: Optional[str] = None
-    platform: Optional[Platform] = None
+    display_name: str | None = None
+    platform: Platform | None = None
     chat_type: str = "dm"
     
     # Token tracking
@@ -456,7 +456,7 @@ class SessionEntry:
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
     was_auto_reset: bool = False
-    auto_reset_reason: Optional[str] = None  # "idle" or "daily"
+    auto_reset_reason: str | None = None  # "idle" or "daily"
     reset_had_activity: bool = False  # whether the expired session had any messages
 
     # Set by reset_session() when the user explicitly sends /new or /reset.
@@ -488,8 +488,8 @@ class SessionEntry:
     # ``.restart_failure_counts`` stuck-loop counter (#7536), not by a
     # parallel counter on this entry.
     resume_pending: bool = False
-    resume_reason: Optional[str] = None  # e.g. "restart_timeout"
-    last_resume_marked_at: Optional[datetime] = None
+    resume_reason: str | None = None  # e.g. "restart_timeout"
+    last_resume_marked_at: datetime | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         result = {
@@ -787,7 +787,7 @@ class SessionStore:
 
         return False
 
-    def _should_reset(self, entry: SessionEntry, source: SessionSource) -> Optional[str]:
+    def _should_reset(self, entry: SessionEntry, source: SessionSource) -> str | None:
         """
         Check if a session should be reset based on policy.
         
@@ -1127,7 +1127,7 @@ class SessionStore:
                 self._save()
         return count
 
-    def reset_session(self, session_key: str, display_name: Optional[str] = None) -> Optional[SessionEntry]:
+    def reset_session(self, session_key: str, display_name: str | None = None) -> SessionEntry | None:
         """Force reset a session, creating a new session ID."""
         db_end_session_id = None
         db_create_kwargs = None
@@ -1179,7 +1179,7 @@ class SessionStore:
 
         return new_entry
 
-    def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
+    def switch_session(self, session_key: str, target_session_id: str) -> SessionEntry | None:
         """Switch a session key to point at an existing session ID.
 
         Used by ``/resume`` to restore a previously-named session.
@@ -1234,7 +1234,7 @@ class SessionStore:
 
         return new_entry
 
-    def list_sessions(self, active_minutes: Optional[int] = None) -> List[SessionEntry]:
+    def list_sessions(self, active_minutes: int | None = None) -> List[SessionEntry]:
         """List all sessions, optionally filtered by activity."""
         with self._lock:
             self._ensure_loaded_locked()
@@ -1313,7 +1313,7 @@ class SessionStore:
 def build_session_context(
     source: SessionSource,
     config: GatewayConfig,
-    session_entry: Optional[SessionEntry] = None
+    session_entry: SessionEntry | None = None
 ) -> SessionContext:
     """
     Build a full session context from a source and config.

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -45,7 +45,7 @@ def _signal_name(sig: Any) -> str:
     return _SIGNAL_NAME_BY_NUM.get(sig_int, f"signal#{sig_int}")
 
 
-def _read_proc_field(pid: int, key: str) -> Optional[str]:
+def _read_proc_field(pid: int, key: str) -> str | None:
     """Read a single field from /proc/<pid>/status.  Linux only; None elsewhere."""
     try:
         with open(f"/proc/{pid}/status", encoding="utf-8") as fh:
@@ -57,7 +57,7 @@ def _read_proc_field(pid: int, key: str) -> Optional[str]:
     return None
 
 
-def _read_proc_cmdline(pid: int) -> Optional[str]:
+def _read_proc_cmdline(pid: int) -> str | None:
     """Read /proc/<pid>/cmdline as a printable string.  Linux only; None elsewhere."""
     try:
         with open(f"/proc/{pid}/cmdline", "rb") as fh:
@@ -199,7 +199,7 @@ def spawn_async_diagnostic(
     signal_name: str,
     *,
     timeout_seconds: float = 5.0,
-) -> Optional[int]:
+) -> int | None:
     """Fire-and-forget ``ps``-style snapshot written to ``log_path``.
 
     Runs as a detached subprocess so it can't block the asyncio event loop
@@ -319,7 +319,7 @@ def context_as_json(ctx: Dict[str, Any]) -> str:
         return "{}"
 
 
-def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, Any]]:
+def check_systemd_timing_alignment(drain_timeout: float) -> Dict[str, Any] | None:
     """At startup, sanity-check that systemd's TimeoutStopSec >= drain_timeout.
 
     When the gateway is run under a stale systemd unit file (e.g. the user
@@ -341,7 +341,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
         return None  # Not running under systemd (or at least not directly)
 
     # Try to identify our unit name and ask systemctl for its config.
-    unit_name: Optional[str] = None
+    unit_name: str | None = None
     try:
         # /proc/self/cgroup gives us "0::/user.slice/.../hermes-gateway.service"
         with open("/proc/self/cgroup", encoding="utf-8") as fh:
@@ -363,7 +363,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
     # on which manager actually owns the unit.  Try user first since
     # that's the common case for hermes.
-    timeout_us: Optional[int] = None
+    timeout_us: int | None = None
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
@@ -406,7 +406,7 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     }
 
 
-def _parse_systemd_duration_to_us(raw: str) -> Optional[int]:
+def _parse_systemd_duration_to_us(raw: str) -> int | None:
     """Parse 'TimeoutStopUSec=1min 30s' / '90s' style values to microseconds.
 
     systemd accepts a wide grammar; we cover the common cases (s, ms, min,

--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -66,7 +66,7 @@ class SlashAccessPolicy:
     admin_user_ids: FrozenSet[str]
     user_allowed_commands: FrozenSet[str]
 
-    def is_admin(self, user_id: Optional[str]) -> bool:
+    def is_admin(self, user_id: str | None) -> bool:
         if not self.enabled:
             # Gating disabled → treat every allowed user as admin so
             # downstream code can keep using ``is_admin`` / ``can_run``
@@ -76,7 +76,7 @@ class SlashAccessPolicy:
             return False
         return str(user_id) in self.admin_user_ids
 
-    def can_run(self, user_id: Optional[str], canonical_cmd: str) -> bool:
+    def can_run(self, user_id: str | None, canonical_cmd: str) -> bool:
         if not self.enabled:
             return True
         if self.is_admin(user_id):
@@ -137,7 +137,7 @@ def _coerce_command_list(raw: Any) -> FrozenSet[str]:
     return frozenset(out)
 
 
-def _scope_for_chat_type(chat_type: Optional[str]) -> str:
+def _scope_for_chat_type(chat_type: str | None) -> str:
     if chat_type and chat_type.lower() in _DM_CHAT_TYPES:
         return "dm"
     return "group"

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -47,7 +47,7 @@ def _get_pid_path() -> Path:
     return home / "gateway.pid"
 
 
-def _get_gateway_lock_path(pid_path: Optional[Path] = None) -> Path:
+def _get_gateway_lock_path(pid_path: Path | None = None) -> Path:
     """Return the path to the runtime gateway lock file."""
     if pid_path is not None:
         return pid_path.with_name(_GATEWAY_LOCK_FILENAME)
@@ -108,7 +108,7 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
     return _get_lock_dir() / f"{scope}-{_scope_hash(identity)}.lock"
 
 
-def _get_process_start_time(pid: int) -> Optional[int]:
+def _get_process_start_time(pid: int) -> int | None:
     """Return the kernel start time for a process when available."""
     stat_path = Path(f"/proc/{pid}/stat")
     try:
@@ -118,12 +118,12 @@ def _get_process_start_time(pid: int) -> Optional[int]:
         return None
 
 
-def get_process_start_time(pid: int) -> Optional[int]:
+def get_process_start_time(pid: int) -> int | None:
     """Public wrapper for retrieving a process start time when available."""
     return _get_process_start_time(pid)
 
 
-def _read_process_cmdline(pid: int) -> Optional[str]:
+def _read_process_cmdline(pid: int) -> str | None:
     """Return the process command line as a space-separated string.
 
     On Linux, reads /proc/<pid>/cmdline directly.  On macOS and other
@@ -222,7 +222,7 @@ def _build_runtime_status_record() -> dict[str, Any]:
     return payload
 
 
-def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
+def _read_json_file(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
     try:
@@ -242,7 +242,7 @@ def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     atomic_json_write(path, payload, indent=None, separators=(",", ":"))
 
 
-def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
+def _read_pid_record(pid_path: Path | None = None) -> dict | None:
     pid_path = pid_path or _get_pid_path()
     if not pid_path.exists():
         return None
@@ -270,11 +270,11 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
     return None
 
 
-def _read_gateway_lock_record(lock_path: Optional[Path] = None) -> Optional[dict[str, Any]]:
+def _read_gateway_lock_record(lock_path: Path | None = None) -> dict[str, Any] | None:
     return _read_pid_record(lock_path or _get_gateway_lock_path())
 
 
-def _pid_from_record(record: Optional[dict[str, Any]]) -> Optional[int]:
+def _pid_from_record(record: dict[str, Any] | None) -> int | None:
     if not record:
         return None
     try:
@@ -453,7 +453,7 @@ def release_gateway_runtime_lock() -> None:
         pass
 
 
-def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
+def is_gateway_runtime_lock_active(lock_path: Path | None = None) -> bool:
     """Return True when some process currently owns the gateway runtime lock."""
     global _gateway_lock_handle
     resolved_lock_path = lock_path or _get_gateway_lock_path()
@@ -546,7 +546,7 @@ def write_runtime_status(
     _write_json_file(path, payload)
 
 
-def read_runtime_status() -> Optional[dict[str, Any]]:
+def read_runtime_status() -> dict[str, Any] | None:
     """Read the persisted gateway runtime health/status information."""
     return _read_json_file(_get_runtime_status_path())
 
@@ -575,7 +575,7 @@ def remove_pid_file() -> None:
         pass
 
 
-def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, Any]] = None) -> tuple[bool, Optional[dict[str, Any]]]:
+def acquire_scoped_lock(scope: str, identity: str, metadata: dict[str, Any] | None = None) -> tuple[bool, dict[str, Any] | None]:
     """Acquire a machine-local lock keyed by scope + identity.
 
     Used to prevent multiple local gateways from using the same external identity
@@ -696,8 +696,8 @@ def release_scoped_lock(scope: str, identity: str) -> None:
 
 def release_all_scoped_locks(
     *,
-    owner_pid: Optional[int] = None,
-    owner_start_time: Optional[int] = None,
+    owner_pid: int | None = None,
+    owner_start_time: int | None = None,
 ) -> int:
     """Remove scoped lock files in the lock directory.
 
@@ -923,10 +923,10 @@ def clear_planned_stop_marker() -> None:
 
 
 def get_running_pid(
-    pid_path: Optional[Path] = None,
+    pid_path: Path | None = None,
     *,
     cleanup_stale: bool = True,
-) -> Optional[int]:
+) -> int | None:
     """Return the PID of a running gateway instance, or ``None``.
 
     Checks the PID file and verifies the process is actually alive.
@@ -963,7 +963,7 @@ def get_running_pid(
 
 
 def is_gateway_running(
-    pid_path: Optional[Path] = None,
+    pid_path: Path | None = None,
     *,
     cleanup_stale: bool = True,
 ) -> bool:

--- a/gateway/sticker_cache.py
+++ b/gateway/sticker_cache.py
@@ -56,7 +56,7 @@ def _save_cache(cache: dict) -> None:
         raise
 
 
-def get_cached_description(file_unique_id: str) -> Optional[dict]:
+def get_cached_description(file_unique_id: str) -> dict | None:
     """
     Look up a cached sticker description.
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -115,10 +115,10 @@ class GatewayStreamConsumer:
         self,
         adapter: Any,
         chat_id: str,
-        config: Optional[StreamConsumerConfig] = None,
-        metadata: Optional[dict] = None,
-        on_new_message: Optional[callable] = None,
-        initial_reply_to_id: Optional[str] = None,
+        config: StreamConsumerConfig | None = None,
+        metadata: dict | None = None,
+        on_new_message: callable | None = None,
+        initial_reply_to_id: str | None = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
@@ -135,13 +135,13 @@ class GatewayStreamConsumer:
         self._initial_reply_to_id = initial_reply_to_id
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
-        self._message_id: Optional[str] = None
+        self._message_id: str | None = None
         # Wall-clock timestamp (time.monotonic) when ``_message_id`` was
         # first assigned from a successful first-send.  Used by the
         # fresh-final logic to detect long-lived previews whose edit
         # timestamps would be stale by completion time.  Ported from
         # openclaw/openclaw#72038.
-        self._message_created_ts: Optional[float] = None
+        self._message_created_ts: float | None = None
         self._already_sent = False
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
@@ -176,7 +176,7 @@ class GatewayStreamConsumer:
         # through the normal first-send path so the user gets a real message
         # in their chat history (drafts have no message_id).
         self._use_draft_streaming = False
-        self._draft_id: Optional[int] = None
+        self._draft_id: int | None = None
         # Cumulative draft-frame failure count for this consumer.  After the
         # first failure we permanently disable drafts for the remainder of
         # this response and route through edit-based for graceful degradation.
@@ -669,7 +669,7 @@ class GatewayStreamConsumer:
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
 
-    async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
+    async def _send_new_chunk(self, text: str, reply_to_id: str | None) -> str | None:
         """Send a new message chunk, optionally threaded to a previous message.
 
         Returns the message_id so callers can thread subsequent chunks.
@@ -790,7 +790,7 @@ class GatewayStreamConsumer:
         chunks = self._split_text_chunks(continuation, safe_limit, len_fn=_len_fn)
 
         stale_message_id = self._message_id  # partial message to clean up
-        last_message_id: Optional[str] = None
+        last_message_id: str | None = None
         last_successful_chunk = ""
         sent_any_chunk = False
         for chunk in chunks:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -636,7 +636,7 @@ ZAI_ENDPOINTS = [
 ]
 
 
-def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Optional[Dict[str, str]]:
+def detect_zai_endpoint(api_key: str, timeout: float = 8.0) -> Dict[str, str] | None:
     """Probe z.ai endpoints to find one that accepts this API key.
 
     Returns {"id": ..., "base_url": ..., "model": ..., "label": ...} for the
@@ -735,7 +735,7 @@ class AuthError(RuntimeError):
         message: str,
         *,
         provider: str = "",
-        code: Optional[str] = None,
+        code: str | None = None,
         relogin_required: bool = False,
     ) -> None:
         super().__init__(message)
@@ -770,7 +770,7 @@ def format_auth_error(error: Exception) -> str:
     return str(error)
 
 
-def _token_fingerprint(token: Any) -> Optional[str]:
+def _token_fingerprint(token: Any) -> str | None:
     """Return a short hash fingerprint for telemetry without leaking token bytes."""
     if not isinstance(token, str):
         return None
@@ -785,7 +785,7 @@ def _oauth_trace_enabled() -> bool:
     return raw in {"1", "true", "yes", "on"}
 
 
-def _oauth_trace(event: str, *, sequence_id: Optional[str] = None, **fields: Any) -> None:
+def _oauth_trace(event: str, *, sequence_id: str | None = None, **fields: Any) -> None:
     if not _oauth_trace_enabled():
         return
     payload: Dict[str, Any] = {"event": event}
@@ -821,7 +821,7 @@ def _auth_file_path() -> Path:
     return path
 
 
-def _global_auth_file_path() -> Optional[Path]:
+def _global_auth_file_path() -> Path | None:
     """Return the global-root auth.json when the process is in profile mode.
 
     Returns ``None`` when the profile and global root resolve to the same
@@ -986,7 +986,7 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         yield
 
 
-def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
+def _load_auth_store(auth_file: Path | None = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
         return {"version": AUTH_STORE_VERSION, "providers": {}}
@@ -1075,7 +1075,7 @@ def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
     return auth_file
 
 
-def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Optional[Dict[str, Any]]:
+def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Dict[str, Any] | None:
     providers = auth_store.get("providers")
     if not isinstance(providers, dict):
         return None
@@ -1120,7 +1120,7 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def read_credential_pool(provider_id: str | None = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1222,7 +1222,7 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
         return True
 
 
-def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
+def get_provider_auth_state(provider_id: str) -> Dict[str, Any] | None:
     """Return persisted auth state for a provider, or None.
 
     In profile mode, falls back to the global-root ``auth.json`` when the
@@ -1244,7 +1244,7 @@ def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
     return _load_provider_state(global_store, provider_id)
 
 
-def get_active_provider() -> Optional[str]:
+def get_active_provider() -> str | None:
     """Return the currently active provider ID from auth store."""
     auth_store = _load_auth_store()
     return auth_store.get("active_provider")
@@ -1301,7 +1301,7 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     return False
 
 
-def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
+def clear_provider_auth(provider_id: str | None = None) -> bool:
     """
     Clear auth state for a provider. Used by `hermes logout`.
     If provider_id is None, clears the active provider.
@@ -1384,10 +1384,10 @@ def _get_config_hint_for_unknown_provider(provider_name: str) -> str:
 
 
 def resolve_provider(
-    requested: Optional[str] = None,
+    requested: str | None = None,
     *,
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
 ) -> str:
     """
     Determine which inference provider to use.
@@ -1521,7 +1521,7 @@ def resolve_provider(
 # Timestamp / TTL helpers
 # =============================================================================
 
-def _parse_iso_timestamp(value: Any) -> Optional[float]:
+def _parse_iso_timestamp(value: Any) -> float | None:
     if not isinstance(value, str) or not value:
         return None
     text = value.strip()
@@ -1553,7 +1553,7 @@ def _coerce_ttl_seconds(expires_in: Any) -> int:
     return max(0, ttl)
 
 
-def _optional_base_url(value: Any) -> Optional[str]:
+def _optional_base_url(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
     cleaned = value.strip().rstrip("/")
@@ -1574,7 +1574,7 @@ _ALLOWED_NOUS_INFERENCE_HOSTS: FrozenSet[str] = frozenset({
 })
 
 
-def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[str]:
+def _validate_nous_inference_url_from_network(url: str | None) -> str | None:
     """Validate a Portal-returned inference URL against the host allowlist.
 
     Returns ``url`` (normalised by stripping trailing slashes) if it's a
@@ -1658,7 +1658,7 @@ def _nous_scope_has_invoke(raw_scope: Any) -> bool:
     return NOUS_INFERENCE_INVOKE_SCOPE in _scope_values(raw_scope)
 
 
-def _normalize_nous_inference_auth_mode(inference_auth_mode: Optional[str]) -> str:
+def _normalize_nous_inference_auth_mode(inference_auth_mode: str | None) -> str:
     mode = str(inference_auth_mode or NOUS_INFERENCE_AUTH_MODE_AUTO).strip().lower()
     if mode not in NOUS_INFERENCE_AUTH_MODES:
         allowed = ", ".join(sorted(NOUS_INFERENCE_AUTH_MODES))
@@ -1675,7 +1675,7 @@ def _nous_invoke_jwt_status(
     scope: Any = None,
     expires_at: Any = None,
     min_ttl_seconds: int = NOUS_INVOKE_JWT_MIN_TTL_SECONDS,
-) -> Optional[str]:
+) -> str | None:
     """Return None when the token can be used for inference, else a reason."""
     claims = _decode_jwt_claims(token)
     if not claims:
@@ -1739,7 +1739,7 @@ def _choose_nous_inference_auth_path(
     access_token: Any = None,
     min_key_ttl_seconds: int = DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
-) -> Tuple[str, Optional[str]]:
+) -> Tuple[str, str | None]:
     inference_auth_mode = _normalize_nous_inference_auth_mode(inference_auth_mode)
     token = state.get("access_token") if access_token is None else access_token
     if (
@@ -1774,7 +1774,7 @@ def _choose_nous_inference_auth_path(
 def _log_nous_invoke_jwt_selected(
     *,
     access_token: Any,
-    sequence_id: Optional[str] = None,
+    sequence_id: str | None = None,
 ) -> None:
     logger.info("Nous inference auth: using NAS invoke JWT")
     _oauth_trace(
@@ -1788,7 +1788,7 @@ def _log_nous_legacy_session_key_selected(
     reason: str,
     *,
     access_token: Any,
-    sequence_id: Optional[str] = None,
+    sequence_id: str | None = None,
 ) -> None:
     logger.info(
         "Nous inference auth: using legacy session key path (%s)",
@@ -1802,7 +1802,7 @@ def _log_nous_legacy_session_key_selected(
     )
 
 
-def _nous_jwt_expires_at(token: Any, fallback_expires_at: Any = None) -> Optional[str]:
+def _nous_jwt_expires_at(token: Any, fallback_expires_at: Any = None) -> str | None:
     claims = _decode_jwt_claims(token)
     exp = claims.get("exp")
     if isinstance(exp, (int, float)):
@@ -1816,7 +1816,7 @@ def _nous_jwt_expires_at(token: Any, fallback_expires_at: Any = None) -> Optiona
 def _set_nous_agent_key_from_invoke_jwt(
     state: Dict[str, Any],
     *,
-    obtained_at: Optional[str] = None,
+    obtained_at: str | None = None,
 ) -> None:
     access_token = state.get("access_token")
     if not isinstance(access_token, str) or not access_token.strip():
@@ -1855,7 +1855,7 @@ def _select_nous_invoke_jwt(
     state: Dict[str, Any],
     *,
     access_token: Any = None,
-    sequence_id: Optional[str] = None,
+    sequence_id: str | None = None,
 ) -> None:
     if isinstance(access_token, str) and access_token.strip():
         state["access_token"] = access_token
@@ -2163,7 +2163,7 @@ def get_gemini_oauth_auth_status() -> Dict[str, Any]:
 # =============================================================================
 
 
-def _spotify_scope_list(raw_scope: Optional[str] = None) -> List[str]:
+def _spotify_scope_list(raw_scope: str | None = None) -> List[str]:
     scope_text = (raw_scope or DEFAULT_SPOTIFY_SCOPE).strip()
     scopes = [part for part in scope_text.split() if part]
     seen: set[str] = set()
@@ -2175,13 +2175,13 @@ def _spotify_scope_list(raw_scope: Optional[str] = None) -> List[str]:
     return ordered
 
 
-def _spotify_scope_string(raw_scope: Optional[str] = None) -> str:
+def _spotify_scope_string(raw_scope: str | None = None) -> str:
     return " ".join(_spotify_scope_list(raw_scope))
 
 
 def _spotify_client_id(
-    explicit: Optional[str] = None,
-    state: Optional[Dict[str, Any]] = None,
+    explicit: str | None = None,
+    state: Dict[str, Any] | None = None,
 ) -> str:
     from hermes_cli.config import get_env_value
 
@@ -2203,8 +2203,8 @@ def _spotify_client_id(
 
 
 def _spotify_redirect_uri(
-    explicit: Optional[str] = None,
-    state: Optional[Dict[str, Any]] = None,
+    explicit: str | None = None,
+    state: Dict[str, Any] | None = None,
 ) -> str:
     from hermes_cli.config import get_env_value
 
@@ -2222,7 +2222,7 @@ def _spotify_redirect_uri(
     return DEFAULT_SPOTIFY_REDIRECT_URI
 
 
-def _spotify_api_base_url(state: Optional[Dict[str, Any]] = None) -> str:
+def _spotify_api_base_url(state: Dict[str, Any] | None = None) -> str:
     from hermes_cli.config import get_env_value
 
     candidates = (
@@ -2237,7 +2237,7 @@ def _spotify_api_base_url(state: Optional[Dict[str, Any]] = None) -> str:
     return DEFAULT_SPOTIFY_API_BASE_URL
 
 
-def _spotify_accounts_base_url(state: Optional[Dict[str, Any]] = None) -> str:
+def _spotify_accounts_base_url(state: Dict[str, Any] | None = None) -> str:
     from hermes_cli.config import get_env_value
 
     candidates = (
@@ -2418,7 +2418,7 @@ def _xai_validate_loopback_redirect_uri(redirect_uri: str) -> tuple[str, int, st
     return host, parsed.port, parsed.path or "/"
 
 
-def _xai_callback_cors_origin(origin: Optional[str]) -> str:
+def _xai_callback_cors_origin(origin: str | None) -> str:
     # CORS allowlist for the loopback callback.  Only xAI's own auth origins
     # are accepted; the redirect_uri itself is bound to 127.0.0.1 and gated by
     # PKCE+state, so additional dev/3p origins are not needed here.
@@ -2532,7 +2532,7 @@ def _xai_start_callback_server(
     if preferred_port != 0:
         ports_to_try.append(0)
     server = None
-    last_error: Optional[OSError] = None
+    last_error: OSError | None = None
     for port in ports_to_try:
         try:
             server = _ReuseHTTPServer((host, port), handler_cls)
@@ -2589,7 +2589,7 @@ def _spotify_token_payload_to_state(
     requested_scope: str,
     accounts_base_url: str,
     api_base_url: str,
-    previous_state: Optional[Dict[str, Any]] = None,
+    previous_state: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     now = datetime.now(timezone.utc)
     expires_in = _coerce_ttl_seconds(token_payload.get("expires_in", 0))
@@ -3315,7 +3315,7 @@ def _refresh_codex_auth_tokens(
     return updated_tokens
 
 
-def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
+def _import_codex_cli_tokens() -> Dict[str, str] | None:
     """Try to read tokens from ~/.codex/auth.json (Codex CLI shared file).
     
     Returns tokens dict if valid and not expired, None otherwise.
@@ -3447,9 +3447,9 @@ def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
 def _save_xai_oauth_tokens(
     tokens: Dict[str, Any],
     *,
-    discovery: Optional[Dict[str, Any]] = None,
+    discovery: Dict[str, Any] | None = None,
     redirect_uri: str = "",
-    last_refresh: Optional[str] = None,
+    last_refresh: str | None = None,
 ) -> None:
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -3866,9 +3866,9 @@ def _default_verify() -> bool | ssl.SSLContext:
 
 def _resolve_verify(
     *,
-    insecure: Optional[bool] = None,
-    ca_bundle: Optional[str] = None,
-    auth_state: Optional[Dict[str, Any]] = None,
+    insecure: bool | None = None,
+    ca_bundle: str | None = None,
+    auth_state: Dict[str, Any] | None = None,
 ) -> bool | ssl.SSLContext:
     tls_state = auth_state.get("tls") if isinstance(auth_state, dict) else {}
     tls_state = tls_state if isinstance(tls_state, dict) else {}
@@ -3907,7 +3907,7 @@ def _request_device_code(
     client: httpx.Client,
     portal_base_url: str,
     client_id: str,
-    scope: Optional[str],
+    scope: str | None,
 ) -> Dict[str, Any]:
     """POST to the device code endpoint. Returns device_code, user_code, etc."""
     response = client.post(
@@ -3959,7 +3959,7 @@ def _is_nous_invoke_scope_refusal(exc: Exception) -> bool:
 
 
 def _nous_device_scope_with_env_override(
-    requested_scope: Optional[str],
+    requested_scope: str | None,
     *,
     default_scope: str = DEFAULT_NOUS_SCOPE,
 ) -> Tuple[str, bool]:
@@ -4261,7 +4261,7 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
         logger.debug("Failed to write shared Nous auth store: %s", exc)
 
 
-def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
+def _read_shared_nous_state() -> Dict[str, Any] | None:
     """Return the shared Nous OAuth state if present and well-formed.
 
     Returns ``None`` when the file is missing, unreadable, malformed, or
@@ -4425,7 +4425,7 @@ def _try_import_shared_nous_state(
     *,
     timeout_seconds: float = 15.0,
     min_key_ttl_seconds: int = 5 * 60,
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any] | None:
     """Attempt to rehydrate Nous OAuth state from the shared store.
 
     Reads the shared file (if present), runs a forced refresh+mint using
@@ -4661,8 +4661,8 @@ def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
 def resolve_nous_access_token(
     *,
     timeout_seconds: float = 15.0,
-    insecure: Optional[bool] = None,
-    ca_bundle: Optional[str] = None,
+    insecure: bool | None = None,
+    ca_bundle: str | None = None,
     refresh_skew_seconds: int = ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> str:
     """Resolve a refresh-aware Nous Portal access token for managed tool gateways."""
@@ -4772,17 +4772,17 @@ def refresh_nous_oauth_pure(
     *,
     token_type: str = "Bearer",
     scope: str = DEFAULT_NOUS_SCOPE,
-    obtained_at: Optional[str] = None,
-    expires_at: Optional[str] = None,
-    agent_key: Optional[str] = None,
-    agent_key_expires_at: Optional[str] = None,
+    obtained_at: str | None = None,
+    expires_at: str | None = None,
+    agent_key: str | None = None,
+    agent_key_expires_at: str | None = None,
     min_key_ttl_seconds: int = DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,
     timeout_seconds: float = 15.0,
-    insecure: Optional[bool] = None,
-    ca_bundle: Optional[str] = None,
+    insecure: bool | None = None,
+    ca_bundle: str | None = None,
     force_refresh: bool = False,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
-    on_state_update: Optional[Callable[[Dict[str, Any], str], None]] = None,
+    on_state_update: Callable[[Dict[str, Any], str], None] | None = None,
 ) -> Dict[str, Any]:
     """Refresh Nous OAuth state without mutating auth.json directly.
 
@@ -4891,7 +4891,7 @@ def refresh_nous_oauth_from_state(
     timeout_seconds: float = 15.0,
     force_refresh: bool = False,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
-    on_state_update: Optional[Callable[[Dict[str, Any], str], None]] = None,
+    on_state_update: Callable[[Dict[str, Any], str], None] | None = None,
 ) -> Dict[str, Any]:
     """Refresh Nous OAuth from a state dict. Thin wrapper around refresh_nous_oauth_pure."""
     tls = state.get("tls") or {}
@@ -4920,7 +4920,7 @@ def refresh_nous_oauth_from_state(
 def persist_nous_credentials(
     creds: Dict[str, Any],
     *,
-    label: Optional[str] = None,
+    label: str | None = None,
 ):
     """Persist minted Nous OAuth credentials as the singleton provider state
     and ensure the credential pool is in sync.
@@ -4990,8 +4990,8 @@ def resolve_nous_runtime_credentials(
     *,
     min_key_ttl_seconds: int = DEFAULT_AGENT_KEY_MIN_TTL_SECONDS,
     timeout_seconds: float = 15.0,
-    insecure: Optional[bool] = None,
-    ca_bundle: Optional[str] = None,
+    insecure: bool | None = None,
+    ca_bundle: str | None = None,
     inference_auth_mode: str = NOUS_INFERENCE_AUTH_MODE_AUTO,
 ) -> Dict[str, Any]:
     """
@@ -5179,7 +5179,7 @@ def resolve_nous_runtime_credentials(
             # path stores the NAS invoke JWT there; legacy path mints/reuses
             # the opaque session key.
             used_cached_key = False
-            mint_payload: Optional[Dict[str, Any]] = None
+            mint_payload: Dict[str, Any] | None = None
             selected_auth_path, fallback_reason = _choose_nous_inference_auth_path(
                 state,
                 access_token=access_token,
@@ -5442,10 +5442,10 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # single-use refresh tokens. Cache the snapshot for a few seconds, keyed on the auth.json
 # mtime so that `hermes auth login/logout/add/remove` invalidate naturally on the next call.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
-_nous_auth_status_cache: Optional[Tuple[float, Optional[float], Dict[str, Any]]] = None
+_nous_auth_status_cache: Tuple[float, float | None, Dict[str, Any]] | None = None
 
 
-def _auth_file_mtime() -> Optional[float]:
+def _auth_file_mtime() -> float | None:
     try:
         return _auth_file_path().stat().st_mtime
     except FileNotFoundError:
@@ -5696,7 +5696,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
-def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def get_auth_status(provider_id: str | None = None) -> Dict[str, Any]:
     """Generic auth status dispatcher."""
     target = (provider_id or get_active_provider() or "").strip().lower()
     if not target:
@@ -5902,7 +5902,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
 def _update_config_for_provider(
     provider_id: str,
     inference_base_url: str,
-    default_model: Optional[str] = None,
+    default_model: str | None = None,
 ) -> Path:
     """Update config.yaml and auth.json to reflect the active provider.
 
@@ -5965,7 +5965,7 @@ def _update_config_for_provider(
     return config_path
 
 
-def _get_config_provider() -> Optional[str]:
+def _get_config_provider() -> str | None:
     """Return model.provider from config.yaml, normalized, if present."""
     try:
         config = read_raw_config()
@@ -5983,14 +5983,14 @@ def _get_config_provider() -> Optional[str]:
     return provider or None
 
 
-def _config_provider_matches(provider_id: Optional[str]) -> bool:
+def _config_provider_matches(provider_id: str | None) -> bool:
     """Return True when config.yaml currently selects *provider_id*."""
     if not provider_id:
         return False
     return _get_config_provider() == provider_id.strip().lower()
 
 
-def _should_reset_config_provider_on_logout(provider_id: Optional[str]) -> bool:
+def _should_reset_config_provider_on_logout(provider_id: str | None) -> bool:
     """Return True when logout should reset the model provider config."""
     if not provider_id:
         return False
@@ -5998,7 +5998,7 @@ def _should_reset_config_provider_on_logout(provider_id: Optional[str]) -> bool:
     return normalized in PROVIDER_REGISTRY and _config_provider_matches(normalized)
 
 
-def _logout_default_provider_from_config() -> Optional[str]:
+def _logout_default_provider_from_config() -> str | None:
     """Fallback logout target when auth.json has no active provider.
 
     `hermes logout` historically keyed off auth.json.active_provider only.
@@ -6035,10 +6035,10 @@ def _reset_config_provider() -> Path:
 def _prompt_model_selection(
     model_ids: List[str],
     current_model: str = "",
-    pricing: Optional[Dict[str, Dict[str, str]]] = None,
-    unavailable_models: Optional[List[str]] = None,
+    pricing: Dict[str, Dict[str, str]] | None = None,
+    unavailable_models: List[str] | None = None,
     portal_url: str = "",
-) -> Optional[str]:
+) -> str | None:
     """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
 
     If *pricing* is provided (``{model_id: {prompt, completion}}``), a compact
@@ -6892,7 +6892,7 @@ def _minimax_resolve_token_expiry_unix(expired_in: int, *, now: datetime) -> flo
 
 def _minimax_poll_token(
     client: httpx.Client, *, portal_base_url: str, client_id: str,
-    user_code: str, code_verifier: str, expired_in: int, interval_ms: Optional[int],
+    user_code: str, code_verifier: str, expired_in: int, interval_ms: int | None,
 ) -> Dict[str, Any]:
     # OpenClaw treats expired_in as a unix-ms timestamp (Date.now() < expireTimeMs).
     # Defensive parsing: if it's small enough to be a duration, treat as seconds.
@@ -7257,14 +7257,14 @@ def _login_minimax_oauth(args, pconfig: ProviderConfig) -> None:
 
 def _nous_device_code_login(
     *,
-    portal_base_url: Optional[str] = None,
-    inference_base_url: Optional[str] = None,
-    client_id: Optional[str] = None,
-    scope: Optional[str] = None,
+    portal_base_url: str | None = None,
+    inference_base_url: str | None = None,
+    client_id: str | None = None,
+    scope: str | None = None,
     open_browser: bool = True,
     timeout_seconds: float = 15.0,
     insecure: bool = False,
-    ca_bundle: Optional[str] = None,
+    ca_bundle: str | None = None,
     min_key_ttl_seconds: int = 5 * 60,
 ) -> Dict[str, Any]:
     """Run the Nous device-code flow and return full OAuth state without persisting."""

--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -68,7 +68,7 @@ class DetectionResult:
 
     #: Detected API transport: ``"chat_completions"``,
     #: ``"anthropic_messages"``, or ``None`` when detection failed.
-    api_mode: Optional[str] = None
+    api_mode: str | None = None
 
     #: Deployment / model IDs returned by ``/models`` (best effort).
     #: Empty when the endpoint doesn't expose the list with an API key.
@@ -90,8 +90,8 @@ class DetectionResult:
 
 
 def _resolve_credential(api_key: Any,
-                        token_provider: Optional[Callable[[], str]] = None,
-                        ) -> tuple[Optional[str], str]:
+                        token_provider: Callable[[], str] | None = None,
+                        ) -> tuple[str | None, str]:
     """Coerce wizard inputs into a (token, mode) pair.
 
     Returns ``(token_or_None, mode)`` where ``mode`` is:
@@ -129,7 +129,7 @@ def _resolve_credential(api_key: Any,
 
 
 def _apply_auth_headers(req: urllib_request.Request,
-                        token: Optional[str],
+                        token: str | None,
                         mode: str) -> None:
     """Attach the right auth headers to ``req`` based on credential mode."""
     if not token:
@@ -149,8 +149,8 @@ def _http_get_json(url: str,
                    api_key: Any,
                    timeout: float = 6.0,
                    *,
-                   token_provider: Optional[Callable[[], str]] = None,
-                   ) -> tuple[int, Optional[dict]]:
+                   token_provider: Callable[[], str] | None = None,
+                   ) -> tuple[int, dict | None]:
     """GET a URL with the appropriate auth headers.  Return
     ``(status_code, parsed_json_or_None)``.  Never raises."""
     token, mode = _resolve_credential(api_key, token_provider)
@@ -211,7 +211,7 @@ def _extract_model_ids(payload: dict) -> list[str]:
 def _probe_openai_models(base_url: str,
                          api_key: Any,
                          *,
-                         token_provider: Optional[Callable[[], str]] = None,
+                         token_provider: Callable[[], str] | None = None,
                          ) -> tuple[bool, list[str]]:
     """Probe ``<base>/models`` for an OpenAI-shaped response.
 
@@ -247,7 +247,7 @@ def _probe_openai_models(base_url: str,
 def _probe_anthropic_messages(base_url: str,
                               api_key: Any,
                               *,
-                              token_provider: Optional[Callable[[], str]] = None,
+                              token_provider: Callable[[], str] | None = None,
                               ) -> bool:
     """Send a zero-token request to ``<base>/v1/messages`` and check
     whether the endpoint at least *recognises* the Anthropic Messages
@@ -297,7 +297,7 @@ def _probe_anthropic_messages(base_url: str,
 def detect(base_url: str,
            api_key: Any = "",
            *,
-           token_provider: Optional[Callable[[], str]] = None,
+           token_provider: Callable[[], str] | None = None,
            ) -> DetectionResult:
     """Inspect an Azure endpoint and describe its transport + models.
 
@@ -363,8 +363,8 @@ def lookup_context_length(model: str,
                           base_url: str,
                           api_key: Any = "",
                           *,
-                          token_provider: Optional[Callable[[], str]] = None,
-                          ) -> Optional[int]:
+                          token_provider: Callable[[], str] | None = None,
+                          ) -> int | None:
     """Thin wrapper around :func:`agent.model_metadata.get_model_context_length`
     that returns ``None`` when only the fallback default (128k) would
     fire, so the wizard can distinguish "we actually know this" from

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -495,15 +495,15 @@ _QUICK_SNAPSHOTS_DIR = "state-snapshots"
 _QUICK_DEFAULT_KEEP = 20
 
 
-def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
+def _quick_snapshot_root(hermes_home: Path | None = None) -> Path:
     home = hermes_home or get_hermes_home()
     return home / _QUICK_SNAPSHOTS_DIR
 
 
 def create_quick_snapshot(
-    label: Optional[str] = None,
-    hermes_home: Optional[Path] = None,
-) -> Optional[str]:
+    label: str | None = None,
+    hermes_home: Path | None = None,
+) -> str | None:
     """Create a quick state snapshot of critical files.
 
     Copies STATE_FILES to a timestamped directory under state-snapshots/.
@@ -585,7 +585,7 @@ def create_quick_snapshot(
 
 def list_quick_snapshots(
     limit: int = 20,
-    hermes_home: Optional[Path] = None,
+    hermes_home: Path | None = None,
 ) -> List[Dict[str, Any]]:
     """List existing quick state snapshots, most recent first."""
     root = _quick_snapshot_root(hermes_home)
@@ -611,7 +611,7 @@ def list_quick_snapshots(
 
 def restore_quick_snapshot(
     snapshot_id: str,
-    hermes_home: Optional[Path] = None,
+    hermes_home: Path | None = None,
 ) -> bool:
     """Restore state from a quick snapshot.
 
@@ -682,7 +682,7 @@ def _prune_quick_snapshots(root: Path, keep: int = _QUICK_DEFAULT_KEEP) -> int:
 
 def prune_quick_snapshots(
     keep: int = _QUICK_DEFAULT_KEEP,
-    hermes_home: Optional[Path] = None,
+    hermes_home: Path | None = None,
 ) -> int:
     """Manually prune quick snapshots. Returns count deleted."""
     return _prune_quick_snapshots(_quick_snapshot_root(hermes_home), keep=keep)
@@ -705,7 +705,7 @@ def run_quick_backup(args) -> None:
 # Shared full-zip backup helper
 # ---------------------------------------------------------------------------
 
-def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
+def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Path | None:
     """Write a full zip snapshot of ``hermes_root`` to ``out_path``.
 
     Uses the same exclusion rules and SQLite safe-copy as :func:`run_backup`.
@@ -782,7 +782,7 @@ _PRE_UPDATE_PREFIX = "pre-update-"
 _PRE_UPDATE_DEFAULT_KEEP = 5
 
 
-def _pre_update_backup_dir(hermes_home: Optional[Path] = None) -> Path:
+def _pre_update_backup_dir(hermes_home: Path | None = None) -> Path:
     home = hermes_home or get_hermes_home()
     return home / _PRE_UPDATE_BACKUPS_DIR
 
@@ -825,9 +825,9 @@ def _prune_pre_update_backups(backup_dir: Path, keep: int) -> int:
 
 
 def create_pre_update_backup(
-    hermes_home: Optional[Path] = None,
+    hermes_home: Path | None = None,
     keep: int = _PRE_UPDATE_DEFAULT_KEEP,
-) -> Optional[Path]:
+) -> Path | None:
     """Create a full zip backup of HERMES_HOME under ``backups/``.
 
     Mirrors :func:`run_backup` (same exclusion rules, same SQLite safe-copy)
@@ -897,9 +897,9 @@ def _prune_pre_migration_backups(backup_dir: Path, keep: int) -> int:
 
 
 def create_pre_migration_backup(
-    hermes_home: Optional[Path] = None,
+    hermes_home: Path | None = None,
     keep: int = _PRE_MIGRATION_DEFAULT_KEEP,
-) -> Optional[Path]:
+) -> Path | None:
     """Create a full zip backup of HERMES_HOME under ``backups/`` before a
     ``hermes claw migrate`` apply.
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -130,7 +130,7 @@ UPDATE_AVAILABLE_NO_COUNT = -1
 _UPSTREAM_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 
 
-def _check_via_rev(local_rev: str) -> Optional[int]:
+def _check_via_rev(local_rev: str) -> int | None:
     """Compare an embedded git revision to upstream main via ls-remote.
 
     Returns 0 if up-to-date, ``UPDATE_AVAILABLE_NO_COUNT`` if behind,
@@ -151,7 +151,7 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
     return 0 if upstream_rev == local_rev else UPDATE_AVAILABLE_NO_COUNT
 
 
-def _check_via_local_git(repo_dir: Path) -> Optional[int]:
+def _check_via_local_git(repo_dir: Path) -> int | None:
     """Count commits behind origin/main in a local checkout."""
     try:
         subprocess.run(
@@ -186,7 +186,7 @@ def _version_tuple(v: str) -> tuple[int, ...]:
     return tuple(parts)
 
 
-def _fetch_pypi_latest(package: str = "hermes-agent") -> Optional[str]:
+def _fetch_pypi_latest(package: str = "hermes-agent") -> str | None:
     """Fetch the latest version of a package from PyPI. Returns None on failure."""
     try:
         import urllib.request
@@ -199,7 +199,7 @@ def _fetch_pypi_latest(package: str = "hermes-agent") -> Optional[str]:
         return None
 
 
-def check_via_pypi() -> Optional[int]:
+def check_via_pypi() -> int | None:
     """Compare installed version against PyPI latest.
 
     Returns 0 if up-to-date, 1 if behind, None on failure.
@@ -217,7 +217,7 @@ def check_via_pypi() -> Optional[int]:
         return 1 if latest != VERSION else 0
 
 
-def check_for_updates() -> Optional[int]:
+def check_for_updates() -> int | None:
     """Check whether a Hermes update is available.
 
     Two paths: if ``HERMES_REVISION`` is set (nix builds embed it), compare
@@ -267,7 +267,7 @@ def check_for_updates() -> Optional[int]:
     return behind
 
 
-def _resolve_repo_dir() -> Optional[Path]:
+def _resolve_repo_dir() -> Path | None:
     """Return the active Hermes git checkout, or None if this isn't a git install.
 
     Prefers the running code's location over the profile-scoped path
@@ -281,7 +281,7 @@ def _resolve_repo_dir() -> Optional[Path]:
     return repo_dir if (repo_dir / ".git").exists() else None
 
 
-def _git_short_hash(repo_dir: Path, rev: str) -> Optional[str]:
+def _git_short_hash(repo_dir: Path, rev: str) -> str | None:
     """Resolve a git revision to an 8-character short hash."""
     try:
         result = subprocess.run(
@@ -299,7 +299,7 @@ def _git_short_hash(repo_dir: Path, rev: str) -> Optional[str]:
     return value or None
 
 
-def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
+def get_git_banner_state(repo_dir: Path | None = None) -> dict | None:
     """Return upstream/local git hashes for the startup banner."""
     repo_dir = repo_dir or _resolve_repo_dir()
     if repo_dir is None:
@@ -328,10 +328,10 @@ def get_git_banner_state(repo_dir: Optional[Path] = None) -> Optional[dict]:
 
 
 _RELEASE_URL_BASE = "https://github.com/NousResearch/hermes-agent/releases/tag"
-_latest_release_cache: Optional[tuple] = None  # (tag, url) once resolved
+_latest_release_cache: tuple | None = None  # (tag, url) once resolved
 
 
-def get_latest_release_tag(repo_dir: Optional[Path] = None) -> Optional[tuple]:
+def get_latest_release_tag(repo_dir: Path | None = None) -> tuple | None:
     """Return ``(tag, release_url)`` for the latest git tag, or None.
 
     Local-only — runs ``git describe --tags --abbrev=0`` against the
@@ -395,7 +395,7 @@ def format_banner_version_label() -> str:
 # Non-blocking update check
 # =========================================================================
 
-_update_result: Optional[int] = None
+_update_result: int | None = None
 _update_check_done = threading.Event()
 
 
@@ -409,7 +409,7 @@ def prefetch_update_check():
     t.start()
 
 
-def get_update_result(timeout: float = 0.5) -> Optional[int]:
+def get_update_result(timeout: float = 0.5) -> int | None:
     """Get result of prefetched check. Returns None if not ready."""
     _update_check_done.wait(timeout=timeout)
     return _update_result

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -505,7 +505,7 @@ def _cmd_migrate(args):
     # restorable with `hermes import`.  Mirrors OpenClaw's
     # createPreMigrationBackup posture — one atomic restore point before
     # any mutation, auto-pruned to the last 5 pre-migration zips.
-    backup_archive: Optional[Path] = None
+    backup_archive: Path | None = None
     if not no_backup:
         try:
             from hermes_cli.backup import create_pre_migration_backup, _format_size

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -111,7 +111,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
     return _add_forward_compat_models([slug for _, slug in sortable])
 
 
-def _read_default_model(codex_home: Path) -> Optional[str]:
+def _read_default_model(codex_home: Path) -> str | None:
     config_path = codex_home / "config.toml"
     if not config_path.exists():
         return None
@@ -166,7 +166,7 @@ def _read_cache_models(codex_home: Path) -> List[str]:
     return deduped
 
 
-def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
+def get_codex_model_ids(access_token: str | None = None) -> List[str]:
     """Return available Codex model IDs, trying API first, then local sources.
     
     Resolution order: API (live, if token provided) > config.toml default >

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -59,12 +59,12 @@ MIGRATION_END_MARKER = (
 class MigrationReport:
     """Outcome of a migration pass."""
 
-    target_path: Optional[Path] = None
+    target_path: Path | None = None
     migrated: list[str] = field(default_factory=list)
     skipped_keys_per_server: dict[str, list[str]] = field(default_factory=dict)
     migrated_plugins: list[str] = field(default_factory=list)
-    plugin_query_error: Optional[str] = None
-    wrote_permissions_default: Optional[str] = None
+    plugin_query_error: str | None = None
+    wrote_permissions_default: str | None = None
     errors: list[str] = field(default_factory=list)
     written: bool = False
     dry_run: bool = False
@@ -126,7 +126,7 @@ _KEYS_DROPPED_WITH_WARNING = {
 
 def _translate_one_server(
     name: str, hermes_cfg: dict
-) -> tuple[Optional[dict], list[str]]:
+) -> tuple[dict | None, list[str]]:
     """Translate one Hermes MCP server config to the codex inline-table dict
     representation. Returns (codex_entry, skipped_keys).
 
@@ -245,8 +245,8 @@ def _quote_key(key: str) -> str:
 
 def render_codex_toml_section(
     servers: dict[str, dict],
-    plugins: Optional[list[dict]] = None,
-    default_permission_profile: Optional[str] = None,
+    plugins: list[dict] | None = None,
+    default_permission_profile: str | None = None,
 ) -> str:
     """Render the managed [mcp_servers.<n>] / [plugins.<id>] / [permissions]
     block for ~/.codex/config.toml.
@@ -317,7 +317,7 @@ def _insert_managed_block_at_top_level(user_text: str, managed_block: str) -> st
         return managed_block
 
     lines = user_text.splitlines(keepends=True)
-    first_table_idx: Optional[int] = None
+    first_table_idx: int | None = None
     for idx, line in enumerate(lines):
         stripped = line.lstrip()
         if stripped.startswith("["):
@@ -448,9 +448,9 @@ def _strip_existing_managed_block(toml_text: str) -> str:
 
 
 def _query_codex_plugins(
-    codex_home: Optional[Path] = None,
+    codex_home: Path | None = None,
     timeout: float = 8.0,
-) -> tuple[list[dict], Optional[str]]:
+) -> tuple[list[dict], str | None]:
     """Query codex's `plugin/list` for installed curated plugins.
 
     Spawns `codex app-server` briefly, sends initialize + plugin/list,
@@ -609,10 +609,10 @@ def _build_hermes_tools_mcp_entry() -> dict:
 def migrate(
     hermes_config: dict,
     *,
-    codex_home: Optional[Path] = None,
+    codex_home: Path | None = None,
     dry_run: bool = False,
     discover_plugins: bool = True,
-    default_permission_profile: Optional[str] = ":workspace",
+    default_permission_profile: str | None = ":workspace",
     expose_hermes_tools: bool = True,
 ) -> MigrationReport:
     """Translate Hermes mcp_servers config + Codex curated plugins into

--- a/hermes_cli/codex_runtime_switch.py
+++ b/hermes_cli/codex_runtime_switch.py
@@ -29,15 +29,15 @@ class CodexRuntimeStatus:
     suits their surface (CLI uses Rich panels, gateway sends a text message)."""
 
     success: bool
-    new_value: Optional[str] = None
-    old_value: Optional[str] = None
+    new_value: str | None = None
+    old_value: str | None = None
     message: str = ""
     requires_new_session: bool = False
     codex_binary_ok: bool = True
-    codex_version: Optional[str] = None
+    codex_version: str | None = None
 
 
-def parse_args(arg_string: str) -> tuple[Optional[str], list[str]]:
+def parse_args(arg_string: str) -> tuple[str | None, list[str]]:
     """Parse the slash-command argument string. Returns (value, errors).
 
     No args         → return current state (value=None)
@@ -87,7 +87,7 @@ def set_runtime(config: dict, new_value: str) -> str:
     return old
 
 
-def check_codex_binary_ok() -> tuple[bool, Optional[str]]:
+def check_codex_binary_ok() -> tuple[bool, str | None]:
     """Best-effort verification that codex CLI is installed at acceptable
     version. Returns (ok, version_or_message)."""
     try:
@@ -100,7 +100,7 @@ def check_codex_binary_ok() -> tuple[bool, Optional[str]]:
 
 def apply(
     config: dict,
-    new_value: Optional[str],
+    new_value: str | None,
     *,
     persist_callback=None,
 ) -> CodexRuntimeStatus:
@@ -120,9 +120,9 @@ def apply(
     # is cheap (~50ms for `codex --version`), but we'd otherwise call it up
     # to 3 times in the enable path (read-only/state, gate, success message).
     # None = not yet checked; (bool, str) = result.
-    _binary_check: Optional[tuple[bool, Optional[str]]] = None
+    _binary_check: tuple[bool, str | None] | None = None
 
-    def _check_binary_cached() -> tuple[bool, Optional[str]]:
+    def _check_binary_cached() -> tuple[bool, str | None]:
         nonlocal _binary_check
         if _binary_check is None:
             _binary_check = check_codex_binary_ok()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -163,7 +163,7 @@ _MANAGED_SYSTEM_NAMES = {
 }
 
 
-def get_managed_system() -> Optional[str]:
+def get_managed_system() -> str | None:
     """Return the package manager owning this install, if any."""
     raw = os.getenv("HERMES_MANAGED", "").strip()
     if raw:
@@ -191,7 +191,7 @@ def is_managed() -> bool:
 _NIX_UPDATE_MSG = "Update your Nix flake input and rebuild (e.g. nix flake update, nixos-rebuild, or home-manager switch)"
 
 
-def get_managed_update_command() -> Optional[str]:
+def get_managed_update_command() -> str | None:
     """Return the preferred upgrade command for a managed install."""
     managed_system = get_managed_system()
     if managed_system == "Homebrew":
@@ -201,7 +201,7 @@ def get_managed_update_command() -> Optional[str]:
     return None
 
 
-def detect_install_method(project_root: Optional[Path] = None) -> str:
+def detect_install_method(project_root: Path | None = None) -> str:
     """Detect how Hermes was installed: 'docker', 'nixos', 'homebrew', 'git', or 'pip'.
 
     Resolution order:
@@ -304,7 +304,7 @@ def managed_error(action: str = "modify configuration"):
 # Container-aware CLI (NixOS container mode)
 # =============================================================================
 
-def get_container_exec_info() -> Optional[dict]:
+def get_container_exec_info() -> dict | None:
     """Read container mode metadata from HERMES_HOME/.container-mode.
 
     Returns a dict with keys: backend, container_name, exec_user, hermes_bin
@@ -3044,7 +3044,7 @@ def _normalize_custom_provider_entry(
     entry: Any,
     *,
     provider_key: str = "",
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any] | None:
     """Return a runtime-compatible custom provider entry or ``None``."""
     if not isinstance(entry, dict):
         return None
@@ -3187,7 +3187,7 @@ def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, An
 
 
 def get_compatible_custom_providers(
-    config: Optional[Dict[str, Any]] = None,
+    config: Dict[str, Any] | None = None,
 ) -> List[Dict[str, Any]]:
     """Return a deduplicated custom-provider view across legacy and v12+ config.
 
@@ -3203,7 +3203,7 @@ def get_compatible_custom_providers(
     seen_provider_keys: set = set()
     seen_name_url_pairs: set = set()
 
-    def _append_if_new(entry: Optional[Dict[str, Any]]) -> None:
+    def _append_if_new(entry: Dict[str, Any] | None) -> None:
         if entry is None:
             return
         provider_key = str(entry.get("provider_key", "") or "").strip().lower()
@@ -3239,9 +3239,9 @@ def get_compatible_custom_providers(
 def get_custom_provider_context_length(
     model: str,
     base_url: str,
-    custom_providers: Optional[List[Dict[str, Any]]] = None,
-    config: Optional[Dict[str, Any]] = None,
-) -> Optional[int]:
+    custom_providers: List[Dict[str, Any]] | None = None,
+    config: Dict[str, Any] | None = None,
+) -> int | None:
     """Look up a per-model ``context_length`` override from ``custom_providers``.
 
     Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
@@ -3348,7 +3348,7 @@ class ConfigIssue:
     hint: str
 
 
-def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
+def validate_config_structure(config: Dict[str, Any] | None = None) -> List["ConfigIssue"]:
     """Validate config.yaml structure and return a list of detected issues.
 
     Catches common YAML formatting mistakes that produce confusing runtime
@@ -3492,7 +3492,7 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
     return issues
 
 
-def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
+def print_config_warnings(config: Dict[str, Any] | None = None) -> None:
     """Print config structure warnings to stderr at startup.
 
     Called early in CLI and gateway init so users see problems before
@@ -3514,7 +3514,7 @@ def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
     sys.stderr.write("\n".join(lines) + "\n\n")
 
 
-def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
+def warn_deprecated_cwd_env_vars(config: Dict[str, Any] | None = None) -> None:
     """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
 
     These env vars are deprecated — the canonical setting is terminal.cwd
@@ -4303,7 +4303,7 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
-def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> Any:
+def cfg_get(cfg: Dict[str, Any] | None, *keys: str, default: Any = None) -> Any:
     """Traverse nested dict keys safely, returning ``default`` on any miss.
 
     Canonical helper for the ``cfg.get("X", {}).get("Y", default)`` pattern
@@ -4436,7 +4436,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         try:
             st = config_path.stat()
-            cache_key: Optional[Tuple[int, int]] = (st.st_mtime_ns, st.st_size)
+            cache_key: Tuple[int, int] | None = (st.st_mtime_ns, st.st_size)
         except FileNotFoundError:
             cache_key = None
 
@@ -4668,7 +4668,7 @@ def load_env() -> Dict[str, str]:
 # is the explicit knob for writers that update .env via this module
 # (set_env_value, save_env, etc.) without relying on filesystem mtime
 # resolution.
-_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+_env_cache: Tuple[Tuple[str, float | None, int | None], Dict[str, str]] | None = None
 
 
 def invalidate_env_cache() -> None:
@@ -5010,7 +5010,7 @@ def reload_env() -> int:
     return count
 
 
-def get_env_value(key: str) -> Optional[str]:
+def get_env_value(key: str) -> str | None:
     """Get a value from ~/.hermes/.env or environment."""
     # Check environment first
     if key in os.environ:

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -116,7 +116,7 @@ def _gh_cli_candidates() -> list[str]:
     return candidates
 
 
-def _try_gh_cli_token() -> Optional[str]:
+def _try_gh_cli_token() -> str | None:
     """Return a token from ``gh auth token`` when the GitHub CLI is available.
 
     When COPILOT_GH_HOST is set, passes ``--hostname`` so gh returns the
@@ -156,7 +156,7 @@ def copilot_device_code_login(
     *,
     host: str = "github.com",
     timeout_seconds: float = 300,
-) -> Optional[str]:
+) -> str | None:
     """Run the GitHub OAuth device code flow for Copilot.
 
     Prints instructions for the user, polls for completion, and returns

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from hermes_cli.colors import Colors, color
 
 
-def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[List[str]]:
+def _normalize_skills(single_skill=None, skills: Iterable[str] | None = None) -> List[str] | None:
     if skills is None:
         if single_skill is None:
             return None

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Optional
 
 
-def _fmt_ts(ts: Optional[str]) -> str:
+def _fmt_ts(ts: str | None) -> str:
     if not ts:
         return "never"
     try:
@@ -282,7 +282,7 @@ def _cmd_archive(args) -> int:
     return 0 if ok else 1
 
 
-def _idle_days(record: dict) -> Optional[int]:
+def _idle_days(record: dict) -> int | None:
     """Days since the skill's last activity (view / use / patch).
 
     Falls back to ``created_at`` so a skill that was authored but never used

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -38,7 +38,7 @@ def curses_checklist(
     selected: Set[int],
     *,
     cancel_returns: Set[int] | None = None,
-    status_fn: Optional[Callable[[Set[int]], str]] = None,
+    status_fn: Callable[[Set[int]], str] | None = None,
 ) -> Set[int]:
     """Curses multi-select checklist. Returns set of selected indices.
 
@@ -442,7 +442,7 @@ def _numbered_fallback(
     items: List[str],
     selected: Set[int],
     cancel_returns: Set[int],
-    status_fn: Optional[Callable[[Set[int]], str]] = None,
+    status_fn: Callable[[Set[int]], str] | None = None,
 ) -> Set[int]:
     """Text-based toggle fallback for terminals without curses."""
     chosen = set(selected)

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -130,7 +130,7 @@ def _record_pending(urls: list[str], delay_seconds: int = _AUTO_DELETE_SECONDS) 
     _save_pending(merged)
 
 
-def _sweep_expired_pastes(now: Optional[float] = None) -> tuple[int, int]:
+def _sweep_expired_pastes(now: float | None = None) -> tuple[int, int]:
     """Synchronously DELETE any pending pastes whose ``expire_at`` has passed.
 
     Returns ``(deleted, remaining)``.  Best-effort: failed deletes stay in
@@ -210,7 +210,7 @@ _GATEWAY_PRIVACY_NOTICE = (
 )
 
 
-def _extract_paste_id(url: str) -> Optional[str]:
+def _extract_paste_id(url: str) -> str | None:
     """Extract the paste ID from a paste.rs or dpaste.com URL.
 
     Returns the ID string, or None if the URL doesn't match a known service.
@@ -358,12 +358,12 @@ def upload_to_pastebin(content: str, expiry_days: int = 7) -> str:
 class LogSnapshot:
     """Single-read snapshot of a log file used by debug-share."""
 
-    path: Optional[Path]
+    path: Path | None
     tail_text: str
-    full_text: Optional[str]
+    full_text: str | None
 
 
-def _primary_log_path(log_name: str) -> Optional[Path]:
+def _primary_log_path(log_name: str) -> Path | None:
     """Where *log_name* would live if present. Doesn't check existence."""
     from hermes_cli.logs import LOG_FILES
 
@@ -371,7 +371,7 @@ def _primary_log_path(log_name: str) -> Optional[Path]:
     return (get_hermes_home() / "logs" / filename) if filename else None
 
 
-def _resolve_log_path(log_name: str) -> Optional[Path]:
+def _resolve_log_path(log_name: str) -> Path | None:
     """Find the log file for *log_name*, falling back to the .1 rotation.
 
     Returns the first non-empty candidate (primary, then .1), or None.
@@ -544,7 +544,7 @@ def collect_debug_report(
     *,
     log_lines: int = 200,
     dump_text: str = "",
-    log_snapshots: Optional[dict[str, LogSnapshot]] = None,
+    log_snapshots: dict[str, LogSnapshot] | None = None,
 ) -> str:
     """Build the summary debug report: system dump + log tails.
 

--- a/hermes_cli/dingtalk_auth.py
+++ b/hermes_cli/dingtalk_auth.py
@@ -107,7 +107,7 @@ def wait_for_registration_success(
     device_code: str,
     interval: int = 3,
     expires_in: int = 7200,
-    on_waiting: Optional[callable] = None,
+    on_waiting: callable | None = None,
 ) -> Tuple[str, str]:
     """Block until the registration succeeds or times out.
 
@@ -227,7 +227,7 @@ def render_qr_to_terminal(url: str) -> bool:
 
 # ── High-level entry point for the setup wizard ───────────────────────────
 
-def dingtalk_qr_auth() -> Optional[Tuple[str, str]]:
+def dingtalk_qr_auth() -> Tuple[str, str] | None:
     """Run the interactive QR-code device-flow authorization.
 
     Returns (client_id, client_secret) on success, or None if the user

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -56,7 +56,7 @@ def _format_entry(entry: Dict[str, Any]) -> str:
     return f"{model}  (via {provider}){suffix}"
 
 
-def _extract_fallback_from_model_cfg(model_cfg: Any) -> Optional[Dict[str, Any]]:
+def _extract_fallback_from_model_cfg(model_cfg: Any) -> Dict[str, Any] | None:
     """Pull the ``{provider, model, base_url?, api_mode?}`` dict from a ``config["model"]`` snapshot."""
     if not isinstance(model_cfg, dict):
         return None
@@ -132,7 +132,7 @@ def cmd_fallback_list(args) -> None:  # noqa: ARG001
     print()
 
 
-def _describe_primary(config: Dict[str, Any]) -> Optional[str]:
+def _describe_primary(config: Dict[str, Any]) -> str | None:
     """One-line description of the primary model for display purposes."""
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
@@ -311,7 +311,7 @@ def cmd_fallback_clear(args) -> None:  # noqa: ARG001
     print()
 
 
-def _numbered_pick(question: str, choices: List[str]) -> Optional[int]:
+def _numbered_pick(question: str, choices: List[str]) -> int | None:
     """Fallback numbered-list picker when curses is unavailable."""
     print(question)
     for i, c in enumerate(choices, 1):

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -149,9 +149,9 @@ class GoalState:
     max_turns: int = DEFAULT_MAX_TURNS
     created_at: float = 0.0
     last_turn_at: float = 0.0
-    last_verdict: Optional[str] = None        # "done" | "continue" | "skipped"
-    last_reason: Optional[str] = None
-    paused_reason: Optional[str] = None       # why we auto-paused (budget, etc.)
+    last_verdict: str | None = None        # "done" | "continue" | "skipped"
+    last_reason: str | None = None
+    paused_reason: str | None = None       # why we auto-paused (budget, etc.)
     consecutive_parse_failures: int = 0       # judge-output parse failures in a row
     # User-added criteria appended mid-loop via the /subgoal command.
     # When non-empty the judge prompt and continuation prompt both
@@ -206,7 +206,7 @@ def _meta_key(session_id: str) -> str:
 _DB_CACHE: Dict[str, Any] = {}
 
 
-def _get_session_db() -> Optional[Any]:
+def _get_session_db() -> Any | None:
     """Return a SessionDB instance for the current HERMES_HOME.
 
     SessionDB has no built-in singleton, but opening a new connection per
@@ -236,7 +236,7 @@ def _get_session_db() -> Optional[Any]:
     return db
 
 
-def load_goal(session_id: str) -> Optional[GoalState]:
+def load_goal(session_id: str) -> GoalState | None:
     """Load the goal for a session, or None if none exists."""
     if not session_id:
         return None
@@ -342,7 +342,7 @@ def _parse_judge_response(raw: str) -> Tuple[bool, str, bool]:
             text = text[nl + 1:]
 
     # First try: parse the whole blob.
-    data: Optional[Dict[str, Any]] = None
+    data: Dict[str, Any] | None = None
     try:
         data = json.loads(text)
     except Exception:
@@ -373,7 +373,7 @@ def judge_goal(
     last_response: str,
     *,
     timeout: float = DEFAULT_JUDGE_TIMEOUT,
-    subgoals: Optional[List[str]] = None,
+    subgoals: List[str] | None = None,
 ) -> Tuple[str, str, bool]:
     """Ask the auxiliary model whether the goal is satisfied.
 
@@ -488,12 +488,12 @@ class GoalManager:
     def __init__(self, session_id: str, *, default_max_turns: int = DEFAULT_MAX_TURNS):
         self.session_id = session_id
         self.default_max_turns = int(default_max_turns or DEFAULT_MAX_TURNS)
-        self._state: Optional[GoalState] = load_goal(session_id)
+        self._state: GoalState | None = load_goal(session_id)
 
     # --- introspection ------------------------------------------------
 
     @property
-    def state(self) -> Optional[GoalState]:
+    def state(self) -> GoalState | None:
         return self._state
 
     def is_active(self) -> bool:
@@ -519,7 +519,7 @@ class GoalManager:
 
     # --- mutation -----------------------------------------------------
 
-    def set(self, goal: str, *, max_turns: Optional[int] = None) -> GoalState:
+    def set(self, goal: str, *, max_turns: int | None = None) -> GoalState:
         goal = (goal or "").strip()
         if not goal:
             raise ValueError("goal text is empty")
@@ -535,7 +535,7 @@ class GoalManager:
         save_goal(self.session_id, state)
         return state
 
-    def pause(self, reason: str = "user-paused") -> Optional[GoalState]:
+    def pause(self, reason: str = "user-paused") -> GoalState | None:
         if not self._state:
             return None
         self._state.status = "paused"
@@ -543,7 +543,7 @@ class GoalManager:
         save_goal(self.session_id, self._state)
         return self._state
 
-    def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
+    def resume(self, *, reset_budget: bool = True) -> GoalState | None:
         if not self._state:
             return None
         self._state.status = "active"
@@ -736,7 +736,7 @@ class GoalManager:
             ),
         }
 
-    def next_continuation_prompt(self) -> Optional[str]:
+    def next_continuation_prompt(self) -> str | None:
         if not self._state or self._state.status != "active":
             return None
         if self._state.subgoals:

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -56,9 +56,9 @@ class ConfigContext:
     def with_overrides(
         self,
         *,
-        current_provider: Optional[str] = None,
-        current_model: Optional[str] = None,
-        current_base_url: Optional[str] = None,
+        current_provider: str | None = None,
+        current_model: str | None = None,
+        current_base_url: str | None = None,
     ) -> "ConfigContext":
         """Return a copy with truthy overrides applied.
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -43,7 +43,7 @@ _STATUS_ICONS = {
 }
 
 
-def _fmt_ts(ts: Optional[int]) -> str:
+def _fmt_ts(ts: int | None) -> str:
     if not ts:
         return ""
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
@@ -81,7 +81,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     }
 
 
-def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
+def _run_state_kwargs(args: argparse.Namespace) -> dict[str, str] | None:
     st = getattr(args, "state_type", None)
     sn = getattr(args, "state_name", None)
     if (st is None) != (sn is None):
@@ -91,7 +91,7 @@ def _run_state_kwargs(args: argparse.Namespace) -> Optional[dict[str, str]]:
     return {"state_type": st, "state_name": sn}
 
 
-def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
+def _parse_workspace_flag(value: str) -> tuple[str, str | None]:
     """Parse ``--workspace`` into ``(kind, path|None)``.
 
     Accepts: ``scratch``, ``worktree``, ``worktree:<path>``, ``dir:<path>``.
@@ -116,7 +116,7 @@ def _parse_workspace_flag(value: str) -> tuple[str, Optional[str]]:
     )
 
 
-def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
+def _parse_branch_flag(value: str | None) -> str | None:
     """Normalize an optional branch name from ``kanban create --branch``."""
     if value is None:
         return None
@@ -1189,7 +1189,7 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _parse_duration(val) -> Optional[int]:
+def _parse_duration(val) -> int | None:
     """Parse ``30s`` / ``5m`` / ``2h`` / ``1d`` or a raw integer → seconds.
 
     Returns None for empty input. Raises ValueError on malformed input so
@@ -1844,7 +1844,7 @@ def _cmd_comment(args: argparse.Namespace) -> int:
     return 0
 
 
-def _worker_run_id_for(task_id: str) -> Optional[int]:
+def _worker_run_id_for(task_id: str) -> int | None:
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return None
     raw = os.environ.get("HERMES_KANBAN_RUN_ID")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -111,7 +111,7 @@ _IS_WINDOWS = sys.platform == "win32"
 DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 
 
-def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
+def _resolve_claim_ttl_seconds(ttl_seconds: int | None = None) -> int:
     """Return the effective claim TTL, honoring the kanban env override.
 
     Explicit call-site values win. Otherwise a positive integer from
@@ -160,7 +160,7 @@ DEFAULT_BOARD = "default"
 _BOARD_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9\-_]{0,63}$")
 
 
-def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
+def _normalize_board_slug(slug: str | None) -> str | None:
     """Lowercase + strip a slug; validate; return ``None`` for empty."""
     if slug is None:
         return None
@@ -283,7 +283,7 @@ def clear_current_board() -> None:
         pass
 
 
-def board_dir(board: Optional[str] = None) -> Path:
+def board_dir(board: str | None = None) -> Path:
     """Return the on-disk directory for ``board``.
 
     ``default`` is ``<root>/kanban/boards/default/`` **for metadata only**
@@ -297,7 +297,7 @@ def board_dir(board: Optional[str] = None) -> Path:
     return boards_root() / slug
 
 
-def board_exists(board: Optional[str] = None) -> bool:
+def board_exists(board: str | None = None) -> bool:
     """Return True if the board has persisted metadata or a DB on disk.
 
     ``default`` is considered to always exist — its DB is created
@@ -311,7 +311,7 @@ def board_exists(board: Optional[str] = None) -> bool:
     return (d / "board.json").exists() or (d / "kanban.db").exists()
 
 
-def kanban_db_path(board: Optional[str] = None) -> Path:
+def kanban_db_path(board: str | None = None) -> Path:
     """Return the path to the ``kanban.db`` for ``board``.
 
     Resolution (highest precedence first):
@@ -336,7 +336,7 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
     return board_dir(slug) / "kanban.db"
 
 
-def workspaces_root(board: Optional[str] = None) -> Path:
+def workspaces_root(board: str | None = None) -> Path:
     """Return the directory under which ``scratch`` workspaces are created.
 
     Anchored per-board so workspaces don't leak between projects.
@@ -358,7 +358,7 @@ def workspaces_root(board: Optional[str] = None) -> Path:
     return board_dir(slug) / "workspaces"
 
 
-def worker_logs_dir(board: Optional[str] = None) -> Path:
+def worker_logs_dir(board: str | None = None) -> Path:
     """Return the directory under which per-task worker logs are written.
 
     ``default`` keeps the legacy path ``<root>/kanban/logs/``. Other
@@ -374,7 +374,7 @@ def worker_logs_dir(board: Optional[str] = None) -> Path:
     return board_dir(slug) / "logs"
 
 
-def board_metadata_path(board: Optional[str] = None) -> Path:
+def board_metadata_path(board: str | None = None) -> Path:
     """Return the path to ``board.json`` for ``board``.
 
     Stores display metadata (display name, description, icon, color,
@@ -395,7 +395,7 @@ def _default_board_display_name(slug: str) -> str:
     return " ".join(part.capitalize() for part in slug.replace("_", "-").split("-") if part) or slug
 
 
-def read_board_metadata(board: Optional[str] = None) -> dict:
+def read_board_metadata(board: str | None = None) -> dict:
     """Return ``board.json`` contents (or synthesized defaults).
 
     Never raises — a missing / malformed ``board.json`` falls back to a
@@ -430,14 +430,14 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
 
 
 def write_board_metadata(
-    board: Optional[str],
+    board: str | None,
     *,
-    name: Optional[str] = None,
-    description: Optional[str] = None,
-    icon: Optional[str] = None,
-    color: Optional[str] = None,
-    archived: Optional[bool] = None,
-    default_workdir: Optional[str] = None,
+    name: str | None = None,
+    description: str | None = None,
+    icon: str | None = None,
+    color: str | None = None,
+    archived: bool | None = None,
+    default_workdir: str | None = None,
 ) -> dict:
     """Create / update ``board.json`` for ``board``.
 
@@ -476,11 +476,11 @@ def write_board_metadata(
 def create_board(
     slug: str,
     *,
-    name: Optional[str] = None,
-    description: Optional[str] = None,
-    icon: Optional[str] = None,
-    color: Optional[str] = None,
-    default_workdir: Optional[str] = None,
+    name: str | None = None,
+    description: str | None = None,
+    icon: str | None = None,
+    color: str | None = None,
+    default_workdir: str | None = None,
 ) -> dict:
     """Create a new board directory + DB + metadata. Idempotent.
 
@@ -605,22 +605,22 @@ class Task:
 
     id: str
     title: str
-    body: Optional[str]
-    assignee: Optional[str]
+    body: str | None
+    assignee: str | None
     status: str
     priority: int
-    created_by: Optional[str]
+    created_by: str | None
     created_at: int
-    started_at: Optional[int]
-    completed_at: Optional[int]
+    started_at: int | None
+    completed_at: int | None
     workspace_kind: str
-    workspace_path: Optional[str]
-    claim_lock: Optional[str]
-    claim_expires: Optional[int]
-    tenant: Optional[str]
-    branch_name: Optional[str] = None
-    result: Optional[str] = None
-    idempotency_key: Optional[str] = None
+    workspace_path: str | None
+    claim_lock: str | None
+    claim_expires: int | None
+    tenant: str | None
+    branch_name: str | None = None
+    result: str | None = None
+    idempotency_key: str | None = None
     # Unified non-success counter. Incremented on any of:
     #   * spawn failure (dispatcher couldn't launch the worker)
     #   * timed_out outcome (worker exceeded max_runtime_seconds)
@@ -629,21 +629,21 @@ class Task:
     # ``_record_task_failure`` for the circuit-breaker trip rule.
     # (Pre-rename column: ``spawn_failures``.)
     consecutive_failures: int = 0
-    worker_pid: Optional[int] = None
+    worker_pid: int | None = None
     # Short excerpt of the last failure's error text (any outcome, not
     # just spawn). Pre-rename column: ``last_spawn_error``.
-    last_failure_error: Optional[str] = None
-    max_runtime_seconds: Optional[int] = None
-    last_heartbeat_at: Optional[int] = None
-    current_run_id: Optional[int] = None
-    workflow_template_id: Optional[str] = None
-    current_step_key: Optional[str] = None
+    last_failure_error: str | None = None
+    max_runtime_seconds: int | None = None
+    last_heartbeat_at: int | None = None
+    current_run_id: int | None = None
+    workflow_template_id: str | None = None
+    current_step_key: str | None = None
     # Force-loaded skills for the worker on this task (appended to the
     # dispatcher's built-in `kanban-worker` via --skills). Stored as a
     # JSON array of skill names. None = use only the defaults; empty
     # list = explicitly no extra skills.
-    skills: Optional[list] = None
-    model_override: Optional[str] = None
+    skills: list | None = None
+    model_override: str | None = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -651,19 +651,19 @@ class Task:
     # ``None`` (the common case) falls through to the dispatcher-level
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
-    max_retries: Optional[int] = None
+    max_retries: int | None = None
     # Originating chat/agent session id, when the task was created from
     # within an agent loop that propagated ``HERMES_SESSION_ID``. NULL for
     # tasks created from the CLI, the dashboard, or any path that doesn't
     # set the env var. Lets clients render a per-session board without
     # relying on tenant + time-window heuristics.
-    session_id: Optional[str] = None
+    session_id: str | None = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
         keys = set(row.keys())
         # Parse skills JSON blob if present
-        skills_value: Optional[list] = None
+        skills_value: list | None = None
         if "skills" in keys and row["skills"]:
             try:
                 parsed = json.loads(row["skills"])
@@ -743,20 +743,20 @@ class Run:
 
     id: int
     task_id: str
-    profile: Optional[str]
-    step_key: Optional[str]
+    profile: str | None
+    step_key: str | None
     status: str
-    claim_lock: Optional[str]
-    claim_expires: Optional[int]
-    worker_pid: Optional[int]
-    max_runtime_seconds: Optional[int]
-    last_heartbeat_at: Optional[int]
+    claim_lock: str | None
+    claim_expires: int | None
+    worker_pid: int | None
+    max_runtime_seconds: int | None
+    last_heartbeat_at: int | None
     started_at: int
-    ended_at: Optional[int]
-    outcome: Optional[str]
-    summary: Optional[str]
-    metadata: Optional[dict]
-    error: Optional[str]
+    ended_at: int | None
+    outcome: str | None
+    summary: str | None
+    metadata: dict | None
+    error: str | None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -798,9 +798,9 @@ class Event:
     id: int
     task_id: str
     kind: str
-    payload: Optional[dict]
+    payload: dict | None
     created_at: int
-    run_id: Optional[int] = None
+    run_id: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -1015,7 +1015,7 @@ class KanbanDbCorruptError(RuntimeError):
     original path and the timestamped backup we made before refusing.
     """
 
-    def __init__(self, db_path: Path, backup_path: Optional[Path], reason: str):
+    def __init__(self, db_path: Path, backup_path: Path | None, reason: str):
         self.db_path = db_path
         self.backup_path = backup_path
         self.reason = reason
@@ -1026,7 +1026,7 @@ class KanbanDbCorruptError(RuntimeError):
         )
 
 
-def _backup_corrupt_db(path: Path) -> Optional[Path]:
+def _backup_corrupt_db(path: Path) -> Path | None:
     """Copy a corrupt DB (and its WAL/SHM sidecars) to a timestamped backup.
 
     Returns the backup path of the main DB file, or ``None`` if the copy
@@ -1112,7 +1112,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         return
     if str(resolved) in _INITIALIZED_PATHS:
         return
-    reason: Optional[str] = None
+    reason: str | None = None
     try:
         probe = sqlite3.connect(str(resolved), timeout=5, isolation_level=None)
         try:
@@ -1133,9 +1133,9 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
 
 
 def connect(
-    db_path: Optional[Path] = None,
+    db_path: Path | None = None,
     *,
-    board: Optional[str] = None,
+    board: str | None = None,
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
@@ -1200,9 +1200,9 @@ def connect(
 
 
 def init_db(
-    db_path: Optional[Path] = None,
+    db_path: Path | None = None,
     *,
-    board: Optional[str] = None,
+    board: str | None = None,
 ) -> Path:
     """Create the schema if it doesn't exist; return the path used.
 
@@ -1515,7 +1515,7 @@ def _claimer_id() -> str:
 # Task creation / mutation
 # ---------------------------------------------------------------------------
 
-def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
+def _canonical_assignee(assignee: str | None) -> str | None:
     """Lowercase-assignee normalization for Kanban rows (dashboard/CLI parity)."""
     if assignee is None:
         return None
@@ -1528,23 +1528,23 @@ def create_task(
     conn: sqlite3.Connection,
     *,
     title: str,
-    body: Optional[str] = None,
-    assignee: Optional[str] = None,
-    created_by: Optional[str] = None,
+    body: str | None = None,
+    assignee: str | None = None,
+    created_by: str | None = None,
     workspace_kind: str = "scratch",
-    workspace_path: Optional[str] = None,
-    branch_name: Optional[str] = None,
-    tenant: Optional[str] = None,
+    workspace_path: str | None = None,
+    branch_name: str | None = None,
+    tenant: str | None = None,
     priority: int = 0,
     parents: Iterable[str] = (),
     triage: bool = False,
-    idempotency_key: Optional[str] = None,
-    max_runtime_seconds: Optional[int] = None,
-    skills: Optional[Iterable[str]] = None,
-    max_retries: Optional[int] = None,
+    idempotency_key: str | None = None,
+    max_runtime_seconds: int | None = None,
+    skills: Iterable[str] | None = None,
+    max_retries: int | None = None,
     initial_status: str = "running",
-    session_id: Optional[str] = None,
-    board: Optional[str] = None,
+    session_id: str | None = None,
+    board: str | None = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1593,7 +1593,7 @@ def create_task(
     # invisibly splatter a comma-joined string into one argv slot — the
     # `hermes --skills X,Y` comma syntax is handled in the dispatcher,
     # not here.
-    skills_list: Optional[list[str]] = None
+    skills_list: list[str] | None = None
     if skills is not None:
         cleaned: list[str] = []
         seen: set[str] = set()
@@ -1772,7 +1772,7 @@ def _find_missing_parents(conn: sqlite3.Connection, parents: Iterable[str]) -> l
     return [p for p in parents if p not in present]
 
 
-def get_task(conn: sqlite3.Connection, task_id: str) -> Optional[Task]:
+def get_task(conn: sqlite3.Connection, task_id: str) -> Task | None:
     row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
     return Task.from_row(row) if row else None
 
@@ -1794,15 +1794,15 @@ VALID_SORT_ORDERS: dict[str, str] = {
 def list_tasks(
     conn: sqlite3.Connection,
     *,
-    assignee: Optional[str] = None,
-    status: Optional[str] = None,
-    tenant: Optional[str] = None,
-    session_id: Optional[str] = None,
+    assignee: str | None = None,
+    status: str | None = None,
+    tenant: str | None = None,
+    session_id: str | None = None,
     include_archived: bool = False,
-    limit: Optional[int] = None,
-    order_by: Optional[str] = None,
-    workflow_template_id: Optional[str] = None,
-    current_step_key: Optional[str] = None,
+    limit: int | None = None,
+    order_by: str | None = None,
+    workflow_template_id: str | None = None,
+    current_step_key: str | None = None,
 ) -> list[Task]:
     query = "SELECT * FROM tasks WHERE 1=1"
     params: list[Any] = []
@@ -1843,7 +1843,7 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
-def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
+def assign_task(conn: sqlite3.Connection, task_id: str, profile: str | None) -> bool:
     """Assign or reassign a task.  Returns True on success.
 
     Refuses to reassign a task that's currently running (claim_lock set).
@@ -1970,7 +1970,7 @@ def child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
     return [r["child_id"] for r in rows]
 
 
-def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Optional[str]]]:
+def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, str | None]]:
     """Return ``(parent_id, result)`` for every done parent of ``task_id``."""
     rows = conn.execute(
         """
@@ -2056,9 +2056,9 @@ def _append_event(
     conn: sqlite3.Connection,
     task_id: str,
     kind: str,
-    payload: Optional[dict] = None,
+    payload: dict | None = None,
     *,
-    run_id: Optional[int] = None,
+    run_id: int | None = None,
 ) -> None:
     """Record an event row.  Called from within an already-open txn.
 
@@ -2081,11 +2081,11 @@ def _end_run(
     task_id: str,
     *,
     outcome: str,
-    summary: Optional[str] = None,
-    error: Optional[str] = None,
-    metadata: Optional[dict] = None,
-    status: Optional[str] = None,
-) -> Optional[int]:
+    summary: str | None = None,
+    error: str | None = None,
+    metadata: dict | None = None,
+    status: str | None = None,
+) -> int | None:
     """Close the currently-active run for ``task_id`` and clear the pointer.
 
     ``outcome`` is the semantic result (completed / blocked / crashed /
@@ -2133,7 +2133,7 @@ def _end_run(
     return run_id
 
 
-def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
+def _current_run_id(conn: sqlite3.Connection, task_id: str) -> int | None:
     row = conn.execute(
         "SELECT current_run_id FROM tasks WHERE id = ?", (task_id,),
     ).fetchone()
@@ -2145,9 +2145,9 @@ def _synthesize_ended_run(
     task_id: str,
     *,
     outcome: str,
-    summary: Optional[str] = None,
-    error: Optional[str] = None,
-    metadata: Optional[dict] = None,
+    summary: str | None = None,
+    error: str | None = None,
+    metadata: dict | None = None,
 ) -> int:
     """Insert a zero-duration, already-closed run row.
 
@@ -2297,9 +2297,9 @@ def claim_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    ttl_seconds: Optional[int] = None,
-    claimer: Optional[str] = None,
-) -> Optional[Task]:
+    ttl_seconds: int | None = None,
+    claimer: str | None = None,
+) -> Task | None:
     """Atomically transition ``ready -> running``.
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
@@ -2411,9 +2411,9 @@ def claim_review_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    ttl_seconds: Optional[int] = None,
-    claimer: Optional[str] = None,
-) -> Optional[Task]:
+    ttl_seconds: int | None = None,
+    claimer: str | None = None,
+) -> Task | None:
     """Atomically transition ``review -> running``.
 
     Returns the claimed ``Task`` on success, ``None`` if the task was
@@ -2486,8 +2486,8 @@ def heartbeat_claim(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    ttl_seconds: Optional[int] = None,
-    claimer: Optional[str] = None,
+    ttl_seconds: int | None = None,
+    claimer: str | None = None,
 ) -> bool:
     """Extend a running claim.  Returns True if we still own it.
 
@@ -2630,7 +2630,7 @@ def reclaim_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    reason: Optional[str] = None,
+    reason: str | None = None,
     signal_fn=None,
 ) -> bool:
     """Operator-driven reclaim: release the claim and reset to ``ready``.
@@ -2698,10 +2698,10 @@ def reclaim_task(
 def reassign_task(
     conn: sqlite3.Connection,
     task_id: str,
-    profile: Optional[str],
+    profile: str | None,
     *,
     reclaim_first: bool = False,
-    reason: Optional[str] = None,
+    reason: str | None = None,
 ) -> bool:
     """Reassign a task, optionally reclaiming a stuck running worker first.
 
@@ -2862,11 +2862,11 @@ def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    result: Optional[str] = None,
-    summary: Optional[str] = None,
-    metadata: Optional[dict] = None,
-    created_cards: Optional[Iterable[str]] = None,
-    expected_run_id: Optional[int] = None,
+    result: str | None = None,
+    summary: str | None = None,
+    metadata: dict | None = None,
+    created_cards: Iterable[str] | None = None,
+    expected_run_id: int | None = None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -3134,8 +3134,8 @@ def _cleanup_workspace(conn: sqlite3.Connection, task_id: str) -> None:
         ).fetchone()
         if not row:
             return
-        kind: Optional[str] = row["workspace_kind"]
-        path: Optional[str] = row["workspace_path"]
+        kind: str | None = row["workspace_kind"]
+        path: str | None = row["workspace_path"]
         if kind != "scratch" or not path:
             return
         import shutil
@@ -3250,7 +3250,7 @@ def _mark_scratch_tip_shown() -> None:
 def _maybe_emit_scratch_tip(
     conn: sqlite3.Connection,
     task_id: str,
-    workspace_kind: Optional[str],
+    workspace_kind: str | None,
 ) -> None:
     """Emit the first-use scratch-workspace tip exactly once per install.
 
@@ -3281,8 +3281,8 @@ def edit_completed_task_result(
     task_id: str,
     *,
     result: str,
-    summary: Optional[str] = None,
-    metadata: Optional[dict] = None,
+    summary: str | None = None,
+    metadata: dict | None = None,
 ) -> bool:
     """Backfill the user-visible result for an already completed task."""
     handoff_summary = summary if summary is not None else result
@@ -3347,8 +3347,8 @@ def block_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    reason: Optional[str] = None,
-    expected_run_id: Optional[int] = None,
+    reason: str | None = None,
+    expected_run_id: int | None = None,
 ) -> bool:
     """Transition ``running -> blocked``."""
     with write_txn(conn):
@@ -3404,10 +3404,10 @@ def promote_task(
     task_id: str,
     *,
     actor: str,
-    reason: Optional[str] = None,
+    reason: str | None = None,
     force: bool = False,
     dry_run: bool = False,
-) -> tuple[bool, Optional[str]]:
+) -> tuple[bool, str | None]:
     """Manually promote a `todo` or `blocked` task to `ready`.
 
     Mirrors the automatic promotion done by ``recompute_ready`` but
@@ -3529,10 +3529,10 @@ def specify_triage_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    title: Optional[str] = None,
-    body: Optional[str] = None,
-    assignee: Optional[str] = None,
-    author: Optional[str] = None,
+    title: str | None = None,
+    body: str | None = None,
+    assignee: str | None = None,
+    author: str | None = None,
 ) -> bool:
     """Flesh out a triage task and promote it to ``todo``.
 
@@ -3620,11 +3620,11 @@ def decompose_triage_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    root_assignee: Optional[str],
+    root_assignee: str | None,
     children: list[dict],
-    author: Optional[str] = None,
+    author: str | None = None,
     auto_promote: bool = True,
-) -> Optional[list[str]]:
+) -> list[str] | None:
     """Fan a triage task out into child tasks and promote the root to ``todo``.
 
     The root task stays alive and becomes the parent of every child —
@@ -3896,7 +3896,7 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 # Workspace resolution
 # ---------------------------------------------------------------------------
 
-def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
+def resolve_workspace(task: Task, *, board: str | None = None) -> Path:
     """Resolve (and create if needed) the workspace for a task.
 
     - ``scratch``: a fresh dir under ``<board-root>/workspaces/<id>/``,
@@ -3975,8 +3975,8 @@ def schedule_task(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    reason: Optional[str] = None,
-    expected_run_id: Optional[int] = None,
+    reason: str | None = None,
+    expected_run_id: int | None = None,
 ) -> bool:
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
@@ -4134,7 +4134,7 @@ def _record_worker_exit(pid: int, raw_status: int) -> None:
             _recent_worker_exits.pop(_pid, None)
 
 
-def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
+def _classify_worker_exit(pid: int) -> "tuple[str, int | None]":
     """Classify a recently-reaped worker by pid.
 
     Returns ``(kind, code)`` where ``kind`` is one of:
@@ -4169,7 +4169,7 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
     return ("unknown", None)
 
 
-def _pid_alive(pid: Optional[int]) -> bool:
+def _pid_alive(pid: int | None) -> bool:
     """Return True if ``pid`` is still running on this host.
 
     Cross-platform: uses ``OpenProcess`` + ``WaitForSingleObject`` on
@@ -4234,8 +4234,8 @@ def _pid_alive(pid: Optional[int]) -> bool:
 
 
 def _terminate_reclaimed_worker(
-    pid: Optional[int],
-    claim_lock: Optional[str],
+    pid: int | None,
+    claim_lock: str | None,
     *,
     signal_fn=None,
 ) -> dict[str, Any]:
@@ -4293,8 +4293,8 @@ def heartbeat_worker(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    note: Optional[str] = None,
-    expected_run_id: Optional[int] = None,
+    note: str | None = None,
+    expected_run_id: int | None = None,
 ) -> bool:
     """Record a ``heartbeat`` event + touch ``last_heartbeat_at``.
 
@@ -4583,7 +4583,7 @@ def detect_stale_running(
 def set_max_runtime(
     conn: sqlite3.Connection,
     task_id: str,
-    seconds: Optional[int],
+    seconds: int | None,
 ) -> bool:
     """Set or clear the per-task max_runtime_seconds. Returns True on
     success."""
@@ -4753,7 +4753,7 @@ def _record_task_failure(
     failure_limit: int = None,
     release_claim: bool = False,
     end_run: bool = False,
-    event_payload_extra: Optional[dict] = None,
+    event_payload_extra: dict | None = None,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -4959,7 +4959,7 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
-def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> str | None:
     """Return a guard reason if ``task_id`` should NOT be re-spawned, else None.
 
     Called per ready task in ``dispatch_once`` before any claim attempt.
@@ -5089,13 +5089,13 @@ def dispatch_once(
     conn: sqlite3.Connection,
     *,
     spawn_fn=None,
-    ttl_seconds: Optional[int] = None,
+    ttl_seconds: int | None = None,
     dry_run: bool = False,
-    max_spawn: Optional[int] = None,
-    max_in_progress: Optional[int] = None,
+    max_spawn: int | None = None,
+    max_in_progress: int | None = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stale_timeout_seconds: int = 0,
-    board: Optional[str] = None,
+    board: str | None = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -5397,7 +5397,7 @@ def _positive_int(value: Any, default: int, *, minimum: int = 1) -> int:
     return parsed if parsed >= minimum else default
 
 
-def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, int]:
+def worker_log_rotation_config(kanban_cfg: dict | None = None) -> tuple[int, int]:
     """Return ``(rotate_bytes, backup_count)`` for worker log rotation.
 
     Defaults preserve the historical behavior: rotate at 2 MiB and keep one
@@ -5511,7 +5511,7 @@ def _path_search_names(command: str) -> list[str]:
     return [command + ext for ext in exts]
 
 
-def _safe_which_no_cwd(command: str) -> Optional[str]:
+def _safe_which_no_cwd(command: str) -> str | None:
     """Resolve a bare command from PATH without implicit current-dir search.
 
     ``shutil.which`` follows platform search behavior. On Windows that can
@@ -5587,7 +5587,7 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
-def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
+def _kanban_worker_skill_available(hermes_home: str | None) -> bool:
     """True if the bundled ``kanban-worker`` skill resolves for the home the
     spawned worker will run under.
 
@@ -5623,9 +5623,9 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
 
 
 def _worker_terminal_timeout_env(
-    max_runtime_seconds: Optional[int],
-    current_timeout: Optional[str],
-) -> Optional[str]:
+    max_runtime_seconds: int | None,
+    current_timeout: str | None,
+) -> str | None:
     """Return a worker-scoped TERMINAL_TIMEOUT override, if needed.
 
     Kanban's ``max_runtime_seconds`` bounds the whole worker attempt. The
@@ -5656,8 +5656,8 @@ def _default_spawn(
     task: Task,
     workspace: str,
     *,
-    board: Optional[str] = None,
-) -> Optional[int]:
+    board: str | None = None,
+) -> int | None:
     """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
 
     Returns the spawned child's PID so the dispatcher can detect crashes
@@ -5826,7 +5826,7 @@ def _default_spawn(
 def run_daemon(
     *,
     interval: float = 60.0,
-    max_spawn: Optional[int] = None,
+    max_spawn: int | None = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stop_event=None,
     on_tick=None,
@@ -5909,7 +5909,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     if not task:
         raise ValueError(f"unknown task {task_id}")
 
-    def _cap(s: Optional[str], limit: int = _CTX_MAX_FIELD_BYTES) -> str:
+    def _cap(s: str | None, limit: int = _CTX_MAX_FIELD_BYTES) -> str:
         """Truncate a string to `limit` chars with a visible ellipsis."""
         if not s:
             return ""
@@ -6124,7 +6124,7 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
-def _to_epoch(val) -> Optional[int]:
+def _to_epoch(val) -> int | None:
     """Normalise a timestamp to unix epoch seconds.
 
     Accepts ints (pass-through), numeric strings, and ISO-8601 strings.
@@ -6180,9 +6180,9 @@ def add_notify_sub(
     task_id: str,
     platform: str,
     chat_id: str,
-    thread_id: Optional[str] = None,
-    user_id: Optional[str] = None,
-    notifier_profile: Optional[str] = None,
+    thread_id: str | None = None,
+    user_id: str | None = None,
+    notifier_profile: str | None = None,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
@@ -6211,7 +6211,7 @@ def add_notify_sub(
 
 
 def list_notify_subs(
-    conn: sqlite3.Connection, task_id: Optional[str] = None,
+    conn: sqlite3.Connection, task_id: str | None = None,
 ) -> list[dict]:
     if task_id is not None:
         rows = conn.execute(
@@ -6228,7 +6228,7 @@ def remove_notify_sub(
     task_id: str,
     platform: str,
     chat_id: str,
-    thread_id: Optional[str] = None,
+    thread_id: str | None = None,
 ) -> bool:
     with write_txn(conn):
         cur = conn.execute(
@@ -6245,8 +6245,8 @@ def unseen_events_for_sub(
     task_id: str,
     platform: str,
     chat_id: str,
-    thread_id: Optional[str] = None,
-    kinds: Optional[Iterable[str]] = None,
+    thread_id: str | None = None,
+    kinds: Iterable[str] | None = None,
 ) -> tuple[int, list[Event]]:
     """Return ``(new_cursor, events)`` for a given subscription.
 
@@ -6294,8 +6294,8 @@ def claim_unseen_events_for_sub(
     task_id: str,
     platform: str,
     chat_id: str,
-    thread_id: Optional[str] = None,
-    kinds: Optional[Iterable[str]] = None,
+    thread_id: str | None = None,
+    kinds: Iterable[str] | None = None,
 ) -> tuple[int, int, list[Event]]:
     """Atomically claim unseen notification events for one subscription.
 
@@ -6345,7 +6345,7 @@ def advance_notify_cursor(
     task_id: str,
     platform: str,
     chat_id: str,
-    thread_id: Optional[str] = None,
+    thread_id: str | None = None,
     new_cursor: int,
 ) -> None:
     with write_txn(conn):
@@ -6362,7 +6362,7 @@ def rewind_notify_cursor(
     task_id: str,
     platform: str,
     chat_id: str,
-    thread_id: Optional[str] = None,
+    thread_id: str | None = None,
     claimed_cursor: int,
     old_cursor: int,
 ) -> bool:
@@ -6408,7 +6408,7 @@ def gc_events(
 
 def gc_worker_logs(
     *, older_than_seconds: int = 30 * 24 * 3600,
-    board: Optional[str] = None,
+    board: str | None = None,
 ) -> int:
     """Delete worker log files older than ``older_than_seconds``. Returns
     the number of files removed. Kept separate from ``gc_events`` because
@@ -6434,7 +6434,7 @@ def gc_worker_logs(
 # Worker log accessor
 # ---------------------------------------------------------------------------
 
-def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
+def worker_log_path(task_id: str, *, board: str | None = None) -> Path:
     """Return the path to a worker's log file. The file may not exist
     (task never spawned, or log already GC'd).
 
@@ -6446,9 +6446,9 @@ def worker_log_path(task_id: str, *, board: Optional[str] = None) -> Path:
 
 
 def read_worker_log(
-    task_id: str, *, tail_bytes: Optional[int] = None,
-    board: Optional[str] = None,
-) -> Optional[str]:
+    task_id: str, *, tail_bytes: int | None = None,
+    board: str | None = None,
+) -> str | None:
     """Read the worker log for ``task_id``. Returns None if the file
     doesn't exist. If ``tail_bytes`` is set, only the last N bytes are
     returned (useful for the dashboard drawer which shouldn't page megabytes)."""
@@ -6559,8 +6559,8 @@ def list_runs(
     task_id: str,
     *,
     include_active: bool = True,
-    state_type: Optional[str] = None,
-    state_name: Optional[str] = None,
+    state_type: str | None = None,
+    state_name: str | None = None,
 ) -> list[Run]:
     """Return all runs for ``task_id`` in start order.
 
@@ -6589,14 +6589,14 @@ def list_runs(
     return [Run.from_row(r) for r in rows]
 
 
-def get_run(conn: sqlite3.Connection, run_id: int) -> Optional[Run]:
+def get_run(conn: sqlite3.Connection, run_id: int) -> Run | None:
     row = conn.execute(
         "SELECT * FROM task_runs WHERE id = ?", (int(run_id),),
     ).fetchone()
     return Run.from_row(row) if row else None
 
 
-def active_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
+def active_run(conn: sqlite3.Connection, task_id: str) -> Run | None:
     """Return the currently-open run for ``task_id`` (``ended_at IS NULL``)."""
     row = conn.execute(
         "SELECT * FROM task_runs WHERE task_id = ? AND ended_at IS NULL "
@@ -6606,7 +6606,7 @@ def active_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
     return Run.from_row(row) if row else None
 
 
-def latest_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
+def latest_run(conn: sqlite3.Connection, task_id: str) -> Run | None:
     """Return the most recent run regardless of outcome (active or closed)."""
     row = conn.execute(
         "SELECT * FROM task_runs WHERE task_id = ? "
@@ -6616,7 +6616,7 @@ def latest_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
     return Run.from_row(row) if row else None
 
 
-def latest_summary(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+def latest_summary(conn: sqlite3.Connection, task_id: str) -> str | None:
     """Return the latest non-null ``task_runs.summary`` for ``task_id``.
 
     The kanban-worker skill writes its handoff to ``task_runs.summary``

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -133,7 +133,7 @@ class DecomposeOutcome:
     reason: str = ""
     fanout: bool = False
     child_ids: list[str] | None = None
-    new_title: Optional[str] = None
+    new_title: str | None = None
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -142,7 +142,7 @@ def _truncate(text: str, limit: int) -> str:
     return text[: limit - 1] + "…"
 
 
-def _extract_json_blob(raw: str) -> Optional[dict]:
+def _extract_json_blob(raw: str) -> dict | None:
     if not raw:
         return None
     stripped = _FENCE_RE.sub("", raw.strip())
@@ -271,8 +271,8 @@ def _normalize_assignee_choice(
 def decompose_task(
     task_id: str,
     *,
-    author: Optional[str] = None,
-    timeout: Optional[int] = None,
+    author: str | None = None,
+    timeout: int | None = None,
 ) -> DecomposeOutcome:
     """Decompose a triage task into a graph of child tasks.
 
@@ -465,7 +465,7 @@ def decompose_task(
     )
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+def list_triage_ids(*, tenant: str | None = None) -> list[str]:
     """Return task ids currently in the triage column."""
     with kb.connect() as conn:
         rows = kb.list_tasks(

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -41,7 +41,7 @@ import time
 SEVERITY_ORDER = ("warning", "error", "critical")
 
 
-def severity_at_or_above(severity: Optional[str], threshold: Optional[str]) -> bool:
+def severity_at_or_above(severity: str | None, threshold: str | None) -> bool:
     """Return True when ``severity`` meets or exceeds ``threshold``."""
     if threshold is None:
         return True
@@ -98,7 +98,7 @@ class Diagnostic:
     last_seen_at: int = 0
     count: int = 1
     # Optional: the run id this diagnostic is scoped to. None = task-wide.
-    run_id: Optional[int] = None
+    run_id: int | None = None
     # Optional structured payload for the UI (phantom ids, failure count).
     data: dict = field(default_factory=dict)
 
@@ -280,7 +280,7 @@ def _main_model_visible(raw_config: Any) -> bool:
     return bool(str(model_cfg or "").strip())
 
 
-def triage_aux_status(config: Optional[dict]) -> Optional[dict]:
+def triage_aux_status(config: dict | None) -> dict | None:
     """Inspect raw config and report whether triage paths look configured.
 
     Returns ``None`` when config context is unavailable (suppress diagnostic
@@ -955,7 +955,7 @@ DEFAULT_CONFIG = {
 }
 
 
-def config_from_kanban_config(kanban_cfg: Optional[dict]) -> dict:
+def config_from_kanban_config(kanban_cfg: dict | None) -> dict:
     """Build diagnostics config from the runtime ``kanban`` config section.
 
     ``kanban.diagnostics.failure_threshold`` remains an explicit override.
@@ -977,7 +977,7 @@ def config_from_kanban_config(kanban_cfg: Optional[dict]) -> dict:
     return diag_cfg
 
 
-def config_from_runtime_config(raw_config: Optional[dict]) -> dict:
+def config_from_runtime_config(raw_config: dict | None) -> dict:
     """Build diagnostics config from the full Hermes runtime config.
 
     Carries through ``kanban``, ``auxiliary``, and ``model`` keys so triage-
@@ -1005,8 +1005,8 @@ def compute_task_diagnostics(
     events: list,
     runs: list,
     *,
-    now: Optional[int] = None,
-    config: Optional[dict] = None,
+    now: int | None = None,
+    config: dict | None = None,
 ) -> list[Diagnostic]:
     """Run every rule against a single task's state and return a
     severity-sorted list of active diagnostics.
@@ -1045,7 +1045,7 @@ def compute_task_diagnostics(
     return out
 
 
-def severity_of_highest(diagnostics: Iterable[Diagnostic]) -> Optional[str]:
+def severity_of_highest(diagnostics: Iterable[Diagnostic]) -> str | None:
     """Highest severity present in the list, or None if empty. Useful
     for card badges that need a single color."""
     highest_idx = -1

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -94,7 +94,7 @@ class SpecifyOutcome:
     task_id: str
     ok: bool
     reason: str = ""
-    new_title: Optional[str] = None
+    new_title: str | None = None
 
 
 def _truncate(text: str, limit: int) -> str:
@@ -106,7 +106,7 @@ def _truncate(text: str, limit: int) -> str:
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$", re.IGNORECASE)
 
 
-def _extract_json_blob(raw: str) -> Optional[dict]:
+def _extract_json_blob(raw: str) -> dict | None:
     """Lenient JSON extraction — tolerates fenced code blocks and
     leading/trailing whitespace. Returns None if nothing parses."""
     if not raw:
@@ -140,8 +140,8 @@ def _profile_author() -> str:
 def specify_task(
     task_id: str,
     *,
-    author: Optional[str] = None,
-    timeout: Optional[int] = None,
+    author: str | None = None,
+    timeout: int | None = None,
 ) -> SpecifyOutcome:
     """Specify a single triage task and promote it to ``todo``.
 
@@ -210,8 +210,8 @@ def specify_task(
 
     parsed = _extract_json_blob(raw)
 
-    new_title: Optional[str]
-    new_body: Optional[str]
+    new_title: str | None
+    new_body: str | None
     if parsed is None:
         # Fall back: treat the whole reply as the body, leave title as-is.
         # Worst case the user edits afterward — still better than stranding
@@ -256,7 +256,7 @@ def specify_task(
     return SpecifyOutcome(task_id, True, "specified", new_title=new_title)
 
 
-def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
+def list_triage_ids(*, tenant: str | None = None) -> list[str]:
     """Return task ids currently in the triage column.
 
     ``tenant`` narrows the sweep; ``None`` returns every triage task.

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -35,7 +35,7 @@ class SwarmWorkerSpec:
     body: str
     skills: list[str] = field(default_factory=list)
     priority: int = 0
-    max_runtime_seconds: Optional[int] = None
+    max_runtime_seconds: int | None = None
 
 
 @dataclass(frozen=True)
@@ -81,15 +81,15 @@ def create_swarm(
     workers: Iterable[SwarmWorkerSpec],
     verifier_assignee: str,
     synthesizer_assignee: str,
-    root_title: Optional[str] = None,
+    root_title: str | None = None,
     verifier_title: str = "Verify swarm outputs",
     synthesizer_title: str = "Synthesize swarm outputs",
-    tenant: Optional[str] = None,
+    tenant: str | None = None,
     created_by: str = "swarm-orchestrator",
     workspace_kind: str = "scratch",
-    workspace_path: Optional[str] = None,
+    workspace_path: str | None = None,
     priority: int = 0,
-    idempotency_key: Optional[str] = None,
+    idempotency_key: str | None = None,
 ) -> SwarmCreated:
     """Create a durable Kanban swarm graph.
 

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -53,7 +53,7 @@ _LOGGER_NAME_RE = re.compile(
 _LEVEL_ORDER = {"DEBUG": 0, "INFO": 1, "WARNING": 2, "ERROR": 3, "CRITICAL": 4}
 
 
-def _parse_since(since_str: str) -> Optional[datetime]:
+def _parse_since(since_str: str) -> datetime | None:
     """Parse a relative time string like '1h', '30m', '2d' into a datetime cutoff.
 
     Returns None if the string can't be parsed.
@@ -73,7 +73,7 @@ def _parse_since(since_str: str) -> Optional[datetime]:
     return datetime.now() - delta
 
 
-def _parse_line_timestamp(line: str) -> Optional[datetime]:
+def _parse_line_timestamp(line: str) -> datetime | None:
     """Extract timestamp from a log line. Returns None if not parseable."""
     m = _TS_RE.match(line)
     if not m:
@@ -84,13 +84,13 @@ def _parse_line_timestamp(line: str) -> Optional[datetime]:
         return None
 
 
-def _extract_level(line: str) -> Optional[str]:
+def _extract_level(line: str) -> str | None:
     """Extract the log level from a line."""
     m = _LEVEL_RE.search(line)
     return m.group(1) if m else None
 
 
-def _extract_logger_name(line: str) -> Optional[str]:
+def _extract_logger_name(line: str) -> str | None:
     """Extract the logger name from a log line."""
     m = _LOGGER_NAME_RE.search(line)
     return m.group(1) if m else None
@@ -107,10 +107,10 @@ def _line_matches_component(line: str, prefixes: Sequence[str]) -> bool:
 def _matches_filters(
     line: str,
     *,
-    min_level: Optional[str] = None,
-    session_filter: Optional[str] = None,
-    since: Optional[datetime] = None,
-    component_prefixes: Optional[Sequence[str]] = None,
+    min_level: str | None = None,
+    session_filter: str | None = None,
+    since: datetime | None = None,
+    component_prefixes: Sequence[str] | None = None,
 ) -> bool:
     """Check if a log line passes all active filters."""
     if since is not None:
@@ -140,10 +140,10 @@ def tail_log(
     *,
     num_lines: int = 50,
     follow: bool = False,
-    level: Optional[str] = None,
-    session: Optional[str] = None,
-    since: Optional[str] = None,
-    component: Optional[str] = None,
+    level: str | None = None,
+    session: str | None = None,
+    since: str | None = None,
+    component: str | None = None,
 ) -> None:
     """Read and display log lines, optionally following in real time.
 
@@ -251,10 +251,10 @@ def _read_tail(
     num_lines: int,
     *,
     has_filters: bool = False,
-    min_level: Optional[str] = None,
-    session_filter: Optional[str] = None,
-    since: Optional[datetime] = None,
-    component_prefixes: Optional[Sequence[str]] = None,
+    min_level: str | None = None,
+    session_filter: str | None = None,
+    since: datetime | None = None,
+    component_prefixes: Sequence[str] | None = None,
 ) -> list:
     """Read the last *num_lines* matching lines from a log file.
 
@@ -334,10 +334,10 @@ def _read_last_n_lines(path: Path, n: int) -> list:
 def _follow_log(
     path: Path,
     *,
-    min_level: Optional[str] = None,
-    session_filter: Optional[str] = None,
-    since: Optional[datetime] = None,
-    component_prefixes: Optional[Sequence[str]] = None,
+    min_level: str | None = None,
+    session_filter: str | None = None,
+    since: datetime | None = None,
+    component_prefixes: Sequence[str] | None = None,
 ) -> None:
     """Poll a log file for new content and print matching lines."""
     with open(path, "r", encoding="utf-8", errors="replace") as f:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -598,7 +598,7 @@ def _has_any_provider_configured() -> bool:
     return False
 
 
-def _session_browse_picker(sessions: list) -> Optional[str]:
+def _session_browse_picker(sessions: list) -> str | None:
     """Interactive curses-based session browser with live search filtering.
 
     Returns the selected session ID, or None if cancelled.
@@ -839,7 +839,7 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
             return None
 
 
-def _resolve_last_session(source: str = "cli") -> Optional[str]:
+def _resolve_last_session(source: str = "cli") -> str | None:
     """Look up the most recently-used session ID for a source."""
     db = None
     try:
@@ -970,7 +970,7 @@ def _exec_in_container(container_info: dict, cli_args: list):
     os.execvp(exec_cmd[0], exec_cmd)
 
 
-def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
+def _resolve_session_by_name_or_id(name_or_id: str) -> str | None:
     """Resolve a session name (title) or ID to a session ID.
 
     - If it looks like a session ID (contains underscore + hex), try direct lookup first.
@@ -988,7 +988,7 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
 
         # Try as exact session ID first
         session = db.get_session(name_or_id)
-        resolved_id: Optional[str] = None
+        resolved_id: str | None = None
         if session:
             resolved_id = session["id"]
         else:
@@ -1010,7 +1010,7 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
     return None
 
 
-def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:
+def _read_tui_active_session_file(path: str | None) -> str | None:
     if not path:
         return None
     try:
@@ -1022,7 +1022,7 @@ def _read_tui_active_session_file(path: Optional[str]) -> Optional[str]:
 
 
 def _print_tui_exit_summary(
-    session_id: Optional[str], active_session_file: Optional[str] = None
+    session_id: str | None, active_session_file: str | None = None
 ) -> None:
     """Print a shell-visible epilogue after TUI exits."""
     target = (
@@ -1448,20 +1448,20 @@ def _normalize_tui_toolsets(toolsets: object) -> list[str]:
 
 
 def _launch_tui(
-    resume_session_id: Optional[str] = None,
+    resume_session_id: str | None = None,
     tui_dev: bool = False,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
+    model: str | None = None,
+    provider: str | None = None,
     toolsets: object = None,
     skills: object = None,
-    verbose: Optional[bool] = None,
+    verbose: bool | None = None,
     quiet: bool = False,
-    query: Optional[str] = None,
-    image: Optional[str] = None,
+    query: str | None = None,
+    image: str | None = None,
     worktree: bool = False,
     checkpoints: bool = False,
     pass_session_id: bool = False,
-    max_turns: Optional[int] = None,
+    max_turns: int | None = None,
     accept_hooks: bool = False,
 ):
     """Replace current process with the TUI."""
@@ -1565,7 +1565,7 @@ def _launch_tui(
         env["HERMES_TUI_RESUME"] = resume_session_id
 
     argv, cwd = _make_tui_argv(tui_dir, tui_dev)
-    code: Optional[int] = None
+    code: int | None = None
     try:
         try:
             code = subprocess.call(argv, cwd=str(cwd), env=env)
@@ -3772,7 +3772,7 @@ def _model_flow_custom(config):
     )
 
 
-def _prompt_custom_api_mode_selection(base_url: str, current_api_mode: str = "") -> Optional[str]:
+def _prompt_custom_api_mode_selection(base_url: str, current_api_mode: str = "") -> str | None:
     """Prompt for a custom provider API mode.
 
     Returns an explicit mode string, or None to keep auto-detect behavior.
@@ -7102,7 +7102,7 @@ def _update_via_zip(args):
     _kill_stale_dashboard_processes()
 
 
-def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[str]:
+def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> str | None:
     status = subprocess.run(
         git_cmd + ["status", "--porcelain"],
         cwd=cwd,
@@ -7150,7 +7150,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
 
 def _resolve_stash_selector(
     git_cmd: list[str], cwd: Path, stash_ref: str
-) -> Optional[str]:
+) -> str | None:
     stash_list = subprocess.run(
         git_cmd + ["stash", "list", "--format=%gd %H"],
         cwd=cwd,
@@ -7166,7 +7166,7 @@ def _resolve_stash_selector(
 
 
 def _print_stash_cleanup_guidance(
-    stash_ref: str, stash_selector: Optional[str] = None
+    stash_ref: str, stash_selector: str | None = None
 ) -> None:
     print(
         "  Check `git status` first so you don't accidentally reapply the same change twice."
@@ -7302,7 +7302,7 @@ OFFICIAL_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
 
 
-def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
+def _get_origin_url(git_cmd: list[str], cwd: Path) -> str | None:
     """Get the URL of the origin remote, or None if not set."""
     try:
         result = subprocess.run(
@@ -7318,7 +7318,7 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
     return None
 
 
-def _is_fork(origin_url: Optional[str]) -> bool:
+def _is_fork(origin_url: str | None) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
         return False

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -74,7 +74,7 @@ def _prompt(question: str, *, password: bool = False, default: str = "") -> str:
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
-def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
+def _get_mcp_servers(config: dict | None = None) -> Dict[str, dict]:
     """Return the ``mcp_servers`` dict from config, or empty dict."""
     if config is None:
         config = load_config()
@@ -109,7 +109,7 @@ def _env_key_for_server(name: str) -> str:
     return f"MCP_{name.upper().replace('-', '_')}_API_KEY"
 
 
-def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
+def _parse_env_assignments(raw_env: List[str] | None) -> Dict[str, str]:
     """Parse ``KEY=VALUE`` strings from CLI args into an env dict."""
     parsed: Dict[str, str] = {}
     for item in raw_env or []:
@@ -131,12 +131,12 @@ def _parse_env_assignments(raw_env: Optional[List[str]]) -> Dict[str, str]:
 def _apply_mcp_preset(
     name: str,
     *,
-    preset_name: Optional[str],
-    url: Optional[str],
-    command: Optional[str],
+    preset_name: str | None,
+    url: str | None,
+    command: str | None,
     cmd_args: List[str],
     server_config: Dict[str, Any],
-) -> tuple[Optional[str], Optional[str], List[str], bool]:
+) -> tuple[str | None, str | None, List[str], bool]:
     """Apply a known MCP preset when transport details were omitted."""
     if not preset_name:
         return url, command, cmd_args, False

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -244,7 +244,7 @@ def _strip_matching_provider_prefix(model_name: str, target_provider: str) -> st
     return model_name
 
 
-def detect_vendor(model_name: str) -> Optional[str]:
+def detect_vendor(model_name: str) -> str | None:
     """Detect the vendor slug from a bare model name.
 
     Uses the first hyphen-delimited token of the model name to look up

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -274,8 +274,8 @@ class ModelSwitchResult:
     warning_message: str = ""
     provider_label: str = ""
     resolved_via_alias: str = ""
-    capabilities: Optional[ModelCapabilities] = None
-    model_info: Optional[ModelInfo] = None
+    capabilities: ModelCapabilities | None = None
+    model_info: ModelInfo | None = None
     is_global: bool = False
 
 
@@ -450,7 +450,7 @@ def _model_sort_key(model_id: str, prefix: str) -> tuple:
 def resolve_alias(
     raw_input: str,
     current_provider: str,
-) -> Optional[tuple[str, str, str]]:
+) -> tuple[str, str, str] | None:
     """Resolve a short alias against the current provider's catalog.
 
     Looks up *raw_input* in :data:`MODEL_ALIASES`, then searches the
@@ -549,7 +549,7 @@ def get_authenticated_provider_slugs(
 def _resolve_alias_fallback(
     raw_input: str,
     authenticated_providers: list[str] = (),
-) -> Optional[tuple[str, str, str]]:
+) -> tuple[str, str, str] | None:
     """Try to resolve an alias on the user's authenticated providers.
 
     Falls back to ``("openrouter", "nous")`` only when no authenticated
@@ -568,10 +568,10 @@ def resolve_display_context_length(
     provider: str,
     base_url: str = "",
     api_key: str = "",
-    model_info: Optional[ModelInfo] = None,
+    model_info: ModelInfo | None = None,
     custom_providers: list | None = None,
     config_context_length: int | None = None,
-) -> Optional[int]:
+) -> int | None:
     """Resolve the context length to show in /model output.
 
     models.dev reports per-vendor context (e.g. gpt-5.5 = 1.05M on openai)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -838,7 +838,7 @@ def _resolve_nous_portal_url() -> str:
         return "https://portal.nousresearch.com"
 
 
-def _extract_model_name(entry: Any) -> Optional[str]:
+def _extract_model_name(entry: Any) -> str | None:
     """Pull the ``modelName`` field from a recommended-model entry, else None."""
     if not isinstance(entry, dict):
         return None
@@ -851,10 +851,10 @@ def _extract_model_name(entry: Any) -> Optional[str]:
 def get_nous_recommended_aux_model(
     *,
     vision: bool = False,
-    free_tier: Optional[bool] = None,
+    free_tier: bool | None = None,
     portal_base_url: str = "",
     force_refresh: bool = False,
-) -> Optional[str]:
+) -> str | None:
     """Return the Portal's recommended model name for an auxiliary task.
 
     Picks the best field from the Portal's recommended-models payload:
@@ -1710,7 +1710,7 @@ def _get_custom_base_url() -> str:
 
 
 def curated_models_for_provider(
-    provider: Optional[str],
+    provider: str | None,
     *,
     force_refresh: bool = False,
 ) -> list[tuple[str, str]]:
@@ -1756,7 +1756,7 @@ _AGGREGATOR_PROVIDERS = frozenset(
 def _resolve_static_model_alias(
     name_lower: str,
     current_keys: set[str],
-) -> Optional[tuple[str, str]]:
+) -> tuple[str, str] | None:
     """Resolve short aliases (e.g. sonnet/opus) using static catalogs only."""
     try:
         from hermes_cli.model_switch import MODEL_ALIASES
@@ -1770,7 +1770,7 @@ def _resolve_static_model_alias(
     vendor = identity.vendor
     family = identity.family
 
-    def _match(provider: str) -> Optional[str]:
+    def _match(provider: str) -> str | None:
         models = _PROVIDER_MODELS.get(provider, [])
         if not models:
             return None
@@ -1804,7 +1804,7 @@ def _resolve_static_model_alias(
 def detect_static_provider_for_model(
     model_name: str,
     current_provider: str,
-) -> Optional[tuple[str, str]]:
+) -> tuple[str, str] | None:
     """Auto-detect a provider from static catalogs only.
 
     Returns ``(provider_id, model_name)``. The model name may be remapped
@@ -1855,7 +1855,7 @@ def detect_static_provider_for_model(
 def detect_provider_for_model(
     model_name: str,
     current_provider: str,
-) -> Optional[tuple[str, str]]:
+) -> tuple[str, str] | None:
     """Auto-detect the best provider for a model name.
 
     Returns ``(provider_id, model_name)`` — the model name may be remapped
@@ -1891,7 +1891,7 @@ def detect_provider_for_model(
     return None
 
 
-def _find_openrouter_slug(model_name: str) -> Optional[str]:
+def _find_openrouter_slug(model_name: str) -> str | None:
     """Find the full OpenRouter model slug for a bare or partial model name.
 
     Handles:
@@ -1918,7 +1918,7 @@ def _find_openrouter_slug(model_name: str) -> Optional[str]:
     return None
 
 
-def normalize_provider(provider: Optional[str]) -> str:
+def normalize_provider(provider: str | None) -> str:
     """Normalize provider aliases to Hermes' canonical provider ids.
 
     Note: ``"auto"`` passes through unchanged — use
@@ -1929,7 +1929,7 @@ def normalize_provider(provider: Optional[str]) -> str:
     return _PROVIDER_ALIASES.get(normalized, normalized)
 
 
-def provider_label(provider: Optional[str]) -> str:
+def provider_label(provider: str | None) -> str:
     """Return a human-friendly label for a provider id or alias."""
     original = (provider or "openrouter").strip()
     normalized = original.lower()
@@ -1956,7 +1956,7 @@ _OPENAI_FAST_MODE_PREFIXES: tuple[str, ...] = (
 )
 
 
-def _is_openai_fast_model(model_id: Optional[str]) -> bool:
+def _is_openai_fast_model(model_id: str | None) -> bool:
     """Return True if the model is an OpenAI flagship eligible for Priority Processing."""
     raw = _strip_vendor_prefix(str(model_id or ""))
     base = raw.split(":")[0]
@@ -1986,12 +1986,12 @@ def _strip_vendor_prefix(model_id: str) -> str:
     return raw
 
 
-def model_supports_fast_mode(model_id: Optional[str]) -> bool:
+def model_supports_fast_mode(model_id: str | None) -> bool:
     """Return whether Hermes should expose the /fast toggle for this model."""
     return _is_anthropic_fast_model(model_id) or _is_openai_fast_model(model_id)
 
 
-def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
+def _is_anthropic_fast_model(model_id: str | None) -> bool:
     """Return True if the model is a Claude model eligible for Anthropic Fast Mode.
 
     Fast mode is currently supported on Claude Opus 4.6 only. Per Anthropic's
@@ -2008,7 +2008,7 @@ def _is_anthropic_fast_model(model_id: Optional[str]) -> bool:
     return "opus-4-6" in base or "opus-4.6" in base
 
 
-def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | None:
+def resolve_fast_mode_overrides(model_id: str | None) -> dict[str, Any] | None:
     """Return request_overrides for fast/priority mode, or None if unsupported.
 
     Returns provider-appropriate overrides:
@@ -2154,7 +2154,7 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     return merged
 
 
-def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
+def provider_model_ids(provider: str | None, *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
     Tries live API endpoints for providers that support them (Codex, Nous),
@@ -2311,7 +2311,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
     return curated_static
 
 
-def _fetch_anthropic_models(timeout: float = 5.0) -> Optional[list[str]]:
+def _fetch_anthropic_models(timeout: float = 5.0) -> list[str] | None:
     """Fetch available models from the Anthropic /v1/models endpoint.
 
     Uses resolve_anthropic_token() to find credentials (env vars or
@@ -2441,8 +2441,8 @@ def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
 
 
 def fetch_github_model_catalog(
-    api_key: Optional[str] = None, timeout: float = 5.0
-) -> Optional[list[dict[str, Any]]]:
+    api_key: str | None = None, timeout: float = 5.0
+) -> list[dict[str, Any]] | None:
     """Fetch the live GitHub Copilot model catalog for this account."""
     attempts: list[dict[str, str]] = []
     if api_key:
@@ -2483,7 +2483,7 @@ _copilot_context_cache_time: float = 0.0
 _COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
-def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> Optional[int]:
+def get_copilot_model_context(model_id: str, api_key: str | None = None) -> int | None:
     """Look up max_prompt_tokens for a Copilot model from the live /models API.
 
     Results are cached in-process for 1 hour to avoid repeated API calls.
@@ -2520,7 +2520,7 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
     return cache.get(model_id)
 
 
-def _is_github_models_base_url(base_url: Optional[str]) -> bool:
+def _is_github_models_base_url(base_url: str | None) -> bool:
     normalized = (base_url or "").strip().rstrip("/").lower()
     return (
         normalized.startswith(COPILOT_BASE_URL)
@@ -2529,7 +2529,7 @@ def _is_github_models_base_url(base_url: Optional[str]) -> bool:
     )
 
 
-def _lmstudio_server_root(base_url: Optional[str]) -> Optional[str]:
+def _lmstudio_server_root(base_url: str | None) -> str | None:
     """Strip ``/v1`` suffix from an LM Studio base URL to get the native API root.
 
     Returns ``None`` when the base URL is empty/invalid.
@@ -2540,7 +2540,7 @@ def _lmstudio_server_root(base_url: Optional[str]) -> Optional[str]:
     return root or None
 
 
-def _lmstudio_request_headers(api_key: Optional[str] = None) -> dict:
+def _lmstudio_request_headers(api_key: str | None = None) -> dict:
     """Build HTTP headers for LM Studio native API requests."""
     headers = {"User-Agent": _HERMES_USER_AGENT}
     token = str(api_key or "").strip()
@@ -2550,10 +2550,10 @@ def _lmstudio_request_headers(api_key: Optional[str] = None) -> dict:
 
 
 def _lmstudio_fetch_raw_models(
-    api_key: Optional[str] = None,
-    base_url: Optional[str] = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
     timeout: float = 5.0,
-) -> Optional[list[dict]]:
+) -> list[dict] | None:
     """Fetch the raw model list from LM Studio's ``/api/v1/models``.
 
     Returns the ``models`` list of dicts on success, ``None`` on network
@@ -2600,10 +2600,10 @@ def _lmstudio_fetch_raw_models(
 
 
 def probe_lmstudio_models(
-    api_key: Optional[str] = None,
-    base_url: Optional[str] = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
     timeout: float = 5.0,
-) -> Optional[list[str]]:
+) -> list[str] | None:
     """Probe LM Studio's model listing.
 
     Returns chat-capable model keys on success, including the valid empty-list
@@ -2631,8 +2631,8 @@ def probe_lmstudio_models(
 
 
 def fetch_lmstudio_models(
-    api_key: Optional[str] = None,
-    base_url: Optional[str] = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
     timeout: float = 5.0,
 ) -> list[str]:
     """Fetch LM Studio chat-capable model keys from native ``/api/v1/models``.
@@ -2651,11 +2651,11 @@ def fetch_lmstudio_models(
 
 def ensure_lmstudio_model_loaded(
     model: str,
-    base_url: Optional[str],
-    api_key: Optional[str],
+    base_url: str | None,
+    api_key: str | None,
     target_context_length: int,
     timeout: float = 120.0,
-) -> Optional[int]:
+) -> int | None:
     """Ensure LM Studio has ``model`` loaded with at least ``target_context_length``.
 
     No-op when an instance is already loaded with sufficient context. Otherwise
@@ -2720,8 +2720,8 @@ def ensure_lmstudio_model_loaded(
 
 def lmstudio_model_reasoning_options(
     model: str,
-    base_url: Optional[str],
-    api_key: Optional[str] = None,
+    base_url: str | None,
+    api_key: str | None = None,
     timeout: float = 5.0,
 ) -> list[str]:
     """Return the reasoning ``allowed_options`` LM Studio publishes for ``model``.
@@ -2751,7 +2751,7 @@ def lmstudio_model_reasoning_options(
     return []
 
 
-def _fetch_github_models(api_key: Optional[str] = None, timeout: float = 5.0) -> Optional[list[str]]:
+def _fetch_github_models(api_key: str | None = None, timeout: float = 5.0) -> list[str] | None:
     catalog = fetch_github_model_catalog(api_key=api_key, timeout=timeout)
     if not catalog:
         return None
@@ -2798,8 +2798,8 @@ _COPILOT_MODEL_ALIASES = {
 
 
 def _copilot_catalog_ids(
-    catalog: Optional[list[dict[str, Any]]] = None,
-    api_key: Optional[str] = None,
+    catalog: list[dict[str, Any]] | None = None,
+    api_key: str | None = None,
 ) -> set[str]:
     if catalog is None and api_key:
         catalog = fetch_github_model_catalog(api_key=api_key)
@@ -2813,10 +2813,10 @@ def _copilot_catalog_ids(
 
 
 def normalize_copilot_model_id(
-    model_id: Optional[str],
+    model_id: str | None,
     *,
-    catalog: Optional[list[dict[str, Any]]] = None,
-    api_key: Optional[str] = None,
+    catalog: list[dict[str, Any]] | None = None,
+    api_key: str | None = None,
 ) -> str:
     raw = str(model_id or "").strip()
     if not raw:
@@ -2881,10 +2881,10 @@ def _should_use_copilot_responses_api(model_id: str) -> bool:
 
 
 def copilot_model_api_mode(
-    model_id: Optional[str],
+    model_id: str | None,
     *,
-    catalog: Optional[list[dict[str, Any]]] = None,
-    api_key: Optional[str] = None,
+    catalog: list[dict[str, Any]] | None = None,
+    api_key: str | None = None,
 ) -> str:
     """Determine the API mode for a Copilot model.
 
@@ -2938,7 +2938,7 @@ _AZURE_FOUNDRY_RESPONSES_PREFIXES = (
 )
 
 
-def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
+def azure_foundry_model_api_mode(model_name: str | None) -> str | None:
     """Infer Azure Foundry api_mode from a deployment/model name.
 
     Returns ``"codex_responses"`` when the model name matches a family that
@@ -2967,7 +2967,7 @@ def azure_foundry_model_api_mode(model_name: Optional[str]) -> Optional[str]:
     return None
 
 
-def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[str]) -> str:
+def normalize_opencode_model_id(provider_id: str | None, model_id: str | None) -> str:
     """Normalize OpenCode config IDs to the bare model slug used in API requests."""
     provider = normalize_provider(provider_id)
     current = str(model_id or "").strip()
@@ -2980,7 +2980,7 @@ def normalize_opencode_model_id(provider_id: Optional[str], model_id: Optional[s
     return current
 
 
-def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str]) -> str:
+def opencode_model_api_mode(provider_id: str | None, model_id: str | None) -> str:
     """Determine the API mode for an OpenCode Zen / Go model.
 
     OpenCode routes different models behind different API surfaces:
@@ -3015,10 +3015,10 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
 
 
 def github_model_reasoning_efforts(
-    model_id: Optional[str],
+    model_id: str | None,
     *,
-    catalog: Optional[list[dict[str, Any]]] = None,
-    api_key: Optional[str] = None,
+    catalog: list[dict[str, Any]] | None = None,
+    api_key: str | None = None,
 ) -> list[str]:
     """Return supported reasoning-effort levels for a Copilot-visible model."""
     normalized = normalize_copilot_model_id(model_id, catalog=catalog, api_key=api_key)
@@ -3059,10 +3059,10 @@ def github_model_reasoning_efforts(
 
 
 def probe_api_models(
-    api_key: Optional[str],
-    base_url: Optional[str],
+    api_key: str | None,
+    base_url: str | None,
     timeout: float = 5.0,
-    api_mode: Optional[str] = None,
+    api_mode: str | None = None,
 ) -> dict[str, Any]:
     """Probe a ``/models`` endpoint with light URL heuristics.
 
@@ -3136,7 +3136,7 @@ def probe_api_models(
     }
 
 
-def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
+def _fetch_ai_gateway_models(timeout: float = 5.0) -> list[str] | None:
     """Fetch available language models with tool-use from AI Gateway."""
     api_key = os.getenv("AI_GATEWAY_API_KEY", "").strip()
     if not api_key:
@@ -3167,11 +3167,11 @@ def _fetch_ai_gateway_models(timeout: float = 5.0) -> Optional[list[str]]:
 
 
 def fetch_api_models(
-    api_key: Optional[str],
-    base_url: Optional[str],
+    api_key: str | None,
+    base_url: str | None,
     timeout: float = 5.0,
-    api_mode: Optional[str] = None,
-) -> Optional[list[str]]:
+    api_mode: str | None = None,
+) -> list[str] | None:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
@@ -3208,7 +3208,7 @@ def _ollama_cloud_cache_path() -> Path:
     return get_hermes_home() / "ollama_cloud_models_cache.json"
 
 
-def _load_ollama_cloud_cache(*, ignore_ttl: bool = False) -> Optional[dict]:
+def _load_ollama_cloud_cache(*, ignore_ttl: bool = False) -> dict | None:
     """Load cached Ollama Cloud models from disk.
 
     Args:
@@ -3247,8 +3247,8 @@ def _save_ollama_cloud_cache(models: list[str]) -> None:
 
 
 def fetch_ollama_cloud_models(
-    api_key: Optional[str] = None,
-    base_url: Optional[str] = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
     *,
     force_refresh: bool = False,
 ) -> list[str]:
@@ -3315,11 +3315,11 @@ def fetch_ollama_cloud_models(
 
 def validate_requested_model(
     model_name: str,
-    provider: Optional[str],
+    provider: str | None,
     *,
-    api_key: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_mode: Optional[str] = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    api_mode: str | None = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -226,7 +226,7 @@ def _resolve_browser_feature_state(
 
 
 def get_nous_subscription_features(
-    config: Optional[Dict[str, object]] = None,
+    config: Dict[str, object] | None = None,
 ) -> NousSubscriptionFeatures:
     if config is None:
         config = load_config() or {}
@@ -492,7 +492,7 @@ def get_nous_subscription_features(
 def apply_nous_managed_defaults(
     config: Dict[str, object],
     *,
-    enabled_toolsets: Optional[Iterable[str]] = None,
+    enabled_toolsets: Iterable[str] | None = None,
 ) -> set[str]:
     if not managed_nous_tools_enabled():
         return set()
@@ -593,7 +593,7 @@ _ALL_GATEWAY_KEYS = ("web", "image_gen", "tts", "browser")
 
 
 def get_gateway_eligible_tools(
-    config: Optional[Dict[str, object]] = None,
+    config: Dict[str, object] | None = None,
 ) -> tuple[list[str], list[str], list[str]]:
     """Return (unconfigured, has_direct, already_managed) tool key lists.
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -124,8 +124,8 @@ def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | No
 
 def run_oneshot(
     prompt: str,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
+    model: str | None = None,
+    provider: str | None = None,
     toolsets: object = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
@@ -217,8 +217,8 @@ def _create_session_db_for_oneshot():
 
 def _run_agent(
     prompt: str,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
+    model: str | None = None,
+    provider: str | None = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
 ) -> str:
@@ -253,7 +253,7 @@ def _run_agent(
     # the user's configured default provider, which may not host the model
     # the caller just asked for.
     effective_provider = (provider or "").strip() or None
-    explicit_base_url_from_alias: Optional[str] = None
+    explicit_base_url_from_alias: str | None = None
     if effective_provider is None and (model or env_model):
         # Only auto-detect when the model was explicitly requested via arg or
         # env var (not when it came from config — that's the "use my defaults"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -193,7 +193,7 @@ def _get_disabled_plugins() -> set:
         return set()
 
 
-def _get_enabled_plugins() -> Optional[set]:
+def _get_enabled_plugins() -> set | None:
     """Read the enabled-plugins allow-list from config.yaml.
 
     Plugins are opt-in by default — only plugins whose name appears in
@@ -242,7 +242,7 @@ class PluginManifest:
     provides_tools: List[str] = field(default_factory=list)
     provides_hooks: List[str] = field(default_factory=list)
     source: str = ""        # "user", "project", or "entrypoint"
-    path: Optional[str] = None
+    path: str | None = None
     # Plugin kind — see plugins.py module docstring for semantics.
     # ``standalone`` (default): hooks/tools of its own; opt-in via
     #                           ``plugins.enabled``.
@@ -272,12 +272,12 @@ class LoadedPlugin:
     """Runtime state for a single loaded plugin."""
 
     manifest: PluginManifest
-    module: Optional[types.ModuleType] = None
+    module: types.ModuleType | None = None
     tools_registered: List[str] = field(default_factory=list)
     hooks_registered: List[str] = field(default_factory=list)
     commands_registered: List[str] = field(default_factory=list)
     enabled: bool = False
-    error: Optional[str] = None
+    error: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -744,7 +744,7 @@ class PluginContext:
         *,
         display_name: str,
         description: str,
-        defaults: Optional[Dict[str, Any]] = None,
+        defaults: Dict[str, Any] | None = None,
     ) -> None:
         """Register a plugin-defined auxiliary LLM task.
 
@@ -1117,7 +1117,7 @@ class PluginManager:
         self,
         path: Path,
         source: str,
-        skip_names: Optional[Set[str]] = None,
+        skip_names: Set[str] | None = None,
     ) -> List[PluginManifest]:
         """Read ``plugin.yaml`` manifests from subdirectories of *path*.
 
@@ -1143,7 +1143,7 @@ class PluginManager:
         path: Path,
         source: str,
         *,
-        skip_names: Optional[Set[str]],
+        skip_names: Set[str] | None,
         prefix: str,
         depth: int,
     ) -> List[PluginManifest]:
@@ -1200,7 +1200,7 @@ class PluginManager:
         plugin_dir: Path,
         source: str,
         prefix: str,
-    ) -> Optional[PluginManifest]:
+    ) -> PluginManifest | None:
         """Parse a single ``plugin.yaml`` into a :class:`PluginManifest`.
 
         Returns ``None`` on parse failure (logs a warning).
@@ -1513,7 +1513,7 @@ class PluginManager:
     # Plugin skill lookups
     # -----------------------------------------------------------------------
 
-    def find_plugin_skill(self, qualified_name: str) -> Optional[Path]:
+    def find_plugin_skill(self, qualified_name: str) -> Path | None:
         """Return the ``Path`` to a plugin skill's SKILL.md, or ``None``."""
         entry = self._plugin_skills.get(qualified_name)
         return entry["path"] if entry else None
@@ -1536,7 +1536,7 @@ class PluginManager:
 # Module-level singleton & convenience functions
 # ---------------------------------------------------------------------------
 
-_plugin_manager: Optional[PluginManager] = None
+_plugin_manager: PluginManager | None = None
 
 
 def get_plugin_manager() -> PluginManager:
@@ -1569,7 +1569,7 @@ _thread_tool_whitelist = threading.local()
 
 
 def set_thread_tool_whitelist(
-    allowed: Optional[Set[str]],
+    allowed: Set[str] | None,
     deny_msg_fmt: str = "Tool '{tool_name}' denied: not in this thread's tool whitelist",
 ) -> None:
     _thread_tool_whitelist.allowed = allowed
@@ -1582,11 +1582,11 @@ def clear_thread_tool_whitelist() -> None:
 
 def get_pre_tool_call_block_message(
     tool_name: str,
-    args: Optional[Dict[str, Any]],
+    args: Dict[str, Any] | None,
     task_id: str = "",
     session_id: str = "",
     tool_call_id: str = "",
-) -> Optional[str]:
+) -> str | None:
     """Check ``pre_tool_call`` hooks for a blocking directive.
 
     Plugins that need to enforce policy (rate limiting, security
@@ -1639,7 +1639,7 @@ def get_plugin_context_engine():
     return _ensure_plugins_discovered()._context_engine
 
 
-def get_plugin_command_handler(name: str) -> Optional[Callable]:
+def get_plugin_command_handler(name: str) -> Callable | None:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 @functools.lru_cache(maxsize=1)
-def _resolve_git_executable() -> Optional[str]:
+def _resolve_git_executable() -> str | None:
     """Resolve a git binary for subprocess use when ``PATH`` may be minimal.
 
     Matches other Hermes subprocess resolution: :func:`shutil.which` first,
@@ -458,7 +458,7 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
 def cmd_install(
     identifier: str,
     force: bool = False,
-    enable: Optional[bool] = None,
+    enable: bool | None = None,
 ) -> None:
     """Install a plugin from a Git URL or owner/repo shorthand.
 
@@ -1407,7 +1407,7 @@ def dashboard_install_plugin(
     }
 
 
-def _get_plugin_toolset_key(name: str) -> Optional[str]:
+def _get_plugin_toolset_key(name: str) -> str | None:
     """Return the toolset key a plugin registers its tools under, or None.
 
     Queries the live tool registry — the plugin must already be loaded.
@@ -1524,7 +1524,7 @@ def dashboard_set_agent_plugin_enabled(name: str, *, enabled: bool) -> dict[str,
     return {"ok": True, "name": name, "unchanged": False}
 
 
-def _user_installed_plugin_dir(name: str) -> Optional[Path]:
+def _user_installed_plugin_dir(name: str) -> Path | None:
     """Resolved path under ``~/.hermes/plugins/<name>`` if it exists."""
     plugins_dir = _plugins_dir()
     try:

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -95,7 +95,7 @@ class DescribeOutcome:
     profile_name: str
     ok: bool
     reason: str = ""
-    description: Optional[str] = None
+    description: str | None = None
 
 
 def _collect_skills(profile_dir: Path) -> list[str]:
@@ -136,7 +136,7 @@ def _collect_skills(profile_dir: Path) -> list[str]:
     return sampled
 
 
-def _extract_json_blob(raw: str) -> Optional[dict]:
+def _extract_json_blob(raw: str) -> dict | None:
     if not raw:
         return None
     stripped = _FENCE_RE.sub("", raw.strip())
@@ -158,7 +158,7 @@ def describe_profile(
     profile_name: str,
     *,
     overwrite: bool = False,
-    timeout: Optional[int] = None,
+    timeout: int | None = None,
 ) -> DescribeOutcome:
     """Auto-generate a description for one profile.
 

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -138,7 +138,7 @@ class EnvRequirement:
     name: str
     description: str = ""
     required: bool = True
-    default: Optional[str] = None
+    default: str | None = None
 
     @classmethod
     def from_dict(cls, data: Any) -> "EnvRequirement":
@@ -256,7 +256,7 @@ def _dump_yaml(data: Any) -> str:
     return yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
 
 
-def read_manifest(profile_dir: Path) -> Optional[DistributionManifest]:
+def read_manifest(profile_dir: Path) -> DistributionManifest | None:
     """Return the manifest for *profile_dir*, or None if it isn't a distribution."""
     mf_path = profile_dir / MANIFEST_FILENAME
     if not mf_path.is_file():
@@ -473,7 +473,7 @@ def _count_skills(staged: Path) -> int:
 def plan_install(
     source: str,
     workdir: Path,
-    override_name: Optional[str] = None,
+    override_name: str | None = None,
 ) -> InstallPlan:
     """Stage *source* and produce a plan describing what install would do."""
     from hermes_cli.profiles import (
@@ -585,7 +585,7 @@ def _bootstrap_user_dirs(target: Path) -> None:
 
 def install_distribution(
     source: str,
-    name: Optional[str] = None,
+    name: str | None = None,
     force: bool = False,
     create_alias: bool = False,
 ) -> InstallPlan:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -316,7 +316,7 @@ def profile_exists(name: str) -> bool:
 # Alias / wrapper script management
 # ---------------------------------------------------------------------------
 
-def check_alias_collision(name: str) -> Optional[str]:
+def check_alias_collision(name: str) -> str | None:
     """Return a human-readable collision message, or None if the name is safe.
 
     Checks: reserved names, hermes subcommands, existing binaries in PATH.
@@ -356,7 +356,7 @@ def _is_wrapper_dir_in_path() -> bool:
     return wrapper_dir in os.environ.get("PATH", "").split(os.pathsep)
 
 
-def create_wrapper_script(name: str) -> Optional[Path]:
+def create_wrapper_script(name: str) -> Path | None:
     """Create a shell wrapper script at ~/.local/bin/<name>.
 
     Returns the path to the created wrapper, or None if creation failed.
@@ -405,15 +405,15 @@ class ProfileInfo:
     path: Path
     is_default: bool
     gateway_running: bool
-    model: Optional[str] = None
-    provider: Optional[str] = None
+    model: str | None = None
+    provider: str | None = None
     has_env: bool = False
     skill_count: int = 0
-    alias_path: Optional[Path] = None
+    alias_path: Path | None = None
     # Distribution metadata (None if the profile wasn't installed from a distribution).
-    distribution_name: Optional[str] = None
-    distribution_version: Optional[str] = None
-    distribution_source: Optional[str] = None
+    distribution_name: str | None = None
+    distribution_version: str | None = None
+    distribution_source: str | None = None
     # Free-form description (1-2 sentences) of what this profile is good
     # at. Persisted in ``<profile_dir>/profile.yaml``. Empty when the
     # user has not described the profile (legacy profiles, fresh
@@ -539,8 +539,8 @@ def read_profile_meta(profile_dir: Path) -> dict:
 def write_profile_meta(
     profile_dir: Path,
     *,
-    description: Optional[str] = None,
-    description_auto: Optional[bool] = None,
+    description: str | None = None,
+    description_auto: bool | None = None,
 ) -> None:
     """Update ``<profile_dir>/profile.yaml`` in place.
 
@@ -635,12 +635,12 @@ def list_profiles() -> List[ProfileInfo]:
 
 def create_profile(
     name: str,
-    clone_from: Optional[str] = None,
+    clone_from: str | None = None,
     clone_all: bool = False,
     clone_config: bool = False,
     no_alias: bool = False,
     no_skills: bool = False,
-    description: Optional[str] = None,
+    description: str | None = None,
 ) -> Path:
     """Create a new profile directory.
 
@@ -788,7 +788,7 @@ def create_profile(
     return profile_dir
 
 
-def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> Optional[dict]:
+def seed_profile_skills(profile_dir: Path, quiet: bool = False) -> dict | None:
     """Seed bundled skills into a profile via subprocess.
 
     Uses subprocess because sync_skills() caches HERMES_HOME at module level.
@@ -1365,7 +1365,7 @@ def _inspect_profile_archive_roots(archive: Path) -> set[str]:
     return top_dirs
 
 
-def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
+def import_profile(archive_path: str, name: str | None = None) -> Path:
     """Import a profile from a tar.gz archive.
 
     If *name* is not given, infers it from the archive's top-level directory.

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -407,7 +407,7 @@ def normalize_provider(name: str) -> str:
     return ALIASES.get(key, key)
 
 
-def get_provider(name: str) -> Optional[ProviderDef]:
+def get_provider(name: str) -> ProviderDef | None:
     """Look up a built-in provider by id or alias.
 
     Resolution order:
@@ -545,7 +545,7 @@ def determine_api_mode(provider: str, base_url: str = "") -> str:
 
 # -- Provider from user config ------------------------------------------------
 
-def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[ProviderDef]:
+def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> ProviderDef | None:
     """Resolve a provider from the user's config.yaml ``providers:`` section.
 
     Args:
@@ -596,8 +596,8 @@ def custom_provider_slug(display_name: str) -> str:
 
 def resolve_custom_provider(
     name: str,
-    custom_providers: Optional[List[Dict[str, Any]]],
-) -> Optional[ProviderDef]:
+    custom_providers: List[Dict[str, Any]] | None,
+) -> ProviderDef | None:
     """Resolve a provider from the user's config.yaml ``custom_providers`` list."""
     if not custom_providers or not isinstance(custom_providers, list):
         return None
@@ -665,9 +665,9 @@ def resolve_custom_provider(
 
 def resolve_provider_full(
     name: str,
-    user_providers: Optional[Dict[str, Any]] = None,
-    custom_providers: Optional[List[Dict[str, Any]]] = None,
-) -> Optional[ProviderDef]:
+    user_providers: Dict[str, Any] | None = None,
+    custom_providers: List[Dict[str, Any]] | None = None,
+) -> ProviderDef | None:
     """Full resolution chain: built-in → models.dev → user config.
 
     This is the main entry point for --provider flag resolution.

--- a/hermes_cli/proxy/adapters/base.py
+++ b/hermes_cli/proxy/adapters/base.py
@@ -31,7 +31,7 @@ class UpstreamCredential:
     token_type: str = "Bearer"
     """Auth scheme — currently always ``Bearer`` for supported providers."""
 
-    expires_at: Optional[str] = None
+    expires_at: str | None = None
     """ISO-8601 expiry timestamp for the bearer, when known. Informational."""
 
 
@@ -86,7 +86,7 @@ class UpstreamAdapter(ABC):
         *,
         failed_credential: UpstreamCredential,
         status_code: int,
-    ) -> Optional[UpstreamCredential]:
+    ) -> UpstreamCredential | None:
         """Return an alternate credential after an upstream auth failure.
 
         The default is no retry. Providers can override this for one-shot

--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -89,7 +89,7 @@ class NousPortalAdapter(UpstreamAdapter):
         *,
         failed_credential: UpstreamCredential,
         status_code: int,
-    ) -> Optional[UpstreamCredential]:
+    ) -> UpstreamCredential | None:
         if status_code != 401:
             return None
         if failed_credential.bearer.count(".") != 2:
@@ -155,7 +155,7 @@ class NousPortalAdapter(UpstreamAdapter):
     # to hermes_cli.auth to avoid expanding that module's public surface.
     # ------------------------------------------------------------------
 
-    def _read_state(self) -> Optional[Dict[str, Any]]:
+    def _read_state(self) -> Dict[str, Any] | None:
         try:
             with _auth_store_lock():
                 store = _load_auth_store()
@@ -172,8 +172,8 @@ class NousPortalAdapter(UpstreamAdapter):
         self,
         state: Dict[str, Any],
         *,
-        quarantine_error: Optional[AuthError] = None,
-        quarantine_reason: Optional[str] = None,
+        quarantine_error: AuthError | None = None,
+        quarantine_reason: str | None = None,
     ) -> None:
         try:
             with _auth_store_lock():

--- a/hermes_cli/proxy/adapters/xai.py
+++ b/hermes_cli/proxy/adapters/xai.py
@@ -35,7 +35,7 @@ class XAIGrokAdapter(UpstreamAdapter):
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._pool: Optional[CredentialPool] = None
+        self._pool: CredentialPool | None = None
 
     @property
     def name(self) -> str:
@@ -78,7 +78,7 @@ class XAIGrokAdapter(UpstreamAdapter):
         *,
         failed_credential: UpstreamCredential,
         status_code: int,
-    ) -> Optional[UpstreamCredential]:
+    ) -> UpstreamCredential | None:
         if status_code != 401:
             return None
 
@@ -99,7 +99,7 @@ class XAIGrokAdapter(UpstreamAdapter):
             logger.info("proxy: xAI upstream rejected bearer; retrying with refreshed pool credential")
             return retry_cred
 
-    def _load_pool(self) -> Optional[CredentialPool]:
+    def _load_pool(self) -> CredentialPool | None:
         try:
             return load_pool(_POOL_PROVIDER)
         except Exception as exc:

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -256,7 +256,7 @@ async def run_server(
     adapter: UpstreamAdapter,
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
-    shutdown_event: Optional[asyncio.Event] = None,
+    shutdown_event: asyncio.Event | None = None,
 ) -> None:
     """Run the proxy in the current event loop until shutdown_event is set.
 

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -87,8 +87,8 @@ class PtyBridge:
         cls,
         argv: Sequence[str],
         *,
-        cwd: Optional[str] = None,
-        env: Optional[dict] = None,
+        cwd: str | None = None,
+        env: dict | None = None,
         cols: int = 80,
         rows: int = 24,
     ) -> "PtyBridge":
@@ -141,7 +141,7 @@ class PtyBridge:
 
     # -- I/O --------------------------------------------------------------
 
-    def read(self, timeout: float = 0.2) -> Optional[bytes]:
+    def read(self, timeout: float = 0.2) -> bytes | None:
         """Read up to 64 KiB of raw bytes from the PTY master.
 
         Returns:

--- a/hermes_cli/relaunch.py
+++ b/hermes_cli/relaunch.py
@@ -77,7 +77,7 @@ def _extract_inherited_flags(argv: Sequence[str]) -> list[str]:
     return flags
 
 
-def resolve_hermes_bin() -> Optional[str]:
+def resolve_hermes_bin() -> str | None:
     """Find the hermes entry point.
 
     Priority:
@@ -125,7 +125,7 @@ def build_relaunch_argv(
     extra_args: Sequence[str],
     *,
     preserve_inherited: bool = True,
-    original_argv: Optional[Sequence[str]] = None,
+    original_argv: Sequence[str] | None = None,
 ) -> list[str]:
     """Construct an argv list for replacing the current process with hermes.
 
@@ -156,7 +156,7 @@ def relaunch(
     extra_args: Sequence[str],
     *,
     preserve_inherited: bool = True,
-    original_argv: Optional[Sequence[str]] = None,
+    original_argv: Sequence[str] | None = None,
 ) -> None:
     """Replace the current process with a fresh hermes invocation.
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -73,7 +73,7 @@ def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider
     return _loopback_hostname(base_url_hostname(bu))
 
 
-def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
+def _detect_api_mode_for_url(base_url: str) -> str | None:
     """Auto-detect api_mode from the resolved base URL.
 
     - Direct api.openai.com endpoints need the Responses API for GPT-5.x
@@ -202,7 +202,7 @@ def _get_model_config() -> Dict[str, Any]:
     return {}
 
 
-def _provider_supports_explicit_api_mode(provider: Optional[str], configured_provider: Optional[str] = None) -> bool:
+def _provider_supports_explicit_api_mode(provider: str | None, configured_provider: str | None = None) -> bool:
     """Check whether a persisted api_mode should be honored for a given provider.
 
     Prevents stale api_mode from a previous provider leaking into a
@@ -251,7 +251,7 @@ _VALID_API_MODES = {
 }
 
 
-def _parse_api_mode(raw: Any) -> Optional[str]:
+def _parse_api_mode(raw: Any) -> str | None:
     """Validate an api_mode value from config. Returns None if invalid."""
     if isinstance(raw, str):
         normalized = raw.strip().lower()
@@ -264,7 +264,7 @@ def _maybe_apply_codex_app_server_runtime(
     *,
     provider: str,
     api_mode: str,
-    model_cfg: Optional[Dict[str, Any]],
+    model_cfg: Dict[str, Any] | None,
 ) -> str:
     """Optional opt-in: rewrite api_mode → "codex_app_server" for OpenAI/Codex
     providers when the user has explicitly enabled that runtime via
@@ -291,9 +291,9 @@ def _resolve_runtime_from_pool_entry(
     provider: str,
     entry: PooledCredential,
     requested_provider: str,
-    model_cfg: Optional[Dict[str, Any]] = None,
-    pool: Optional[CredentialPool] = None,
-    target_model: Optional[str] = None,
+    model_cfg: Dict[str, Any] | None = None,
+    pool: CredentialPool | None = None,
+    target_model: str | None = None,
 ) -> Dict[str, Any]:
     model_cfg = model_cfg or _get_model_config()
     # When the caller is resolving for a specific target model (e.g. a /model
@@ -423,7 +423,7 @@ def _resolve_runtime_from_pool_entry(
     }
 
 
-def resolve_requested_provider(requested: Optional[str] = None) -> str:
+def resolve_requested_provider(requested: str | None = None) -> str:
     """Resolve provider request from explicit arg, config, then env."""
     if requested and requested.strip():
         return requested.strip().lower()
@@ -445,9 +445,9 @@ def resolve_requested_provider(requested: Optional[str] = None) -> str:
 def _try_resolve_from_custom_pool(
     base_url: str,
     provider_label: str,
-    api_mode_override: Optional[str] = None,
-    provider_name: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+    api_mode_override: str | None = None,
+    provider_name: str | None = None,
+) -> Dict[str, Any] | None:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
     if not pool_key:
@@ -474,7 +474,7 @@ def _try_resolve_from_custom_pool(
         return None
 
 
-def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
+def _get_named_custom_provider(requested_provider: str) -> Dict[str, Any] | None:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm or requested_norm == "custom":
         return None
@@ -626,9 +626,9 @@ def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[
 def _resolve_named_custom_runtime(
     *,
     requested_provider: str,
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
+) -> Dict[str, Any] | None:
     # Bare `provider="custom"` with an explicit base_url (e.g. propagated
     # from a `model_aliases:` direct-alias resolution) — build a runtime
     # directly so the alias's base_url actually takes effect.
@@ -745,8 +745,8 @@ def _resolve_named_custom_runtime(
 def _resolve_openrouter_runtime(
     *,
     requested_provider: str,
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
 ) -> Dict[str, Any]:
     model_cfg = _get_model_config()
     cfg_base_url = model_cfg.get("base_url") if isinstance(model_cfg.get("base_url"), str) else ""
@@ -886,9 +886,9 @@ def _resolve_azure_foundry_runtime(
     *,
     requested_provider: str,
     model_cfg: Dict[str, Any],
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
-    target_model: Optional[str] = None,
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
+    target_model: str | None = None,
 ) -> Dict[str, Any]:
     """Resolve an Azure Foundry runtime entry.
 
@@ -1056,9 +1056,9 @@ def _resolve_explicit_runtime(
     provider: str,
     requested_provider: str,
     model_cfg: Dict[str, Any],
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
-) -> Optional[Dict[str, Any]]:
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
+) -> Dict[str, Any] | None:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
     if not explicit_api_key and not explicit_base_url:
@@ -1199,10 +1199,10 @@ def _resolve_explicit_runtime(
 
 def resolve_runtime_provider(
     *,
-    requested: Optional[str] = None,
-    explicit_api_key: Optional[str] = None,
-    explicit_base_url: Optional[str] = None,
-    target_model: Optional[str] = None,
+    requested: str | None = None,
+    explicit_api_key: str | None = None,
+    explicit_base_url: str | None = None,
+    target_model: str | None = None,
 ) -> Dict[str, Any]:
     """Resolve runtime provider credentials for agent execution.
 

--- a/hermes_cli/secrets_cli.py
+++ b/hermes_cli/secrets_cli.py
@@ -441,7 +441,7 @@ def _bws_version(binary: Path) -> str:
 
 def _list_projects(
     binary: Path, token: str, console: Console, *, server_url: str = ""
-) -> Optional[List[dict]]:
+) -> List[dict] | None:
     """Call ``bws project list`` and return the parsed list, or None on failure."""
     env = os.environ.copy()
     env["BWS_ACCESS_TOKEN"] = token
@@ -502,7 +502,7 @@ def _resolve_server_url(
     args: argparse.Namespace,
     secrets_cfg: dict,
     console: Console,
-) -> Optional[str]:
+) -> str | None:
     """Pick a Bitwarden server URL for setup.
 
     Resolution order:

--- a/hermes_cli/security_advisories.py
+++ b/hermes_cli/security_advisories.py
@@ -141,7 +141,7 @@ class AdvisoryHit:
     installed_version: str
 
 
-def _installed_version(pkg_name: str) -> Optional[str]:
+def _installed_version(pkg_name: str) -> str | None:
     """Return the installed version of ``pkg_name``, or None if not installed.
 
     Uses ``importlib.metadata`` so we don't depend on pip being importable
@@ -322,7 +322,7 @@ _BANNER_CACHE_FILE = "advisory_banner_seen"
 _BANNER_REPEAT_HOURS = 24
 
 
-def _banner_cache_path() -> Optional[Path]:
+def _banner_cache_path() -> Path | None:
     try:
         from hermes_constants import get_hermes_home
         cache_dir = Path(get_hermes_home()) / "cache"
@@ -419,7 +419,7 @@ def render_doctor_section(hits: list[AdvisoryHit]) -> tuple[bool, list[str]]:
     return True, lines
 
 
-def startup_banner(hits: list[AdvisoryHit]) -> Optional[str]:
+def startup_banner(hits: list[AdvisoryHit]) -> str | None:
     """Return a printable startup banner, or None if nothing is due.
 
     Updates the banner cache as a side effect (so the next call within
@@ -436,7 +436,7 @@ def startup_banner(hits: list[AdvisoryHit]) -> Optional[str]:
     return "\n".join(lines)
 
 
-def gateway_log_message(hits: list[AdvisoryHit]) -> Optional[str]:
+def gateway_log_message(hits: list[AdvisoryHit]) -> str | None:
     """Return a one-line log message for gateway operators, or None."""
     fresh = filter_unacked(hits)
     if not fresh:

--- a/hermes_cli/security_audit.py
+++ b/hermes_cli/security_audit.py
@@ -213,7 +213,7 @@ _NPX_PKG = re.compile(r"^(@[A-Za-z0-9._-]+/[A-Za-z0-9._-]+|[A-Za-z0-9._-]+)@([A-
 _UVX_PKG = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([A-Za-z0-9._+!-]+)$")
 
 
-def _extract_mcp_component(server_name: str, command: str, args: list[str]) -> Optional[Component]:
+def _extract_mcp_component(server_name: str, command: str, args: list[str]) -> Component | None:
     """Best-effort: parse `command/args` into a (name, version, ecosystem).
 
     Returns None when the entry doesn't pin a version we can audit (local
@@ -340,7 +340,7 @@ def _osv_severity_from_record(record: dict) -> str:
         if upper in SEVERITY_ORDER:
             return upper
     # Fall back to CVSS score → tier
-    score: Optional[float] = None
+    score: float | None = None
     for sev_entry in record.get("severity") or []:
         s = sev_entry.get("score")
         if isinstance(s, str):
@@ -416,7 +416,7 @@ def run_audit(
     skip_venv: bool = False,
     skip_plugins: bool = False,
     skip_mcp: bool = False,
-    hermes_home: Optional[Path] = None,
+    hermes_home: Path | None = None,
 ) -> list[Finding]:
     """Discover components, query OSV, return findings sorted by severity desc."""
     home = hermes_home or Path(get_hermes_home())

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -39,9 +39,9 @@ _SUCCESS_EXIT = 0
 
 
 def _read_message_body(
-    positional: Optional[str],
-    file_path: Optional[str],
-) -> Optional[str]:
+    positional: str | None,
+    file_path: str | None,
+) -> str | None:
     """Resolve the message body from (in order):
 
     1. An explicit positional message argument.
@@ -74,7 +74,7 @@ def _read_message_body(
     return None
 
 
-def _resolve_target(arg_to: Optional[str]) -> Optional[str]:
+def _resolve_target(arg_to: str | None) -> str | None:
     """Return a cleaned ``--to`` value, or ``None`` when nothing is set."""
     if arg_to and arg_to.strip():
         return arg_to.strip()
@@ -126,7 +126,7 @@ def _emit_result(
     return _FAILURE_EXIT
 
 
-def _list_targets(platform_filter: Optional[str], *, json_mode: bool) -> int:
+def _list_targets(platform_filter: str | None, *, json_mode: bool) -> int:
     """Print the channel directory (all configured targets across platforms).
 
     Uses ``load_directory()`` for structured JSON output and

--- a/hermes_cli/session_recap.py
+++ b/hermes_cli/session_recap.py
@@ -135,7 +135,7 @@ def _count_visible_turns(
 
 def _latest_user_prompt(
     messages: Sequence[Mapping[str, Any]],
-) -> Optional[str]:
+) -> str | None:
     for msg in reversed(messages):
         if isinstance(msg, Mapping) and msg.get("role") == "user":
             text = _coerce_text(msg.get("content")).strip()
@@ -146,7 +146,7 @@ def _latest_user_prompt(
 
 def _latest_assistant_text(
     messages: Sequence[Mapping[str, Any]],
-) -> Optional[str]:
+) -> str | None:
     for msg in reversed(messages):
         if not isinstance(msg, Mapping):
             continue
@@ -238,9 +238,9 @@ def _truncate(text: str, limit: int) -> str:
 def build_recap(
     messages: Sequence[Mapping[str, Any]],
     *,
-    session_title: Optional[str] = None,
-    session_id: Optional[str] = None,
-    platform: Optional[str] = None,
+    session_title: str | None = None,
+    session_id: str | None = None,
+    platform: str | None = None,
 ) -> str:
     """Build a multi-line recap of recent activity.
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2707,7 +2707,7 @@ def _gateway_platform_short_label(label: str) -> str:
     return base or label
 
 
-def _get_section_config_summary(config: dict, section_key: str) -> Optional[str]:
+def _get_section_config_summary(config: dict, section_key: str) -> str | None:
     """Return a short summary if a setup section is already configured, else None.
 
     Used after OpenClaw migration to detect which sections can be skipped.

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -24,7 +24,7 @@ PLATFORMS = {k: info.label for k, info in _PLATFORMS.items() if k != "api_server
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
-def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str]:
+def get_disabled_skills(config: dict, platform: str | None = None) -> Set[str]:
     """Return disabled skill names. Platform-specific list falls back to global."""
     skills_cfg = config.get("skills", {})
     global_disabled = set(skills_cfg.get("disabled", []))
@@ -36,7 +36,7 @@ def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str
     return set(platform_disabled)
 
 
-def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):
+def save_disabled_skills(config: dict, disabled: Set[str], platform: str | None = None):
     """Persist disabled skill names to config."""
     config.setdefault("skills", {})
     if platform is None:
@@ -65,7 +65,7 @@ def _get_categories(skills: List[dict]) -> List[str]:
 
 # ─── Platform Selection ──────────────────────────────────────────────────────
 
-def _select_platform() -> Optional[str]:
+def _select_platform() -> str | None:
     """Ask user which platform to configure, or global."""
     options = [("global", "All platforms (global default)")] + list(PLATFORMS.items())
     print()

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -193,7 +193,7 @@ def _existing_categories() -> List[str]:
     return sorted(set(out))
 
 
-def _prompt_for_skill_name(c: Console, url: str, default: str = "") -> Optional[str]:
+def _prompt_for_skill_name(c: Console, url: str, default: str = "") -> str | None:
     """Prompt interactively for a skill name. Returns None on cancel/EOF."""
     c.print()
     c.print(
@@ -244,7 +244,7 @@ def _prompt_for_category(c: Console, existing: List[str]) -> str:
 
 
 def do_search(query: str, source: str = "all", limit: int = 10,
-              console: Optional[Console] = None) -> None:
+              console: Console | None = None) -> None:
     """Search registries and display results as a Rich table."""
     from tools.skills_hub import GitHubAuth, create_source_router, unified_search
 
@@ -284,7 +284,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
 
 
 def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
-              console: Optional[Console] = None) -> None:
+              console: Console | None = None) -> None:
     """Browse all available skills across registries, paginated.
 
     Official skills are always shown first, regardless of source filter.
@@ -412,7 +412,7 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
 
 
 def do_install(identifier: str, category: str = "", force: bool = False,
-               console: Optional[Console] = None, skip_confirm: bool = False,
+               console: Console | None = None, skip_confirm: bool = False,
                invalidate_cache: bool = True,
                name_override: str = "") -> None:
     """Fetch, quarantine, scan, confirm, and install a skill.
@@ -630,7 +630,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
         c.print("[dim]Use /reset to start a new session now, or --now to activate immediately (invalidates prompt cache).[/]\n")
 
 
-def do_inspect(identifier: str, console: Optional[Console] = None) -> None:
+def do_inspect(identifier: str, console: Console | None = None) -> None:
     """Preview a skill's SKILL.md content without installing."""
     from tools.skills_hub import GitHubAuth, create_source_router
 
@@ -726,7 +726,7 @@ def browse_skills(page: int = 1, page_size: int = 20, source: str = "all") -> di
     }
 
 
-def inspect_skill(identifier: str) -> Optional[dict]:
+def inspect_skill(identifier: str) -> dict | None:
     """Skill metadata (+ SKILL.md preview) for programmatic callers."""
     from tools.skills_hub import GitHubAuth, create_source_router
 
@@ -766,7 +766,7 @@ def inspect_skill(identifier: str) -> Optional[dict]:
 
 def do_list(source_filter: str = "all",
             enabled_only: bool = False,
-            console: Optional[Console] = None) -> None:
+            console: Console | None = None) -> None:
     """List installed skills, distinguishing hub, builtin, and local skills.
 
     Args:
@@ -863,7 +863,7 @@ def do_list(source_filter: str = "all",
     c.print(summary)
 
 
-def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> None:
+def do_check(name: str | None = None, console: Console | None = None) -> None:
     """Check hub-installed skills for upstream updates."""
     from tools.skills_hub import check_for_skill_updates
 
@@ -886,7 +886,7 @@ def do_check(name: Optional[str] = None, console: Optional[Console] = None) -> N
     c.print(f"[dim]{update_count} update(s) available across {len(results)} checked skill(s)[/]\n")
 
 
-def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> None:
+def do_update(name: str | None = None, console: Console | None = None) -> None:
     """Update hub-installed skills with upstream changes."""
     from tools.skills_hub import HubLockFile, check_for_skill_updates
 
@@ -906,7 +906,7 @@ def do_update(name: Optional[str] = None, console: Optional[Console] = None) -> 
     c.print(f"[bold green]Updated {len(updates)} skill(s).[/]\n")
 
 
-def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
+def do_audit(name: str | None = None, console: Console | None = None,
              deep: bool = False) -> None:
     """Re-run security scan on installed hub skills.
 
@@ -952,7 +952,7 @@ def do_audit(name: Optional[str] = None, console: Optional[Console] = None,
         c.print()
 
 
-def do_uninstall(name: str, console: Optional[Console] = None,
+def do_uninstall(name: str, console: Console | None = None,
                  skip_confirm: bool = False,
                  invalidate_cache: bool = True) -> None:
     """Remove a hub-installed skill with confirmation."""
@@ -988,7 +988,7 @@ def do_uninstall(name: str, console: Optional[Console] = None,
 
 
 def do_reset(name: str, restore: bool = False,
-             console: Optional[Console] = None,
+             console: Console | None = None,
              skip_confirm: bool = False,
              invalidate_cache: bool = True) -> None:
     """Reset a bundled skill's manifest tracking (+ optionally restore from bundled)."""
@@ -1032,7 +1032,7 @@ def do_reset(name: str, restore: bool = False,
         c.print("[dim]Use /reset to start a new session now, or --now to apply immediately (invalidates prompt cache).[/]\n")
 
 
-def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> None:
+def do_tap(action: str, repo: str = "", console: Console | None = None) -> None:
     """Manage taps (custom GitHub repo sources)."""
     from tools.skills_hub import TapsManager
 
@@ -1076,7 +1076,7 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
 
 
 def do_publish(skill_path: str, target: str = "github", repo: str = "",
-               console: Optional[Console] = None) -> None:
+               console: Console | None = None) -> None:
     """Publish a local skill to a registry (GitHub PR or ClawHub submission)."""
     from tools.skills_hub import GitHubAuth, SKILLS_DIR
     from tools.skills_guard import scan_skill, format_scan_report
@@ -1241,7 +1241,7 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
         return False, f"Network error creating PR: {e}"
 
 
-def do_snapshot_export(output_path: str, console: Optional[Console] = None) -> None:
+def do_snapshot_export(output_path: str, console: Console | None = None) -> None:
     """Export current hub skill configuration to a portable JSON file."""
     from tools.skills_hub import HubLockFile, TapsManager
 
@@ -1282,7 +1282,7 @@ def do_snapshot_export(output_path: str, console: Optional[Console] = None) -> N
 
 
 def do_snapshot_import(input_path: str, force: bool = False,
-                       console: Optional[Console] = None) -> None:
+                       console: Console | None = None) -> None:
     """Re-install skills from a snapshot file."""
     from tools.skills_hub import TapsManager
 
@@ -1393,7 +1393,7 @@ def skills_command(args) -> None:
 # Slash command entry point (/skills in chat)
 # ---------------------------------------------------------------------------
 
-def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
+def handle_skills_slash(cmd: str, console: Console | None = None) -> None:
     """
     Parse and dispatch `/skills <subcommand> [args]` from the chat interface.
 

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -649,7 +649,7 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
 # Skin loading and management
 # =============================================================================
 
-_active_skin: Optional[SkinConfig] = None
+_active_skin: SkinConfig | None = None
 _active_skin_name: str = "default"
 
 
@@ -658,7 +658,7 @@ def _skins_dir() -> Path:
     return get_hermes_home() / "skins"
 
 
-def _load_skin_from_yaml(path: Path) -> Optional[Dict[str, Any]]:
+def _load_skin_from_yaml(path: Path) -> Dict[str, Any] | None:
     """Load a skin definition from a YAML file."""
     try:
         import yaml

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1078,7 +1078,7 @@ def _get_enabled_platforms() -> List[str]:
     return enabled
 
 
-def _platform_toolset_summary(config: dict, platforms: Optional[List[str]] = None) -> Dict[str, Set[str]]:
+def _platform_toolset_summary(config: dict, platforms: List[str] | None = None) -> Dict[str, Set[str]]:
     """Return a summary of enabled toolsets per platform.
 
     When ``platforms`` is None, this uses ``_get_enabled_platforms`` to
@@ -1448,7 +1448,7 @@ def _prompt_choice(question: str, choices: list, default: int = 0) -> int:
 # ─── Token Estimation ────────────────────────────────────────────────────────
 
 # Module-level cache so discovery + tokenization runs at most once per process.
-_tool_token_cache: Optional[Dict[str, int]] = None
+_tool_token_cache: Dict[str, int] | None = None
 
 
 def _estimate_tool_tokens() -> Dict[str, int]:

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -296,9 +296,9 @@ _continuous_recorder: Any = None
 # leak into the mic.
 _tts_playing = threading.Event()
 _tts_playing.set()  # initially "not playing"
-_continuous_on_transcript: Optional[Callable[[str], None]] = None
-_continuous_on_status: Optional[Callable[[str], None]] = None
-_continuous_on_silent_limit: Optional[Callable[[], None]] = None
+_continuous_on_transcript: Callable[[str], None] | None = None
+_continuous_on_status: Callable[[str], None] | None = None
+_continuous_on_silent_limit: Callable[[], None] | None = None
 _continuous_no_speech_count = 0
 _CONTINUOUS_NO_SPEECH_LIMIT = 3
 
@@ -321,7 +321,7 @@ def start_recording() -> None:
         _recorder = rec
 
 
-def stop_and_transcribe() -> Optional[str]:
+def stop_and_transcribe() -> str | None:
     """Stop the active push-to-talk recording, transcribe, return text.
 
     Returns ``None`` when no recording is active, when the microphone
@@ -368,8 +368,8 @@ def stop_and_transcribe() -> Optional[str]:
 
 def start_continuous(
     on_transcript: Callable[[str], None],
-    on_status: Optional[Callable[[str], None]] = None,
-    on_silent_limit: Optional[Callable[[], None]] = None,
+    on_status: Callable[[str], None] | None = None,
+    on_silent_limit: Callable[[], None] | None = None,
     silence_threshold: int = 200,
     silence_duration: float = 3.0,
     auto_restart: bool = True,
@@ -492,7 +492,7 @@ def stop_continuous(force_transcribe: bool = False) -> None:
 
             def _transcribe_and_cleanup():
                 global _continuous_no_speech_count, _continuous_stopping
-                transcript: Optional[str] = None
+                transcript: str | None = None
                 should_halt = False
 
                 try:
@@ -615,7 +615,7 @@ def _continuous_on_silence() -> None:
     # CoreAudio conflict that blocks pre-start beeps).
     _play_beep(frequency=660, count=2)
 
-    transcript: Optional[str] = None
+    transcript: str | None = None
 
     if wav_path:
         try:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -757,8 +757,8 @@ async def get_action_status(name: str, lines: int = 200):
     proc = _ACTION_PROCS.get(name)
     if proc is None:
         running = False
-        exit_code: Optional[int] = None
-        pid: Optional[int] = None
+        exit_code: int | None = None
+        pid: int | None = None
     else:
         exit_code = proc.poll()
         running = exit_code is None
@@ -1284,7 +1284,7 @@ async def reveal_env_var(body: EnvVarReveal, request: Request):
 # can surface a one-click copy.
 
 
-def _truncate_token(value: Optional[str], visible: int = 6) -> str:
+def _truncate_token(value: str | None, visible: int = 6) -> str:
     """Return ``...XXXXXX`` (last N chars) for safe display in the UI.
 
     We never expose more than the trailing ``visible`` characters of an
@@ -2516,9 +2516,9 @@ async def delete_session_endpoint(session_id: str):
 async def get_logs(
     file: str = "agent",
     lines: int = 100,
-    level: Optional[str] = None,
-    component: Optional[str] = None,
-    search: Optional[str] = None,
+    level: str | None = None,
+    component: str | None = None,
+    search: str | None = None,
 ):
     from hermes_cli.logs import _read_tail, LOG_FILES
 
@@ -2594,7 +2594,7 @@ def _cron_profile_dicts() -> List[Dict[str, Any]]:
         return _fallback_profile_dicts(profiles_mod)
 
 
-def _cron_profile_home(profile: Optional[str]) -> Tuple[str, Path]:
+def _cron_profile_home(profile: str | None) -> Tuple[str, Path]:
     """Resolve a profile query value to (profile_name, HERMES_HOME)."""
     from hermes_cli import profiles as profiles_mod
 
@@ -2618,7 +2618,7 @@ def _annotate_cron_job(job: Dict[str, Any], profile: str, home: Path) -> Dict[st
     return annotated
 
 
-def _call_cron_for_profile(profile: Optional[str], func_name: str, *args, **kwargs):
+def _call_cron_for_profile(profile: str | None, func_name: str, *args, **kwargs):
     """Run cron.jobs helpers against the selected profile's cron directory.
 
     cron.jobs keeps CRON_DIR/JOBS_FILE/OUTPUT_DIR as module globals resolved
@@ -2650,7 +2650,7 @@ def _call_cron_for_profile(profile: Optional[str], func_name: str, *args, **kwar
     return result
 
 
-def _find_cron_job_profile(job_id: str) -> Optional[str]:
+def _find_cron_job_profile(job_id: str) -> str | None:
     for profile in _cron_profile_dicts():
         name = str(profile.get("name") or "")
         if not name:
@@ -2680,7 +2680,7 @@ async def list_cron_jobs(profile: str = "all"):
 
 
 @app.get("/api/cron/jobs/{job_id}")
-async def get_cron_job(job_id: str, profile: Optional[str] = None):
+async def get_cron_job(job_id: str, profile: str | None = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -2707,7 +2707,7 @@ async def create_cron_job(body: CronJobCreate, profile: str = "default"):
 
 
 @app.put("/api/cron/jobs/{job_id}")
-async def update_cron_job(job_id: str, body: CronJobUpdate, profile: Optional[str] = None):
+async def update_cron_job(job_id: str, body: CronJobUpdate, profile: str | None = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -2718,7 +2718,7 @@ async def update_cron_job(job_id: str, body: CronJobUpdate, profile: Optional[st
 
 
 @app.post("/api/cron/jobs/{job_id}/pause")
-async def pause_cron_job(job_id: str, profile: Optional[str] = None):
+async def pause_cron_job(job_id: str, profile: str | None = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -2729,7 +2729,7 @@ async def pause_cron_job(job_id: str, profile: Optional[str] = None):
 
 
 @app.post("/api/cron/jobs/{job_id}/resume")
-async def resume_cron_job(job_id: str, profile: Optional[str] = None):
+async def resume_cron_job(job_id: str, profile: str | None = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -2740,7 +2740,7 @@ async def resume_cron_job(job_id: str, profile: Optional[str] = None):
 
 
 @app.post("/api/cron/jobs/{job_id}/trigger")
-async def trigger_cron_job(job_id: str, profile: Optional[str] = None):
+async def trigger_cron_job(job_id: str, profile: str | None = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -2751,7 +2751,7 @@ async def trigger_cron_job(job_id: str, profile: Optional[str] = None):
 
 
 @app.delete("/api/cron/jobs/{job_id}")
-async def delete_cron_job(job_id: str, profile: Optional[str] = None):
+async def delete_cron_job(job_id: str, profile: str | None = None):
     selected = profile or _find_cron_job_profile(job_id)
     if not selected:
         raise HTTPException(status_code=404, detail="Job not found")
@@ -3366,9 +3366,9 @@ _event_lock = asyncio.Lock()
 
 
 def _resolve_chat_argv(
-    resume: Optional[str] = None,
-    sidecar_url: Optional[str] = None,
-) -> tuple[list[str], Optional[str], Optional[dict]]:
+    resume: str | None = None,
+    sidecar_url: str | None = None,
+) -> tuple[list[str], str | None, dict | None]:
     """Resolve the argv + cwd + env for the chat PTY.
 
     Default: whatever ``hermes --tui`` would run.  Tests monkeypatch this
@@ -3410,7 +3410,7 @@ def _resolve_chat_argv(
     return list(argv), str(cwd) if cwd else None, env
 
 
-def _build_sidecar_url(channel: str) -> Optional[str]:
+def _build_sidecar_url(channel: str) -> str | None:
     """ws:// URL the PTY child should publish events to, or None when unbound."""
     host = getattr(app.state, "bound_host", None)
     port = getattr(app.state, "bound_port", None)
@@ -3438,7 +3438,7 @@ async def _broadcast_event(channel: str, payload: str) -> None:
             _log.warning("broadcast send failed for subscriber on %s", channel, exc_info=True)
 
 
-def _channel_or_close_code(ws: WebSocket) -> Optional[str]:
+def _channel_or_close_code(ws: WebSocket) -> str | None:
     """Return the channel id from the query string or None if invalid."""
     channel = ws.query_params.get("channel", "")
 
@@ -3671,7 +3671,7 @@ async def events_ws(ws: WebSocket) -> None:
                     _event_channels.pop(channel, None)
 
 
-def _normalise_prefix(raw: Optional[str]) -> str:
+def _normalise_prefix(raw: str | None) -> str:
     """Normalise an X-Forwarded-Prefix header value.
 
     Returns a string like ``"/hermes"`` (no trailing slash) or ``""`` when
@@ -3804,7 +3804,7 @@ _BUILTIN_DASHBOARD_THEMES = [
 ]
 
 
-def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0) -> Optional[Dict[str, Any]]:
+def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0) -> Dict[str, Any] | None:
     """Normalise a theme layer spec from YAML into `{hex, alpha}` form.
 
     Accepts shorthand (a bare hex string) or full dict form.  Returns
@@ -3873,7 +3873,7 @@ _THEME_LAYOUT_VARIANTS = {"standard", "cockpit", "tiled"}
 _THEME_CUSTOM_CSS_MAX = 32 * 1024
 
 
-def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _normalise_theme_definition(data: Dict[str, Any]) -> Dict[str, Any] | None:
     """Normalise a user theme YAML into the wire format `ThemeProvider`
     expects.  Returns ``None`` if the theme is unusable.
 
@@ -3966,7 +3966,7 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
     # here — the dashboard is localhost-only and themes are user-authored
     # YAML in ~/.hermes/, same trust level as the config file itself.
     custom_css_val = data.get("customCSS")
-    custom_css: Optional[str] = None
+    custom_css: str | None = None
     if isinstance(custom_css_val, str) and custom_css_val.strip():
         custom_css = custom_css_val[:_THEME_CUSTOM_CSS_MAX]
 
@@ -4090,7 +4090,7 @@ async def set_dashboard_theme(body: ThemeSetBody):
 # Dashboard plugin system
 # ---------------------------------------------------------------------------
 
-def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional[str]:
+def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> str | None:
     """Validate the manifest's ``api`` field for the plugin loader.
 
     The web server later imports this file as a Python module via
@@ -4232,7 +4232,7 @@ def _discover_dashboard_plugins() -> list:
 
 
 # Cache discovered plugins per-process (refresh on explicit re-scan).
-_dashboard_plugins_cache: Optional[list] = None
+_dashboard_plugins_cache: list | None = None
 
 
 def _get_dashboard_plugins(force_rescan: bool = False) -> list:
@@ -4483,8 +4483,8 @@ async def delete_agent_plugin(request: Request, name: str):
 
 
 class _PluginProvidersPutBody(BaseModel):
-    memory_provider: Optional[str] = None
-    context_engine: Optional[str] = None
+    memory_provider: str | None = None
+    context_engine: str | None = None
 
 
 @app.put("/api/dashboard/plugin-providers")

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -20,7 +20,7 @@ RETIREMENT_DATE = "May 15, 2026"
 # Some entries set ``reasoning_effort`` because non-reasoning variants don't
 # have a one-to-one replacement: ``grok-4.3`` reasons by default, so emulating
 # ``*-non-reasoning`` behavior on it requires ``reasoning_effort="none"``.
-_RETIRED_MODELS: Dict[str, Dict[str, Optional[str]]] = {
+_RETIRED_MODELS: Dict[str, Dict[str, str | None]] = {
     "grok-4-0709":                  {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
     "grok-4-fast-reasoning":        {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
     "grok-4-fast-non-reasoning":    {"replacement": "grok-4.3", "reasoning_effort": "none", "note": None},
@@ -39,8 +39,8 @@ class RetirementIssue:
     config_path: str            # e.g. "principal.model" or "auxiliary.vision.model"
     current_model: str          # exact value found in config (preserves casing/prefix)
     replacement: str            # recommended xAI replacement
-    reasoning_effort: Optional[str] = None  # set if non-reasoning variant migration
-    note: Optional[str] = None  # disambiguation note when applicable
+    reasoning_effort: str | None = None  # set if non-reasoning variant migration
+    note: str | None = None  # disambiguation note when applicable
 
 
 def _normalize(model_id: str) -> str:
@@ -53,7 +53,7 @@ def _normalize(model_id: str) -> str:
     return m
 
 
-def _looks_like_xai(model_id: Optional[str]) -> bool:
+def _looks_like_xai(model_id: str | None) -> bool:
     if not isinstance(model_id, str) or not model_id.strip():
         return False
     return _normalize(model_id).startswith("grok-")
@@ -146,7 +146,7 @@ class ApplyResult:
     """Outcome of an apply_migration call."""
 
     file_path: Path
-    backup_path: Optional[Path]
+    backup_path: Path | None
     issues_resolved: List[RetirementIssue]
     config_changed: bool
 
@@ -234,7 +234,7 @@ def apply_migration(
             config_changed=False,
         )
 
-    backup_path: Optional[Path] = None
+    backup_path: Path | None = None
     if backup:
         ts = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
         backup_path = config_path.with_name(

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -155,11 +155,11 @@ COMPONENT_PREFIXES = {
 
 def setup_logging(
     *,
-    hermes_home: Optional[Path] = None,
-    log_level: Optional[str] = None,
-    max_size_mb: Optional[int] = None,
-    backup_count: Optional[int] = None,
-    mode: Optional[str] = None,
+    hermes_home: Path | None = None,
+    log_level: str | None = None,
+    max_size_mb: int | None = None,
+    backup_count: int | None = None,
+    mode: str | None = None,
     force: bool = False,
 ) -> Path:
     """Configure the Hermes logging subsystem.
@@ -335,7 +335,7 @@ def _add_rotating_handler(
     max_bytes: int,
     backup_count: int,
     formatter: logging.Formatter,
-    log_filter: Optional[logging.Filter] = None,
+    log_filter: logging.Filter | None = None,
 ) -> None:
     """Add a ``RotatingFileHandler`` to *logger*, skipping if one already
     exists for the same resolved file path (idempotent).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -63,7 +63,7 @@ _WAL_INCOMPAT_MARKERS = (
 # Only SessionDB.__init__ writes to this; kanban_db.connect() failures
 # do not update it (by design — kanban failures are reported via their
 # own caller's error handling, not via /resume-style slash commands).
-_last_init_error: Optional[str] = None
+_last_init_error: str | None = None
 _last_init_error_lock = threading.Lock()
 
 # Paths for which we've already logged a WAL-fallback WARNING.  Without
@@ -74,7 +74,7 @@ _wal_fallback_warned_paths: set[str] = set()
 _wal_fallback_warned_lock = threading.Lock()
 
 
-def _set_last_init_error(msg: Optional[str]) -> None:
+def _set_last_init_error(msg: str | None) -> None:
     """Record (or clear) the most recent state.db init failure.
 
     Thread-safe via _last_init_error_lock.  Callers pass a message to
@@ -91,7 +91,7 @@ def _set_last_init_error(msg: Optional[str]) -> None:
         _last_init_error = msg
 
 
-def get_last_init_error() -> Optional[str]:
+def get_last_init_error() -> str | None:
     """Return the most recent state.db init failure, if any.
 
     Slash-command handlers (``/resume``, ``/title``, ``/history``, ``/branch``)
@@ -389,7 +389,7 @@ class SessionDB:
 
         Returns whatever *fn* returns.
         """
-        last_err: Optional[Exception] = None
+        last_err: Exception | None = None
         for attempt in range(self._WRITE_MAX_RETRIES):
             try:
                 with self._lock:
@@ -774,14 +774,14 @@ class SessionDB:
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
         reasoning_tokens: int = 0,
-        estimated_cost_usd: Optional[float] = None,
-        actual_cost_usd: Optional[float] = None,
-        cost_status: Optional[str] = None,
-        cost_source: Optional[str] = None,
-        pricing_version: Optional[str] = None,
-        billing_provider: Optional[str] = None,
-        billing_base_url: Optional[str] = None,
-        billing_mode: Optional[str] = None,
+        estimated_cost_usd: float | None = None,
+        actual_cost_usd: float | None = None,
+        cost_status: str | None = None,
+        cost_source: str | None = None,
+        pricing_version: str | None = None,
+        billing_provider: str | None = None,
+        billing_base_url: str | None = None,
+        billing_mode: str | None = None,
         api_call_count: int = 0,
         absolute: bool = False,
     ) -> None:
@@ -875,7 +875,7 @@ class SessionDB:
         self._insert_session_row(session_id, source, model=model, **kwargs)
         return session_id
 
-    def prune_empty_ghost_sessions(self, sessions_dir: "Optional[Path]" = None) -> int:
+    def prune_empty_ghost_sessions(self, sessions_dir: "Path | None" = None) -> int:
         """Remove empty TUI ghost sessions (no messages, no title, >24hr old)."""
         cutoff = time.time() - 86400  # Only sessions older than 24 hours
 
@@ -944,7 +944,7 @@ class SessionDB:
 
         return self._execute_write(_do) or 0
 
-    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def get_session(self, session_id: str) -> Dict[str, Any] | None:
         """Get a session by ID."""
         with self._lock:
             cursor = self._conn.execute(
@@ -953,7 +953,7 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
+    def resolve_session_id(self, session_id_or_prefix: str) -> str | None:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
 
         Returns the exact ID when it exists. Otherwise treats the input as a
@@ -984,7 +984,7 @@ class SessionDB:
     MAX_TITLE_LENGTH = 100
 
     @staticmethod
-    def sanitize_title(title: Optional[str]) -> Optional[str]:
+    def sanitize_title(title: str | None) -> str | None:
         """Validate and sanitize a session title.
 
         - Strips leading/trailing whitespace
@@ -1056,7 +1056,7 @@ class SessionDB:
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
-    def get_session_title(self, session_id: str) -> Optional[str]:
+    def get_session_title(self, session_id: str) -> str | None:
         """Get the title for a session, or None."""
         with self._lock:
             cursor = self._conn.execute(
@@ -1065,7 +1065,7 @@ class SessionDB:
             row = cursor.fetchone()
         return row["title"] if row else None
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+    def get_session_by_title(self, title: str) -> Dict[str, Any] | None:
         """Look up a session by exact title. Returns session dict or None."""
         with self._lock:
             cursor = self._conn.execute(
@@ -1074,7 +1074,7 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(self, title: str) -> str | None:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
@@ -1138,7 +1138,7 @@ class SessionDB:
 
         return f"{base} #{max_num + 1}"
 
-    def get_compression_tip(self, session_id: str) -> Optional[str]:
+    def get_compression_tip(self, session_id: str) -> str | None:
         """Walk the compression-continuation chain forward and return the tip.
 
         A compression continuation is a child session where:
@@ -1364,7 +1364,7 @@ class SessionDB:
 
         return sessions
 
-    def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def _get_session_rich_row(self, session_id: str) -> Dict[str, Any] | None:
         """Fetch a single session with the same enriched columns as
         ``list_sessions_rich`` (preview + last_active). Returns None if the
         session doesn't exist.
@@ -1734,7 +1734,7 @@ class SessionDB:
         around_message_id: int,
         window: int = 5,
         bookend: int = 3,
-        keep_roles: Optional[Tuple[str, ...]] = ("user", "assistant"),
+        keep_roles: Tuple[str, ...] | None = ("user", "assistant"),
     ) -> Dict[str, Any]:
         """Return an anchored window plus session bookends.
 
@@ -2482,7 +2482,7 @@ class SessionDB:
     # Export and cleanup
     # =========================================================================
 
-    def export_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def export_session(self, session_id: str) -> Dict[str, Any] | None:
         """Export a single session with all its messages as a dict."""
         session = self.get_session(session_id)
         if not session:
@@ -2515,7 +2515,7 @@ class SessionDB:
         self._execute_write(_do)
 
     @staticmethod
-    def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
+    def _remove_session_files(sessions_dir: Path | None, session_id: str) -> None:
         """Remove on-disk transcript files for a session.
 
         Cleans up ``{session_id}.json``, ``{session_id}.jsonl``, and any
@@ -2544,7 +2544,7 @@ class SessionDB:
     def delete_session(
         self,
         session_id: str,
-        sessions_dir: Optional[Path] = None,
+        sessions_dir: Path | None = None,
     ) -> bool:
         """Delete a session and all its messages.
 
@@ -2579,7 +2579,7 @@ class SessionDB:
         self,
         older_than_days: int = 90,
         source: str = None,
-        sessions_dir: Optional[Path] = None,
+        sessions_dir: Path | None = None,
     ) -> int:
         """Delete sessions older than N days. Returns count of deleted sessions.
 
@@ -2632,7 +2632,7 @@ class SessionDB:
 
     # ── Meta key/value (for scheduler bookkeeping) ──
 
-    def get_meta(self, key: str) -> Optional[str]:
+    def get_meta(self, key: str) -> str | None:
         """Read a value from the state_meta key/value store."""
         with self._lock:
             row = self._conn.execute(
@@ -2757,8 +2757,8 @@ class SessionDB:
         *,
         chat_id: str,
         user_id: str,
-        has_topics_enabled: Optional[bool] = None,
-        allows_users_to_create_topics: Optional[bool] = None,
+        has_topics_enabled: bool | None = None,
+        allows_users_to_create_topics: bool | None = None,
     ) -> None:
         """Enable Telegram DM topic mode for one private chat/user.
 
@@ -2768,7 +2768,7 @@ class SessionDB:
         self.apply_telegram_topic_migration()
         now = time.time()
 
-        def _to_int(value: Optional[bool]) -> Optional[int]:
+        def _to_int(value: bool | None) -> int | None:
             if value is None:
                 return None
             return 1 if value else 0
@@ -2857,7 +2857,7 @@ class SessionDB:
         *,
         chat_id: str,
         thread_id: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any] | None:
         """Return the session binding for a Telegram DM topic, if present."""
         with self._lock:
             try:
@@ -2897,7 +2897,7 @@ class SessionDB:
         self,
         *,
         session_id: str,
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any] | None:
         """Return the Telegram DM topic binding for a given session_id, if present.
 
         Uses the UNIQUE INDEX on telegram_dm_topic_bindings(session_id) for an
@@ -3109,7 +3109,7 @@ class SessionDB:
         retention_days: int = 90,
         min_interval_hours: int = 24,
         vacuum: bool = True,
-        sessions_dir: Optional[Path] = None,
+        sessions_dir: Path | None = None,
     ) -> Dict[str, Any]:
         """Idempotent auto-maintenance: prune old sessions + optional VACUUM.
 
@@ -3208,7 +3208,7 @@ class SessionDB:
             return cur.rowcount > 0
         return self._execute_write(_do)
 
-    def get_handoff_state(self, session_id: str) -> Optional[Dict[str, Any]]:
+    def get_handoff_state(self, session_id: str) -> Dict[str, Any] | None:
         """Read the current handoff state for a session.
 
         Returns ``{"state", "platform", "error"}`` or None if the session has

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -29,8 +29,8 @@ except ImportError:
 
 # Cached state — resolved once, reused on every call.
 # Call reset_cache() to force re-resolution (e.g. after config changes).
-_cached_tz: Optional[ZoneInfo] = None
-_cached_tz_name: Optional[str] = None
+_cached_tz: ZoneInfo | None = None
+_cached_tz_name: str | None = None
 _cache_resolved: bool = False
 
 
@@ -61,7 +61,7 @@ def _resolve_timezone_name() -> str:
     return ""
 
 
-def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
+def _get_zoneinfo(name: str) -> ZoneInfo | None:
     """Validate and return a ZoneInfo, or None if invalid."""
     if not name:
         return None
@@ -75,7 +75,7 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
 
 
-def get_timezone() -> Optional[ZoneInfo]:
+def get_timezone() -> ZoneInfo | None:
     """Return the user's configured ZoneInfo, or None (meaning server-local).
 
     Resolved once and cached. Call ``reset_cache()`` after config changes.

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -215,7 +215,7 @@ class EventBridge:
         self._lock = threading.Lock()
         self._new_event = threading.Event()
         self._running = False
-        self._thread: Optional[threading.Thread] = None
+        self._thread: threading.Thread | None = None
         self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
@@ -244,7 +244,7 @@ class EventBridge:
     def poll_events(
         self,
         after_cursor: int = 0,
-        session_key: Optional[str] = None,
+        session_key: str | None = None,
         limit: int = 20,
     ) -> dict:
         """Return events since after_cursor, optionally filtered by session_key."""
@@ -268,9 +268,9 @@ class EventBridge:
     def wait_for_event(
         self,
         after_cursor: int = 0,
-        session_key: Optional[str] = None,
+        session_key: str | None = None,
         timeout_ms: int = 30000,
-    ) -> Optional[dict]:
+    ) -> dict | None:
         """Block until a matching event arrives or timeout expires."""
         deadline = time.monotonic() + (timeout_ms / 1000.0)
 
@@ -447,7 +447,7 @@ class EventBridge:
 # MCP Server
 # ---------------------------------------------------------------------------
 
-def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
+def create_mcp_server(event_bridge: EventBridge | None = None) -> "FastMCP":
     """Create and return the Hermes MCP server with all tools registered."""
     if not _MCP_SERVER_AVAILABLE:
         raise ImportError(
@@ -470,9 +470,9 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
 
     @mcp.tool()
     def conversations_list(
-        platform: Optional[str] = None,
+        platform: str | None = None,
         limit: int = 50,
-        search: Optional[str] = None,
+        search: str | None = None,
     ) -> str:
         """List active messaging conversations across connected platforms.
 
@@ -670,7 +670,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
     @mcp.tool()
     def events_poll(
         after_cursor: int = 0,
-        session_key: Optional[str] = None,
+        session_key: str | None = None,
         limit: int = 20,
     ) -> str:
         """Poll for new conversation events since a cursor position.
@@ -699,7 +699,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
     @mcp.tool()
     def events_wait(
         after_cursor: int = 0,
-        session_key: Optional[str] = None,
+        session_key: str | None = None,
         timeout_ms: int = 30000,
     ) -> str:
         """Wait for the next conversation event (long-poll).
@@ -767,7 +767,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
     # -- channels_list -----------------------------------------------------
 
     @mcp.tool()
-    def channels_list(platform: Optional[str] = None) -> str:
+    def channels_list(platform: str | None = None) -> str:
         """List available messaging channels and targets across platforms.
 
         Returns channels that you can send messages to. The target strings

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -46,8 +46,8 @@ load_dotenv()
 
 def _effective_temperature_for_model(
     model: str,
-    base_url: Optional[str] = None,
-) -> Optional[float]:
+    base_url: str | None = None,
+) -> float | None:
     """Return a fixed temperature for models with strict sampling contracts.
 
     Returns ``None`` when the model manages temperature server-side (Kimi);

--- a/model_tools.py
+++ b/model_tools.py
@@ -114,7 +114,7 @@ def _run_async(coro):
         # worker, which previously leaked the thread on every 300 s timeout).
         import concurrent.futures
 
-        worker_loop: Optional[asyncio.AbstractEventLoop] = None
+        worker_loop: asyncio.AbstractEventLoop | None = None
         loop_ready = threading.Event()
 
         def _run_in_worker():
@@ -741,11 +741,11 @@ def _coerce_boolean(value: str):
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
-    task_id: Optional[str] = None,
-    tool_call_id: Optional[str] = None,
-    session_id: Optional[str] = None,
-    user_task: Optional[str] = None,
-    enabled_tools: Optional[List[str]] = None,
+    task_id: str | None = None,
+    tool_call_id: str | None = None,
+    session_id: str | None = None,
+    user_task: str | None = None,
+    enabled_tools: List[str] | None = None,
     skip_pre_tool_call_hook: bool = False,
 ) -> str:
     """
@@ -782,7 +782,7 @@ def handle_function_call(
         # pass. When skip=True, the caller already fired it — do nothing
         # here.
         if not skip_pre_tool_call_hook:
-            block_message: Optional[str] = None
+            block_message: str | None = None
             try:
                 from hermes_cli.plugins import get_pre_tool_call_block_message
                 block_message = get_pre_tool_call_block_message(
@@ -903,7 +903,7 @@ def get_all_tool_names() -> List[str]:
     return registry.get_all_tool_names()
 
 
-def get_toolset_for_tool(tool_name: str) -> Optional[str]:
+def get_toolset_for_tool(tool_name: str) -> str | None:
     """Return the toolset a tool belongs to."""
     return registry.get_toolset_for_tool(tool_name)
 

--- a/optional-skills/blockchain/evm/scripts/evm_client.py
+++ b/optional-skills/blockchain/evm/scripts/evm_client.py
@@ -503,7 +503,7 @@ ERC20_SELECTORS: Dict[str, str] = {
     "balanceOf(address)":      "0x70a08231",
 }
 
-def eth_call_erc20(chain: str, contract: str, fn: str, arg_addr: Optional[str] = None) -> str:
+def eth_call_erc20(chain: str, contract: str, fn: str, arg_addr: str | None = None) -> str:
     selector = ERC20_SELECTORS[fn]
     data = selector
     if arg_addr:
@@ -544,7 +544,7 @@ def decode_uint8(hex_data: str) -> int:
 
 COINGECKO_BASE = "https://api.coingecko.com/api/v3"
 
-def cg_price_by_id(cg_id: str) -> Optional[float]:
+def cg_price_by_id(cg_id: str) -> float | None:
     try:
         url = f"{COINGECKO_BASE}/simple/price?ids={cg_id}&vs_currencies=usd"
         data = _http_get(url)
@@ -564,7 +564,7 @@ def cg_price_by_ids(cg_ids: List[str]) -> Dict[str, float]:
     except Exception:
         return {}
 
-def cg_price_by_contract(chain: str, contract: str) -> Optional[float]:
+def cg_price_by_contract(chain: str, contract: str) -> float | None:
     cg_platform_map = {
         "ethereum": "ethereum",
         "bsc":      "binance-smart-chain",
@@ -592,7 +592,7 @@ def cg_price_by_contract(chain: str, contract: str) -> Optional[float]:
     except Exception:
         return None
 
-def get_native_price(chain: str) -> Optional[float]:
+def get_native_price(chain: str) -> float | None:
     cg_id = CHAINS[chain]["coingecko"]
     return cg_price_by_id(cg_id)
 
@@ -613,7 +613,7 @@ def cmd_stats(args: argparse.Namespace) -> None:
     gas_price_wei = hex_to_int(results[1] or "0x0")
 
     # TPS estimate: compare latest block timestamp with parent
-    tps: Optional[float] = None
+    tps: float | None = None
     try:
         latest_block = rpc_call(chain, "eth_getBlockByNumber", ["latest", False])
         if latest_block:
@@ -654,8 +654,8 @@ def cmd_wallet(args: argparse.Namespace) -> None:
     native_wei  = hex_to_int(balance_hex or "0x0")
     native_val  = wei_to_native(native_wei, cfg["decimals"])
 
-    native_usd_price: Optional[float] = None
-    native_usd: Optional[float] = None
+    native_usd_price: float | None = None
+    native_usd: float | None = None
     if not no_prices:
         native_usd_price = get_native_price(chain)
         if native_usd_price is not None:
@@ -684,8 +684,8 @@ def cmd_wallet(args: argparse.Namespace) -> None:
             decimals = decode_uint8(dec_hex) if dec_hex and dec_hex != "0x" else 18
             bal_human = wei_to_native(raw_bal, decimals)
 
-            token_price: Optional[float] = None
-            token_usd: Optional[float] = None
+            token_price: float | None = None
+            token_usd: float | None = None
             if not no_prices:
                 try:
                     cg_id = COINGECKO_IDS.get(symbol)
@@ -736,7 +736,7 @@ def cmd_tx(args: argparse.Namespace) -> None:
         return
 
     block_num = hex_to_int(tx.get("blockNumber") or "0x0")
-    timestamp: Optional[int] = None
+    timestamp: int | None = None
     try:
         blk = rpc_call(chain, "eth_getBlockByNumber", [hex(block_num), False])
         if blk:
@@ -759,8 +759,8 @@ def cmd_tx(args: argparse.Namespace) -> None:
     native_price = get_native_price(chain)
     value_usd = round(value_eth * native_price, 4) if native_price else None
 
-    fee_eth: Optional[float] = None
-    fee_usd: Optional[float] = None
+    fee_eth: float | None = None
+    fee_usd: float | None = None
     if gas_used is not None:
         fee_eth = wei_to_native(gas_used * gas_price, cfg["decimals"])
         if native_price:
@@ -806,8 +806,8 @@ def cmd_token(args: argparse.Namespace) -> None:
     supply_raw = decode_uint256(results[3] or "0x0")
     supply   = wei_to_native(supply_raw, decimals)
 
-    price: Optional[float] = None
-    market_cap: Optional[float] = None
+    price: float | None = None
+    market_cap: float | None = None
     cg_id = COINGECKO_IDS.get(symbol.upper())
     if cg_id:
         price = cg_price_by_id(cg_id)
@@ -921,7 +921,7 @@ def cmd_price(args: argparse.Namespace) -> None:
     token = args.token
     chain = args.chain
 
-    price: Optional[float] = None
+    price: float | None = None
     source = "unknown"
 
     # Check if it's a contract address
@@ -967,7 +967,7 @@ def _fetch_chain_stats(chain: str) -> Dict[str, Any]:
     cg_id = CHAINS[chain]["coingecko"]
     native_price = cg_price_by_id(cg_id)
 
-    transfer_usd: Optional[float] = None
+    transfer_usd: float | None = None
     if gas_gwei is not None and native_price is not None:
         gas_wei_val = int(gas_gwei * 1e9)
         cost_wei    = gas_wei_val * GAS_ESTIMATES["transfer"]
@@ -1244,7 +1244,7 @@ def cmd_decode(args: argparse.Namespace) -> None:
         signatures = [r["text_signature"] for r in data["results"]]
 
     # Decode known transfer(address,uint256) manually as fallback
-    decoded_args: Optional[Dict] = None
+    decoded_args: Dict | None = None
     if signatures and len(input_data) >= 74:
         sig = signatures[0]
         if sig == "transfer(address,uint256)" and len(input_data) == 138:

--- a/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
+++ b/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
@@ -104,7 +104,7 @@ def _info_url() -> str:
     return f"{api_base}/info"
 
 
-def _resolve_user(user: Optional[str]) -> str:
+def _resolve_user(user: str | None) -> str:
     candidate = (user or "").strip()
     if candidate:
         return candidate
@@ -146,7 +146,7 @@ def _post_info(payload: Dict[str, Any], timeout: int = 20, retries: int = 2) -> 
     return None
 
 
-def _safe_float(value: Any) -> Optional[float]:
+def _safe_float(value: Any) -> float | None:
     try:
         if value is None or value == "":
             return None
@@ -161,7 +161,7 @@ def _limit_items(items: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]
     return items[:limit]
 
 
-def _hours_ago_ms(hours: float, now_ms: Optional[int] = None) -> int:
+def _hours_ago_ms(hours: float, now_ms: int | None = None) -> int:
     end_ms = now_ms if now_ms is not None else int(time.time() * 1000)
     return end_ms - int(hours * 60 * 60 * 1000)
 
@@ -218,7 +218,7 @@ def _format_fraction_percent(value: Any, decimals: int = 4) -> str:
     return f"{number * 100:+.{decimals}f}%"
 
 
-def _percent_change(current: Any, previous: Any) -> Optional[float]:
+def _percent_change(current: Any, previous: Any) -> float | None:
     curr = _safe_float(current)
     prev = _safe_float(previous)
     if curr is None or prev is None or prev == 0:
@@ -600,7 +600,7 @@ def _direction_bucket(direction: Any) -> str:
     return "other"
 
 
-def _average(values: Iterable[Optional[float]]) -> Optional[float]:
+def _average(values: Iterable[float | None]) -> float | None:
     clean_values = [value for value in values if value is not None]
     if not clean_values:
         return None
@@ -1644,7 +1644,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def main(argv: List[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/optional-skills/blockchain/solana/scripts/solana_client.py
+++ b/optional-skills/blockchain/solana/scripts/solana_client.py
@@ -197,7 +197,7 @@ def fetch_prices(mints: List[str], max_lookups: int = 20) -> Dict[str, float]:
     return prices
 
 
-def fetch_sol_price() -> Optional[float]:
+def fetch_sol_price() -> float | None:
     """Fetch current SOL price in USD via CoinGecko."""
     data = _http_get_json(
         "https://api.coingecko.com/api/v3/simple/price?ids=solana&vs_currencies=usd"
@@ -207,7 +207,7 @@ def fetch_sol_price() -> Optional[float]:
     return None
 
 
-def resolve_token_name(mint: str) -> Optional[Dict[str, str]]:
+def resolve_token_name(mint: str) -> Dict[str, str] | None:
     """Look up token name and symbol from CoinGecko by mint address.
 
     Returns {"name": ..., "symbol": ...} or None.

--- a/optional-skills/devops/watchers/scripts/_watermark.py
+++ b/optional-skills/devops/watchers/scripts/_watermark.py
@@ -119,7 +119,7 @@ def format_items_as_markdown(
     *,
     title_key: str = "title",
     url_key: str = "url",
-    body_key: Optional[str] = None,
+    body_key: str | None = None,
     max_body_chars: int = 500,
 ) -> str:
     """Render a list of items as Markdown for cron delivery.

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -245,15 +245,15 @@ REASON_BLOCKED_BY_APPLY_CONFLICT = "blocked by earlier apply conflict"
 @dataclass
 class ItemResult:
     kind: str
-    source: Optional[str]
-    destination: Optional[str]
+    source: str | None
+    destination: str | None
     status: str
     reason: str = ""
     details: Dict[str, Any] = field(default_factory=dict)
     sensitive: bool = False
 
 
-def parse_selection_values(values: Optional[Sequence[str]]) -> List[str]:
+def parse_selection_values(values: Sequence[str] | None) -> List[str]:
     parsed: List[str] = []
     for value in values or ():
         for part in str(value).split(","):
@@ -264,9 +264,9 @@ def parse_selection_values(values: Optional[Sequence[str]]) -> List[str]:
 
 
 def resolve_selected_options(
-    include: Optional[Sequence[str]] = None,
-    exclude: Optional[Sequence[str]] = None,
-    preset: Optional[str] = None,
+    include: Sequence[str] | None = None,
+    exclude: Sequence[str] | None = None,
+    preset: str | None = None,
 ) -> set[str]:
     include_values = parse_selection_values(include)
     exclude_values = parse_selection_values(exclude)
@@ -323,7 +323,7 @@ def ensure_parent(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
 
 
-def resolve_secret_input(value: Any, env: Optional[Dict[str, str]] = None) -> Optional[str]:
+def resolve_secret_input(value: Any, env: Dict[str, str] | None = None) -> str | None:
     """Resolve an OpenClaw SecretInput value to a plain string.
 
     SecretInput can be:
@@ -382,7 +382,7 @@ def save_env_file(path: Path, data: Dict[str, str]) -> None:
     path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
 
 
-def backup_existing(path: Path, backup_root: Path) -> Optional[Path]:
+def backup_existing(path: Path, backup_root: Path) -> Path | None:
     if not path.exists():
         return None
     rel = Path(*path.parts[1:]) if path.is_absolute() and len(path.parts) > 1 else path
@@ -714,11 +714,11 @@ class Migrator:
         source_root: Path,
         target_root: Path,
         execute: bool,
-        workspace_target: Optional[Path],
+        workspace_target: Path | None,
         overwrite: bool,
         migrate_secrets: bool,
-        output_dir: Optional[Path],
-        selected_options: Optional[set[str]] = None,
+        output_dir: Path | None,
+        selected_options: set[str] | None = None,
         preset_name: str = "",
         skill_conflict_mode: str = "skip",
     ):
@@ -751,7 +751,7 @@ class Migrator:
         # have a custom workspace path (e.g. ~/clawd/) that differs from the
         # default ~/.openclaw/workspace/.  Reading agents.defaults.workspace
         # lets source_candidate() find files in the actual workspace.
-        self._custom_workspace: Optional[Path] = None
+        self._custom_workspace: Path | None = None
         oc_config = self.load_openclaw_config()
         ws = (oc_config.get("agents", {}).get("defaults", {}).get("workspace") or "").strip()
         if ws:
@@ -810,8 +810,8 @@ class Migrator:
     def record(
         self,
         kind: str,
-        source: Optional[Path],
-        destination: Optional[Path],
+        source: Path | None,
+        destination: Path | None,
         status: str,
         reason: str = "",
         **details: Any,
@@ -836,7 +836,7 @@ class Migrator:
             if dest_str.endswith("config.yaml") or dest_str.endswith("config.yml"):
                 self._config_apply_blocked = True
 
-    def source_candidate(self, *relative_paths: str) -> Optional[Path]:
+    def source_candidate(self, *relative_paths: str) -> Path | None:
         for rel in relative_paths:
             candidate = self.source_root / rel
             if candidate.exists():
@@ -1091,12 +1091,12 @@ class Migrator:
             )
         return steps
 
-    def maybe_backup(self, path: Path) -> Optional[Path]:
+    def maybe_backup(self, path: Path) -> Path | None:
         if not self.execute or not self.backup_dir or not path.exists():
             return None
         return backup_existing(path, self.backup_dir)
 
-    def write_overflow_entries(self, kind: str, entries: Sequence[str]) -> Optional[Path]:
+    def write_overflow_entries(self, kind: str, entries: Sequence[str]) -> Path | None:
         if not entries or not self.overflow_dir:
             return None
         self.overflow_dir.mkdir(parents=True, exist_ok=True)
@@ -1106,7 +1106,7 @@ class Migrator:
         return path
 
     def copy_file(self, source: Path, destination: Path, kind: str,
-                  transform: Optional[Any] = None) -> None:
+                  transform: Any | None = None) -> None:
         if not source or not source.exists():
             return
 
@@ -1153,7 +1153,7 @@ class Migrator:
         destination = self.workspace_target / WORKSPACE_INSTRUCTIONS_FILENAME
         self.copy_file(source, destination, kind="workspace-agents", transform=rebrand_text)
 
-    def migrate_memory(self, source: Optional[Path], destination: Path, limit: int, kind: str) -> None:
+    def migrate_memory(self, source: Path | None, destination: Path, limit: int, kind: str) -> None:
         if not source or not source.exists():
             self.record(kind, None, destination, "skipped", "Source file not found")
             return
@@ -1318,7 +1318,7 @@ class Migrator:
                 conflicting_keys=conflicts,
             )
 
-    def migrate_messaging_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_messaging_settings(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         additions: Dict[str, str] = {}
 
@@ -1358,7 +1358,7 @@ class Migrator:
         else:
             self.record("messaging-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Hermes-compatible messaging settings found")
 
-    def handle_secret_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def handle_secret_settings(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         if self.migrate_secrets:
             self.migrate_secret_settings(config)
@@ -1404,7 +1404,7 @@ class Migrator:
                 supported_targets=sorted(SUPPORTED_SECRET_TARGETS),
             )
 
-    def _resolve_channel_secret(self, value: Any) -> Optional[str]:
+    def _resolve_channel_secret(self, value: Any) -> str | None:
         """Resolve a channel config value that may be a SecretRef."""
         return resolve_secret_input(value, self.load_openclaw_env())
 
@@ -1421,7 +1421,7 @@ class Migrator:
                 return default.get(field)
         return None
 
-    def migrate_discord_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_discord_settings(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         additions: Dict[str, str] = {}
         discord = config.get("channels", {}).get("discord", {})
@@ -1439,7 +1439,7 @@ class Migrator:
         else:
             self.record("discord-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Discord settings found")
 
-    def migrate_slack_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_slack_settings(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         additions: Dict[str, str] = {}
         slack = config.get("channels", {}).get("slack", {})
@@ -1460,7 +1460,7 @@ class Migrator:
         else:
             self.record("slack-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Slack settings found")
 
-    def migrate_whatsapp_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_whatsapp_settings(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         additions: Dict[str, str] = {}
         whatsapp = config.get("channels", {}).get("whatsapp", {})
@@ -1475,7 +1475,7 @@ class Migrator:
         else:
             self.record("whatsapp-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No WhatsApp settings found")
 
-    def migrate_signal_settings(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_signal_settings(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         additions: Dict[str, str] = {}
         signal = config.get("channels", {}).get("signal", {})
@@ -1496,7 +1496,7 @@ class Migrator:
         else:
             self.record("signal-settings", self.source_root / "openclaw.json", self.target_root / ".env", "skipped", "No Signal settings found")
 
-    def handle_provider_keys(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def handle_provider_keys(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         if not self.migrate_secrets:
             config_path = self.source_root / "openclaw.json"
@@ -1650,7 +1650,7 @@ class Migrator:
                 supported_targets=sorted(SUPPORTED_SECRET_TARGETS),
             )
 
-    def migrate_model_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_model_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         destination = self.target_root / "config.yaml"
         source_path = self.source_root / "openclaw.json"
@@ -1719,7 +1719,7 @@ class Migrator:
         else:
             self.record("model-config", source_path, destination, "migrated", "Would set model", model=model_str)
 
-    def migrate_tts_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_tts_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         destination = self.target_root / "config.yaml"
         source_path = self.source_root / "openclaw.json"
@@ -1999,10 +1999,10 @@ class Migrator:
 
     def copy_tree_non_destructive(
         self,
-        source_root: Optional[Path],
+        source_root: Path | None,
         destination_root: Path,
         kind: str,
-        ignore_dir_names: Optional[set[str]] = None,
+        ignore_dir_names: set[str] | None = None,
     ) -> None:
         if not source_root or not source_root.exists():
             self.record(kind, None, destination_root, "skipped", "Source directory not found")
@@ -2100,7 +2100,7 @@ class Migrator:
             self.record("archive", source, destination, "archived", reason)
 
     # ── MCP servers ─────────────────────────────────────────────
-    def migrate_mcp_servers(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_mcp_servers(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         mcp_raw = (config.get("mcp") or {}).get("servers") or {}
         if not mcp_raw:
@@ -2176,7 +2176,7 @@ class Migrator:
             dump_yaml_file(hermes_cfg_path, hermes_cfg)
 
     # ── Plugins ───────────────────────────────────────────────
-    def migrate_plugins_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_plugins_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         plugins = config.get("plugins") or {}
         if not plugins:
@@ -2214,7 +2214,7 @@ class Migrator:
                     self._set_env_var(env_key, api_key, f"plugins.entries.{plugin_name}.apiKey")
 
     # ── Cron jobs ─────────────────────────────────────────────
-    def migrate_cron_jobs(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_cron_jobs(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         cron = config.get("cron") or {}
         cron_store = self.source_root / "cron"
@@ -2246,7 +2246,7 @@ class Migrator:
             self.record("cron-jobs", None, None, "skipped", "No cron configuration found")
 
     # ── Hooks ─────────────────────────────────────────────────
-    def migrate_hooks_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_hooks_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         hooks = config.get("hooks") or {}
         if not hooks:
@@ -2276,7 +2276,7 @@ class Migrator:
                 break
 
     # ── Agent config ──────────────────────────────────────────
-    def migrate_agent_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_agent_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         agents = config.get("agents") or {}
         defaults = agents.get("defaults") or {}
@@ -2395,7 +2395,7 @@ class Migrator:
                         "archived", f"Agent routing bindings ({len(bindings)} rules) archived")
 
     # ── Gateway config ────────────────────────────────────────
-    def migrate_gateway_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_gateway_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         gateway = config.get("gateway") or {}
         if not gateway:
@@ -2416,7 +2416,7 @@ class Migrator:
             self._set_env_var("HERMES_GATEWAY_TOKEN", auth["token"], "gateway.auth.token")
 
     # ── Session config ────────────────────────────────────────
-    def migrate_session_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_session_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         session = config.get("session") or {}
         if not session:
@@ -2479,7 +2479,7 @@ class Migrator:
                         "Advanced session settings archived (identity links, thread bindings, etc.)")
 
     # ── Full model providers ──────────────────────────────────
-    def migrate_full_providers(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_full_providers(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         models = config.get("models") or {}
         providers = models.get("providers") or {}
@@ -2553,7 +2553,7 @@ class Migrator:
                         "archived", f"Model aliases/catalog ({len(model_aliases)} entries) archived")
 
     # ── Deep channel config ───────────────────────────────────
-    def migrate_deep_channels(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_deep_channels(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         channels = config.get("channels") or {}
         if not channels:
@@ -2641,7 +2641,7 @@ class Migrator:
                         f"Deep channel config for {len(complex_archive)} channels archived")
 
     # ── Browser config ────────────────────────────────────────
-    def migrate_browser_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_browser_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         browser = config.get("browser") or {}
         if not browser:
@@ -2681,7 +2681,7 @@ class Migrator:
                         "archive/browser-config.json", "archived")
 
     # ── Tools config ──────────────────────────────────────────
-    def migrate_tools_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_tools_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         tools = config.get("tools") or {}
         if not tools:
@@ -2725,7 +2725,7 @@ class Migrator:
                         "archived", "Full tools config archived for reference")
 
     # ── Approvals config ──────────────────────────────────────
-    def migrate_approvals_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_approvals_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         approvals = config.get("approvals") or {}
         if not approvals:
@@ -2758,7 +2758,7 @@ class Migrator:
                         "archive/approvals-config.json", "archived")
 
     # ── Memory backend ────────────────────────────────────────
-    def migrate_memory_backend(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_memory_backend(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         memory = config.get("memory") or {}
         if not memory:
@@ -2773,7 +2773,7 @@ class Migrator:
                     "archived", "Memory backend config (QMD, vector search, citations) archived for manual review")
 
     # ── Skills config ─────────────────────────────────────────
-    def migrate_skills_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_skills_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         skills = config.get("skills") or {}
         entries = skills.get("entries") or {}
@@ -2789,7 +2789,7 @@ class Migrator:
                     "archived", f"Skills registry config ({len(entries)} entries) archived")
 
     # ── UI / Identity ─────────────────────────────────────────
-    def migrate_ui_identity(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_ui_identity(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         ui = config.get("ui") or {}
         if not ui:
@@ -2804,7 +2804,7 @@ class Migrator:
                     "archived", "UI theme and identity settings archived")
 
     # ── Logging / Diagnostics ─────────────────────────────────
-    def migrate_logging_config(self, config: Optional[Dict[str, Any]] = None) -> None:
+    def migrate_logging_config(self, config: Dict[str, Any] | None = None) -> None:
         config = config or self.load_openclaw_config()
         logging_cfg = config.get("logging") or {}
         diagnostics = config.get("diagnostics") or {}

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -125,7 +125,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
     # Config resolution (direct API key OR managed Nous gateway)
     # ------------------------------------------------------------------
 
-    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+    def _get_config_or_none(self) -> Dict[str, Any] | None:
         # Import here to avoid a hard dependency at module-import time —
         # managed_tool_gateway pulls in the Nous auth stack which can be
         # heavy and is not needed for direct-API-key users.

--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -65,7 +65,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
     # Config resolution
     # ------------------------------------------------------------------
 
-    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+    def _get_config_or_none(self) -> Dict[str, Any] | None:
         api_key = os.environ.get("BROWSERBASE_API_KEY")
         project_id = os.environ.get("BROWSERBASE_PROJECT_ID")
         if api_key and project_id:

--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -76,7 +76,7 @@ def discover_context_engines() -> List[Tuple[str, str, bool]]:
     return results
 
 
-def load_context_engine(name: str) -> Optional["ContextEngine"]:
+def load_context_engine(name: str) -> "ContextEngine" | None:
     """Load and return a ContextEngine instance by name.
 
     Returns None if the engine is not found or fails to load.
@@ -97,7 +97,7 @@ def load_context_engine(name: str) -> Optional["ContextEngine"]:
         return None
 
 
-def _load_engine_from_dir(engine_dir: Path) -> Optional["ContextEngine"]:
+def _load_engine_from_dir(engine_dir: Path) -> "ContextEngine" | None:
     """Import an engine module and extract the ContextEngine instance.
 
     The module must have either:

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -127,7 +127,7 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
 
 def _on_post_tool_call(
     tool_name: str = "",
-    args: Optional[Dict[str, Any]] = None,
+    args: Dict[str, Any] | None = None,
     result: Any = None,
     task_id: str = "",
     session_id: str = "",
@@ -220,7 +220,7 @@ def _fmt_summary(summary: Dict[str, Any]) -> str:
     return base
 
 
-def _handle_slash(raw_args: str) -> Optional[str]:
+def _handle_slash(raw_args: str) -> str | None:
     argv = raw_args.strip().split()
     if not argv or argv[0] in {"help", "-h", "--help"}:
         return _HELP_TEXT

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -340,7 +340,7 @@ def quick() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def deep(
-    confirm: Optional[callable] = None,
+    confirm: callable | None = None,
 ) -> Dict[str, Any]:
     """Deep cleanup.
 
@@ -461,7 +461,7 @@ _TEST_PATTERNS = ("test_", "tmp_")
 _TEST_SUFFIXES = (".test.py", ".test.js", ".test.ts", ".test.md")
 
 
-def guess_category(path: Path) -> Optional[str]:
+def guess_category(path: Path) -> str | None:
     """Return a category label for *path*, or None if we shouldn't track it.
 
     Used by the ``post_tool_call`` hook to auto-track ephemeral files.

--- a/plugins/google_meet/audio_bridge.py
+++ b/plugins/google_meet/audio_bridge.py
@@ -36,9 +36,9 @@ class AudioBridge:
 
     def __init__(self, name_prefix: str = "hermes_meet") -> None:
         self._name_prefix = name_prefix
-        self._platform: Optional[str] = None
-        self._device_name: Optional[str] = None
-        self._write_target: Optional[str] = None
+        self._platform: str | None = None
+        self._device_name: str | None = None
+        self._write_target: str | None = None
         self._module_ids: list[int] = []
         self._torn_down = False
 

--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -373,10 +373,10 @@ def _cmd_join(
     url: str,
     *,
     guest_name: str,
-    duration: Optional[str],
+    duration: str | None,
     headed: bool,
     mode: str = "transcribe",
-    node: Optional[str] = None,
+    node: str | None = None,
 ) -> int:
     if not _is_safe_meet_url(url):
         print(f"refusing: not a meet.google.com URL: {url}")
@@ -419,7 +419,7 @@ def _cmd_join(
     return 0 if res.get("ok") else 1
 
 
-def _cmd_say(text: str, node: Optional[str] = None) -> int:
+def _cmd_say(text: str, node: str | None = None) -> int:
     if not (text or "").strip():
         print("refusing: empty text")
         return 2
@@ -455,7 +455,7 @@ def _cmd_status() -> int:
     return 0 if res.get("ok") else 1
 
 
-def _cmd_transcript(last: Optional[int]) -> int:
+def _cmd_transcript(last: int | None) -> int:
     res = pm.transcript(last=last)
     if not res.get("ok"):
         print(json.dumps(res, indent=2))

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -93,20 +93,20 @@ class _BotState:
         self.captioning = False
         self.captions_enabled_attempted = False
         self.lobby_waiting = False
-        self.join_attempted_at: Optional[float] = None
-        self.joined_at: Optional[float] = None
-        self.last_caption_at: Optional[float] = None
+        self.join_attempted_at: float | None = None
+        self.joined_at: float | None = None
+        self.last_caption_at: float | None = None
         self.transcript_lines = 0
-        self.error: Optional[str] = None
+        self.error: str | None = None
         self.exited = False
         # v2 realtime fields.
         self.realtime = False
         self.realtime_ready = False
-        self.realtime_device: Optional[str] = None
+        self.realtime_device: str | None = None
         self.audio_bytes_out: int = 0
-        self.last_audio_out_at: Optional[float] = None
-        self.last_barge_in_at: Optional[float] = None
-        self.leave_reason: Optional[str] = None
+        self.last_audio_out_at: float | None = None
+        self.last_barge_in_at: float | None = None
+        self.leave_reason: str | None = None
         # Scraped captions, in order, deduped. Each entry is a dict of
         # {"ts": <epoch>, "speaker": str, "text": str}.
         self._seen: set = set()
@@ -831,7 +831,7 @@ def _click_join(page, state: _BotState) -> None:
             continue
 
 
-def _parse_duration(raw: str) -> Optional[float]:
+def _parse_duration(raw: str) -> float | None:
     """Parse ``30m`` / ``2h`` / ``90`` (seconds) → float seconds, or None."""
     if not raw:
         return None

--- a/plugins/google_meet/node/client.py
+++ b/plugins/google_meet/node/client.py
@@ -74,7 +74,7 @@ class NodeClient:
         self,
         url: str,
         guest_name: str = "Hermes Agent",
-        duration: Optional[str] = None,
+        duration: str | None = None,
         headed: bool = False,
         mode: str = "transcribe",
     ) -> Dict[str, Any]:
@@ -94,7 +94,7 @@ class NodeClient:
     def status(self) -> Dict[str, Any]:
         return self._rpc("status", {})
 
-    def transcript(self, last: Optional[int] = None) -> Dict[str, Any]:
+    def transcript(self, last: int | None = None) -> Dict[str, Any]:
         payload: Dict[str, Any] = {}
         if last is not None:
             payload["last"] = int(last)

--- a/plugins/google_meet/node/registry.py
+++ b/plugins/google_meet/node/registry.py
@@ -35,7 +35,7 @@ class NodeRegistry:
     """Simple file-backed registry. Not concurrent-safe across processes
     — single writer assumed (the gateway CLI)."""
 
-    def __init__(self, path: Optional[Path] = None) -> None:
+    def __init__(self, path: Path | None = None) -> None:
         self.path = Path(path) if path is not None else _default_path()
 
     # ----- storage ------------------------------------------------------
@@ -59,7 +59,7 @@ class NodeRegistry:
 
     # ----- public API ---------------------------------------------------
 
-    def get(self, name: str) -> Optional[Dict[str, Any]]:
+    def get(self, name: str) -> Dict[str, Any] | None:
         data = self._load()
         entry = data["nodes"].get(name)
         if entry is None:
@@ -96,7 +96,7 @@ class NodeRegistry:
             out.append({"name": name, **entry})
         return out
 
-    def resolve(self, chrome_node: Optional[str]) -> Optional[Dict[str, Any]]:
+    def resolve(self, chrome_node: str | None) -> Dict[str, Any] | None:
         """Resolve a node name to its entry.
 
         If ``chrome_node`` is provided, return that named node (or None).

--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -45,14 +45,14 @@ class NodeServer:
         self,
         host: str = "127.0.0.1",
         port: int = 18789,
-        token_path: Optional[Path] = None,
+        token_path: Path | None = None,
         display_name: str = "hermes-meet-node",
     ) -> None:
         self.host = host
         self.port = port
         self.display_name = display_name
         self.token_path = Path(token_path) if token_path is not None else _default_token_path()
-        self._token: Optional[str] = None
+        self._token: str | None = None
 
     # ----- token management --------------------------------------------
 

--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -44,7 +44,7 @@ def _active_file() -> Path:
     return _root() / ".active.json"
 
 
-def _read_active() -> Optional[Dict[str, Any]]:
+def _read_active() -> Dict[str, Any] | None:
     p = _active_file()
     if not p.is_file():
         return None
@@ -84,17 +84,17 @@ def _pid_alive(pid: int) -> bool:
 def start(
     url: str,
     *,
-    out_dir: Optional[Path] = None,
+    out_dir: Path | None = None,
     headed: bool = False,
-    auth_state: Optional[str] = None,
+    auth_state: str | None = None,
     guest_name: str = "Hermes Agent",
-    duration: Optional[str] = None,
-    session_id: Optional[str] = None,
+    duration: str | None = None,
+    session_id: str | None = None,
     mode: str = "transcribe",
-    realtime_model: Optional[str] = None,
-    realtime_voice: Optional[str] = None,
-    realtime_instructions: Optional[str] = None,
-    realtime_api_key: Optional[str] = None,
+    realtime_model: str | None = None,
+    realtime_voice: str | None = None,
+    realtime_instructions: str | None = None,
+    realtime_api_key: str | None = None,
 ) -> Dict[str, Any]:
     """Spawn the meet_bot subprocess for *url*.
 
@@ -216,7 +216,7 @@ def status() -> Dict[str, Any]:
     }
 
 
-def transcript(last: Optional[int] = None) -> Dict[str, Any]:
+def transcript(last: int | None = None) -> Dict[str, Any]:
     """Read the current transcript file. Returns ok=False if none exists."""
     active = _read_active()
     if not active:

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -55,7 +55,7 @@ class RealtimeSession:
         model: str = "gpt-realtime",
         voice: str = "alloy",
         instructions: str = "",
-        audio_sink_path: Optional[Path] = None,
+        audio_sink_path: Path | None = None,
         sample_rate: int = 24000,
     ) -> None:
         import threading as _threading
@@ -67,10 +67,10 @@ class RealtimeSession:
         self.sample_rate = sample_rate
         self._ws: Any = None
         self._send_lock = _threading.Lock()
-        self._last_response_id: Optional[str] = None
+        self._last_response_id: str | None = None
         # Public counters for status reporting.
         self.audio_bytes_out: int = 0
-        self.last_audio_out_at: Optional[float] = None
+        self.last_audio_out_at: float | None = None
 
     # ── lifecycle ─────────────────────────────────────────────────────────
 
@@ -225,7 +225,7 @@ class RealtimeSession:
         with self._send_lock:
             self._ws.send(json.dumps(payload))
 
-    def _recv(self, timeout: Optional[float] = None):
+    def _recv(self, timeout: float | None = None):
         assert self._ws is not None
         try:
             if timeout is None:
@@ -250,7 +250,7 @@ class RealtimeSpeaker:
         self,
         session: RealtimeSession,
         queue_path: Path,
-        processed_path: Optional[Path] = None,
+        processed_path: Path | None = None,
     ) -> None:
         self.session = session
         self.queue_path = Path(queue_path)

--- a/plugins/google_meet/tools.py
+++ b/plugins/google_meet/tools.py
@@ -49,7 +49,7 @@ def check_meet_requirements() -> bool:
 # Node client helper
 # ---------------------------------------------------------------------------
 
-def _resolve_node_client(node: Optional[str]):
+def _resolve_node_client(node: str | None):
     """Return (NodeClient, node_name) for *node*, or (None, None) to run local.
 
     Raises RuntimeError with a readable message if the node is named but

--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -33,7 +33,7 @@ router = APIRouter()
 
 SNAPSHOT_TTL_SECONDS = 120
 _SCAN_LOCK = threading.Lock()
-_SNAPSHOT_CACHE: Optional[Dict[str, Any]] = None
+_SNAPSHOT_CACHE: Dict[str, Any] | None = None
 _SNAPSHOT_CACHE_AT = 0
 _SCAN_STATUS: Dict[str, Any] = {
     "state": "idle",
@@ -180,7 +180,7 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
-def load_snapshot() -> Optional[Dict[str, Any]]:
+def load_snapshot() -> Dict[str, Any] | None:
     path = snapshot_path()
     if not path.exists():
         return None
@@ -235,7 +235,7 @@ def _cache_is_fresh(now: int) -> bool:
     return _SNAPSHOT_CACHE is not None and (now - _SNAPSHOT_CACHE_AT) <= SNAPSHOT_TTL_SECONDS
 
 
-def _is_snapshot_stale(snapshot: Optional[Dict[str, Any]], now: Optional[int] = None) -> bool:
+def _is_snapshot_stale(snapshot: Dict[str, Any] | None, now: int | None = None) -> bool:
     if not isinstance(snapshot, dict):
         return True
     ts = int(snapshot.get("generated_at") or 0)
@@ -245,7 +245,7 @@ def _is_snapshot_stale(snapshot: Optional[Dict[str, Any]], now: Optional[int] = 
     return (current - ts) > SNAPSHOT_TTL_SECONDS
 
 
-def _scan_status_payload(now: Optional[int] = None) -> Dict[str, Any]:
+def _scan_status_payload(now: int | None = None) -> Dict[str, Any]:
     current = int(now or time.time())
     snap = _SNAPSHOT_CACHE if isinstance(_SNAPSHOT_CACHE, dict) else None
     generated_at = int((snap or {}).get("generated_at") or 0) if snap else 0
@@ -263,7 +263,7 @@ def _scan_status_payload(now: Optional[int] = None) -> Dict[str, Any]:
     }
 
 
-def _tool_name_from_call(call: Any) -> Optional[str]:
+def _tool_name_from_call(call: Any) -> str | None:
     if not isinstance(call, dict):
         return None
     fn = call.get("function") or {}
@@ -287,7 +287,7 @@ def _count_tool(tool_names: List[str], *needles: str) -> int:
     return sum(1 for name in lowered if any(needle in name for needle in needles))
 
 
-def model_provider(model_name: str) -> Optional[str]:
+def model_provider(model_name: str) -> str | None:
     name = (model_name or "").strip().lower()
     if not name or name == "none":
         return None
@@ -558,8 +558,8 @@ def display_achievement(item: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def scan_sessions(
-    limit: Optional[int] = None,
-    progress_callback: Optional[Any] = None,
+    limit: int | None = None,
+    progress_callback: Any | None = None,
     progress_every: int = 250,
 ) -> Dict[str, Any]:
     """Scan Hermes sessions and build per-session achievement stats.
@@ -763,7 +763,7 @@ def evaluate_definition(definition: Dict[str, Any], aggregate: Dict[str, Any]) -
     return evaluate_boolean(definition, aggregate)
 
 
-def evidence_for(definition: Dict[str, Any], sessions: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def evidence_for(definition: Dict[str, Any], sessions: List[Dict[str, Any]]) -> Dict[str, Any] | None:
     if not sessions:
         return None
     metric = definition.get("threshold_metric")
@@ -826,12 +826,12 @@ def _compute_from_scan(scan: Dict[str, Any], *, is_partial: bool = False) -> Dic
     }
 
 
-def compute_all(progress_callback: Optional[Any] = None, progress_every: int = 250) -> Dict[str, Any]:
+def compute_all(progress_callback: Any | None = None, progress_every: int = 250) -> Dict[str, Any]:
     scan = scan_sessions(progress_callback=progress_callback, progress_every=progress_every)
     return _compute_from_scan(scan, is_partial=False)
 
 
-_BACKGROUND_SCAN_THREAD: Optional[threading.Thread] = None
+_BACKGROUND_SCAN_THREAD: threading.Thread | None = None
 _BACKGROUND_SCAN_LOCK = threading.Lock()
 
 

--- a/plugins/image_gen/fal/__init__.py
+++ b/plugins/image_gen/fal/__init__.py
@@ -79,7 +79,7 @@ class FalImageGenProvider(ImageGenProvider):
             for model_id, meta in _it.FAL_MODELS.items()
         ]
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         import tools.image_generation_tool as _it
         return _it.DEFAULT_MODEL
 

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -108,7 +108,7 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
 
     cfg = _load_image_gen_config()
     sub = cfg.get("openai-codex") if isinstance(cfg.get("openai-codex"), dict) else {}
-    candidate: Optional[str] = None
+    candidate: str | None = None
     if isinstance(sub, dict):
         value = sub.get("model")
         if isinstance(value, str) and value in _MODELS:
@@ -124,7 +124,7 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
     return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
 
 
-def _read_codex_access_token() -> Optional[str]:
+def _read_codex_access_token() -> str | None:
     """Return a usable Codex OAuth token, or None.
 
     Delegates to the canonical reader in ``agent.auxiliary_client`` so token
@@ -161,9 +161,9 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> str | None:
     """Stream a Codex Responses image_generation call and return the b64 image."""
-    image_b64: Optional[str] = None
+    image_b64: str | None = None
 
     with client.responses.stream(
         model=_CODEX_CHAT_MODEL,
@@ -251,7 +251,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             for model_id, meta in _MODELS.items()
         ]
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         return DEFAULT_MODEL
 
     def get_setup_schema(self) -> Dict[str, Any]:

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -101,7 +101,7 @@ def _resolve_model() -> Tuple[str, Dict[str, Any]]:
 
     cfg = _load_openai_config()
     openai_cfg = cfg.get("openai") if isinstance(cfg.get("openai"), dict) else {}
-    candidate: Optional[str] = None
+    candidate: str | None = None
     if isinstance(openai_cfg, dict):
         value = openai_cfg.get("model")
         if isinstance(value, str) and value in _MODELS:
@@ -154,7 +154,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
             for model_id, meta in _MODELS.items()
         ]
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         return DEFAULT_MODEL
 
     def get_setup_schema(self) -> Dict[str, Any]:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -61,7 +61,7 @@ router = APIRouter()
 # existing plugin-bypass; this is documented above).
 # ---------------------------------------------------------------------------
 
-def _check_ws_token(provided: Optional[str]) -> bool:
+def _check_ws_token(provided: str | None) -> bool:
     """Constant-time compare against the dashboard session token.
 
     Imported lazily so the plugin still loads in test contexts where the
@@ -83,7 +83,7 @@ def _check_ws_token(provided: Optional[str]) -> bool:
     return hmac.compare_digest(str(provided), str(expected))
 
 
-def _resolve_board(board: Optional[str]) -> Optional[str]:
+def _resolve_board(board: str | None) -> str | None:
     """Validate and normalise a board slug from a query param.
 
     Raises :class:`HTTPException` 400 on malformed slugs so the browser
@@ -105,7 +105,7 @@ def _resolve_board(board: Optional[str]) -> Optional[str]:
     return normed
 
 
-def _conn(board: Optional[str] = None):
+def _conn(board: str | None = None):
     """Open a kanban_db connection, creating the schema on first use.
 
     Every handler that mutates the DB goes through this so the plugin
@@ -147,7 +147,7 @@ _CARD_SUMMARY_PREVIEW_CHARS = 200
 def _task_dict(
     task: kanban_db.Task,
     *,
-    latest_summary: Optional[str] = None,
+    latest_summary: str | None = None,
 ) -> dict[str, Any]:
     d = asdict(task)
     # Add derived age metrics so the UI can colour stale cards without
@@ -221,7 +221,7 @@ _WARNING_EVENT_KINDS = (
 
 def _compute_task_diagnostics(
     conn: sqlite3.Connection,
-    task_ids: Optional[list[str]] = None,
+    task_ids: list[str] | None = None,
 ) -> dict[str, list[dict]]:
     """Run the diagnostic rule engine against every task (or a subset)
     and return ``{task_id: [diagnostic_dict, ...]}``.
@@ -289,7 +289,7 @@ def _compute_task_diagnostics(
 
 def _warnings_summary_from_diagnostics(
     diagnostics: list[dict],
-) -> Optional[dict]:
+) -> dict | None:
     """Compact summary for cards: {count, highest_severity, kinds,
     latest_at}. Replaces the old hallucination-only ``warnings`` object
     — same shape additions plus ``highest_severity`` so the UI can color
@@ -304,7 +304,7 @@ def _warnings_summary_from_diagnostics(
     kinds: dict[str, int] = {}
     latest = 0
     highest_idx = -1
-    highest_sev: Optional[str] = None
+    highest_sev: str | None = None
     count = 0
     for d in diagnostics:
         kinds[d["kind"]] = kinds.get(d["kind"], 0) + d.get("count", 1)
@@ -351,13 +351,13 @@ def _links_for(conn: sqlite3.Connection, task_id: str) -> dict[str, list[str]]:
 
 @router.get("/board")
 def get_board(
-    tenant: Optional[str] = Query(None, description="Filter to a single tenant"),
+    tenant: str | None = Query(None, description="Filter to a single tenant"),
     include_archived: bool = Query(False),
-    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
-    workflow_template_id: Optional[str] = Query(
+    board: str | None = Query(None, description="Kanban board slug (omit for current)"),
+    workflow_template_id: str | None = Query(
         None, description="Restrict to tasks using this workflow template id",
     ),
-    current_step_key: Optional[str] = Query(
+    current_step_key: str | None = Query(
         None, description="Restrict to tasks at this workflow step key",
     ),
 ):
@@ -491,11 +491,11 @@ def get_board(
 @router.get("/tasks/{task_id}")
 def get_task(
     task_id: str,
-    board: Optional[str] = Query(None),
-    run_state_type: Optional[str] = Query(
+    board: str | None = Query(None),
+    run_state_type: str | None = Query(
         None, description="With run_state_name: filter runs by column 'status' or 'outcome'",
     ),
-    run_state_name: Optional[str] = Query(
+    run_state_name: str | None = Query(
         None, description="With run_state_type: exact value for that run column",
     ),
 ):
@@ -552,21 +552,21 @@ def get_task(
 
 class CreateTaskBody(BaseModel):
     title: str
-    body: Optional[str] = None
-    assignee: Optional[str] = None
-    tenant: Optional[str] = None
+    body: str | None = None
+    assignee: str | None = None
+    tenant: str | None = None
     priority: int = 0
     workspace_kind: str = "scratch"
-    workspace_path: Optional[str] = None
+    workspace_path: str | None = None
     parents: list[str] = Field(default_factory=list)
     triage: bool = False
-    idempotency_key: Optional[str] = None
-    max_runtime_seconds: Optional[int] = None
-    skills: Optional[list[str]] = None
+    idempotency_key: str | None = None
+    max_runtime_seconds: int | None = None
+    skills: list[str] | None = None
 
 
 @router.post("/tasks")
-def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
+def create_task(payload: CreateTaskBody, board: str | None = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -614,22 +614,22 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
 # ---------------------------------------------------------------------------
 
 class UpdateTaskBody(BaseModel):
-    status: Optional[str] = None
-    assignee: Optional[str] = None
-    priority: Optional[int] = None
-    title: Optional[str] = None
-    body: Optional[str] = None
-    result: Optional[str] = None
-    block_reason: Optional[str] = None
+    status: str | None = None
+    assignee: str | None = None
+    priority: int | None = None
+    title: str | None = None
+    body: str | None = None
+    result: str | None = None
+    block_reason: str | None = None
     # Structured handoff fields — forwarded to complete_task when status
     # transitions to 'done'. Dashboard parity with ``hermes kanban
     # complete --summary ... --metadata ...``.
-    summary: Optional[str] = None
-    metadata: Optional[dict] = None
+    summary: str | None = None
+    metadata: dict | None = None
 
 
 @router.patch("/tasks/{task_id}")
-def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Query(None)):
+def update_task(task_id: str, payload: UpdateTaskBody, board: str | None = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -752,7 +752,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
 # ---------------------------------------------------------------------------
 
 @router.delete("/tasks/{task_id}")
-def delete_task(task_id: str, board: Optional[str] = Query(None)):
+def delete_task(task_id: str, board: str | None = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -895,11 +895,11 @@ def _set_status_direct(
 
 class CommentBody(BaseModel):
     body: str
-    author: Optional[str] = "dashboard"
+    author: str | None = "dashboard"
 
 
 @router.post("/tasks/{task_id}/comments")
-def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query(None)):
+def add_comment(task_id: str, payload: CommentBody, board: str | None = Query(None)):
     if not payload.body.strip():
         raise HTTPException(status_code=400, detail="body is required")
     board = _resolve_board(board)
@@ -925,7 +925,7 @@ class LinkBody(BaseModel):
 
 
 @router.post("/links")
-def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
+def add_link(payload: LinkBody, board: str | None = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
@@ -941,7 +941,7 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
 def delete_link(
     parent_id: str = Query(...),
     child_id: str = Query(...),
-    board: Optional[str] = Query(None),
+    board: str | None = Query(None),
 ):
     board = _resolve_board(board)
     conn = _conn(board=board)
@@ -958,18 +958,18 @@ def delete_link(
 
 class BulkTaskBody(BaseModel):
     ids: list[str]
-    status: Optional[str] = None
-    assignee: Optional[str] = None  # "" or None = unassign
-    priority: Optional[int] = None
+    status: str | None = None
+    assignee: str | None = None  # "" or None = unassign
+    priority: int | None = None
     archive: bool = False
-    result: Optional[str] = None
-    summary: Optional[str] = None
-    metadata: Optional[dict] = None
+    result: str | None = None
+    summary: str | None = None
+    metadata: dict | None = None
     reclaim_first: bool = False
 
 
 @router.post("/tasks/bulk")
-def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
+def bulk_update(payload: BulkTaskBody, board: str | None = Query(None)):
     """Apply the same patch to every id in ``payload.ids``.
 
     This is an *independent* iteration — per-task failures don't abort
@@ -1073,8 +1073,8 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
 
 @router.get("/diagnostics")
 def list_diagnostics(
-    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
-    severity: Optional[str] = Query(
+    board: str | None = Query(None, description="Kanban board slug (omit for current)"),
+    severity: str | None = Query(
         None,
         description="Filter by severity: warning|error|critical",
     ),
@@ -1161,7 +1161,7 @@ except ImportError:
 
 @router.get("/workers/active")
 def list_active_workers(
-    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    board: str | None = Query(None, description="Kanban board slug (omit for current)"),
 ):
     """Return every currently-running worker on the board.
 
@@ -1223,7 +1223,7 @@ def list_active_workers(
 @router.get("/runs/{run_id}")
 def get_run_endpoint(
     run_id: int,
-    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    board: str | None = Query(None, description="Kanban board slug (omit for current)"),
 ):
     """Direct lookup of a ``task_runs`` row by its integer id.
 
@@ -1245,7 +1245,7 @@ def get_run_endpoint(
 @router.get("/runs/{run_id}/inspect")
 def inspect_run_endpoint(
     run_id: int,
-    board: Optional[str] = Query(None, description="Kanban board slug (omit for current)"),
+    board: str | None = Query(None, description="Kanban board slug (omit for current)"),
 ):
     """Live PID stats for a run's worker process via psutil.
 
@@ -1315,14 +1315,14 @@ def inspect_run_endpoint(
 # ---------------------------------------------------------------------------
 
 class ReclaimBody(BaseModel):
-    reason: Optional[str] = None
+    reason: str | None = None
 
 
 @router.post("/tasks/{task_id}/reclaim")
 def reclaim_task_endpoint(
     task_id: str,
     payload: ReclaimBody,
-    board: Optional[str] = Query(None),
+    board: str | None = Query(None),
 ):
     """Release an active worker claim on a running task.
 
@@ -1353,14 +1353,14 @@ class SpecifyBody(BaseModel):
     dashboard — model + prompt come from ``auxiliary.triage_specifier``
     in config.yaml, same as the CLI."""
 
-    author: Optional[str] = None
+    author: str | None = None
 
 
 @router.post("/tasks/{task_id}/specify")
 def specify_task_endpoint(
     task_id: str,
     payload: SpecifyBody,
-    board: Optional[str] = Query(None),
+    board: str | None = Query(None),
 ):
     """Flesh out a triage-column task via the auxiliary LLM and promote
     it to ``todo``. Maps 1:1 to ``hermes kanban specify <task_id>``.
@@ -1404,16 +1404,16 @@ def specify_task_endpoint(
 
 
 class ReassignBody(BaseModel):
-    profile: Optional[str] = None  # "" or None = unassign
+    profile: str | None = None  # "" or None = unassign
     reclaim_first: bool = False
-    reason: Optional[str] = None
+    reason: str | None = None
 
 
 @router.post("/tasks/{task_id}/reassign")
 def reassign_task_endpoint(
     task_id: str,
     payload: ReassignBody,
-    board: Optional[str] = Query(None),
+    board: str | None = Query(None),
 ):
     """Reassign a task to a different profile, optionally reclaiming first.
 
@@ -1539,8 +1539,8 @@ def _home_sub_matches(sub: dict, home: dict) -> bool:
 
 @router.get("/home-channels")
 def get_home_channels(
-    task_id: Optional[str] = Query(None),
-    board: Optional[str] = Query(None),
+    task_id: str | None = Query(None),
+    board: str | None = Query(None),
 ):
     """List every platform with a home channel, plus whether *task_id*
     (if given) is currently subscribed to that home.
@@ -1572,7 +1572,7 @@ def get_home_channels(
 
 
 @router.post("/tasks/{task_id}/home-subscribe/{platform}")
-def subscribe_home(task_id: str, platform: str, board: Optional[str] = Query(None)):
+def subscribe_home(task_id: str, platform: str, board: str | None = Query(None)):
     """Subscribe *task_id* to notifications routed to *platform*'s home channel.
 
     Idempotent — re-subscribing is a no-op at the DB layer. 404 if the
@@ -1607,7 +1607,7 @@ def subscribe_home(task_id: str, platform: str, board: Optional[str] = Query(Non
 
 
 @router.delete("/tasks/{task_id}/home-subscribe/{platform}")
-def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(None)):
+def unsubscribe_home(task_id: str, platform: str, board: str | None = Query(None)):
     """Remove any notify subscription on *task_id* that matches *platform*'s home."""
     homes = _configured_home_channels()
     home = next((h for h in homes if h["platform"] == platform), None)
@@ -1636,7 +1636,7 @@ def unsubscribe_home(task_id: str, platform: str, board: Optional[str] = Query(N
 # ---------------------------------------------------------------------------
 
 @router.get("/stats")
-def get_stats(board: Optional[str] = Query(None)):
+def get_stats(board: str | None = Query(None)):
     """Per-status + per-assignee counts + oldest-ready age.
 
     Designed for the dashboard HUD and for router profiles that need to
@@ -1652,7 +1652,7 @@ def get_stats(board: Optional[str] = Query(None)):
 
 
 @router.get("/assignees")
-def get_assignees(board: Optional[str] = Query(None)):
+def get_assignees(board: str | None = Query(None)):
     """Known profiles + per-profile task counts.
 
     Returns the union of ``~/.hermes/profiles/*`` on disk and every
@@ -1675,8 +1675,8 @@ def get_assignees(board: Optional[str] = Query(None)):
 @router.get("/tasks/{task_id}/log")
 def get_task_log(
     task_id: str,
-    tail: Optional[int] = Query(None, ge=1, le=2_000_000),
-    board: Optional[str] = Query(None),
+    tail: int | None = Query(None, ge=1, le=2_000_000),
+    board: str | None = Query(None),
 ):
     """Return the worker's stdout/stderr log.
 
@@ -1716,7 +1716,7 @@ def get_task_log(
 def dispatch(
     dry_run: bool = Query(False),
     max_n: int = Query(8, alias="max"),
-    board: Optional[str] = Query(None),
+    board: str | None = Query(None),
 ):
     board = _resolve_board(board)
     conn = _conn(board=board)
@@ -1739,18 +1739,18 @@ def dispatch(
 
 class CreateBoardBody(BaseModel):
     slug: str
-    name: Optional[str] = None
-    description: Optional[str] = None
-    icon: Optional[str] = None
-    color: Optional[str] = None
+    name: str | None = None
+    description: str | None = None
+    icon: str | None = None
+    color: str | None = None
     switch: bool = False
 
 
 class RenameBoardBody(BaseModel):
-    name: Optional[str] = None
-    description: Optional[str] = None
-    icon: Optional[str] = None
-    color: Optional[str] = None
+    name: str | None = None
+    description: str | None = None
+    icon: str | None = None
+    color: str | None = None
 
 
 def _board_counts(slug: str) -> dict[str, int]:
@@ -1866,7 +1866,7 @@ _EVENT_POLL_SECONDS = 0.3
 # ---------------------------------------------------------------------------
 
 class DescribeBody(BaseModel):
-    description: Optional[str] = None  # explicit user-authored text
+    description: str | None = None  # explicit user-authored text
 
 
 class DescribeAutoBody(BaseModel):
@@ -1969,14 +1969,14 @@ def auto_describe_profile(profile_name: str, payload: DescribeAutoBody):
 # ---------------------------------------------------------------------------
 
 class DecomposeBody(BaseModel):
-    author: Optional[str] = None
+    author: str | None = None
 
 
 @router.post("/tasks/{task_id}/decompose")
 def decompose_task_endpoint(
     task_id: str,
     payload: DecomposeBody,
-    board: Optional[str] = Query(None),
+    board: str | None = Query(None),
 ):
     """Fan a triage-column task out into a graph of child tasks via the
     auxiliary LLM, routed to specialist profiles by description. Maps
@@ -2020,10 +2020,10 @@ def decompose_task_endpoint(
 # ---------------------------------------------------------------------------
 
 class OrchestrationSettingsBody(BaseModel):
-    orchestrator_profile: Optional[str] = None
-    default_assignee: Optional[str] = None
-    auto_decompose: Optional[bool] = None
-    auto_promote_children: Optional[bool] = None
+    orchestrator_profile: str | None = None
+    default_assignee: str | None = None
+    auto_decompose: bool | None = None
+    auto_promote_children: bool | None = None
 
 
 @router.get("/orchestration")

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -38,7 +38,7 @@ _MEMORY_PLUGINS_DIR = Path(__file__).parent
 # Directory helpers
 # ---------------------------------------------------------------------------
 
-def _get_user_plugins_dir() -> Optional[Path]:
+def _get_user_plugins_dir() -> Path | None:
     """Return ``$HERMES_HOME/plugins/`` or None if unavailable."""
     try:
         from hermes_constants import get_hermes_home
@@ -98,7 +98,7 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     return dirs
 
 
-def find_provider_dir(name: str) -> Optional[Path]:
+def find_provider_dir(name: str) -> Path | None:
     """Resolve a provider name to its directory.
 
     Checks bundled first, then user-installed.
@@ -157,7 +157,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     return results
 
 
-def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
+def load_memory_provider(name: str) -> "MemoryProvider" | None:
     """Load and return a MemoryProvider instance by name.
 
     Checks both bundled (``plugins/memory/<name>/``) and user-installed
@@ -182,7 +182,7 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
         return None
 
 
-def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
+def _load_provider_from_dir(provider_dir: Path) -> "MemoryProvider" | None:
     """Import a provider module and extract the MemoryProvider instance.
 
     The module must have either:
@@ -305,7 +305,7 @@ class _ProviderCollector:
         pass  # CLI registration happens via discover_plugin_cli_commands()
 
 
-def _get_active_memory_provider() -> Optional[str]:
+def _get_active_memory_provider() -> str | None:
     """Read the active memory provider name from config.yaml.
 
     Returns the provider name (e.g. ``"honcho"``) or None if no

--- a/plugins/memory/byterover/__init__.py
+++ b/plugins/memory/byterover/__init__.py
@@ -45,10 +45,10 @@ _MIN_OUTPUT_LEN = 20
 # ---------------------------------------------------------------------------
 
 _brv_path_lock = threading.Lock()
-_cached_brv_path: Optional[str] = None
+_cached_brv_path: str | None = None
 
 
-def _resolve_brv_path() -> Optional[str]:
+def _resolve_brv_path() -> str | None:
     """Find the brv binary on PATH or well-known install locations."""
     global _cached_brv_path
     with _brv_path_lock:
@@ -175,7 +175,7 @@ class ByteRoverMemoryProvider(MemoryProvider):
         self._cwd = ""
         self._session_id = ""
         self._turn_count = 0
-        self._sync_thread: Optional[threading.Thread] = None
+        self._sync_thread: threading.Thread | None = None
 
     @property
     def name(self) -> str:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -197,14 +197,14 @@ class HonchoMemoryProvider(MemoryProvider):
         self._session_key = ""
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
-        self._prefetch_thread: Optional[threading.Thread] = None
-        self._sync_thread: Optional[threading.Thread] = None
+        self._prefetch_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
 
         # B1: recall_mode — set during initialize from config
         self._recall_mode = "hybrid"  # "context", "tools", or "hybrid"
 
         # Base context cache — refreshed on context_cadence, not frozen
-        self._base_context_cache: Optional[str] = None
+        self._base_context_cache: str | None = None
         self._base_context_lock = threading.Lock()
 
         # B5: Cost-awareness turn counting and cadence
@@ -226,8 +226,8 @@ class HonchoMemoryProvider(MemoryProvider):
 
         # Port #1957: lazy session init for tools-only mode
         self._session_initialized = False
-        self._lazy_init_kwargs: Optional[dict] = None
-        self._lazy_init_session_id: Optional[str] = None
+        self._lazy_init_kwargs: dict | None = None
+        self._lazy_init_session_id: str | None = None
 
         # Port #4053: cron guard — when True, plugin is fully inactive
         self._cron_skipped = False
@@ -1155,7 +1155,7 @@ class HonchoMemoryProvider(MemoryProvider):
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> None:
         """Mirror built-in user profile writes as Honcho conclusions.
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -72,7 +72,7 @@ _MEMORY_WRITE_TARGET_SUBDIR_MAP = {
 # even if shutdown_memory_provider is never called (e.g. gateway crash,
 # SIGKILL, or exception in the session expiry watcher preventing shutdown).
 # ---------------------------------------------------------------------------
-_last_active_provider: Optional["OpenVikingMemoryProvider"] = None
+_last_active_provider: "OpenVikingMemoryProvider" | None = None
 
 
 def _atexit_commit_sessions():
@@ -413,15 +413,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
     """Full bidirectional memory via OpenViking context database."""
 
     def __init__(self):
-        self._client: Optional[_VikingClient] = None
+        self._client: _VikingClient | None = None
         self._endpoint = ""
         self._api_key = ""
         self._session_id = ""
         self._turn_count = 0
-        self._sync_thread: Optional[threading.Thread] = None
+        self._sync_thread: threading.Thread | None = None
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
-        self._prefetch_thread: Optional[threading.Thread] = None
+        self._prefetch_thread: threading.Thread | None = None
 
     @property
     def name(self) -> str:
@@ -636,7 +636,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         action: str,
         target: str,
         content: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> None:
         """Mirror built-in memory writes to OpenViking via content/write."""
         if not self._client or action != "add" or not content:
@@ -935,7 +935,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         else:
             source_path = Path(url).expanduser()
 
-        cleanup_path: Optional[Path] = None
+        cleanup_path: Path | None = None
         try:
             if source_path is not None:
                 if source_path.exists():

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -270,9 +270,9 @@ class _SupermemoryClient:
         self._timeout = timeout
         self._client = Supermemory(api_key=api_key, timeout=timeout, max_retries=0)
 
-    def add_memory(self, content: str, metadata: Optional[dict] = None, *,
-                   entity_context: str = "", container_tag: Optional[str] = None,
-                   custom_id: Optional[str] = None) -> dict:
+    def add_memory(self, content: str, metadata: dict | None = None, *,
+                   entity_context: str = "", container_tag: str | None = None,
+                   custom_id: str | None = None) -> dict:
         tag = container_tag or self._container_tag
         kwargs: dict[str, Any] = {
             "content": content.strip(),
@@ -288,8 +288,8 @@ class _SupermemoryClient:
         return {"id": getattr(result, "id", "")}
 
     def search_memories(self, query: str, *, limit: int = 5,
-                        container_tag: Optional[str] = None,
-                        search_mode: Optional[str] = None) -> list[dict]:
+                        container_tag: str | None = None,
+                        search_mode: str | None = None) -> list[dict]:
         tag = container_tag or self._container_tag
         mode = search_mode or self._search_mode
         kwargs: dict[str, Any] = {"q": query, "container_tag": tag, "limit": limit}
@@ -307,8 +307,8 @@ class _SupermemoryClient:
             })
         return results
 
-    def get_profile(self, query: Optional[str] = None, *,
-                    container_tag: Optional[str] = None) -> dict:
+    def get_profile(self, query: str | None = None, *,
+                    container_tag: str | None = None) -> dict:
         tag = container_tag or self._container_tag
         kwargs: dict[str, Any] = {"container_tag": tag}
         if query:
@@ -332,11 +332,11 @@ class _SupermemoryClient:
                     })
         return {"static": static, "dynamic": dynamic, "search_results": search_results}
 
-    def forget_memory(self, memory_id: str, *, container_tag: Optional[str] = None) -> None:
+    def forget_memory(self, memory_id: str, *, container_tag: str | None = None) -> None:
         tag = container_tag or self._container_tag
         self._client.memories.forget(container_tag=tag, id=memory_id)
 
-    def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
+    def forget_by_query(self, query: str, *, container_tag: str | None = None) -> dict:
         results = self.search_memories(query, limit=5, container_tag=container_tag)
         if not results:
             return {"success": False, "message": "No matching memory found to forget."}
@@ -421,15 +421,15 @@ class SupermemoryMemoryProvider(MemoryProvider):
     def __init__(self):
         self._config = _default_config()
         self._api_key = ""
-        self._client: Optional[_SupermemoryClient] = None
+        self._client: _SupermemoryClient | None = None
         self._container_tag = _DEFAULT_CONTAINER_TAG
         self._session_id = ""
         self._turn_count = 0
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
-        self._prefetch_thread: Optional[threading.Thread] = None
-        self._sync_thread: Optional[threading.Thread] = None
-        self._write_thread: Optional[threading.Thread] = None
+        self._prefetch_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
+        self._write_thread: threading.Thread | None = None
         self._auto_recall = True
         self._auto_capture = True
         self._max_recall_results = _DEFAULT_MAX_RECALL_RESULTS
@@ -643,7 +643,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
                 thread.join(timeout=5.0)
             setattr(self, attr_name, None)
 
-    def _resolve_tool_container_tag(self, args: dict) -> Optional[str]:
+    def _resolve_tool_container_tag(self, args: dict) -> str | None:
         """Validate and resolve container_tag from tool call args.
 
         Returns None (use primary) if multi-container is disabled or no tag provided.

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -117,7 +117,7 @@ def _redact_key_preview(value: str) -> str:
     return repr(value[:6] + "...")
 
 
-def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
+def _validate_langfuse_key(env_name: str, value: str) -> str | None:
     """Return an error message if ``value`` is not a real Langfuse key.
 
     Returns ``None`` when the value matches the documented Langfuse
@@ -137,7 +137,7 @@ def _validate_langfuse_key(env_name: str, value: str) -> Optional[str]:
     )
 
 
-def _get_langfuse() -> Optional[Langfuse]:
+def _get_langfuse() -> Langfuse | None:
     """Return a cached Langfuse client, or ``None`` if unavailable.
 
     Activation of this plugin is controlled by the Hermes plugin system —
@@ -361,7 +361,7 @@ def _normalize_payload(value: Any, *, tool_name: str = "", args: Any = None) -> 
     return value
 
 
-def _safe_value(value: Any, *, max_chars: Optional[int] = None, depth: int = 0,
+def _safe_value(value: Any, *, max_chars: int | None = None, depth: int = 0,
                 parse_json_strings: bool = False) -> Any:
     max_chars = max_chars if max_chars is not None else int(_env("HERMES_LANGFUSE_MAX_CHARS", "12000") or "12000")
     if depth > 4:
@@ -604,8 +604,8 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
 
 
 def _start_child_observation(state: TraceState, *, client: Langfuse, name: str, as_type: str,
-                             input_value: Any, metadata: Optional[dict] = None,
-                             model: Optional[str] = None, model_parameters: Optional[dict] = None) -> Any:
+                             input_value: Any, metadata: dict | None = None,
+                             model: str | None = None, model_parameters: dict | None = None) -> Any:
     return state.root_span.start_observation(
         name=name,
         as_type=as_type,
@@ -616,8 +616,8 @@ def _start_child_observation(state: TraceState, *, client: Langfuse, name: str, 
     )
 
 
-def _end_observation(observation: Any, *, output: Any = None, metadata: Optional[dict] = None,
-                     usage_details: Optional[dict] = None, cost_details: Optional[dict] = None) -> None:
+def _end_observation(observation: Any, *, output: Any = None, metadata: dict | None = None,
+                     usage_details: dict | None = None, cost_details: dict | None = None) -> None:
     if observation is None:
         return
     try:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -170,7 +170,7 @@ class VoiceReceiver:
         self._running = False
 
         # Decryption
-        self._secret_key: Optional[bytes] = None
+        self._secret_key: bytes | None = None
         self._dave_session = None
         self._bot_ssrc: int = 0
 
@@ -502,7 +502,7 @@ class VoiceReceiver:
                 pass
 
 
-def _read_dm_role_auth_guild() -> Optional[int]:
+def _read_dm_role_auth_guild() -> int | None:
     """Return the guild ID opted-in for DM role-based auth, or None.
 
     Reads ``discord.dm_role_auth_guild`` from config.yaml. This is
@@ -553,7 +553,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
-        self._client: Optional[commands.Bot] = None
+        self._client: commands.Bot | None = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
         self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
@@ -572,8 +572,8 @@ class DiscordAdapter(BasePlatformAdapter):
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
-        self._voice_input_callback: Optional[Callable] = None  # set by run.py
-        self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        self._voice_input_callback: Callable | None = None  # set by run.py
+        self._on_voice_disconnect: Callable | None = None  # set by run.py
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
@@ -581,8 +581,8 @@ class DiscordAdapter(BasePlatformAdapter):
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
-        self._bot_task: Optional[asyncio.Task] = None
-        self._post_connect_task: Optional[asyncio.Task] = None
+        self._bot_task: asyncio.Task | None = None
+        self._post_connect_task: asyncio.Task | None = None
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
@@ -942,7 +942,7 @@ class DiscordAdapter(BasePlatformAdapter):
         payload = json.dumps(desired, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-    def _command_sync_skip_reason(self, app_id: Any, fingerprint: str) -> Optional[str]:
+    def _command_sync_skip_reason(self, app_id: Any, fingerprint: str) -> str | None:
         entry = self._read_command_sync_state().get(self._command_sync_state_key(app_id))
         if not isinstance(entry, dict):
             return None
@@ -995,7 +995,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._write_command_sync_state(state)
 
     @staticmethod
-    def _extract_discord_retry_after(exc: BaseException) -> Optional[float]:
+    def _extract_discord_retry_after(exc: BaseException) -> float | None:
         value = getattr(exc, "retry_after", None)
         if value is not None:
             try:
@@ -1173,7 +1173,7 @@ class DiscordAdapter(BasePlatformAdapter):
         }
 
     @staticmethod
-    def _normalize_permissions(value: Any) -> Optional[str]:
+    def _normalize_permissions(value: Any) -> str | None:
         """Discord emits default_member_permissions as str server-side but discord.py
         sets it as int locally. Normalize to str-or-None so the comparison is stable."""
         if value is None:
@@ -1372,8 +1372,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None
     ) -> SendResult:
         """Send a message to a Discord channel or thread.
 
@@ -1540,10 +1540,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         forum_channel: Any,
         *,
-        thread_name: Optional[str] = None,
+        thread_name: str | None = None,
         content: str = "",
         file: Any = None,
-        files: Optional[list] = None,
+        files: list | None = None,
     ) -> SendResult:
         """Create a forum thread whose starter message carries file attachments.
 
@@ -1625,8 +1625,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
@@ -1658,7 +1658,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single Discord message with multiple attachments.
@@ -1804,9 +1804,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
@@ -2039,7 +2039,7 @@ class DiscordAdapter(BasePlatformAdapter):
         vc = self._voice_clients.get(guild_id)
         return vc is not None and vc.is_connected()
 
-    def get_voice_channel_info(self, guild_id: int) -> Optional[Dict[str, Any]]:
+    def get_voice_channel_info(self, guild_id: int) -> Dict[str, Any] | None:
         """Return voice channel awareness info for the given guild.
 
         Returns None if the bot is not in a voice channel.  Otherwise
@@ -2293,7 +2293,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _evaluate_slash_authorization(
         self, interaction: "discord.Interaction",
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> Tuple[bool, str | None]:
         """Evaluate slash authorization without producing any response.
 
         Returns ``(allowed, reason)``. ``reason`` is populated only when
@@ -2507,9 +2507,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
@@ -2524,9 +2524,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an image natively as a Discord file attachment."""
         if not self._client:
@@ -2603,9 +2603,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         animation_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Discord file attachment."""
         if not self._client:
@@ -2672,9 +2672,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
@@ -2689,10 +2689,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
@@ -3814,7 +3814,7 @@ class DiscordAdapter(BasePlatformAdapter):
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
 
-    async def _resolve_interaction_channel(self, interaction: discord.Interaction) -> Optional[Any]:
+    async def _resolve_interaction_channel(self, interaction: discord.Interaction) -> Any | None:
         """Return the interaction channel, fetching it if the payload is partial."""
         channel = getattr(interaction, "channel", None)
         if channel is not None:
@@ -3907,7 +3907,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # Auto-thread helpers
     # ------------------------------------------------------------------
 
-    async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
+    async def _auto_create_thread(self, message: 'DiscordMessage') -> Any | None:
         """Create a thread from a user message for auto-threading.
 
         Returns the created thread object, or ``None`` on failure.
@@ -3952,7 +3952,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         parent_chat_id: str,
         name: str,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Create a Discord thread under a text channel for a handoff.
 
         Falls back to a seed-message + ``message.create_thread`` path if
@@ -4029,7 +4029,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[dict] = None,
+        metadata: dict | None = None,
     ) -> SendResult:
         """
         Send a button-based exec approval prompt for a dangerous command.
@@ -4074,7 +4074,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
-        confirm_id: str, metadata: Optional[dict] = None,
+        confirm_id: str, metadata: dict | None = None,
     ) -> SendResult:
         """Send a three-button slash-command confirmation prompt."""
         if not self._client or not DISCORD_AVAILABLE:
@@ -4114,10 +4114,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         question: str,
-        choices: Optional[list],
+        choices: list | None,
         clarify_id: str,
         session_key: str,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Render a clarify prompt with one Discord button per choice.
 
@@ -4191,7 +4191,7 @@ class DiscordAdapter(BasePlatformAdapter):
     async def send_update_prompt(
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an interactive button-based update prompt (Yes / No).
 
@@ -4230,7 +4230,7 @@ class DiscordAdapter(BasePlatformAdapter):
         current_provider: str,
         session_key: str,
         on_model_selected,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an interactive select-menu model picker.
 
@@ -4283,7 +4283,7 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_model_picker failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
-    def _get_parent_channel_id(self, channel: Any) -> Optional[str]:
+    def _get_parent_channel_id(self, channel: Any) -> str | None:
         """Return the parent channel ID for a Discord thread-like channel, if present."""
         parent = getattr(channel, "parent", None)
         if parent is not None and getattr(parent, "id", None) is not None:
@@ -4307,7 +4307,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 return True
         return False
 
-    def _get_effective_topic(self, channel: Any, is_thread: bool = False) -> Optional[str]:
+    def _get_effective_topic(self, channel: Any, is_thread: bool = False) -> str | None:
         """Return the channel topic, falling back to the parent forum's topic for forum threads."""
         topic = getattr(channel, "topic", None)
         if not topic and is_thread:
@@ -4357,7 +4357,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # non-CDN URL into the ``att.url`` field. (issue #11345)
     # ------------------------------------------------------------------
 
-    async def _read_attachment_bytes(self, att) -> Optional[bytes]:
+    async def _read_attachment_bytes(self, att) -> bytes | None:
         """Read an attachment via discord.py's authenticated bot session.
 
         Returns the raw bytes on success, or ``None`` if ``att`` doesn't
@@ -4640,7 +4640,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # vision tool can access them reliably (Discord CDN URLs can expire).
         media_urls = []
         media_types = []
-        pending_text_injection: Optional[str] = None
+        pending_text_injection: str | None = None
         for att in all_attachments:
             content_type = att.content_type or "unknown"
             if content_type.startswith("image/"):
@@ -4928,8 +4928,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
 def _component_check_auth(
     interaction,
-    allowed_user_ids: Optional[set],
-    allowed_role_ids: Optional[set],
+    allowed_user_ids: set | None,
+    allowed_role_ids: set | None,
 ) -> bool:
     """Shared user-or-role OR semantics for component view button clicks.
 
@@ -5017,7 +5017,7 @@ def _define_discord_view_classes() -> None:
             self,
             session_key: str,
             allowed_user_ids: set,
-            allowed_role_ids: Optional[set] = None,
+            allowed_role_ids: set | None = None,
         ):
             super().__init__(timeout=300)  # 5-minute timeout
             self.session_key = session_key
@@ -5126,7 +5126,7 @@ def _define_discord_view_classes() -> None:
             session_key: str,
             confirm_id: str,
             allowed_user_ids: set,
-            allowed_role_ids: Optional[set] = None,
+            allowed_role_ids: set | None = None,
         ):
             super().__init__(timeout=300)
             self.session_key = session_key
@@ -5220,7 +5220,7 @@ def _define_discord_view_classes() -> None:
             self,
             session_key: str,
             allowed_user_ids: set,
-            allowed_role_ids: Optional[set] = None,
+            allowed_role_ids: set | None = None,
         ):
             super().__init__(timeout=300)
             self.session_key = session_key
@@ -5308,7 +5308,7 @@ def _define_discord_view_classes() -> None:
             session_key: str,
             on_model_selected,
             allowed_user_ids: set,
-            allowed_role_ids: Optional[set] = None,
+            allowed_role_ids: set | None = None,
         ):
             super().__init__(timeout=120)
             self.providers = providers
@@ -5538,7 +5538,7 @@ def _define_discord_view_classes() -> None:
             choices: List[str],
             clarify_id: str,
             allowed_user_ids: set,
-            allowed_role_ids: Optional[set] = None,
+            allowed_role_ids: set | None = None,
         ):
             super().__init__(timeout=300)  # 5-minute timeout
             self.choices = list(choices)[:24]
@@ -5623,7 +5623,7 @@ def _define_discord_view_classes() -> None:
             # Resolve via the gateway clarify primitive — same mechanism as
             # Telegram. Look up the canonical choice text from the entry so
             # we round-trip the original value, not a button-label variant.
-            resolved_text: Optional[str] = None
+            resolved_text: str | None = None
             try:
                 from tools.clarify_gateway import _entries as _clarify_entries  # type: ignore
                 entry = _clarify_entries.get(self.clarify_id)
@@ -5725,7 +5725,7 @@ def _remember_channel_is_forum(chat_id: str, is_forum: bool) -> None:
     _DISCORD_CHANNEL_TYPE_PROBE_CACHE[str(chat_id)] = bool(is_forum)
 
 
-def _probe_is_forum_cached(chat_id: str) -> Optional[bool]:
+def _probe_is_forum_cached(chat_id: str) -> bool | None:
     return _DISCORD_CHANNEL_TYPE_PROBE_CACHE.get(str(chat_id))
 
 
@@ -5760,8 +5760,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[list] = None,
+    thread_id: str | None = None,
+    media_files: list | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Send via Discord REST API without a live gateway adapter.

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -464,8 +464,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # ~110ms / ~33MB on every CLI invocation. Idempotent — pays the cost
         # exactly once per process.
         _load_google_modules()
-        self._subscriber: Optional[Any] = None
-        self._chat_api: Optional[Any] = None
+        self._subscriber: Any | None = None
+        self._chat_api: Any | None = None
         # User-authed Chat API client built lazily from the OAuth refresh
         # token persisted by the plugin's ``oauth.py`` helper. Required for
         # native ``media.upload`` (bot identity is rejected by that
@@ -482,8 +482,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # but now hold the LEGACY single-user token (if any) — used as a
         # last-ditch fallback when the requesting user has no per-user
         # token yet. Pre-multi-user installs continue to work unchanged.
-        self._user_chat_api: Optional[Any] = None
-        self._user_credentials: Optional[Any] = None
+        self._user_chat_api: Any | None = None
+        self._user_credentials: Any | None = None
         # Per-email caches. Populated lazily by ``_get_user_chat_for_chat``.
         self._user_creds_by_email: Dict[str, Any] = {}
         self._user_chat_api_by_email: Dict[str, Any] = {}
@@ -493,13 +493,13 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # in ``_send_file`` so the bot uploads as the user who triggered
         # the request, not as some other authorized user.
         self._last_sender_by_chat: Dict[str, str] = {}
-        self._credentials: Optional[Any] = None
-        self._project_id: Optional[str] = None
-        self._subscription_path: Optional[str] = None
-        self._streaming_pull_future: Optional[Any] = None
-        self._supervisor_task: Optional[asyncio.Task] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._bot_user_id: Optional[str] = None  # users/{id}
+        self._credentials: Any | None = None
+        self._project_id: str | None = None
+        self._subscription_path: str | None = None
+        self._streaming_pull_future: Any | None = None
+        self._supervisor_task: asyncio.Task | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._bot_user_id: str | None = None  # users/{id}
         self._dedup = MessageDeduplicator()
         self._typing_messages: Dict[str, str] = {}
         self._shutting_down = False
@@ -658,7 +658,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             logger.exception("[GoogleChat] Background inbound processing failed")
 
     @staticmethod
-    def _loop_accepts_callbacks(loop: Optional[asyncio.AbstractEventLoop]) -> bool:
+    def _loop_accepts_callbacks(loop: asyncio.AbstractEventLoop | None) -> bool:
         return loop is not None and not bool(getattr(loop, "is_closed", lambda: False)())
 
     def _submit_on_loop(self, coro: Any) -> None:
@@ -692,7 +692,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
         return _Path(base) / "google_chat_bot_id.json"
 
-    def _load_cached_bot_id(self) -> Optional[str]:
+    def _load_cached_bot_id(self) -> str | None:
         path = self._bot_id_cache_path()
         if not path.exists():
             return None
@@ -713,7 +713,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         except OSError:
             logger.debug("[GoogleChat] Could not persist bot_user_id cache", exc_info=True)
 
-    async def _resolve_bot_user_id(self) -> Optional[str]:
+    async def _resolve_bot_user_id(self) -> str | None:
         """Resolve ``users/{id}`` via Chat API members.list on a known space.
 
         Tries the home channel first, then any space from the allowlist.
@@ -1018,7 +1018,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
     @staticmethod
     def _extract_message_payload(
         envelope: Dict[str, Any], ce_type: str = ""
-    ) -> Optional[Tuple[Dict[str, Any], Dict[str, Any], str]]:
+    ) -> Tuple[Dict[str, Any], Dict[str, Any], str] | None:
         """Detect Pub/Sub envelope format and return ``(message, space, format_name)``.
 
         Three known formats are accepted. Returns ``None`` when the envelope
@@ -1297,9 +1297,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
     async def _handle_setup_files_command(
         self,
         chat_id: str,
-        thread_id: Optional[str],
+        thread_id: str | None,
         raw_text: str,
-        sender_email: Optional[str] = None,
+        sender_email: str | None = None,
     ) -> bool:
         """Run the in-chat OAuth setup flow for native attachment delivery.
 
@@ -1520,7 +1520,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
     async def _build_message_event(
         self, msg: Dict[str, Any], envelope: Dict[str, Any]
-    ) -> Optional[MessageEvent]:
+    ) -> MessageEvent | None:
         """Parse a Chat API message into a hermes MessageEvent."""
         space = envelope.get("space") or msg.get("space") or {}
         space_name = space.get("name") or ""  # "spaces/XXX"
@@ -1646,7 +1646,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
     async def _download_attachment(
         self, attachment: Dict[str, Any]
-    ) -> Tuple[Optional[str], Optional[str]]:
+    ) -> Tuple[str | None, str | None]:
         """Download an inbound attachment to the local cache; return (path, mime).
 
         Priority for bot Service Accounts:
@@ -1685,7 +1685,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             )
             return None, mime
 
-        data: Optional[bytes] = None
+        data: bytes | None = None
 
         # Path 1: media.download with attachmentDataRef.resourceName (bot-path).
         if resource_name:
@@ -1766,8 +1766,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a text message.
 
@@ -1798,7 +1798,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             if not chunks:
                 return SendResult(success=False, error="empty message")
 
-            last_result: Optional[SendResult] = None
+            last_result: SendResult | None = None
             typing_msg_name = self._typing_messages.pop(chat_id, None)
             # Treat any earlier sentinel as "no real card to patch" — defensive.
             if typing_msg_name == _TYPING_CONSUMED_SENTINEL:
@@ -2093,10 +2093,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
     def _resolve_thread_id(
         self,
-        reply_to: Optional[str],
-        metadata: Optional[Dict[str, Any]],
-        chat_id: Optional[str] = None,
-    ) -> Optional[str]:
+        reply_to: str | None,
+        metadata: Dict[str, Any] | None,
+        chat_id: str | None = None,
+    ) -> str | None:
         """Return the Google Chat thread resource name to reply under, or None.
 
         Priority:
@@ -2155,7 +2155,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
         Pattern lifted from PR #14965.
         """
         delay = _RETRY_BASE_DELAY
-        last_exc: Optional[BaseException] = None
+        last_exc: BaseException | None = None
         for attempt in range(1, _RETRY_MAX_ATTEMPTS + 1):
             try:
                 return await asyncio.to_thread(sync_fn)
@@ -2434,7 +2434,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     async def _consume_typing_card_with_text(
         self, chat_id: str, text: str
-    ) -> Optional[SendResult]:
+    ) -> SendResult | None:
         """Patch the tracked typing card with ``text`` (no tombstone).
 
         Returns ``None`` if there's no real typing card to patch (caller
@@ -2468,9 +2468,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an inline image via attachment URL (no upload).
 
@@ -2500,8 +2500,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs: Any,
     ) -> SendResult:
         return await self._send_file(
@@ -2514,9 +2514,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
         **kwargs: Any,
     ) -> SendResult:
         return await self._send_file(
@@ -2530,8 +2530,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs: Any,
     ) -> SendResult:
         return await self._send_file(
@@ -2544,8 +2544,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs: Any,
     ) -> SendResult:
         return await self._send_file(
@@ -2558,9 +2558,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         animation_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Google Chat has no native animation type; fall back to send_image."""
         return await self.send_image(
@@ -2604,7 +2604,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
     _LEGACY_USER_IDENTITY = "__legacy__"
 
-    async def _load_per_user_chat_api(self, email: str) -> Optional[Any]:
+    async def _load_per_user_chat_api(self, email: str) -> Any | None:
         """Get (or build + cache) a user-authed Chat client for ``email``.
 
         Hits ``self._user_chat_api_by_email`` first; on miss, loads the
@@ -2653,8 +2653,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         return api
 
     async def _acquire_user_chat_api(
-        self, sender_email: Optional[str]
-    ) -> Tuple[Optional[Any], Optional[str]]:
+        self, sender_email: str | None
+    ) -> Tuple[Any | None, str | None]:
         """Resolve the user-authed Chat client for an outbound attachment.
 
         Lookup order:
@@ -2699,7 +2699,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
         return None, None
 
-    def _invalidate_user_creds(self, identity: Optional[str]) -> None:
+    def _invalidate_user_creds(self, identity: str | None) -> None:
         """Drop creds for ``identity`` after an auth failure.
 
         ``identity`` comes from ``_acquire_user_chat_api`` — either the
@@ -2719,10 +2719,10 @@ class GoogleChatAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         path: str,
-        caption: Optional[str],
-        mime_hint: Optional[str],
-        thread_id: Optional[str] = None,
-        override_filename: Optional[str] = None,
+        caption: str | None,
+        mime_hint: str | None,
+        thread_id: str | None = None,
+        override_filename: str | None = None,
     ) -> SendResult:
         """Native Chat attachment via user-OAuth media.upload.
 
@@ -2870,8 +2870,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
         chat_id: str,
         path: str,
         filename: str,
-        caption: Optional[str],
-        thread_id: Optional[str],
+        caption: str | None,
+        thread_id: str | None,
     ) -> SendResult:
         """Post a text notice when native attachment delivery is unavailable.
 
@@ -2979,7 +2979,7 @@ def _is_connected(config: PlatformConfig) -> bool:
     return bool(getattr(config, "enabled", False)) and _validate_config(config)
 
 
-def _env_enablement() -> Optional[Dict[str, Any]]:
+def _env_enablement() -> Dict[str, Any] | None:
     """Seed ``PlatformConfig.extra`` from env vars during
     ``_apply_env_overrides``.
 
@@ -3126,8 +3126,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    thread_id: str | None = None,
+    media_files: List[str] | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """POST a single Google Chat message via the REST API without the SDK.

--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -132,7 +132,7 @@ def _user_pending_dir() -> Path:
     return _hermes_home() / "google_chat_user_oauth_pending"
 
 
-def _token_path(email: Optional[str] = None) -> Path:
+def _token_path(email: str | None = None) -> Path:
     """Return the on-disk token path for ``email`` or the legacy path."""
     if email:
         return _user_tokens_dir() / f"{_sanitize_email(email)}.json"
@@ -143,7 +143,7 @@ def _client_secret_path() -> Path:
     return _hermes_home() / "google_chat_user_client_secret.json"
 
 
-def _pending_auth_path(email: Optional[str] = None) -> Path:
+def _pending_auth_path(email: str | None = None) -> Path:
     if email:
         return _user_pending_dir() / f"{_sanitize_email(email)}.json"
     return _legacy_pending_path()
@@ -176,7 +176,7 @@ _REDIRECT_URI = "http://localhost:1"
 # =============================================================================
 
 
-def load_user_credentials(email: Optional[str] = None) -> Optional[Any]:
+def load_user_credentials(email: str | None = None) -> Any | None:
     """Load + validate persisted user OAuth credentials.
 
     ``email`` selects the per-user token file; ``None`` falls back to the
@@ -236,7 +236,7 @@ def load_user_credentials(email: Optional[str] = None) -> Optional[Any]:
     return None
 
 
-def refresh_or_none(creds: Any, email: Optional[str] = None) -> Optional[Any]:
+def refresh_or_none(creds: Any, email: str | None = None) -> Any | None:
     """Refresh ``creds`` if expired. Returns the credentials or ``None``.
 
     Used by the adapter just before calling media.upload to ensure the
@@ -392,7 +392,7 @@ def install_deps() -> bool:
         return False
 
 
-def check_auth(email: Optional[str] = None) -> bool:
+def check_auth(email: str | None = None) -> bool:
     """Print status; return True if creds are usable.
 
     Per-user when ``email`` given, legacy single-user when omitted.
@@ -440,7 +440,7 @@ def store_client_secret(path: str) -> None:
 
 
 def _save_pending_auth(*, state: str, code_verifier: str,
-                      email: Optional[str] = None) -> None:
+                      email: str | None = None) -> None:
     pending = _pending_auth_path(email)
     _write_private_json(
         pending,
@@ -453,7 +453,7 @@ def _save_pending_auth(*, state: str, code_verifier: str,
     )
 
 
-def _load_pending_auth(email: Optional[str] = None) -> dict:
+def _load_pending_auth(email: str | None = None) -> dict:
     pending = _pending_auth_path(email)
     if not pending.exists():
         print("ERROR: No pending OAuth session found. Run --auth-url first.")
@@ -471,7 +471,7 @@ def _load_pending_auth(email: Optional[str] = None) -> dict:
     return data
 
 
-def _extract_code_and_state(code_or_url: str) -> Tuple[str, Optional[str]]:
+def _extract_code_and_state(code_or_url: str) -> Tuple[str, str | None]:
     """Accept a raw auth code OR the full failed-redirect URL the user pastes."""
     if not code_or_url.startswith("http"):
         return code_or_url, None
@@ -487,7 +487,7 @@ def _extract_code_and_state(code_or_url: str) -> Tuple[str, Optional[str]]:
     return params["code"][0], state
 
 
-def get_auth_url(email: Optional[str] = None) -> None:
+def get_auth_url(email: str | None = None) -> None:
     """Print the OAuth URL for the user to visit. Persists PKCE state.
 
     ``email`` namespaces the pending state so two users can be mid-flow
@@ -514,7 +514,7 @@ def get_auth_url(email: Optional[str] = None) -> None:
     print(auth_url)
 
 
-def exchange_auth_code(code: str, email: Optional[str] = None) -> None:
+def exchange_auth_code(code: str, email: str | None = None) -> None:
     """Exchange an auth code (or pasted redirect URL) for a refresh token.
 
     ``email`` selects the destination token path. ``None`` writes to the
@@ -589,7 +589,7 @@ def exchange_auth_code(code: str, email: Optional[str] = None) -> None:
     print(f"Profile path: {rel_label}")
 
 
-def revoke(email: Optional[str] = None) -> None:
+def revoke(email: str | None = None) -> None:
     """Revoke the stored token with Google and delete it locally.
 
     Per-user when ``email`` given, legacy single-user when omitted.

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -137,9 +137,9 @@ class IRCAdapter(BasePlatformAdapter):
         self.max_message_length = int(max_msg or 450)
 
         # Runtime state
-        self._reader: Optional[asyncio.StreamReader] = None
-        self._writer: Optional[asyncio.StreamWriter] = None
-        self._recv_task: Optional[asyncio.Task] = None
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._recv_task: asyncio.Task | None = None
         self._current_nick = self.nickname
         self._registered = False  # IRC registration complete
         self._registration_event = asyncio.Event()
@@ -257,8 +257,8 @@ class IRCAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ):
         if not self._writer or self._writer.is_closing():
             return SendResult(success=False, error="Not connected")
@@ -719,8 +719,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    thread_id: str | None = None,
+    media_files: List[str] | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Open an ephemeral IRC connection, send a PRIVMSG, and quit.

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -304,7 +304,7 @@ class RequestCache:
         self._entries[rid] = _CacheEntry(state=State.PENDING, chat_id=chat_id)
         return rid
 
-    def get(self, request_id: str) -> Optional[_CacheEntry]:
+    def get(self, request_id: str) -> _CacheEntry | None:
         return self._entries.get(request_id)
 
     def set_ready(self, request_id: str, payload: Any) -> None:
@@ -330,7 +330,7 @@ class RequestCache:
         entry.state = State.DELIVERED
         entry.updated_at = time.time()
 
-    def find_pending_for_chat(self, chat_id: str) -> Optional[str]:
+    def find_pending_for_chat(self, chat_id: str) -> str | None:
         for rid, entry in self._entries.items():
             if entry.state is State.PENDING and entry.chat_id == chat_id:
                 return rid
@@ -499,7 +499,7 @@ class _LineClient:
                     raise RuntimeError(f"LINE content {resp.status}")
                 return await resp.read()
 
-    async def get_bot_user_id(self) -> Optional[str]:
+    async def get_bot_user_id(self) -> str | None:
         """Fetch this channel's own userId so we can filter self-messages."""
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=10.0)
@@ -525,7 +525,7 @@ def _text_message(text: str) -> Dict[str, Any]:
     return {"type": "text", "text": text}
 
 
-def _image_message(original_url: str, preview_url: Optional[str] = None) -> Dict[str, Any]:
+def _image_message(original_url: str, preview_url: str | None = None) -> Dict[str, Any]:
     return {
         "type": "image",
         "originalContentUrl": original_url,
@@ -703,15 +703,15 @@ class LineAdapter(BasePlatformAdapter):
         )
 
         # Runtime state
-        self._client: Optional[_LineClient] = None
+        self._client: _LineClient | None = None
         self._app = None  # aiohttp.web.Application
         self._runner = None  # aiohttp.web.AppRunner
         self._site = None  # aiohttp.web.TCPSite
         self._reply_tokens: Dict[str, Tuple[str, float]] = {}  # chat_id → (token, expiry)
         self._cache = RequestCache()
         self._dedup = _MessageDeduplicator()
-        self._bot_user_id: Optional[str] = None
-        self._lock_key: Optional[str] = None
+        self._bot_user_id: str | None = None
+        self._lock_key: str | None = None
 
         # Media state
         self._media_tokens: Dict[str, Tuple[str, float]] = {}  # token → (path, expiry)
@@ -1038,7 +1038,7 @@ class LineAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-    async def _download_media(self, message_id: str, msg_type: str) -> Optional[str]:
+    async def _download_media(self, message_id: str, msg_type: str) -> str | None:
         if not self._client or not message_id:
             return None
         try:
@@ -1066,8 +1066,8 @@ class LineAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         if not self._client:
             return SendResult(success=False, error="LINE adapter not connected")
@@ -1307,8 +1307,8 @@ class LineAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         path = Path(image_path)
         if not path.exists() or not path.is_file():
@@ -1338,7 +1338,7 @@ class LineAdapter(BasePlatformAdapter):
         chat_id: str,
         audio_path: str,
         duration_ms: int = 1000,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         path = Path(audio_path)
         if not path.exists() or not path.is_file():
@@ -1361,8 +1361,8 @@ class LineAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        preview_path: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        preview_path: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         path = Path(video_path)
         if not path.exists() or not path.is_file():
@@ -1492,7 +1492,7 @@ def is_connected(config) -> bool:
     return validate_config(config)
 
 
-def _env_enablement() -> Optional[Dict[str, Any]]:
+def _env_enablement() -> Dict[str, Any] | None:
     """Auto-seed PlatformConfig.extra from env-only setups.
 
     Lets ``hermes status`` reflect a LINE configuration that lives entirely
@@ -1521,8 +1521,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    thread_id: str | None = None,
+    media_files: List[str] | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Out-of-process push delivery for cron jobs running detached from the gateway.

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -86,8 +86,8 @@ class MattermostAdapter(BasePlatformAdapter):
         # aiohttp session + websocket handle
         self._session: Any = None  # aiohttp.ClientSession
         self._ws: Any = None       # aiohttp.ClientWebSocketResponse
-        self._ws_task: Optional[asyncio.Task] = None
-        self._reconnect_task: Optional[asyncio.Task] = None
+        self._ws_task: asyncio.Task | None = None
+        self._reconnect_task: asyncio.Task | None = None
         self._closing = False
 
         # Reply mode: "thread" to nest replies, "off" for flat messages.
@@ -165,7 +165,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
     async def _upload_file(
         self, channel_id: str, file_data: bytes, filename: str, content_type: str = "application/octet-stream"
-    ) -> Optional[str]:
+    ) -> str | None:
         """Upload a file and return its file ID, or None on failure."""
         import aiohttp
 
@@ -270,8 +270,8 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a message (or multiple chunks) to a channel."""
         if not content:
@@ -315,7 +315,7 @@ class MattermostAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(
-        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+        self, chat_id: str, metadata: Dict[str, Any] | None = None
     ) -> None:
         """Send a typing indicator."""
         await self._api_post(
@@ -340,9 +340,9 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Download an image and upload it as a file attachment."""
         return await self._send_url_as_file(
@@ -353,9 +353,9 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload a local image file."""
         return await self._send_local_file(
@@ -366,10 +366,10 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload a local file as a document."""
         return await self._send_local_file(
@@ -380,9 +380,9 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(
@@ -393,9 +393,9 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Upload a video file."""
         return await self._send_local_file(
@@ -420,8 +420,8 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         url: str,
-        caption: Optional[str],
-        reply_to: Optional[str],
+        caption: str | None,
+        reply_to: str | None,
         kind: str = "file",
     ) -> SendResult:
         """Download a URL and upload it as a file attachment."""
@@ -482,9 +482,9 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str],
-        reply_to: Optional[str],
-        file_name: Optional[str] = None,
+        caption: str | None,
+        reply_to: str | None,
+        file_name: str | None = None,
     ) -> SendResult:
         """Upload a local file and attach it to a post."""
         import mimetypes
@@ -521,7 +521,7 @@ class MattermostAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         images: List[Tuple[str, str]],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
         human_delay: float = 0.0,
     ) -> None:
         """Send a batch of images as a single Mattermost post with multiple attachments.
@@ -883,8 +883,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[list] = None,
+    thread_id: str | None = None,
+    media_files: list | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Send via the Mattermost v4 REST API without a live gateway adapter.

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -174,8 +174,8 @@ class NtfyAdapter(BasePlatformAdapter):
         )
         self._token: str = extra.get("token") or os.getenv("NTFY_TOKEN", "")
 
-        self._stream_task: Optional[asyncio.Task] = None
-        self._http_client: Optional["httpx.AsyncClient"] = None
+        self._stream_task: asyncio.Task | None = None
+        self._http_client: "httpx.AsyncClient" | None = None
 
         # Message deduplication: msg_id -> timestamp
         self._seen_messages: Dict[str, float] = {}
@@ -375,8 +375,8 @@ class NtfyAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Publish a message to the configured publish topic."""
         metadata = metadata or {}
@@ -481,8 +481,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    thread_id: str | None = None,
+    media_files: List[str] | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Out-of-process publish for cron / send_message_tool fallbacks.

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -128,8 +128,8 @@ class SimplexAdapter(BasePlatformAdapter):
 
         # Running state
         self._ws = None  # websockets connection
-        self._ws_task: Optional[asyncio.Task] = None
-        self._health_task: Optional[asyncio.Task] = None
+        self._ws_task: asyncio.Task | None = None
+        self._health_task: asyncio.Task | None = None
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._running = False
         self._last_ws_activity = 0.0
@@ -428,7 +428,7 @@ class SimplexAdapter(BasePlatformAdapter):
 
         await self.handle_message(event_obj)
 
-    async def _fetch_file(self, file_id: Any, file_name: str) -> Optional[str]:
+    async def _fetch_file(self, file_id: Any, file_name: str) -> str | None:
         """Ask the daemon to receive and return a file attachment."""
         # simplex-chat exposes `/api/v1/files/{fileId}` on an HTTP port
         # when started with --http-port. However, the canonical WebSocket API
@@ -498,8 +498,8 @@ class SimplexAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a text message to a contact or group."""
         corr_id = self._make_corr_id()
@@ -526,9 +526,9 @@ class SimplexAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an image (URL) as a message with optional caption.
 
@@ -611,8 +611,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    thread_id: str | None = None,
+    media_files: List[str] | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Open an ephemeral WebSocket to the daemon, send, and close.

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -162,7 +162,7 @@ class TeamsSummaryWriter:
         self,
         payload: Any,
         config: dict[str, Any] | None,
-        existing_record: Optional[dict[str, Any]] = None,
+        existing_record: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         merged = self._resolve_delivery_config(config)
         if existing_record and not _parse_bool(merged.get("force_resend"), default=False):
@@ -470,7 +470,7 @@ import re as _re_teams
 _TEAMS_CONV_ID_RE = _re_teams.compile(r"^[A-Za-z0-9:@\-_.]+$")
 
 
-def _validate_teams_service_url(raw: str) -> Optional[str]:
+def _validate_teams_service_url(raw: str) -> str | None:
     """Return a normalized service URL or ``None`` if it is not allowed.
 
     Requires ``https://`` and a host in ``_ALLOWED_TEAMS_SERVICE_HOSTS``.
@@ -498,8 +498,8 @@ async def _standalone_send(
     chat_id: str,
     message: str,
     *,
-    thread_id: Optional[str] = None,
-    media_files: Optional[list] = None,
+    thread_id: str | None = None,
+    media_files: list | None = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Acquire a Bot Framework bearer token and POST a single message activity.
@@ -633,8 +633,8 @@ class TeamsAdapter(BasePlatformAdapter):
         self._port = _coerce_port(
             extra.get("port") or os.getenv("TEAMS_PORT", str(_DEFAULT_PORT))
         )
-        self._app: Optional["App"] = None
-        self._runner: Optional["web.AppRunner"] = None
+        self._app: "App" | None = None
+        self._runner: "web.AppRunner" | None = None
         self._dedup = MessageDeduplicator(max_size=1000)
         # Maps chat_id → ConversationReference captured from incoming messages.
         # Used to send cards with the correct conversation type (personal/group/channel).
@@ -919,7 +919,7 @@ class TeamsAdapter(BasePlatformAdapter):
         command: str,
         session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an Adaptive Card approval prompt with Allow/Deny buttons."""
         if not self._app:
@@ -979,8 +979,8 @@ class TeamsAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")
@@ -1011,7 +1011,7 @@ class TeamsAdapter(BasePlatformAdapter):
 
         return SendResult(success=True, message_id=last_message_id)
 
-    async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    async def send_typing(self, chat_id: str, metadata: Dict[str, Any] | None = None) -> None:
         if not self._app:
             return
         try:
@@ -1023,9 +1023,9 @@ class TeamsAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> SendResult:
         if not self._app:
             return SendResult(success=False, error="Teams app not initialized")
@@ -1065,8 +1065,8 @@ class TeamsAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
         **kwargs,
     ) -> SendResult:
         return await self.send_image(

--- a/plugins/spotify/client.py
+++ b/plugins/spotify/client.py
@@ -29,8 +29,8 @@ class SpotifyAPIError(SpotifyError):
         self,
         message: str,
         *,
-        status_code: Optional[int] = None,
-        response_body: Optional[str] = None,
+        status_code: int | None = None,
+        response_body: str | None = None,
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
@@ -66,10 +66,10 @@ class SpotifyClient:
         method: str,
         path: str,
         *,
-        params: Optional[Dict[str, Any]] = None,
-        json_body: Optional[Dict[str, Any]] = None,
+        params: Dict[str, Any] | None = None,
+        json_body: Dict[str, Any] | None = None,
         allow_retry_on_401: bool = True,
-        empty_response: Optional[Dict[str, Any]] = None,
+        empty_response: Dict[str, Any] | None = None,
     ) -> Any:
         url = f"{self.base_url}{path}"
         response = httpx.request(
@@ -119,7 +119,7 @@ class SpotifyClient:
             "play": play,
         })
 
-    def get_playback_state(self, *, market: Optional[str] = None) -> Any:
+    def get_playback_state(self, *, market: str | None = None) -> Any:
         return self.request(
             "GET",
             "/me/player",
@@ -131,7 +131,7 @@ class SpotifyClient:
             },
         )
 
-    def get_currently_playing(self, *, market: Optional[str] = None) -> Any:
+    def get_currently_playing(self, *, market: str | None = None) -> Any:
         return self.request(
             "GET",
             "/me/player/currently-playing",
@@ -146,11 +146,11 @@ class SpotifyClient:
     def start_playback(
         self,
         *,
-        device_id: Optional[str] = None,
-        context_uri: Optional[str] = None,
-        uris: Optional[list[str]] = None,
-        offset: Optional[Dict[str, Any]] = None,
-        position_ms: Optional[int] = None,
+        device_id: str | None = None,
+        context_uri: str | None = None,
+        uris: list[str] | None = None,
+        offset: Dict[str, Any] | None = None,
+        position_ms: int | None = None,
     ) -> Any:
         return self.request(
             "PUT",
@@ -164,28 +164,28 @@ class SpotifyClient:
             },
         )
 
-    def pause_playback(self, *, device_id: Optional[str] = None) -> Any:
+    def pause_playback(self, *, device_id: str | None = None) -> Any:
         return self.request("PUT", "/me/player/pause", params={"device_id": device_id})
 
-    def skip_next(self, *, device_id: Optional[str] = None) -> Any:
+    def skip_next(self, *, device_id: str | None = None) -> Any:
         return self.request("POST", "/me/player/next", params={"device_id": device_id})
 
-    def skip_previous(self, *, device_id: Optional[str] = None) -> Any:
+    def skip_previous(self, *, device_id: str | None = None) -> Any:
         return self.request("POST", "/me/player/previous", params={"device_id": device_id})
 
-    def seek(self, *, position_ms: int, device_id: Optional[str] = None) -> Any:
+    def seek(self, *, position_ms: int, device_id: str | None = None) -> Any:
         return self.request("PUT", "/me/player/seek", params={
             "position_ms": position_ms,
             "device_id": device_id,
         })
 
-    def set_repeat(self, *, state: str, device_id: Optional[str] = None) -> Any:
+    def set_repeat(self, *, state: str, device_id: str | None = None) -> Any:
         return self.request("PUT", "/me/player/repeat", params={"state": state, "device_id": device_id})
 
-    def set_shuffle(self, *, state: bool, device_id: Optional[str] = None) -> Any:
+    def set_shuffle(self, *, state: bool, device_id: str | None = None) -> Any:
         return self.request("PUT", "/me/player/shuffle", params={"state": str(bool(state)).lower(), "device_id": device_id})
 
-    def set_volume(self, *, volume_percent: int, device_id: Optional[str] = None) -> Any:
+    def set_volume(self, *, volume_percent: int, device_id: str | None = None) -> Any:
         return self.request("PUT", "/me/player/volume", params={
             "volume_percent": volume_percent,
             "device_id": device_id,
@@ -194,7 +194,7 @@ class SpotifyClient:
     def get_queue(self) -> Any:
         return self.request("GET", "/me/player/queue")
 
-    def add_to_queue(self, *, uri: str, device_id: Optional[str] = None) -> Any:
+    def add_to_queue(self, *, uri: str, device_id: str | None = None) -> Any:
         return self.request("POST", "/me/player/queue", params={"uri": uri, "device_id": device_id})
 
     def search(
@@ -204,8 +204,8 @@ class SpotifyClient:
         search_types: list[str],
         limit: int = 10,
         offset: int = 0,
-        market: Optional[str] = None,
-        include_external: Optional[str] = None,
+        market: str | None = None,
+        include_external: str | None = None,
     ) -> Any:
         return self.request("GET", "/search", params={
             "q": query,
@@ -219,7 +219,7 @@ class SpotifyClient:
     def get_my_playlists(self, *, limit: int = 20, offset: int = 0) -> Any:
         return self.request("GET", "/me/playlists", params={"limit": limit, "offset": offset})
 
-    def get_playlist(self, *, playlist_id: str, market: Optional[str] = None) -> Any:
+    def get_playlist(self, *, playlist_id: str, market: str | None = None) -> Any:
         return self.request("GET", f"/playlists/{playlist_id}", params={"market": market})
 
     def create_playlist(
@@ -228,7 +228,7 @@ class SpotifyClient:
         name: str,
         public: bool = False,
         collaborative: bool = False,
-        description: Optional[str] = None,
+        description: str | None = None,
     ) -> Any:
         return self.request("POST", "/me/playlists", json_body={
             "name": name,
@@ -242,7 +242,7 @@ class SpotifyClient:
         *,
         playlist_id: str,
         uris: list[str],
-        position: Optional[int] = None,
+        position: int | None = None,
     ) -> Any:
         return self.request("POST", f"/playlists/{playlist_id}/items", json_body={
             "uris": uris,
@@ -254,7 +254,7 @@ class SpotifyClient:
         *,
         playlist_id: str,
         uris: list[str],
-        snapshot_id: Optional[str] = None,
+        snapshot_id: str | None = None,
     ) -> Any:
         return self.request("DELETE", f"/playlists/{playlist_id}/items", json_body={
             "items": [{"uri": uri} for uri in uris],
@@ -265,10 +265,10 @@ class SpotifyClient:
         self,
         *,
         playlist_id: str,
-        name: Optional[str] = None,
-        public: Optional[bool] = None,
-        collaborative: Optional[bool] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        public: bool | None = None,
+        collaborative: bool | None = None,
+        description: str | None = None,
     ) -> Any:
         return self.request("PUT", f"/playlists/{playlist_id}", json_body={
             "name": name,
@@ -277,17 +277,17 @@ class SpotifyClient:
             "description": description,
         })
 
-    def get_album(self, *, album_id: str, market: Optional[str] = None) -> Any:
+    def get_album(self, *, album_id: str, market: str | None = None) -> Any:
         return self.request("GET", f"/albums/{album_id}", params={"market": market})
 
-    def get_album_tracks(self, *, album_id: str, limit: int = 20, offset: int = 0, market: Optional[str] = None) -> Any:
+    def get_album_tracks(self, *, album_id: str, limit: int = 20, offset: int = 0, market: str | None = None) -> Any:
         return self.request("GET", f"/albums/{album_id}/tracks", params={
             "limit": limit,
             "offset": offset,
             "market": market,
         })
 
-    def get_saved_tracks(self, *, limit: int = 20, offset: int = 0, market: Optional[str] = None) -> Any:
+    def get_saved_tracks(self, *, limit: int = 20, offset: int = 0, market: str | None = None) -> Any:
         return self.request("GET", "/me/tracks", params={"limit": limit, "offset": offset, "market": market})
 
     def save_library_items(self, *, uris: list[str]) -> Any:
@@ -296,7 +296,7 @@ class SpotifyClient:
     def library_contains(self, *, uris: list[str]) -> Any:
         return self.request("GET", "/me/library/contains", params={"uris": ",".join(uris)})
 
-    def get_saved_albums(self, *, limit: int = 20, offset: int = 0, market: Optional[str] = None) -> Any:
+    def get_saved_albums(self, *, limit: int = 20, offset: int = 0, market: str | None = None) -> Any:
         return self.request("GET", "/me/albums", params={"limit": limit, "offset": offset, "market": market})
 
     def remove_saved_tracks(self, *, track_ids: list[str]) -> Any:
@@ -311,8 +311,8 @@ class SpotifyClient:
         self,
         *,
         limit: int = 20,
-        after: Optional[int] = None,
-        before: Optional[int] = None,
+        after: int | None = None,
+        before: int | None = None,
     ) -> Any:
         return self.request("GET", "/me/player/recently-played", params={
             "limit": limit,
@@ -342,7 +342,7 @@ def _friendly_spotify_error_message(
     detail: str,
     method: str,
     path: str,
-    retry_after: Optional[str],
+    retry_after: str | None,
 ) -> str:
     normalized_detail = detail.lower()
     is_playback_path = path.startswith("/me/player")
@@ -376,13 +376,13 @@ def _friendly_spotify_error_message(
     return f"Spotify API request failed with status {status_code}."
 
 
-def _strip_none(payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _strip_none(payload: Dict[str, Any] | None) -> Dict[str, Any]:
     if not payload:
         return {}
     return {key: value for key, value in payload.items() if value is not None}
 
 
-def normalize_spotify_id(value: str, expected_type: Optional[str] = None) -> str:
+def normalize_spotify_id(value: str, expected_type: str | None = None) -> str:
     cleaned = (value or "").strip()
     if not cleaned:
         raise SpotifyError("Spotify id/uri/url is required.")
@@ -404,7 +404,7 @@ def normalize_spotify_id(value: str, expected_type: Optional[str] = None) -> str
     return cleaned
 
 
-def normalize_spotify_uri(value: str, expected_type: Optional[str] = None) -> str:
+def normalize_spotify_uri(value: str, expected_type: str | None = None) -> str:
     cleaned = (value or "").strip()
     if not cleaned:
         raise SpotifyError("Spotify URI/url/id is required.")
@@ -420,7 +420,7 @@ def normalize_spotify_uri(value: str, expected_type: Optional[str] = None) -> st
     return cleaned
 
 
-def normalize_spotify_uris(values: Iterable[str], expected_type: Optional[str] = None) -> list[str]:
+def normalize_spotify_uris(values: Iterable[str], expected_type: str | None = None) -> list[str]:
     uris: list[str] = []
     for value in values:
         uri = normalize_spotify_uri(str(value), expected_type)

--- a/plugins/teams_pipeline/pipeline.py
+++ b/plugins/teams_pipeline/pipeline.py
@@ -67,10 +67,10 @@ class TeamsPipelineArtifactNotFoundError(TeamsPipelineRetryableError):
     """Raised when meeting artifacts are not yet available."""
 
 
-TranscribeFn = Callable[[str, Optional[str]], dict[str, Any]]
+TranscribeFn = Callable[[str, str | None], dict[str, Any]]
 SummarizeFn = Callable[..., Awaitable[dict[str, Any] | TeamsMeetingSummaryPayload]]
 SinkFn = Callable[
-    [TeamsMeetingSummaryPayload, dict[str, Any], Optional[dict[str, Any]]],
+    [TeamsMeetingSummaryPayload, dict[str, Any], dict[str, Any] | None],
     Awaitable[dict[str, Any]],
 ]
 
@@ -89,7 +89,7 @@ class TeamsPipelineConfig:
     teams_delivery: dict[str, Any] | None = None
 
     @classmethod
-    def from_dict(cls, payload: Optional[dict[str, Any]]) -> "TeamsPipelineConfig":
+    def from_dict(cls, payload: dict[str, Any] | None) -> "TeamsPipelineConfig":
         data = dict(payload or {})
         tmp_dir = data.get("tmp_dir") or data.get("tmpDir")
         return cls(
@@ -118,7 +118,7 @@ class NotionWriter:
         self,
         payload: TeamsMeetingSummaryPayload,
         config: dict[str, Any],
-        existing_record: Optional[dict[str, Any]] = None,
+        existing_record: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if not self.api_key:
             raise TeamsPipelineSinkError("NOTION_API_KEY is not configured.")
@@ -214,7 +214,7 @@ class LinearWriter:
         self,
         payload: TeamsMeetingSummaryPayload,
         config: dict[str, Any],
-        existing_record: Optional[dict[str, Any]] = None,
+        existing_record: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         if not self.api_key:
             raise TeamsPipelineSinkError("LINEAR_API_KEY is not configured.")
@@ -278,10 +278,10 @@ class TeamsMeetingPipeline:
         store: TeamsPipelineStore,
         config: TeamsPipelineConfig | dict[str, Any] | None = None,
         transcribe_fn: TranscribeFn = transcribe_audio,
-        summarize_fn: Optional[SummarizeFn] = None,
-        notion_writer: Optional[NotionWriter] = None,
-        linear_writer: Optional[LinearWriter] = None,
-        teams_sender: Optional[SinkFn] = None,
+        summarize_fn: SummarizeFn | None = None,
+        notion_writer: NotionWriter | None = None,
+        linear_writer: LinearWriter | None = None,
+        teams_sender: SinkFn | None = None,
     ) -> None:
         self.graph_client = graph_client
         self.store = store

--- a/plugins/teams_pipeline/store.py
+++ b/plugins/teams_pipeline/store.py
@@ -80,7 +80,7 @@ class TeamsPipelineStore:
         with self._lock:
             return deepcopy(self._state["subscriptions"])
 
-    def get_subscription(self, subscription_id: str) -> Optional[Dict[str, Any]]:
+    def get_subscription(self, subscription_id: str) -> Dict[str, Any] | None:
         with self._lock:
             record = self._state["subscriptions"].get(subscription_id)
             return deepcopy(record) if isinstance(record, dict) else None
@@ -120,9 +120,9 @@ class TeamsPipelineStore:
     def record_notification_receipt(
         self,
         receipt_key: str,
-        payload: Optional[Dict[str, Any]] = None,
+        payload: Dict[str, Any] | None = None,
         *,
-        received_at: Optional[str] = None,
+        received_at: str | None = None,
     ) -> bool:
         with self._lock:
             if receipt_key in self._state["notification_receipts"]:
@@ -134,14 +134,14 @@ class TeamsPipelineStore:
             self._persist()
             return True
 
-    def record_event_timestamp(self, event_key: str, timestamp: Optional[str] = None) -> str:
+    def record_event_timestamp(self, event_key: str, timestamp: str | None = None) -> str:
         with self._lock:
             value = timestamp or _utc_now_iso()
             self._state["event_timestamps"][event_key] = value
             self._persist()
             return value
 
-    def get_event_timestamp(self, event_key: str) -> Optional[str]:
+    def get_event_timestamp(self, event_key: str) -> str | None:
         with self._lock:
             value = self._state["event_timestamps"].get(event_key)
             return str(value) if value is not None else None
@@ -167,7 +167,7 @@ class TeamsPipelineStore:
             self._persist()
             return deepcopy(merged)
 
-    def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+    def get_job(self, job_id: str) -> Dict[str, Any] | None:
         with self._lock:
             record = self._state["jobs"].get(job_id)
             return deepcopy(record) if isinstance(record, dict) else None
@@ -187,7 +187,7 @@ class TeamsPipelineStore:
             self._persist()
             return deepcopy(merged)
 
-    def get_sink_record(self, sink_key: str) -> Optional[Dict[str, Any]]:
+    def get_sink_record(self, sink_key: str) -> Dict[str, Any] | None:
         with self._lock:
             record = self._state["sink_records"].get(sink_key)
             return deepcopy(record) if isinstance(record, dict) else None

--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -172,7 +172,7 @@ def _is_duration_range(durations: Any) -> bool:
     return durations[1] - durations[0] > 1
 
 
-def _clamp_duration(family: Dict[str, Any], duration: Optional[int]) -> Optional[int]:
+def _clamp_duration(family: Dict[str, Any], duration: int | None) -> int | None:
     durations = family.get("durations")
     if not durations:
         return duration
@@ -204,9 +204,9 @@ def _load_video_gen_section() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_family(explicit: Optional[str]) -> Tuple[str, Dict[str, Any]]:
+def _resolve_family(explicit: str | None) -> Tuple[str, Dict[str, Any]]:
     """Decide which FAL family to use. Returns ``(family_id, meta)``."""
-    candidates: List[Optional[str]] = []
+    candidates: List[str | None] = []
     candidates.append(explicit)
     candidates.append(os.environ.get("FAL_VIDEO_MODEL"))
 
@@ -235,13 +235,13 @@ def _build_payload(
     family: Dict[str, Any],
     *,
     prompt: str,
-    image_url: Optional[str],
-    duration: Optional[int],
+    image_url: str | None,
+    duration: int | None,
     aspect_ratio: str,
     resolution: str,
-    negative_prompt: Optional[str],
-    audio: Optional[bool],
-    seed: Optional[int],
+    negative_prompt: str | None,
+    audio: bool | None,
+    seed: int | None,
 ) -> Dict[str, Any]:
     """Build a family-specific payload, dropping keys the family doesn't declare."""
     payload: Dict[str, Any] = {}
@@ -350,7 +350,7 @@ class FALVideoGenProvider(VideoGenProvider):
             })
         return out
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         return DEFAULT_MODEL
 
     def get_setup_schema(self) -> Dict[str, Any]:
@@ -383,15 +383,15 @@ class FALVideoGenProvider(VideoGenProvider):
         self,
         prompt: str,
         *,
-        model: Optional[str] = None,
-        image_url: Optional[str] = None,
-        reference_image_urls: Optional[List[str]] = None,
-        duration: Optional[int] = None,
+        model: str | None = None,
+        image_url: str | None = None,
+        reference_image_urls: List[str] | None = None,
+        duration: int | None = None,
         aspect_ratio: str = "16:9",
         resolution: str = "720p",
-        negative_prompt: Optional[str] = None,
-        audio: Optional[bool] = None,
-        seed: Optional[int] = None,
+        negative_prompt: str | None = None,
+        audio: bool | None = None,
+        seed: int | None = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         if not os.environ.get("FAL_KEY", "").strip():
@@ -485,7 +485,7 @@ class FALVideoGenProvider(VideoGenProvider):
             )
 
         video = (result or {}).get("video") if isinstance(result, dict) else None
-        url: Optional[str] = None
+        url: str | None = None
         if isinstance(video, dict):
             url = video.get("url")
         elif isinstance(video, str):

--- a/plugins/video_gen/xai/__init__.py
+++ b/plugins/video_gen/xai/__init__.py
@@ -111,7 +111,7 @@ def _xai_headers(api_key: str) -> Dict[str, str]:
     }
 
 
-def _normalize_reference_images(reference_image_urls: Optional[List[str]]):
+def _normalize_reference_images(reference_image_urls: List[str] | None):
     refs = []
     for url in reference_image_urls or []:
         normalized = (url or "").strip()
@@ -120,7 +120,7 @@ def _normalize_reference_images(reference_image_urls: Optional[List[str]]):
     return refs or None
 
 
-def _clamp_duration(duration: Optional[int], has_reference_images: bool) -> int:
+def _clamp_duration(duration: int | None, has_reference_images: bool) -> int:
     value = duration if duration is not None else DEFAULT_DURATION
     if value < 1:
         value = 1
@@ -209,7 +209,7 @@ class XAIVideoGenProvider(VideoGenProvider):
     def list_models(self) -> List[Dict[str, Any]]:
         return [{"id": mid, **meta} for mid, meta in _MODELS.items()]
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         return DEFAULT_MODEL
 
     def get_setup_schema(self) -> Dict[str, Any]:
@@ -243,15 +243,15 @@ class XAIVideoGenProvider(VideoGenProvider):
         self,
         prompt: str,
         *,
-        model: Optional[str] = None,
-        image_url: Optional[str] = None,
-        reference_image_urls: Optional[List[str]] = None,
-        duration: Optional[int] = None,
+        model: str | None = None,
+        image_url: str | None = None,
+        reference_image_urls: List[str] | None = None,
+        duration: int | None = None,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
         resolution: str = DEFAULT_RESOLUTION,
-        negative_prompt: Optional[str] = None,
-        audio: Optional[bool] = None,
-        seed: Optional[int] = None,
+        negative_prompt: str | None = None,
+        audio: bool | None = None,
+        seed: int | None = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         try:
@@ -283,10 +283,10 @@ class XAIVideoGenProvider(VideoGenProvider):
         self,
         *,
         prompt: str,
-        model: Optional[str],
-        image_url: Optional[str],
-        reference_image_urls: Optional[List[str]],
-        duration: Optional[int],
+        model: str | None,
+        image_url: str | None,
+        reference_image_urls: List[str] | None,
+        duration: int | None,
         aspect_ratio: str,
         resolution: str,
     ) -> Dict[str, Any]:

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from firecrawl import Firecrawl as FirecrawlSDK  # noqa: F401 — type hints only
 
-_FIRECRAWL_CLS_CACHE: Optional[type] = None
+_FIRECRAWL_CLS_CACHE: type | None = None
 
 
 def _load_firecrawl_cls() -> type:
@@ -119,7 +119,7 @@ Firecrawl = _FirecrawlProxy()
 # :func:`_get_firecrawl_client` below.
 
 
-def _get_direct_firecrawl_config() -> Optional[tuple]:
+def _get_direct_firecrawl_config() -> tuple | None:
     """Return explicit direct Firecrawl kwargs + cache key, or None when unset."""
     api_key = os.getenv("FIRECRAWL_API_KEY", "").strip()
     api_url = os.getenv("FIRECRAWL_API_URL", "").strip().rstrip("/")

--- a/plugins/web/xai/provider.py
+++ b/plugins/web/xai/provider.py
@@ -452,7 +452,7 @@ class XAIWebSearchProvider(WebSearchProvider):
         text: str,
         *,
         limit: int,
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> List[Dict[str, Any]] | None:
         """Parse a JSON object with a ``results`` array out of ``text``.
 
         Returns the normalized result list on success, ``None`` when the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["UP045", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/run_agent.py
+++ b/run_agent.py
@@ -303,9 +303,9 @@ class _StreamErrorEvent(Exception):
         self,
         message: str,
         *,
-        code: Optional[str] = None,
-        param: Optional[str] = None,
-        status_code: Optional[int] = None,
+        code: str | None = None,
+        param: str | None = None,
+        status_code: int | None = None,
     ) -> None:
         super().__init__(message)
         self.message = message
@@ -374,7 +374,7 @@ class AIAgent:
         provider_sort: str = None,
         provider_require_parameters: bool = False,
         provider_data_collection: str = None,
-        openrouter_min_coding_score: Optional[float] = None,
+        openrouter_min_coding_score: float | None = None,
         session_id: str = None,
         tool_progress_callback: callable = None,
         tool_start_callback: callable = None,
@@ -564,7 +564,7 @@ class AIAgent:
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
 
-    def _ensure_lmstudio_runtime_loaded(self, config_context_length: Optional[int] = None) -> None:
+    def _ensure_lmstudio_runtime_loaded(self, config_context_length: int | None = None) -> None:
         """
         Preload the LM Studio model with at least Hermes' minimum context.
         """
@@ -766,7 +766,7 @@ class AIAgent:
         attempt: int,
         max_attempts: int,
         mid_tool_call: bool,
-        diag: Optional[Dict[str, Any]] = None,
+        diag: Dict[str, Any] | None = None,
     ) -> None:
         """Forwarder — see ``agent.stream_diag.log_stream_retry``."""
         from agent.stream_diag import log_stream_retry
@@ -782,7 +782,7 @@ class AIAgent:
         attempt: int,
         max_attempts: int,
         mid_tool_call: bool,
-        diag: Optional[Dict[str, Any]] = None,
+        diag: Dict[str, Any] | None = None,
     ) -> None:
         """Forwarder — see ``agent.stream_diag.emit_stream_drop``."""
         from agent.stream_diag import emit_stream_drop
@@ -923,10 +923,10 @@ class AIAgent:
     def _anthropic_prompt_cache_policy(
         self,
         *,
-        provider: Optional[str] = None,
-        base_url: Optional[str] = None,
-        api_mode: Optional[str] = None,
-        model: Optional[str] = None,
+        provider: str | None = None,
+        base_url: str | None = None,
+        api_mode: str | None = None,
+        model: str | None = None,
     ) -> tuple[bool, bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.anthropic_prompt_cache_policy``."""
         from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
@@ -951,7 +951,7 @@ class AIAgent:
     def _provider_model_requires_responses_api(
         model: str,
         *,
-        provider: Optional[str] = None,
+        provider: str | None = None,
     ) -> bool:
         """Return True when this provider/model pair should use Responses API."""
         normalized_provider = (provider or "").strip().lower()
@@ -1044,7 +1044,7 @@ class AIAgent:
         self,
         finish_reason: str,
         assistant_message,
-        messages: Optional[list] = None,
+        messages: list | None = None,
     ) -> bool:
         """Detect conservative stop->length misreports for Ollama-hosted GLM models."""
         if finish_reason != "stop" or self.api_mode != "chat_completions":
@@ -1081,7 +1081,7 @@ class AIAgent:
         from agent.agent_runtime_helpers import looks_like_codex_intermediate_ack
         return looks_like_codex_intermediate_ack(self, user_message, assistant_content, messages)
 
-    def _extract_reasoning(self, assistant_message) -> Optional[str]:
+    def _extract_reasoning(self, assistant_message) -> str | None:
         """Forwarder — see ``agent.agent_runtime_helpers.extract_reasoning``."""
         from agent.agent_runtime_helpers import extract_reasoning
         return extract_reasoning(self, assistant_message)
@@ -1136,10 +1136,10 @@ class AIAgent:
     def _build_memory_write_metadata(
         self,
         *,
-        write_origin: Optional[str] = None,
-        execution_context: Optional[str] = None,
-        task_id: Optional[str] = None,
-        tool_call_id: Optional[str] = None,
+        write_origin: str | None = None,
+        execution_context: str | None = None,
+        task_id: str | None = None,
+        tool_call_id: str | None = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.background_review.build_memory_write_metadata``."""
         from agent.background_review import build_memory_write_metadata
@@ -1355,8 +1355,8 @@ class AIAgent:
 
     @staticmethod
     def _is_entitlement_failure(
-        error_context: Optional[Dict[str, Any]],
-        status_code: Optional[int],
+        error_context: Dict[str, Any] | None,
+        status_code: int | None,
     ) -> bool:
         """Detect subscription/entitlement 403s that masquerade as auth failures.
 
@@ -1467,7 +1467,7 @@ class AIAgent:
         prefix = f"HTTP {status_code}: " if status_code else ""
         return f"{prefix}{raw[:500]}"
 
-    def _mask_api_key_for_logs(self, key: Any) -> Optional[str]:
+    def _mask_api_key_for_logs(self, key: Any) -> str | None:
         # Azure Foundry Entra ID bearer providers are callables — never
         # invoke them in log paths; identify the auth surface instead.
         if callable(key) and not isinstance(key, str):
@@ -1510,7 +1510,7 @@ class AIAgent:
         from agent.agent_runtime_helpers import extract_api_error_context
         return extract_api_error_context(error)
 
-    def _usage_summary_for_api_request_hook(self, response: Any) -> Optional[Dict[str, Any]]:
+    def _usage_summary_for_api_request_hook(self, response: Any) -> Dict[str, Any] | None:
         """Token buckets for ``post_api_request`` plugins (no raw ``response`` object)."""
         if response is None:
             return None
@@ -1531,8 +1531,8 @@ class AIAgent:
         api_kwargs: Dict[str, Any],
         *,
         reason: str,
-        error: Optional[Exception] = None,
-    ) -> Optional[Path]:
+        error: Exception | None = None,
+    ) -> Path | None:
         """Forwarder — see ``agent.agent_runtime_helpers.dump_api_request_debug``."""
         from agent.agent_runtime_helpers import dump_api_request_debug
         return dump_api_request_debug(self, api_kwargs, reason=reason, error=error)
@@ -1800,7 +1800,7 @@ class AIAgent:
                 self._pending_steer = cleaned
         return True
 
-    def _drain_pending_steer(self) -> Optional[str]:
+    def _drain_pending_steer(self) -> str | None:
         """Return the pending steer text (if any) and clear the slot.
 
         Safe to call from the agent execution thread after appending tool
@@ -2411,14 +2411,14 @@ class AIAgent:
         return _codex_deterministic_call_id(fn_name, arguments, index)
 
     @staticmethod
-    def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]:
+    def _split_responses_tool_id(raw_id: Any) -> tuple[str | None, str | None]:
         """Split a stored tool id into (call_id, response_item_id)."""
         return _codex_split_responses_tool_id(raw_id)
 
     def _derive_responses_function_call_id(
         self,
         call_id: str,
-        response_item_id: Optional[str] = None,
+        response_item_id: str | None = None,
     ) -> str:
         """Build a valid Responses `function_call.id` (must start with `fc_`)."""
         return _codex_derive_responses_function_call_id(call_id, response_item_id)
@@ -2603,7 +2603,7 @@ class AIAgent:
 
         return copilot_request_headers(is_agent_turn=True, is_vision=is_vision)
 
-    def _create_request_openai_client(self, *, reason: str, api_kwargs: Optional[dict] = None) -> Any:
+    def _create_request_openai_client(self, *, reason: str, api_kwargs: dict | None = None) -> Any:
         from unittest.mock import Mock
 
         primary_client = self._ensure_primary_openai_client(reason=reason)
@@ -2954,10 +2954,10 @@ class AIAgent:
     def _recover_with_credential_pool(
         self,
         *,
-        status_code: Optional[int],
+        status_code: int | None,
         has_retried_429: bool,
-        classified_reason: Optional[FailoverReason] = None,
-        error_context: Optional[Dict[str, Any]] = None,
+        classified_reason: FailoverReason | None = None,
+        error_context: Dict[str, Any] | None = None,
     ) -> tuple[bool, bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.recover_with_credential_pool``."""
         from agent.agent_runtime_helpers import recover_with_credential_pool
@@ -3216,7 +3216,7 @@ class AIAgent:
         return False
 
     @staticmethod
-    def _materialize_data_url_for_vision(image_url: str) -> tuple[str, Optional[Path]]:
+    def _materialize_data_url_for_vision(image_url: str) -> tuple[str, Path | None]:
         header, _, data = str(image_url or "").partition(",")
         mime = "image/jpeg"
         if header.startswith("data:"):
@@ -3262,7 +3262,7 @@ class AIAgent:
         )
 
         vision_source = str(image_url or "")
-        cleanup_path: Optional[Path] = None
+        cleanup_path: Path | None = None
         if vision_source.startswith("data:"):
             vision_source, cleanup_path = self._materialize_data_url_for_vision(vision_source)
 
@@ -3762,7 +3762,7 @@ class AIAgent:
         cache[key] = (opts, _time.monotonic())
         return opts
 
-    def _resolve_lmstudio_summary_reasoning_effort(self) -> Optional[str]:
+    def _resolve_lmstudio_summary_reasoning_effort(self) -> str | None:
         """Resolve a safe top-level ``reasoning_effort`` for LM Studio.
 
         The iteration-limit summary path calls ``chat.completions.create()``
@@ -4043,7 +4043,7 @@ class AIAgent:
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
-                     tool_call_id: Optional[str] = None, messages: list = None,
+                     tool_call_id: str | None = None, messages: list = None,
                      pre_tool_block_checked: bool = False) -> str:
         """Forwarder — see ``agent.agent_runtime_helpers.invoke_tool``."""
         from agent.agent_runtime_helpers import invoke_tool
@@ -4095,14 +4095,14 @@ class AIAgent:
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
         task_id: str = None,
-        stream_callback: Optional[callable] = None,
-        persist_user_message: Optional[str] = None,
+        stream_callback: callable | None = None,
+        persist_user_message: str | None = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
         return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
 
-    def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
+    def chat(self, message: str, stream_callback: callable | None = None) -> str:
         """
         Simple chat interface that returns just the final response.
 

--- a/tests/agent/test_tts_registry.py
+++ b/tests/agent/test_tts_registry.py
@@ -33,9 +33,9 @@ class _FakeProvider(TTSProvider):
     def __init__(
         self,
         name: str = "fake",
-        display: Optional[str] = None,
+        display: str | None = None,
         voice_compat: bool = False,
-        synthesize_impl: Optional[Any] = None,
+        synthesize_impl: Any | None = None,
     ):
         self._name = name
         self._display = display

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -47,7 +47,7 @@ class FakeClient:
         return {"userAgent": "fake/0.0.0", "codexHome": "/tmp",
                 "platformOs": "linux", "platformFamily": "unix"}
 
-    def request(self, method: str, params: Optional[dict] = None, timeout: float = 30.0):
+    def request(self, method: str, params: dict | None = None, timeout: float = 30.0):
         self.requests.append((method, params or {}))
         if self._request_handler is not None:
             return self._request_handler(method, params or {})

--- a/tests/fakes/fake_ha_server.py
+++ b/tests/fakes/fake_ha_server.py
@@ -100,8 +100,8 @@ class FakeHAServer:
         self.force_500 = False
 
         # Internal bookkeeping.
-        self._app: Optional[web.Application] = None
-        self._server: Optional[TestServer] = None
+        self._app: web.Application | None = None
+        self._server: TestServer | None = None
         self._ws_connections: List[web.WebSocketResponse] = []
 
     # -- Public helpers --------------------------------------------------------
@@ -162,7 +162,7 @@ class FakeHAServer:
 
     # -- Auth helper -----------------------------------------------------------
 
-    def _check_rest_auth(self, request: web.Request) -> Optional[web.Response]:
+    def _check_rest_auth(self, request: web.Request) -> web.Response | None:
         """Return a 401 response if the Bearer token is wrong, else None."""
         auth = request.headers.get("Authorization", "")
         if auth != f"Bearer {self.token}":

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 
 def make_sender(sender_type: str = "user", open_id: str = "ou_human",
-                user_id: Optional[str] = None, union_id: Optional[str] = None) -> Any:
+                user_id: str | None = None, union_id: str | None = None) -> Any:
     return SimpleNamespace(
         sender_type=sender_type,
         sender_id=SimpleNamespace(open_id=open_id, user_id=user_id, union_id=union_id),
@@ -16,7 +16,7 @@ def make_sender(sender_type: str = "user", open_id: str = "ou_human",
 
 
 def make_message(message_id: str = "om_xxx", chat_type: str = "p2p",
-                 chat_id: str = "oc_1", mentions: Optional[list] = None) -> Any:
+                 chat_id: str = "oc_1", mentions: list | None = None) -> Any:
     return SimpleNamespace(
         message_id=message_id,
         chat_type=chat_type,
@@ -52,7 +52,7 @@ def make_adapter_skeleton(
     return adapter
 
 
-def install_dedup_state(adapter: Any, seen: Optional[dict] = None) -> None:
+def install_dedup_state(adapter: Any, seen: dict | None = None) -> None:
     adapter._seen_message_ids = dict(seen) if seen else {}
     adapter._seen_message_order = list((seen or {}).keys())
     adapter._dedup_cache_size = 100

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -112,7 +112,7 @@ def adapter(monkeypatch):
 def make_attachment(
     *,
     filename: str,
-    content_type: Optional[str],
+    content_type: str | None,
     size: int = 1024,
     url: str = "https://cdn.discordapp.com/attachments/fake/file",
 ) -> SimpleNamespace:

--- a/tests/hermes_cli/test_video_gen_picker.py
+++ b/tests/hermes_cli/test_video_gen_picker.py
@@ -21,8 +21,8 @@ class _FakeVideoProvider(VideoGenProvider):
         self,
         name: str,
         available: bool = True,
-        schema: Optional[Dict[str, Any]] = None,
-        models: Optional[List[Dict[str, Any]]] = None,
+        schema: Dict[str, Any] | None = None,
+        models: List[Dict[str, Any]] | None = None,
     ):
         self._name = name
         self._available = available

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -65,15 +65,15 @@ class _FakeSessionDB:
     def __init__(self, session_count: int, scan_delay: float = 0):
         self.session_count = session_count
         self.scan_delay = scan_delay
-        self.last_limit: Optional[int] = None
-        self.last_include_children: Optional[bool] = None
+        self.last_limit: int | None = None
+        self.last_include_children: bool | None = None
         self.list_calls = 0
         self.messages_calls = 0
 
     def list_sessions_rich(
         self,
-        source: Optional[str] = None,
-        exclude_sources: Optional[List[str]] = None,
+        source: str | None = None,
+        exclude_sources: List[str] | None = None,
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,

--- a/tests/plugins/video_gen/test_xai_plugin_integration.py
+++ b/tests/plugins/video_gen/test_xai_plugin_integration.py
@@ -24,7 +24,7 @@ def _reset_registry():
 
 
 class _FakeResponse:
-    def __init__(self, status: int = 200, payload: Optional[Dict[str, Any]] = None):
+    def __init__(self, status: int = 200, payload: Dict[str, Any] | None = None):
         self.status_code = status
         self._payload = payload or {}
         self.text = json.dumps(self._payload)

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -18,7 +18,7 @@ class TestClarifyToolBasics:
 
     def test_simple_question_with_callback(self):
         """Should return user response for simple question."""
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             assert question == "What color?"
             assert choices is None
             return "blue"
@@ -30,7 +30,7 @@ class TestClarifyToolBasics:
 
     def test_question_with_choices(self):
         """Should pass choices to callback and return response."""
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             assert question == "Pick a number"
             assert choices == ["1", "2", "3"]
             return "2"
@@ -69,7 +69,7 @@ class TestClarifyToolChoicesValidation:
         """Should trim choices to MAX_CHOICES."""
         choices_passed = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             choices_passed.extend(choices or [])
             return "picked"
 
@@ -82,7 +82,7 @@ class TestClarifyToolChoicesValidation:
         """Empty choices list should become None (open-ended)."""
         choices_received = ["marker"]
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             choices_received.clear()
             if choices is not None:
                 choices_received.extend(choices)
@@ -95,7 +95,7 @@ class TestClarifyToolChoicesValidation:
         """Whitespace-only choices should be stripped out."""
         choices_received = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             choices_received.extend(choices or [])
             return "answer"
 
@@ -116,7 +116,7 @@ class TestClarifyToolChoicesValidation:
         """Non-string choices should be converted to strings."""
         choices_received = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             choices_received.extend(choices or [])
             return "answer"
 
@@ -129,7 +129,7 @@ class TestClarifyToolCallbackHandling:
 
     def test_callback_exception_returns_error(self):
         """Should return error if callback raises exception."""
-        def failing_callback(question: str, choices: Optional[List[str]]) -> str:
+        def failing_callback(question: str, choices: List[str] | None) -> str:
             raise RuntimeError("User cancelled")
 
         result = json.loads(clarify_tool("Question?", callback=failing_callback))
@@ -141,7 +141,7 @@ class TestClarifyToolCallbackHandling:
         """Callback should receive trimmed question."""
         received_question = []
 
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             received_question.append(question)
             return "answer"
 
@@ -150,7 +150,7 @@ class TestClarifyToolCallbackHandling:
 
     def test_user_response_stripped(self):
         """User response should be stripped of whitespace."""
-        def mock_callback(question: str, choices: Optional[List[str]]) -> str:
+        def mock_callback(question: str, choices: List[str] | None) -> str:
             return "  response with spaces  \n"
 
         result = json.loads(clarify_tool("Q?", callback=mock_callback))

--- a/tests/tools/test_tts_plugin_dispatch.py
+++ b/tests/tools/test_tts_plugin_dispatch.py
@@ -42,15 +42,15 @@ class _FakeTTSProvider(TTSProvider):
         self,
         name: str,
         voice_compat: bool = False,
-        raise_exc: Optional[BaseException] = None,
-        return_path: Optional[str] = None,
+        raise_exc: BaseException | None = None,
+        return_path: str | None = None,
     ):
         self._name = name
         self._voice_compat = voice_compat
         self._raise_exc = raise_exc
         self._return_path = return_path
         # Recorded for assertions
-        self.last_call: Optional[dict] = None
+        self.last_call: dict | None = None
 
     @property
     def name(self) -> str:

--- a/tests/tools/test_video_generation_dispatch.py
+++ b/tests/tools/test_video_generation_dispatch.py
@@ -32,7 +32,7 @@ class _RecordingProvider(VideoGenProvider):
     def list_models(self) -> List[Dict[str, Any]]:
         return [{"id": "model-a"}]
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         return "model-a"
 
     def generate(self, prompt, **kwargs):
@@ -60,7 +60,7 @@ class _RaisingProvider(VideoGenProvider):
 
 
 class TestUnifiedDispatch:
-    def _run(self, args: Dict[str, Any], *, configured: Optional[str] = None) -> Dict[str, Any]:
+    def _run(self, args: Dict[str, Any], *, configured: str | None = None) -> Dict[str, Any]:
         from tools import video_generation_tool
         import hermes_cli.plugins as plugins_module
 

--- a/tests/tools/test_video_generation_dynamic_schema.py
+++ b/tests/tools/test_video_generation_dynamic_schema.py
@@ -41,7 +41,7 @@ class _BothModalitiesProvider(VideoGenProvider):
     def list_models(self) -> List[Dict[str, Any]]:
         return [{"id": "family-a", "modalities": ["text", "image"]}]
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         return "family-a"
 
     def capabilities(self) -> Dict[str, Any]:
@@ -73,7 +73,7 @@ class _ImageOnlyProvider(VideoGenProvider):
     def list_models(self) -> List[Dict[str, Any]]:
         return [{"id": "img-only-v1", "modalities": ["image"]}]
 
-    def default_model(self) -> Optional[str]:
+    def default_model(self) -> str | None:
         return "img-only-v1"
 
     def capabilities(self) -> Dict[str, Any]:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -507,7 +507,7 @@ class _ApprovalEntry:
     def __init__(self, data: dict):
         self.event = threading.Event()
         self.data = data          # command, description, pattern_keys, …
-        self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
+        self.result: str | None = None  # "once"|"session"|"always"|"deny"
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 30  # seconds per HTTP request
 _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
-_vnc_url: Optional[str] = None  # cached from /health response
+_vnc_url: str | None = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
 
 
@@ -91,7 +91,7 @@ def check_camofox_available() -> bool:
         return False
 
 
-def get_vnc_url() -> Optional[str]:
+def get_vnc_url() -> str | None:
     """Return the VNC URL if the Camofox server exposes one, or None."""
     if not _vnc_url_checked:
         check_camofox_available()
@@ -120,7 +120,7 @@ def _managed_persistence_enabled() -> bool:
     return bool(_get_camofox_config().get("managed_persistence"))
 
 
-def _camofox_identity_override(task_id: Optional[str], camofox_cfg: Dict[str, Any]) -> Optional[Dict[str, str]]:
+def _camofox_identity_override(task_id: str | None, camofox_cfg: Dict[str, Any]) -> Dict[str, str] | None:
     """Return an externally configured Camofox identity, if one is set.
 
     Integrations that own the visible Camofox browser can set a shared user ID
@@ -139,7 +139,7 @@ def _camofox_identity_override(task_id: Optional[str], camofox_cfg: Dict[str, An
     return {"user_id": user_id, "session_key": session_key}
 
 
-def _env_flag(name: str) -> Optional[bool]:
+def _env_flag(name: str) -> bool | None:
     raw = os.getenv(name, "").strip().lower()
     if not raw:
         return None
@@ -205,7 +205,7 @@ def _adopt_existing_tab(session: Dict[str, Any]) -> Dict[str, Any]:
     return session
 
 
-def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
+def _get_session(task_id: str | None) -> Dict[str, Any]:
     """Get or create a camofox session for the given task.
 
     When managed persistence is enabled, uses a deterministic userId
@@ -248,7 +248,7 @@ def _get_session(task_id: Optional[str]) -> Dict[str, Any]:
         return _adopt_existing_tab(session)
 
 
-def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, Any]:
+def _ensure_tab(task_id: str | None, url: str = "about:blank") -> Dict[str, Any]:
     """Ensure a tab exists for the session, creating one if needed."""
     session = _get_session(task_id)
     if session["tab_id"]:
@@ -269,14 +269,14 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     return session
 
 
-def _drop_session(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
+def _drop_session(task_id: str | None) -> Dict[str, Any] | None:
     """Remove and return session info."""
     task_id = task_id or "default"
     with _sessions_lock:
         return _sessions.pop(task_id, None)
 
 
-def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
+def camofox_soft_cleanup(task_id: str | None = None) -> bool:
     """Release the in-memory session without destroying the server-side context.
 
     When managed persistence is enabled the browser profile (and its cookies)
@@ -333,7 +333,7 @@ def _delete(path: str, body: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> di
 # Tool implementations
 # ---------------------------------------------------------------------------
 
-def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
+def camofox_navigate(url: str, task_id: str | None = None) -> str:
     """Navigate to a URL via Camofox."""
     try:
         session = _get_session(task_id)
@@ -393,8 +393,8 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
         return tool_error(str(e), success=False)
 
 
-def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
-                     user_task: Optional[str] = None) -> str:
+def camofox_snapshot(full: bool = False, task_id: str | None = None,
+                     user_task: str | None = None) -> str:
     """Get accessibility tree snapshot from Camofox."""
     try:
         session = _get_session(task_id)
@@ -431,7 +431,7 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
         return tool_error(str(e), success=False)
 
 
-def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
+def camofox_click(ref: str, task_id: str | None = None) -> str:
     """Click an element by ref via Camofox."""
     try:
         session = _get_session(task_id)
@@ -454,7 +454,7 @@ def camofox_click(ref: str, task_id: Optional[str] = None) -> str:
         return tool_error(str(e), success=False)
 
 
-def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
+def camofox_type(ref: str, text: str, task_id: str | None = None) -> str:
     """Type text into an element by ref via Camofox."""
     try:
         session = _get_session(task_id)
@@ -476,7 +476,7 @@ def camofox_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         return tool_error(str(e), success=False)
 
 
-def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
+def camofox_scroll(direction: str, task_id: str | None = None) -> str:
     """Scroll the page via Camofox."""
     try:
         session = _get_session(task_id)
@@ -492,7 +492,7 @@ def camofox_scroll(direction: str, task_id: Optional[str] = None) -> str:
         return tool_error(str(e), success=False)
 
 
-def camofox_back(task_id: Optional[str] = None) -> str:
+def camofox_back(task_id: str | None = None) -> str:
     """Navigate back via Camofox."""
     try:
         session = _get_session(task_id)
@@ -508,7 +508,7 @@ def camofox_back(task_id: Optional[str] = None) -> str:
         return tool_error(str(e), success=False)
 
 
-def camofox_press(key: str, task_id: Optional[str] = None) -> str:
+def camofox_press(key: str, task_id: str | None = None) -> str:
     """Press a keyboard key via Camofox."""
     try:
         session = _get_session(task_id)
@@ -524,7 +524,7 @@ def camofox_press(key: str, task_id: Optional[str] = None) -> str:
         return tool_error(str(e), success=False)
 
 
-def camofox_close(task_id: Optional[str] = None) -> str:
+def camofox_close(task_id: str | None = None) -> str:
     """Close the browser session via Camofox."""
     try:
         session = _drop_session(task_id)
@@ -539,7 +539,7 @@ def camofox_close(task_id: Optional[str] = None) -> str:
         return json.dumps({"success": True, "closed": True, "warning": str(e)})
 
 
-def camofox_get_images(task_id: Optional[str] = None) -> str:
+def camofox_get_images(task_id: str | None = None) -> str:
     """Get images on the current page via Camofox.
 
     Extracts image information from the accessibility tree snapshot,
@@ -587,7 +587,7 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
 
 def camofox_vision(question: str, annotate: bool = False,
-                   task_id: Optional[str] = None) -> str:
+                   task_id: str | None = None) -> str:
     """Take a screenshot and analyze it with vision AI via Camofox."""
     try:
         session = _get_session(task_id)
@@ -679,7 +679,7 @@ def camofox_vision(question: str, annotate: bool = False,
         return tool_error(str(e), success=False)
 
 
-def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
+def camofox_console(clear: bool = False, task_id: str | None = None) -> str:
     """Get console output — limited support in Camofox.
 
     Camofox does not expose browser console logs via its REST API.

--- a/tools/browser_camofox_state.py
+++ b/tools/browser_camofox_state.py
@@ -24,7 +24,7 @@ def get_camofox_state_dir() -> Path:
     return get_hermes_home() / CAMOFOX_STATE_DIR_NAME / CAMOFOX_STATE_SUBDIR
 
 
-def get_camofox_identity(task_id: Optional[str] = None) -> Dict[str, str]:
+def get_camofox_identity(task_id: str | None = None) -> Dict[str, str]:
     """Return the stable Hermes-managed Camofox identity for this profile.
 
     The user identity is profile-scoped (same Hermes profile = same userId).

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -95,7 +95,7 @@ async def _cdp_call(
     ws_url: str,
     method: str,
     params: Dict[str, Any],
-    target_id: Optional[str],
+    target_id: str | None,
     timeout: float,
 ) -> Dict[str, Any]:
     """Make a single CDP call, optionally attaching to a target first.
@@ -117,7 +117,7 @@ async def _cdp_call(
         ping_interval=None,  # CDP server doesn't expect pings
     ) as ws:
         next_id = 1
-        session_id: Optional[str] = None
+        session_id: str | None = None
 
         # --- Step 1: attach to target if requested ---
         if target_id:
@@ -191,7 +191,7 @@ def _browser_cdp_via_supervisor(
     task_id: str,
     frame_id: str,
     method: str,
-    params: Optional[Dict[str, Any]],
+    params: Dict[str, Any] | None,
     timeout: float,
 ) -> str:
     """Route a CDP call through the live supervisor session for an OOPIF frame.
@@ -222,7 +222,7 @@ def _browser_cdp_via_supervisor(
     snap = supervisor.snapshot()
     # Search both the top frame and the children for the requested id.
     top = snap.frame_tree.get("top")
-    frame_info: Optional[Dict[str, Any]] = None
+    frame_info: Dict[str, Any] | None = None
     if top and top.get("frame_id") == frame_id:
         frame_info = top
     else:
@@ -300,11 +300,11 @@ def _browser_cdp_via_supervisor(
 
 def browser_cdp(
     method: str,
-    params: Optional[Dict[str, Any]] = None,
-    target_id: Optional[str] = None,
-    frame_id: Optional[str] = None,
+    params: Dict[str, Any] | None = None,
+    target_id: str | None = None,
+    frame_id: str | None = None,
     timeout: float = 30.0,
-    task_id: Optional[str] = None,
+    task_id: str | None = None,
 ) -> str:
     """Send a raw CDP command.  See ``CDP_DOCS_URL`` for method documentation.
 

--- a/tools/browser_dialog_tool.py
+++ b/tools/browser_dialog_tool.py
@@ -81,9 +81,9 @@ BROWSER_DIALOG_SCHEMA: Dict[str, Any] = {
 
 def browser_dialog(
     action: str,
-    prompt_text: Optional[str] = None,
-    dialog_id: Optional[str] = None,
-    task_id: Optional[str] = None,
+    prompt_text: str | None = None,
+    dialog_id: str | None = None,
+    task_id: str | None = None,
 ) -> str:
     """Respond to a pending dialog on the active task's CDP supervisor."""
     effective_task_id = task_id or "default"

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -137,11 +137,11 @@ class PendingDialog:
     default_prompt: str
     opened_at: float
     cdp_session_id: str  # which attached CDP session the dialog fired in
-    frame_id: Optional[str] = None
+    frame_id: str | None = None
     # When set, the dialog was captured via the bridge XHR path (Fetch domain).
     # Response must be delivered via Fetch.fulfillRequest, NOT
     # Page.handleJavaScriptDialog — the native dialog never fired.
-    bridge_request_id: Optional[str] = None
+    bridge_request_id: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -169,7 +169,7 @@ class DialogRecord:
     opened_at: float
     closed_at: float
     closed_by: str  # "agent" | "auto_policy" | "remote" | "watchdog"
-    frame_id: Optional[str] = None
+    frame_id: str | None = None
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -195,9 +195,9 @@ class FrameInfo:
     frame_id: str
     url: str
     origin: str
-    parent_frame_id: Optional[str]
+    parent_frame_id: str | None
     is_oopif: bool
-    cdp_session_id: Optional[str] = None
+    cdp_session_id: str | None = None
     name: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
@@ -223,7 +223,7 @@ class ConsoleEvent:
     ts: float
     level: str  # "log" | "error" | "warning" | "exception"
     text: str
-    url: Optional[str] = None
+    url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -300,17 +300,17 @@ class CDPSupervisor:
         self._active = False
 
         # Supervisor loop machinery — populated in start().
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._thread: Optional[threading.Thread] = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
         self._ready_event = threading.Event()
-        self._start_error: Optional[BaseException] = None
+        self._start_error: BaseException | None = None
         self._stop_requested = False
 
         # CDP call tracking (runs on supervisor loop only).
         self._next_call_id = 1
         self._pending_calls: Dict[int, asyncio.Future] = {}
-        self._ws: Optional[ClientConnection] = None
-        self._page_session_id: Optional[str] = None
+        self._ws: ClientConnection | None = None
+        self._page_session_id: str | None = None
         self._child_sessions: Dict[str, Dict[str, Any]] = {}  # session_id -> info
 
         # Dialog auto-dismiss watchdog handles (per dialog id).
@@ -404,8 +404,8 @@ class CDPSupervisor:
         self,
         action: str,
         *,
-        prompt_text: Optional[str] = None,
-        dialog_id: Optional[str] = None,
+        prompt_text: str | None = None,
+        dialog_id: str | None = None,
         timeout: float = 10.0,
     ) -> Dict[str, Any]:
         """Accept/dismiss a pending dialog. Sync bridge onto the supervisor loop.
@@ -767,9 +767,9 @@ class CDPSupervisor:
     async def _cdp(
         self,
         method: str,
-        params: Optional[Dict[str, Any]] = None,
+        params: Dict[str, Any] | None = None,
         *,
-        session_id: Optional[str] = None,
+        session_id: str | None = None,
         timeout: float = 10.0,
     ) -> Dict[str, Any]:
         """Send a CDP command and await its response."""
@@ -819,7 +819,7 @@ class CDPSupervisor:
     # ── Event dispatch ──────────────────────────────────────────────────────
 
     async def _on_event(
-        self, method: str, params: Dict[str, Any], session_id: Optional[str]
+        self, method: str, params: Dict[str, Any], session_id: str | None
     ) -> None:
         if method == "Page.javascriptDialogOpening":
             await self._on_dialog_opening(params, session_id)
@@ -843,7 +843,7 @@ class CDPSupervisor:
             self._on_console(params, level_from="exception")
 
     async def _on_dialog_opening(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: Dict[str, Any], session_id: str | None
     ) -> None:
         self._dialog_seq += 1
         dialog = PendingDialog(
@@ -997,7 +997,7 @@ class CDPSupervisor:
                 handle.cancel()
 
     async def _on_dialog_closed(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: Dict[str, Any], session_id: str | None
     ) -> None:
         # ``Page.javascriptDialogClosed`` spec has only ``result`` (bool) and
         # ``userInput`` (string), not the original ``message``.  Match by
@@ -1026,7 +1026,7 @@ class CDPSupervisor:
                     handle.cancel()
 
     async def _on_fetch_paused(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: Dict[str, Any], session_id: str | None
     ) -> None:
         """Bridge XHR captured mid-flight — materialize as a pending dialog.
 
@@ -1138,7 +1138,7 @@ class CDPSupervisor:
     # ── Frame / target tracking ─────────────────────────────────────────────
 
     def _on_frame_attached(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: Dict[str, Any], session_id: str | None
     ) -> None:
         frame_id = params.get("frameId")
         if not frame_id:
@@ -1154,7 +1154,7 @@ class CDPSupervisor:
             )
 
     def _on_frame_navigated(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: Dict[str, Any], session_id: str | None
     ) -> None:
         frame = params.get("frame") or {}
         frame_id = frame.get("id")
@@ -1174,7 +1174,7 @@ class CDPSupervisor:
             self._frames[frame_id] = info
 
     def _on_frame_detached(
-        self, params: Dict[str, Any], session_id: Optional[str]
+        self, params: Dict[str, Any], session_id: str | None
     ) -> None:
         """Remove a frame from our state only when it's truly gone.
 
@@ -1372,7 +1372,7 @@ class _SupervisorRegistry:
         self._lock = threading.Lock()
         self._by_task: Dict[str, CDPSupervisor] = {}
 
-    def get(self, task_id: str) -> Optional[CDPSupervisor]:
+    def get(self, task_id: str) -> CDPSupervisor | None:
         """Return the supervisor for ``task_id`` if running, else ``None``."""
         with self._lock:
             return self._by_task.get(task_id)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -192,7 +192,7 @@ SNAPSHOT_SUMMARIZE_THRESHOLD = 8000
 # Commands that legitimately return empty stdout (e.g. close, record).
 _EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record"})
 
-_cached_command_timeout: Optional[int] = None
+_cached_command_timeout: int | None = None
 _command_timeout_resolved = False
 
 
@@ -221,12 +221,12 @@ def _get_command_timeout() -> int:
     return result
 
 
-def _get_vision_model() -> Optional[str]:
+def _get_vision_model() -> str | None:
     """Model for browser_vision (screenshot analysis — multimodal)."""
     return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
 
 
-def _get_extraction_model() -> Optional[str]:
+def _get_extraction_model() -> str | None:
     """Model for page snapshot text summarization — same as web_extract."""
     return os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip() or None
 
@@ -429,16 +429,16 @@ _PROVIDER_REGISTRY: Dict[str, type] = {
 # monkeypatching. NEVER mutate this dict.
 _DEFAULT_PROVIDER_REGISTRY: Dict[str, type] = dict(_PROVIDER_REGISTRY)
 
-_cached_cloud_provider: Optional[CloudBrowserProvider] = None
+_cached_cloud_provider: CloudBrowserProvider | None = None
 _cloud_provider_resolved = False
 _allow_private_urls_resolved = False
-_cached_allow_private_urls: Optional[bool] = None
-_cached_agent_browser: Optional[str] = None
+_cached_allow_private_urls: bool | None = None
+_cached_agent_browser: str | None = None
 _agent_browser_resolved = False
 
 # Lightpanda engine support — cached like _get_cloud_provider().
 # agent-browser v0.25.3+ supports ``--engine lightpanda`` natively.
-_cached_browser_engine: Optional[str] = None
+_cached_browser_engine: str | None = None
 _browser_engine_resolved = False
 
 
@@ -485,7 +485,7 @@ def _ensure_browser_plugins_loaded() -> None:
         logger.debug("Browser plugin discovery failed (non-fatal): %s", exc)
 
 
-def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
+def _get_cloud_provider() -> CloudBrowserProvider | None:
     """Return the configured cloud browser provider, or None for local mode.
 
     Reads ``config["browser"]["cloud_provider"]`` once and caches the result
@@ -506,7 +506,7 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
     if _cloud_provider_resolved:
         return _cached_cloud_provider
 
-    resolved: Optional[CloudBrowserProvider] = None
+    resolved: CloudBrowserProvider | None = None
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
@@ -700,7 +700,7 @@ def _using_lightpanda_engine() -> bool:
     return _get_browser_engine() == "lightpanda"
 
 
-def _lightpanda_fallback_reason(engine: str, command: str, result: Dict[str, Any]) -> Optional[str]:
+def _lightpanda_fallback_reason(engine: str, command: str, result: Dict[str, Any]) -> str | None:
     """Return the user-visible reason a Lightpanda result needs Chrome fallback.
 
     ``None`` means no fallback should run.  The returned string is copied into
@@ -1343,7 +1343,7 @@ def _reap_orphaned_browser_sessions():
 
         # Ownership check: prefer owner_pid file (cross-process safe).
         owner_pid_file = os.path.join(socket_dir, f"{session_name}.owner_pid")
-        owner_alive: Optional[bool] = None  # None = owner_pid missing/unreadable
+        owner_alive: bool | None = None  # None = owner_pid missing/unreadable
         if os.path.isfile(owner_pid_file):
             try:
                 owner_pid = int(Path(owner_pid_file).read_text(encoding="utf-8").strip())
@@ -1649,7 +1649,7 @@ def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
     }
 
 
-def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
+def _get_session_info(task_id: str | None = None) -> Dict[str, str]:
     """
     Get or create session info for the given session key.
 
@@ -1852,7 +1852,7 @@ def _find_agent_browser() -> str:
     )
 
 
-def _extract_screenshot_path_from_text(text: str) -> Optional[str]:
+def _extract_screenshot_path_from_text(text: str) -> str | None:
     """Extract a screenshot file path from agent-browser human-readable output."""
     if not text:
         return None
@@ -1877,8 +1877,8 @@ def _run_browser_command(
     task_id: str,
     command: str,
     args: List[str] = None,
-    timeout: Optional[int] = None,
-    _engine_override: Optional[str] = None,
+    timeout: int | None = None,
+    _engine_override: str | None = None,
 ) -> Dict[str, Any]:
     """
     Run an agent-browser CLI command using our pre-created Browserbase session.
@@ -2198,7 +2198,7 @@ def _run_browser_command(
 
 def _extract_relevant_content(
     snapshot_text: str,
-    user_task: Optional[str] = None
+    user_task: str | None = None
 ) -> str:
     """Use LLM to extract relevant content from a snapshot based on the user's task.
 
@@ -2287,7 +2287,7 @@ def _truncate_snapshot(snapshot_text: str, max_chars: int = 8000) -> str:
 # Browser Tool Functions
 # ============================================================================
 
-def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
+def browser_navigate(url: str, task_id: str | None = None) -> str:
     """
     Navigate to a URL in the browser.
 
@@ -2489,8 +2489,8 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
 
 def browser_snapshot(
     full: bool = False,
-    task_id: Optional[str] = None,
-    user_task: Optional[str] = None
+    task_id: str | None = None,
+    user_task: str | None = None
 ) -> str:
     """
     Get a text-based snapshot of the current page's accessibility tree.
@@ -2556,7 +2556,7 @@ def browser_snapshot(
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_click(ref: str, task_id: Optional[str] = None) -> str:
+def browser_click(ref: str, task_id: str | None = None) -> str:
     """
     Click on an element.
 
@@ -2593,7 +2593,7 @@ def browser_click(ref: str, task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
+def browser_type(ref: str, text: str, task_id: str | None = None) -> str:
     """
     Type text into an input field.
 
@@ -2633,7 +2633,7 @@ def browser_type(ref: str, text: str, task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
+def browser_scroll(direction: str, task_id: str | None = None) -> str:
     """
     Scroll the page.
 
@@ -2682,7 +2682,7 @@ def browser_scroll(direction: str, task_id: Optional[str] = None) -> str:
     return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_back(task_id: Optional[str] = None) -> str:
+def browser_back(task_id: str | None = None) -> str:
     """
     Navigate back in browser history.
 
@@ -2714,7 +2714,7 @@ def browser_back(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_press(key: str, task_id: Optional[str] = None) -> str:
+def browser_press(key: str, task_id: str | None = None) -> str:
     """
     Press a keyboard key.
 
@@ -2749,7 +2749,7 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
 
 
 
-def browser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:
+def browser_console(clear: bool = False, expression: str | None = None, task_id: str | None = None) -> str:
     """Get browser console messages and JavaScript errors, or evaluate JS in the page.
 
     When ``expression`` is provided, evaluates JavaScript in the page context
@@ -2811,7 +2811,7 @@ def browser_console(clear: bool = False, expression: Optional[str] = None, task_
     return json.dumps(response, ensure_ascii=False)
 
 
-def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
+def _browser_eval(expression: str, task_id: str | None = None) -> str:
     """Evaluate a JavaScript expression in the page context and return the result."""
     if _is_camofox_mode():
         return _camofox_eval(expression, task_id)
@@ -2901,7 +2901,7 @@ def _browser_eval(expression: str, task_id: Optional[str] = None) -> str:
     return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False, default=str)
 
 
-def _camofox_eval(expression: str, task_id: Optional[str] = None) -> str:
+def _camofox_eval(expression: str, task_id: str | None = None) -> str:
     """Evaluate JS via Camofox's /tabs/{tab_id}/eval endpoint (if available)."""
     from tools.browser_camofox import _ensure_tab, _post
     try:
@@ -2984,7 +2984,7 @@ def _maybe_stop_recording(task_id: str):
             _recording_sessions.discard(task_id)
 
 
-def browser_get_images(task_id: Optional[str] = None) -> str:
+def browser_get_images(task_id: str | None = None) -> str:
     """
     Get all images on the current page.
 
@@ -3045,7 +3045,7 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         return json.dumps(_copy_fallback_warning(response, result), ensure_ascii=False)
 
 
-def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
+def browser_vision(question: str, annotate: bool = False, task_id: str | None = None) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
 
@@ -3334,7 +3334,7 @@ def _cleanup_old_recordings(max_age_hours=72):
 # Cleanup and Management Functions
 # ============================================================================
 
-def cleanup_browser(task_id: Optional[str] = None) -> None:
+def cleanup_browser(task_id: str | None = None) -> None:
     """
     Clean up browser session(s) for a task.
 
@@ -3490,7 +3490,7 @@ def cleanup_all_browsers() -> None:
 
 
 # Cache for Chromium discovery. Invalidated by _reset_browser_caches.
-_cached_chromium_installed: Optional[bool] = None
+_cached_chromium_installed: bool | None = None
 
 
 def _chromium_search_roots() -> List[str]:

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -152,7 +152,7 @@ _COMMIT_HASH_RE = re.compile(r'^[0-9a-fA-F]{4,64}$')
 # Input validation helpers
 # ---------------------------------------------------------------------------
 
-def _validate_commit_hash(commit_hash: str) -> Optional[str]:
+def _validate_commit_hash(commit_hash: str) -> str | None:
     """Validate a commit hash to prevent git argument injection.
 
     Returns an error string if invalid, None if valid.
@@ -168,7 +168,7 @@ def _validate_commit_hash(commit_hash: str) -> Optional[str]:
     return None
 
 
-def _validate_file_path(file_path: str, working_dir: str) -> Optional[str]:
+def _validate_file_path(file_path: str, working_dir: str) -> str | None:
     """Validate a file path to prevent path traversal outside the working directory.
 
     Returns an error string if invalid, None if valid.
@@ -201,7 +201,7 @@ def _project_hash(working_dir: str) -> str:
     return hashlib.sha256(abs_path.encode()).hexdigest()[:16]
 
 
-def _store_path(base: Optional[Path] = None) -> Path:
+def _store_path(base: Path | None = None) -> Path:
     """Return the single shared shadow store path."""
     return (base or CHECKPOINT_BASE) / _STORE_DIRNAME
 
@@ -236,7 +236,7 @@ def _project_meta_path(store: Path, dir_hash: str) -> Path:
 def _git_env(
     store: Path,
     working_dir: str,
-    index_file: Optional[Path] = None,
+    index_file: Path | None = None,
 ) -> dict:
     """Build env dict that redirects git to the shared store.
 
@@ -275,8 +275,8 @@ def _run_git(
     store: Path,
     working_dir: str,
     timeout: int = _GIT_TIMEOUT,
-    allowed_returncodes: Optional[Set[int]] = None,
-    index_file: Optional[Path] = None,
+    allowed_returncodes: Set[int] | None = None,
+    index_file: Path | None = None,
 ) -> Tuple[bool, str, str]:
     """Run a git command against the shared store.  Returns (ok, stdout, stderr).
 
@@ -336,7 +336,7 @@ def _run_git(
 # Store initialisation + legacy migration
 # ---------------------------------------------------------------------------
 
-def _migrate_legacy_store(base: Path) -> Optional[Path]:
+def _migrate_legacy_store(base: Path) -> Path | None:
     """Move pre-v2 per-project shadow repos into a ``legacy-<ts>/`` dir.
 
     The pre-v2 layout had one shadow git repo per working directory directly
@@ -351,7 +351,7 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
     if not base.exists():
         return None
     store = _store_path(base)
-    legacy_root: Optional[Path] = None
+    legacy_root: Path | None = None
     # Reserved top-level entries managed by v2.
     reserved = {_STORE_DIRNAME, _PRUNE_MARKER_NAME}
     for child in list(base.iterdir()):
@@ -384,7 +384,7 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
     return legacy_root
 
 
-def _init_store(store: Path, working_dir: str) -> Optional[str]:
+def _init_store(store: Path, working_dir: str) -> str | None:
     """Initialise the shared shadow store if needed.  Returns error or None.
 
     Also performs one-time migration of pre-v2 per-directory shadow repos
@@ -545,7 +545,7 @@ def _dir_size_bytes(path: Path) -> int:
 # those markers, but inside the shared store + under ``projects/<hash>.json``.
 # The shim initialises the store and registers the project so the old
 # surface keeps roughly the same shape.
-def _init_shadow_repo(shadow_repo: Path, working_dir: str) -> Optional[str]:
+def _init_shadow_repo(shadow_repo: Path, working_dir: str) -> str | None:
     """Backwards-compatible initialiser.
 
     In v1 ``shadow_repo`` was a per-project dir; in v2 it's the shared
@@ -606,7 +606,7 @@ class CheckpointManager:
         self.max_total_size_mb = max(0, int(max_total_size_mb))
         self.max_file_size_mb = max(0, int(max_file_size_mb))
         self._checkpointed_dirs: Set[str] = set()
-        self._git_available: Optional[bool] = None  # lazy probe
+        self._git_available: bool | None = None  # lazy probe
 
     # ------------------------------------------------------------------
     # Turn lifecycle
@@ -1049,7 +1049,7 @@ class CheckpointManager:
         keep = commits[-self.max_snapshots:]
 
         # Rebuild a linear chain off keep[0]'s tree.
-        new_parent: Optional[str] = None
+        new_parent: str | None = None
         for sha in keep:
             ok_tree, tree_sha, _ = _run_git(
                 ["rev-parse", f"{sha}^{{tree}}"], store, working_dir,
@@ -1132,7 +1132,7 @@ class CheckpointManager:
                     continue
                 commits = list_out.splitlines()
                 keep = commits[1:]  # drop oldest
-                new_parent: Optional[str] = None
+                new_parent: str | None = None
                 fail = False
                 for sha in keep:
                     ok_tree, tree_sha, _ = _run_git(
@@ -1223,7 +1223,7 @@ def _delete_ref(store: Path, ref: str) -> bool:
 def prune_checkpoints(
     retention_days: int = 7,
     delete_orphans: bool = True,
-    checkpoint_base: Optional[Path] = None,
+    checkpoint_base: Path | None = None,
     max_total_size_mb: int = 0,
 ) -> Dict[str, int]:
     """Delete stale/orphan checkpoints and reclaim store space.
@@ -1295,9 +1295,9 @@ def prune_checkpoints(
         if not (child / "HEAD").exists():
             continue
         result["scanned"] += 1
-        reason: Optional[str] = None
+        reason: str | None = None
         if delete_orphans:
-            workdir: Optional[str] = None
+            workdir: str | None = None
             wd_marker = child / "HERMES_WORKDIR"
             if wd_marker.exists():
                 try:
@@ -1415,7 +1415,7 @@ def prune_checkpoints(
                         continue
                     commits = lo.splitlines()
                     keep = commits[1:]
-                    new_parent: Optional[str] = None
+                    new_parent: str | None = None
                     fail = False
                     for sha in keep:
                         ok_t, tsha, _ = _run_git(
@@ -1463,7 +1463,7 @@ def maybe_auto_prune_checkpoints(
     retention_days: int = 7,
     min_interval_hours: int = 24,
     delete_orphans: bool = True,
-    checkpoint_base: Optional[Path] = None,
+    checkpoint_base: Path | None = None,
     max_total_size_mb: int = 0,
 ) -> Dict[str, object]:
     """Idempotent wrapper around ``prune_checkpoints`` for startup hooks.
@@ -1530,7 +1530,7 @@ def maybe_auto_prune_checkpoints(
 # Public helpers for `hermes checkpoints` CLI
 # ---------------------------------------------------------------------------
 
-def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
+def store_status(checkpoint_base: Path | None = None) -> Dict:
     """Return a summary of the shadow store.
 
     ``{"base": path, "store_size_bytes": N, "legacy_size_bytes": N,
@@ -1597,7 +1597,7 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
     return out
 
 
-def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
+def clear_all(checkpoint_base: Path | None = None) -> Dict[str, int]:
     """Nuke the entire checkpoint base (store + legacy).  Irreversible.
 
     Returns ``{"bytes_freed": N, "deleted": bool}``.
@@ -1616,7 +1616,7 @@ def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
     return out
 
 
-def clear_legacy(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
+def clear_legacy(checkpoint_base: Path | None = None) -> Dict[str, int]:
     """Delete all ``legacy-*`` archive directories.
 
     Returns ``{"bytes_freed": N, "deleted": count}``.

--- a/tools/clarify_gateway.py
+++ b/tools/clarify_gateway.py
@@ -50,9 +50,9 @@ class _ClarifyEntry:
     clarify_id: str
     session_key: str
     question: str
-    choices: Optional[List[str]]
+    choices: List[str] | None
     event: threading.Event = field(default_factory=threading.Event)
-    response: Optional[str] = None
+    response: str | None = None
     awaiting_text: bool = False  # set when user picked "Other" or clarify is open-ended
 
     def signature(self) -> Dict[str, object]:
@@ -79,7 +79,7 @@ def register(
     clarify_id: str,
     session_key: str,
     question: str,
-    choices: Optional[List[str]],
+    choices: List[str] | None,
 ) -> _ClarifyEntry:
     """Register a pending clarify request and return the entry.
 
@@ -100,7 +100,7 @@ def register(
     return entry
 
 
-def wait_for_response(clarify_id: str, timeout: float) -> Optional[str]:
+def wait_for_response(clarify_id: str, timeout: float) -> str | None:
     """Block on the entry's event until resolved or timeout fires.
 
     Polls in 1-second slices so the agent's inactivity heartbeat keeps
@@ -162,7 +162,7 @@ def resolve_gateway_clarify(clarify_id: str, response: str) -> bool:
     return True
 
 
-def get_pending_for_session(session_key: str) -> Optional[_ClarifyEntry]:
+def get_pending_for_session(session_key: str) -> _ClarifyEntry | None:
     """Return the OLDEST pending clarify entry for a session, or None.
 
     Used by the text-fallback intercept in ``_handle_message`` — when a
@@ -273,6 +273,6 @@ def unregister_notify(session_key: str) -> None:
     clear_session(session_key)
 
 
-def get_notify(session_key: str) -> Optional[Callable[[_ClarifyEntry], None]]:
+def get_notify(session_key: str) -> Callable[[_ClarifyEntry], None] | None:
     with _lock:
         return _notify_cbs.get(session_key)

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -22,8 +22,8 @@ MAX_CHOICES = 4
 
 def clarify_tool(
     question: str,
-    choices: Optional[List[str]] = None,
-    callback: Optional[Callable] = None,
+    choices: List[str] | None = None,
+    callback: Callable | None = None,
 ) -> str:
     """
     Ask the user a question, optionally with multiple-choice options.

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -840,8 +840,8 @@ def _rpc_poll_loop(
 
 def _execute_remote(
     code: str,
-    task_id: Optional[str],
-    enabled_tools: Optional[List[str]],
+    task_id: str | None,
+    enabled_tools: List[str] | None,
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -1035,8 +1035,8 @@ def _execute_remote(
 
 def execute_code(
     code: str,
-    task_id: Optional[str] = None,
-    enabled_tools: Optional[List[str]] = None,
+    task_id: str | None = None,
+    enabled_tools: List[str] | None = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -45,7 +45,7 @@ class CaptureResult:
     mode: str
     width: int                      # screenshot width (logical px, pre-Anthropic-scale)
     height: int
-    png_b64: Optional[str] = None
+    png_b64: str | None = None
     elements: List[UIElement] = field(default_factory=list)
     # Optional: the target app/window the elements were captured for.
     app: str = ""
@@ -63,7 +63,7 @@ class ActionResult:
     message: str = ""                # human-readable summary
     # Optional trailing screenshot — set when the caller asked for a
     # post-action capture or the backend always returns one.
-    capture: Optional[CaptureResult] = None
+    capture: CaptureResult | None = None
     # Arbitrary extra fields for debugging / telemetry.
     meta: Dict[str, Any] = field(default_factory=dict)
 
@@ -86,31 +86,31 @@ class ComputerUseBackend(ABC):
 
     # ── Capture ─────────────────────────────────────────────────────
     @abstractmethod
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult: ...
+    def capture(self, mode: str = "som", app: str | None = None) -> CaptureResult: ...
 
     # ── Pointer actions ─────────────────────────────────────────────
     @abstractmethod
     def click(
         self,
         *,
-        element: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
+        element: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
         button: str = "left",           # left | right | middle
         click_count: int = 1,
-        modifiers: Optional[List[str]] = None,
+        modifiers: List[str] | None = None,
     ) -> ActionResult: ...
 
     @abstractmethod
     def drag(
         self,
         *,
-        from_element: Optional[int] = None,
-        to_element: Optional[int] = None,
-        from_xy: Optional[Tuple[int, int]] = None,
-        to_xy: Optional[Tuple[int, int]] = None,
+        from_element: int | None = None,
+        to_element: int | None = None,
+        from_xy: Tuple[int, int] | None = None,
+        to_xy: Tuple[int, int] | None = None,
         button: str = "left",
-        modifiers: Optional[List[str]] = None,
+        modifiers: List[str] | None = None,
     ) -> ActionResult: ...
 
     @abstractmethod
@@ -119,10 +119,10 @@ class ComputerUseBackend(ABC):
         *,
         direction: str,                 # up | down | left | right
         amount: int = 3,                # wheel ticks
-        element: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        modifiers: Optional[List[str]] = None,
+        element: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        modifiers: List[str] | None = None,
     ) -> ActionResult: ...
 
     # ── Keyboard ────────────────────────────────────────────────────
@@ -144,7 +144,7 @@ class ComputerUseBackend(ABC):
 
     # ── Native-value mutation ────────────────────────────────────────
     @abstractmethod
-    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+    def set_value(self, value: str, element: int | None = None) -> ActionResult:
         """Set a native value on an element (e.g. AXPopUpButton selection).
 
         `element` is the 1-based SOM index returned by a prior capture call.

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -141,7 +141,7 @@ def _split_tree_text(full_text: str) -> Tuple[str, str]:
     return summary, tree
 
 
-def _parse_key_combo(keys: str) -> Tuple[Optional[str], List[str]]:
+def _parse_key_combo(keys: str) -> Tuple[str | None, List[str]]:
     """Parse a key string like 'cmd+s' into (key, modifiers).
 
     Returns (key, modifiers) where key is the non-modifier key and modifiers
@@ -170,8 +170,8 @@ class _AsyncBridge:
     """Runs one asyncio loop on a daemon thread; marshals coroutines from the caller."""
 
     def __init__(self) -> None:
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._thread: Optional[threading.Thread] = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
         self._ready = threading.Event()
 
     def start(self) -> None:
@@ -196,7 +196,7 @@ class _AsyncBridge:
         if not self._ready.wait(timeout=5.0):
             raise RuntimeError("cua-driver asyncio bridge failed to start")
 
-    def run(self, coro, timeout: Optional[float] = 30.0) -> Any:
+    def run(self, coro, timeout: float | None = 30.0) -> Any:
         from agent.async_utils import safe_schedule_threadsafe
         if not self._loop or not self._thread or not self._thread.is_alive():
             if asyncio.iscoroutine(coro):
@@ -307,7 +307,7 @@ def _extract_tool_result(mcp_result: Any) -> Dict[str, Any]:
     data: Any = None
     images: List[str] = []
     is_error = bool(getattr(mcp_result, "isError", False))
-    structured: Optional[Dict] = getattr(mcp_result, "structuredContent", None) or None
+    structured: Dict | None = getattr(mcp_result, "structuredContent", None) or None
     text_chunks: List[str] = []
     for part in getattr(mcp_result, "content", []) or []:
         ptype = getattr(part, "type", None)
@@ -337,9 +337,9 @@ class CuaDriverBackend(ComputerUseBackend):
         self._bridge = _AsyncBridge()
         self._session = _CuaDriverSession(self._bridge)
         # Sticky context — updated by capture(), used by action tools.
-        self._active_pid: Optional[int] = None
-        self._active_window_id: Optional[int] = None
-        self._last_app: Optional[str] = None  # last app name targeted via capture/focus_app
+        self._active_pid: int | None = None
+        self._active_window_id: int | None = None
+        self._last_app: str | None = None  # last app name targeted via capture/focus_app
 
     # ── Lifecycle ──────────────────────────────────────────────────
     def start(self) -> None:
@@ -357,7 +357,7 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
+    def capture(self, mode: str = "som", app: str | None = None) -> CaptureResult:
         """Capture the frontmost on-screen window (optionally filtered by app name).
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
@@ -426,7 +426,7 @@ class CuaDriverBackend(ComputerUseBackend):
             self._last_app = app_name
 
         # Step 2: capture.
-        png_b64: Optional[str] = None
+        png_b64: str | None = None
         elements: List[UIElement] = []
         width = height = 0
         window_title = ""
@@ -484,12 +484,12 @@ class CuaDriverBackend(ComputerUseBackend):
     def click(
         self,
         *,
-        element: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
+        element: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
         button: str = "left",
         click_count: int = 1,
-        modifiers: Optional[List[str]] = None,
+        modifiers: List[str] | None = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
@@ -525,12 +525,12 @@ class CuaDriverBackend(ComputerUseBackend):
     def drag(
         self,
         *,
-        from_element: Optional[int] = None,
-        to_element: Optional[int] = None,
-        from_xy: Optional[Tuple[int, int]] = None,
-        to_xy: Optional[Tuple[int, int]] = None,
+        from_element: int | None = None,
+        to_element: int | None = None,
+        from_xy: Tuple[int, int] | None = None,
+        to_xy: Tuple[int, int] | None = None,
         button: str = "left",
-        modifiers: Optional[List[str]] = None,
+        modifiers: List[str] | None = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
@@ -557,10 +557,10 @@ class CuaDriverBackend(ComputerUseBackend):
         *,
         direction: str,
         amount: int = 3,
-        element: Optional[int] = None,
-        x: Optional[int] = None,
-        y: Optional[int] = None,
-        modifiers: Optional[List[str]] = None,
+        element: int | None = None,
+        x: int | None = None,
+        y: int | None = None,
+        modifiers: List[str] | None = None,
     ) -> ActionResult:
         pid = self._active_pid
         if pid is None:
@@ -605,7 +605,7 @@ class CuaDriverBackend(ComputerUseBackend):
             return self._action("press_key", {"pid": pid, "key": key_name})
 
     # ── Value setter ────────────────────────────────────────────────
-    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+    def set_value(self, value: str, element: int | None = None) -> ActionResult:
         """Set a value on an element. Handles AXPopUpButton selects natively."""
         pid = self._active_pid
         window_id = self._active_window_id

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -107,7 +107,7 @@ _BLOCKED_TYPE_PATTERNS = [
 ]
 
 
-def _is_blocked_type(text: str) -> Optional[str]:
+def _is_blocked_type(text: str) -> str | None:
     for pat in _BLOCKED_TYPE_PATTERNS:
         if pat.search(text):
             return pat.pattern
@@ -120,7 +120,7 @@ def _is_blocked_type(text: str) -> Optional[str]:
 
 # Per-process cached backend; lazily instantiated on first call.
 _backend_lock = threading.Lock()
-_backend: Optional[ComputerUseBackend] = None
+_backend: ComputerUseBackend | None = None
 # Session-scoped approval state.
 _session_auto_approve = False
 _always_allow: set = set()  # action names the user unlocked for the session
@@ -167,7 +167,7 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
     def stop(self) -> None: self._started = False
     def is_available(self) -> bool: return True
 
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
+    def capture(self, mode: str = "som", app: str | None = None) -> CaptureResult:
         self.calls.append(("capture", {"mode": mode, "app": app}))
         return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
                              elements=[], app=app or "", window_title="")
@@ -200,7 +200,7 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
         self.calls.append(("focus_app", {"app": app, "raise": raise_window}))
         return ActionResult(ok=True, action="focus_app")
 
-    def set_value(self, value: str, element: Optional[int] = None) -> ActionResult:
+    def set_value(self, value: str, element: int | None = None) -> ActionResult:
         self.calls.append(("set_value", {"value": value, "element": element}))
         return ActionResult(ok=True, action="set_value")
 
@@ -261,7 +261,7 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         return json.dumps({"error": f"{action} failed: {e}"})
 
 
-def _request_approval(action: str, args: Dict[str, Any]) -> Optional[str]:
+def _request_approval(action: str, args: Dict[str, Any]) -> str | None:
     """Return None if approved, or a JSON error string if denied."""
     global _session_auto_approve, _always_allow
     if _session_auto_approve:
@@ -575,7 +575,7 @@ def _should_route_through_aux_vision() -> bool:
 def _route_capture_through_aux_vision(
     cap: CaptureResult,
     summary: str,
-) -> Optional[str]:
+) -> str | None:
     """Pre-analyse the captured PNG via ``vision_analyze`` and return a text result.
 
     The captured base64 PNG is materialised to ``$HERMES_HOME/cache/vision/``

--- a/tools/computer_use/vision_routing.py
+++ b/tools/computer_use/vision_routing.py
@@ -49,7 +49,7 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 
-def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
+def _explicit_aux_vision_override(cfg: Dict[str, Any] | None) -> bool:
     """True when ``auxiliary.vision`` carries a non-default user override.
 
     Mirrors ``agent.image_routing._explicit_aux_vision_override`` so the
@@ -76,7 +76,7 @@ def _explicit_aux_vision_override(cfg: Optional[Dict[str, Any]]) -> bool:
     return True
 
 
-def _lookup_supports_vision(provider: str, model: str) -> Optional[bool]:
+def _lookup_supports_vision(provider: str, model: str) -> bool | None:
     """Return models.dev ``supports_vision`` for *(provider, model)* or None."""
     if not provider or not model:
         return None
@@ -94,7 +94,7 @@ def _lookup_supports_vision(provider: str, model: str) -> Optional[bool]:
     return bool(getattr(caps, "supports_vision", False))
 
 
-def _provider_accepts_multimodal_tool_result(provider: str, model: str) -> Optional[bool]:
+def _provider_accepts_multimodal_tool_result(provider: str, model: str) -> bool | None:
     """Return whether *provider*+*model* carries images inside tool-result messages.
 
     Reuses ``tools.vision_tools._supports_media_in_tool_results`` so the
@@ -118,7 +118,7 @@ def _provider_accepts_multimodal_tool_result(provider: str, model: str) -> Optio
 def should_route_capture_to_aux_vision(
     provider: str,
     model: str,
-    cfg: Optional[Dict[str, Any]],
+    cfg: Dict[str, Any] | None,
 ) -> bool:
     """Return True iff the captured screenshot should be pre-analysed via aux vision.
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -140,7 +140,7 @@ def _scan_cron_prompt(prompt: str) -> str:
     return ""
 
 
-def _origin_from_env() -> Optional[Dict[str, str]]:
+def _origin_from_env() -> Dict[str, str] | None:
     from gateway.session_context import get_session_env
     origin_platform = get_session_env("HERMES_SESSION_PLATFORM")
     origin_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
@@ -170,7 +170,7 @@ def _repeat_display(job: Dict[str, Any]) -> str:
     return f"{completed}/{times}" if completed else f"{times} times"
 
 
-def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
+def _canonical_skills(skill: str | None = None, skills: Any | None = None) -> List[str]:
     if skills is None:
         raw_items = [skill] if skill else []
     elif isinstance(skills, str):
@@ -188,7 +188,7 @@ def _canonical_skills(skill: Optional[str] = None, skills: Optional[Any] = None)
 
 
 
-def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
+def _resolve_model_override(model_obj: Dict[str, Any] | None) -> tuple:
     """Resolve a model override object into (provider, model) for job storage.
 
     If provider is omitted, pins the current main provider from config so the
@@ -222,7 +222,7 @@ def _resolve_model_override(model_obj: Optional[Dict[str, Any]]) -> tuple:
     return (provider_name, model_name)
 
 
-def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash: bool = False) -> Optional[str]:
+def _normalize_optional_job_value(value: Any | None, *, strip_trailing_slash: bool = False) -> str | None:
     if value is None:
         return None
     text = str(value).strip()
@@ -231,7 +231,7 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
-def _normalize_deliver_param(value: Any) -> Optional[str]:
+def _normalize_deliver_param(value: Any) -> str | None:
     """Normalize a user-supplied ``deliver`` value to the canonical string form.
 
     The cron schema documents ``deliver`` as a string (``"local"``, ``"origin"``,
@@ -252,7 +252,7 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
     return text or None
 
 
-def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
+def _validate_cron_script_path(script: str | None) -> str | None:
     """Validate a cron job script path at the API boundary.
 
     Scripts must be relative paths that resolve within HERMES_HOME/scripts/.
@@ -332,25 +332,25 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
 
 def cronjob(
     action: str,
-    job_id: Optional[str] = None,
-    prompt: Optional[str] = None,
-    schedule: Optional[str] = None,
-    name: Optional[str] = None,
-    repeat: Optional[int] = None,
-    deliver: Optional[str] = None,
+    job_id: str | None = None,
+    prompt: str | None = None,
+    schedule: str | None = None,
+    name: str | None = None,
+    repeat: int | None = None,
+    deliver: str | None = None,
     include_disabled: bool = False,
-    skill: Optional[str] = None,
-    skills: Optional[List[str]] = None,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
-    reason: Optional[str] = None,
-    script: Optional[str] = None,
-    context_from: Optional[Union[str, List[str]]] = None,
-    enabled_toolsets: Optional[List[str]] = None,
-    workdir: Optional[str] = None,
-    profile: Optional[str] = None,
-    no_agent: Optional[bool] = None,
+    skill: str | None = None,
+    skills: List[str] | None = None,
+    model: str | None = None,
+    provider: str | None = None,
+    base_url: str | None = None,
+    reason: str | None = None,
+    script: str | None = None,
+    context_from: Union[str, List[str]] | None = None,
+    enabled_toolsets: List[str] | None = None,
+    workdir: str | None = None,
+    profile: str | None = None,
+    no_agent: bool | None = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -309,7 +309,7 @@ def _looks_like_error_output(content: str) -> bool:
     )
 
 
-def _normalize_role(r: Optional[str]) -> str:
+def _normalize_role(r: str | None) -> str:
     """Normalise a caller-provided role to 'leaf' or 'orchestrator'.
 
     None/empty -> 'leaf'.  Unknown strings coerce to 'leaf' with a
@@ -568,9 +568,9 @@ def check_delegate_requirements() -> bool:
 
 def _build_child_system_prompt(
     goal: str,
-    context: Optional[str] = None,
+    context: str | None = None,
     *,
-    workspace_path: Optional[str] = None,
+    workspace_path: str | None = None,
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
@@ -642,7 +642,7 @@ def _build_child_system_prompt(
     return "\n".join(parts)
 
 
-def _resolve_workspace_hint(parent_agent) -> Optional[str]:
+def _resolve_workspace_hint(parent_agent) -> str | None:
     """Best-effort local workspace hint for child prompts.
 
     We only inject a path when we have a concrete absolute directory. This avoids
@@ -686,12 +686,12 @@ def _build_child_progress_callback(
     parent_agent,
     task_count: int = 1,
     *,
-    subagent_id: Optional[str] = None,
-    parent_id: Optional[str] = None,
-    depth: Optional[int] = None,
-    model: Optional[str] = None,
-    toolsets: Optional[List[str]] = None,
-) -> Optional[callable]:
+    subagent_id: str | None = None,
+    parent_id: str | None = None,
+    depth: int | None = None,
+    model: str | None = None,
+    toolsets: List[str] | None = None,
+) -> callable | None:
     """Build a callback that relays child agent tool calls to the parent display.
 
     Two display paths:
@@ -870,20 +870,20 @@ def _build_child_progress_callback(
 def _build_child_agent(
     task_index: int,
     goal: str,
-    context: Optional[str],
-    toolsets: Optional[List[str]],
-    model: Optional[str],
+    context: str | None,
+    toolsets: List[str] | None,
+    model: str | None,
     max_iterations: int,
     task_count: int,
     parent_agent,
     # Credential overrides from delegation config (provider:model resolution)
-    override_provider: Optional[str] = None,
-    override_base_url: Optional[str] = None,
-    override_api_key: Optional[str] = None,
-    override_api_mode: Optional[str] = None,
+    override_provider: str | None = None,
+    override_base_url: str | None = None,
+    override_api_key: str | None = None,
+    override_api_mode: str | None = None,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
-    override_acp_command: Optional[str] = None,
-    override_acp_args: Optional[List[str]] = None,
+    override_acp_command: str | None = None,
+    override_acp_args: List[str] | None = None,
     # Per-call role controlling whether the child can further delegate.
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
@@ -1180,9 +1180,9 @@ def _dump_subagent_timeout_diagnostic(
     task_index: int,
     timeout_seconds: float,
     duration_seconds: float,
-    worker_thread: Optional[threading.Thread],
+    worker_thread: threading.Thread | None,
     goal: str,
-) -> Optional[str]:
+) -> str | None:
     """Write a structured diagnostic dump for a subagent that timed out
     before making any API call.
 
@@ -1500,7 +1500,7 @@ def _run_single_child(
         )
         # Capture the worker thread so the timeout diagnostic can dump its
         # Python stack (see #14726 — 0-API-call hangs are opaque without it).
-        _worker_thread_holder: Dict[str, Optional[threading.Thread]] = {"t": None}
+        _worker_thread_holder: Dict[str, threading.Thread | None] = {"t": None}
 
         def _run_with_thread_capture():
             _worker_thread_holder["t"] = threading.current_thread()
@@ -1534,7 +1534,7 @@ def _run_single_child(
             # When a subagent times out BEFORE making any API call, dump a
             # diagnostic to help users (and us) see what the child was doing.
             # See #14726 — without this, 0-API-call hangs are black boxes.
-            diagnostic_path: Optional[str] = None
+            diagnostic_path: str | None = None
             child_api_calls = 0
             try:
                 _summary = child.get_activity_summary()
@@ -1894,7 +1894,7 @@ def _run_single_child(
 
 def _recover_tasks_from_json_string(
     tasks: Any,
-) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+) -> tuple[List[Dict[str, Any]] | None, str | None]:
     if not isinstance(tasks, str):
         return None, None
     raw = tasks.strip()
@@ -1916,14 +1916,14 @@ def _recover_tasks_from_json_string(
 
 
 def delegate_task(
-    goal: Optional[str] = None,
-    context: Optional[str] = None,
-    toolsets: Optional[List[str]] = None,
-    tasks: Optional[List[Dict[str, Any]]] = None,
-    max_iterations: Optional[int] = None,
-    acp_command: Optional[str] = None,
-    acp_args: Optional[List[str]] = None,
-    role: Optional[str] = None,
+    goal: str | None = None,
+    context: str | None = None,
+    toolsets: List[str] | None = None,
+    tasks: List[Dict[str, Any]] | None = None,
+    max_iterations: int | None = None,
+    acp_command: str | None = None,
+    acp_args: List[str] | None = None,
+    role: str | None = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2309,7 +2309,7 @@ def delegate_task(
     )
 
 
-def _resolve_child_credential_pool(effective_provider: Optional[str], parent_agent):
+def _resolve_child_credential_pool(effective_provider: str | None, parent_agent):
     """Resolve a credential pool for the child agent.
 
     Rules:

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -50,7 +50,7 @@ _FLAG_GATEWAY_MESSAGE_CONTENT_LIMITED = 1 << 19
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _get_bot_token() -> Optional[str]:
+def _get_bot_token() -> str | None:
     """Resolve the Discord bot token from environment."""
     return os.getenv("DISCORD_BOT_TOKEN", "").strip() or None
 
@@ -59,8 +59,8 @@ def _discord_request(
     method: str,
     path: str,
     token: str,
-    params: Optional[Dict[str, str]] = None,
-    body: Optional[Dict[str, Any]] = None,
+    params: Dict[str, str] | None = None,
+    body: Dict[str, Any] | None = None,
     timeout: int = 15,
 ) -> Any:
     """Make a request to the Discord REST API."""
@@ -224,7 +224,7 @@ def _list_channels(token: str, guild_id: str, **_kwargs: Any) -> str:
     channels = _discord_request("GET", f"/guilds/{guild_id}/channels", token)
 
     # Organize: categories first, then channels under each
-    categories: Dict[Optional[str], Dict[str, Any]] = {}
+    categories: Dict[str | None, Dict[str, Any]] = {}
     uncategorized: List[Dict[str, Any]] = []
 
     # First pass: collect categories
@@ -350,7 +350,7 @@ def _search_members(token: str, guild_id: str, query: str, limit: int = 20, **_k
 
 def _fetch_messages(
     token: str, channel_id: str, limit: int = 50,
-    before: Optional[str] = None, after: Optional[str] = None,
+    before: str | None = None, after: str | None = None,
     **_kwargs: Any,
 ) -> str:
     """Fetch recent messages from a channel."""
@@ -426,7 +426,7 @@ def _delete_message(token: str, channel_id: str, message_id: str, **_kwargs: Any
 
 def _create_thread(
     token: str, channel_id: str, name: str,
-    message_id: Optional[str] = None,
+    message_id: str | None = None,
     auto_archive_duration: int = 1440,
     **_kwargs: Any,
 ) -> str:
@@ -541,7 +541,7 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
 # Config-based action allowlist
 # ---------------------------------------------------------------------------
 
-def _load_allowed_actions_config() -> Optional[List[str]]:
+def _load_allowed_actions_config() -> List[str] | None:
     """Read ``discord.server_actions`` from user config.
 
     Returns a list of allowed action names, or ``None`` if the user
@@ -584,7 +584,7 @@ def _load_allowed_actions_config() -> Optional[List[str]]:
 
 def _available_actions(
     caps: Dict[str, Any],
-    allowlist: Optional[List[str]],
+    allowlist: List[str] | None,
 ) -> List[str]:
     """Compute the visible action list from intents + config allowlist.
 
@@ -608,9 +608,9 @@ def _available_actions(
 
 def _build_schema(
     actions: List[str],
-    caps: Optional[Dict[str, Any]] = None,
+    caps: Dict[str, Any] | None = None,
     tool_name: str = "discord",
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any] | None:
     """Build the tool schema for the given filtered action list.
 
     Returns ``None`` when *actions* is empty — callers should drop the
@@ -728,7 +728,7 @@ def _build_schema(
 def _get_dynamic_schema(
     action_subset: Dict[str, Any],
     tool_name: str,
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any] | None:
     """Build a dynamic schema for *action_subset* filtered by intents + config."""
     token = _get_bot_token()
     if not token:
@@ -741,15 +741,15 @@ def _get_dynamic_schema(
     return _build_schema(actions, caps, tool_name=tool_name)
 
 
-def get_dynamic_schema_core() -> Optional[Dict[str, Any]]:
+def get_dynamic_schema_core() -> Dict[str, Any] | None:
     return _get_dynamic_schema(_CORE_ACTIONS, "discord")
 
 
-def get_dynamic_schema_admin() -> Optional[Dict[str, Any]]:
+def get_dynamic_schema_admin() -> Dict[str, Any] | None:
     return _get_dynamic_schema(_ADMIN_ACTIONS, "discord_admin")
 
 
-def get_dynamic_schema() -> Optional[Dict[str, Any]]:
+def get_dynamic_schema() -> Dict[str, Any] | None:
     """Backward-compat wrapper — returns core schema."""
     return get_dynamic_schema_core()
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -29,7 +29,7 @@ _DOCKER_SEARCH_PATHS = [
     "/Applications/Docker.app/Contents/Resources/bin/docker",
 ]
 
-_docker_executable: Optional[str] = None  # resolved once, cached
+_docker_executable: str | None = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -98,7 +98,7 @@ def _load_hermes_env_vars() -> dict[str, str]:
         return {}
 
 
-def find_docker() -> Optional[str]:
+def find_docker() -> str | None:
     """Locate the docker (or podman) CLI binary.
 
     Resolution order:
@@ -187,7 +187,7 @@ def _build_security_args(run_as_host_user: bool) -> list[str]:
     return list(_BASE_SECURITY_ARGS) + list(_PRIVDROP_CAP_ARGS)
 
 
-def _resolve_host_user_spec() -> Optional[str]:
+def _resolve_host_user_spec() -> str | None:
     """Return ``<uid>:<gid>`` for the current host user, or ``None`` on platforms
     where this is not meaningful (e.g. Windows without posix ids).
 
@@ -205,7 +205,7 @@ def _resolve_host_user_spec() -> Optional[str]:
         return None
 
 
-_storage_opt_ok: Optional[bool] = None  # cached result across instances
+_storage_opt_ok: bool | None = None  # cached result across instances
 
 
 def _ensure_docker_available() -> None:
@@ -312,7 +312,7 @@ class DockerEnvironment(BaseEnvironment):
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
-        self._container_id: Optional[str] = None
+        self._container_id: str | None = None
         logger.info(f"DockerEnvironment volumes: {volumes}")
         # Ensure volumes is a list (config.yaml could be malformed)
         if volumes is not None and not isinstance(volumes, list):
@@ -371,8 +371,8 @@ class DockerEnvironment(BaseEnvironment):
         if auto_mount_cwd and host_cwd and not os.path.isdir(host_cwd_abs):
             logger.debug(f"Skipping docker cwd mount: host_cwd is not a valid directory: {host_cwd}")
 
-        self._workspace_dir: Optional[str] = None
-        self._home_dir: Optional[str] = None
+        self._workspace_dir: str | None = None
+        self._home_dir: str | None = None
         writable_args = []
         if self._persistent:
             sandbox = get_sandbox_dir() / "docker" / task_id

--- a/tools/environments/managed_modal.py
+++ b/tools/environments/managed_modal.py
@@ -48,7 +48,7 @@ class ManagedModalEnvironment(BaseModalExecutionEnvironment):
         image: str,
         cwd: str = "/root",
         timeout: int = 60,
-        modal_sandbox_kwargs: Optional[Dict[str, Any]] = None,
+        modal_sandbox_kwargs: Dict[str, Any] | None = None,
         persistent_filesystem: bool = True,
         task_id: str = "default",
     ):

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -128,8 +128,8 @@ class _AsyncWorker:
     """Background thread with its own event loop for async-safe Modal calls."""
 
     def __init__(self):
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._thread: Optional[threading.Thread] = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
         self._started = threading.Event()
 
     def start(self):
@@ -176,7 +176,7 @@ class ModalEnvironment(BaseEnvironment):
         image: str,
         cwd: str = "/root",
         timeout: int = 60,
-        modal_sandbox_kwargs: Optional[dict[str, Any]] = None,
+        modal_sandbox_kwargs: dict[str, Any] | None = None,
         persistent_filesystem: bool = True,
         task_id: str = "default",
     ):

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -179,7 +179,7 @@ class SingularityEnvironment(BaseEnvironment):
         self._instance_started = False
         self._persistent = persistent_filesystem
         self._task_id = task_id
-        self._overlay_dir: Optional[Path] = None
+        self._overlay_dir: Path | None = None
         self._cpu = cpu
         self._memory = memory
 

--- a/tools/fal_common.py
+++ b/tools/fal_common.py
@@ -59,7 +59,7 @@ def _normalize_fal_queue_url_format(queue_run_origin: str) -> str:
     return f"{normalized_origin}/"
 
 
-def _extract_http_status(exc: BaseException) -> Optional[int]:
+def _extract_http_status(exc: BaseException) -> int | None:
     """Return an HTTP status code from httpx/fal exceptions, else None.
 
     Defensive across exception shapes — httpx.HTTPStatusError exposes
@@ -119,11 +119,11 @@ class _ManagedFalSyncClient:
         arguments: Dict[str, Any],
         *,
         path: str = "",
-        hint: Optional[str] = None,
-        webhook_url: Optional[str] = None,
+        hint: str | None = None,
+        webhook_url: str | None = None,
         priority: Any = None,
-        headers: Optional[Dict[str, str]] = None,
-        start_timeout: Optional[Union[int, float]] = None,
+        headers: Dict[str, str] | None = None,
+        start_timeout: Union[int, float] | None = None,
     ):
         url = self._queue_url_format + application
         if path:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -74,7 +74,7 @@ def _strip_terminal_fence_leaks(text: str) -> str:
     return "".join(cleaned_lines)
 
 
-def _get_safe_write_root() -> Optional[str]:
+def _get_safe_write_root() -> str | None:
     """Return the resolved HERMES_WRITE_SAFE_ROOT path, or None if unset.
 
     When set, all write_file/patch operations are constrained to this
@@ -101,13 +101,13 @@ class ReadResult:
     total_lines: int = 0
     file_size: int = 0
     truncated: bool = False
-    hint: Optional[str] = None
+    hint: str | None = None
     is_binary: bool = False
     is_image: bool = False
-    base64_content: Optional[str] = None
-    mime_type: Optional[str] = None
-    dimensions: Optional[str] = None  # For images: "WIDTHxHEIGHT"
-    error: Optional[str] = None
+    base64_content: str | None = None
+    mime_type: str | None = None
+    dimensions: str | None = None  # For images: "WIDTHxHEIGHT"
+    error: str | None = None
     similar_files: List[str] = field(default_factory=list)
     
     def to_dict(self) -> dict:
@@ -119,16 +119,16 @@ class WriteResult:
     """Result from writing a file."""
     bytes_written: int = 0
     dirs_created: bool = False
-    lint: Optional[Dict[str, Any]] = None
+    lint: Dict[str, Any] | None = None
     # Semantic diagnostics from the LSP layer, when applicable.  Kept in
     # its own field (not folded into ``lint``) so the model and any
     # downstream parsers can read syntax errors and semantic errors as
     # separate signals.  ``None`` when LSP is disabled, when the file
     # isn't in a git workspace, or when no diagnostics were introduced
     # by this edit.
-    lsp_diagnostics: Optional[str] = None
-    error: Optional[str] = None
-    warning: Optional[str] = None
+    lsp_diagnostics: str | None = None
+    error: str | None = None
+    warning: str | None = None
 
     def to_dict(self) -> dict:
         return {k: v for k, v in self.__dict__.items() if v is not None}
@@ -142,10 +142,10 @@ class PatchResult:
     files_modified: List[str] = field(default_factory=list)
     files_created: List[str] = field(default_factory=list)
     files_deleted: List[str] = field(default_factory=list)
-    lint: Optional[Dict[str, Any]] = None
+    lint: Dict[str, Any] | None = None
     # See :class:`WriteResult.lsp_diagnostics`.
-    lsp_diagnostics: Optional[str] = None
-    error: Optional[str] = None
+    lsp_diagnostics: str | None = None
+    error: str | None = None
     
     def to_dict(self) -> dict:
         result = {"success": self.success}
@@ -183,7 +183,7 @@ class SearchResult:
     counts: Dict[str, int] = field(default_factory=dict)
     total_count: int = 0
     truncated: bool = False
-    error: Optional[str] = None
+    error: str | None = None
     
     def to_dict(self) -> dict:
         result = {"total_count": self.total_count}
@@ -302,7 +302,7 @@ class FileOperations(ABC):
 
     @abstractmethod
     def search(self, pattern: str, path: str = ".", target: str = "content",
-               file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
+               file_glob: str | None = None, limit: int = 50, offset: int = 0,
                output_mode: str = "content", context: int = 0) -> SearchResult:
         """Search for content or files."""
         ...
@@ -963,7 +963,7 @@ class ShellFileOperations(FileOperations):
         # extensions outside both sets (binaries, opaque formats),
         # skipping the read keeps the hot path fast.
         ext = os.path.splitext(path)[1].lower()
-        pre_content: Optional[str] = None
+        pre_content: str | None = None
         want_pre = ext in LINTERS_INPROC or self._lsp_handles_extension(ext)
         if want_pre:
             # Best-effort read; failure (file missing, permission) leaves
@@ -1018,7 +1018,7 @@ class ShellFileOperations(FileOperations):
         # content so the LSP layer can build a line-shift map and
         # remap baseline diagnostics into post-edit coordinates.
         # Best-effort: ``""`` is returned for any failure path.
-        lsp_diagnostics: Optional[str] = None
+        lsp_diagnostics: str | None = None
         if lint_result.success or lint_result.skipped:
             block = self._maybe_lsp_diagnostics(
                 path, pre_content=pre_content, post_content=content
@@ -1166,7 +1166,7 @@ class ShellFileOperations(FileOperations):
         result = apply_v4a_operations(operations, self)
         return result
     
-    def _check_lint(self, path: str, content: Optional[str] = None) -> LintResult:
+    def _check_lint(self, path: str, content: str | None = None) -> LintResult:
         """
         Run syntax check on a file after editing.
 
@@ -1254,8 +1254,8 @@ class ShellFileOperations(FileOperations):
             output=result.stdout.strip() if result.stdout.strip() else ""
         )
 
-    def _check_lint_delta(self, path: str, pre_content: Optional[str],
-                          post_content: Optional[str] = None) -> LintResult:
+    def _check_lint_delta(self, path: str, pre_content: str | None,
+                          post_content: str | None = None) -> LintResult:
         """
         Run post-write syntax lint with pre-write baseline comparison.
 
@@ -1444,8 +1444,8 @@ class ShellFileOperations(FileOperations):
         self,
         path: str,
         *,
-        pre_content: Optional[str] = None,
-        post_content: Optional[str] = None,
+        pre_content: str | None = None,
+        post_content: str | None = None,
     ) -> str:
         """Best-effort LSP semantic diagnostics for ``path``.
 
@@ -1511,7 +1511,7 @@ class ShellFileOperations(FileOperations):
     # =========================================================================
     
     def search(self, pattern: str, path: str = ".", target: str = "content",
-               file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
+               file_glob: str | None = None, limit: int = 50, offset: int = 0,
                output_mode: str = "content", context: int = 0) -> SearchResult:
         """
         Search for content or files.
@@ -1698,7 +1698,7 @@ class ShellFileOperations(FileOperations):
             truncated=len(all_files) >= fetch_limit,
         )
     
-    def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
+    def _search_content(self, pattern: str, path: str, file_glob: str | None,
                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Search for content inside files (grep-like)."""
         # Try ripgrep first (fast), fallback to grep (slower but works)
@@ -1715,7 +1715,7 @@ class ShellFileOperations(FileOperations):
                       "Install ripgrep: https://github.com/BurntSushi/ripgrep#installation"
             )
     
-    def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
+    def _search_with_rg(self, pattern: str, path: str, file_glob: str | None,
                         limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Search using ripgrep."""
         cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
@@ -1813,7 +1813,7 @@ class ShellFileOperations(FileOperations):
                 truncated=total > offset + limit
             )
     
-    def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
+    def _search_with_grep(self, pattern: str, path: str, file_glob: str | None,
                           limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Fallback search using grep."""
         cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -96,7 +96,7 @@ class FileStateRegistry:
         resolved: str,
         *,
         partial: bool = False,
-        mtime: Optional[float] = None,
+        mtime: float | None = None,
     ) -> None:
         if _disabled():
             return
@@ -116,7 +116,7 @@ class FileStateRegistry:
         task_id: str,
         resolved: str,
         *,
-        mtime: Optional[float] = None,
+        mtime: float | None = None,
     ) -> None:
         """Record a successful write.
 
@@ -139,7 +139,7 @@ class FileStateRegistry:
             self._reads[task_id][resolved] = (float(mtime), now, False)
             _cap_dict(self._reads[task_id], _MAX_PATHS_PER_AGENT)
 
-    def check_stale(self, task_id: str, resolved: str) -> Optional[str]:
+    def check_stale(self, task_id: str, resolved: str) -> str | None:
         """Return a model-facing warning if this write would be stale.
 
         Three staleness classes, in order of severity:
@@ -300,7 +300,7 @@ def note_write(task_id: str, resolved_or_path: str | Path) -> None:
     _registry.note_write(task_id, str(resolved_or_path))
 
 
-def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
+def check_stale(task_id: str, resolved_or_path: str | Path) -> str | None:
     return _registry.check_stale(task_id, str(resolved_or_path))
 
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -48,7 +48,7 @@ def _unicode_normalize(text: str) -> str:
 
 
 def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
-                            replace_all: bool = False) -> Tuple[str, int, Optional[str], Optional[str]]:
+                            replace_all: bool = False) -> Tuple[str, int, str | None, str | None]:
     """
     Find and replace text using a chain of increasingly fuzzy matching strategies.
 
@@ -117,7 +117,7 @@ def fuzzy_find_and_replace(content: str, old_string: str, new_string: str,
 
 
 def _detect_escape_drift(content: str, matches: List[Tuple[int, int]],
-                         old_string: str, new_string: str) -> Optional[str]:
+                         old_string: str, new_string: str) -> str | None:
     """Detect tool-call escape-drift artifacts in new_string.
 
     Looks for ``\\'`` or ``\\"`` sequences that are present in both
@@ -682,7 +682,7 @@ def find_closest_lines(old_string: str, content: str, context_lines: int = 2, ma
     return "\n---\n".join(parts)
 
 
-def format_no_match_hint(error: Optional[str], match_count: int,
+def format_no_match_hint(error: str | None, match_count: int,
                          old_string: str, content: str) -> str:
     """Return a '\\n\\nDid you mean...' snippet for plain no-match errors.
 

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -76,8 +76,8 @@ def _get_headers(token: str = "") -> Dict[str, str]:
 
 def _filter_and_summarize(
     states: list,
-    domain: Optional[str] = None,
-    area: Optional[str] = None,
+    domain: str | None = None,
+    area: str | None = None,
 ) -> Dict[str, Any]:
     """Filter raw HA states by domain/area and return a compact summary."""
     if domain:
@@ -103,8 +103,8 @@ def _filter_and_summarize(
 
 
 async def _async_list_entities(
-    domain: Optional[str] = None,
-    area: Optional[str] = None,
+    domain: str | None = None,
+    area: str | None = None,
 ) -> Dict[str, Any]:
     """Fetch entity states from HA and optionally filter by domain/area."""
     import aiohttp
@@ -140,8 +140,8 @@ async def _async_get_state(entity_id: str) -> Dict[str, Any]:
 
 
 def _build_service_payload(
-    entity_id: Optional[str] = None,
-    data: Optional[Dict[str, Any]] = None,
+    entity_id: str | None = None,
+    data: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Build the JSON payload for a HA service call."""
     payload: Dict[str, Any] = {}
@@ -177,8 +177,8 @@ def _parse_service_response(
 async def _async_call_service(
     domain: str,
     service: str,
-    entity_id: Optional[str] = None,
-    data: Optional[Dict[str, Any]] = None,
+    entity_id: str | None = None,
+    data: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Call a Home Assistant service."""
     import aiohttp
@@ -292,7 +292,7 @@ def _handle_call_service(args: dict, **kw) -> str:
 # List services
 # ---------------------------------------------------------------------------
 
-async def _async_list_services(domain: Optional[str] = None) -> Dict[str, Any]:
+async def _async_list_services(domain: str | None = None) -> Dict[str, Any]:
     """Fetch available services from HA and optionally filter by domain."""
     import aiohttp
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -456,8 +456,8 @@ def _build_fal_payload(
     model_id: str,
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
-    seed: Optional[int] = None,
-    overrides: Optional[Dict[str, Any]] = None,
+    seed: int | None = None,
+    overrides: Dict[str, Any] | None = None,
 ) -> Dict[str, Any]:
     """Build a FAL request payload for `model_id` from unified inputs.
 
@@ -498,7 +498,7 @@ def _build_fal_payload(
 # ---------------------------------------------------------------------------
 # Upscaler
 # ---------------------------------------------------------------------------
-def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, Any]]:
+def _upscale_image(image_url: str, original_prompt: str) -> Dict[str, Any] | None:
     """Upscale an image using FAL.ai's Clarity Upscaler.
 
     Returns upscaled image dict, or None on failure (caller falls back to
@@ -550,11 +550,11 @@ def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, A
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
-    num_inference_steps: Optional[int] = None,
-    guidance_scale: Optional[float] = None,
-    num_images: Optional[int] = None,
-    output_format: Optional[str] = None,
-    seed: Optional[int] = None,
+    num_inference_steps: int | None = None,
+    guidance_scale: float | None = None,
+    num_images: int | None = None,
+    output_format: str | None = None,
+    seed: int | None = None,
 ) -> str:
     """Generate an image from a text prompt using the configured FAL model.
 

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -94,7 +94,7 @@ def _check_kanban_orchestrator_mode() -> bool:
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-def _default_task_id(arg: Optional[str]) -> Optional[str]:
+def _default_task_id(arg: str | None) -> str | None:
     """Resolve ``task_id`` arg or fall back to the env var the dispatcher set."""
     if arg:
         return arg
@@ -102,7 +102,7 @@ def _default_task_id(arg: Optional[str]) -> Optional[str]:
     return env_tid or None
 
 
-def _worker_run_id(task_id: str) -> Optional[int]:
+def _worker_run_id(task_id: str) -> int | None:
     """Return this worker's dispatcher run id when it is scoped to task_id."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return None
@@ -116,8 +116,8 @@ def _worker_run_id(task_id: str) -> Optional[int]:
 
 
 def _stamp_worker_session_metadata(
-    task_id: str, metadata: Optional[dict]
-) -> Optional[dict]:
+    task_id: str, metadata: dict | None
+) -> dict | None:
     """Add trusted worker session id metadata for this worker's own task."""
     if os.environ.get("HERMES_KANBAN_TASK") != task_id:
         return metadata
@@ -129,7 +129,7 @@ def _stamp_worker_session_metadata(
     return stamped
 
 
-def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
+def _enforce_worker_task_ownership(tid: str) -> str | None:
     """Reject worker-driven destructive calls on foreign task IDs.
 
     A process spawned by the dispatcher has ``HERMES_KANBAN_TASK`` set
@@ -161,7 +161,7 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     return None
 
 
-def _connect(board: Optional[str] = None):
+def _connect(board: str | None = None):
     """Import + connect lazily so the module imports cleanly in non-kanban
     contexts (e.g. test rigs that import every tool module).
 
@@ -180,7 +180,7 @@ def _ok(**fields: Any) -> str:
     return json.dumps({"ok": True, **fields})
 
 
-def _normalize_profile(value: Any) -> Optional[str]:
+def _normalize_profile(value: Any) -> str | None:
     """Normalize CLI-compatible assignee sentinels for the tool surface."""
     if value is None:
         return None
@@ -204,7 +204,7 @@ def _parse_bool_arg(args: dict, name: str, *, default: bool = False):
     return default, f"{name} must be a boolean or 'true'/'false'"
 
 
-def _require_orchestrator_tool(tool_name: str) -> Optional[str]:
+def _require_orchestrator_tool(tool_name: str) -> str | None:
     """Belt-and-suspenders runtime guard for orchestrator-only handlers.
 
     The check_fn (`_check_kanban_orchestrator_mode`) keeps these tools

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -501,7 +501,7 @@ def is_available(feature: str) -> bool:
     return not feature_missing(feature)
 
 
-def feature_install_command(feature: str) -> Optional[str]:
+def feature_install_command(feature: str) -> str | None:
     """Return the ``pip install`` command a user could run manually, or None."""
     if feature not in LAZY_DEPS:
         return None

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -32,7 +32,7 @@ def auth_json_path():
     return get_hermes_home() / "auth.json"
 
 
-def _read_nous_provider_state() -> Optional[dict]:
+def _read_nous_provider_state() -> dict | None:
     try:
         path = auth_json_path()
         if not path.is_file():
@@ -49,7 +49,7 @@ def _read_nous_provider_state() -> Optional[dict]:
     return None
 
 
-def _parse_timestamp(value: object) -> Optional[datetime]:
+def _parse_timestamp(value: object) -> datetime | None:
     if not isinstance(value, str) or not value.strip():
         return None
     normalized = value.strip()
@@ -72,7 +72,7 @@ def _access_token_is_expiring(expires_at: object, skew_seconds: int) -> bool:
     return remaining <= max(0, int(skew_seconds))
 
 
-def read_nous_access_token() -> Optional[str]:
+def read_nous_access_token() -> str | None:
     """Read a Nous Subscriber OAuth access token from auth store or env override."""
     explicit = os.getenv("TOOL_GATEWAY_USER_TOKEN")
     if isinstance(explicit, str) and explicit.strip():
@@ -131,9 +131,9 @@ def build_vendor_gateway_url(vendor: str) -> str:
 
 def resolve_managed_tool_gateway(
     vendor: str,
-    gateway_builder: Optional[Callable[[str], str]] = None,
-    token_reader: Optional[Callable[[], Optional[str]]] = None,
-) -> Optional[ManagedToolGatewayConfig]:
+    gateway_builder: Callable[[str], str] | None = None,
+    token_reader: Callable[[], str | None] | None = None,
+) -> ManagedToolGatewayConfig | None:
     """Resolve shared managed-tool gateway config for a vendor."""
     if not managed_nous_tools_enabled():
         return None
@@ -156,8 +156,8 @@ def resolve_managed_tool_gateway(
 
 def is_managed_tool_gateway_ready(
     vendor: str,
-    gateway_builder: Optional[Callable[[str], str]] = None,
-    token_reader: Optional[Callable[[], Optional[str]]] = None,
+    gateway_builder: Callable[[str], str] | None = None,
+    token_reader: Callable[[], str | None] | None = None,
 ) -> bool:
     """Return True when gateway URL and Nous access token are available."""
     return resolve_managed_tool_gateway(

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -69,8 +69,8 @@ class _ProviderEntry:
     """
 
     server_url: str
-    oauth_config: Optional[dict]
-    provider: Optional[Any] = None
+    oauth_config: dict | None
+    provider: Any | None = None
     last_mtime_ns: int = 0
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     pending_401: dict[str, "asyncio.Future[bool]"] = field(default_factory=dict)
@@ -81,7 +81,7 @@ class _ProviderEntry:
 # ---------------------------------------------------------------------------
 
 
-def _make_hermes_provider_class() -> Optional[type]:
+def _make_hermes_provider_class() -> type | None:
     """Lazy-import the SDK base class and return our subclass.
 
     Wrapped in a function so this module imports cleanly even when the
@@ -328,7 +328,7 @@ def _make_hermes_provider_class() -> Optional[type]:
 
 
 # Cached at import time. Tested and used by :class:`MCPOAuthManager`.
-_HERMES_PROVIDER_CLS: Optional[type] = _make_hermes_provider_class()
+_HERMES_PROVIDER_CLS: type | None = _make_hermes_provider_class()
 
 
 # ---------------------------------------------------------------------------
@@ -354,8 +354,8 @@ class MCPOAuthManager:
         self,
         server_name: str,
         server_url: str,
-        oauth_config: Optional[dict],
-    ) -> Optional[Any]:
+        oauth_config: dict | None,
+    ) -> Any | None:
         """Return a cached OAuth provider for ``server_name`` or build one.
 
         Idempotent: repeat calls with the same name return the same instance.
@@ -389,7 +389,7 @@ class MCPOAuthManager:
         self,
         server_name: str,
         entry: _ProviderEntry,
-    ) -> Optional[Any]:
+    ) -> Any | None:
         """Build the underlying OAuth provider.
 
         Constructs :class:`HermesMCPOAuthProvider` directly using the helpers
@@ -506,7 +506,7 @@ class MCPOAuthManager:
     async def handle_401(
         self,
         server_name: str,
-        failed_access_token: Optional[str] = None,
+        failed_access_token: str | None = None,
     ) -> bool:
         """Handle a 401 from a tool call, deduplicated across concurrent callers.
 
@@ -587,7 +587,7 @@ class MCPOAuthManager:
 # ---------------------------------------------------------------------------
 
 
-_MANAGER: Optional[MCPOAuthManager] = None
+_MANAGER: MCPOAuthManager | None = None
 _MANAGER_LOCK = threading.Lock()
 
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -113,7 +113,7 @@ logger = logging.getLogger(__name__)
 #
 # Fallback is os.devnull if opening the log file fails for any reason.
 
-_mcp_stderr_log_fh: Optional[Any] = None
+_mcp_stderr_log_fh: Any | None = None
 _mcp_stderr_log_lock = threading.Lock()
 
 
@@ -293,7 +293,7 @@ _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
 # Security helpers
 # ---------------------------------------------------------------------------
 
-def _build_safe_env(user_env: Optional[dict]) -> dict:
+def _build_safe_env(user_env: dict | None) -> dict:
     """Build a filtered environment dict for stdio subprocesses.
 
     Only passes through safe baseline variables (PATH, HOME, etc.) and XDG_*
@@ -562,7 +562,7 @@ def _validate_remote_mcp_url(server_name: str, url: Any) -> str:
 def _format_connect_error(exc: BaseException) -> str:
     """Render nested MCP connection errors into an actionable short message."""
 
-    def _find_missing(current: BaseException) -> Optional[str]:
+    def _find_missing(current: BaseException) -> str | None:
         nested = getattr(current, "exceptions", None)
         if nested:
             for child in nested:
@@ -688,7 +688,7 @@ class SamplingHandler:
 
     # -- Model resolution ----------------------------------------------------
 
-    def _resolve_model(self, preferences) -> Optional[str]:
+    def _resolve_model(self, preferences) -> str | None:
         """Config override > server hint > None (use default)."""
         if self.model_override:
             return self.model_override
@@ -1030,9 +1030,9 @@ class MCPServerTask:
 
     def __init__(self, name: str):
         self.name = name
-        self.session: Optional[Any] = None
+        self.session: Any | None = None
         self.tool_timeout: float = _DEFAULT_TOOL_TIMEOUT
-        self._task: Optional[asyncio.Task] = None
+        self._task: asyncio.Task | None = None
         self._ready = asyncio.Event()
         self._shutdown_event = asyncio.Event()
         # Set by tool handlers on auth failure after manager.handle_401()
@@ -1042,9 +1042,9 @@ class MCPServerTask:
         # rebuilt with fresh credentials.
         self._reconnect_event = asyncio.Event()
         self._tools: list = []
-        self._error: Optional[Exception] = None
+        self._error: Exception | None = None
         self._config: dict = {}
-        self._sampling: Optional[SamplingHandler] = None
+        self._sampling: SamplingHandler | None = None
         self._registered_tool_names: list[str] = []
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
@@ -1061,7 +1061,7 @@ class MCPServerTask:
         # server's real advertised capabilities (``.capabilities.resources``,
         # ``.capabilities.prompts``) instead of assuming every ``ClientSession``
         # method attribute corresponds to a supported server method. See #18051.
-        self.initialize_result: Optional[Any] = None
+        self.initialize_result: Any | None = None
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -2086,8 +2086,8 @@ _parallel_safe_servers: set = set()
 _mcp_tool_server_names: Dict[str, str] = {}
 
 # Dedicated event loop running in a background daemon thread.
-_mcp_loop: Optional[asyncio.AbstractEventLoop] = None
-_mcp_thread: Optional[threading.Thread] = None
+_mcp_loop: asyncio.AbstractEventLoop | None = None
+_mcp_thread: threading.Thread | None = None
 
 # Protects _mcp_loop, _mcp_thread, _servers, _parallel_safe_servers,
 # _mcp_tool_server_names, and _stdio_pids.

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -90,7 +90,7 @@ _INVISIBLE_CHARS = {
 }
 
 
-def _scan_memory_content(content: str) -> Optional[str]:
+def _scan_memory_content(content: str) -> str | None:
     """Scan memory content for injection/exfil patterns. Returns error string if blocked."""
     # Check invisible unicode
     for char in _INVISIBLE_CHARS:
@@ -216,7 +216,7 @@ class MemoryStore:
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
 
-    def _reload_target(self, target: str) -> Optional[str]:
+    def _reload_target(self, target: str) -> str | None:
         """Re-read entries from disk into in-memory state.
 
         Called under file lock to get the latest state before mutating.
@@ -407,7 +407,7 @@ class MemoryStore:
 
         return self._success_response(target, "Entry removed.")
 
-    def format_for_system_prompt(self, target: str) -> Optional[str]:
+    def format_for_system_prompt(self, target: str) -> str | None:
         """
         Return the frozen snapshot for system prompt injection.
 
@@ -479,7 +479,7 @@ class MemoryStore:
         entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
         return [e for e in entries if e]
 
-    def _detect_external_drift(self, target: str) -> Optional[str]:
+    def _detect_external_drift(self, target: str) -> str | None:
         """Return a backup-path string if on-disk content shows external drift.
 
         The memory file is supposed to be a list of small entries the tool
@@ -571,7 +571,7 @@ def memory_tool(
     target: str = "memory",
     content: str = None,
     old_text: str = None,
-    store: Optional[MemoryStore] = None,
+    store: MemoryStore | None = None,
 ) -> str:
     """
     Single entry point for the memory tool. Dispatches to MemoryStore methods.

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -235,8 +235,8 @@ async def _run_aggregator_model(
 
 async def mixture_of_agents_tool(
     user_prompt: str,
-    reference_models: Optional[List[str]] = None,
-    aggregator_model: Optional[str] = None
+    reference_models: List[str] | None = None,
+    aggregator_model: str | None = None
 ) -> str:
     """
     Process a complex query using the Mixture-of-Agents methodology.

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -25,7 +25,7 @@ _TIMEOUT = 10  # seconds
 
 def check_package_for_malware(
     command: str, args: list
-) -> Optional[str]:
+) -> str | None:
     """Check if an MCP server package has known malware advisories.
 
     Inspects the *command* (e.g. ``npx``, ``uvx``) and *args* to infer the
@@ -62,7 +62,7 @@ def check_package_for_malware(
     return None
 
 
-def _infer_ecosystem(command: str) -> Optional[str]:
+def _infer_ecosystem(command: str) -> str | None:
     """Infer package ecosystem from the command name."""
     base = os.path.basename(command).lower()
     if base in {"npx", "npx.cmd"}:
@@ -74,7 +74,7 @@ def _infer_ecosystem(command: str) -> Optional[str]:
 
 def _parse_package_from_args(
     args: list, ecosystem: str
-) -> Tuple[Optional[str], Optional[str]]:
+) -> Tuple[str | None, str | None]:
     """Extract package name and optional version from command args.
 
     Returns (package_name, version) or (None, None) if not parseable.
@@ -102,7 +102,7 @@ def _parse_package_from_args(
     return package_token, None
 
 
-def _parse_npm_package(token: str) -> Tuple[Optional[str], Optional[str]]:
+def _parse_npm_package(token: str) -> Tuple[str | None, str | None]:
     """Parse npm package: @scope/name@version or name@version."""
     if token.startswith("@"):
         # Scoped: @scope/name@version
@@ -119,7 +119,7 @@ def _parse_npm_package(token: str) -> Tuple[Optional[str], Optional[str]]:
     return token, None
 
 
-def _parse_pypi_package(token: str) -> Tuple[Optional[str], Optional[str]]:
+def _parse_pypi_package(token: str) -> Tuple[str | None, str | None]:
     """Parse PyPI package: name==version or name[extras]==version."""
     # Strip extras: name[extra1,extra2]==version
     match = re.match(r"^([a-zA-Z0-9._-]+)(?:\[[^\]]*\])?(?:==(.+))?$", token)
@@ -129,7 +129,7 @@ def _parse_pypi_package(token: str) -> Tuple[Optional[str], Optional[str]]:
 
 
 def _query_osv(
-    package: str, ecosystem: str, version: Optional[str] = None
+    package: str, ecosystem: str, version: str | None = None
 ) -> list:
     """Query the OSV API for MAL-* advisories. Returns list of malware vulns."""
     payload = {"package": {"name": package, "ecosystem": ecosystem}}

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -52,7 +52,7 @@ class HunkLine:
 @dataclass
 class Hunk:
     """A group of changes within a file."""
-    context_hint: Optional[str] = None
+    context_hint: str | None = None
     lines: List[HunkLine] = field(default_factory=list)
 
 
@@ -61,12 +61,12 @@ class PatchOperation:
     """A single operation in a V4A patch."""
     operation: OperationType
     file_path: str
-    new_path: Optional[str] = None  # For move operations
+    new_path: str | None = None  # For move operations
     hunks: List[Hunk] = field(default_factory=list)
-    content: Optional[str] = None  # For add file operations
+    content: str | None = None  # For add file operations
 
 
-def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[str]]:
+def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], str | None]:
     """
     Parse a V4A format patch.
     
@@ -101,8 +101,8 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
     
     # Parse operations between boundaries
     i = start_idx + 1
-    current_op: Optional[PatchOperation] = None
-    current_hunk: Optional[Hunk] = None
+    current_op: PatchOperation | None = None
+    current_hunk: Hunk | None = None
     
     while i < end_idx:
         line = lines[i]
@@ -452,7 +452,7 @@ def apply_v4a_operations(operations: List[PatchOperation],
     )
 
 
-def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optional[str]]:
+def _apply_add(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, str | None]:
     """Apply an add file operation.
 
     Returns ``(success, diff_or_error, lsp_diagnostics)``.  The third
@@ -511,7 +511,7 @@ def _apply_move(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     return True, diff
 
 
-def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, Optional[str]]:
+def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str, str | None]:
     """Apply an update file operation.
 
     Returns ``(success, diff_or_error, lsp_diagnostics)`` — see

--- a/tools/path_security.py
+++ b/tools/path_security.py
@@ -12,7 +12,7 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
-def validate_within_dir(path: Path, root: Path) -> Optional[str]:
+def validate_within_dir(path: Path, root: Path) -> str | None:
     """Ensure *path* resolves to a location within *root*.
 
     Returns an error message string if validation fails, or ``None`` if the

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -93,13 +93,13 @@ class ProcessSession:
     command: str                                 # Original command string
     task_id: str = ""                           # Task/sandbox isolation key
     session_key: str = ""                       # Gateway session key (for reset protection)
-    pid: Optional[int] = None                   # OS process ID
-    process: Optional[subprocess.Popen] = None  # Popen handle (local only)
+    pid: int | None = None                   # OS process ID
+    process: subprocess.Popen | None = None  # Popen handle (local only)
     env_ref: Any = None                         # Reference to the environment object
-    cwd: Optional[str] = None                   # Working directory
+    cwd: str | None = None                   # Working directory
     started_at: float = 0.0                     # time.time() of spawn
     exited: bool = False                        # Whether the process has finished
-    exit_code: Optional[int] = None             # Exit code (None if still running)
+    exit_code: int | None = None             # Exit code (None if still running)
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
     detached: bool = False                      # True if recovered from crash (no pipe)
@@ -130,7 +130,7 @@ class ProcessSession:
     _watch_strike_candidate: bool = field(default=False, repr=False)
     _watch_consecutive_strikes: int = field(default=0, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock)
-    _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
+    _reader_thread: threading.Thread | None = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
 
 
@@ -404,7 +404,7 @@ class ProcessRegistry:
         return admit
 
     @staticmethod
-    def _is_host_pid_alive(pid: Optional[int]) -> bool:
+    def _is_host_pid_alive(pid: int | None) -> bool:
         """Best-effort liveness check for host-visible PIDs."""
         if not pid:
             return False
@@ -413,7 +413,7 @@ class ProcessRegistry:
         from gateway.status import _pid_exists
         return _pid_exists(pid)
 
-    def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
+    def _refresh_detached_session(self, session: ProcessSession | None) -> ProcessSession | None:
         """Update recovered host-PID sessions when the underlying process has exited."""
         if session is None or session.exited or not session.detached or session.pid_scope != "host":
             return session
@@ -894,7 +894,7 @@ class ProcessRegistry:
                 results.append((evt, text))
         return results
 
-    def get(self, session_id: str) -> Optional[ProcessSession]:
+    def get(self, session_id: str) -> ProcessSession | None:
         """Get a session by ID (running or finished)."""
         with self._lock:
             session = self._running.get(session_id) or self._finished.get(session_id)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -54,7 +54,7 @@ def _module_registers_tools(module_path: Path) -> bool:
     return any(_is_registry_register_call(stmt) for stmt in tree.body)
 
 
-def discover_builtin_tools(tools_dir: Optional[Path] = None) -> List[str]:
+def discover_builtin_tools(tools_dir: Path | None = None) -> List[str]:
     """Import built-in self-registering tool modules and return their module names."""
     tools_path = Path(tools_dir) if tools_dir is not None else Path(__file__).resolve().parent
     module_names = [
@@ -189,7 +189,7 @@ class ToolRegistry:
             logger.debug("Toolset %s check raised; marking unavailable", toolset)
             return False
 
-    def get_entry(self, name: str) -> Optional[ToolEntry]:
+    def get_entry(self, name: str) -> ToolEntry | None:
         """Return a registered tool entry by name, or None."""
         with self._lock:
             return self._tools.get(name)
@@ -222,7 +222,7 @@ class ToolRegistry:
         with self._lock:
             return dict(self._toolset_aliases)
 
-    def get_toolset_alias_target(self, alias: str) -> Optional[str]:
+    def get_toolset_alias_target(self, alias: str) -> str | None:
         """Return the canonical toolset name for an alias, or None."""
         with self._lock:
             return self._toolset_aliases.get(alias)
@@ -433,7 +433,7 @@ class ToolRegistry:
         """Return sorted list of all registered tool names."""
         return sorted(entry.name for entry in self._snapshot_entries())
 
-    def get_schema(self, name: str) -> Optional[dict]:
+    def get_schema(self, name: str) -> dict | None:
         """Return a tool's raw schema dict, bypassing check_fn filtering.
 
         Useful for token estimation and introspection where availability
@@ -442,7 +442,7 @@ class ToolRegistry:
         entry = self.get_entry(name)
         return entry.schema if entry else None
 
-    def get_toolset_for_tool(self, name: str) -> Optional[str]:
+    def get_toolset_for_tool(self, name: str) -> str | None:
         """Return the toolset a tool belongs to, or None."""
         entry = self.get_entry(name)
         return entry.toolset if entry else None

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -86,7 +86,7 @@ def _resolve_to_parent(db, session_id: str) -> str:
     return cur
 
 
-def _shape_message(m: Dict[str, Any], anchor_id: Optional[int] = None) -> Dict[str, Any]:
+def _shape_message(m: Dict[str, Any], anchor_id: int | None = None) -> Dict[str, Any]:
     """Slim a message row for the tool response. Keeps content even if empty."""
     entry = {
         "id": m.get("id"),
@@ -277,9 +277,9 @@ def _scroll(
 def _discover(
     db,
     query: str,
-    role_filter: Optional[List[str]],
+    role_filter: List[str] | None,
     limit: int,
-    sort: Optional[str],
+    sort: str | None,
     current_session_id: str = None,
 ) -> str:
     """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
@@ -429,12 +429,12 @@ def session_search(
         return _list_recent_sessions(db, limit, current_session_id)
 
     # Parse role_filter
-    role_list: Optional[List[str]] = None
+    role_list: List[str] | None = None
     if isinstance(role_filter, str) and role_filter.strip():
         role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
 
     # Normalise sort
-    sort_norm: Optional[str] = None
+    sort_norm: str | None = None
     if isinstance(sort, str):
         candidate = sort.strip().lower()
         if candidate in ("newest", "oldest"):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -75,7 +75,7 @@ def _guard_agent_created_enabled() -> bool:
         return False
 
 
-def _security_scan_skill(skill_dir: Path) -> Optional[str]:
+def _security_scan_skill(skill_dir: Path) -> str | None:
     """Scan a skill directory after write. Returns error string if blocked, else None.
 
     No-op when skills.guard_agent_created is disabled (the default).
@@ -134,7 +134,7 @@ def _containing_skills_root(skill_path: Path) -> Path:
     return SKILLS_DIR
 
 
-def _pinned_guard(name: str) -> Optional[str]:
+def _pinned_guard(name: str) -> str | None:
     """Return a refusal message if *name* is pinned, else None.
 
     Pin protects a skill from **deletion** — both the curator's auto-archive
@@ -175,7 +175,7 @@ ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
 # Validation helpers
 # =============================================================================
 
-def _validate_name(name: str) -> Optional[str]:
+def _validate_name(name: str) -> str | None:
     """Validate a skill name. Returns error message or None if valid."""
     if not name:
         return "Skill name is required."
@@ -189,7 +189,7 @@ def _validate_name(name: str) -> Optional[str]:
     return None
 
 
-def _validate_category(category: Optional[str]) -> Optional[str]:
+def _validate_category(category: str | None) -> str | None:
     """Validate an optional category name used as a single directory segment."""
     if category is None:
         return None
@@ -214,7 +214,7 @@ def _validate_category(category: Optional[str]) -> Optional[str]:
     return None
 
 
-def _validate_frontmatter(content: str) -> Optional[str]:
+def _validate_frontmatter(content: str) -> str | None:
     """
     Validate that SKILL.md content has proper frontmatter with required fields.
     Returns error message or None if valid.
@@ -253,7 +253,7 @@ def _validate_frontmatter(content: str) -> Optional[str]:
     return None
 
 
-def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[str]:
+def _validate_content_size(content: str, label: str = "SKILL.md") -> str | None:
     """Check that content doesn't exceed the character limit for agent writes.
 
     Returns an error message or None if within bounds.
@@ -275,7 +275,7 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
     return SKILLS_DIR / name
 
 
-def _find_skill(name: str) -> Optional[Dict[str, Any]]:
+def _find_skill(name: str) -> Dict[str, Any] | None:
     """
     Find a skill by name across all skill directories.
 
@@ -398,7 +398,7 @@ def _skill_not_found_error(name: str, suffix: str = "") -> str:
     return base
 
 
-def _validate_file_path(file_path: str) -> Optional[str]:
+def _validate_file_path(file_path: str) -> str | None:
     """
     Validate a file path for write_file/remove_file.
     Must be under an allowed subdirectory and not escape the skill dir.
@@ -426,7 +426,7 @@ def _validate_file_path(file_path: str) -> Optional[str]:
     return None
 
 
-def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Optional[Path], Optional[str]]:
+def _resolve_skill_target(skill_dir: Path, file_path: str) -> Tuple[Path | None, str | None]:
     """Resolve a supporting-file path and ensure it stays within the skill directory."""
     from tools.path_security import validate_within_dir
 
@@ -657,7 +657,7 @@ def _patch_skill(
     }
 
 
-def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
+def _delete_skill(name: str, absorbed_into: str | None = None) -> Dict[str, Any]:
     """Delete a skill.
 
     ``absorbed_into`` declares intent:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -108,7 +108,7 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _parse_iso_timestamp(value: Any) -> Optional[datetime]:
+def _parse_iso_timestamp(value: Any) -> datetime | None:
     """Parse an ISO timestamp defensively for activity comparisons."""
     if not value:
         return None
@@ -121,15 +121,15 @@ def _parse_iso_timestamp(value: Any) -> Optional[datetime]:
     return parsed
 
 
-def latest_activity_at(record: Dict[str, Any]) -> Optional[str]:
+def latest_activity_at(record: Dict[str, Any]) -> str | None:
     """Return the newest actual activity timestamp for a usage record.
 
     "Activity" means a skill was used, viewed, or patched. Creation time is
     intentionally excluded so callers can still distinguish never-active skills;
     lifecycle code can fall back to ``created_at`` as its own anchor.
     """
-    latest_dt: Optional[datetime] = None
-    latest_raw: Optional[str] = None
+    latest_dt: datetime | None = None
+    latest_raw: str | None = None
     for key in ("last_used_at", "last_viewed_at", "last_patched_at"):
         raw = record.get(key)
         dt = _parse_iso_timestamp(raw)
@@ -567,7 +567,7 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     return True, f"restored to {dest}"
 
 
-def _find_skill_dir(skill_name: str) -> Optional[Path]:
+def _find_skill_dir(skill_name: str) -> Path | None:
     """Locate the directory for a skill by its frontmatter `name:` field.
 
     Handles both flat (~/.hermes/skills/<skill>/SKILL.md) and category-nested

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -74,8 +74,8 @@ class SkillMeta:
     source: str           # "official", "github", "clawhub", "claude-marketplace", "lobehub"
     identifier: str       # source-specific ID (e.g. "openai/skills/skill-creator")
     trust_level: str      # "builtin" | "trusted" | "community"
-    repo: Optional[str] = None
-    path: Optional[str] = None
+    repo: str | None = None
+    path: str | None = None
     tags: List[str] = field(default_factory=list)
     extra: Dict[str, Any] = field(default_factory=dict)
 
@@ -124,7 +124,7 @@ def _validate_category_name(category: str) -> str:
     return _normalize_bundle_path(category, field_name="category", allow_nested=False)
 
 
-def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response]:
+def _guarded_http_get(url: str, *, timeout: int = 20) -> httpx.Response | None:
     """Fetch a URL with SSRF and redirect-target validation."""
     current_url = url
 
@@ -179,8 +179,8 @@ class GitHubAuth:
     """
 
     def __init__(self):
-        self._cached_token: Optional[str] = None
-        self._cached_method: Optional[str] = None
+        self._cached_token: str | None = None
+        self._cached_method: str | None = None
         self._app_token_expiry: float = 0
 
     def get_headers(self) -> Dict[str, str]:
@@ -199,7 +199,7 @@ class GitHubAuth:
         self._resolve_token()
         return self._cached_method or "anonymous"
 
-    def _resolve_token(self) -> Optional[str]:
+    def _resolve_token(self) -> str | None:
         # Return cached token if still valid
         if self._cached_token:
             if self._cached_method != "github-app" or time.time() < self._app_token_expiry:
@@ -230,7 +230,7 @@ class GitHubAuth:
         self._cached_method = "anonymous"
         return None
 
-    def _try_gh_cli(self) -> Optional[str]:
+    def _try_gh_cli(self) -> str | None:
         """Try to get a token from the gh CLI."""
         try:
             result = subprocess.run(
@@ -243,7 +243,7 @@ class GitHubAuth:
             logger.debug("gh CLI token lookup failed: %s", e)
         return None
 
-    def _try_github_app(self) -> Optional[str]:
+    def _try_github_app(self) -> str | None:
         """Try GitHub App JWT authentication if credentials are configured."""
         app_id = os.environ.get("GITHUB_APP_ID")
         key_path = os.environ.get("GITHUB_APP_PRIVATE_KEY_PATH")
@@ -301,12 +301,12 @@ class SkillSource(ABC):
         ...
 
     @abstractmethod
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         """Download a skill bundle by identifier."""
         ...
 
     @abstractmethod
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         """Fetch metadata for a skill without downloading all files."""
         ...
 
@@ -336,7 +336,7 @@ class GitHubSource(SkillSource):
         {"repo": "MiniMax-AI/cli", "path": "skill/"},
     ]
 
-    def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):
+    def __init__(self, auth: GitHubAuth, extra_taps: List[Dict] | None = None):
         self.auth = auth
         self.taps = list(self.DEFAULT_TAPS)
         if extra_taps:
@@ -394,7 +394,7 @@ class GitHubSource(SkillSource):
 
         return results[:limit]
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         """
         Download a skill from GitHub.
         identifier format: "owner/repo/path/to/skill-dir"
@@ -421,7 +421,7 @@ class GitHubSource(SkillSource):
             trust_level=trust,
         )
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         """Fetch just the SKILL.md metadata for preview."""
         parts = identifier.split("/", 2)
         if len(parts) < 3:
@@ -502,7 +502,7 @@ class GitHubSource(SkillSource):
 
     # -- Repo tree cache (avoids redundant API calls) --
 
-    def _get_repo_tree(self, repo: str) -> Optional[Tuple[str, List[dict]]]:
+    def _get_repo_tree(self, repo: str) -> Tuple[str, List[dict]] | None:
         """Get cached or fresh repo tree.
 
         Returns ``(default_branch, tree_entries)`` or ``None``.
@@ -577,7 +577,7 @@ class GitHubSource(SkillSource):
         logger.debug("Tree API unavailable for %s/%s, falling back to Contents API", repo, path)
         return self._download_directory_recursive(repo, path)
 
-    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, str]]:
+    def _download_directory_via_tree(self, repo: str, path: str) -> Dict[str, str] | None:
         """Download an entire directory using the Git Trees API (single request).
 
         Returns:
@@ -654,7 +654,7 @@ class GitHubSource(SkillSource):
 
         return files
 
-    def _find_skill_in_repo_tree(self, repo: str, skill_name: str) -> Optional[str]:
+    def _find_skill_in_repo_tree(self, repo: str, skill_name: str) -> str | None:
         """Use the GitHub Trees API to find a skill directory anywhere in the repo.
 
         Returns the full identifier (``repo/path/to/skill``) or ``None``.
@@ -680,7 +680,7 @@ class GitHubSource(SkillSource):
 
         return None
 
-    def _fetch_file_content(self, repo: str, path: str) -> Optional[str]:
+    def _fetch_file_content(self, repo: str, path: str) -> str | None:
         """Fetch a single file's content from GitHub."""
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
         try:
@@ -696,7 +696,7 @@ class GitHubSource(SkillSource):
             logger.debug("GitHub contents API fetch failed: %s", e)
         return None
 
-    def _read_cache(self, key: str) -> Optional[list]:
+    def _read_cache(self, key: str) -> list | None:
         """Read cached index if not expired."""
         cache_file = INDEX_CACHE_DIR / f"{key}.json"
         if not cache_file.exists():
@@ -793,7 +793,7 @@ class WellKnownSkillSource(SkillSource):
             ))
         return results
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         parsed = self._parse_identifier(identifier)
         if not parsed:
             return None
@@ -824,7 +824,7 @@ class WellKnownSkillSource(SkillSource):
             },
         )
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         parsed = self._parse_identifier(identifier)
         if not parsed:
             return None
@@ -878,7 +878,7 @@ class WellKnownSkillSource(SkillSource):
             },
         )
 
-    def _query_to_index_url(self, query: str) -> Optional[str]:
+    def _query_to_index_url(self, query: str) -> str | None:
         query = query.strip()
         if not query.startswith(("http://", "https://")):
             return None
@@ -889,7 +889,7 @@ class WellKnownSkillSource(SkillSource):
             return f"{base_url}/index.json"
         return query.rstrip("/") + f"{self.BASE_PATH}/index.json"
 
-    def _parse_identifier(self, identifier: str) -> Optional[dict]:
+    def _parse_identifier(self, identifier: str) -> dict | None:
         raw = identifier[len("well-known:"):] if identifier.startswith("well-known:") else identifier
         if not raw.startswith(("http://", "https://")):
             return None
@@ -927,7 +927,7 @@ class WellKnownSkillSource(SkillSource):
             "skill_url": skill_url,
         }
 
-    def _parse_index(self, index_url: str) -> Optional[dict]:
+    def _parse_index(self, index_url: str) -> dict | None:
         cache_key = f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict) and isinstance(cached.get("skills"), list):
@@ -953,7 +953,7 @@ class WellKnownSkillSource(SkillSource):
         _write_index_cache(cache_key, parsed)
         return parsed
 
-    def _index_entry(self, index_url: str, skill_name: str) -> Optional[dict]:
+    def _index_entry(self, index_url: str, skill_name: str) -> dict | None:
         parsed = self._parse_index(index_url)
         if not parsed:
             return None
@@ -963,7 +963,7 @@ class WellKnownSkillSource(SkillSource):
         return None
 
     @staticmethod
-    def _fetch_text(url: str) -> Optional[str]:
+    def _fetch_text(url: str) -> str | None:
         resp = _guarded_http_get(url, timeout=20)
         if resp is not None and resp.status_code == 200:
             return resp.text
@@ -1024,7 +1024,7 @@ class UrlSource(SkillSource):
             return False
         return path.lower().endswith(".md")
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         if not self._matches(identifier):
             return None
         url = identifier.strip()
@@ -1053,7 +1053,7 @@ class UrlSource(SkillSource):
             extra={"url": url, "awaiting_name": name is None},
         )
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         if not self._matches(identifier):
             return None
         url = identifier.strip()
@@ -1087,7 +1087,7 @@ class UrlSource(SkillSource):
         )
 
     @staticmethod
-    def _fetch_text(url: str) -> Optional[str]:
+    def _fetch_text(url: str) -> str | None:
         resp = _guarded_http_get(url, timeout=20)
         if resp is not None and resp.status_code == 200:
             return resp.text
@@ -1099,7 +1099,7 @@ class UrlSource(SkillSource):
     _VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
 
     @classmethod
-    def _is_valid_skill_name(cls, name: Optional[str]) -> bool:
+    def _is_valid_skill_name(cls, name: str | None) -> bool:
         if not isinstance(name, str):
             return False
         candidate = name.strip().lower()
@@ -1108,7 +1108,7 @@ class UrlSource(SkillSource):
         return bool(cls._VALID_NAME_RE.match(candidate))
 
     @classmethod
-    def _resolve_skill_name(cls, fm: dict, url: str) -> Optional[str]:
+    def _resolve_skill_name(cls, fm: dict, url: str) -> str | None:
         """Pick a skill name from frontmatter or URL.
 
         Returns ``None`` when neither source produces a valid identifier;
@@ -1210,7 +1210,7 @@ class SkillsShSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(item) for item in results])
         return results
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         canonical = self._normalize_identifier(identifier)
         detail = self._fetch_detail_page(canonical)
         for candidate in self._candidate_identifiers(canonical):
@@ -1231,7 +1231,7 @@ class SkillsShSource(SkillSource):
                 return bundle
         return None
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         canonical = self._normalize_identifier(identifier)
         detail = self._fetch_detail_page(canonical)
         meta = self._resolve_github_meta(canonical, detail=detail)
@@ -1279,7 +1279,7 @@ class SkillsShSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(item) for item in results])
         return results
 
-    def _meta_from_search_item(self, item: dict) -> Optional[SkillMeta]:
+    def _meta_from_search_item(self, item: dict) -> SkillMeta | None:
         if not isinstance(item, dict):
             return None
 
@@ -1315,7 +1315,7 @@ class SkillsShSource(SkillSource):
             },
         )
 
-    def _fetch_detail_page(self, identifier: str) -> Optional[dict]:
+    def _fetch_detail_page(self, identifier: str) -> dict | None:
         cache_key = f"skills_sh_detail_{hashlib.md5(identifier.encode()).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict):
@@ -1333,7 +1333,7 @@ class SkillsShSource(SkillSource):
             _write_index_cache(cache_key, detail)
         return detail
 
-    def _parse_detail_page(self, identifier: str, html: str) -> Optional[dict]:
+    def _parse_detail_page(self, identifier: str, html: str) -> dict | None:
         parts = identifier.split("/", 2)
         if len(parts) < 3:
             return None
@@ -1370,7 +1370,7 @@ class SkillsShSource(SkillSource):
             "security_audits": security_audits,
         }
 
-    def _discover_identifier(self, identifier: str, detail: Optional[dict] = None) -> Optional[str]:
+    def _discover_identifier(self, identifier: str, detail: dict | None = None) -> str | None:
         parts = identifier.split("/", 2)
         if len(parts) < 3:
             return None
@@ -1439,7 +1439,7 @@ class SkillsShSource(SkillSource):
 
         return None
 
-    def _resolve_github_meta(self, identifier: str, detail: Optional[dict] = None) -> Optional[SkillMeta]:
+    def _resolve_github_meta(self, identifier: str, detail: dict | None = None) -> SkillMeta | None:
         for candidate in self._candidate_identifiers(identifier):
             meta = self.github.inspect(candidate)
             if meta:
@@ -1450,7 +1450,7 @@ class SkillsShSource(SkillSource):
             return self.github.inspect(resolved)
         return None
 
-    def _finalize_inspect_meta(self, meta: SkillMeta, canonical: str, detail: Optional[dict]) -> SkillMeta:
+    def _finalize_inspect_meta(self, meta: SkillMeta, canonical: str, detail: dict | None) -> SkillMeta:
         meta.source = "skills.sh"
         meta.identifier = self._wrap_identifier(canonical)
         meta.trust_level = self.trust_level_for(canonical)
@@ -1481,7 +1481,7 @@ class SkillsShSource(SkillSource):
         return False
 
     @staticmethod
-    def _token_variants(value: Optional[str]) -> set[str]:
+    def _token_variants(value: str | None) -> set[str]:
         if not value:
             return set()
 
@@ -1512,7 +1512,7 @@ class SkillsShSource(SkillSource):
         return {v for v in variants if v}
 
     @staticmethod
-    def _extract_repo_slug(repo_value: str) -> Optional[str]:
+    def _extract_repo_slug(repo_value: str) -> str | None:
         repo_value = repo_value.strip()
         if repo_value.startswith("https://github.com/"):
             repo_value = repo_value[len("https://github.com/"):]
@@ -1523,7 +1523,7 @@ class SkillsShSource(SkillSource):
         return None
 
     @staticmethod
-    def _extract_first_match(pattern: re.Pattern, text: str) -> Optional[str]:
+    def _extract_first_match(pattern: re.Pattern, text: str) -> str | None:
         match = pattern.search(text)
         if not match:
             return None
@@ -1532,7 +1532,7 @@ class SkillsShSource(SkillSource):
             return None
         return SkillsShSource._strip_html(value).strip() or None
 
-    def _detail_to_metadata(self, canonical: str, detail: Optional[dict]) -> Dict[str, Any]:
+    def _detail_to_metadata(self, canonical: str, detail: dict | None) -> Dict[str, Any]:
         parts = canonical.split("/", 2)
         repo = f"{parts[0]}/{parts[1]}" if len(parts) >= 2 else ""
         metadata = {
@@ -1548,7 +1548,7 @@ class SkillsShSource(SkillSource):
         return metadata
 
     @staticmethod
-    def _extract_weekly_installs(html: str) -> Optional[str]:
+    def _extract_weekly_installs(html: str) -> str | None:
         match = SkillsShSource._WEEKLY_INSTALLS_RE.search(html)
         if not match:
             return None
@@ -1640,7 +1640,7 @@ class ClawHubSource(SkillSource):
         return []
 
     @staticmethod
-    def _coerce_skill_payload(data: Any) -> Optional[Dict[str, Any]]:
+    def _coerce_skill_payload(data: Any) -> Dict[str, Any] | None:
         if not isinstance(data, dict):
             return None
         nested = data.get("skill")
@@ -1717,7 +1717,7 @@ class ClawHubSource(SkillSource):
             deduped.append(result)
         return deduped
 
-    def _exact_slug_meta(self, query: str) -> Optional[SkillMeta]:
+    def _exact_slug_meta(self, query: str) -> SkillMeta | None:
         slug = query.strip().split("/")[-1]
         query_terms = self._query_terms(query)
         candidates: List[str] = []
@@ -1839,7 +1839,7 @@ class ClawHubSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(s) for s in final_results])
         return final_results
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         slug = identifier.split("/")[-1]
 
         skill_data = self._get_json(f"{self.BASE_URL}/skills/{slug}")
@@ -1881,7 +1881,7 @@ class ClawHubSource(SkillSource):
             trust_level="community",
         )
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         slug = identifier.split("/")[-1]
         data = self._coerce_skill_payload(self._get_json(f"{self.BASE_URL}/skills/{slug}"))
         if not isinstance(data, dict):
@@ -1918,7 +1918,7 @@ class ClawHubSource(SkillSource):
         if cached is not None:
             return [SkillMeta(**s) for s in cached]
 
-        cursor: Optional[str] = None
+        cursor: str | None = None
         results: List[SkillMeta] = []
         seen: set[str] = set()
         max_pages = 50
@@ -1964,7 +1964,7 @@ class ClawHubSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(s) for s in results])
         return results
 
-    def _get_json(self, url: str, timeout: int = 20) -> Optional[Any]:
+    def _get_json(self, url: str, timeout: int = 20) -> Any | None:
         try:
             resp = httpx.get(url, timeout=timeout)
             if resp.status_code != 200:
@@ -1973,7 +1973,7 @@ class ClawHubSource(SkillSource):
         except (httpx.HTTPError, json.JSONDecodeError):
             return None
 
-    def _resolve_latest_version(self, slug: str, skill_data: Dict[str, Any]) -> Optional[str]:
+    def _resolve_latest_version(self, slug: str, skill_data: Dict[str, Any]) -> str | None:
         latest = skill_data.get("latestVersion")
         if isinstance(latest, dict):
             version = latest.get("version")
@@ -2089,7 +2089,7 @@ class ClawHubSource(SkillSource):
         logger.debug("ClawHub ZIP download exhausted retries for %s v%s", slug, version)
         return files
 
-    def _fetch_text(self, url: str) -> Optional[str]:
+    def _fetch_text(self, url: str) -> str | None:
         resp = _guarded_http_get(url, timeout=20)
         if resp is not None and resp.status_code == 200:
             return resp.text
@@ -2153,7 +2153,7 @@ class ClaudeMarketplaceSource(SkillSource):
 
         return results[:limit]
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         # Delegate to GitHub Contents API since marketplace skills live in GitHub repos
         gh = GitHubSource(auth=self.auth)
         bundle = gh.fetch(identifier)
@@ -2161,7 +2161,7 @@ class ClaudeMarketplaceSource(SkillSource):
             bundle.source = "claude-marketplace"
         return bundle
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         gh = GitHubSource(auth=self.auth)
         meta = gh.inspect(identifier)
         if meta:
@@ -2248,7 +2248,7 @@ class LobeHubSource(SkillSource):
 
         return results
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         # Strip "lobehub/" prefix if present
         agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
 
@@ -2265,7 +2265,7 @@ class LobeHubSource(SkillSource):
             trust_level="community",
         )
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         agent_id = identifier.split("/", 1)[-1] if identifier.startswith("lobehub/") else identifier
         index = self._fetch_index()
         if not index:
@@ -2288,7 +2288,7 @@ class LobeHubSource(SkillSource):
                 )
         return None
 
-    def _fetch_index(self) -> Optional[Any]:
+    def _fetch_index(self) -> Any | None:
         """Fetch the LobeHub agent index (cached for 1 hour)."""
         cache_key = "lobehub_index"
         cached = _read_index_cache(cache_key)
@@ -2306,7 +2306,7 @@ class LobeHubSource(SkillSource):
         _write_index_cache(cache_key, data)
         return data
 
-    def _fetch_agent(self, agent_id: str) -> Optional[dict]:
+    def _fetch_agent(self, agent_id: str) -> dict | None:
         """Fetch a single agent's JSON file."""
         url = f"https://chat-agents.lobehub.com/{agent_id}.json"
         try:
@@ -2396,7 +2396,7 @@ class BrowseShSource(SkillSource):
             _write_index_cache(self._CACHE_KEY, skills)
         return skills if isinstance(skills, list) else []
 
-    def _item_to_meta(self, item: Dict) -> Optional[SkillMeta]:
+    def _item_to_meta(self, item: Dict) -> SkillMeta | None:
         slug = item.get("slug", "")
         name = item.get("name", "")
         title = item.get("title", name)
@@ -2444,7 +2444,7 @@ class BrowseShSource(SkillSource):
                 break
         return results
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         slug = self._slug_from_identifier(identifier)
         if not slug:
             return None
@@ -2454,7 +2454,7 @@ class BrowseShSource(SkillSource):
                 return self._item_to_meta(item)
         return None
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         slug = self._slug_from_identifier(identifier)
         if not slug:
             return None
@@ -2494,7 +2494,7 @@ class BrowseShSource(SkillSource):
             },
         )
 
-    def _resolve_skill_md_url(self, slug: str, item: Dict) -> Optional[str]:
+    def _resolve_skill_md_url(self, slug: str, item: Dict) -> str | None:
         """Resolve the SKILL.md content URL for a slug.
 
         Primary path: hit ``/api/skills/{slug}`` and read ``skillMdUrl``.
@@ -2572,7 +2572,7 @@ class OptionalSkillSource(SkillSource):
 
     # -- fetch ------------------------------------------------------------
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         # identifier format: "official/category/skill" or "official/skill"
         rel = identifier.split("/", 1)[-1] if identifier.startswith("official/") else identifier
         skill_dir = self._optional_dir / rel
@@ -2624,7 +2624,7 @@ class OptionalSkillSource(SkillSource):
 
     # -- inspect ----------------------------------------------------------
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         rel = identifier.split("/", 1)[-1] if identifier.startswith("official/") else identifier
         skill_name = rel.rsplit("/", 1)[-1]
 
@@ -2635,7 +2635,7 @@ class OptionalSkillSource(SkillSource):
 
     # -- internal helpers -------------------------------------------------
 
-    def _find_skill_dir(self, name: str) -> Optional[Path]:
+    def _find_skill_dir(self, name: str) -> Path | None:
         """Find a skill directory by name anywhere in optional-skills/."""
         if not self._optional_dir.is_dir():
             return None
@@ -2706,7 +2706,7 @@ class OptionalSkillSource(SkillSource):
 # Shared cache helpers (used by multiple adapters)
 # ---------------------------------------------------------------------------
 
-def _read_index_cache(key: str) -> Optional[Any]:
+def _read_index_cache(key: str) -> Any | None:
     """Read cached data if not expired."""
     cache_file = INDEX_CACHE_DIR / f"{key}.json"
     if not cache_file.exists():
@@ -2786,7 +2786,7 @@ class HubLockFile:
         skill_hash: str,
         install_path: str,
         files: List[str],
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] | None = None,
     ) -> None:
         data = self.load()
         data["installed"][name] = {
@@ -2808,7 +2808,7 @@ class HubLockFile:
         data["installed"].pop(name, None)
         self.save(data)
 
-    def get_installed(self, name: str) -> Optional[dict]:
+    def get_installed(self, name: str) -> dict | None:
         data = self.load()
         return data["installed"].get(name)
 
@@ -3041,11 +3041,11 @@ def _source_matches(source: SkillSource, source_name: str) -> bool:
 
 
 def check_for_skill_updates(
-    name: Optional[str] = None,
+    name: str | None = None,
     *,
-    lock: Optional[HubLockFile] = None,
-    sources: Optional[List[SkillSource]] = None,
-    auth: Optional[GitHubAuth] = None,
+    lock: HubLockFile | None = None,
+    sources: List[SkillSource] | None = None,
+    auth: GitHubAuth | None = None,
 ) -> List[dict]:
     """Check installed hub skills for upstream changes."""
     lock = lock or HubLockFile()
@@ -3105,7 +3105,7 @@ HERMES_INDEX_CACHE_FILE = INDEX_CACHE_DIR / "hermes-index.json"
 HERMES_INDEX_TTL = 6 * 3600  # 6 hours
 
 
-def _load_hermes_index() -> Optional[dict]:
+def _load_hermes_index() -> dict | None:
     """Fetch the centralized skills index, with local cache.
 
     The index is a JSON file hosted on the docs site, rebuilt daily by CI.
@@ -3146,7 +3146,7 @@ def _load_hermes_index() -> Optional[dict]:
     return data
 
 
-def _load_stale_index_cache() -> Optional[dict]:
+def _load_stale_index_cache() -> dict | None:
     """Fall back to stale cache when the network fetch fails."""
     if HERMES_INDEX_CACHE_FILE.exists():
         try:
@@ -3169,12 +3169,12 @@ class HermesIndexSource(SkillSource):
     """
 
     def __init__(self, auth: GitHubAuth):
-        self._index: Optional[dict] = None
+        self._index: dict | None = None
         self._loaded = False
         self.auth = auth
         # Lazily create GitHubSource for fetch — only used when actually
         # downloading files, which requires real GitHub API calls.
-        self._github: Optional[GitHubSource] = None
+        self._github: GitHubSource | None = None
 
     def _ensure_loaded(self) -> dict:
         if not self._loaded:
@@ -3224,7 +3224,7 @@ class HermesIndexSource(SkillSource):
                     break
         return results
 
-    def fetch(self, identifier: str) -> Optional[SkillBundle]:
+    def fetch(self, identifier: str) -> SkillBundle | None:
         """Fetch a skill using the resolved path from the index.
 
         If the index has a ``resolved_github_id`` for this skill, we skip
@@ -3259,7 +3259,7 @@ class HermesIndexSource(SkillSource):
 
         return None
 
-    def inspect(self, identifier: str) -> Optional[SkillMeta]:
+    def inspect(self, identifier: str) -> SkillMeta | None:
         """Return metadata from the index.  Zero API calls."""
         index = self._ensure_loaded()
         entry = self._find_entry(identifier, index)
@@ -3267,7 +3267,7 @@ class HermesIndexSource(SkillSource):
             return self._to_meta(entry)
         return None
 
-    def _find_entry(self, identifier: str, index: dict) -> Optional[dict]:
+    def _find_entry(self, identifier: str, index: dict) -> dict | None:
         """Look up a skill in the index by identifier or name."""
         skills = index.get("skills", [])
 
@@ -3312,7 +3312,7 @@ class HermesIndexSource(SkillSource):
         )
 
 
-def create_source_router(auth: Optional[GitHubAuth] = None) -> List[SkillSource]:
+def create_source_router(auth: GitHubAuth | None = None) -> List[SkillSource]:
     """
     Create all configured source adapters.
     Returns a list of active sources for search/fetch operations.
@@ -3353,10 +3353,10 @@ def _search_one_source(
 def parallel_search_sources(
     sources: List[SkillSource],
     query: str = "",
-    per_source_limits: Optional[Dict[str, int]] = None,
+    per_source_limits: Dict[str, int] | None = None,
     source_filter: str = "all",
     overall_timeout: float = 30,
-    on_source_done: Optional[Any] = None,
+    on_source_done: Any | None = None,
 ) -> Tuple[List[SkillMeta], Dict[str, int], List[str]]:
     """Search all sources in parallel with per-source timeout.
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -444,7 +444,7 @@ def _parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     return parse_frontmatter(content)
 
 
-def _get_category_from_path(skill_path: Path) -> Optional[str]:
+def _get_category_from_path(skill_path: Path) -> str | None:
     """
     Extract category from skill path based on directory structure.
 
@@ -629,7 +629,7 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
-def _load_category_description(category_dir: Path) -> Optional[str]:
+def _load_category_description(category_dir: Path) -> str | None:
     """
     Load category description from DESCRIPTION.md if it exists.
 
@@ -965,10 +965,10 @@ def skill_view(
         # loaded the other) so we surface it loudly instead of guessing.
         from agent.skill_utils import iter_skill_index_files
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
+        candidates: List[Tuple[Path | None, Path]] = []  # (skill_dir, skill_md)
         seen_md: set = set()
 
-        def _record(sd: Optional[Path], smd: Path) -> None:
+        def _record(sd: Path | None, smd: Path) -> None:
             try:
                 key = smd.resolve()
             except Exception:

--- a/tools/slash_confirm.py
+++ b/tools/slash_confirm.py
@@ -52,7 +52,7 @@ def register(
     session_key: str,
     confirm_id: str,
     command: str,
-    handler: Callable[[str], Awaitable[Optional[str]]],
+    handler: Callable[[str], Awaitable[str | None]],
 ) -> None:
     """Register a pending slash-command confirmation.
 
@@ -68,7 +68,7 @@ def register(
         }
 
 
-def get_pending(session_key: str) -> Optional[Dict[str, Any]]:
+def get_pending(session_key: str) -> Dict[str, Any] | None:
     """Return the pending confirm dict for a session, or None."""
     with _lock:
         entry = _pending.get(session_key)
@@ -101,7 +101,7 @@ async def resolve(
     confirm_id: str,
     choice: str,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
-) -> Optional[str]:
+) -> str | None:
     """Resolve a pending confirm.
 
     ``choice`` must be one of ``"once"``, ``"always"``, or ``"cancel"``.
@@ -145,7 +145,7 @@ def resolve_sync_compat(
     session_key: str,
     confirm_id: str,
     choice: str,
-) -> Optional[str]:
+) -> str | None:
     """Synchronous helper: schedule resolve() on a loop and wait for the result.
 
     Used by platform callback paths that run on a different thread than the

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -964,7 +964,7 @@ def clear_task_env_overrides(task_id: str):
     _task_env_overrides.pop(task_id, None)
 
 
-def _resolve_container_task_id(task_id: Optional[str]) -> str:
+def _resolve_container_task_id(task_id: str | None) -> str:
     """
     Map a tool-call ``task_id`` to the container/sandbox key used by
     ``_active_environments``.
@@ -1659,13 +1659,13 @@ def _resolve_notification_flag_conflict(
 def terminal_tool(
     command: str,
     background: bool = False,
-    timeout: Optional[int] = None,
-    task_id: Optional[str] = None,
+    timeout: int | None = None,
+    task_id: str | None = None,
     force: bool = False,
-    workdir: Optional[str] = None,
+    workdir: str | None = None,
     pty: bool = False,
     notify_on_complete: bool = False,
-    watch_patterns: Optional[List[str]] = None,
+    watch_patterns: List[str] | None = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -87,7 +87,7 @@ class TodoStore:
         """Check if there are any items in the list."""
         return bool(self._items)
 
-    def format_for_injection(self) -> Optional[str]:
+    def format_for_injection(self) -> str | None:
         """
         Render the todo list for post-compression injection.
 
@@ -154,9 +154,9 @@ class TodoStore:
 
 
 def todo_tool(
-    todos: Optional[List[Dict[str, Any]]] = None,
+    todos: List[Dict[str, Any]] | None = None,
     merge: bool = False,
-    store: Optional[TodoStore] = None,
+    store: TodoStore | None = None,
 ) -> str:
     """
     Single entry point for the todo tool. Reads or writes depending on params.

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -101,8 +101,8 @@ OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
 GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
 
 # Singleton for the local model — loaded once, reused across calls
-_local_model: Optional[object] = None
-_local_model_name: Optional[str] = None
+_local_model: object | None = None
+_local_model_name: str | None = None
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -119,7 +119,7 @@ def _load_stt_config() -> dict:
         return {}
 
 
-def is_stt_enabled(stt_config: Optional[dict] = None) -> bool:
+def is_stt_enabled(stt_config: dict | None = None) -> bool:
     """Return whether STT is enabled in config."""
     if stt_config is None:
         stt_config = _load_stt_config()
@@ -136,7 +136,7 @@ def _has_openai_audio_backend() -> bool:
         return False
 
 
-def _find_binary(binary_name: str) -> Optional[str]:
+def _find_binary(binary_name: str) -> str | None:
     """Find a local binary, checking common Homebrew/local prefixes as well as PATH."""
     for directory in COMMON_LOCAL_BIN_DIRS:
         candidate = Path(directory) / binary_name
@@ -145,15 +145,15 @@ def _find_binary(binary_name: str) -> Optional[str]:
     return shutil.which(binary_name)
 
 
-def _find_ffmpeg_binary() -> Optional[str]:
+def _find_ffmpeg_binary() -> str | None:
     return _find_binary("ffmpeg")
 
 
-def _find_whisper_binary() -> Optional[str]:
+def _find_whisper_binary() -> str | None:
     return _find_binary("whisper")
 
 
-def _get_local_command_template() -> Optional[str]:
+def _get_local_command_template() -> str | None:
     configured = os.getenv(LOCAL_STT_COMMAND_ENV, "").strip()
     if configured:
         return configured
@@ -172,7 +172,7 @@ def _has_local_command() -> bool:
     return _get_local_command_template() is not None
 
 
-def _normalize_local_model(model_name: Optional[str]) -> str:
+def _normalize_local_model(model_name: str | None) -> str:
     """Return a valid faster-whisper model size, mapping cloud-only names to the default.
 
     Cloud providers like OpenAI use names such as ``whisper-1`` which are not
@@ -193,7 +193,7 @@ def _normalize_local_model(model_name: Optional[str]) -> str:
     return model_name
 
 
-def _normalize_local_command_model(model_name: Optional[str]) -> str:
+def _normalize_local_command_model(model_name: str | None) -> str:
     return _normalize_local_model(model_name)
 
 
@@ -332,7 +332,7 @@ def _get_provider(stt_config: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
+def _validate_audio_file(file_path: str) -> Dict[str, Any] | None:
     """Validate the audio file.  Returns an error dict or None if OK."""
     audio_path = Path(file_path)
 
@@ -485,7 +485,7 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
 
 
-def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:
+def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[str | None, str | None]:
     """Normalize audio for local CLI STT when needed."""
     audio_path = Path(file_path)
     if audio_path.suffix.lower() in LOCAL_NATIVE_AUDIO_FORMATS:
@@ -838,7 +838,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def transcribe_audio(file_path: str, model: str | None = None) -> Dict[str, Any]:
     """
     Transcribe an audio file using the configured STT provider.
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -223,8 +223,8 @@ MAX_TEXT_LENGTH = FALLBACK_MAX_TEXT_LENGTH
 
 
 def _resolve_max_text_length(
-    provider: Optional[str],
-    tts_config: Optional[Dict[str, Any]] = None,
+    provider: str | None,
+    tts_config: Dict[str, Any] | None = None,
 ) -> int:
     """Return the input-character cap for *provider*.
 
@@ -401,7 +401,7 @@ def _is_command_provider_config(config: Dict[str, Any]) -> bool:
 def _resolve_command_provider_config(
     provider: str,
     tts_config: Dict[str, Any],
-) -> Optional[Dict[str, Any]]:
+) -> Dict[str, Any] | None:
     """Return the provider config if *provider* resolves to a command type.
 
     Built-in provider names are rejected (they have native handlers).
@@ -424,7 +424,7 @@ def _dispatch_to_plugin_provider(
     output_path: str,
     provider: str,
     tts_config: Dict[str, Any],
-) -> Optional[str]:
+) -> str | None:
     """Route the call to a plugin-registered TTS provider, or return None.
 
     Returns the path to the written audio file on dispatch, or ``None``
@@ -561,7 +561,7 @@ def _get_command_tts_timeout(config: Dict[str, Any]) -> float:
 
 def _get_command_tts_output_format(
     config: Dict[str, Any],
-    output_path: Optional[str] = None,
+    output_path: str | None = None,
 ) -> str:
     """Return the validated output format (mp3/wav/ogg/flac)."""
     if output_path:
@@ -585,13 +585,13 @@ def _is_command_tts_voice_compatible(config: Dict[str, Any]) -> bool:
     return bool(value)
 
 
-def _shell_quote_context(command_template: str, position: int) -> Optional[str]:
+def _shell_quote_context(command_template: str, position: int) -> str | None:
     """Return the shell quote character active right before *position*.
 
     Returns ``"'"`` / ``'"'`` when inside a single- / double-quoted region
     of the template, ``None`` for bare context.
     """
-    quote: Optional[str] = None
+    quote: str | None = None
     escaped = False
     i = 0
     while i < position:
@@ -616,7 +616,7 @@ def _shell_quote_context(command_template: str, position: int) -> Optional[str]:
     return quote
 
 
-def _quote_command_tts_placeholder(value: str, quote_context: Optional[str]) -> str:
+def _quote_command_tts_placeholder(value: str, quote_context: str | None) -> str:
     """Quote a placeholder value for its position in a shell command template."""
     if quote_context == "'":
         return value.replace("'", r"'\''")
@@ -828,7 +828,7 @@ def _generate_command_tts(
     return str(output)
 
 
-def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+def _has_any_command_tts_provider(tts_config: Dict[str, Any] | None = None) -> bool:
     """Return True when any command-type TTS provider is configured."""
     if tts_config is None:
         tts_config = _load_tts_config()
@@ -845,7 +845,7 @@ def _has_ffmpeg() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
-def _convert_to_opus(mp3_path: str) -> Optional[str]:
+def _convert_to_opus(mp3_path: str) -> str | None:
     """
     Convert an MP3 file to OGG Opus format for Telegram voice bubbles.
 
@@ -1817,7 +1817,7 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
 # ===========================================================================
 def text_to_speech_tool(
     text: str,
-    output_path: Optional[str] = None,
+    output_path: str | None = None,
 ) -> str:
     """
     Convert text to speech audio.
@@ -2239,7 +2239,7 @@ def stream_tts_to_speaker(
     text_queue: queue.Queue,
     stop_event: threading.Event,
     tts_done_event: threading.Event,
-    display_callback: Optional[Callable[[str], None]] = None,
+    display_callback: Callable[[str], None] | None = None,
 ):
     """Consume text deltas from *text_queue*, buffer them into sentences,
     and stream each sentence through ElevenLabs TTS to the speaker in

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -177,14 +177,14 @@ def _read_video_gen_section() -> Dict[str, Any]:
         return {}
 
 
-def _read_configured_video_provider() -> Optional[str]:
+def _read_configured_video_provider() -> str | None:
     value = _read_video_gen_section().get("provider")
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
 
 
-def _read_configured_video_model() -> Optional[str]:
+def _read_configured_video_model() -> str | None:
     value = _read_video_gen_section().get("model")
     if isinstance(value, str) and value.strip():
         return value.strip()
@@ -244,7 +244,7 @@ def _resolve_active_provider():
         return None
 
 
-def _missing_provider_error(configured: Optional[str]) -> str:
+def _missing_provider_error(configured: str | None) -> str:
     if configured:
         msg = (
             f"video_gen.provider='{configured}' is set but no plugin "
@@ -270,7 +270,7 @@ def _missing_provider_error(configured: Optional[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _coerce_int(value: Any) -> Optional[int]:
+def _coerce_int(value: Any) -> int | None:
     if value is None or value == "":
         return None
     try:
@@ -279,7 +279,7 @@ def _coerce_int(value: Any) -> Optional[int]:
         return None
 
 
-def _coerce_bool(value: Any) -> Optional[bool]:
+def _coerce_bool(value: Any) -> bool | None:
     if value is None:
         return None
     if isinstance(value, bool):
@@ -293,7 +293,7 @@ def _coerce_bool(value: Any) -> Optional[bool]:
     return None
 
 
-def _normalize_reference_images(value: Any) -> Optional[List[str]]:
+def _normalize_reference_images(value: Any) -> List[str] | None:
     if value is None:
         return None
     if isinstance(value, str):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -105,7 +105,7 @@ def _validate_image_url(url: str) -> bool:
     return True
 
 
-def _detect_image_mime_type(image_path: Path) -> Optional[str]:
+def _detect_image_mime_type(image_path: Path) -> str | None:
     """Return a MIME type when the file looks like a supported image."""
     with image_path.open("rb") as f:
         header = f.read(64)
@@ -253,7 +253,7 @@ def _determine_mime_type(image_path: Path) -> str:
     return mime_types.get(extension, 'image/jpeg')
 
 
-def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None) -> str:
+def _image_to_base64_data_url(image_path: Path, mime_type: str | None = None) -> str:
     """
     Convert an image file to a base64-encoded data URL.
     
@@ -298,7 +298,7 @@ def _is_image_size_error(error: Exception) -> bool:
     ))
 
 
-def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
+def _resize_image_for_vision(image_path: Path, mime_type: str | None = None,
                               max_base64_bytes: int = _RESIZE_TARGET_BYTES) -> str:
     """Convert an image to a base64 data URL, auto-resizing if too large.
 
@@ -550,7 +550,7 @@ async def _vision_analyze_native(
     if not isinstance(image_url, str) or not image_url.strip():
         return tool_error("image_url is required", success=False)
 
-    temp_image_path: Optional[Path] = None
+    temp_image_path: Path | None = None
     should_cleanup = False
     try:
         from tools.interrupt import is_interrupted
@@ -1092,13 +1092,13 @@ _MAX_VIDEO_BASE64_BYTES = 50 * 1024 * 1024  # 50 MB hard cap
 _VIDEO_SIZE_WARN_BYTES = 20 * 1024 * 1024
 
 
-def _detect_video_mime_type(video_path: Path) -> Optional[str]:
+def _detect_video_mime_type(video_path: Path) -> str | None:
     """Return a video MIME type based on file extension, or None if unsupported."""
     ext = video_path.suffix.lower()
     return _VIDEO_MIME_TYPES.get(ext)
 
 
-def _video_to_base64_data_url(video_path: Path, mime_type: Optional[str] = None) -> str:
+def _video_to_base64_data_url(video_path: Path, mime_type: str | None = None) -> str:
     """Convert a video file to a base64-encoded data URL."""
     data = video_path.read_bytes()
     encoded = base64.b64encode(data).decode("ascii")

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -58,7 +58,7 @@ def _voice_capture_install_hint() -> str:
     return "pip install sounddevice numpy"
 
 
-def _termux_microphone_command() -> Optional[str]:
+def _termux_microphone_command() -> str | None:
     if not _is_termux_environment():
         return None
     return shutil.which("termux-microphone-record")
@@ -253,7 +253,7 @@ class TermuxAudioRecorder:
         self._lock = threading.Lock()
         self._recording = False
         self._start_time = 0.0
-        self._recording_path: Optional[str] = None
+        self._recording_path: str | None = None
         self._current_rms = 0
 
     @property
@@ -320,7 +320,7 @@ class TermuxAudioRecorder:
             return
         subprocess.run([mic_cmd, "-q"], capture_output=True, text=True, timeout=15, check=False)
 
-    def stop(self) -> Optional[str]:
+    def stop(self) -> str | None:
         with self._lock:
             if not self._recording:
                 return None
@@ -634,7 +634,7 @@ class AudioRecorder:
         if t.is_alive():
             logger.warning("Audio stream close timed out after %.1fs — forcing ahead", timeout)
 
-    def stop(self) -> Optional[str]:
+    def stop(self) -> str | None:
         """Stop recording and write captured audio to a WAV file.
 
         The underlying stream is kept alive for reuse — only frame
@@ -787,7 +787,7 @@ def is_whisper_hallucination(transcript: str) -> bool:
 # ============================================================================
 # STT dispatch
 # ============================================================================
-def transcribe_recording(wav_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def transcribe_recording(wav_path: str, model: str | None = None) -> Dict[str, Any]:
     """Transcribe a WAV recording using the existing Whisper pipeline.
 
     Delegates to ``tools.transcription_tools.transcribe_audio()``.
@@ -828,7 +828,7 @@ def _should_chunk_for_transcription(file_path: str, max_file_size: int) -> bool:
 def _transcribe_wav_in_chunks(
     wav_path: str,
     *,
-    model: Optional[str],
+    model: str | None,
     max_file_size: int,
 ) -> Dict[str, Any]:
     """Split an oversized WAV into provider-sized chunks and join transcripts."""
@@ -928,7 +928,7 @@ def _split_wav_for_transcription(wav_path: str, *, max_file_size: int) -> List[s
 # ============================================================================
 
 # Global reference to the active playback process so it can be interrupted.
-_active_playback: Optional[subprocess.Popen] = None
+_active_playback: subprocess.Popen | None = None
 _playback_lock = threading.Lock()
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -91,11 +91,11 @@ from plugins.web.exa.provider import _get_exa_client  # noqa: F401
 # Module-level cache slots for the per-vendor clients. The plugins read/write
 # these via tools.web_tools so unit tests that reset
 # ``tools.web_tools._<vendor>_client = None`` between cases keep working.
-_firecrawl_client: Optional[Any] = None
-_firecrawl_client_config: Optional[Any] = None
-_parallel_client: Optional[Any] = None
-_async_parallel_client: Optional[Any] = None
-_exa_client: Optional[Any] = None
+_firecrawl_client: Any | None = None
+_firecrawl_client_config: Any | None = None
+_parallel_client: Any | None = None
+_async_parallel_client: Any | None = None
+_exa_client: Any | None = None
 
 from agent.auxiliary_client import (
     async_call_llm,
@@ -304,7 +304,7 @@ def _is_nous_auxiliary_client(client: Any) -> bool:
     return host == "nousresearch.com" or host.endswith(".nousresearch.com")
 
 
-def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optional[Any], Optional[str], Dict[str, Any]]:
+def _resolve_web_extract_auxiliary(model: str | None = None) -> tuple[Any | None, str | None, Dict[str, Any]]:
     """Resolve the current web-extract auxiliary client, model, and extra body."""
     client, default_model = get_async_text_auxiliary_client("web_extract")
     configured_model = os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip()
@@ -319,7 +319,7 @@ def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optiona
     return client, effective_model, extra_body
 
 
-def _get_default_summarizer_model() -> Optional[str]:
+def _get_default_summarizer_model() -> str | None:
     """Return the current default model for web extraction summarization."""
     _, model, _ = _resolve_web_extract_auxiliary()
     return model
@@ -331,9 +331,9 @@ async def process_content_with_llm(
     content: str, 
     url: str = "", 
     title: str = "",
-    model: Optional[str] = None,
+    model: str | None = None,
     min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
-) -> Optional[str]:
+) -> str | None:
     """
     Process web content using LLM to create intelligent summaries with key excerpts.
     
@@ -430,11 +430,11 @@ async def process_content_with_llm(
 async def _call_summarizer_llm(
     content: str, 
     context_str: str, 
-    model: Optional[str], 
+    model: str | None, 
     max_tokens: int = 20000,
     is_chunk: bool = False,
     chunk_info: str = ""
-) -> Optional[str]:
+) -> str | None:
     """
     Make a single LLM call to summarize content.
     
@@ -548,10 +548,10 @@ Create a markdown summary that captures all key information in a well-organized,
 async def _process_large_content_chunked(
     content: str, 
     context_str: str, 
-    model: Optional[str], 
+    model: str | None, 
     chunk_size: int,
     max_output_size: int
-) -> Optional[str]:
+) -> str | None:
     """
     Process large content by chunking, summarizing each chunk in parallel,
     then synthesizing the summaries.
@@ -575,7 +575,7 @@ async def _process_large_content_chunked(
     logger.info("Split into %d chunks of ~%d chars each", len(chunks), chunk_size)
     
     # Summarize each chunk in parallel
-    async def summarize_chunk(chunk_idx: int, chunk_content: str) -> tuple[int, Optional[str]]:
+    async def summarize_chunk(chunk_idx: int, chunk_content: str) -> tuple[int, str | None]:
         """Summarize a single chunk."""
         try:
             chunk_info = f"[Processing chunk {chunk_idx + 1} of {len(chunks)}]"
@@ -853,7 +853,7 @@ async def web_extract_tool(
     urls: List[str],
     format: str = None,
     use_llm_processing: bool = True,
-    model: Optional[str] = None,
+    model: str | None = None,
     min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
 ) -> str:
     """
@@ -1135,7 +1135,7 @@ async def web_crawl_tool(
     instructions: str = None, 
     depth: str = "basic", 
     use_llm_processing: bool = True,
-    model: Optional[str] = None,
+    model: str | None = None,
     min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
 ) -> str:
     """

--- a/tools/website_policy.py
+++ b/tools/website_policy.py
@@ -32,8 +32,8 @@ _DEFAULT_WEBSITE_BLOCKLIST = {
 # URL check (a web_crawl with 50 pages would otherwise mean 51 YAML parses).
 _CACHE_TTL_SECONDS = 30.0
 _cache_lock = threading.Lock()
-_cached_policy: Optional[Dict[str, Any]] = None
-_cached_policy_path: Optional[str] = None
+_cached_policy: Dict[str, Any] | None = None
+_cached_policy_path: str | None = None
 _cached_policy_time: float = 0.0
 
 
@@ -49,7 +49,7 @@ def _normalize_host(host: str) -> str:
     return (host or "").strip().lower().rstrip(".")
 
 
-def _normalize_rule(rule: Any) -> Optional[str]:
+def _normalize_rule(rule: Any) -> str | None:
     if not isinstance(rule, str):
         return None
     value = rule.strip().lower()
@@ -90,7 +90,7 @@ def _iter_blocklist_file_rules(path: Path) -> List[str]:
     return rules
 
 
-def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
+def _load_policy_config(config_path: Path | None = None) -> Dict[str, Any]:
     config_path = config_path or _get_default_config_path()
     if not config_path.exists():
         return dict(_DEFAULT_WEBSITE_BLOCKLIST)
@@ -128,7 +128,7 @@ def _load_policy_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
     return policy
 
 
-def load_website_blocklist(config_path: Optional[Path] = None) -> Dict[str, Any]:
+def load_website_blocklist(config_path: Path | None = None) -> Dict[str, Any]:
     """Load and return the parsed website blocklist policy.
 
     Results are cached for ``_CACHE_TTL_SECONDS`` to avoid re-reading
@@ -229,7 +229,7 @@ def _extract_host_from_urlish(url: str) -> str:
     return ""
 
 
-def check_website_access(url: str, config_path: Optional[Path] = None) -> Optional[Dict[str, str]]:
+def check_website_access(url: str, config_path: Path | None = None) -> Dict[str, str] | None:
     """Check whether a URL is allowed by the website blocklist policy.
 
     Returns ``None`` if access is allowed, or a dict with block metadata

--- a/tools/x_search_tool.py
+++ b/tools/x_search_tool.py
@@ -144,7 +144,7 @@ def check_x_search_requirements() -> bool:
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _normalize_handles(handles: Optional[List[str]], field_name: str) -> List[str]:
+def _normalize_handles(handles: List[str] | None, field_name: str) -> List[str]:
     cleaned: List[str] = []
     for handle in handles or []:
         normalized = str(handle or "").strip().lstrip("@")
@@ -185,8 +185,8 @@ def _validate_date_range(from_date: str, to_date: str) -> None:
         to return zero citations. ``to_date`` in the future is allowed
         (callers may legitimately set "from yesterday to tomorrow").
     """
-    parsed_from: Optional[date] = None
-    parsed_to: Optional[date] = None
+    parsed_from: date | None = None
+    parsed_to: date | None = None
     if from_date.strip():
         parsed_from = _parse_iso_date(from_date, "from_date")
     if to_date.strip():
@@ -274,8 +274,8 @@ def _http_error_message(exc: requests.HTTPError) -> str:
 
 def x_search_tool(
     query: str,
-    allowed_x_handles: Optional[List[str]] = None,
-    excluded_x_handles: Optional[List[str]] = None,
+    allowed_x_handles: List[str] | None = None,
+    excluded_x_handles: List[str] | None = None,
     from_date: str = "",
     to_date: str = "",
     enable_image_understanding: bool = False,
@@ -328,7 +328,7 @@ def x_search_tool(
 
         timeout_seconds = _get_x_search_timeout_seconds()
         max_retries = _get_x_search_retries()
-        response: Optional[requests.Response] = None
+        response: requests.Response | None = None
         for attempt in range(max_retries + 1):
             try:
                 response = requests.post(

--- a/tools/yuanbao_tools.py
+++ b/tools/yuanbao_tools.py
@@ -240,7 +240,7 @@ async def send_sticker(
         return {"success": False, "error": "Yuanbao adapter is not connected"}
 
     raw = (sticker or "").strip()
-    sticker_obj: Optional[dict] = None
+    sticker_obj: dict | None = None
     if not raw:
         sticker_obj = get_random_sticker()
     else:
@@ -292,7 +292,7 @@ async def send_dm(
     name: str,
     message: str,
     user_id: str = "",
-    media_files: Optional[List[Tuple[str, bool]]] = None,
+    media_files: List[Tuple[str, bool]] | None = None,
 ) -> dict:
     """
     Send a DM (private chat message) to a group member, with optional media.

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Dict[str, any] | None:
     """
     Get a toolset distribution by name.
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -546,7 +546,7 @@ TOOLSETS = {
 
 
 
-def get_toolset(name: str) -> Optional[Dict[str, Any]]:
+def get_toolset(name: str) -> Dict[str, Any] | None:
     """
     Get a toolset definition by name.
     

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -59,8 +59,8 @@ load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
 def _effective_temperature_for_model(
     model: str,
     requested_temperature: float,
-    base_url: Optional[str] = None,
-) -> Optional[float]:
+    base_url: str | None = None,
+) -> float | None:
     """Apply fixed model temperature contracts to direct client calls.
 
     Returns ``None`` when the model manages temperature server-side (Kimi);

--- a/tui_gateway/event_publisher.py
+++ b/tui_gateway/event_publisher.py
@@ -43,10 +43,10 @@ class WsPublisherTransport:
     def __init__(self, url: str, *, connect_timeout: float = 2.0) -> None:
         self._url = url
         self._lock = threading.Lock()
-        self._ws: Optional[object] = None
+        self._ws: object | None = None
         self._dead = False
         self._q: queue.Queue[object] = queue.Queue(maxsize=_QUEUE_MAX)
-        self._worker: Optional[threading.Thread] = None
+        self._worker: threading.Thread | None = None
 
         if ws_connect is None:
             self._dead = True

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -473,7 +473,7 @@ def handle_request(req: dict) -> dict | None:
     return fn(rid, params)
 
 
-def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
+def dispatch(req: dict, transport: Transport | None = None) -> dict | None:
     """Route inbound RPCs — long handlers to the pool, everything else inline.
 
     Returns a response dict when handled inline. Returns None when the

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -74,7 +74,7 @@ class Transport(Protocol):
         """Release any resources owned by this transport."""
 
 
-_current_transport: contextvars.ContextVar[Optional[Transport]] = (
+_current_transport: contextvars.ContextVar[Transport | None] = (
     contextvars.ContextVar(
         "hermes_gateway_transport",
         default=None,
@@ -82,12 +82,12 @@ _current_transport: contextvars.ContextVar[Optional[Transport]] = (
 )
 
 
-def current_transport() -> Optional[Transport]:
+def current_transport() -> Transport | None:
     """Return the transport bound for the current request, if any."""
     return _current_transport.get()
 
 
-def bind_transport(transport: Optional[Transport]):
+def bind_transport(transport: Transport | None):
     """Bind *transport* for the current context. Returns a token for :func:`reset_transport`."""
     return _current_transport.set(transport)
 


### PR DESCRIPTION
## What does this PR do?

chore: ruff auto-fix UP045 — non-pep604-annotation-optional.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

chore: ruff auto-fix UP045 — non-pep604-annotation-optional.

## What Changed

- `pyproject.toml`: added `UP045` to `[tool.ruff.lint] select`
- **313 files** changed: **+3726/-3728** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `UP045` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_