### PR TITLE
skills(himalaya): add Gmail OAuth2 auth patterns, gog fallback, and scope mismatch docs

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -2,7 +2,7 @@
 name: himalaya
 description: "Himalaya CLI: IMAP/SMTP email from terminal."
 version: 1.1.0
-author: community
+author: Eugene Ohu (gingerol)
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -17,10 +17,16 @@ prerequisites:
 
 Himalaya is a CLI email client that lets you manage emails from the terminal using IMAP, SMTP, Notmuch, or Sendmail backends.
 
+## When to Use
+
+Load this skill when the user asks to check, read, search, send, or manage email from the terminal, or when email-related tools (himalaya, gog) are detected in the environment.
+
 ## References
 
 - `references/configuration.md` (config file setup + IMAP/SMTP authentication)
 - `references/message-composition.md` (MML syntax for composing emails)
+- `references/gog-gmail.md` (gog OAuth fallback, keychain patterns, scope constraints)
+- `references/oauth-imap-flow.md` (browser OAuth flow to get IMAP-scoped tokens for himalaya)
 
 ## Prerequisites
 
@@ -248,10 +254,11 @@ List accounts:
 himalaya account list
 ```
 
-Use a specific account:
+Use a specific account (v1.2.0: `-a` is a subcommand flag, not top-level):
 
 ```bash
-himalaya --account work envelope list
+himalaya envelope list -a work --page-size 20
+himalaya envelope list -a personal subject meeting
 ```
 
 ## Attachments
@@ -291,9 +298,89 @@ Full trace with backtrace:
 RUST_LOG=trace RUST_BACKTRACE=1 himalaya envelope list
 ```
 
+## Gmail OAuth (gog fallback)
+
+When himalaya fails on a Gmail/Google Workspace account with the error:
+
+```
+Application-specific password required: https://support.google.com/accounts/answer/185833
+```
+
+**DO NOT tell the user to generate an app-specific password or assume credentials are missing.** Many setups have `gog` already installed with working OAuth tokens. Check first:
+
+```bash
+which gog && gog version
+```
+
+If `gog` v0.11.0+ is present, use it to read and search Gmail via OAuth (it handles the token lifecycle):
+
+```bash
+# List recent inbox
+gog -a user@domain.com gmail search "newer_than:7d" --max 20 --json
+
+# Search inbox
+gog -a user@domain.com gmail search "subject:meeting" --max 10 --json
+
+# Read a specific thread (by thread ID from search results)
+gog -a user@domain.com gmail get <thread-id>
+```
+
+`gog` credentials live at `~/Library/Application Support/gogcli/` and tokens are stored in the macOS keychain under service `gogcli`, account `token:default:user@domain.com`. OAuth is self-maintaining — no password scripts needed. See `references/gog-gmail.md` for keychain token retrieval patterns.
+
+### Building himalaya with OAuth2 support
+
+The Homebrew build of himalaya 1.2.0 does **not** include the `oauth2` Cargo feature. If you need native OAuth2 in himalaya, build from source:
+
+```bash
+# Check current features — if +oauth2 is missing, rebuild
+himalaya --version
+
+# Build with oauth2
+cargo install himalaya --version 1.2.0 --locked --features "oauth2,smtp,imap"
+```
+
+### himalaya OAuth2 config (TOML format)
+
+himalaya v1.2.0 OAuth2 config requires these fields (all mandatory except `pkce` which defaults false):
+
+```toml
+backend.auth.type = "oauth2"
+backend.auth.method = "xoauth2"         # or "oauth-bearer"
+backend.auth.client-id = "..."           # string
+backend.auth.client-secret = { cmd = "/path/to/script" }  # Secret: { cmd = "..." } or { raw = "..." } or { keyring = "..." }
+backend.auth.refresh-token = { cmd = "/path/to/script" }
+backend.auth.access-token = { cmd = "/path/to/script" }    # can be empty if refresh-token is set
+backend.auth.auth-url = "https://accounts.google.com/o/oauth2/auth"
+backend.auth.token-url = "https://oauth2.googleapis.com/token"
+backend.auth.pkce = false
+backend.auth.scope = "https://mail.google.com/"            # single scope; use `scopes = ["...", "..."]` for multiple
+```
+
+### Critical pitfall: scope mismatch
+
+Google's Gmail REST API scope (`https://www.googleapis.com/auth/gmail.modify`) is **not** the same as Google's IMAP/SMTP scope (`https://mail.google.com/`). If a gog refresh token was authorized for the REST API only, it will fail with XOAUTH2 on IMAP. Google responds with `{"status":"400","schemes":"Bearer","scope":"https://mail.google.com/"}` — this means the token doesn't have the right scope, not that credentials are broken.
+
+When this happens, do NOT attempt to re-authorize via browser flow immediately — just use `gog` for reading/searching (it works fine with REST API scope). The OAuth re-auth to add the IMAP scope is a separate user-browser action.
+
+### Account flag location (v1.2.0)
+
+v1.2.0 moved the account flag to subcommand level, NOT top level:
+
+```bash
+# CORRECT (v1.2.0+)
+himalaya envelope list -a lbs --page-size 5
+
+# WRONG — silently ignored in v1.2.0
+himalaya --account lbs envelope list
+```
+
+Verify with `himalaya account list` first to see configured accounts.
+
 ## Tips
 
 - Use `himalaya --help` or `himalaya <command> --help` for detailed usage.
 - Message IDs are relative to the current folder; re-list after folder changes.
 - For composing rich emails with attachments, use MML syntax (see `references/message-composition.md`).
 - Store passwords securely using `pass`, system keyring, or a command that outputs the password.
