### PR TITLE
fix(auxiliary,config): wire auxiliary.vision.api_key + warn on toolset/provider mismatch (#31996)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3768,21 +3768,39 @@ def _normalize_vision_provider(provider: Optional[str]) -> str:
 def _resolve_strict_vision_backend(
     provider: str,
     model: Optional[str] = None,
+    *,
+    api_key: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
+    """Resolve a dedicated client for ``provider``'s strict vision backend.
+
+    ``api_key`` (when provided) overrides env-var lookup so configs that
+    set ``auxiliary.vision.api_key`` actually use the configured key
+    instead of silently falling back to ``OPENROUTER_API_KEY`` / etc.
+    Without the override, users who set ``auxiliary.vision.provider:
+    openrouter`` *and* ``auxiliary.vision.api_key`` in ``config.yaml``
+    would still see ``Auxiliary: marking openrouter unhealthy for 60s``
+    because the provider-router branches below never read the resolved
+    config key.  See issue #31996 sub-issue 2.
+    """
     provider = _normalize_vision_provider(provider)
+    explicit_key = (api_key or "").strip() or None
     if provider == "copilot":
-        return resolve_provider_client("copilot", model, is_vision=True)
+        return resolve_provider_client(
+            "copilot", model, is_vision=True, explicit_api_key=explicit_key
+        )
     if provider == "openrouter":
-        return _try_openrouter(model=model)
+        return _try_openrouter(model=model, explicit_api_key=explicit_key)
     if provider == "nous":
         return _try_nous(vision=True)
     if provider == "openai-codex":
         # Route through resolve_provider_client so the caller's explicit
         # model is used.  There is no safe default Codex model (shifting
         # allow-list); callers must specify via auxiliary.<task>.model.
-        return resolve_provider_client("openai-codex", model, is_vision=True)
+        return resolve_provider_client(
+            "openai-codex", model, is_vision=True, explicit_api_key=explicit_key
+        )
     if provider == "anthropic":
-        return _try_anthropic()
+        return _try_anthropic(explicit_api_key=explicit_key)
     if provider == "custom":
         return _try_custom_endpoint()
     return None, None
@@ -3944,8 +3962,15 @@ def resolve_vision_provider_client(
         return None, None, None
 
     if requested in _VISION_AUTO_PROVIDER_ORDER:
+        # Plumb the resolved api_key through so an explicit
+        # ``auxiliary.vision.api_key`` in config.yaml actually overrides
+        # the env-var lookup (#31996 sub-issue 2).  Without this, users
+        # who configured ``provider: openrouter`` + ``api_key: …`` would
+        # still see "marking openrouter unhealthy for 60s" when their
+        # ``OPENROUTER_API_KEY`` env var was empty, and the vision call
+        # would silently fall through to a non-vision fallback.
         sync_client, default_model = _resolve_strict_vision_backend(
-            requested, resolved_model
+            requested, resolved_model, api_key=resolved_api_key,
         )
         return _finalize(requested, sync_client, default_model)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3488,6 +3488,186 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 f"Move '{key}' under the appropriate section",
             ))
 
+    # ── Tool-config / provider-config consistency (#31996) ───────────────
+    # If a user wires a backend provider for image generation or vision
+    # but the matching toolset is *explicitly* disabled, the
+    # ``image_generate`` / ``vision_analyze`` tools never reach the LLM
+    # and the configured backend looks broken from the user's side.
+    # Detect that exact mismatch so doctor surfaces a clear pointer
+    # instead of leaving users to grep ``hermes tools`` output.
+    issues.extend(_validate_tool_provider_consistency(config))
+
+    # ── Auxiliary task api_key without provider (#31996 sub-issue 2) ─────
+    # Configuring ``auxiliary.<task>.api_key`` without also setting
+    # ``auxiliary.<task>.provider`` silently leaves the key unused —
+    # auto-resolution falls through to env-var lookup and the explicit
+    # config value is ignored.  Warn so users wire both keys instead of
+    # debugging a "marking openrouter unhealthy for 60s" log line.
+    issues.extend(_validate_auxiliary_api_key_has_provider(config))
+
+    return issues
+
+
+def _platform_explicit_toolsets(config: Dict[str, Any]) -> Dict[str, List[str]]:
+    """Return ``platform_toolsets`` as a normalised name→list mapping.
+
+    Drops non-list / non-dict shapes silently — those are caught by
+    schema validation elsewhere and we don't want a stale value to
+    crash the consistency check.
+    """
+    pt = config.get("platform_toolsets")
+    if not isinstance(pt, dict):
+        return {}
+    out: Dict[str, List[str]] = {}
+    for plat, names in pt.items():
+        if isinstance(names, list):
+            out[str(plat)] = [str(n) for n in names]
+    return out
+
+
+def _validate_tool_provider_consistency(config: Dict[str, Any]) -> List["ConfigIssue"]:
+    """Surface mismatches between configured providers and enabled toolsets.
+
+    Two checks (#31996 sub-issues 1 and 3):
+
+    * ``image_gen.provider`` is set, but every platform's toolset list
+      that the user has explicitly written *omits* ``image_gen`` and
+      doesn't contain a composite (``hermes-cli``, ``hermes-api-server``,
+      …) that would expand to it.  This produces "image_generate tool
+      never reaches the model even though the plugin is loaded".
+    * ``auxiliary.vision`` is configured (non-default ``provider`` /
+      ``base_url`` / ``api_key`` / ``model``) but the same explicit
+      toolset list omits ``vision``.  Same failure mode — vision_analyze
+      is invisible to the LLM.
+
+    Implicit defaults (no ``platform_toolsets`` entry, falls through to
+    ``hermes-cli``) keep working out of the box; this only fires when
+    the user has *explicitly* narrowed the toolset list and forgot the
+    matching entry.
+    """
+    issues: List[ConfigIssue] = []
+
+    explicit = _platform_explicit_toolsets(config)
+    if not explicit:
+        # User hasn't narrowed any platform — defaults include the
+        # full ``hermes-cli`` composite which already wires both tools.
+        return issues
+
+    try:
+        from toolsets import TOOLSETS, resolve_toolset
+    except Exception:
+        return issues
+
+    def _platforms_missing_tool(target_tool: str) -> List[str]:
+        """Return platforms whose explicit toolset list omits ``target_tool``."""
+        bad: List[str] = []
+        for plat, names in explicit.items():
+            tools = set()
+            for ts_name in names:
+                if ts_name in TOOLSETS:
+                    try:
+                        tools.update(resolve_toolset(ts_name))
+                    except Exception:
+                        continue
+            if target_tool not in tools:
+                bad.append(plat)
+        return bad
+
+    image_gen_cfg = config.get("image_gen") or {}
+    image_gen_provider = ""
+    if isinstance(image_gen_cfg, dict):
+        image_gen_provider = str(image_gen_cfg.get("provider") or "").strip().lower()
+    if image_gen_provider and image_gen_provider not in {"none", "off", "disabled"}:
+        bad = _platforms_missing_tool("image_generate")
+        if bad:
+            issues.append(ConfigIssue(
+                "warning",
+                (
+                    f"image_gen.provider is set to '{image_gen_provider}' but the "
+                    f"following platform toolsets omit image_gen: {', '.join(sorted(bad))} — "
+                    f"the image_generate tool will never reach the model on those platforms"
+                ),
+                "Add 'image_gen' to platform_toolsets entries that should expose image generation, "
+                "e.g. `hermes tools` → check '🎨 Image Generation', or add it manually:\n"
+                "  platform_toolsets:\n"
+                f"    {bad[0]}:\n"
+                "      - hermes-cli\n"
+                "      - image_gen",
+            ))
+
+    aux_cfg = config.get("auxiliary") or {}
+    vision_cfg = aux_cfg.get("vision") if isinstance(aux_cfg, dict) else None
+    if isinstance(vision_cfg, dict):
+        configured = any(
+            str(vision_cfg.get(field) or "").strip()
+            for field in ("provider", "model", "base_url", "api_key")
+        )
+        if configured:
+            bad = _platforms_missing_tool("vision_analyze")
+            if bad:
+                issues.append(ConfigIssue(
+                    "warning",
+                    (
+                        "auxiliary.vision is configured but the following platform "
+                        f"toolsets omit vision: {', '.join(sorted(bad))} — vision_analyze "
+                        f"will never reach the model on those platforms"
+                    ),
+                    "Add 'vision' to platform_toolsets entries that should expose vision analysis, "
+                    "e.g. `hermes tools` → check '👁️ Vision / Image Analysis', or add it manually:\n"
+                    "  platform_toolsets:\n"
+                    f"    {bad[0]}:\n"
+                    "      - hermes-cli\n"
+                    "      - vision",
+                ))
+
+    return issues
+
+
+def _validate_auxiliary_api_key_has_provider(config: Dict[str, Any]) -> List["ConfigIssue"]:
+    """Warn when ``auxiliary.<task>.api_key`` is set but ``provider`` is not.
+
+    The auxiliary-client resolver only forwards ``api_key`` after a
+    concrete provider has been selected (``_resolve_task_provider_model``
+    short-circuits to ``"auto"`` when ``provider`` is empty/auto).  In
+    auto mode every backend reads its own env var (``OPENROUTER_API_KEY``,
+    ``ANTHROPIC_API_KEY``, …) and the configured ``api_key`` is silently
+    ignored.  Users hit this and report "I set the key in the right
+    place but vision still 401s" — see #31996 sub-issue 2.
+    """
+    issues: List[ConfigIssue] = []
+    aux_cfg = config.get("auxiliary")
+    if not isinstance(aux_cfg, dict):
+        return issues
+    for task, task_cfg in aux_cfg.items():
+        if not isinstance(task_cfg, dict):
+            continue
+        api_key = str(task_cfg.get("api_key") or "").strip()
+        if not api_key:
+            continue
+        provider = str(task_cfg.get("provider") or "").strip().lower()
+        base_url = str(task_cfg.get("base_url") or "").strip()
+        # ``provider: <something>`` or an explicit ``base_url`` both
+        # carry the api_key into the resolved client.  Only complain
+        # when neither is wired.
+        if provider and provider != "auto":
+            continue
+        if base_url:
+            continue
+        issues.append(ConfigIssue(
+            "warning",
+            (
+                f"auxiliary.{task}.api_key is set but auxiliary.{task}.provider is "
+                f"empty/auto — the key will be silently ignored during auto-resolution"
+            ),
+            (
+                f"Either set auxiliary.{task}.provider to the backend that owns this key "
+                f"(e.g. 'openrouter', 'nous', 'anthropic'), or move the key into "
+                f"~/.hermes/.env under the provider's standard variable name "
+                f"(OPENROUTER_API_KEY, ANTHROPIC_API_KEY, etc.).  Without one of those, "
+                f"the resolver falls back to env-var lookup and your config value is "
+                f"never used."
+            ),
+        ))
     return issues
 
 

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -394,7 +394,9 @@ class TestResolveVisionMainFirst:
 
         # Explicit "nous" override → uses strict backend, NOT main model path
         assert provider == "nous"
-        mock_strict.assert_called_once_with("nous", None)
+        # ``api_key=None`` is forwarded after #31996 wired the resolved
+        # auxiliary api_key through to the strict-backend dispatcher.
+        mock_strict.assert_called_once_with("nous", None, api_key=None)
 
 
 # ── Constant cleanup ────────────────────────────────────────────────────────

--- a/tests/agent/test_vision_aux_api_key_31996.py
+++ b/tests/agent/test_vision_aux_api_key_31996.py
@@ -1,0 +1,215 @@
+"""Regression tests for #31996 sub-issue 2 — auxiliary.vision.api_key plumbing.
+
+Issue #31996 reports that setting ``auxiliary.vision.api_key`` in
+``config.yaml`` does not actually authenticate the OpenRouter (or
+similar) vision client — instead the auxiliary client falls back to
+``os.getenv("OPENROUTER_API_KEY")`` and, when that env var is empty,
+marks the provider unhealthy for 60s.
+
+Root cause: ``_resolve_strict_vision_backend`` discarded the
+``resolved_api_key`` value and called ``_try_openrouter(model=…)`` with
+no ``explicit_api_key``, so the env-var lookup was the only auth source.
+
+The fix (a) adds an ``api_key`` keyword argument to
+``_resolve_strict_vision_backend`` and routes it through to
+``_try_openrouter`` / ``_try_anthropic`` / ``resolve_provider_client``,
+and (b) updates the explicit-provider branch of
+``resolve_vision_provider_client`` to pass ``resolved_api_key`` down.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _resolve_strict_vision_backend forwards api_key to every backend
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStrictVisionBackendForwardsApiKey:
+    """The strict-vision dispatcher now plumbs ``api_key`` to each provider."""
+
+    def test_signature_accepts_keyword_api_key(self):
+        """``api_key`` must be a keyword-only parameter so callers self-document."""
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+        sig = inspect.signature(_resolve_strict_vision_backend)
+        assert "api_key" in sig.parameters
+        param = sig.parameters["api_key"]
+        # Keyword-only: no positional shadowing of older 2-arg call sites.
+        assert param.kind == inspect.Parameter.KEYWORD_ONLY
+        assert param.default is None
+
+    def test_openrouter_branch_passes_api_key_to_try_openrouter(self):
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        with patch(
+            "agent.auxiliary_client._try_openrouter",
+            return_value=(MagicMock(), "vision-model"),
+        ) as mock_try:
+            _resolve_strict_vision_backend(
+                "openrouter", model="some-model", api_key="sk-or-v1-config"
+            )
+
+        mock_try.assert_called_once()
+        kwargs = mock_try.call_args.kwargs
+        assert kwargs.get("explicit_api_key") == "sk-or-v1-config"
+        assert kwargs.get("model") == "some-model"
+
+    def test_anthropic_branch_passes_api_key_to_try_anthropic(self):
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        with patch(
+            "agent.auxiliary_client._try_anthropic",
+            return_value=(MagicMock(), "claude-3"),
+        ) as mock_try:
+            _resolve_strict_vision_backend("anthropic", api_key="sk-ant-config")
+
+        mock_try.assert_called_once()
+        kwargs = mock_try.call_args.kwargs
+        assert kwargs.get("explicit_api_key") == "sk-ant-config"
+
+    def test_copilot_branch_passes_api_key_to_resolve_provider_client(self):
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(MagicMock(), "gpt-4o"),
+        ) as mock_rpc:
+            _resolve_strict_vision_backend(
+                "copilot", model="gpt-4o", api_key="ghu_token"
+            )
+
+        mock_rpc.assert_called_once()
+        kwargs = mock_rpc.call_args.kwargs
+        assert kwargs.get("explicit_api_key") == "ghu_token"
+        assert kwargs.get("is_vision") is True
+
+    def test_codex_branch_passes_api_key_to_resolve_provider_client(self):
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(MagicMock(), "gpt-5"),
+        ) as mock_rpc:
+            _resolve_strict_vision_backend(
+                "openai-codex", model="gpt-5", api_key="sk-config"
+            )
+
+        mock_rpc.assert_called_once()
+        kwargs = mock_rpc.call_args.kwargs
+        assert kwargs.get("explicit_api_key") == "sk-config"
+        assert kwargs.get("is_vision") is True
+
+    def test_empty_or_whitespace_api_key_normalized_to_none(self):
+        """Whitespace-only keys must NOT shadow env-var lookup downstream.
+
+        ``str(task_config.get("api_key", "")).strip() or None`` is the
+        contract upstream — pin it inside ``_resolve_strict_vision_backend``
+        so a forgotten ``.strip()`` at any future call site doesn't pass
+        ``"   "`` through as if it were a real credential.
+        """
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        with patch(
+            "agent.auxiliary_client._try_openrouter",
+            return_value=(MagicMock(), "model"),
+        ) as mock_try:
+            _resolve_strict_vision_backend("openrouter", api_key="   ")
+            _resolve_strict_vision_backend("openrouter", api_key="")
+            _resolve_strict_vision_backend("openrouter", api_key=None)
+
+        for call in mock_try.call_args_list:
+            assert call.kwargs.get("explicit_api_key") is None
+
+
+class TestResolveVisionProviderClientPlumbsApiKey:
+    """The wrapper that callers actually use plumbs the resolved key down."""
+
+    def test_explicit_provider_branch_passes_resolved_api_key(self):
+        """``provider: openrouter`` + ``api_key: …`` reaches _try_openrouter.
+
+        End-to-end check for the bug as reported: configure
+        ``auxiliary.vision.provider: openrouter`` AND
+        ``auxiliary.vision.api_key: sk-or-v1-…`` in config.yaml, then
+        call ``resolve_vision_provider_client()`` (the entry point used
+        by ``vision_analyze``).  Before the fix, _try_openrouter saw an
+        empty env var and marked the provider unhealthy.  After the
+        fix, the configured key reaches the SDK constructor.
+        """
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("openrouter", "vision-model", None, "sk-or-v1-cfg", None),
+        ), patch(
+            "agent.auxiliary_client._try_openrouter",
+            return_value=(MagicMock(), "vision-model"),
+        ) as mock_try:
+            resolve_vision_provider_client()
+
+        # Sanity: _try_openrouter was reached and got the configured key.
+        mock_try.assert_called_once()
+        assert mock_try.call_args.kwargs.get("explicit_api_key") == "sk-or-v1-cfg"
+
+    def test_auto_branch_does_not_force_misleading_api_key(self):
+        """Auto-resolution must NOT inject a stale config api_key into env path.
+
+        When ``auxiliary.vision.provider`` is unset/auto,
+        ``_resolve_task_provider_model`` returns api_key=None — pin
+        that contract so the explicit-provider branch's plumbing
+        doesn't accidentally leak a ghost key into the auto-detection
+        chain.  Otherwise users with a stale config api_key would see
+        the wrong credential get tried for unrelated providers.
+        """
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ), patch(
+            "agent.auxiliary_client._read_main_provider", return_value=""
+        ), patch(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            return_value=(None, None),
+        ) as mock_strict:
+            resolve_vision_provider_client()
+
+        # Every fallthrough call in auto mode passes api_key=None.
+        for call in mock_strict.call_args_list:
+            assert call.kwargs.get("api_key") is None or "api_key" not in call.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards — the wiring stays in place under refactors
+# ---------------------------------------------------------------------------
+
+
+class TestSourceGuards31996:
+    """Make accidental removal of the api_key plumbing loud at code review."""
+
+    def test_resolve_strict_vision_backend_references_31996(self):
+        from agent.auxiliary_client import _resolve_strict_vision_backend
+
+        src = inspect.getsource(_resolve_strict_vision_backend)
+        assert "31996" in src
+        # Must forward to _try_openrouter with explicit_api_key (not a
+        # bare positional arg that future callers could accidentally
+        # drop).
+        assert "_try_openrouter(model=model, explicit_api_key=" in src
+
+    def test_resolve_vision_provider_client_passes_resolved_api_key(self):
+        from agent.auxiliary_client import resolve_vision_provider_client
+
+        src = inspect.getsource(resolve_vision_provider_client)
+        # The fix's explicit hint — "31996" must show up in the fixed
+        # branch so a refactor that drops the api_key kwarg can't skip
+        # the issue context.
+        assert "31996" in src
+        # The buggy v0.5.1 shape is gone.  Pin that we no longer call
+        # ``_resolve_strict_vision_backend(requested, resolved_model)``
+        # without the keyword key.
+        assert "_resolve_strict_vision_backend(\n            requested, resolved_model\n        )" not in src

--- a/tests/hermes_cli/test_validate_toolset_consistency_31996.py
+++ b/tests/hermes_cli/test_validate_toolset_consistency_31996.py
@@ -1,0 +1,319 @@
+"""Regression tests for #31996 — toolset-vs-provider consistency warnings.
+
+Issue #31996 sub-issues 1 and 3 trace the same failure: a user wires a
+backend (``image_gen.provider: minimax`` or
+``auxiliary.vision.provider: openrouter``) but their explicit
+``platform_toolsets`` list omits the matching toolset.  The plugin
+loads, the provider resolves, the runtime client connects — but the
+``image_generate`` / ``vision_analyze`` schema never reaches the LLM,
+so the model never knows the tool exists.
+
+Sub-issue 2 trace: ``auxiliary.<task>.api_key`` is silently ignored
+when ``provider`` is empty/auto — the resolver falls through to the
+"auto" branch which reads each backend's env var directly.
+
+The validators below surface both classes as ``ConfigIssue`` warnings
+that ``hermes doctor`` and the startup config-warning printer pick up.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from hermes_cli.config import (
+    ConfigIssue,
+    _validate_auxiliary_api_key_has_provider,
+    _validate_tool_provider_consistency,
+    validate_config_structure,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool ↔ provider consistency
+# ---------------------------------------------------------------------------
+
+
+class TestImageGenToolsetConsistency:
+    """Detect ``image_gen.provider`` set + ``image_gen`` toolset missing."""
+
+    def test_explicit_toolsets_missing_image_gen_with_provider_set_warns(self):
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "platform_toolsets": {"cli": ["web", "vision"]},
+        }
+        issues = _validate_tool_provider_consistency(config)
+        assert any(
+            "image_gen.provider" in i.message and "cli" in i.message
+            for i in issues
+        ), f"got: {[i.message for i in issues]}"
+
+    def test_explicit_toolsets_with_image_gen_listed_does_not_warn(self):
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "platform_toolsets": {"cli": ["web", "image_gen"]},
+        }
+        issues = _validate_tool_provider_consistency(config)
+        assert not any("image_gen.provider" in i.message for i in issues)
+
+    def test_explicit_hermes_cli_composite_includes_image_gen(self):
+        """The ``hermes-cli`` composite already wires ``image_generate``.
+
+        Users who keep the default composite shouldn't be flagged —
+        that's the out-of-the-box behaviour and it works.
+        """
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "platform_toolsets": {"cli": ["hermes-cli"]},
+        }
+        issues = _validate_tool_provider_consistency(config)
+        assert not any("image_gen.provider" in i.message for i in issues)
+
+    def test_implicit_default_does_not_warn(self):
+        """No ``platform_toolsets`` → falls back to ``hermes-cli`` defaults.
+
+        Until the user explicitly narrows the toolset list, the runtime
+        already exposes ``image_generate``.  Warning here would be
+        noise on every fresh install.
+        """
+        config = {"image_gen": {"provider": "minimax"}}
+        issues = _validate_tool_provider_consistency(config)
+        assert not issues
+
+    def test_disabled_image_gen_provider_does_not_warn(self):
+        for sentinel in ("none", "off", "disabled", ""):
+            config = {
+                "image_gen": {"provider": sentinel},
+                "platform_toolsets": {"cli": ["web"]},
+            }
+            issues = _validate_tool_provider_consistency(config)
+            assert not any(
+                "image_gen.provider" in i.message for i in issues
+            ), f"sentinel {sentinel!r} unexpectedly warned"
+
+    def test_warning_hint_offers_concrete_fix(self):
+        """Hint text must show the user *exactly* what to add to their YAML."""
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "platform_toolsets": {"cli": ["web"]},
+        }
+        issues = _validate_tool_provider_consistency(config)
+        hints = [i.hint for i in issues if "image_gen.provider" in i.message]
+        assert hints
+        h = hints[0]
+        assert "platform_toolsets" in h
+        assert "image_gen" in h
+        assert "cli" in h
+
+
+class TestVisionToolsetConsistency:
+    """Detect ``auxiliary.vision`` configured + ``vision`` toolset missing."""
+
+    @pytest.mark.parametrize(
+        "vision_cfg",
+        [
+            {"provider": "openrouter"},
+            {"model": "google/gemini-3-flash-preview"},
+            {"base_url": "https://api.example/v1"},
+            {"api_key": "sk-or-v1-…"},
+        ],
+    )
+    def test_any_vision_field_set_with_missing_toolset_warns(self, vision_cfg):
+        config = {
+            "auxiliary": {"vision": vision_cfg},
+            "platform_toolsets": {"cli": ["web", "image_gen"]},
+        }
+        issues = _validate_tool_provider_consistency(config)
+        assert any(
+            "auxiliary.vision" in i.message and "cli" in i.message
+            for i in issues
+        )
+
+    def test_vision_toolset_listed_does_not_warn(self):
+        config = {
+            "auxiliary": {"vision": {"provider": "openrouter"}},
+            "platform_toolsets": {"cli": ["vision"]},
+        }
+        issues = _validate_tool_provider_consistency(config)
+        assert not any("auxiliary.vision" in i.message for i in issues)
+
+    def test_empty_vision_section_does_not_warn(self):
+        for empty in ({}, {"provider": ""}, {"provider": "  "}):
+            config = {
+                "auxiliary": {"vision": empty},
+                "platform_toolsets": {"cli": ["web"]},
+            }
+            issues = _validate_tool_provider_consistency(config)
+            assert not any(
+                "auxiliary.vision" in i.message for i in issues
+            ), f"empty {empty!r} unexpectedly warned"
+
+
+class TestMultiPlatformAggregation:
+    """The warning enumerates *every* platform that's missing the tool."""
+
+    def test_multiple_bad_platforms_listed_in_single_warning(self):
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "platform_toolsets": {
+                "cli": ["web"],
+                "discord": ["web"],
+                "telegram": ["hermes-cli"],  # OK — composite includes image_generate
+            },
+        }
+        issues = _validate_tool_provider_consistency(config)
+        msgs = [i.message for i in issues if "image_gen.provider" in i.message]
+        assert msgs
+        m = msgs[0]
+        # Both bad platforms surfaced; the composite-using one is silent.
+        assert "cli" in m
+        assert "discord" in m
+        assert "telegram" not in m
+
+
+# ---------------------------------------------------------------------------
+# auxiliary.<task>.api_key without provider warning
+# ---------------------------------------------------------------------------
+
+
+class TestAuxiliaryApiKeyWithoutProvider:
+    """``api_key`` set without ``provider`` is a silent-drop trap (#31996.2)."""
+
+    def test_api_key_without_provider_warns(self):
+        config = {"auxiliary": {"vision": {"api_key": "sk-or-v1-…"}}}
+        issues = _validate_auxiliary_api_key_has_provider(config)
+        assert any(
+            "auxiliary.vision.api_key" in i.message
+            and "ignored" in i.message.lower()
+            for i in issues
+        )
+
+    def test_api_key_with_provider_does_not_warn(self):
+        config = {
+            "auxiliary": {
+                "vision": {
+                    "api_key": "sk-or-v1-…",
+                    "provider": "openrouter",
+                },
+            },
+        }
+        issues = _validate_auxiliary_api_key_has_provider(config)
+        assert not issues
+
+    def test_api_key_with_explicit_base_url_does_not_warn(self):
+        """``base_url`` alone routes the key through the custom endpoint.
+
+        ``_resolve_task_provider_model`` returns ``"custom"`` whenever
+        ``base_url`` is set, and the api_key flows through that branch
+        even without an explicit provider.  Don't false-positive.
+        """
+        config = {
+            "auxiliary": {
+                "vision": {
+                    "api_key": "sk-…",
+                    "base_url": "https://api.example.com/v1",
+                },
+            },
+        }
+        issues = _validate_auxiliary_api_key_has_provider(config)
+        assert not issues
+
+    def test_provider_auto_with_api_key_warns(self):
+        """``provider: auto`` short-circuits to env-var lookup → key ignored."""
+        config = {
+            "auxiliary": {
+                "vision": {
+                    "api_key": "sk-or-v1-…",
+                    "provider": "auto",
+                },
+            },
+        }
+        issues = _validate_auxiliary_api_key_has_provider(config)
+        assert any("auxiliary.vision.api_key" in i.message for i in issues)
+
+    def test_multiple_tasks_each_get_their_own_warning(self):
+        config = {
+            "auxiliary": {
+                "vision":   {"api_key": "sk-1"},
+                "compression": {"api_key": "sk-2"},
+            },
+        }
+        issues = _validate_auxiliary_api_key_has_provider(config)
+        msgs = [i.message for i in issues]
+        assert any("auxiliary.vision.api_key" in m for m in msgs)
+        assert any("auxiliary.compression.api_key" in m for m in msgs)
+
+    def test_empty_or_whitespace_api_key_does_not_warn(self):
+        for empty in ("", "   ", None):
+            config = {"auxiliary": {"vision": {"api_key": empty}}}
+            issues = _validate_auxiliary_api_key_has_provider(config)
+            assert not issues, f"unexpected warning for empty key {empty!r}"
+
+
+# ---------------------------------------------------------------------------
+# Integration with validate_config_structure (the doctor entry point)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigStructureIntegration:
+    """Both new checks are wired into the doctor's structural validator."""
+
+    def test_validate_config_structure_surfaces_image_gen_warning(self):
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "platform_toolsets": {"cli": ["web"]},
+        }
+        issues = validate_config_structure(config)
+        assert any(
+            "image_gen.provider" in i.message
+            for i in issues
+        ), f"got: {[i.message for i in issues]}"
+
+    def test_validate_config_structure_surfaces_aux_api_key_warning(self):
+        config = {"auxiliary": {"vision": {"api_key": "sk-…"}}}
+        issues = validate_config_structure(config)
+        assert any("auxiliary.vision.api_key" in i.message for i in issues)
+
+    def test_clean_config_does_not_introduce_new_issues(self):
+        """A correctly-wired config produces no #31996-related warnings."""
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "auxiliary": {
+                "vision": {"provider": "openrouter", "api_key": "sk-or-v1-…"},
+            },
+            "platform_toolsets": {"cli": ["hermes-cli"]},
+        }
+        issues = validate_config_structure(config)
+        offending = [
+            i for i in issues
+            if "image_gen.provider" in i.message
+            or "auxiliary.vision" in i.message
+        ]
+        assert not offending, f"unexpected: {[i.message for i in offending]}"
+
+
+# ---------------------------------------------------------------------------
+# Source-level guards
+# ---------------------------------------------------------------------------
+
+
+class TestSourceGuards:
+    """Pin the integration so accidental removal is loud at code review."""
+
+    def test_validate_config_structure_calls_both_helpers(self):
+        src = inspect.getsource(validate_config_structure)
+        assert "_validate_tool_provider_consistency" in src
+        assert "_validate_auxiliary_api_key_has_provider" in src
+        assert "31996" in src
+
+    def test_helpers_return_typed_config_issues(self):
+        config = {
+            "image_gen": {"provider": "minimax"},
+            "platform_toolsets": {"cli": ["web"]},
+        }
+        for issue in _validate_tool_provider_consistency(config):
+            assert isinstance(issue, ConfigIssue)
+            assert issue.severity in {"error", "warning"}
+            assert issue.message
+            assert issue.hint


