### PR TITLE
feat(cli): show live background terminal-process count in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3503,6 +3503,7 @@ class HermesCLI:
             "session_api_calls": 0,
             "compressions": 0,
             "active_background_tasks": 0,
+            "active_background_processes": 0,
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -3512,6 +3513,14 @@ class HermesCLI:
             bg_tasks = getattr(self, "_background_tasks", None)
             if bg_tasks:
                 snapshot["active_background_tasks"] = len(bg_tasks)
+        except Exception:
+            pass
+
+        # Count live background terminal processes (terminal tool background
+        # sessions tracked by tools.process_registry). Cheap O(1) read.
+        try:
+            from tools.process_registry import process_registry
+            snapshot["active_background_processes"] = process_registry.count_running()
         except Exception:
             pass
 
@@ -3753,6 +3762,9 @@ class HermesCLI:
                 bg_count = snapshot.get("active_background_tasks", 0)
                 if bg_count:
                     parts.append(f"▶ {bg_count}")
+                bg_proc_count = snapshot.get("active_background_processes", 0)
+                if bg_proc_count:
+                    parts.append(f"⚙ {bg_proc_count}")
                 parts.append(duration_label)
                 if yolo_active:
                     parts.append("⚠ YOLO")
@@ -3772,6 +3784,9 @@ class HermesCLI:
             bg_count = snapshot.get("active_background_tasks", 0)
             if bg_count:
                 parts.append(f"▶ {bg_count}")
+            bg_proc_count = snapshot.get("active_background_processes", 0)
+            if bg_proc_count:
+                parts.append(f"⚙ {bg_proc_count}")
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
@@ -3813,6 +3828,7 @@ class HermesCLI:
                 if width < 76:
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
+                    bg_proc_count = snapshot.get("active_background_processes", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
@@ -3825,6 +3841,9 @@ class HermesCLI:
                     if bg_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"▶ {bg_count}"))
+                    if bg_proc_count:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
@@ -3844,6 +3863,7 @@ class HermesCLI:
                     bar_style = self._status_bar_context_style(percent)
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
+                    bg_proc_count = snapshot.get("active_background_processes", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
@@ -3860,6 +3880,9 @@ class HermesCLI:
                     if bg_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"▶ {bg_count}"))
+                    if bg_proc_count:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
                     frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),

--- a/tests/cli/test_cli_background_status_indicator.py
+++ b/tests/cli/test_cli_background_status_indicator.py
@@ -102,3 +102,90 @@ def test_fragments_omit_bg_segment_when_idle():
     frags = cli_obj._get_status_bar_fragments()
     rendered = "".join(text for _style, text in frags)
     assert "▶" not in rendered
