### PR TITLE
fix(pricing): add deepseek-v4-flash to official docs pricing table

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -372,6 +372,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ),
     (
         "deepseek",
+        "deepseek-v4-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://api-docs.deepseek.com/quick_start/pricing",
+        pricing_version="deepseek-pricing-2026-05-12",
+    ),
+    (
+        "deepseek",
         "deepseek-v4-pro",
     ): PricingEntry(
         input_cost_per_million=Decimal("1.74"),

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -224,3 +224,36 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+def test_deepseek_v4_flash_pricing_entry_exists():
+    """Regression test: deepseek-v4-flash must have a pricing entry.
+
+    Same pricing as deepseek-chat ($0.14/M input, $0.28/M output)
+    plus cache-read pricing ($0.0028/M).
+    """
+    entry = get_pricing_entry(
+        "deepseek-v4-flash",
+        provider="deepseek",
+    )
+
+    assert entry is not None
+    assert entry.input_cost_per_million is not None
+    assert entry.output_cost_per_million is not None
+    assert float(entry.input_cost_per_million) == 0.14
+    assert float(entry.output_cost_per_million) == 0.28
+    assert float(entry.cache_read_cost_per_million) == 0.0028
+
+
+def test_deepseek_v4_flash_estimate_usage_cost():
+    """Ensure deepseek-v4-flash sessions get a dollar estimate, not unknown."""
+    result = estimate_usage_cost(
+        "deepseek-v4-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="deepseek",
+    )
+
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M input × $0.14/M + 500K output × $0.28/M = $0.14 + $0.14 = $0.28
+    assert float(result.amount_usd) == 0.28


### PR DESCRIPTION
## What does this PR do?

Using #24579 as reference, this fix adds DeepSeek v4 Flash pricing

- DeepSeek official pricing (https://api-docs.deepseek.com/quick_start/pricing) for v4-flash:
  - input $0.14 / 1M (cache miss)
  - output $0.28 / 1M
  - input $0.0028 / 1M (cache hit)
- New regression tests pass
- Partially resolves #24141 


<img width="592" height="528" alt="image" src="https://github.com/user-attachments/assets/9be4a085-5c54-4fd2-9634-1223bed2ffbb" />