### PR DESCRIPTION
## What does this PR do?

Resolves the three sub-issues in #31996 — *image_gen and vision tools not working after fresh install*:

1. **Sub-issue 1 (image_gen toolset)** — A user installs the MiniMax image-gen plugin, sets `image_gen.provider: minimax` in `config.yaml`, but `image_generate` never reaches the model.
2. **Sub-issue 2 (auxiliary.vision.api_key written to wrong location)** — `auxiliary.vision.api_key: sk-or-v1-…` succeeds via `hermes config set`, but vision still fails with `Auxiliary: marking openrouter unhealthy for 60s` because `_try_openrouter()` only reads `os.getenv("OPENROUTER_API_KEY")` and the configured key is silently ignored.
3. **Sub-issue 3 (vision toolset)** — Same as sub-issue 1 for the vision toolset.

This PR is a **two-pronged fix**:

- **Code fix**: plumb the resolved `auxiliary.<task>.api_key` from `_resolve_task_provider_model` all the way into `_try_openrouter` / `_try_anthropic` / `resolve_provider_client` so config keys actually authenticate. The bug was in `_resolve_strict_vision_backend`, which dropped the `api_key` and called the backends with only `model`. Sub-issue 2 is now fixed at the root.
- **Diagnostic fix**: extend `validate_config_structure` (the source for `hermes doctor` warnings and the startup config-warning printer) with two new validators that catch the configuration shapes behind sub-issues 1, 2, and 3 — *only* when the user has explicitly narrowed `platform_toolsets` (so fresh installs with default composites stay quiet). Each warning shows the user the exact YAML to paste to fix their config.

