### PR TITLE
feat(prompt): inject runtime model + provider identity into system prompt

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -97,6 +97,23 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
 
+    # Runtime model identity — LLMs don't reliably know which model is
+    # serving them (Grok will claim "Claude Opus", Claude will claim
+    # "GPT-4") so we pin the fact in the stable tier of the system
+    # prompt. Placed after the persona but before behavioral guidance
+    # so SOUL.md still owns voice and the identity is just a fact the
+    # model can quote when asked. Stable across turns → upstream
+    # prompt cache stays warm.
+    _model = getattr(agent, "model", None)
+    _provider = getattr(agent, "provider", None)
+    if _model and _provider:
+        stable_parts.append(
+            f"Runtime identity: you are running on model `{_model}` "
+            f"via provider `{_provider}`. If a user asks which model "
+            "powers you, answer with exactly these two values; do not "
+            "guess or invent."
+        )
+
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
 


### PR DESCRIPTION
## Problem

Hermes agents routinely hallucinate their own underlying model when
asked. The chat surface goes like this:

```
$ hermes --profile <grok-or-gpt-profile> chat -q "What model are you?"
> I'm Claude Opus 4.6, an AI assistant made by Anthropic.   # ← false
```

Same agent, no routing problem — `xai/grok-4.3` was actually serving
the response. The model is simply guessing based on its training-time
prior over "AI assistant" descriptions, which leans heavily Claude/GPT.

This is a confidence-destroying bug for any deployment surface that
doesn't render the model name in its own UI (voice assistants,
Telegram, Slack, plain WS clients). Once a user catches the agent
lying about itself, they reasonably stop trusting the rest of its
answers.

## Root cause

`agent/prompt_builder.py` and the `AIAgent._build_system_prompt`
assembly in `run_agent.py` never put the runtime model id into the
system prompt. SOUL.md / `DEFAULT_AGENT_IDENTITY` carries the persona,
`HERMES_AGENT_HELP_GUIDANCE` covers Hermes itself, the tool guidance
blocks describe tools — but the model identity (`self.model`,
`self.provider`) is nowhere.

LLMs have no reliable internal sense of which model they are. Without
an explicit fact in context, they confabulate from priors.

## Fix

Add a one-line factual block to the **stable** tier of the system
prompt, right after the persona and before behavioral / tool guidance:

```
Runtime identity: you are running on model `<self.model>` via provider
`<self.provider>`. If a user asks which model powers you, answer with
exactly these two values; do not guess or invent.
```

Properties:

- **Stable across turns.** Depends only on `self.model` /
  `self.provider`, both set at AIAgent construction and immutable for
  the session. The system-prompt string stays byte-identical
  turn-to-turn → upstream prompt caches stay warm.
- **Doesn't override persona.** Placed after SOUL.md so the persona
  retains control of voice and behavior; this block only contributes
  a fact the model can quote when asked.
- **Defensive.** Wrapped in `if self.model and self.provider` so a
  half-initialized agent (e.g. mid-construction errors) doesn't
  produce a malformed line.

## Verification

Tested locally against:

| Profile           | Model            | Provider   | Before                                  | After             |
|-------------------|------------------|------------|-----------------------------------------|-------------------|
| `aria-grok`       | grok-4.3         | xai        | "I'm Claude Opus 4.6 via Anthropic"     | "grok-4.3 via xai" |
| `aria-claude`     | claude-opus-4-7  | anthropic  | "I'm Claude Opus 4.7, made by Anthropic" | unchanged          |

Both correct after the patch. Anthropic case stays correct because
Claude's self-id was already accurate; the new line just confirms it
without conflict.

## Out of scope

- A `/model` slash-command surface in `hermes_cli/main.py` that
  prints the same values without round-tripping the LLM at all. That's
  a separate UX improvement worth doing, but orthogonal — this PR
  covers the *agentic* case where the user is already in a chat and
  asks via natural language.
- Test snapshot updates if any exist in
  `tests/agent/test_prompt_builder.py` — happy to add to this PR if
  reviewers flag them.

## Related issues

- #15080 — OAuth Claude Max tool-use rejection (mentions agents
  reporting wrong model in error messages)
- #10575 — Claude Max proxy / extra-usage misclassification