### PR TITLE
feat(dashboard): add sort dropdown to cron jobs page

### DIFF
--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -217,6 +217,13 @@ export const af: Translations = {
     next: "Volgende",
     pause: "Pouse",
     resume: "Hervat",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Voer nou uit",
     delivery: {
       local: "Plaaslik",

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -217,6 +217,13 @@ export const de: Translations = {
     next: "Nächste",
     pause: "Pausieren",
     resume: "Fortsetzen",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Jetzt auslösen",
     delivery: {
       local: "Lokal",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -218,6 +218,13 @@ export const en: Translations = {
     pause: "Pause",
     resume: "Resume",
     triggerNow: "Trigger now",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     delivery: {
       local: "Local",
       telegram: "Telegram",

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -217,6 +217,13 @@ export const es: Translations = {
     next: "Próxima",
     pause: "Pausar",
     resume: "Reanudar",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Ejecutar ahora",
     delivery: {
       local: "Local",

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -217,6 +217,13 @@ export const fr: Translations = {
     next: "Prochaine",
     pause: "Pause",
     resume: "Reprendre",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Déclencher maintenant",
     delivery: {
       local: "Local",

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -217,6 +217,13 @@ export const ga: Translations = {
     next: "Ar aghaidh",
     pause: "Sos",
     resume: "Lean ar aghaidh",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Spreag anois",
     delivery: {
       local: "Áitiúil",

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -217,6 +217,13 @@ export const hu: Translations = {
     next: "Következő",
     pause: "Szüneteltetés",
     resume: "Folytatás",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Indítás most",
     delivery: {
       local: "Helyi",

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -217,6 +217,13 @@ export const it: Translations = {
     next: "Prossima",
     pause: "Pausa",
     resume: "Riprendi",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Esegui ora",
     delivery: {
       local: "Locale",

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -217,6 +217,13 @@ export const ja: Translations = {
     next: "次回",
     pause: "一時停止",
     resume: "再開",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "今すぐ実行",
     delivery: {
       local: "ローカル",

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -217,6 +217,13 @@ export const ko: Translations = {
     next: "다음",
     pause: "일시 정지",
     resume: "재개",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "지금 실행",
     delivery: {
       local: "로컬",

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -217,6 +217,13 @@ export const pt: Translations = {
     next: "Próxima",
     pause: "Pausar",
     resume: "Retomar",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Acionar agora",
     delivery: {
       local: "Local",

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -217,6 +217,13 @@ export const ru: Translations = {
     next: "Следующий",
     pause: "Пауза",
     resume: "Возобновить",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Запустить сейчас",
     delivery: {
       local: "Локально",

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -217,6 +217,13 @@ export const tr: Translations = {
     next: "Sonraki",
     pause: "Duraklat",
     resume: "Devam ettir",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Şimdi tetikle",
     delivery: {
       local: "Yerel",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -238,6 +238,13 @@ export interface Translations {
     pause: string;
     resume: string;
     triggerNow: string;
+    sortBy: string;
+    sortNextSoonest: string;
+    sortNextLatest: string;
+    sortLastRecent: string;
+    sortLastOldest: string;
+    sortName: string;
+    sortState: string;
     delivery: {
       local: string;
       telegram: string;

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -217,6 +217,13 @@ export const uk: Translations = {
     next: "Наступне",
     pause: "Призупинити",
     resume: "Відновити",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "Запустити зараз",
     delivery: {
       local: "Локально",

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -217,6 +217,13 @@ export const zhHant: Translations = {
     next: "下次",
     pause: "暫停",
     resume: "繼續",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "立即觸發",
     delivery: {
       local: "本機",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -214,6 +214,13 @@ export const zh: Translations = {
     next: "下次",
     pause: "暂停",
     resume: "恢复",
+    sortBy: "Sort by",
+    sortNextSoonest: "Next run (soonest)",
+    sortNextLatest: "Next run (latest)",
+    sortLastRecent: "Last run (recent)",
+    sortLastOldest: "Last run (oldest)",
+    sortName: "Name",
+    sortState: "State",
     triggerNow: "立即触发",
     delivery: {
       local: "本地",

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
-import { Clock, Pause, Play, Plus, Trash2, X, Zap, ArrowUpDown } from "lucide-react";
+import { Clock, Pause, Play, Trash2, X, Zap, ArrowUpDown } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
-import { Clock, Pause, Play, Trash2, X, Zap } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { Clock, Pause, Play, Plus, Trash2, X, Zap, ArrowUpDown } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
@@ -100,6 +100,7 @@ export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [selectedProfile, setSelectedProfile] = useState("all");
+  const [sortBy, setSortBy] = useState("next_asc");
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { t } = useI18n();
@@ -137,6 +138,62 @@ export default function CronPage() {
   useEffect(() => {
     loadJobs();
   }, [loadJobs]);
+
+  // Sort jobs client-side
+  const sortedJobs = useMemo(() => {
+    const sorted = [...jobs];
+    switch (sortBy) {
+      case "next_asc":
+        sorted.sort((a, b) => {
+          const aTime = a.next_run_at ? new Date(a.next_run_at).getTime() : Infinity;
+          const bTime = b.next_run_at ? new Date(b.next_run_at).getTime() : Infinity;
+          return aTime - bTime;
+        });
+        break;
+      case "next_desc":
+        sorted.sort((a, b) => {
+          const aTime = a.next_run_at ? new Date(a.next_run_at).getTime() : -Infinity;
+          const bTime = b.next_run_at ? new Date(b.next_run_at).getTime() : -Infinity;
+          return bTime - aTime;
+        });
+        break;
+      case "last_desc":
+        sorted.sort((a, b) => {
+          const aTime = a.last_run_at ? new Date(a.last_run_at).getTime() : -Infinity;
+          const bTime = b.last_run_at ? new Date(b.last_run_at).getTime() : -Infinity;
+          return bTime - aTime;
+        });
+        break;
+      case "last_asc":
+        sorted.sort((a, b) => {
+          const aTime = a.last_run_at ? new Date(a.last_run_at).getTime() : Infinity;
+          const bTime = b.last_run_at ? new Date(b.last_run_at).getTime() : Infinity;
+          return aTime - bTime;
+        });
+        break;
+      case "name_asc":
+        sorted.sort((a, b) => {
+          const aName = getJobTitle(a).toLowerCase();
+          const bName = getJobTitle(b).toLowerCase();
+          return aName.localeCompare(bName);
+        });
+        break;
+      case "state":
+        sorted.sort((a, b) => {
+          const aState = getJobState(a);
+          const bState = getJobState(b);
+          // enabled/scheduled first, then paused, then error/completed
+          const order: Record<string, number> = {
+            enabled: 0, scheduled: 0, paused: 1, error: 2, completed: 2, disabled: 2,
+          };
+          return (order[aState] ?? 3) - (order[bState] ?? 3);
+        });
+        break;
+      default:
+        break;
+    }
+    return sorted;
+  }, [jobs, sortBy]);
 
   const handleCreate = async () => {
     if (!prompt.trim() || !schedule.trim()) {
@@ -250,7 +307,7 @@ export default function CronPage() {
   }
 
   const pendingJob = jobDelete.pendingId
-    ? jobs.find((j) => getJobKey(j) === jobDelete.pendingId)
+    ? sortedJobs.find((j) => getJobKey(j) === jobDelete.pendingId)
     : null;
 
   return (
@@ -401,27 +458,48 @@ export default function CronPage() {
             className="flex items-center gap-2 text-muted-foreground"
           >
             <Clock className="h-4 w-4" />
-            {t.cron.scheduledJobs} ({jobs.length})
+            {t.cron.scheduledJobs} ({sortedJobs.length})
           </H2>
 
-          <div className="grid gap-1 min-w-[220px]">
-            <Label htmlFor="cron-profile-filter">Profile</Label>
-            <Select
-              id="cron-profile-filter"
-              value={selectedProfile}
-              onValueChange={(v) => setSelectedProfile(v)}
-            >
-              <SelectOption value="all">All profiles</SelectOption>
-              {profiles.map((profile) => (
-                <SelectOption key={profile.name} value={profile.name}>
-                  {profileLabel(profile.name)}
-                </SelectOption>
-              ))}
-            </Select>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <div className="grid gap-1 min-w-[180px]">
+              <Label htmlFor="cron-sort">
+                <ArrowUpDown className="h-3 w-3 inline mr-1" />
+                {t.cron.sortBy}
+              </Label>
+              <Select
+                id="cron-sort"
+                value={sortBy}
+                onValueChange={(v) => setSortBy(v)}
+              >
+                <SelectOption value="next_asc">{t.cron.sortNextSoonest}</SelectOption>
+                <SelectOption value="next_desc">{t.cron.sortNextLatest}</SelectOption>
+                <SelectOption value="last_desc">{t.cron.sortLastRecent}</SelectOption>
+                <SelectOption value="last_asc">{t.cron.sortLastOldest}</SelectOption>
+                <SelectOption value="name_asc">{t.cron.sortName}</SelectOption>
+                <SelectOption value="state">{t.cron.sortState}</SelectOption>
+              </Select>
+            </div>
+
+            <div className="grid gap-1 min-w-[200px]">
+              <Label htmlFor="cron-profile-filter">Profile</Label>
+              <Select
+                id="cron-profile-filter"
+                value={selectedProfile}
+                onValueChange={(v) => setSelectedProfile(v)}
+              >
+                <SelectOption value="all">All profiles</SelectOption>
+                {profiles.map((profile) => (
+                  <SelectOption key={profile.name} value={profile.name}>
+                    {profileLabel(profile.name)}
+                  </SelectOption>
+                ))}
+              </Select>
+            </div>
           </div>
         </div>
 
-        {jobs.length === 0 && (
+        {sortedJobs.length === 0 && (
           <Card>
             <CardContent className="py-8 text-center text-sm text-muted-foreground">
               {t.cron.noJobs}
@@ -429,7 +507,7 @@ export default function CronPage() {
           </Card>
         )}
 
-        {jobs.map((job) => {
+        {sortedJobs.map((job) => {
           const state = getJobState(job);
           const promptText = getJobPrompt(job);
           const title = getJobTitle(job);


### PR DESCRIPTION
## Summary

Adds a **sort dropdown** to the Cron dashboard page (`/cron`) so users can order jobs by execution time instead of relying on the default API order.

## Motivation

Currently, the cron jobs page displays jobs in whatever order the backend returns them — typically insertion order. For users with more than a handful of scheduled jobs, this makes it hard to quickly see:

- Which jobs are running next
- Which jobs just ran
- Which jobs are in error state

A sort control lets users organize the list by the dimension they care about.

## Screenshot

The sort dropdown is placed next to the existing profile filter in the page header:

```
┌──────────────────────────────────────────────────────────┐
│  🕐 Scheduled Jobs (12)                                  │
│                          [Sort: Next run (soonest) ▼] [Profile: All ▼] │
├──────────────────────────────────────────────────────────┤
│  Daily briefing    enabled  default                      │
│  Next run: 5/25/2026, 9:00 AM   Last: 5/24/2026, 9:00 AM │
├──────────────────────────────────────────────────────────┤
│  PR Monitor        enabled  default                      │
│  Next run: 5/25/2026, 10:00 AM  Last: —                  │
└──────────────────────────────────────────────────────────┘
```

## Sort Options

| Option | Behavior |
|---|---|
| **Next run (soonest)** | Default. Jobs with upcoming executions first. Nulls at the end. |
| **Next run (latest)** | Jobs furthest in the future first. Nulls at the end. |
| **Last run (recent)** | Most recently executed first. Nulls at the end. |
| **Last run (oldest)** | Least recently executed first. Nulls at the end. |
| **Name** | Alphabetical by job name (or prompt if unnamed) |
| **State** | Grouped: enabled/scheduled → paused → error/completed/disabled |

## Implementation Details

- **`useMemo`** ensures sorting only recomputes when `jobs` or `sortBy` changes — zero overhead on re-renders from other state changes
- All rendering paths (job list, empty state, delete confirmation dialog) use the sorted array so the selected order is preserved consistently
- Jobs with missing timestamps (`null` `next_run_at` / `last_run_at`) sort to the appropriate ends depending on direction
- The sort dropdown is placed in the same header row as the profile filter for natural discovery — users don't need to hunt for it

## Files Changed

| File | Change |
|---|---|
| `web/src/pages/CronPage.tsx` | Sort state, `useMemo` sorting logic, sort dropdown UI |
| `web/src/i18n/types.ts` | 7 new translation keys |
| `web/src/i18n/en.ts` | English sort labels |
| `web/src/i18n/{af,de,es,fr,ga,hu,it,ja,ko,pt,ru,tr,uk,zh,zh-hant}.ts` | Sort labels (English fallbacks) |

## Testing

- ✅ `tsc -b` (strict project-references build) passes with zero errors
- ✅ No regressions — all existing functionality (create, pause/resume, trigger, delete, profile filter) unchanged
- ✅ Sort selection persists across profile filter changes