### PR TITLE
fix(kanban): wrap columns into rows instead of horizontal scroll

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -64,17 +64,15 @@
 
 .hermes-kanban-columns {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
   align-items: start;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-.hermes-kanban-columns::-webkit-scrollbar {
-  display: none;
 }
 
 .hermes-kanban-column {
-  flex: 0 0 280px;
+  flex: 1 1 220px;
+  min-width: 200px;
+  max-width: 360px;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);
@@ -84,6 +82,14 @@
   min-height: 200px;
   max-height: calc(100vh - 220px);
   transition: border-color 120ms ease, background-color 120ms ease;
+}
+
+/* On wide screens (≥3 columns comfortably), stretch columns to fill the row */
+@media (min-width: 1200px) {
+  .hermes-kanban-column {
+    max-width: 1fr;
+    max-width: calc(33.333% - 0.5rem);
+  }
 }
 
 .hermes-kanban-column--drop {


### PR DESCRIPTION
The kanban board used flex: 0 0 280px columns with a hidden scrollbar (scrollbar-width: none), making columns beyond the viewport invisible unless the screen was ultra-wide (7 columns = ~2100px+).

Changes:
- flex-wrap: wrap on .hermes-kanban-columns so columns flow to new rows
- flex: 1 1 220px with min-width: 200px / max-width: 360px for flexible sizing that adapts to the viewport
- Removed hidden scrollbar (scrollbar-width: none) and scroll snap since wrapping eliminates the need for horizontal scrolling
- Wide-screen media query caps columns to ~1/3 width for even fill

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

plugins/kanban/dashboard/dist/style.css — .hermes-kanban-columns: changed from fixed-width horizontal scroll (flex: 0 0 280px, overflow-x: auto, scrollbar-width: none) to wrapping flex layout (flex-wrap: wrap, flex: 1 1 220px). Removed hidden scrollbar rules. Added @media (min-width: 1200px) to cap column width at ~1/3 of the row for even fill on wide screens.


## How to Test

1. Open the Kanban board in the dashboard on a typical laptop-width screen (~1280px). Before: only the leftmost 4–5 of 8 columns are visible; the rest overflow off-screen with no scrollbar. After: all 8 columns wrap into 2 rows of ~4 columns, fully visible.
2. Resize the browser window narrower (~768px). Columns should wrap to ~3 per row and remain readable — no horizontal scroll needed.
4. Resize to a wide monitor (~1920px+). Columns should fill evenly across the row with the media query cap, not stretch to extreme widths.

## Checklist

<!-- Complete these before requesting review. -->

### Code

[x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
[x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
[x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
[x] My PR contains only changes related to this fix/feature (no unrelated commits)
[x] I've run pytest tests/ -q and all tests pass — CSS-only change, no Python touched; N/A
[ ] I've added tests for my changes — N/A: visual/layout CSS fix with no testable backend logic
[x] I've tested on my platform: Ubuntu 24.04, Chrome (dashboard at hermes.makeflow.dev:9119)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
-[x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
-[x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
-[x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

<img width="2870" height="846" alt="image" src="https://github.com/user-attachments/assets/14593c6a-c28d-4ca5-b851-1499bfb88ed9" />
<img width="2157" height="918" alt="image" src="https://github.com/user-attachments/assets/b3592ddd-f36a-4c8d-9f58-dba0fff65500" />
<img width="1415" height="1177" alt="image" src="https://github.com/user-attachments/assets/03164118-010e-49b9-9a84-255a586be5ca" />
