### PR TITLE
fix: throttle respawn guard events

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4056,6 +4056,12 @@ _RESPAWN_GUARD_SUCCESS_WINDOW = 3600  # 1 hour
 # Within this window a GitHub PR URL in a comment blocks re-spawn.
 _RESPAWN_GUARD_PR_WINDOW = 86400  # 24 hours
 
+# Throttle diagnostic events for ready-but-guarded tasks. The guard leaves the
+# task in ``ready`` by design, so every dispatcher tick will encounter it again.
+# Without a durable throttle, multiple profile gateways can turn a single
+# active-PR card into an unbounded task_events write loop.
+_RESPAWN_GUARD_EVENT_WINDOW = 3600  # 1 hour
+
 # Pattern matching a GitHub PR URL in task comments.
 _RESPAWN_GUARD_PR_URL_RE = re.compile(
     r"https?://github\.com/[^/\s]+/[^/\s]+/pull/\d+",
@@ -5028,6 +5034,39 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     return None
 
 
+def _should_emit_respawn_guard_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    reason: str,
+    *,
+    now: Optional[int] = None,
+) -> bool:
+    """Return True if a respawn_guarded event should be written now.
+
+    ``check_respawn_guard`` intentionally leaves tasks in ``ready`` so a future
+    tick/operator action can retry without manual unblock. That also means a
+    guarded task is revisited every dispatcher tick. Emit the diagnostic event
+    at most once per task+reason per throttle window to keep the event log from
+    becoming a hot write loop.
+    """
+    current = int(time.time()) if now is None else int(now)
+    cutoff = current - _RESPAWN_GUARD_EVENT_WINDOW
+    rows = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'respawn_guarded' AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC LIMIT 20",
+        (task_id, cutoff),
+    ).fetchall()
+    for row in rows:
+        try:
+            payload = json.loads(row["payload"]) if row["payload"] else {}
+        except Exception:
+            payload = {}
+        if isinstance(payload, dict) and payload.get("reason") == reason:
+            return False
+    return True
+
+
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
@@ -5253,12 +5292,16 @@ def dispatch_once(
             # Emit an event so operators can see why the task was
             # skipped when reading `hermes kanban tail` — without
             # this the task appears stuck in ready with no diagnosis.
+            # Do not emit it every tick: guarded tasks intentionally
+            # stay in ready, and repeated diagnostics can otherwise
+            # become a multi-gateway write loop.
             if not dry_run:
-                with write_txn(conn):
-                    _append_event(
-                        conn, row["id"], "respawn_guarded",
-                        {"reason": guard_reason},
-                    )
+                if _should_emit_respawn_guard_event(conn, row["id"], guard_reason):
+                    with write_txn(conn):
+                        _append_event(
+                            conn, row["id"], "respawn_guarded",
+                            {"reason": guard_reason},
+                        )
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1432,6 +1432,27 @@ def test_dispatch_respawn_guard_emits_event_for_skipped_task(
     assert guarded_evt.payload.get("reason") == "recent_success"
 
 
+def test_dispatch_respawn_guard_event_is_throttled_for_hot_ready_task(
+    kanban_home, all_assignees_spawnable
+):
+    """Repeated guarded ticks should not append unbounded respawn_guarded events."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="active-pr-hot-loop", assignee="alice")
+        kb.add_comment(
+            conn, t, "worker",
+            "Opened https://github.com/totemx-AI/subsidysmart/pull/123",
+        )
+        first = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        second = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+        events = [e for e in kb.list_events(conn, t) if e.kind == "respawn_guarded"]
+
+    assert (t, "active_pr") in first.respawn_guarded
+    assert (t, "active_pr") in second.respawn_guarded
+    assert len(events) == 1
+    assert isinstance(events[0].payload, dict)
+    assert events[0].payload.get("reason") == "active_pr"
+
+
 # ---------------------------------------------------------------------------
 # Workspace resolution
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- throttle respawn_guarded task_event writes per task/reason so ready-but-guarded tasks do not hot-loop writes every dispatcher tick
- keep dispatch results reporting respawn_guarded so operators still see why a task was skipped
- add regression coverage for repeated active_pr guarded ticks producing a single diagnostic event

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_emits_event_for_skipped_task tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_event_is_throttled_for_hot_ready_task tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_skips_active_pr -q -o 'addopts='
- git diff --check