### PR TITLE
fix(credential-pool): correct pool rotation when weekly usage limit is reached

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -588,6 +588,8 @@ def recover_with_credential_pool(
             context_message = str(error_context.get("message") or "").lower()
             usage_limit_reached = (
                 "usage_limit_reached" in context_reason
+                or "gousagelimit" in context_reason
+                or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
             )
         if not has_retried_429 and not usage_limit_reached:
@@ -2066,19 +2068,33 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
     if "reset_at" not in context:
         message = context.get("message") or ""
         if isinstance(message, str):
-            delay_match = re.search(r"quotaResetDelay[:\s\"]+(\\d+(?:\\.\\d+)?)(ms|s)", message, re.IGNORECASE)
+            delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
             if delay_match:
                 value = float(delay_match.group(1))
                 seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
                 context["reset_at"] = time.time() + seconds
             else:
-                sec_match = re.search(
-                    r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+                resets_in_match = re.search(
+                    r"resets?\s+in\s+"
+                    r"(?:(\d+(?:\.\d+)?)\s*(?:h|hr|hrs|hour|hours)\b\s*)?"
+                    r"(?:(\d+(?:\.\d+)?)\s*(?:m|min|mins|minute|minutes)\b\s*)?"
+                    r"(?:(\d+(?:\.\d+)?)\s*(?:s|sec|secs|second|seconds)\b)?",
                     message,
                     re.IGNORECASE,
                 )
-                if sec_match:
-                    context["reset_at"] = time.time() + float(sec_match.group(1))
+                if resets_in_match and any(resets_in_match.groups()):
+                    hours = float(resets_in_match.group(1) or 0)
+                    minutes = float(resets_in_match.group(2) or 0)
+                    seconds = float(resets_in_match.group(3) or 0)
+                    context["reset_at"] = time.time() + (hours * 3600) + (minutes * 60) + seconds
+                else:
+                    sec_match = re.search(
+                        r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+                        message,
+                        re.IGNORECASE,
+                    )
+                    if sec_match:
+                        context["reset_at"] = time.time() + float(sec_match.group(1))
 
     return context
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1406,6 +1406,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
     for provider_id, pconfig in PROVIDER_REGISTRY.items():
         if pconfig.auth_type != "api_key":
             continue
+        if _is_provider_unhealthy(provider_id):
+            logger.debug("Auxiliary api-key chain: %s is unhealthy, skipping", provider_id)
+            continue
         if provider_id == "anthropic":
             # Only try anthropic when the user has explicitly configured it.
             # Without this gate, Claude Code credentials get silently used
@@ -2260,11 +2263,12 @@ def _is_payment_error(exc: Exception) -> bool:
             "credits", "insufficient funds",
             "can only afford", "billing",
             "payment required",
-            # Daily / monthly quota exhaustion keywords
+            # Daily / monthly / weekly quota exhaustion keywords
             "quota exceeded", "quota_exceeded",
             "too many tokens per day", "daily limit",
             "tokens per day", "daily quota",
             "resource exhausted",  # Vertex AI / gRPC quota errors
+            "weekly usage limit", "weekly limit",  # OpenCode Go weekly subscription cap
         )):
             return True
     return False
@@ -2478,7 +2482,11 @@ def _pool_error_context(exc: Exception) -> Dict[str, Any]:
     return payload
 
 
