### PR TITLE
fix(cli): skip profile override for cron commands (#32046)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -181,10 +181,22 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # Falls back to ~/.hermes/active_profile for sticky default.
 # ---------------------------------------------------------------------------
 def _apply_profile_override() -> None:
-    """Pre-parse --profile/-p and set HERMES_HOME before module imports."""
+    """Pre-parse --profile/-p and set HERMES_HOME before module imports.
+
+    Cron commands use --profile to pin a job's target profile, NOT to switch
+    the CLI's HERMES_HOME.  If we switch HERMES_HOME here, the cron job gets
+    stored in the target profile's jobs.json (where no scheduler ticks it)
+    instead of the active profile's jobs.json with profile= pin set.
+    See issue #32046.
+    """
     argv = sys.argv[1:]
     profile_name = None
     consume = 0
+
+    # 0. Skip profile override for cron subcommands — their --profile flag
+    # is a job-level pin, not a CLI-level HERMES_HOME switch.
+    if argv and argv[0] == "cron":
+        return
 
     # 1. Check for explicit -p / --profile flag
     for i, arg in enumerate(argv):

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -139,3 +139,59 @@ class TestApplyProfileOverrideHermesHomeGuard:
         _apply_profile_override()
 
         assert os.environ.get("HERMES_HOME") is None
+
+
+class TestApplyProfileOverrideCronSkip:
+    """Regression guard for issue #32046.
+
+    Cron commands use --profile to pin a job's target profile, NOT to switch
+    the CLI's HERMES_HOME.  If we switch HERMES_HOME here, the cron job gets
+    stored in the target profile's jobs.json (where no scheduler ticks it)
+    instead of the active profile's jobs.json with profile= pin set.
+    """
+
+    def test_cron_create_with_profile_does_not_switch_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        """hermes cron create --profile oracle must NOT switch HERMES_HOME.
+
+        The --profile flag for cron is a job-level pin, not a CLI-level
+        HERMES_HOME switch.  The job should land in the active profile's
+        jobs.json with profile='oracle' set.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "oracle").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["hermes", "cron", "create", "0 3 * * *", "do something", "--profile", "oracle"],
+        )
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        # HERMES_HOME must NOT be set — cron command should not switch profiles
+        assert os.environ.get("HERMES_HOME") is None
+
+    def test_cron_list_with_profile_does_not_switch_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        """hermes cron list (any cron subcommand) must not trigger profile switch."""
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "oracle").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["hermes", "cron", "list", "--profile", "oracle"],
+        )
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") is None


### PR DESCRIPTION
## What broke
`hermes cron create --profile <name>` switches `HERMES_HOME` at CLI level before module imports, causing the cron job to land in the target profile's `jobs.json` (where no scheduler ticks it) instead of the active profile's `jobs.json` with `profile=<name>` pin set. Users with multi-profile Pantheon-style setups (where secondary profile gateways are stopped) silently lose every cron created with `--profile`.

## Root cause
`_apply_profile_override()` in `hermes_cli/main.py` intercepts `--profile` from `sys.argv` and sets `HERMES_HOME` before any modules are imported. For cron commands, the `--profile` flag is meant to be a job-level pin (stored in the job's `profile` field), not a CLI-level `HERMES_HOME` switch. When `HERMES_HOME` is switched early, `cron/jobs.py` imports with `CRON_DIR` and `JOBS_FILE` pointing to the target profile's directory.

## Why this fix is minimal
Single early-return guard added to `_apply_profile_override()`: if `argv[0] == "cron"`, skip the profile override entirely. The `--profile` flag is passed through to the cronjob tool unchanged, which correctly stores it as the job's `profile` field. No changes to cron storage, cron execution, or any other command.

## What I tested
Added `TestApplyProfileOverrideCronSkip` class in `tests/hermes_cli/test_apply_profile_override.py`:
- `test_cron_create_with_profile_does_not_switch_hermes_home` — verifies `hermes cron create --profile oracle` does not set `HERMES_HOME`
- `test_cron_list_with_profile_does_not_switch_hermes_home` — verifies `hermes cron list --profile oracle` does not set `HERMES_HOME`

All existing `TestApplyProfileOverrideHermesHomeGuard` tests continue to pass (non-cron commands still get profile override as before).

## What I intentionally did not change
- Cron storage logic (`cron/jobs.py`)
- Cronjob tool (`tools/cronjob_tools.py`)
- Profile resolution for non-cron commands
- `cron edit --profile` behavior (separate issue #32045)