### PR TITLE
fix(test): mock _pid_exists to avoid psutil open_binary conflict in test_mcp_pid_tracking

### DIFF
--- a/tests/tools/test_mcp_pid_tracking.py
+++ b/tests/tools/test_mcp_pid_tracking.py
@@ -1,0 +1,167 @@
+"""Tests for MCP stdio PID tracking — grandchild process discovery.
+
+Verifies the fix for #26042: shell-wrapper MCP servers spawn grandchildren
+that escape direct-child PID snapshots, leading to zombie accumulation.
+"""
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock, mock_open
+
+# Import the function under test
+from tools.mcp_tool import _snapshot_child_pids, _kill_orphaned_mcp_children
+
+
+class TestSnapshotChildPidsRecursive:
+    """Verify _snapshot_child_pids discovers grandchildren, not just direct children."""
+
+    def test_recursive_linux_proc_children(self):
+        """Simulate /proc/{pid}/task/{pid}/children with a process tree:
+        
+        Hermes (PID 1) -> bash (PID 10) -> node (PID 20)
+        
+        Old code only saw PID 10 (direct child).
+        New code should discover PID 20 (grandchild) by recursing.
+        """
+        my_pid = 1234
+        
+        # Simulate /proc reading:
+        # - PID 1234 (Hermes) has children: [10]
+        # - PID 10 (bash wrapper) has children: [20]
+        # - PID 20 (node server) has no children
+        proc_children = {
+            my_pid: "10",
+            10: "20",
+            20: "",
+        }
+        
+        def mock_open_children(path):
+            # Extract PID from path like /proc/1234/task/1234/children
+            parts = path.split("/")
+            pid = int(parts[2])
+            return mock_open(read_data=proc_children.get(pid, ""))()
+        
+        with patch("os.getpid", return_value=my_pid), \
+             patch("builtins.open", side_effect=lambda p, *a, **kw: mock_open_children(p)):
+            result = _snapshot_child_pids()
+        
+        # Must include both direct child (10) AND grandchild (20)
+        assert 10 in result, "Direct child PID should be discovered"
+        assert 20 in result, "Grandchild PID should be discovered via recursive walk"
+        assert my_pid not in result, "Own PID should not be in the result"
+
+    def test_psutil_fallback_uses_recursive(self):
+        """When /proc is unavailable, psutil fallback should use recursive=True.
+        
+        Since the test environment has /proc, we verify the code path by
+        reading the source directly. The functional behavior is already
+        covered by the /proc recursive tests above.
+        """
+        import inspect
+        source = inspect.getsource(_snapshot_child_pids)
+        # Verify the psutil fallback uses recursive=True
+        assert "children(recursive=True)" in source, (
+            "psutil fallback must use recursive=True to discover grandchildren"
+        )
+
+    def test_empty_result_when_no_children(self):
+        """When no children exist, return empty set."""
+        my_pid = 9999
+        
+        with patch("os.getpid", return_value=my_pid), \
+             patch("builtins.open", side_effect=FileNotFoundError("no /proc")):
+            # psutil also fails
+            with patch.dict(sys.modules, {}):
+                # Force psutil import to fail
+                result = _snapshot_child_pids()
+        
+        assert isinstance(result, set)
+        # May or may not be empty depending on psutil availability in test env
+
+    def test_handles_proc_read_errors_gracefully(self):
+        """Individual /proc reads that fail should not prevent other children."""
+        my_pid = 42
+        
+        # PID 42 has children [100, 101]
+        # PID 100 has children [200] (readable)
+        # PID 101 raises OSError (unreadable — process already exited)
+        call_count = {"n": 0}
+        
+        def selective_open(path, *args, **kwargs):
+            if str(my_pid) in path:
+                return mock_open(read_data="100 101")()
+            elif "100" in path:
+                return mock_open(read_data="200")()
+            elif "101" in path:
+                raise OSError("process gone")
+            raise FileNotFoundError(path)
+        
+        with patch("os.getpid", return_value=my_pid), \
+             patch("builtins.open", side_effect=selective_open):
+            result = _snapshot_child_pids()
+        
+        # Should still find 100 and 200, skipping 101 gracefully
+        assert 100 in result
+        assert 200 in result
+        # 101 itself is a direct child so it's discovered from PID 42's children file
+        assert 101 in result
+
+
+class TestKillOrphanedMcpChildren:
+    """Verify _kill_orphaned_mcp_children also terminates children of tracked PIDs."""
+
+    def test_kills_children_of_orphans(self):
+        """When killing an orphan PID, also discover and kill its children."""
+        import tools.mcp_tool as mcp_mod
+        
+        # Set up orphan set with PID 100, which has a child PID 200
+        mcp_mod._orphan_stdio_pids.clear()
+        mcp_mod._orphan_stdio_pids.add(100)
+        mcp_mod._stdio_pids.clear()
+        
+        killed_pids = []
+        
+        def mock_kill(pid, sig):
+            killed_pids.append(pid)
+        
+        # PID 100's children file says it has child 200
+        def selective_open(path, *args, **kwargs):
+            if "/proc/100/" in path:
+                return mock_open(read_data="200")()
+            raise FileNotFoundError(path)
+        
+        import signal
+        with patch("os.kill", side_effect=mock_kill), \
+             patch("builtins.open", side_effect=selective_open), \
+             patch("time.sleep"):  # skip the 2s wait
+            _kill_orphaned_mcp_children()
+        
+        # Should have sent SIGTERM to both 100 and 200
+        assert 100 in killed_pids, "Orphan PID should be killed"
+        assert 200 in killed_pids, "Child of orphan should also be killed"
+        
+        # Cleanup
+        mcp_mod._orphan_stdio_pids.clear()
+
+    def test_no_proc_still_kills_tracked_pids(self):
+        """Even when /proc is unavailable, tracked orphan PIDs are still killed."""
+        import tools.mcp_tool as mcp_mod
+        
+        mcp_mod._orphan_stdio_pids.clear()
+        mcp_mod._orphan_stdio_pids.add(300)
+        mcp_mod._stdio_pids.clear()
+        
+        killed_pids = []
+        
+        def mock_kill(pid, sig):
+            killed_pids.append(pid)
+        
+        with patch("os.kill", side_effect=mock_kill), \
+             patch("builtins.open", side_effect=FileNotFoundError("no /proc")), \
+             patch("time.sleep"):
+            _kill_orphaned_mcp_children()
+        
+        assert 300 in killed_pids
+        
+        # Cleanup
+        mcp_mod._orphan_stdio_pids.clear()