-def _recoverable_pool_provider(resolved_provider: str, client: Any) -> Optional[str]:
+def _recoverable_pool_provider(
+    resolved_provider: str,
+    client: Any,
+    main_runtime: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
     """Infer which provider pool can recover the current auxiliary client."""
     normalized = _normalize_aux_provider(resolved_provider)
     if normalized not in {"", "auto", "custom"}:
@@ -2496,11 +2504,33 @@ def _recoverable_pool_provider(resolved_provider: str, client: Any) -> Optional[
         return "copilot"
     if base_url_host_matches(base, "api.kimi.com"):
         return "kimi-coding"
+    # For api_key providers not in the hardcoded list (e.g. opencode-go), match
+    # the client base URL against all registered api_key providers so that
+    # credential-pool rotation works for any provider the user configured.
+    if main_runtime:
+        rt = _normalize_main_runtime(main_runtime)
+        rt_provider = rt.get("provider", "")
+        if rt_provider and rt_provider not in {"", "auto", "custom"}:
+            try:
+                from hermes_cli.auth import PROVIDER_REGISTRY
+                pconfig = PROVIDER_REGISTRY.get(rt_provider)
+                if pconfig and getattr(pconfig, "auth_type", None) == "api_key":
+                    rt_base = str(getattr(pconfig, "inference_base_url", "") or "").rstrip("/")
+                    if rt_base and base_url_host_matches(base, base_url_hostname(rt_base)):
+                        return rt_provider
+            except Exception:
+                pass
     return None
 
 
-def _recover_provider_pool(provider: str, exc: Exception) -> bool:
-    """Try same-provider credential-pool recovery for auxiliary calls."""
+def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str = "") -> bool:
+    """Try same-provider credential-pool recovery for auxiliary calls.
+
+    ``failed_api_key`` is the API key that was actually used for the failing
+    request.  Passing it lets mark_exhausted_and_rotate identify the correct
+    pool entry even when another process has already rotated the pool (which
+    would leave current() as None, causing the wrong entry to be marked).
+    """
     normalized = _normalize_aux_provider(provider)
     try:
         pool = load_pool(normalized)
@@ -2512,6 +2542,7 @@ def _recover_provider_pool(provider: str, exc: Exception) -> bool:
 
     status_code = getattr(exc, "status_code", None)
     error_context = _pool_error_context(exc)
+    hint = failed_api_key or None
 
     if _is_auth_error(exc):
         refreshed = pool.try_refresh_current()
@@ -2521,6 +2552,7 @@ def _recover_provider_pool(provider: str, exc: Exception) -> bool:
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else 401,
             error_context=error_context,
+            api_key_hint=hint,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -2532,6 +2564,7 @@ def _recover_provider_pool(provider: str, exc: Exception) -> bool:
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context,
+            api_key_hint=hint,
         )
         if next_entry is not None:
             _evict_cached_clients(normalized)
@@ -2936,6 +2969,11 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
             resolved_provider = "custom"
             explicit_base_url = runtime_base_url
             explicit_api_key = runtime_api_key or None
+        elif runtime_api_key:
+            # Pin auxiliary to the same api_key as the active main chat session
+            # so that a working key is reused instead of re-selecting from the pool
+            # (which might pick a different, potentially exhausted key).
+            explicit_api_key = runtime_api_key
         # Skip Step-1 if the main provider was recently 402'd. The unhealthy
         # cache TTL bounds how long we bypass it, so a topped-up account
         # recovers automatically. If we tried Step-1 anyway, every aux call
