### PR TITLE
fix(memory): filter framework artifacts before sync

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -25,9 +25,10 @@ Usage in run_agent.py:
 
 from __future__ import annotations
 
+import inspect
+import json
 import logging
 import re
-import inspect
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -57,6 +58,88 @@ def sanitize_context(text: str) -> str:
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
     return text
+
+
+_TEXT_BLOCK_TYPES = {"text", "input_text"}
+_IMAGE_BLOCK_TYPES = {"image_url", "input_image"}
+_AUDIO_BLOCK_TYPES = {"audio", "input_audio"}
+_VIDEO_BLOCK_TYPES = {"video", "input_video"}
+_MEDIA_BLOCK_MARKERS = {
+    "image": "[image attached]",
+    "audio": "[audio attached]",
+    "video": "[video attached]",
+}
+
+
+def normalize_memory_turn_content(content: Any) -> str:
+    """Convert turn content to plain text before provider sync.
+
+    Some gateway/model paths represent multimodal messages as OpenAI-style
+    content block lists. Memory providers expect text; passing raw lists can
+    crash providers, and serializing the blocks verbatim may persist base64
+    media payloads. Keep human text and replace media blocks with short
+    markers.
+    """
+    normalized = _flatten_rich_content(content)
+    return sanitize_context(normalized).strip()
+
+
+def _flatten_rich_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        parsed = _parse_serialized_content_blocks(content)
+        if parsed is not None:
+            return _flatten_content_blocks(parsed)
+        return content
+    if isinstance(content, list):
+        return _flatten_content_blocks(content)
+    if isinstance(content, dict):
+        block = _flatten_content_block(content)
+        return block if block is not None else json.dumps(content, ensure_ascii=False)
+    return str(content)
+
+
+def _parse_serialized_content_blocks(content: str) -> Optional[list[Any]]:
+    stripped = content.strip()
+    if not stripped.startswith("["):
+        return None
+    try:
+        parsed = json.loads(stripped)
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, list) else None
+
+
+def _flatten_content_blocks(blocks: list[Any]) -> str:
+    parts: list[str] = []
+    saw_known_block = False
+    for block in blocks:
+        flattened = _flatten_content_block(block)
+        if flattened is None:
+            continue
+        saw_known_block = True
+        if flattened:
+            parts.append(flattened)
+    if saw_known_block:
+        return "\n\n".join(parts)
+    return json.dumps(blocks, ensure_ascii=False)
+
+
+def _flatten_content_block(block: Any) -> Optional[str]:
+    if not isinstance(block, dict):
+        return None
+    block_type = block.get("type")
+    if block_type in _TEXT_BLOCK_TYPES:
+        text = block.get("text")
+        return text.strip() if isinstance(text, str) else ""
+    if block_type in _IMAGE_BLOCK_TYPES:
+        return _MEDIA_BLOCK_MARKERS["image"]
+    if block_type in _AUDIO_BLOCK_TYPES:
+        return _MEDIA_BLOCK_MARKERS["audio"]
+    if block_type in _VIDEO_BLOCK_TYPES:
+        return _MEDIA_BLOCK_MARKERS["video"]
+    return None
 
 
 class StreamingContextScrubber:
@@ -368,11 +451,13 @@ class MemoryManager:
 
     # -- Sync ----------------------------------------------------------------
 
