### PR TITLE
fix(security): deny entire HERMES_HOME tree in media delivery denylist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -924,11 +924,14 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The Hermes home itself contains credentials (auth.json, .env) — only the
-    # cache subdirectories under it are explicitly allowlisted above.
-    denied.append(_HERMES_HOME / ".env")
-    denied.append(_HERMES_HOME / "auth.json")
-    denied.append(_HERMES_HOME / "credentials")
+    # Deny the entire Hermes home directory tree. It contains credentials
+    # (auth.json, .env, mcp-tokens/, pairing/, .anthropic_oauth.json, etc.)
+    # that must never be delivered as gateway attachments regardless of mtime.
+    # Cache subdirectories within HERMES_HOME (image_cache/, cache/documents/,
+    # etc.) live in MEDIA_DELIVERY_SAFE_ROOTS and are returned by the allowlist
+    # check before this denylist is ever consulted — denying HERMES_HOME here
+    # does not affect legitimate cache deliveries.
+    denied.append(_HERMES_HOME)
     return denied
 
 


### PR DESCRIPTION
## Summary

`_media_delivery_denied_paths()` (introduced in #32060) listed only three specific files under `HERMES_HOME`: `.env`, `auth.json`, and `credentials`. This left all other credential-bearing paths unprotected against the recency-trust delivery path:

- `~/.hermes/mcp-tokens/<server>.json` — OAuth tokens for MCP servers
- `~/.hermes/pairing/telegram-approved.json` — platform pairing tokens
- `~/.hermes/.anthropic_oauth.json` — Anthropic PKCE credentials (protected for writes by #31747 but not by this denylist)
- `~/.hermes/skills/.hub/` — internal hub cache

**Exploit path:** A recently-authenticated MCP token (mtime = seconds ago) passes the 600s recency window and is not under any denied prefix → `validate_media_delivery_path` returns the token file path → gateway delivers it as an attachment.

## Fix

Replace the three explicit file entries with a single `_HERMES_HOME` directory entry. Cache subdirectories within `HERMES_HOME` (`image_cache/`, `cache/documents/`, etc.) live in `MEDIA_DELIVERY_SAFE_ROOTS` and are returned by the **allowlist check before the denylist is consulted** — so legitimate cache deliveries are unaffected.

```diff
-    denied.append(_HERMES_HOME / ".env")
-    denied.append(_HERMES_HOME / "auth.json")
-    denied.append(_HERMES_HOME / "credentials")
+    # Deny the entire Hermes home directory tree. Cache subdirs are in
+    # MEDIA_DELIVERY_SAFE_ROOTS and pass the allowlist check before this
+    # denylist is reached — denying HERMES_HOME does not affect them.
+    denied.append(_HERMES_HOME)
```

## Test plan

- [x] `mcp-tokens/github.json` (recently written) → DENIED
- [x] `pairing/telegram-approved.json` → DENIED
- [x] `.anthropic_oauth.json` (recently refreshed) → DENIED
- [x] `auth.json` (was in old explicit list) → still DENIED
- [x] `cache/documents/report.pdf` (legit cache file) → still ALLOWED
- [x] `/tmp/report.pdf` (agent-produced file) → still ALLOWED
- [x] `skills/.hub/index-cache.json` → DENIED
- [x] 229/229 existing media-delivery tests pass (`test_platform_base.py`, `test_tts_media_routing.py`, `test_send_message_tool.py`)