> **Scope note**: I deliberately did *not* change defaults (e.g. auto-enabling `image_gen` / `vision` toolsets when their providers are configured). That's a riskier behaviour change with broader implications — auto-detection of installed plugins, toolset gating semantics, etc. — and warrants its own design discussion. The PR's diagnostic surface points the user at the missing piece without silently flipping their config, so they retain full control while losing the cryptic failure mode.

## Related Issue

Closes #31996.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

3 atomic commits, all authored by `xxxigm`:

1. **`fix(auxiliary_client): plumb auxiliary.<task>.api_key into strict-vision backends`** — `agent/auxiliary_client.py` (+27 lines) + `tests/agent/test_auxiliary_main_first.py` (+3 lines)
   - Add a keyword-only `api_key: Optional[str] = None` parameter to `_resolve_strict_vision_backend`.
   - Forward into `_try_openrouter(model=…, explicit_api_key=…)`, `_try_anthropic(explicit_api_key=…)`, and `resolve_provider_client(..., explicit_api_key=…)` for the copilot / openai-codex branches.
   - Whitespace-only keys normalise to `None` so a stray `api_key: "  "` doesn't shadow env-var fallback at the SDK boundary.
   - In `resolve_vision_provider_client`, the explicit-provider branch now passes `resolved_api_key` down to the dispatcher.
   - Update one existing test that asserted the old 2-arg call shape.