@@ -4300,13 +4338,25 @@ def _get_cached_client(
             else:
                 effective = _compat_model(cached_client, model, cached_default)
                 return cached_client, effective
-    # Build outside the lock
+    # Build outside the lock.
+    # For pool-backed api_key providers, derive the active API key from the
+    # pool entry rather than from env vars.  resolve_api_key_provider_credentials
+    # always prefers env vars (first-entry bias), which bypasses pool rotation:
+    # after key #1 is marked exhausted the retry would still get key #1 from
+    # the env var and fail again, causing the retry2_err handler to mark key #2.
+    effective_api_key = api_key
+    if not effective_api_key:
+        _pe = _peek_pool_entry(_normalize_aux_provider(provider))
+        if _pe is not None:
+            _pk = _pool_runtime_api_key(_pe)
+            if _pk:
+                effective_api_key = _pk
     client, default_model = resolve_provider_client(
         provider,
         model,
         async_mode,
         explicit_base_url=base_url,
-        explicit_api_key=api_key,
+        explicit_api_key=effective_api_key,
         api_mode=api_mode,
         main_runtime=runtime,
         is_vision=is_vision,
@@ -4920,10 +4970,17 @@ def call_llm(
                 )
 
         # ── Same-provider credential-pool recovery ─────────────────────
-        pool_provider = _recoverable_pool_provider(resolved_provider, client)
+        pool_provider = _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime)
+        # Capture the exact API key used so mark_exhausted_and_rotate can find
+        # the correct pool entry even when another process rotated the pool
+        # between this call and recovery (which leaves current()=None and makes
+        # _select_unlocked() return the NEXT key by mistake).
+        _client_api_key = str(getattr(client, "api_key", "") or "")
         if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
             recovery_err = first_err
-            if _is_rate_limit_error(first_err):
+            # Skip the extra retry for clear payment/quota errors — the endpoint
+            # won't accept another request with the same exhausted key.
+            if _is_rate_limit_error(first_err) and not _is_payment_error(first_err):
                 try:
                     return _validate_llm_response(
                         client.chat.completions.create(**kwargs), task)
@@ -4931,27 +4988,40 @@ def call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err):
+            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key):
                 logger.info(
                     "Auxiliary %s: recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
                 )
-                return _retry_same_provider_sync(
-                    task=task,
-                    resolved_provider=resolved_provider,
-                    resolved_model=resolved_model,
-                    resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
-                    resolved_api_mode=resolved_api_mode,
-                    main_runtime=main_runtime,
-                    final_model=final_model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    effective_timeout=effective_timeout,
-                    effective_extra_body=effective_extra_body,
-                )
+                try:
+                    return _retry_same_provider_sync(
+                        task=task,
+                        resolved_provider=resolved_provider,
+                        resolved_model=resolved_model,
+                        resolved_base_url=resolved_base_url,
+                        resolved_api_key=resolved_api_key,
+                        resolved_api_mode=resolved_api_mode,
+                        main_runtime=main_runtime,
+                        final_model=final_model,
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        effective_timeout=effective_timeout,
+                        effective_extra_body=effective_extra_body,
+                    )
+                except Exception as retry2_err:
+                    # The rotated key also hit a quota/auth wall.  Mark it
+                    # immediately so concurrent processes don't make a
+                    # redundant API call to discover it's exhausted too.
+                    # Then fall through to the payment fallback below so
+                    # alternative providers can still serve the request.
+                    if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
+                            or _is_rate_limit_error(retry2_err)):
+                        _recover_provider_pool(pool_provider, retry2_err)
+                        first_err = retry2_err
+                    else:
+                        raise
 
         # ── Payment / credit exhaustion fallback ──────────────────────
         # When the resolved provider returns 402 or a credit-related error,
@@ -4993,7 +5063,7 @@ def call_llm(
                 # 402). Mark THAT label unhealthy so subsequent aux calls
                 # skip it instead of paying another doomed RTT.
                 _mark_provider_unhealthy(
-                    _recoverable_pool_provider(resolved_provider, client) or resolved_provider
+                    _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime) or resolved_provider
                 )
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
@@ -5299,10 +5369,13 @@ async def async_call_llm(
                 )
 
         # ── Same-provider credential-pool recovery (mirrors sync) ─────
-        pool_provider = _recoverable_pool_provider(resolved_provider, client)
+        pool_provider = _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime)
+        _client_api_key = str(getattr(client, "api_key", "") or "")
         if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
             recovery_err = first_err
-            if _is_rate_limit_error(first_err):
+            # Skip the extra retry for clear payment/quota errors — the endpoint
+            # won't accept another request with the same exhausted key.
+            if _is_rate_limit_error(first_err) and not _is_payment_error(first_err):
                 try:
                     return _validate_llm_response(
                         await client.chat.completions.create(**kwargs), task)
