### PR TITLE
fix(cli): keep --profile flag on cron create|add|edit subparser (#32046)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -226,11 +226,32 @@ def _apply_profile_override() -> None:
     # we silently switch HERMES_HOME to ``oracle`` at create time and the
     # job lands in oracle's jobs.json with ``profile=null``, never firing
     # from the default scheduler. See issue #32046.
+    #
+    # Only treat ``cron`` as the actual subcommand when it appears at the
+    # subcommand position — i.e. as the first positional token, after any
+    # leading ``-p VAL`` / ``--profile VAL`` / ``--profile=VAL`` pair (and
+    # skipping unknown leading ``-x`` flags as nargs=0). Otherwise a literal
+    # ``cron create`` string buried in a positional arg (e.g.
+    # ``hermes chat tell me about cron create``) would incorrectly suppress
+    # global ``--profile`` parsing.
     cron_subcmd_pos = None
-    for i, arg in enumerate(argv):
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in {"-p", "--profile"} and i + 1 < len(argv):
+            i += 2
+            continue
+        if arg.startswith("--profile="):
+            i += 1
+            continue
+        if arg.startswith("-"):
+            # Unknown leading flag — assume nargs=0 and keep walking.
+            i += 1
+            continue
+        # First positional token: this is argparse's subcommand.
         if arg == "cron" and i + 1 < len(argv) and argv[i + 1] in {"create", "add", "edit"}:
             cron_subcmd_pos = i
-            break
+        break
 
     # 1. Check for explicit -p / --profile flag
     for i, arg in enumerate(argv):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -219,8 +219,23 @@ def _apply_profile_override() -> None:
     profile_name = None
     consume = 0
 
+    # ``cron create|add|edit`` has its own ``--profile`` argument with
+    # job-pin semantics (cf. ``hermes_cli/cron.py``). When the user writes
+    # ``hermes cron create ... --profile oracle``, the trailing flag belongs
+    # to the cron subparser, not to the global profile override — otherwise
+    # we silently switch HERMES_HOME to ``oracle`` at create time and the
+    # job lands in oracle's jobs.json with ``profile=null``, never firing
+    # from the default scheduler. See issue #32046.
+    cron_subcmd_pos = None
+    for i, arg in enumerate(argv):
+        if arg == "cron" and i + 1 < len(argv) and argv[i + 1] in {"create", "add", "edit"}:
+            cron_subcmd_pos = i
+            break
+
     # 1. Check for explicit -p / --profile flag
     for i, arg in enumerate(argv):
+        if cron_subcmd_pos is not None and i >= cron_subcmd_pos:
+            break
         if arg in {"--profile", "-p"} and i + 1 < len(argv):
             profile_name = argv[i + 1]
             consume = 2

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -336,3 +336,79 @@ class TestApplyProfileOverrideCronJobPin:
         assert hermes_home is not None and hermes_home.endswith("ozzy")
         assert "--profile" not in sys.argv
         assert "ozzy" not in sys.argv
+
+    def test_literal_cron_create_in_positional_does_not_suppress_global(
+        self, tmp_path, monkeypatch
+    ):
+        """``cron create`` literals buried inside another subcommand's
+        positional args must NOT be treated as the cron subcommand boundary.
+
+        Example: ``hermes chat tell me about cron create --profile ozzy``.
+        ``chat`` is the real subcommand here and has no ``--profile`` arg
+        of its own, so ``--profile ozzy`` is a legitimate global override
+        and HERMES_HOME must switch to ozzy. A naive "any cron token in
+        argv" scan would set a boundary at the literal ``cron`` and leave
+        the global ``--profile`` unprocessed.
+        """
+        hermes_root = tmp_path / ".hermes"
+        (hermes_root / "profiles" / "ozzy").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "hermes",
+                "chat",
+                "tell",
+                "me",
+                "about",
+                "cron",
+                "create",
+                "--profile",
+                "ozzy",
+            ],
+        )
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        hermes_home = os.environ.get("HERMES_HOME")
+        assert hermes_home is not None and hermes_home.endswith("ozzy"), (
+            "Global --profile must still apply when ``cron create`` is only "
+            "a positional literal under a different subcommand"
+        )
+
+    def test_unknown_leading_flag_then_cron_create_still_protects_pin(
+        self, tmp_path, monkeypatch
+    ):
+        """A leading unrecognised global flag must not prevent the cron
+        boundary from being detected. ``hermes --debug cron create ...
+        --profile oracle`` is the cron subcommand (``--debug`` is nargs=0).
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "hermes",
+                "--debug",
+                "cron",
+                "create",
+                "0 3 * * *",
+                "task",
+                "--profile",
+                "oracle",
+            ],
+        )
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None
+        assert sys.argv[-2:] == ["--profile", "oracle"]

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -138,3 +138,201 @@ class TestApplyProfileOverrideHermesHomeGuard:
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") is None
+
+
+class TestApplyProfileOverrideCronJobPin:
+    """Regression guard for issue #32046.
+
+    ``hermes cron create|add|edit`` defines its own ``--profile`` argument with
+    job-pin semantics (write the job to the active scheduler's jobs.json with
+    ``profile=<name>``). The pre-parse hook must NOT consume those trailing
+    flags as a global HERMES_HOME switch — otherwise the job lands in
+    ``<name>``'s jobs.json with ``profile=null`` and is never ticked by the
+    default scheduler.
+    """
+
+    def test_cron_create_profile_flag_not_consumed_as_global(
+        self, tmp_path, monkeypatch
+    ):
+        """``hermes cron create ... --profile oracle`` must leave ``--profile
+        oracle`` in argv for the cron subparser and must NOT set
+        HERMES_HOME to oracle.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        argv = [
+            "hermes",
+            "cron",
+            "create",
+            "--name",
+            "oracle-nightly",
+            "0 3 * * *",
+            "do the thing",
+            "--profile",
+            "oracle",
+        ]
+        monkeypatch.setattr(sys, "argv", list(argv))
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None, (
+            "cron create --profile must not switch the global HERMES_HOME"
+        )
+        assert sys.argv == argv, (
+            "cron create --profile flag must survive in argv for the subparser"
+        )
+
+    def test_cron_edit_profile_flag_not_consumed_as_global(
+        self, tmp_path, monkeypatch
+    ):
+        """``hermes cron edit <id> --profile oracle`` likewise leaves the
+        cron subparser's ``--profile`` argument alone.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        argv = ["hermes", "cron", "edit", "f0467c04d70f", "--profile", "oracle"]
+        monkeypatch.setattr(sys, "argv", list(argv))
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None
+        assert sys.argv == argv
+
+    def test_cron_add_alias_also_protected(self, tmp_path, monkeypatch):
+        """The ``add`` alias of ``cron create`` is registered in argparse —
+        the pre-parse hook must treat it the same way.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        argv = [
+            "hermes",
+            "cron",
+            "add",
+            "0 3 * * *",
+            "do the thing",
+            "--profile",
+            "oracle",
+        ]
+        monkeypatch.setattr(sys, "argv", list(argv))
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None
+        assert sys.argv == argv
+
+    def test_cron_create_profile_equals_form_not_consumed(
+        self, tmp_path, monkeypatch
+    ):
+        """The ``--profile=oracle`` (single-token equals form) is likewise a
+        cron-subparser arg, not a global override.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        argv = ["hermes", "cron", "create", "0 3 * * *", "task", "--profile=oracle"]
+        monkeypatch.setattr(sys, "argv", list(argv))
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None
+        assert sys.argv == argv
+
+    def test_cron_create_short_p_flag_not_consumed_as_global(
+        self, tmp_path, monkeypatch
+    ):
+        """The cron subparser does not define ``-p`` for job-pin, but a
+        defensive read of the pre-parse hook ignores -p trailing the cron
+        subcommand too — otherwise we would mis-route a user-typed ``-p``
+        as global, breaking the subparser's later error message.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        argv = ["hermes", "cron", "create", "0 3 * * *", "task", "-p", "oracle"]
+        monkeypatch.setattr(sys, "argv", list(argv))
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None
+        assert sys.argv == argv
+
+    def test_global_dash_p_before_cron_still_consumed(self, tmp_path, monkeypatch):
+        """``hermes -p ozzy cron create ... --profile oracle`` keeps both
+        semantics intact: -p (before cron) is the global switch, and
+        --profile (after cron create) is the job pin.
+        """
+        hermes_root = tmp_path / ".hermes"
+        (hermes_root / "profiles" / "ozzy").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "hermes",
+                "-p",
+                "ozzy",
+                "cron",
+                "create",
+                "0 3 * * *",
+                "task",
+                "--profile",
+                "oracle",
+            ],
+        )
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        # Global -p ozzy was consumed → HERMES_HOME points at ozzy.
+        hermes_home = os.environ.get("HERMES_HOME")
+        assert hermes_home is not None and hermes_home.endswith("ozzy")
+        # ``-p ozzy`` was stripped from argv but ``--profile oracle`` survives
+        # for the cron subparser.
+        assert "-p" not in sys.argv
+        assert "ozzy" not in sys.argv
+        assert sys.argv[-2:] == ["--profile", "oracle"]
+
+    def test_cron_list_with_global_profile_still_consumed(
+        self, tmp_path, monkeypatch
+    ):
+        """``hermes cron list --profile ozzy`` has no cron-subparser
+        ``--profile`` arg on ``list``, but the pre-parse hook is gated on
+        ``create|add|edit`` only — so this remains a global switch, matching
+        the historical behaviour.
+        """
+        hermes_root = tmp_path / ".hermes"
+        (hermes_root / "profiles" / "ozzy").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            sys, "argv", ["hermes", "cron", "list", "--profile", "ozzy"]
+        )
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        hermes_home = os.environ.get("HERMES_HOME")
+        assert hermes_home is not None and hermes_home.endswith("ozzy")
+        assert "--profile" not in sys.argv
+        assert "ozzy" not in sys.argv


