### PR TITLE
fix(agent): preserve user_id when compression spawns continuation session

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -391,6 +391,7 @@ def compress_context(
             agent._session_db.create_session(
                 session_id=agent.session_id,
                 source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                user_id=getattr(agent, "_user_id", None),
                 model=agent.model,
                 model_config=agent._session_init_model_config,
                 parent_session_id=old_session_id,


### PR DESCRIPTION
## What does this PR do?

`compress_context()` in `agent/conversation_compression.py` spawns a continuation session via `agent._session_db.create_session(...)` but does not pass `user_id`. Result: every session created by mid-conversation compression lands with `user_id = NULL` in `state.db`, even though the human peer attached to the parent session is unchanged.

This breaks downstream user-scoped queries (Honcho memory provider, peer-attribution logic, any consumer that filters by `user_id`). Each compression turns a properly-attributed session into an orphan.

The fix is one line: pass `agent._user_id` through to `create_session()`. `getattr(agent, "_user_id", None)` preserves existing behavior for code paths where `_user_id` was never set (CLI, some test paths) — the default `None` matches what the old call did implicitly.

## Related Issue

Same class of bug as #24333 (which fixes the equivalent site in `run_agent.py` for bg/cron/delegate sessions). This PR closes the same hole at the compression site. No issue filed; happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py:393` — add `user_id=getattr(agent, "_user_id", None)` to the `create_session()` call inside `compress_context()`.

## How to Test

**Reproduction (without the fix):**

1. Start a Hermes agent through a platform that sets `user_id` (Telegram gateway, Slack gateway, etc.).
2. Drive the conversation past the compression threshold so `compress_context()` fires.
3. Inspect `state.db`: the parent session has `user_id = <expected>`, the post-compression continuation session has `user_id = NULL`.

**With the fix:** both sessions share the same `user_id`.

**Discovery context:** Surfaced while debugging a multi-peer Honcho integration where compressed sessions were silently becoming unattributed even though the Telegram user was unchanged. Tracked to this one line.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): ...`)
- [x] I searched for existing PRs (closest is #24333, different site, same bug class — see Related Issue)
- [x] My PR contains **only** changes related to this fix (one line)
- [ ] I've run `pytest tests/ -q` and all tests pass — couldn't run full suite from contributor environment; the change is isolated and pattern-matches #24333. Happy to add a regression test mirroring `tests/agent/test_session_user_id.py` if maintainers want one.
- [ ] I've added tests for my changes — see above; willing to add if requested.
- [x] I've tested on my platform: Ubuntu 24.04 (Hetzner VPS) — running this patch in production for the Sophia Telegram bot since 2026-05-25. No regressions; the NULL-user_id orphan class of sessions stopped occurring.

### Documentation & Housekeeping

- [x] N/A — no doc changes
- [x] N/A — no config-key changes
- [x] N/A — no architecture changes
- [x] Cross-platform: pure Python, no platform-specific behavior
- [x] N/A — no tool-schema changes