-    def sync_all(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_all(self, user_content: Any, assistant_content: Any, *, session_id: str = "") -> None:
         """Sync a completed turn to all providers."""
+        user_text = normalize_memory_turn_content(user_content)
+        assistant_text = normalize_memory_turn_content(assistant_content)
         for provider in self._providers:
             try:
-                provider.sync_turn(user_content, assistant_content, session_id=session_id)
+                provider.sync_turn(user_text, assistant_text, session_id=session_id)
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' sync_turn failed: %s",

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -69,6 +69,31 @@ _MEDIA_BLOCK_MARKERS = {
     "audio": "[audio attached]",
     "video": "[video attached]",
 }
+_MAX_MEMORY_SYNC_CHARS = 8000
+_MEMORY_SYNC_BOILERPLATE_PREFIXES = (
+    "[IMPORTANT: The user has invoked",
+    "[CONTEXT COMPACTION",
+    "[System note:",
+    "Knowledge cutoff:",
+    "# Tools",
+    "# Instructions",
+)
+_MEMORY_SYNC_BOILERPLATE_MARKERS = (
+    "<memory-context>",
+    "<available_skills>",
+    "## Skills (mandatory)",
+    "Tool definitions",
+    "namespace functions",
+    "full skill content is loaded below",
+    "AGENTS.md",
+    "════════════════════════════════",
+)
+_MEMORY_SYNC_BINARY_PAYLOAD_MARKERS = (
+    "data:image/",
+    "data:video/",
+    "data:audio/",
+    ";base64,",
+)
 
 
 def normalize_memory_turn_content(content: Any) -> str:
@@ -80,8 +105,23 @@ def normalize_memory_turn_content(content: Any) -> str:
     media payloads. Keep human text and replace media blocks with short
     markers.
     """
-    normalized = _flatten_rich_content(content)
-    return sanitize_context(normalized).strip()
+    normalized = sanitize_context(_flatten_rich_content(content)).strip()
+    if not _should_store_memory_turn_content(normalized):
+        return ""
+    return normalized[:_MAX_MEMORY_SYNC_CHARS].rstrip()
+
+
+def _should_store_memory_turn_content(content: str) -> bool:
+    stripped = content.lstrip()
+    if not stripped:
+        return False
+    if any(stripped.startswith(prefix) for prefix in _MEMORY_SYNC_BOILERPLATE_PREFIXES):
+        return False
+    if any(marker in content for marker in _MEMORY_SYNC_BOILERPLATE_MARKERS):
+        return False
+    if any(marker in content for marker in _MEMORY_SYNC_BINARY_PAYLOAD_MARKERS):
+        return False
+    return True
 
 
 def _flatten_rich_content(content: Any) -> str:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -268,6 +268,39 @@ class TestMemoryManager:
 
         assert provider.synced_turns == [("Describe this\n\n[image attached]", "ok")]
 
+    def test_sync_all_drops_framework_boilerplate_per_side(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            '[IMPORTANT: The user has invoked the "hermes-agent" skill. Full skill content follows.]',
+            "Normal assistant response",
+        )
+
+        assert provider.synced_turns == [("", "Normal assistant response")]
+
+    def test_sync_all_drops_raw_base64_payloads_but_keeps_media_markers(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            "Here is an inline payload: data:image/png;base64,AAAA",
+            [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}],
+        )
+
+        assert provider.synced_turns == [("", "[image attached]")]
+
+    def test_sync_all_caps_excessive_turn_content(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all("x" * 9000, "ok")
+
+        assert provider.synced_turns == [("x" * 8000, "ok")]
+
     def test_sync_failure_doesnt_block_others(self):
         """If one provider's sync fails, others still run."""
         mgr = MemoryManager()

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -236,6 +236,38 @@ class TestMemoryManager:
         assert p1.synced_turns == [("user msg", "assistant msg")]
         assert p2.synced_turns == [("user msg", "assistant msg")]
 
+    def test_sync_all_normalizes_python_multimodal_blocks(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            [
+                {"type": "text", "text": "What is in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AAAA"},
+                },
+            ],
+            [{"type": "text", "text": "A red square."}],
+        )
+
+        assert provider.synced_turns == [
+            ("What is in this image?\n\n[image attached]", "A red square.")
+        ]
+
+    def test_sync_all_normalizes_serialized_multimodal_blocks(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        mgr.sync_all(
+            '[{"type":"input_text","text":"Describe this"},{"type":"input_image","image_url":"data:image/png;base64,AAAA"}]',
+            "ok",
+        )
+
+        assert provider.synced_turns == [("Describe this\n\n[image attached]", "ok")]
+
     def test_sync_failure_doesnt_block_others(self):
         """If one provider's sync fails, others still run."""
         mgr = MemoryManager()


### PR DESCRIPTION
## Summary
- add a centralized memory-sync hygiene guard in `MemoryManager`
- drop obvious Hermes framework artifacts per side before provider sync
- drop raw base64 media payloads while preserving normalized media markers from #32030
- cap excessive synced turn content at 8k chars

## Stack
Draft and stacked on #32030. Please review/merge #32030 first; this follow-up is intentionally framed as provider-agnostic memory hygiene rather than Honcho-specific behavior.

## Test Plan
- `pytest tests/agent/test_memory_provider.py tests/agent/test_memory_session_switch.py tests/honcho_plugin/test_session.py::TestConcludeToolDispatch -q`

Refs #3943