@@ -5310,26 +5383,34 @@ async def async_call_llm(
                     if not (_is_auth_error(retry_err) or _is_payment_error(retry_err) or _is_rate_limit_error(retry_err)):
                         raise
                     recovery_err = retry_err
-            if _recover_provider_pool(pool_provider, recovery_err):
+            if _recover_provider_pool(pool_provider, recovery_err, failed_api_key=_client_api_key):
                 logger.info(
                     "Auxiliary %s (async): recovered %s via credential-pool rotation after %s",
                     task or "call", pool_provider, type(recovery_err).__name__,
                 )
-                return await _retry_same_provider_async(
-                    task=task,
-                    resolved_provider=resolved_provider,
-                    resolved_model=resolved_model,
-                    resolved_base_url=resolved_base_url,
-                    resolved_api_key=resolved_api_key,
-                    resolved_api_mode=resolved_api_mode,
-                    final_model=final_model,
-                    messages=messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    effective_timeout=effective_timeout,
-                    effective_extra_body=effective_extra_body,
-                )
+                try:
+                    return await _retry_same_provider_async(
+                        task=task,
+                        resolved_provider=resolved_provider,
+                        resolved_model=resolved_model,
+                        resolved_base_url=resolved_base_url,
+                        resolved_api_key=resolved_api_key,
+                        resolved_api_mode=resolved_api_mode,
+                        final_model=final_model,
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        effective_timeout=effective_timeout,
+                        effective_extra_body=effective_extra_body,
+                    )
+                except Exception as retry2_err:
+                    if (_is_payment_error(retry2_err) or _is_auth_error(retry2_err)
+                            or _is_rate_limit_error(retry2_err)):
+                        _recover_provider_pool(pool_provider, retry2_err)
+                        first_err = retry2_err
+                    else:
+                        raise
 
         # ── Payment / connection / rate-limit fallback (mirrors sync call_llm) ──
         should_fallback = (

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -249,6 +249,16 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
     if sec_match:
         return float(sec_match.group(1))
+    # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits
+    hr_min_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\s+(\d+)\s*min", message, re.IGNORECASE)
+    if hr_min_match:
+        return int(hr_min_match.group(1)) * 3600 + int(hr_min_match.group(2)) * 60
+    hr_only_match = re.search(r"resets?\s+in\s+(\d+)\s*hr\b", message, re.IGNORECASE)
+    if hr_only_match:
+        return int(hr_only_match.group(1)) * 3600
+    min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
+    if min_only_match:
+        return int(min_only_match.group(1)) * 60
     return None
 
 
@@ -1265,9 +1275,21 @@ class CredentialPool:
         *,
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
+        api_key_hint: Optional[str] = None,
     ) -> Optional[PooledCredential]:
         with self._lock:
-            entry = self.current() or self._select_unlocked()
+            entry = None
+            if api_key_hint:
+                # Prefer the specific entry whose API key matches the one that
+                # actually failed.  When this pool was freshly loaded from disk
+                # (another process already rotated), current() is None and
+                # _select_unlocked() would return the NEXT key — the wrong one.
+                entry = next(
+                    (e for e in self._entries if e.runtime_api_key == api_key_hint),
+                    None,
+                )
+            if entry is None:
+                entry = self.current() or self._select_unlocked()
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4135,6 +4135,238 @@ class TestCredentialPoolRecovery:
         assert captured["status_code"] == 429
         assert captured["error_context"]["reason"] == "device_code_exhausted"
 
+    def test_mark_exhausted_and_rotate_api_key_hint_when_current_is_none(self, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED
+
+        # Suppress file I/O — these tests exercise in-memory pool state only.
+        monkeypatch.setattr(CredentialPool, "_persist", lambda self: None)
+
+        entry1 = PooledCredential(
+            provider="opencode-go",
+            id="key-a",
+            label="primary",
+            auth_type="api_key",
+            priority=0,
+            source="manual",
+            access_token="sk-key-a",
+        )
+        entry2 = PooledCredential(
+            provider="opencode-go",
+            id="key-b",
+            label="secondary",
+            auth_type="api_key",
+            priority=1,
+            source="manual",
+            access_token="sk-key-b",
+        )
+        pool = CredentialPool("opencode-go", [entry1, entry2])
+        # Simulate the TOCTOU race: another process already rotated, so _current_id is None.
+        pool._current_id = None
+
+        result = pool.mark_exhausted_and_rotate(
+            api_key_hint="sk-key-b",
+            status_code=429,
+            error_context={"reason": "usage_limit_reached"},
+        )
+
+        entries_by_id = {e.id: e for e in pool._entries}
+        # Only the entry whose key matched the hint should be exhausted.
+        assert entries_by_id["key-b"].last_status == STATUS_EXHAUSTED
+        assert entries_by_id["key-a"].last_status != STATUS_EXHAUSTED
+        # Pool must have rotated to the remaining healthy entry.
+        assert result is not None
+        assert result.id == "key-a"
+        assert pool.current() is not None
+        assert pool.current().id == "key-a"
+
+    def test_mark_exhausted_and_rotate_api_key_hint_normal_rotation(self, monkeypatch):
+        """Normal case: pool is healthy, api_key_hint correctly identifies the failed key."""
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED
+
+        monkeypatch.setattr(CredentialPool, "_persist", lambda self: None)
+
+        entry1 = PooledCredential(
+            provider="opencode-go",
+            id="key-a",
+            label="primary",
+            auth_type="api_key",
+            priority=0,
+            source="manual",
+            access_token="sk-key-a",
+        )
+        entry2 = PooledCredential(
+            provider="opencode-go",
+            id="key-b",
+            label="secondary",
+            auth_type="api_key",
+            priority=1,
+            source="manual",
+            access_token="sk-key-b",
+        )
+        pool = CredentialPool("opencode-go", [entry1, entry2])
+        # Simulate normal operation: pool has selected its first entry.
+        pool._current_id = "key-a"
+        assert pool.current() is not None
+        assert pool.current().id == "key-a"
+
+        # key-a hits 429 → api_key_hint identifies it
+        result = pool.mark_exhausted_and_rotate(
+            api_key_hint="sk-key-a",
+            status_code=429,
+            error_context={"reason": "usage_limit_reached"},
+        )
+
+        entries_by_id = {e.id: e for e in pool._entries}
+        # Only key-a should be exhausted.
+        assert entries_by_id["key-a"].last_status == STATUS_EXHAUSTED
+        assert entries_by_id["key-b"].last_status != STATUS_EXHAUSTED
+        # Pool rotates to key-b.
+        assert result is not None
+        assert result.id == "key-b"
+        assert pool.current().id == "key-b"
+
+    def test_mark_exhausted_and_rotate_exhausts_all_keys_returns_none(self, monkeypatch):
+        """Exhaust both keys: first rotation succeeds, second returns None."""
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED
+
+        monkeypatch.setattr(CredentialPool, "_persist", lambda self: None)
+
+        entry1 = PooledCredential(
+            provider="opencode-go",
+            id="key-a",
+            label="first",
+            auth_type="api_key",
+            priority=0,
+            source="manual",
+            access_token="sk-key-a",
+        )
+        entry2 = PooledCredential(
+            provider="opencode-go",
+            id="key-b",
+            label="second",
+            auth_type="api_key",
+            priority=1,
+            source="manual",
+            access_token="sk-key-b",
+        )
+        pool = CredentialPool("opencode-go", [entry1, entry2])
+        pool._current_id = "key-a"
+
+        # Exhaust key-a.
+        result1 = pool.mark_exhausted_and_rotate(
+            api_key_hint="sk-key-a",
+            status_code=429,
+            error_context={"reason": "usage_limit_reached"},
+        )
+        assert result1 is not None
+        assert result1.id == "key-b"
+        assert pool.current().id == "key-b"
+
+        # Exhaust key-b — nothing left.
+        result2 = pool.mark_exhausted_and_rotate(
+            api_key_hint="sk-key-b",
+            status_code=429,
+        )
+        assert result2 is None
+        assert pool.current() is None
+
+    def test_mark_exhausted_and_rotate_hint_matches_already_exhausted_entry(self, monkeypatch):
+        """api_key_hint matches an entry that another process already exhausted.
+        
+        Simulates the worst TOCTOU: Process A exhausted key-b, Process B still
+        has api_key_hint=sk-key-b but the entry is already STATUS_EXHAUSTED.
+        Should not crash or double-exhaust — falls through to _select_unlocked()."""
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED
+
+        monkeypatch.setattr(CredentialPool, "_persist", lambda self: None)
+
+        entry1 = PooledCredential(
+            provider="opencode-go",
+            id="key-a",
+            label="first",
+            auth_type="api_key",
+            priority=0,
+            source="manual",
+            access_token="sk-key-a",
+        )
+        entry2 = PooledCredential(
+            provider="opencode-go",
+            id="key-b",
+            label="second",
+            auth_type="api_key",
+            priority=1,
+            source="manual",
+            access_token="sk-key-b",
+        )
+        entry3 = PooledCredential(
+            provider="opencode-go",
+            id="key-c",
+            label="third",
+            auth_type="api_key",
+            priority=2,
+            source="manual",
+            access_token="sk-key-c",
+        )
+        pool = CredentialPool("opencode-go", [entry1, entry2, entry3])
+        pool._current_id = None
+
+        # Another process already exhausted key-b.
+        entry2.last_status = STATUS_EXHAUSTED
+
+        # Process B still has api_key_hint=sk-key-b → finds key-b, but it's
+        # already exhausted. Must fall through to the next available entry.
+        result = pool.mark_exhausted_and_rotate(
+            api_key_hint="sk-key-b",
+            status_code=429,
+        )
+
+        assert result is not None
+        # Pool skips the already-exhausted key-b and rotates to key-a,
+        # but does NOT mark key-a exhausted — key-a didn't fail.
+        assert result.id == "key-a"
+        entries_by_id = {e.id: e for e in pool._entries}
+        assert entries_by_id["key-b"].last_status == STATUS_EXHAUSTED  # already was
+        assert entries_by_id["key-a"].last_status != STATUS_EXHAUSTED  # preserved
+        assert entries_by_id["key-c"].last_status != STATUS_EXHAUSTED  # preserved
+
+    def test_mark_exhausted_and_rotate_api_key_hint_fallback_when_no_match(self, monkeypatch):
+        from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED
+
+        monkeypatch.setattr(CredentialPool, "_persist", lambda self: None)
+
+        entry1 = PooledCredential(
+            provider="opencode-go",
+            id="key-a",
+            label="first",
+            auth_type="api_key",
+            priority=0,
+            source="manual",
+            access_token="sk-key-a",
+        )
+        entry2 = PooledCredential(
+            provider="opencode-go",
+            id="key-b",
+            label="second",
+            auth_type="api_key",
+            priority=1,
+            source="manual",
+            access_token="sk-key-b",
+        )
+        pool = CredentialPool("opencode-go", [entry1, entry2])
+        pool._current_id = None
+
+        # A hint that matches no entry must not crash; it falls back to
+        # _select_unlocked(), which picks the first available entry (priority 0).
+        result = pool.mark_exhausted_and_rotate(
+            api_key_hint="sk-nonexistent-key",
+            status_code=429,
+        )
+
+        entries_by_id = {e.id: e for e in pool._entries}
+        assert entries_by_id["key-a"].last_status == STATUS_EXHAUSTED
+        assert result is not None
+        assert result.id == "key-b"
+
 
 class TestMaxTokensParam:
     """Verify _max_tokens_param returns the correct key for each provider."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4089,6 +4089,25 @@ class TestCredentialPoolRecovery:
         assert context["reason"] == "usage_limit_reached"
         assert context["message"] == "The usage limit has been reached"
 
+    def test_extract_api_error_context_parses_resets_in_hours_and_minutes(self, agent, monkeypatch):
+        from agent import agent_runtime_helpers
+
+        monkeypatch.setattr(agent_runtime_helpers.time, "time", lambda: 1_000.0)
+        error = SimpleNamespace(
+            body={
+                "error": {
+                    "type": "GoUsageLimitError",
+                    "message": "Weekly usage limit reached. Resets in 6hr 29min.",
+                }
+            },
+            response=SimpleNamespace(headers={}),
+        )
+
+        context = agent._extract_api_error_context(error)
+
+        assert context["reason"] == "GoUsageLimitError"
+        assert context["reset_at"] == 1_000.0 + (6 * 60 * 60) + (29 * 60)
+
     def test_recover_with_pool_passes_error_context_on_rotated_429(self, agent):
         next_entry = SimpleNamespace(label="secondary")
         captured = {}


### PR DESCRIPTION
## What does this PR do?

Fix credential pool rotation when a provider returns a usage-limit error (e.g., OpenCode Go `"Weekly usage limit reached. Resets in 6hr 29min"`).

### Root cause — Two independent bugs, same symptom

When key #1 hits its weekly limit, both the CLI and the gateway call `maybe_auto_title` as **separate processes sharing `auth.json`**. Two bugs compound to produce the same outcome: **both keys end up marked exhausted even though only key #1 was at fault.**

---

**Bug 1 — env-var bias (PRIMARY)**

`_get_cached_client` calls `resolve_api_key_provider_credentials`, which always prefers env vars (`OPENCODE_GO_API_KEY`) over the credential pool. After the pool rotates to key #2, every retry still gets key #1 from the env var:

```
key #1 → 429 → pool rotates to key #2
retry  → resolve_api_key_provider_credentials → env var → key #1 AGAIN → 429
retry2 → error handler marks key #2 exhausted   ← BUG: marks wrong key
```

**Fix:** peek the pool in `_get_cached_client` and pass the active entry's key as `explicit_api_key` to `resolve_provider_client`, bypassing the env-var lookup entirely.

---

**Bug 2 — TOCTOU race (SECONDARY)**

CLI and gateway are two separate processes. When both hit a 429 concurrently, each loads a fresh pool from disk where `current_id=None`. Without knowing which key actually failed:

```
T1: Agent (CLI)              T2: Title Gen (gateway)       T3: auth.json (disk)
─────────────────────────────────────────────────────────────────────────────────
t=0  key #1 active
t=1  call API → 429           call API → key #1
t=2  mark_exhausted()          mark_exhausted()             CLI writes exhausted
     → rotates to key #2       → rotates to key #2          Gateway writes exhausted
t=3  _get_cached_client()      _get_cached_client()           NOW BOTH ENTRY 1
     → env OPENCODE_GO_KEY      → env OPENCODE_GO_KEY         AND ENTRY 2 ARE
     → RETURNS KEY #1 !!!       → RETURNS KEY #1 !!!          MARKED EXHAUSTED
```

**The TOCTOU:** `mark_exhausted_and_rotate()` falls back to `_select_unlocked()` when `current_id` is `None` — which returns key #2 (the next *available* key), not key #1 (the one that actually failed).

**Fix:** capture the exact API key value before the call and pass it as `api_key_hint` to `mark_exhausted_and_rotate`. The hint is matched against pool entries by value, so the correct entry is marked even after a cross-process rotation.

> **Note:** `maybe_auto_title` is the most frequent trigger, but the same race applies to any concurrent auxiliary consumer sharing `auth.json` — smart approval, session auto-title, and compression all call through the same pool.

---

```
┌──────────────────────────────────────────────────┐
│                Hermes Agent                      │
│  ┌──────────┐  ┌──────────┐  ┌──────────┐        │
│  │   CLI    │  │ Gateway  │  │  Title   │        │
│  │ (client) │  │ (client) │  │   Gen    │        │
│  └────┬─────┘  └────┬─────┘  └────┬─────┘        │
│       │     "give me a key"       │              │
│       └──────────────┬────────────┘              │
│                      ▼                           │
│          ┌───────────────────┐                   │
│          │  Credential Pool  │ ← api_key_hint    │
│          │  ┌─────────────┐  │   identifies the  │
│          │  │ key #1  ✓   │  │   CORRECT entry   │
│          │  │ key #2  ✓   │  │                   │
│          │  └─────────────┘  │                   │
│          └───────────────────┘                   │
└──────────────────────────────────────────────────┘
```

## Related Issue

No tracking issue — discovered during daily use with a multi-key credential pool hitting OpenCode Go weekly limits. The auxiliary title generation was poisoning the pool by marking the wrong key exhausted.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py`: `mark_exhausted_and_rotate` accepts optional `api_key_hint`; `_extract_retry_delay_seconds` parses `"Resets in Xhr Ymin"`
- `agent/agent_runtime_helpers.py`: detect `GoUsageLimitError` + `"usage limit reached"`; parse `"resets in"` in `extract_api_error_context`
- `agent/auxiliary_client.py`: peek pool for `explicit_api_key` in `_get_cached_client`; pass `api_key_hint` through recovery
- `tests/run_agent/test_run_agent.py`: test for `"Resets in 6hr 29min"` parsing

## How to Test

### Unit test

```bash
pytest tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery -q
# 11 passed, including test_extract_api_error_context_parses_resets_in_hours_and_minutes
```

### Manual end-to-end test

1. **Setup** — add 2+ keys to the pool:

```bash
hermes auth add   # key #1: sk-a1b2c3...
hermes auth add   # key #2: sk-d4e5f6...
hermes auth list
# ┌─────────┬──────────┬───────────┐
# │ #1  ✓   │ #2  ✓    │ (both OK) │
# └─────────┴──────────┴───────────┘
```

2. **Trigger Bug 1 (env-var bias)** — chat until key #1 hits its weekly limit:

```bash
hermes
# > send several messages until you see:
#   "⚠ Auxiliary title generation failed: HTTP 429: Weekly usage limit reached"
```

3. **Before fix (expected bug):**

```bash
hermes auth list
# ┌──────────────┬──────────────┬──────────────────┐
# │ #1 EXHAUSTED │ #2 EXHAUSTED │  ← BOTH dead     │
# └──────────────┴──────────────┴──────────────────┘
```

4. **After fix (expected behavior):**

```bash
hermes auth list
# ┌──────────────┬──────────┬─────────────────────┐
# │ #1 EXHAUSTED │ #2  ✓    │  ← rotates to #2    │
# └──────────────┴──────────┴─────────────────────┘
```

5. **Trigger Bug 2 (TOCTOU race)** — with the gateway running, restart it while a chat is active:

```bash
hermes gateway restart   # two processes now race on auth.json
hermes auth list         # Before fix: both marked exhausted
                         # After fix:  only the correct entry marked
```

6. **Recovery** — reset exhausted keys and verify they come back:

```bash
hermes auth reset opencode-go     # clear exhaustion status
hermes auth list
# ┌─────────┬──────────┬───────────┐
# │ #1  ✓   │ #2  ✓    │ (normal)  │
# └─────────┴──────────┴───────────┘
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run `pytest tests/ -q` and all tests pass (`TestCredentialPoolRecovery`: 11/11 passed)
- [x] I have added tests for my changes
- [x] I have tested on my platform: Arch Linux (zen kernel)

### Documentation & Housekeeping

- [x] I have updated relevant documentation — N/A
- [x] I have updated cli-config.yaml.example if I added/changed config keys — N/A
- [x] I have updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact — N/A (pure Python string parsing)
- [x] I have updated tool descriptions/schemas if I changed tool behavior — N/A