### PR DESCRIPTION
## What does this PR do?

`_apply_profile_override()` pre-parses `sys.argv` before argparse so any `-p` / `--profile` flag can set `HERMES_HOME` at module-import time. The scan was greedy — any occurrence anywhere in argv got treated as a global override and stripped from argv.

But `hermes cron create|add|edit` defines its own `--profile` argument with **job-pin** semantics (`hermes_cli/cron.py:180,245`) — write the job to the active scheduler's `jobs.json` with `profile=<name>` set as a pin. The greedy pre-parser was consuming that trailing flag as a global `HERMES_HOME` switch instead, so:

```bash
hermes cron create --name oracle-nightly \"0 3 * * *\" \"...\" --profile oracle
```

silently switched `HERMES_HOME` to `oracle` at create time, wrote the job into `~/.hermes/profiles/oracle/cron/jobs.json` with `profile: null`, and the default scheduler never ticked it. Same mechanism produced \"Job not found\" for `hermes cron edit <id> --profile X` (#32045): the global switch flipped `HERMES_HOME` first, then `resolve_job_ref` looked for `<id>` in the wrong profile's `jobs.json`.

Fix: gate the pre-parser on subcommand position. When the first `cron` token in argv is immediately followed by `create`, `add`, or `edit`, stop scanning argv for `--profile`/`-p` at the cron token. The trailing flag survives in argv for the cron subparser to consume.