+- For Gmail/Google Workspace accounts where password auth is blocked, use `gog` (OAuth) for reading/searching. See `references/gog-gmail.md` for token details and scope constraints.
+- Never assume credentials are broken when you see "Application-specific password required" — check for `gog` first. Users often have OAuth already set up from prior tools.

--- a/skills/email/himalaya/references/gog-gmail.md
+++ b/skills/email/himalaya/references/gog-gmail.md
@@ -1,0 +1,79 @@
+# gog Gmail OAuth: token storage and keychain patterns
+
+When `gog` (v0.11.0+) authorizes a Gmail/Google Workspace account, it stores OAuth 2.0 credentials and tokens as follows:
+
+## Storage locations
+
+```
+~/Library/Application Support/gogcli/
+  credentials.json   # OAuth client_id + client_secret (one per client)
+  keyring/           # keyring backend state (often empty on macOS)
+  tokens/            # token cache (often empty; tokens live in system keychain)
+```
+
+## Keychain entries (macOS)
+
+All tokens are stored in the login keychain under service name `gogcli`:
+
+```
+security find-generic-password -s "gogcli"
+```
+
+Account names follow the pattern `token:<client>:<email>`:
+- `token:default:user@domain.com` — default client
+- `token:imap:user@domain.com` — if using a named client
+
+## Token format
+
+The keychain value is a JSON object:
+```json
+{
+  "refresh_token": "1//03C...",
+  "services": ["gmail", "calendar", "contacts", "drive", "docs", "sheets"],
+  "scopes": [
+    "email",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
+    "https://www.googleapis.com/auth/gmail.settings.sharing",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "openid"
+  ],
+  "created_at": "2026-03-05T11:04:00.905617Z"
+}
+```
+
+## Reading refresh token from keychain
+
+```bash
+security find-generic-password -s "gogcli" -a "token:default:user@domain.com" -w | \
+  python3 -c "import sys,json; print(json.load(sys.stdin)['refresh_token'])"
+```
+
+## Scope constraints
+
+`gog`'s default Gmail authorization uses the REST API scope (`gmail.modify`), **not** the IMAP/SMTP scope (`https://mail.google.com/`). This means:
+
+- `gog` can read/search Gmail via REST API (works perfectly)
+- The refresh token **cannot** be used for IMAP XOAUTH2 authentication
+- Google's IMAP server will return `{"status":"400","schemes":"Bearer","scope":"https://mail.google.com/"}` — a scope mismatch, not a credential failure
+- To use the same client ID for IMAP, the user must re-authorize with `https://mail.google.com/` scope via a browser OAuth flow
+
+## Using gog as a himalaya fallback
+
+When himalaya can't authenticate (password blocked by Google, no OAuth2 build, scope mismatch), `gog` provides a working fallback for reading and searching email:
+
+```bash
+# Recent inbox
+gog -a user@domain.com gmail search "newer_than:7d" --max 20 --json
+
+# By subject
+gog -a user@domain.com gmail search "subject:meeting" --max 10 --json
+
+# By sender
+gog -a user@domain.com gmail search "from:boss@company.com" --max 10 --json
+
+# Unread only
+gog -a user@domain.com gmail search "is:unread" --max 20 --json
+```
+
+The `--json` flag gives structured output with thread IDs, dates, senders, subjects, labels (including UNREAD), and message counts.