--- a/tests/tools/test_mcp_pid_tracking.py
+++ b/tests/tools/test_mcp_pid_tracking.py
@@ -133,7 +133,8 @@ class TestKillOrphanedMcpChildren:
         import signal
         with patch("os.kill", side_effect=mock_kill), \
              patch("builtins.open", side_effect=selective_open), \
-             patch("time.sleep"):  # skip the 2s wait
+             patch("time.sleep"), \
+             patch("gateway.status._pid_exists", return_value=True):
             _kill_orphaned_mcp_children()
         
         # Should have sent SIGTERM to both 100 and 200

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2108,25 +2108,46 @@ _orphan_stdio_pids: set = set()
 
 
 def _snapshot_child_pids() -> set:
-    """Return a set of current child process PIDs.
+    """Return a set of current child AND grandchild process PIDs.
 
     Uses /proc on Linux, falls back to psutil, then empty set.
+    Recursively discovers descendants so that MCP servers spawned via
+    shell wrappers (e.g. ``/bin/bash run-mcp.sh → node server.js``)
+    are tracked even when the wrapper exits and the real server becomes
+    a grandchild of the Hermes process.
+
     Used by _run_stdio to identify the subprocess spawned by stdio_client.
     """
     my_pid = os.getpid()
 
-    # Linux: read from /proc
+    # Linux: read from /proc recursively
     try:
-        children_path = f"/proc/{my_pid}/task/{my_pid}/children"
-        with open(children_path, encoding="utf-8") as f:
-            return {int(p) for p in f.read().split() if p.strip()}
-    except (FileNotFoundError, OSError, ValueError):
+        all_pids: set = set()
+        frontier = [my_pid]
+        visited: set = set()
+        while frontier:
+            pid = frontier.pop()
+            if pid in visited:
+                continue
+            visited.add(pid)
+            try:
+                children_path = f"/proc/{pid}/task/{pid}/children"
+                with open(children_path, encoding="utf-8") as f:
+                    child_pids = {int(p) for p in f.read().split() if p.strip()}
+                all_pids |= child_pids
+                frontier.extend(child_pids)
+            except (FileNotFoundError, OSError, ValueError):
+                pass
+        # Exclude the Hermes process itself
+        all_pids.discard(my_pid)
+        return all_pids
+    except Exception:
         pass
 
-    # Fallback: psutil
+    # Fallback: psutil (recursive children)
     try:
         import psutil
-        return {c.pid for c in psutil.Process(my_pid).children()}
+        return {c.pid for c in psutil.Process(my_pid).children(recursive=True)}
     except Exception:
         pass
 
@@ -3543,12 +3564,34 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
         return
 
     # Phase 1: SIGTERM (graceful)
+    # For each PID, also attempt to SIGTERM its direct children — handles
+    # cases where the tracked PID is a wrapper that spawned the real server.
+    _children_of_tracked = set()
     for pid, server_name in pids.items():
         try:
             os.kill(pid, _signal.SIGTERM)
             logger.debug("Sent SIGTERM to orphaned MCP process %d (%s)", pid, server_name)
         except (ProcessLookupError, PermissionError, OSError):
             pass
+        # Discover and terminate direct children of this PID
+        try:
+            children_path = f"/proc/{pid}/task/{pid}/children"
+            with open(children_path, encoding="utf-8") as f:
+                for child_str in f.read().split():
+                    if child_str.strip():
+                        child_pid = int(child_str)
+                        _children_of_tracked.add(child_pid)
+                        try:
+                            os.kill(child_pid, _signal.SIGTERM)
+                            logger.debug(
+                                "Sent SIGTERM to child %d of orphaned MCP process %d (%s)",
+                                child_pid, pid, server_name,
+                            )
+                        except (ProcessLookupError, PermissionError, OSError):
+                            pass
+        except (FileNotFoundError, OSError, ValueError):
+            pass
+    pids.update({cp: "orphan-child" for cp in _children_of_tracked})
 
     # Phase 2: Wait for graceful exit
     time.sleep(2)


### PR DESCRIPTION
## What

Fixes flaky test `test_kills_children_of_orphans` that fails with `TypeError: startswith first arg must be str or a tuple of str, not bytes`.

## Root Cause

The test patches `builtins.open` with a text-mode mock. In phase 3 of `_kill_orphaned_mcp_children()`, the code calls `gateway.status._pid_exists(100)` which delegates to `psutil.pid_exists()`. On Linux, psutil reads `/proc/100/status` via `open_binary()` and calls `line.startswith(b"Tgid:")` — the text-mode mock returns str lines, triggering the TypeError.

## Fix

Add `patch("gateway.status._pid_exists", return_value=True)` to bypass psutil in the test. The test already mocks `os.kill` for SIGTERM/SIGKILL verification, so no coverage is weakened.

## CI Failure

- **Run**: https://github.com/NousResearch/hermes-agent/actions/runs/26397217247
- **Failed jobs**: test (2), test (5)