Mirrors the cron CLI's promise that `--profile <name>` is a job pin (see `hermes_cli/cron.py:180` and `hermes_cli/main.py:11808,11876`). The fix is positional, not heuristic — it cannot mis-route a `-p ozzy` that appears before `cron`, which remains a global switch.

## Related Issue

Fixes #32046
Also resolves #32045 (`cron edit --profile` \"Job not found\") — same root cause, different symptom.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` — `_apply_profile_override()`: detect a `cron create|add|edit` subcommand token in argv and stop the global `--profile`/`-p` scan at that position, so the cron subparser sees its own `--profile` arg.
- `tests/hermes_cli/test_apply_profile_override.py` — 7 new regression tests covering: `cron create --profile`, `cron edit --profile`, the `add` alias, the `--profile=oracle` equals form, `-p oracle` defensive form, the both-flags form (`-p ozzy cron create … --profile oracle`), and a negative control that `cron list --profile X` is still routed as a global switch.

## How to Test

```bash
uv run --with pytest --with pytest-xdist --with pytest-asyncio \\
    python3 -m pytest tests/hermes_cli/test_apply_profile_override.py -v
```

All 11 tests pass; 5 of the 7 new tests fail on `origin/main` without the fix (positive controls confirm the regression guard).

Manual smoke (any multi-profile install):

```bash
# Before: silently wrote into oracle/jobs.json with profile=null
# After: writes into default/jobs.json with profile=\"oracle\" pin
hermes cron create --name oracle-nightly \"0 3 * * *\" \"do the thing\" --profile oracle
cat ~/.hermes/cron/jobs.json | jq '.jobs[] | select(.name==\"oracle-nightly\") | .profile'
# => \"oracle\"
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (7 new tests, with regression guard against `origin/main`)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the docs at `/docs/user-guide/features/cron` already describe the intended behaviour this PR is making true.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — argv parsing is platform-agnostic.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

> Audited siblings: the cron subparser declares `--profile` on `create` (with `add` alias) and `edit` (`hermes_cli/main.py:11808,11876`). The fix gates on exactly those three subcommand tokens; no other cron subcommand (`list`, `tick`, `status`, `pause`, `resume`, `run`, `remove`) declares its own `--profile`, so they remain pure global-switch consumers — pinned by the `test_cron_list_with_global_profile_still_consumed` regression guard. No widening needed.