### PR TITLE
fix(gateway): reload provider routing and bust cached agents on routing changes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11596,7 +11596,7 @@ class GatewayRunner:
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
-            pr = self._provider_routing
+            pr = self._refresh_provider_routing()
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
@@ -14880,6 +14880,14 @@ class GatewayRunner:
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
     )
+    _PROVIDER_ROUTING_CACHE_KEYS: tuple = (
+        "only",
+        "ignore",
+        "order",
+        "sort",
+        "require_parameters",
+        "data_collection",
+    )
 
     @classmethod
     def _extract_cache_busting_config(cls, user_config: dict | None) -> dict:
@@ -14903,6 +14911,13 @@ class GatewayRunner:
                 out[f"{section}.{key}"] = section_val.get(key)
             else:
                 out[f"{section}.{key}"] = None
+        provider_routing = cfg.get("provider_routing")
+        if isinstance(provider_routing, dict):
+            for key in cls._PROVIDER_ROUTING_CACHE_KEYS:
+                out[f"provider_routing.{key}"] = provider_routing.get(key)
+        else:
+            for key in cls._PROVIDER_ROUTING_CACHE_KEYS:
+                out[f"provider_routing.{key}"] = None
         try:
             from tools.registry import registry
 
@@ -14910,6 +14925,14 @@ class GatewayRunner:
         except Exception:
             out["tools.registry_generation"] = None
         return out
+
+    def _refresh_provider_routing(self) -> dict:
+        """Reload provider routing from config.yaml for the next agent turn."""
+        provider_routing = self._load_provider_routing()
+        if not isinstance(provider_routing, dict):
+            provider_routing = {}
+        self._provider_routing = provider_routing
+        return provider_routing
 
     @staticmethod
     def _agent_config_signature(
@@ -16370,7 +16393,7 @@ class GatewayRunner:
                     "tools": [],
                 }
 
-            pr = self._provider_routing
+            pr = self._refresh_provider_routing()
             reasoning_config = self._resolve_session_reasoning_config(
                 source=source,
                 session_key=session_key,

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -201,6 +201,35 @@ class TestAgentConfigSignature:
 
         assert sig_before != sig_after
 
+    def test_provider_routing_change_busts_cache(self):
+        """Editing provider_routing in config must rebuild the cached agent."""
+        from gateway.run import GatewayRunner
+
+        runtime = {"api_key": "k", "base_url": "u", "provider": "openrouter"}
+        cfg_before = {
+            "provider_routing": {
+                "only": ["alpha-provider"],
+                "order": ["alpha-provider"],
+            }
+        }
+        cfg_after = {
+            "provider_routing": {
+                "only": ["beta-provider"],
+                "order": ["beta-provider"],
+            }
+        }
+
+        sig_before = GatewayRunner._agent_config_signature(
+            "m", runtime, ["telegram"], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_before),
+        )
+        sig_after = GatewayRunner._agent_config_signature(
+            "m", runtime, ["telegram"], "",
+            cache_keys=GatewayRunner._extract_cache_busting_config(cfg_after),
+        )
+
+        assert sig_before != sig_after
+
 
 class TestExtractCacheBustingConfig:
     """Verify _extract_cache_busting_config pulls the documented subset of
@@ -239,6 +268,30 @@ class TestExtractCacheBustingConfig:
         assert out["compression.threshold"] == 0.6
         assert out["compression.target_ratio"] == 0.3
         assert out["compression.protect_last_n"] == 25
+
+    def test_reads_provider_routing_subkeys(self):
+        from gateway.run import GatewayRunner
+
+        out = GatewayRunner._extract_cache_busting_config(
+            {
+                "provider_routing": {
+                    "only": ["alpha-provider"],
+                    "ignore": ["beta-provider"],
+                    "order": ["alpha-provider", "gamma-provider"],
+                    "sort": "latency",
+                    "require_parameters": True,
+                    "data_collection": "deny",
+                    "extra": "ignored",
+                }
+            }
+        )
+
+        assert out["provider_routing.only"] == ["alpha-provider"]
+        assert out["provider_routing.ignore"] == ["beta-provider"]
+        assert out["provider_routing.order"] == ["alpha-provider", "gamma-provider"]
+        assert out["provider_routing.sort"] == "latency"
+        assert out["provider_routing.require_parameters"] is True
+        assert out["provider_routing.data_collection"] == "deny"
 
     def test_missing_keys_yield_none(self):
         """Absent config keys must produce None values (still contribute to signature)."""

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -23,9 +23,14 @@ class _CapturingAgent:
     """Fake agent that records init kwargs for assertions."""
 
     last_init = None
+    init_history = []
+    instances = []
 
     def __init__(self, *args, **kwargs):
-        type(self).last_init = dict(kwargs)
+        snapshot = dict(kwargs)
+        type(self).last_init = snapshot
+        type(self).init_history.append(snapshot)
+        type(self).instances.append(self)
         self.tools = []
 
     def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
@@ -124,6 +129,85 @@ def test_run_agent_prefers_session_override_over_global_runtime(monkeypatch):
     assert _CapturingAgent.last_init["base_url"] == "https://chatgpt.com/backend-api/codex"
     assert _CapturingAgent.last_init["api_key"] == "***"
     assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "high"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_reloads_provider_routing_and_busts_cached_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    route_a = {"only": ["alpha-provider"], "order": ["alpha-provider"]}
+    route_b = {"only": ["beta-provider"], "order": ["beta-provider"]}
+    route_state = {"current": route_a}
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"provider_routing": dict(route_state["current"])},
+    )
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_reload_runtime_env_preserving_config_authority", lambda: None)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    _CapturingAgent.init_history = []
+    _CapturingAgent.instances = []
+
+    runner = _make_runner()
+    runner._load_provider_routing = lambda: dict(route_state["current"])
+    runner._load_service_tier = lambda: None
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="c1",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = "agent:main:telegram:dm:c1"
+
+    first = await runner._run_agent(
+        message="first",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key=session_key,
+    )
+    first_cached_agent = runner._agent_cache[session_key][0]
+
+    route_state["current"] = route_b
+
+    second = await runner._run_agent(
+        message="second",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="session-1",
+        session_key=session_key,
+    )
+    second_cached_agent = runner._agent_cache[session_key][0]
+
+    assert first["final_response"] == "ok"
+    assert second["final_response"] == "ok"
+    assert len(_CapturingAgent.init_history) == 2
+    assert _CapturingAgent.init_history[0]["providers_allowed"] == ["alpha-provider"]
+    assert _CapturingAgent.init_history[1]["providers_allowed"] == ["beta-provider"]
+    assert first_cached_agent is not second_cached_agent
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Reload `provider_routing` at agent construction time so live config edits take effect on the next turn, and include routing fields in the gateway agent cache signature so stale agents are not reused after routing changes.

## Why
The gateway was holding on to the startup routing snapshot, which meant config edits could leave subsequent turns using an outdated OpenRouter routing policy.

## Testing
- `62 passed`
- `test_provider_routing_change_busts_cache`
- `test_reads_provider_routing_subkeys`
- `test_run_agent_reloads_provider_routing_and_busts_cached_agent`
- full `test_agent_cache.py`
- full `test_session_model_override_routing.py`