+
+
+# ── Background terminal-process indicator (⚙ N) ───────────────────────────
+# Source of truth is tools.process_registry.process_registry._running (a dict
+# of currently-running shell processes spawned by terminal(background=true)).
+# Distinct from /background tasks above: ▶ counts agent threads, ⚙ counts
+# shell processes. Both can be active simultaneously.
+
+
+class _FakeRunningRegistry:
+    """Minimal stand-in for process_registry; exposes count_running()."""
+
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def count_running(self) -> int:
+        return self._count
+
+
+def _patch_process_registry(monkeypatch, count: int) -> None:
+    import tools.process_registry as pr_mod
+    monkeypatch.setattr(pr_mod, "process_registry", _FakeRunningRegistry(count))
+
+
+def test_snapshot_reports_zero_when_no_background_processes(monkeypatch):
+    cli_obj = _make_cli()
+    _patch_process_registry(monkeypatch, 0)
+    snap = cli_obj._get_status_bar_snapshot()
+    assert snap["active_background_processes"] == 0
+
+
+def test_snapshot_counts_live_background_processes(monkeypatch):
+    cli_obj = _make_cli()
+    _patch_process_registry(monkeypatch, 3)
+    snap = cli_obj._get_status_bar_snapshot()
+    assert snap["active_background_processes"] == 3
+
+
+def test_snapshot_safe_when_process_registry_raises(monkeypatch):
+    """If count_running() raises the snapshot stays at 0; no propagate."""
+    cli_obj = _make_cli()
+    import tools.process_registry as pr_mod
+
+    class _BoomRegistry:
+        def count_running(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(pr_mod, "process_registry", _BoomRegistry())
+    snap = cli_obj._get_status_bar_snapshot()
+    assert snap["active_background_processes"] == 0
+
+
+def test_plain_text_status_shows_proc_indicator_when_active(monkeypatch):
+    cli_obj = _make_cli()
+    _patch_process_registry(monkeypatch, 2)
+    text = cli_obj._build_status_bar_text(width=80)
+    assert "⚙ 2" in text
+
+
+def test_plain_text_status_omits_proc_indicator_when_idle(monkeypatch):
+    cli_obj = _make_cli()
+    _patch_process_registry(monkeypatch, 0)
+    text = cli_obj._build_status_bar_text(width=80)
+    assert "⚙" not in text
+
+
+def test_fragments_include_proc_segment_when_active(monkeypatch):
+    cli_obj = _make_cli()
+    _patch_process_registry(monkeypatch, 1)
+    cli_obj._status_bar_visible = True
+    cli_obj._get_tui_terminal_width = lambda: 120  # type: ignore[method-assign]
+    frags = cli_obj._get_status_bar_fragments()
+    rendered = "".join(text for _style, text in frags)
+    assert "⚙ 1" in rendered
+
+
+def test_indicators_independent_agents_and_processes(monkeypatch):
+    """▶ (agent tasks) and ⚙ (shell processes) render side-by-side."""
+    cli_obj = _make_cli()
+    cli_obj._background_tasks = {"bg_a": _stub_thread()}
+    _patch_process_registry(monkeypatch, 2)
+    cli_obj._status_bar_visible = True
+    cli_obj._get_tui_terminal_width = lambda: 120  # type: ignore[method-assign]
+    frags = cli_obj._get_status_bar_fragments()
+    rendered = "".join(text for _style, text in frags)
+    assert "▶ 1" in rendered
+    assert "⚙ 2" in rendered

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1235,6 +1235,19 @@ class ProcessRegistry:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
+    def count_running(self) -> int:
+        """Return the count of currently-running background processes.
+
+        Cheap O(1) read of the running dict, suitable for status-bar polling
+        on every render tick. CPython dict ``len()`` is atomic; callers do not
+        need to hold ``self._lock``. Reflects ``_running`` only: sessions are
+        moved to ``_finished`` when their subprocess exits.
+        """
+        try:
+            return len(self._running)
+        except Exception:
+            return 0
+
     def list_sessions(self, task_id: str = None) -> list:
         """List all running and recently-finished processes."""
         with self._lock:


### PR DESCRIPTION
## Summary
The status bar gains a `⚙ N` indicator that shows how many background terminal processes are currently alive — `▶` and `⚙` render side-by-side when both kinds of background work are running.

## Why
`▶ N` already counted /background agent threads. Shell processes spawned via `terminal(background=true)` had no in-bar signal — easy to forget you have one running and miss its completion. Came up during a CI watch poll: the watcher process was dead but the bar gave no hint.

## Changes
- `tools/process_registry.py` — `count_running()` returns `len(_running)` lock-free (O(1), CPython dict len is atomic; safe for per-tick status-bar polling).
- `cli.py` — snapshot adds `active_background_processes`; renders `⚙ N` at all 4 status-bar tiers (text fallback + prompt_toolkit fragments × narrow/wide widths). The <52 tier still drops both indicators for space.
- `tests/cli/test_cli_background_status_indicator.py` — +7 tests covering snapshot count, raise-safety, indicator visibility in text/fragments, and side-by-side rendering with `▶`.

## Visual
```
Wide (>= 76):  ⚕ model │ ctx 12k/200k │ ░░ 6% │ ▶ 1 │ ⚙ 2 │ 1m23s │ ⏲ 4s │ ⚠ YOLO
Mid  (>= 52):  ⚕ model · 6% · ▶ 1 · ⚙ 2 · 1m23s · ⚠ YOLO
```

## Validation
```
tests/cli/test_cli_background_status_indicator.py    16/16 ✓ (9 existing + 7 new)
tests/cli/  + tests/tools/test_process_tool.py      792/792 ✓
```


## Infographic

![bg-process-indicator](https://v3b.fal.media/files/b/0a9ba0a0/8rTpu9UVTrI7X32qu6HUQ_FkekFEWv.png)
