### PR TITLE
fix: reduce noisy gateway warning logs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18202,6 +18202,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             _shutdown_ctx = None
             logger.debug("snapshot_shutdown_context failed: %s", _e)
 
+        if (
+            not planned_takeover
+            and not planned_stop
+            and received_signal == signal.SIGTERM
+            and _shutdown_ctx is not None
+            and _shutdown_ctx.get("under_systemd")
+        ):
+            # ``systemctl stop|restart`` delivers SIGTERM without a Hermes
+            # planned-stop marker.  Treat that service-manager signal as an
+            # orderly shutdown so normal operator restarts don't produce a
+            # spurious ``Failed with result 'exit-code'`` journal warning.
+            planned_stop = True
+
         if planned_takeover:
             logger.info(
                 "Received %s as a planned --replace takeover — exiting cleanly",
@@ -18224,7 +18237,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # is one line, key=value, parent_cmdline last (often long).
         if _shutdown_ctx is not None:
             try:
-                logger.warning(
+                logger.info(
                     "Shutdown context: %s", format_context_for_log(_shutdown_ctx)
                 )
             except Exception as _e:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3436,13 +3436,31 @@ async def _broadcast_event(channel: str, payload: str) -> None:
     async with _event_lock:
         subs = list(_event_channels.get(channel, ()))
 
+    stale_subs = []
     for sub in subs:
         try:
             await sub.send_text(payload)
-        except Exception:
-            # Subscriber went away mid-send; the /api/events finally clause
-            # will remove it from the registry on its next iteration.
-            _log.warning("broadcast send failed for subscriber on %s", channel, exc_info=True)
+        except Exception as exc:
+            # Browser event subscribers can disappear before /api/events reaches
+            # its receive-loop finally block (e.g. tab closed or WebSocket
+            # keepalive timeout).  Remove them immediately so every subsequent
+            # tool event does not log the same benign disconnect with a full
+            # traceback.
+            stale_subs.append(sub)
+            _log.debug(
+                "dropping stale event subscriber on %s after send failure: %s",
+                channel,
+                exc,
+            )
+
+    if stale_subs:
+        async with _event_lock:
+            channel_subs = _event_channels.get(channel)
+            if channel_subs is not None:
+                for sub in stale_subs:
+                    channel_subs.discard(sub)
+                if not channel_subs:
+                    _event_channels.pop(channel, None)
 
 
 def _channel_or_close_code(ws: WebSocket) -> Optional[str]:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2366,6 +2366,27 @@ class TestPtyWebSocket:
         assert "tool.start" in received
         assert '"tool_id":"t1"' in received
 
+    def test_broadcast_removes_stale_subscriber_without_warning(self, caplog):
+        """Dead dashboard event sockets are benign and must not spam logs."""
+        import asyncio
+        import logging
+        from hermes_cli import web_server as ws_mod
+
+        class DeadSubscriber:
+            async def send_text(self, _payload):
+                raise RuntimeError('Cannot call "send" once a close message has been sent.')
+
+        stale = DeadSubscriber()
+        channel = "stale-broadcast-test"
+        ws_mod._event_channels[channel] = {stale}
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.web_server"):
+            asyncio.run(ws_mod._broadcast_event(channel, '{"type":"tool.start"}'))
+            asyncio.run(ws_mod._broadcast_event(channel, '{"type":"tool.progress"}'))
+
+        assert channel not in ws_mod._event_channels
+        assert "broadcast send failed" not in caplog.text
+
     def test_events_rejects_missing_channel(self):
         from starlette.websockets import WebSocketDisconnect
 


### PR DESCRIPTION
## Summary
- remove stale event subscribers after websocket send failures without warning tracebacks
- log shutdown context at info level
- treat systemd stop/restart SIGTERM as an orderly gateway shutdown
- add regression coverage for stale event subscriber cleanup

## Test Plan
- python -m py_compile hermes_cli/web_server.py gateway/run.py
- python -m pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_broadcast_removes_stale_subscriber_without_warning tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_pub_broadcasts_to_events_subscribers -q -o 'addopts='
