### PR TITLE
chore: ruff auto-fix RSE — unnecessary-paren-on-raise

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -14295,7 +14295,7 @@ class HermesCLI:
                         return  # clean unwind — no traceback, no ENTER pause
             except Exception:
                 pass
-            raise KeyboardInterrupt()  # fallback for non-prompt_toolkit contexts
+            raise KeyboardInterrupt  # fallback for non-prompt_toolkit contexts
         
         try:
             import signal as _signal
@@ -14724,7 +14724,7 @@ def main(
                     time.sleep(_grace)
         except Exception:
             pass  # never block signal handling
-        raise KeyboardInterrupt()
+        raise KeyboardInterrupt
     try:
         import signal as _signal
         _signal.signal(_signal.SIGTERM, _signal_handler_q)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -660,7 +660,7 @@ def _pick_provider(prompt: str = "Provider") -> str:
     try:
         raw = input(f"{prompt}: ").strip()
     except (EOFError, KeyboardInterrupt):
-        raise SystemExit()
+        raise SystemExit
     return _normalize_provider(raw)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,7 @@ preview = true  # required for PLW1514 (unspecified-encoding) — preview rule
 # which silently corrupts any non-ASCII file content.  We had three
 # separate Windows sandbox regressions in one debug session before
 # adding the explicit encoding.  This rule keeps new code honest.
-select = ["PLW1514"]
+select = ["RSE", "PLW1514"]
 
 [tool.ruff.lint.per-file-ignores]
 # Tests can intentionally exercise locale-encoding edge cases.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1781,7 +1781,7 @@ class _FailingThenSuccessCompletions:
     def create(self, **kwargs):
         self.calls += 1
         if self.calls == 1:
-            raise _AuxAuth401()
+            raise _AuxAuth401
         return _DummyResponse("sync-ok")
 
 
@@ -1792,7 +1792,7 @@ class _AsyncFailingThenSuccessCompletions:
     async def create(self, **kwargs):
         self.calls += 1
         if self.calls == 1:
-            raise _AuxAuth401()
+            raise _AuxAuth401
         return _DummyResponse("async-ok")
 
 

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -117,7 +117,7 @@ class TestMain:
 
         class FakeServer:
             def run(self):
-                raise KeyboardInterrupt()
+                raise KeyboardInterrupt
 
         monkeypatch.setattr(m, "_build_server", lambda: FakeServer())
         rc = m.main([])

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -85,7 +85,7 @@ class _Codex401ThenSuccessAgent(run_agent.AIAgent):
         def _fake_api_call(api_kwargs):
             calls["api"] += 1
             if calls["api"] == 1:
-                raise _UnauthorizedError()
+                raise _UnauthorizedError
             return _codex_message_response("Recovered via refresh")
 
         self._interruptible_api_call = _fake_api_call

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2117,7 +2117,7 @@ class TestResponsesStreaming:
             # ...then give the drain loop a moment to pick it up before
             # raising CancelledError to simulate a server-side cancel.
             await asyncio.sleep(0.01)
-            raise asyncio.CancelledError()
+            raise asyncio.CancelledError
 
         agent_task = asyncio.ensure_future(_agent_coro())
         response_id = f"resp_{uuid.uuid4().hex[:28]}"

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -268,7 +268,7 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
 
     async def fake_wait_for(awaitable, timeout):
         awaitable.close()
-        raise asyncio.TimeoutError()
+        raise asyncio.TimeoutError
 
     monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
 

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -625,7 +625,7 @@ class TestIRCStandaloneSend:
             try:
                 return await coro
             except asyncio.IncompleteReadError:
-                raise asyncio.TimeoutError()
+                raise asyncio.TimeoutError
 
         monkeypatch.setattr(_irc_mod.asyncio, "wait_for", _fast_timeout)
 

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -376,7 +376,7 @@ async def test_heartbeat_probe_reenters_ladder_when_get_me_times_out():
     async def fast_wait_for(coro, timeout):
         if asyncio.iscoroutine(coro):
             coro.close()
-        raise asyncio.TimeoutError()
+        raise asyncio.TimeoutError
 
     with patch("asyncio.sleep", new_callable=AsyncMock):
         with patch("gateway.platforms.telegram.asyncio.wait_for", new=fast_wait_for):

--- a/tests/hermes_cli/test_auth_manual_paste.py
+++ b/tests/hermes_cli/test_auth_manual_paste.py
@@ -187,7 +187,7 @@ def test_prompt_reads_stdin_and_parses(monkeypatch):
 
 def test_prompt_eof_returns_all_none(monkeypatch):
     def _raise_eof(*_a, **_k):
-        raise EOFError()
+        raise EOFError
 
     monkeypatch.setattr(builtins, "input", _raise_eof)
     with contextlib.redirect_stdout(io.StringIO()):
@@ -199,7 +199,7 @@ def test_prompt_eof_returns_all_none(monkeypatch):
 
 def test_prompt_keyboard_interrupt_returns_all_none(monkeypatch):
     def _raise_kbi(*_a, **_k):
-        raise KeyboardInterrupt()
+        raise KeyboardInterrupt
 
     monkeypatch.setattr(builtins, "input", _raise_kbi)
     with contextlib.redirect_stdout(io.StringIO()):

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -314,7 +314,7 @@ def test_setup_keyboard_interrupt_gracefully_handled(tmp_path, monkeypatch):
     config = load_config()
 
     def fake_select():
-        raise KeyboardInterrupt()
+        raise KeyboardInterrupt
 
     monkeypatch.setattr("hermes_cli.main.select_provider_and_model", fake_select)
 

--- a/tests/hermes_cli/test_suppress_eio_on_interrupt.py
+++ b/tests/hermes_cli/test_suppress_eio_on_interrupt.py
@@ -154,7 +154,7 @@ def _make_signal_handler(logger, agent_state):
                 agent_state["agent"].interrupt(f"received signal {signum}")
         except Exception:
             pass  # never block signal handling
-        raise KeyboardInterrupt()
+        raise KeyboardInterrupt
     return _signal_handler
 
 

--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -133,7 +133,7 @@ class TestUpdateOutputStream:
                 return True
 
             def write(self, data):
-                raise BrokenPipeError()
+                raise BrokenPipeError
 
             def flush(self):
                 return None

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3165,7 +3165,7 @@ class TestRunConversation:
         def _fake_api_call(api_kwargs):
             calls["api"] += 1
             if calls["api"] == 1:
-                raise _UnauthorizedError()
+                raise _UnauthorizedError
             return _mock_response(
                 content="Recovered after remint", finish_reason="stop"
             )

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -555,7 +555,7 @@ def test_run_conversation_codex_refreshes_after_401_and_retries(monkeypatch):
     def _fake_api_call(api_kwargs):
         calls["api"] += 1
         if calls["api"] == 1:
-            raise _UnauthorizedError()
+            raise _UnauthorizedError
         return _codex_message_response("Recovered after refresh")
 
     def _fake_refresh(*, force=True):
@@ -648,7 +648,7 @@ def test_run_conversation_xai_oauth_refreshes_after_401_and_retries(monkeypatch)
     def _fake_api_call(api_kwargs):
         calls["api"] += 1
         if calls["api"] == 1:
-            raise _UnauthorizedError()
+            raise _UnauthorizedError
         return _codex_message_response("Recovered after xAI refresh")
 
     def _fake_refresh(*, force=True):
@@ -776,7 +776,7 @@ def test_run_conversation_copilot_refreshes_after_401_and_retries(monkeypatch):
     def _fake_api_call(api_kwargs):
         calls["api"] += 1
         if calls["api"] == 1:
-            raise _UnauthorizedError()
+            raise _UnauthorizedError
         return _codex_message_response("Recovered after copilot refresh")
 
     def _fake_refresh():

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -220,7 +220,7 @@ class TestRunAsyncWithRunningLoop:
         class TimeoutFuture:
             def result(self, timeout=None):
                 events["result_timeout"] = timeout
-                raise concurrent.futures.TimeoutError()
+                raise concurrent.futures.TimeoutError
 
             def cancel(self):
                 return True


### PR DESCRIPTION
## What does this PR do?

chore: ruff auto-fix RSE — unnecessary-paren-on-raise.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

chore: ruff auto-fix RSE — unnecessary-paren-on-raise.

## What Changed

- `pyproject.toml`: added `RSE` to `[tool.ruff.lint] select`
- **17 files** changed: **+22/-22** lines

## Fluxo

O ruff percorre a árvore do projeto aplicando a regra `RSE` onde encontra violações. As transformações foram feitas por auto-fix e mantêm o comportamento do código.

## Visão

Com a regra habilitada no lint, o projeto passa a bloquear regressões futuras no mesmo padrão e fica mais consistente para novos commits.

## Test Plan

- `ruff check` passa com zero erros (regra já ativa na config)
- Nenhuma mudança de comportamento em runtime — apenas transformações sintáticas
- `pytest` mantém o comportamento esperado

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_