--- a/skills/email/himalaya/references/oauth-imap-flow.md
+++ b/skills/email/himalaya/references/oauth-imap-flow.md
@@ -1,0 +1,137 @@
+# Browser OAuth flow for himalaya IMAP scope
+
+When a himalaya account using Google IMAP needs an OAuth2 refresh token with the `https://mail.google.com/` scope, and no such token exists yet, the user must complete a one-time browser OAuth authorization.
+
+## When this is needed
+
+- Password auth is blocked by Google ("Application-specific password required")
+- Existing OAuth tokens have REST API scope only (e.g., from `gog`)
+- Building himalaya from source with `+oauth2` feature
+
+## Flow overview
+
+1. Start a local HTTP server on a random high port to catch the OAuth redirect
+2. Open the user's browser to Google's OAuth consent screen with `https://mail.google.com/` scope
+3. User approves (Google auto-selects the correct account if `login_hint` is set)
+4. Browser redirects to local server with `code` parameter
+5. Exchange authorization code for access + refresh tokens
+6. Store refresh token in system keychain for himalaya to use
+
+## Automated script pattern
+
+```python
+#!/usr/bin/env python3
+"""OAuth for Google IMAP scope. Run once per account."""
+import http.server, json, subprocess, sys, threading, time
+import urllib.parse, urllib.request, webbrowser
+
+CLIENT_ID = "YOUR_CLIENT_ID"
+CLIENT_SECRET="YOUR...= 60072
+REDIRECT = f"http://127.0.0.1:{PORT}/oauth2/callback"
+SCOPE = "https://mail.google.com/"
+EMAIL = "user@domain.com"
+ACCT = f"token:imap:{EMAIL}"
+
+code = None
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        global code
+        params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+        if 'code' in params:
+            code = params['code'][0]
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html')
+            self.end_headers()
+            self.wfile.write(b'<h1>Done! Close this window.</h1>')
+            threading.Thread(target=self.server.shutdown, daemon=True).start()
+    def log_message(self, *a): pass
+
+server = http.server.HTTPServer(('127.0.0.1', PORT), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+
+auth_url = "https://accounts.google.com/o/oauth2/auth?" + urllib.parse.urlencode({
+    'client_id': CLIENT_ID, 'redirect_uri': REDIRECT,
+    'response_type': 'code', 'scope': SCOPE,
+    'access_type': 'offline', 'prompt': 'consent',
+    'login_hint': EMAIL, 'include_granted_scopes': 'true',
+})
+
+print(f"Opening browser for {EMAIL}...", flush=True)
+webbrowser.open(auth_url)
+
+for _ in range(120):
+    if code: break
+    time.sleep(0.5)
+server.shutdown()
+
+if not code:
+    print("ERROR: Timed out", flush=True)
+    sys.exit(1)
+
+# Exchange code for tokens
+data = urllib.parse.urlencode({
+    'code': code, 'client_id': CLIENT_ID,
+    'client_secret': CLIENT_SECRET, 'redirect_uri': REDIRECT,
+    'grant_type': 'authorization_code',
+}).encode()
+
+req = urllib.request.Request(
+    'https://oauth2.googleapis.com/token', data=data, method='POST',
+    headers={'Content-Type': 'application/x-www-form-urlencoded'}
+)
+resp = json.loads(urllib.request.urlopen(req, timeout=10).read())
+
+rt = resp.get('refresh_token', 'MISSING')
+print(f"Got refresh token: {rt[:20]}...", flush=True)
+
+# Store in keychain
+subprocess.run(['security', 'delete-generic-password',
+    '-a', ACCT, '-s', 'himalaya-oauth'], capture_output=True)
+subprocess.run(['security', 'add-generic-password',
+    '-a', ACCT, '-s', 'himalaya-oauth',
+    '-w', json.dumps(resp), '-U'])
+print("Saved to keychain!", flush=True)
+```
+
+## Key points
+
+- **`include_granted_scopes=true`** ensures existing scopes aren't lost
+- **`prompt=consent`** forces a refresh token (without it, Google may not issue one if previously authorized)
+- **`login_hint`** pre-fills the account picker so the user just clicks "Allow"
+- The local server listens on `127.0.0.1` only — never accessible from the network
+- The redirect URI must exactly match what's registered in the Google Cloud Console
+- Store the full token response (not just the refresh token) — access token is useful for immediate use
+
+## After the flow
+
+Update himalaya's config.toml to reference the keychain entry:
+
+```toml
+backend.auth.refresh-token = { cmd = "/path/to/get-refresh-token.sh" }
+backend.auth.access-token = { cmd = "/path/to/get-access-token.sh" }
+```
+
+Where `get-refresh-token.sh` reads from keychain:
+```bash
+#!/bin/bash
+security find-generic-password -s "himalaya-oauth" -a "token:imap:user@domain.com" -w | \
+  python3 -c 'import sys,json; print(json.load(sys.stdin)["refresh_token"])'
+```
+
+And `get-access-token.sh` exchanges refresh for access:
+```bash
+#!/bin/bash
+CLIENT_ID="..."
+CLIENT_SECRET=*** find-generic-password -s "himalaya-oauth" -a "token:imap:user@domain.com" -w | python3 -c 'import sys,json; print(json.load(sys.stdin)["refresh_token"])')
+
+curl -s --max-time 10 \
+  -d "client_id=${CLIENT_ID}" \
+  -d "client_secret=${CLIENT_SECRET}" \
+  -d "refresh_token=${REFRESH_TOKEN}" \
+  -d "grant_type=refresh_token" \
+  "https://oauth2.googleapis.com/token" | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])'
+```
+
+## Why not `gog auth add`?
+
+`gog auth add` uses the Gmail REST API scope (`gmail.modify`), not the IMAP scope (`https://mail.google.com/`). Running `gog auth add --services gmail` will NOT give you an IMAP-compatible token. You must use `https://mail.google.com/` as the scope, which requires either a custom OAuth flow (above) or a Google Cloud Console project with the IMAP scope enabled.


