### PR TITLE
fix(utils): unify YAML list indent across all config writers (#31999)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1219,23 +1219,13 @@ class TelegramAdapter(BasePlatformAdapter):
                         break
 
             if changed:
-                fd, tmp_path = tempfile.mkstemp(
-                    dir=str(config_path.parent),
-                    suffix=".tmp",
-                    prefix=".config_",
-                )
-                try:
-                    with os.fdopen(fd, "w", encoding="utf-8") as f:
-                        _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-                        f.flush()
-                        os.fsync(f.fileno())
-                    atomic_replace(tmp_path, config_path)
-                except BaseException:
-                    try:
-                        os.unlink(tmp_path)
-                    except OSError:
-                        pass
-                    raise
+                # Use the shared writer so this path emits the same
+                # 2-indent layout as every other config writer (#31999).
+                # Without IndentDumper the dm_topics list would flip to
+                # 0-indent every time Telegram persisted a thread_id,
+                # corrupting the file alongside other writers' output.
+                from utils import atomic_yaml_write
+                atomic_yaml_write(config_path, config)
                 logger.info(
                     "[%s] Persisted thread_id=%s for topic '%s' in config.yaml",
                     self.name, thread_id, topic_name,

--- a/tests/test_yaml_indent_consistency_31999.py
+++ b/tests/test_yaml_indent_consistency_31999.py
@@ -1,0 +1,281 @@
+"""Regression tests for #31999 — YAML indent consistency across writers.
+
+The bug: ``utils.atomic_yaml_write`` used default PyYAML, which emits
+"indentless" sequences (list items at column 0 under their parent
+mapping key).  ``utils.atomic_roundtrip_yaml_update`` uses ``ruamel.yaml``
+configured with ``indent(mapping=2, sequence=4, offset=2)``, which emits
+list items at column 2.  When both writers touched the same
+``config.yaml`` (e.g. CLI sets ``/skin`` via ruamel, then the Web UI
+saves via PyYAML), indentation flipped on every save, eventually
+landing in a mixed-indent state that ``js-yaml`` rejects with
+``bad indentation of a mapping entry``.  In production this surfaced
+as the Gateway silently dropping ``custom_providers`` and falling back
+to defaults.
+
+Fix: route ``atomic_yaml_write`` through ``IndentDumper`` (a PyYAML
+``SafeDumper`` subclass that forces ``indentless=False``) so the two
+serializers produce byte-identical layouts.  Also fold the Web UI
+save path (``tui_gateway.server._save_cfg``) and the Telegram DM-topic
+persistence path through the same writer so every config-mutating
+code path emits the same shape.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+import yaml
+
+from utils import IndentDumper, atomic_roundtrip_yaml_update, atomic_yaml_write
+
+
+# ---------------------------------------------------------------------------
+# Shared sample data — exercises the exact list-under-mapping shape from
+# the issue's traceback (``custom_providers``).
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CONFIG = {
+    "custom_providers": [
+        {"name": "NVIDIA", "base_url": "https://api.nvidia.example/v1", "api_key": "x"},
+        {"name": "Together", "base_url": "https://api.together.xyz/v1", "api_key": "y"},
+    ],
+    "platforms": {
+        "telegram": {
+            "extra": {
+                "dm_topics": [
+                    {"chat_id": 1234, "topics": [{"name": "general"}]},
+                ],
+            },
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# IndentDumper: PyYAML output now matches ruamel.yaml byte-for-byte
+# ---------------------------------------------------------------------------
+
+
+class TestIndentDumperShape:
+    """The PyYAML dumper now emits 2-indent list items under mappings."""
+
+    def test_indent_dumper_indents_top_level_list_items(self):
+        """The top-level ``custom_providers`` entries open at column 2."""
+        out = yaml.dump(
+            _SAMPLE_CONFIG,
+            Dumper=IndentDumper,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+        assert "custom_providers:\n  - name: NVIDIA" in out
+
+    def test_default_pyyaml_emits_indentless_list_for_comparison(self):
+        """Sanity check: the un-fixed PyYAML default still emits 0-indent.
+
+        Pins the regression baseline so a future PyYAML behavior change
+        doesn't silently make the fix redundant (or break it).
+        """
+        out = yaml.dump(_SAMPLE_CONFIG, default_flow_style=False, sort_keys=False)
+        # Without IndentDumper, top-level ``custom_providers`` list items
+        # sit at column 0 (immediately after the parent key, no indent).
+        assert "custom_providers:\n- name: NVIDIA" in out
+
+    def test_indent_dumper_round_trips_through_safe_load(self):
+        """Output must still parse back to the same data."""
+        out = yaml.dump(
+            _SAMPLE_CONFIG,
+            Dumper=IndentDumper,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+        loaded = yaml.safe_load(out)
+        assert loaded == _SAMPLE_CONFIG
+
+
+class TestAtomicYamlWriteAndRuamelMatch:
+    """``atomic_yaml_write`` and ``atomic_roundtrip_yaml_update`` agree on layout.
+
+    The whole point of the fix: regardless of which writer the user
+    happens to trip first, every subsequent writer produces the same
+    indentation so the file never flips between styles.
+    """
+
+    def test_atomic_yaml_write_uses_2_indent_lists(self, tmp_path: Path):
+        """The primary writer now emits ruamel-compatible 2-indent lists."""
+        path = tmp_path / "config.yaml"
+        atomic_yaml_write(path, _SAMPLE_CONFIG)
+        text = path.read_text(encoding="utf-8")
+        # Each list item under custom_providers is at column 2.
+        assert "custom_providers:\n  - name: NVIDIA" in text
+        # 0-indent list shape (the broken layout) must NOT appear at the
+        # top level for ``custom_providers``.
+        assert "custom_providers:\n- name:" not in text
+
+    def test_atomic_yaml_write_layout_matches_ruamel_seed(self, tmp_path: Path):
+        """A file seeded by ruamel and re-saved by atomic_yaml_write keeps shape.
+
+        Models the mixed-writer sequence that produced #31999:
+            CLI ``/skin`` (ruamel) → Web UI ``Save`` (atomic_yaml_write).
+        Before the fix the second write toggled the layout and either
+        wiped comments or produced mixed indent.  After the fix the
+        second write leaves the list-item indentation identical.
+        """
+        path = tmp_path / "config.yaml"
+        # First write through ruamel (the CLI single-key-update path).
+        atomic_roundtrip_yaml_update(
+            path, "custom_providers", _SAMPLE_CONFIG["custom_providers"]
+        )
+        ruamel_layout = path.read_text(encoding="utf-8")
+
+        # Now have ``atomic_yaml_write`` rewrite the same data.  The list
+        # column for ``- name:`` items must match.
+        atomic_yaml_write(path, _SAMPLE_CONFIG)
+        pyyaml_layout = path.read_text(encoding="utf-8")
+
+        ruamel_dash_col = next(
+            line.index("- name:")
+            for line in ruamel_layout.splitlines()
+            if "- name:" in line
+        )
+        pyyaml_dash_col = next(
+            line.index("- name:")
+            for line in pyyaml_layout.splitlines()
+            if "- name:" in line
+        )
+        assert ruamel_dash_col == pyyaml_dash_col == 2
+
+    def test_round_trip_pyyaml_then_ruamel_then_pyyaml_stays_consistent(
+        self, tmp_path: Path,
+    ):
+        """The PyYAML/ruamel toggle dance no longer flips layout each pass.
+
+        Reproduces the exact 4-step sequence from the issue's "Steps to
+        Reproduce": fresh save → scanner save → Web UI save → CLI key
+        update.  After the fix every step emits the same 2-indent shape
+        so the file converges instead of bouncing between styles.
+        """
+        path = tmp_path / "config.yaml"
+
+        # Step 1: fresh ``atomic_yaml_write``.
+        atomic_yaml_write(path, _SAMPLE_CONFIG)
+        layout_1 = path.read_text(encoding="utf-8")
+
+        # Step 2: ruamel single-key update (touches one nested value).
+        atomic_roundtrip_yaml_update(path, "ui.skin", "monokai")
+        layout_2 = path.read_text(encoding="utf-8")
+
+        # Step 3: ``atomic_yaml_write`` again (Web UI Save).
+        merged = yaml.safe_load(layout_2) or {}
+        atomic_yaml_write(path, merged)
+        layout_3 = path.read_text(encoding="utf-8")
+
+        # Step 4: another ruamel update.
+        atomic_roundtrip_yaml_update(path, "ui.compact", True)
+        layout_4 = path.read_text(encoding="utf-8")
+
+        # All four files must keep ``custom_providers`` items at column 2
+        # — no flip-flop.  Earlier PyYAML default would have emitted them
+        # at column 0 on every other write.
+        for layout in (layout_1, layout_2, layout_3, layout_4):
+            assert "custom_providers:\n  - name: NVIDIA" in layout, (
+                f"layout flipped to 0-indent: {layout!r}"
+            )
+            assert "custom_providers:\n- name:" not in layout
+            # And every layout still parses cleanly through both readers.
+            assert yaml.safe_load(layout) is not None
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards: every config writer goes through the unified path
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedConfigWriters:
+    """All ``config.yaml`` writers route through ``atomic_yaml_write``.
+
+    Pins the wiring in source so an accidental ``yaml.safe_dump(...)``
+    re-introduction is loud at code review.
+    """
+
+    def test_atomic_yaml_write_uses_indent_dumper(self):
+        """The primary writer must reference ``IndentDumper`` explicitly."""
+        src = inspect.getsource(atomic_yaml_write)
+        assert "IndentDumper" in src
+        assert "Dumper=IndentDumper" in src
+        # Issue reference so the guard isn't refactored away silently.
+        assert "31999" in src
+
+    def test_tui_gateway_save_cfg_uses_atomic_yaml_write(self):
+        """The Web UI save path no longer calls ``yaml.safe_dump`` directly."""
+        from tui_gateway.server import _save_cfg
+        src = inspect.getsource(_save_cfg)
+        assert "atomic_yaml_write" in src
+        # Direct ``yaml.safe_dump(`` (the buggy v0.14.0 shape) is gone.
+        assert "yaml.safe_dump(" not in src
+
+    def test_telegram_persist_dm_topic_uses_atomic_yaml_write(self):
+        """The Telegram DM-topic persist path goes through the shared writer."""
+        from gateway.platforms.telegram import TelegramAdapter
+        src = inspect.getsource(TelegramAdapter._persist_dm_topic_thread_id)
+        assert "atomic_yaml_write" in src
+        # Direct ``_yaml.dump(config, ...)`` is gone.
+        assert "_yaml.dump(config" not in src
+
+
+class TestIndentDumperHandlesUnicode:
+    """The fix preserves the previous behaviour for non-ASCII config values."""
+
+    def test_unicode_keys_survive_round_trip(self, tmp_path: Path):
+        """Chinese / Japanese model names in ``custom_providers`` round-trip."""
+        path = tmp_path / "config.yaml"
+        cfg = {
+            "custom_providers": [
+                {"name": "智谱-GLM", "base_url": "https://open.bigmodel.cn/api/paas/v4"},
+                {"name": "ムーンショット", "base_url": "https://api.moonshot.ai"},
+            ],
+        }
+        atomic_yaml_write(path, cfg)
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert loaded == cfg
+        # Should be human-readable (allow_unicode=True), not escaped \u…
+        assert "智谱-GLM" in path.read_text(encoding="utf-8")
+
+
+class TestAtomicYamlWritePreservesAtomicity:
+    """The IndentDumper change must not regress the atomic-write contract.
+
+    ``atomic_yaml_write`` is guaranteed to (a) never leave a partially-
+    written file and (b) preserve symlinks.  Both are unrelated to the
+    indent fix, but they would silently regress if a careless refactor
+    swapped the writer for plain ``open(..., "w")``.
+    """
+
+    def test_atomic_replace_target_overwritten_in_place(self, tmp_path: Path):
+        path = tmp_path / "config.yaml"
+        path.write_text("placeholder", encoding="utf-8")
+        original_inode = path.stat().st_ino
+
+        atomic_yaml_write(path, _SAMPLE_CONFIG)
+
+        # File still exists at the same logical path.
+        assert path.exists()
+        # Content is the new YAML, not the placeholder.
+        text = path.read_text(encoding="utf-8")
+        assert "custom_providers:" in text
+        # Inode may differ (atomic replace via rename), but content is fresh.
+        assert path.stat().st_ino != original_inode or text != "placeholder"
+
+    def test_existing_permissions_preserved(self, tmp_path: Path):
+        """File mode must survive the atomic temp-file swap."""
+        import os
+        import stat
+
+        path = tmp_path / "config.yaml"
+        path.write_text("seed", encoding="utf-8")
+        # Make the file world-readable to verify permission survival.
+        os.chmod(path, 0o644)
+        atomic_yaml_write(path, _SAMPLE_CONFIG)
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o644

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -680,11 +680,16 @@ def _load_cfg() -> dict:
 
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
-    import yaml
+    # Route through atomic_yaml_write so the Web UI's save path uses the
+    # same atomic temp-file + fsync + IndentDumper layout as every other
+    # writer.  A direct ``yaml.safe_dump`` (the previous shape) emitted
+    # 0-indent list items, which collided with the 2-indent output of
+    # ``atomic_roundtrip_yaml_update`` and corrupted ``config.yaml`` over
+    # time — the exact failure mode reported in #31999.
+    from utils import atomic_yaml_write
 
     path = _hermes_home / "config.yaml"
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+    atomic_yaml_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path

--- a/utils.py
+++ b/utils.py
@@ -136,6 +136,38 @@ def atomic_json_write(
         raise
 
 
+class IndentDumper(yaml.SafeDumper):
+    """PyYAML dumper that indents list items under mapping keys (2-space).
+
+    Default PyYAML emits "indentless" sequences — list items start at the
+    same column as their parent mapping key:
+
+        custom_providers:
+        - name: NVIDIA      # ← column 0
+
+    ``ruamel.yaml`` (used by :func:`atomic_roundtrip_yaml_update` for
+    comment-preserving single-key updates) instead emits 2-space-indented
+    sequences:
+
+        custom_providers:
+          - name: NVIDIA    # ← column 2
+
+    Mixing both styles in the same ``config.yaml`` (one path writes flat,
+    the next writes indented, then the user adds a comment) produces a
+    file that PyYAML still tolerates but stricter parsers like ``js-yaml``
+    reject with ``bad indentation of a mapping entry``.  In production
+    that surfaced as the Gateway silently dropping ``custom_providers``
+    and falling back to defaults — model switching appeared to work in
+    the UI but every request used the wrong backend.  See issue #31999.
+
+    Forcing ``indentless=False`` on the PyYAML side aligns the two
+    serializers so all write paths emit byte-identical layouts.
+    """
+
+    def increase_indent(self, flow=False, indentless=False):  # noqa: ARG002 — signature locked by base class
+        return super().increase_indent(flow, False)
+
+
 def atomic_yaml_write(
     path: Union[str, Path],
     data: Any,
@@ -149,6 +181,13 @@ def atomic_yaml_write(
     Uses temp file + fsync + os.replace to ensure the target file is never
     left in a partially-written state.  If the process crashes mid-write,
     the previous version of the file remains intact.
+
+    The dump is routed through :class:`IndentDumper` so list-under-mapping
+    items emit at column 2 — matching the layout produced by
+    :func:`atomic_roundtrip_yaml_update` (ruamel.yaml).  Without this,
+    cross-path writes to ``config.yaml`` toggle indentation on every
+    save, eventually producing a mixed-indent file that ``js-yaml``
+    rejects (issue #31999).
 
     Args:
         path: Target file path (will be created or overwritten).
@@ -170,7 +209,14 @@ def atomic_yaml_write(
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=default_flow_style, sort_keys=sort_keys)
+            yaml.dump(
+                data,
+                f,
+                Dumper=IndentDumper,
+                default_flow_style=default_flow_style,
+                sort_keys=sort_keys,
+                allow_unicode=True,
+            )
             if extra_content:
                 f.write(extra_content)
             f.flush()


### PR DESCRIPTION
## What does this PR do?

Resolves the cross-serializer YAML indentation flip-flop reported in #31999.

`utils.atomic_yaml_write` used default PyYAML, which emits *indentless* sequences (list items at column 0, immediately under their parent mapping key).  `utils.atomic_roundtrip_yaml_update` (the CLI single-key writer used by `/skin`, `/compact`, `/model`) uses `ruamel.yaml` configured with `indent(mapping=2, sequence=4, offset=2)`, which emits list items at column 2.

Cross-path writes to the same `config.yaml` therefore flipped indentation on every save:

- fresh save (PyYAML, 0-indent) → CLI `/skin` (ruamel, 2-indent) → Web UI Save (PyYAML, 0-indent) → CLI `/compact` (ruamel, 2-indent)

Eventually the file landed in a mixed-indent state that `js-yaml` (and stricter PyYAML loaders) reject with `bad indentation of a mapping entry`, which surfaced in production as the Gateway silently dropping all `custom_providers` and falling back to defaults — model switching looked fine in the UI but every request used the wrong backend.

This PR follows **Fix 1** from the issue: a tiny `IndentDumper` PyYAML subclass that forces `indentless=False`, wired into every remaining config-writing code path so all writers emit byte-identical layouts matching the ruamel.yaml roundtrip writer.

## Related Issue

Closes #31999.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

3 atomic commits, all authored by `xxxigm`:

1. **`fix(utils): unify YAML list indent across PyYAML and ruamel writers`** — `utils.py`
   - New `IndentDumper(yaml.SafeDumper)` overriding `increase_indent(..., indentless=False)`.
   - `atomic_yaml_write` now passes `Dumper=IndentDumper` and `allow_unicode=True` so non-ASCII provider names round-trip cleanly.
2. **`fix(gateway,tui): route remaining config writers through atomic_yaml_write`** — `tui_gateway/server.py`, `gateway/platforms/telegram.py`
   - `_save_cfg` (Web UI Save) replaced bare `yaml.safe_dump` + `open(..., "w")` with `atomic_yaml_write` (atomic + 2-indent + symlink-preserving).
   - `_persist_dm_topic_thread_id` replaced its manual temp-file shuffle + `_yaml.dump(..., default_flow_style=False, sort_keys=False)` with the same `atomic_yaml_write` call so DM-topic persistence emits the same shape as every other writer.
3. **`test(utils): pin YAML indent contract and unified-writer wiring (#31999)`** — `tests/test_yaml_indent_consistency_31999.py` (+281 lines, 12 cases)
   - `TestIndentDumperShape` (3 cases) — pins the column-2 output, the column-0 baseline (so a future PyYAML behavior change doesn't silently invalidate the fix), and round-trip-through-`safe_load`.
   - `TestAtomicYamlWriteAndRuamelMatch` (3 cases) — `atomic_yaml_write` and `atomic_roundtrip_yaml_update` produce the same column for `custom_providers`, the layout matches a ruamel-seeded file, and the four-step "Steps to Reproduce" sequence from the issue (PyYAML → ruamel → PyYAML → ruamel) keeps the layout stable on every step.
   - `TestUnifiedConfigWriters` (3 source-level guards) — `atomic_yaml_write` references `IndentDumper` and `#31999`; `_save_cfg` no longer contains `yaml.safe_dump(`; `_persist_dm_topic_thread_id` no longer contains `_yaml.dump(config`.  Re-introducing any bare call is loud at code review.
   - `TestIndentDumperHandlesUnicode` (1 case) — Chinese / Japanese provider names survive round-trip without `\u…` escaping.
   - `TestAtomicYamlWritePreservesAtomicity` (2 cases) — the IndentDumper change did not regress the atomic-replace or mode-preservation contract.

No public API changes; all callers of `atomic_yaml_write` keep working unchanged.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/test_yaml_indent_consistency_31999.py
   ```
   Expected: `12 tests passed`.
3. Run the full YAML-touching suite to confirm no regressions:
   ```
   scripts/run_tests.sh tests/test_yaml_indent_consistency_31999.py tests/hermes_cli/test_atomic_yaml_write.py tests/gateway/test_dm_topics.py tests/cli/test_cli_save_config_value.py tests/hermes_cli/test_config.py tests/hermes_cli/test_model_provider_persistence.py tests/hermes_cli/test_auth_commands.py
   ```
   Expected: `169 tests passed`.
4. Manual reproduction of the issue's scenario:
   ```python
   from utils import atomic_yaml_write, atomic_roundtrip_yaml_update
   p = "/tmp/cfg.yaml"
   atomic_yaml_write(p, {"custom_providers": [{"name": "NVIDIA", "base_url": "x"}]})
   atomic_roundtrip_yaml_update(p, "ui.skin", "monokai")
   atomic_yaml_write(p, {"custom_providers": [{"name": "NVIDIA", "base_url": "x"}], "ui": {"skin": "monokai"}})
   print(open(p).read())
   ```
   Before this PR: `- name:` toggles between column 0 and column 2.  After: stays at column 2 every time.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(utils): …`, `fix(gateway,tui): …`, `test(utils): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the targeted suites and all tests pass (12 new + 157 cross-suite, 169 total)
- [x] I've added tests for my changes (`tests/test_yaml_indent_consistency_31999.py`)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `atomic_yaml_write`'s docstring explicitly references the IndentDumper rationale and #31999.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config schema change).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `IndentDumper` is pure-Python PyYAML, no platform-specific calls.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/test_yaml_indent_consistency_31999.py
=== Summary: 1 files, 12 tests passed, 0 failed (100% complete) in 0.6s (24 workers) ===

$ scripts/run_tests.sh tests/test_yaml_indent_consistency_31999.py tests/hermes_cli/test_atomic_yaml_write.py tests/gateway/test_dm_topics.py tests/cli/test_cli_save_config_value.py tests/hermes_cli/test_config.py tests/hermes_cli/test_model_provider_persistence.py tests/hermes_cli/test_auth_commands.py
=== Summary: 7 files, 169 tests passed, 0 failed (100% complete) in 2.4s (24 workers) ===
```

https://github.com/NousResearch/hermes-agent/compare/main...xxxigm:hermes-agent:fix/31999-yaml-indent-consistency?expand=1
