### PR TITLE
fix(security): add bws_cache.json to file_safety read guard

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -249,6 +249,10 @@ def get_read_block_error(path: str) -> Optional[str]:
         ".env",
         "webhook_subscriptions.json",
         os.path.join("auth", "google_oauth.json"),
+        # Bitwarden Secrets Manager disk cache: stores plaintext secret values
+        # to avoid re-fetching across back-to-back CLI invocations. The file
+        # was introduced by #31968 but not added to this guard.
+        os.path.join("cache", "bws_cache.json"),
     )
     for hd in hermes_dirs:
         for name in credential_file_names:


### PR DESCRIPTION
## Summary

PR #31968 introduced a Bitwarden Secrets Manager disk cache at `<hermes_home>/cache/bws_cache.json` to avoid re-fetching secrets across back-to-back CLI invocations. The cache stores **plaintext secret values** (API keys, database passwords, etc. pulled from BSM projects).

`get_read_block_error()` in `agent/file_safety.py` was not updated to include this path, leaving the agent able to read it directly via the `read_file` tool — the same tool that already cannot read `auth.json`, `.anthropic_oauth.json`, or `mcp-tokens/*`.

## Fix

Add `os.path.join("cache", "bws_cache.json")` to `credential_file_names` in `get_read_block_error()`, using the same exact-file match pattern already in place for `auth.json`, `.anthropic_oauth.json`, and `auth/google_oauth.json`. Both `HERMES_HOME` and the global Hermes root are covered, consistent with the existing per-profile + root-level guard shape (#15981).

Other files under `cache/` (images, documents, audio) are unaffected — the check is an exact-file match, not a prefix match.

```diff
 credential_file_names = (
     "auth.json",
     "auth.lock",
     ".anthropic_oauth.json",
     ".env",
     "webhook_subscriptions.json",
     os.path.join("auth", "google_oauth.json"),
+    # Bitwarden Secrets Manager disk cache: stores plaintext secret values
+    # to avoid re-fetching across back-to-back CLI invocations. The file
+    # was introduced by #31968 but not added to this guard.
+    os.path.join("cache", "bws_cache.json"),
 )
```

## Test plan

- [x] `cache/bws_cache.json` under HERMES_HOME → BLOCKED
- [x] Error message mentions `credential` (consistent with existing messages)
- [x] `auth.json`, `.anthropic_oauth.json`, `.env`, `webhook_subscriptions.json`, `mcp-tokens/*` → still BLOCKED (no regressions)
- [x] `cache/images/photo.png`, `cache/documents/report.pdf`, `cache/audio/clip.mp3` → still ALLOWED
- [x] `bws_cache.json` outside HERMES_HOME → ALLOWED (per-location gate, not a basename block)
- [x] 38/38 existing `test_file_safety.py` + `test_file_safety_credentials.py` tests pass