2. **`fix(config): warn on toolset / provider mismatches surfaced by #31996`** — `hermes_cli/config.py` (+180 lines)
   - `_validate_tool_provider_consistency(config)` — flags `image_gen.provider` set + every explicit `platform_toolsets` list omits `image_gen` and doesn't expand to a composite that wires `image_generate`. Same for `auxiliary.vision` + `vision_analyze`. Implicit defaults stay silent.
   - `_validate_auxiliary_api_key_has_provider(config)` — flags every `auxiliary.<task>.api_key` set without `provider` or `base_url`, with concrete remediation steps (set provider, or move key into `~/.hermes/.env`).
   - Both helpers fold into `validate_config_structure`, which is already called by `hermes doctor` and the startup config-warning printer.

3. **`test(auxiliary,config): pin #31996 fixes with regression coverage`** — 2 new test files (+534 lines, 34 cases)
   - `tests/agent/test_vision_aux_api_key_31996.py` (10 cases) — strict-backend dispatcher forwards `api_key` to every branch; whitespace normalisation; end-to-end plumbing for `provider: openrouter` + `api_key: …`; auto-mode does *not* leak a ghost key into unrelated providers; source-level guards.
   - `tests/hermes_cli/test_validate_toolset_consistency_31996.py` (24 cases) — toolset/provider consistency triggers, no-false-positives for default composites and disabled providers, multi-platform aggregation, parametrized vision-field detection, api_key-without-provider matrix, integration with `validate_config_structure`, source-level guards.

