### PR TITLE
fix(test): set _YOLO_MODE_FROZEN directly in yolo override test

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -240,6 +240,11 @@ class TestCronModeInteractions:
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
 
+        # _YOLO_MODE_FROZEN is frozen at import time — monkeypatch.setenv
+        # cannot override it (security hardening in b1adb95).
+        import tools.approval as approval_module
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+
         from unittest.mock import patch as mock_patch
         with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
             # Use a dangerous-but-not-hardline command — `rm -rf /` is now


### PR DESCRIPTION
## What

Fixes `test_yolo_overrides_cron_deny` that fails with `assert result[approved]` (False).

## Root Cause

`_YOLO_MODE_FROZEN` is captured at module import time from `os.environ` (trap #18: module-level frozen env-var constants). `monkeypatch.setenv(HERMES_YOLO_MODE, 1)` changes `os.environ` but `_YOLO_MODE_FROZEN` is already `False`, so the yolo bypass in `check_dangerous_command()` never triggers.

## Fix

Add `monkeypatch.setattr(approval_module, _YOLO_MODE_FROZEN, True)` to directly set the frozen constant.

## CI Failure

- **Run**: https://github.com/NousResearch/hermes-agent/actions/runs/26397238189
- **Failed job**: test (5)
- **Branch**: fix/20369-ssh-skill-local-target (deleted, no open PR — bug exists on main)