### PR TITLE
fix(gateway): report skipped media attachments instead of silently dropping them

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2235,27 +2235,67 @@ class BasePlatformAdapter(ABC):
         return validate_media_delivery_path(path)
 
     @staticmethod
-    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
-        """Drop unsafe MEDIA paths and normalize accepted paths."""
+    def partition_media_delivery_paths(media_files) -> Tuple[List[Tuple[str, bool]], List[str]]:
+        """Partition MEDIA paths into safe deliveries and skipped paths.
+
+        Returns a tuple of (safe_media, skipped_paths) where:
+        - safe_media is a list of (resolved_path, is_voice) tuples
+        - skipped_paths is a list of original path strings that were rejected
+        """
         safe_media: List[Tuple[str, bool]] = []
+        skipped: List[str] = []
         for media_path, is_voice in media_files or []:
             safe_path = validate_media_delivery_path(str(media_path))
             if safe_path:
                 safe_media.append((safe_path, bool(is_voice)))
             else:
-                logger.warning("Skipping unsafe MEDIA directive path outside allowed roots")
-        return safe_media
+                skipped.append(str(media_path))
+        return safe_media, skipped
 
     @staticmethod
-    def filter_local_delivery_paths(file_paths) -> List[str]:
-        """Drop unsafe bare local file paths and normalize accepted paths."""
+    def partition_local_delivery_paths(file_paths) -> Tuple[List[str], List[str]]:
+        """Partition local file paths into safe deliveries and skipped paths.
+
+        Returns a tuple of (safe_paths, skipped_paths).
+        """
         safe_paths: List[str] = []
+        skipped: List[str] = []
         for file_path in file_paths or []:
             safe_path = validate_media_delivery_path(str(file_path))
             if safe_path:
                 safe_paths.append(safe_path)
             else:
-                logger.warning("Skipping unsafe local file path outside allowed roots")
+                skipped.append(str(file_path))
+        return safe_paths, skipped
+
+    @staticmethod
+    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
+        """Drop unsafe MEDIA paths and normalize accepted paths.
+
+        Deprecated: use partition_media_delivery_paths() when you need to
+        report skipped attachments to the user.
+        """
+        safe_media, skipped = BasePlatformAdapter.partition_media_delivery_paths(media_files)
+        for skipped_path in skipped:
+            logger.warning(
+                "Skipping unsafe MEDIA directive path outside allowed roots: %s",
+                skipped_path,
+            )
+        return safe_media
+
+    @staticmethod
+    def filter_local_delivery_paths(file_paths) -> List[str]:
+        """Drop unsafe bare local file paths and normalize accepted paths.
+
+        Deprecated: use partition_local_delivery_paths() when you need to
+        report skipped attachments to the user.
+        """
+        safe_paths, skipped = BasePlatformAdapter.partition_local_delivery_paths(file_paths)
+        for skipped_path in skipped:
+            logger.warning(
+                "Skipping unsafe local file path outside allowed roots: %s",
+                skipped_path,
+            )
         return safe_paths
 
     @staticmethod

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -426,6 +426,56 @@ class TestMediaDeliveryPathValidation:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(media_file)) == str(media_file.resolve())
 
+    def test_partition_media_returns_safe_and_skipped(self, tmp_path, monkeypatch):
+        root = tmp_path / "media-cache"
+        safe = root / "ok.png"
+        unsafe = tmp_path / "outside.png"
+        safe.parent.mkdir(parents=True)
+        safe.write_bytes(b"PNG")
+        unsafe.write_bytes(b"PNG")
+        self._patch_roots(monkeypatch, root)
+
+        safe_media, skipped = BasePlatformAdapter.partition_media_delivery_paths([
+            (str(unsafe), False),
+            (str(safe), True),
+        ])
+
+        assert safe_media == [(str(safe.resolve()), True)]
+        assert skipped == [str(unsafe)]
+
+    def test_partition_local_returns_safe_and_skipped(self, tmp_path, monkeypatch):
+        root = tmp_path / "media-cache"
+        safe = root / "ok.txt"
+        unsafe = tmp_path / "outside.txt"
+        safe.parent.mkdir(parents=True)
+        safe.write_text("safe")
+        unsafe.write_text("unsafe")
+        self._patch_roots(monkeypatch, root)
+
+        safe_paths, skipped = BasePlatformAdapter.partition_local_delivery_paths([
+            str(unsafe),
+            str(safe),
+        ])
+
+        assert safe_paths == [str(safe.resolve())]
+        assert skipped == [str(unsafe)]
+
+    def test_filter_backward_compatible(self, tmp_path, monkeypatch):
+        root = tmp_path / "media-cache"
+        safe = root / "ok.png"
+        unsafe = tmp_path / "outside.png"
+        safe.parent.mkdir(parents=True)
+        safe.write_bytes(b"PNG")
+        unsafe.write_bytes(b"PNG")
+        self._patch_roots(monkeypatch, root)
+
+        filtered = BasePlatformAdapter.filter_media_delivery_paths([
+            (str(unsafe), False),
+            (str(safe), True),
+        ])
+
+        assert filtered == [(str(safe.resolve()), True)]
+
 
 # ---------------------------------------------------------------------------
 # should_send_media_as_audio

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -251,7 +251,7 @@ def _handle_send(args):
     force_document_attachments = "[[as_document]]" in message
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_files, skipped_media = BasePlatformAdapter.partition_media_delivery_paths(media_files)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
@@ -313,6 +313,15 @@ def _handle_send(args):
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+
+        # Surface skipped attachments to the user
+        if isinstance(result, dict) and skipped_media:
+            result["skipped_attachments"] = skipped_media
+            result.setdefault("warnings", []).append(
+                f"Attachment{'s' if len(skipped_media) > 1 else ''} skipped: outside allowed media roots. "
+                f"Set HERMES_MEDIA_ALLOW_DIRS to include your directory, "
+                f"or move files to a Hermes media cache."
+            )
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:


### PR DESCRIPTION
## Bug Report

Discord (and all platform) media attachments are silently dropped when outside `MEDIA_DELIVERY_SAFE_ROOTS`.

### Symptom
When the model emits `MEDIA:<path>` inline directives, image/file attachments never appear in Discord (or other platforms). Text-only messages arrive fine. No error is surfaced to the user.

### Root Cause
`BasePlatformAdapter.filter_media_delivery_paths()` validates every path against allowed roots. When a file lives outside the whitelist, the gateway logs a generic `WARNING` with no path name, and silently drops the attachment with zero user-visible feedback.

### Current Allowed Roots
- `~/.hermes/cache/{images,audio,video,documents,screenshots}`
- Legacy dirs: `~/.hermes/{image_cache,audio_cache,video_cache,document_cache,browser_screenshots}`
- Any paths configured via the `HERMES_MEDIA_ALLOW_DIRS` environment variable

### Impact
Any media stored outside these directories is silently stripped before reaching any platform.

## Scope of this PR

This PR targets the **send_message tool** path specifically (the path where an LLM explicitly calls `send_message` with a `MEDIA:` tag).

The **gateway auto-delivery path** (`gateway/platforms/base.py:3508/3522`) is left unchanged — it still calls `filter_*` and only gets log-line visibility of skipped paths. Fixing that path properly would require injecting skipped-attachment warnings into the response text itself (so the user sees them), which is a distinct design decision from surfacing skips in a tool JSON result.

If desired, a follow-up PR can extend the same `partition_*` + user-visible warning pattern to the gateway auto-delivery path.

## Changes

- `gateway/platforms/base.py`: Add `partition_media_delivery_paths()` and `partition_local_delivery_paths()` returning `(safe, skipped)` tuples. Keep `filter_*` as backward-compatible wrappers (they already log each skipped path by name, so no changes needed at other call sites).
- `tools/send_message_tool.py`: Use `partition_media_delivery_paths()`, surface skipped paths in JSON result under `skipped_attachments` and `warnings`, so the LLM can see why files did not arrive.
- `tests/gateway/test_platform_base.py`: Regression tests for partition methods plus backward-compatibility check on `filter_media_delivery_paths()`.

## Why so few files?

All other call sites (`gateway/run.py`, `cron/scheduler.py`, `tools/yuanbao_tools.py`, `gateway/platforms/weixin.py`) already get correct per-path logging via the existing `filter_*` wrappers. The only place where skipped attachments were truly invisible was `send_message_tool.py`, where the JSON result went back to the LLM without any mention of what was dropped.

## Testing

```bash
pytest tests/gateway/test_platform_base.py -v -x
```
```text
    100 passed in 0.79s
```

```bash
pytest tests/gateway/test_send_image_file.py tests/gateway/test_signal.py        tests/gateway/test_tts_media_routing.py tests/cron/test_scheduler.py::TestDeliverResultWrapping        -v -x
```
```text
    149 passed in 2.22s
```

New regression tests:
- `test_partition_media_returns_safe_and_skipped`
- `test_partition_local_returns_safe_and_skipped`
- `test_filter_backward_compatible`

Fixes the silent-drop behavior on the send_message tool path.
