### PR TITLE
fix(tui): remap /q alias from quit to queue (salvage #14681 + #31985)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1308,6 +1308,8 @@ AUTHOR_MAP = {
     "claw@openclaw.ai": "wanwan2qq",  # PR #10215 (strip brackets/quotes from /resume; gateway session-ID lookup)
     "simo.kiihamaki@gmail.com": "SimoKiihamaki",  # PR #30773 (Windows /reset+/new freeze; stdin fallback for modal)
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #27518 (bracketed-paste timeout)
+    "8bit64k@pm.me": "8bit64k",  # PR #14681 (TUI /q alias from quit to queue)
+    "chenglunhu@gmail.com": "hclsys",  # PR #31985 (TUI /q alias regression test)
 }
 
 

--- a/ui-tui/src/__tests__/slashParity.test.ts
+++ b/ui-tui/src/__tests__/slashParity.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 import { describe, expect, it } from 'vitest'
 
-import { SLASH_COMMANDS } from '../app/slash/registry.js'
+import { findSlashCommand, SLASH_COMMANDS } from '../app/slash/registry.js'
 
 type CommandRoute = 'fallback' | 'local' | 'native'
 
@@ -109,5 +109,15 @@ describe('slash parity matrix', () => {
       expect(routes[name], `missing command in registry: ${name}`).toBeDefined()
       expect(routes[name], `mutating command must not fallback: ${name}`).not.toBe('fallback')
     }
+  })
+
+  it('/q alias resolves to queue, not quit (#31983)', () => {
+    // Regression for #31983: the TUI `quit` command used to carry alias `q`,
+    // which collided with the Python-side `/queue` alias. TUI-local commands
+    // dispatch before the backend, so `/q` resolved to /quit (session.die)
+    // instead of queueing a prompt.
+    const cmd = findSlashCommand('q')
+    expect(cmd, '/q must resolve to a command').toBeDefined()
+    expect(cmd!.name).toBe('queue')
   })
 })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -110,7 +110,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
-    aliases: ['exit', 'q'],
+    aliases: ['exit'],
     help: 'exit hermes',
     name: 'quit',
     run: (_arg, ctx) => ctx.session.die()
@@ -547,6 +547,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['q'],
     help: 'inspect or enqueue a message',
     name: 'queue',
     run: (arg, ctx) => {


### PR DESCRIPTION
## Summary
`/q` in the TUI resolves to `/queue`, not `/quit`. Previously the quit command carried alias `q` in `core.ts`, shadowing the Python-side `/queue` alias — typing `/q <msg>` exited the TUI instead of queueing a prompt.

Salvage of PR #14681 by @8bit64k (code fix) + regression test adapted from PR #31985 by @hclsys.

## Changes
- `ui-tui/src/app/slash/commands/core.ts`: remove `q` from quit aliases, add `aliases: ["q"]` to queue
- `ui-tui/src/__tests__/slashParity.test.ts`: regression test asserting `findSlashCommand("q")` resolves to queue
- `scripts/release.py`: AUTHOR_MAP entries for 8bit64k + hclsys

## Validation
| | Before | After |
|---|---|---|
| `/q hello` in TUI | exits (session.die) | queues prompt |
| `/quit` / `/exit` | exits | exits (unchanged) |
| vitest slashParity | 2 passed | 3 passed + regression guard |

Fixes #31983. Closes #14681. Credits #31985.