No public API changes; the new `api_key` keyword on `_resolve_strict_vision_backend` is internal and keyword-only so older 2-arg call sites keep working unchanged.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/agent/test_vision_aux_api_key_31996.py tests/hermes_cli/test_validate_toolset_consistency_31996.py
   ```
   Expected: `34 tests passed`.
3. Run the full vision/auxiliary/config suite to confirm no regressions:
   ```
   scripts/run_tests.sh tests/agent/test_vision_aux_api_key_31996.py tests/hermes_cli/test_validate_toolset_consistency_31996.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py tests/agent/test_vision_routing_31179.py tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_runtime_provider_resolution.py
   ```
   Expected: `404 tests passed`.
4. Manual reproduction of sub-issue 2:
   ```python
   from unittest.mock import patch, MagicMock
   from agent.auxiliary_client import resolve_vision_provider_client
   with patch("agent.auxiliary_client._resolve_task_provider_model",
              return_value=("openrouter", "vision-model", None, "sk-or-v1-config", None)), \
        patch("agent.auxiliary_client._try_openrouter",
              return_value=(MagicMock(), "vision-model")) as mock_try:
       resolve_vision_provider_client()
   print(mock_try.call_args.kwargs)  # → {'model': 'vision-model', 'explicit_api_key': 'sk-or-v1-config'}
   ```
5. Manual reproduction of sub-issue 1 + 3 doctor warnings:
   ```yaml
   # config.yaml
   image_gen:
     provider: minimax
   auxiliary:
     vision:
       api_key: sk-or-v1-…
   platform_toolsets:
     cli:
       - web
   ```
   ```
   $ hermes doctor
   ⚠ image_gen.provider is set to 'minimax' but the following platform toolsets omit image_gen: cli — the image_generate tool will never reach the model on those platforms
       Add 'image_gen' to platform_toolsets entries that should expose image generation, …
   ⚠ auxiliary.vision.api_key is set but auxiliary.vision.provider is empty/auto — the key will be silently ignored during auto-resolution
       Either set auxiliary.vision.provider to the backend that owns this key …
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(auxiliary_client): …`, `fix(config): …`, `test(auxiliary,config): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_vision_aux_api_key_31996.py tests/hermes_cli/test_validate_toolset_consistency_31996.py` and all 34 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `_resolve_strict_vision_backend`, `_validate_tool_provider_consistency`, and `_validate_auxiliary_api_key_has_provider` all carry docstrings that describe the bug and remediation, with references to #31996.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no schema change).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python plumbing and config validation, no platform-specific calls.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/agent/test_vision_aux_api_key_31996.py tests/hermes_cli/test_validate_toolset_consistency_31996.py
=== Summary: 2 files, 34 tests passed, 0 failed (100% complete) in 0.7s (24 workers) ===

$ scripts/run_tests.sh tests/agent/test_vision_aux_api_key_31996.py tests/hermes_cli/test_validate_toolset_consistency_31996.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py tests/agent/test_vision_routing_31179.py tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_runtime_provider_resolution.py
=== Summary: 8 files, 404 tests passed, 0 failed (100% complete) in 3.3s (24 workers) ===
```

https://github.com/NousResearch/hermes-agent/compare/main...xxxigm:hermes-agent:fix/31996-vision-image-gen-toolset-discovery?expand=1