### PR DESCRIPTION
## Summary

The himalaya skill was missing critical information for Gmail/Google Workspace users. After spending hours debugging authentication failures, I documented everything discovered.

## Changes

### SKILL.md additions (skills/email/himalaya/SKILL.md)
- **gog fallback section** — When himalaya fails with "Application-specific password required", check for `gog` first. Many users have OAuth already set up from prior tools (OpenClaw, etc.). `gog` can read and search Gmail via REST API without any additional config.
- **Homebrew OAuth2 warning** — The Homebrew himalaya 1.2.0 build does NOT include the `oauth2` Cargo feature. Document the `cargo install` command to rebuild with OAuth2 support.
- **Correct OAuth2 TOML schema** — All mandatory fields documented (`method`, `pkce`, `scope`). The reference config had none of these, causing opaque parse errors.
- **Scope mismatch pitfall** — `gmail.modify` (REST API) ≠ `https://mail.google.com/` (IMAP). Google returns a confusing error that looks like broken credentials. Documented the pattern and the correct response (use gog, don't chase app passwords).
- **Account flag fix** — v1.2.0 moved `-a` to subcommand level. The old `himalaya --account` syntax silently fails.

### New references
- **gog-gmail.md** — Keychain token storage patterns, service names (`gogcli`), account format (`token:default:email`), token JSON format, scope constraints
- **oauth-imap-flow.md** — Complete automated browser OAuth flow script to obtain IMAP-scoped refresh tokens when needed

## Motivation

I was migrating from password auth to OAuth2 for two Gmail accounts. The himalaya skill had no guidance on any of these issues — every error required reading Rust source code, reverse-engineering TOML deserialization, and trial-and-error with Google's OAuth endpoints.

This PR prevents other Hermes users from going through the same debugging gauntlet.

## Testing

The OAuth2 config has been verified working with himalaya v1.2.0 (built from source with `+oauth2`) against two Google accounts (personal Gmail and Google Workspace). The gog fallback has been verified with gog v0.11.0.