### PR TITLE
fix(kanban): strip TUI env from worker spawns

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5680,6 +5680,13 @@ def _default_spawn(
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
+    # Kanban workers are launched headlessly with stdin detached. If the
+    # dispatcher process was started from a TUI environment, inherited
+    # HERMES_TUI* hand-off variables can make `chat -q` enter TUI mode and
+    # fail before the worker calls kanban_complete/kanban_block.
+    for key in list(env):
+        if key == "HERMES_TUI" or key.startswith("HERMES_TUI_"):
+            env.pop(key, None)
 
     # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
     # (fallback_providers, toolsets, agent settings, etc.) instead of the root

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1975,6 +1975,8 @@ class TestSharedBoardPaths:
         default_home = tmp_path / ".hermes"
         default_home.mkdir()
         self._set_home(monkeypatch, tmp_path, default_home)
+        monkeypatch.setenv("HERMES_TUI", "1")
+        monkeypatch.setenv("HERMES_TUI_QUERY", "stale tui query")
 
         captured = {}
 
@@ -2013,6 +2015,8 @@ class TestSharedBoardPaths:
         )
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
+        assert "HERMES_TUI" not in env
+        assert "HERMES_TUI_QUERY" not in env
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- strip inherited `HERMES_TUI*` hand-off variables from kanban worker subprocess environments
- keep kanban workers on the existing `chat -q` lifecycle instead of switching to `-z`
- add regression coverage that a dispatcher with stale TUI env still spawns a headless worker env without those variables

## Why
Kanban workers run headlessly (`stdin=DEVNULL`) but are spawned via `hermes ... chat -q`. If the dispatcher inherits `HERMES_TUI=1` or related `HERMES_TUI_*` variables from a parent TUI/dashboard/shell environment, `cmd_chat()` can enter TUI mode and exit before the worker reaches `kanban_complete` / `kanban_block`, producing protocol-violation churn.

This is a narrower fix than changing worker launch from `chat -q` to `-z`: it preserves the current worker session/lifecycle semantics while preventing accidental TUI hand-off state from leaking into headless workers.

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='`
