### PR TITLE
fix: harden kanban corrupt board quarantine

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5353,6 +5353,8 @@ class GatewayRunner:
             return (resolved, stat.st_mtime_ns, stat.st_size)
 
         def _is_corrupt_board_db_error(exc: Exception) -> bool:
+            if isinstance(exc, _kb.KanbanDbCorruptError):
+                return True
             if not isinstance(exc, sqlite3.DatabaseError):
                 return False
             msg = str(exc).lower()
@@ -5397,7 +5399,7 @@ class GatewayRunner:
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
                 )
-            except sqlite3.DatabaseError as exc:
+            except (sqlite3.DatabaseError, _kb.KanbanDbCorruptError) as exc:
                 if _is_corrupt_board_db_error(exc):
                     disabled_corrupt_boards[slug] = fingerprint
                     logger.error(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -151,6 +151,8 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 # ---------------------------------------------------------------------------
 
 DEFAULT_BOARD = "default"
+CORRUPT_DB_BACKUP_RETENTION = 3
+_CORRUPT_DB_MARKER_SUFFIX = ".corrupt-quarantine.json"
 
 # Slug validator: lowercase alphanumerics, digits, hyphens; 1–64 chars.
 # Strict enough to stop traversal (`..`) and embedded path separators, loose
@@ -1026,6 +1028,170 @@ class KanbanDbCorruptError(RuntimeError):
         )
 
 
+def _corrupt_db_marker_path(path: Path) -> Path:
+    """Return the durable per-board quarantine marker path."""
+    resolved = path.resolve()
+    parent = resolved.parent
+    marker = parent / f"{resolved.name}{_CORRUPT_DB_MARKER_SUFFIX}"
+    return marker if marker.parent == parent else parent / f"kanban.db{_CORRUPT_DB_MARKER_SUFFIX}"
+
+
+def _corrupt_db_sidecar_paths(path: Path) -> dict[str, Path]:
+    """Return the DB path and its WAL/SHM sidecars."""
+    resolved = path.resolve()
+    parent = resolved.parent
+    base_name = resolved.name
+    return {
+        "db": resolved,
+        "wal": parent / f"{base_name}-wal",
+        "shm": parent / f"{base_name}-shm",
+    }
+
+
+def _corrupt_db_snapshot(path: Path) -> dict[str, dict[str, int | bool | None]]:
+    """Capture a cheap on-disk fingerprint for a corrupt DB and its sidecars."""
+    snapshot: dict[str, dict[str, int | bool | None]] = {}
+    for label, artifact in _corrupt_db_sidecar_paths(path).items():
+        info: dict[str, int | bool | None] = {
+            "exists": False,
+            "size": None,
+            "mtime_ns": None,
+        }
+        try:
+            stat = artifact.stat()
+        except OSError:
+            pass
+        else:
+            info["exists"] = True
+            info["size"] = int(stat.st_size)
+            info["mtime_ns"] = int(stat.st_mtime_ns)
+        snapshot[label] = info
+    return snapshot
+
+
+def _load_corrupt_db_marker(path: Path) -> Optional[dict[str, Any]]:
+    """Best-effort load of the quarantine marker."""
+    marker = _corrupt_db_marker_path(path)
+    try:
+        raw = marker.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        _log.warning("kanban corrupt marker unreadable at %s: %s", marker, exc)
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError as exc:
+        _log.warning("kanban corrupt marker invalid at %s: %s", marker, exc)
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _write_corrupt_db_marker(
+    path: Path,
+    *,
+    snapshot: dict[str, dict[str, int | bool | None]],
+    reason: str,
+    backup_path: Optional[Path],
+) -> None:
+    """Persist the latest corrupt-board quarantine state."""
+    marker = _corrupt_db_marker_path(path)
+    payload = {
+        "version": 1,
+        "status": "quarantined",
+        "db_path": str(path.resolve()),
+        "snapshot": snapshot,
+        "reason": reason,
+        "backup_path": str(backup_path) if backup_path is not None else None,
+        "quarantined_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "retention_limit": CORRUPT_DB_BACKUP_RETENTION,
+    }
+    tmp = marker.with_name(f"{marker.name}.tmp")
+    try:
+        with tmp.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        tmp.replace(marker)
+    except OSError as exc:
+        _log.warning("failed to persist kanban corrupt marker %s: %s", marker, exc)
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+
+
+def _clear_corrupt_db_marker(path: Path) -> None:
+    """Best-effort removal of a stale quarantine marker after recovery."""
+    marker = _corrupt_db_marker_path(path)
+    try:
+        marker.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        _log.debug("failed to remove kanban corrupt marker %s: %s", marker, exc)
+
+
+def _marker_backup_path(payload: dict[str, Any]) -> Optional[Path]:
+    """Return the main backup path recorded in a quarantine marker."""
+    raw = payload.get("backup_path")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    backup = Path(raw).expanduser()
+    try:
+        exists = backup.exists()
+    except OSError:
+        exists = False
+    return backup if exists else None
+
+
+def _existing_corrupt_quarantine(
+    path: Path,
+    snapshot: dict[str, dict[str, int | bool | None]],
+) -> tuple[Optional[Path], Optional[str]] | None:
+    """Return a matching persisted quarantine for the current corrupt files."""
+    payload = _load_corrupt_db_marker(path)
+    if not payload:
+        return None
+    try:
+        db_path = str(path.resolve())
+    except OSError:
+        db_path = str(path)
+    if payload.get("db_path") != db_path:
+        return None
+    if payload.get("snapshot") != snapshot:
+        return None
+    reason = str(payload.get("reason") or "").strip() or None
+    return (_marker_backup_path(payload), reason)
+
+
+def _prune_corrupt_db_backups(path: Path, keep: int = CORRUPT_DB_BACKUP_RETENTION) -> None:
+    """Cap retained corrupt-board backups and delete matching sidecars."""
+    if keep < 1:
+        keep = 1
+    resolved = path.resolve()
+    parent = resolved.parent
+    backups: list[Path] = []
+    for candidate in parent.glob(f"{resolved.name}.corrupt.*.bak"):
+        if candidate.parent != parent:
+            continue
+        backups.append(candidate)
+    backups.sort(
+        key=lambda candidate: (
+            candidate.stat().st_mtime_ns if candidate.exists() else -1,
+            candidate.name,
+        ),
+        reverse=True,
+    )
+    for stale in backups[keep:]:
+        for artifact in (stale, parent / f"{stale.name}-wal", parent / f"{stale.name}-shm"):
+            try:
+                artifact.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                _log.warning("failed pruning kanban corrupt backup %s: %s", artifact, exc)
+
+
 def _backup_corrupt_db(path: Path) -> Optional[Path]:
     """Copy a corrupt DB (and its WAL/SHM sidecars) to a timestamped backup.
 
@@ -1128,7 +1294,25 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         reason = f"sqlite refused to open file: {exc}"
     if reason is None:
         return
+    snapshot = _corrupt_db_snapshot(resolved)
+    existing = _existing_corrupt_quarantine(resolved, snapshot)
+    if existing is not None:
+        backup, prior_reason = existing
+        _prune_corrupt_db_backups(resolved)
+        detail = prior_reason or reason
+        if backup is not None:
+            detail = f"{detail} (board already quarantined; no new backup created)"
+        else:
+            detail = f"{detail} (board already quarantined; previous backup is unavailable)"
+        raise KanbanDbCorruptError(resolved, backup, detail)
     backup = _backup_corrupt_db(resolved)
+    _prune_corrupt_db_backups(resolved)
+    _write_corrupt_db_marker(
+        resolved,
+        snapshot=snapshot,
+        reason=reason,
+        backup_path=backup,
+    )
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 
@@ -1193,6 +1377,7 @@ def connect(
                 conn.executescript(SCHEMA_SQL)
                 _migrate_add_optional_columns(conn)
                 _INITIALIZED_PATHS.add(resolved)
+        _clear_corrupt_db_marker(path)
     except Exception:
         conn.close()
         raise

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -502,10 +502,29 @@
     const [taskEventTick, setTaskEventTick] = useState({});
 
     const cursorRef = useRef(0);
+    const currentBoardRef = useRef(null);
     const reloadTimerRef = useRef(null);
     const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
     const wsClosedRef = useRef(false);
+
+    function fallbackToCurrentBoard(reason) {
+      const fallback = currentBoardRef.current || "default";
+      function applyFallback(slug) {
+        if (board === slug) return Promise.reject(reason);
+        setBoard(slug);
+        writeSelectedBoard(slug);
+        setError(null);
+        return Promise.resolve(slug);
+      }
+      if (currentBoardRef.current) return applyFallback(fallback);
+      return SDK.fetchJSON(`${API}/boards`)
+        .then(function (data) {
+          currentBoardRef.current = (data && data.current) || fallback;
+          return applyFallback(currentBoardRef.current);
+        })
+        .catch(function () { return applyFallback(fallback); });
+    }
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -535,6 +554,7 @@
           setError(null);
         })
         .catch(function (err) {
+          if (board) return fallbackToCurrentBoard(err);
           setError(String(err && err.message ? err.message : err));
         })
         .finally(function () { setLoading(false); });
@@ -546,6 +566,7 @@
         .then(function (data) {
           const boards = (data && data.boards) || [];
           const storedBoard = readSelectedBoard();
+          currentBoardRef.current = (data && data.current) || "default";
           setBoardList(boards);
           if (!storedBoard && !board && data && data.current) {
             setBoard(data.current);
@@ -553,10 +574,10 @@
           }
           // If the stored slug isn't in the list any longer (board was
           // deleted in the CLI while dashboard was open), fall back to
-          // default so the UI doesn't hang on a 404.
-          if (board && board !== "default" && !boards.find(function (b) { return b.slug === board; })) {
-            setBoard("default");
-            writeSelectedBoard("default");
+          // the backend's active board so a stale browser pin cannot strand
+          // /kanban on an unreadable or missing board.
+          if (board && !boards.find(function (b) { return b.slug === board; })) {
+            fallbackToCurrentBoard("selected board is no longer available");
           }
         })
         .catch(function () { /* non-fatal */ });

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -105,6 +105,19 @@ def _resolve_board(board: Optional[str]) -> Optional[str]:
     return normed
 
 
+def _board_unreadable_error(board: Optional[str], exc: BaseException) -> HTTPException:
+    slug = board or kanban_db.get_current_board()
+    message = f"kanban board {slug!r} is unreadable: {exc}"
+    return HTTPException(
+        status_code=422,
+        detail={
+            "error": "kanban_board_unreadable",
+            "board": slug,
+            "message": message,
+        },
+    )
+
+
 def _conn(board: Optional[str] = None):
     """Open a kanban_db connection, creating the schema on first use.
 
@@ -119,9 +132,13 @@ def _conn(board: Optional[str] = None):
     """
     try:
         kanban_db.init_db(board=board)
+        return kanban_db.connect(board=board)
+    except (sqlite3.DatabaseError, kanban_db.KanbanDbCorruptError) as exc:
+        log.warning("kanban board read failed: %s", exc)
+        raise _board_unreadable_error(board, exc)
     except Exception as exc:
-        log.warning("kanban init_db failed: %s", exc)
-    return kanban_db.connect(board=board)
+        log.warning("kanban init/connect failed: %s", exc)
+        raise
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +497,8 @@ def get_board(
             "latest_event_id": int(latest_event_id),
             "now": int(time.time()),
         }
+    except (sqlite3.DatabaseError, kanban_db.KanbanDbCorruptError) as exc:
+        raise _board_unreadable_error(board, exc)
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3682,6 +3682,85 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert calls["connect"] == 5
 
 
+def test_gateway_dispatcher_disables_quarantined_corrupt_board_without_traceback(
+    monkeypatch, tmp_path, caplog
+):
+    """Quarantined corrupt boards should hit the same one-log suppression path."""
+    import asyncio
+    import logging
+
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    corrupt_db = tmp_path / "kanban.db"
+    corrupt_db.write_text("placeholder", encoding="utf-8")
+    backup = tmp_path / "kanban.db.corrupt.20260525_132241.bak"
+    backup.write_text("backup", encoding="utf-8")
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
+
+    calls = {"connect": 0, "to_thread": 0}
+
+    def _connect(*args, **kwargs):
+        calls["connect"] += 1
+        raise _kb.KanbanDbCorruptError(
+            corrupt_db,
+            backup,
+            "integrity_check returned '*** in database main ***'",
+        )
+
+    async def _to_thread(fn, *args, **kwargs):
+        calls["to_thread"] += 1
+        result = fn(*args, **kwargs)
+        if calls["to_thread"] >= 4:
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.ERROR, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum("disabling dispatch for this board" in msg for msg in messages) == 1
+    assert not any("tick failed on board" in msg for msg in messages)
+    assert not any(record.exc_info for record in caplog.records)
+    assert calls["connect"] == 5
+
+
 # ---------------------------------------------------------------------------
 # Hallucination gate (created_cards verify + prose scan)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3138,7 +3138,7 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
 # Corruption guard (issue #30687)
 # ---------------------------------------------------------------------------
 
-def _write_corrupt_db(path: Path) -> bytes:
+def _write_corrupt_db(path: Path, token: str = "") -> bytes:
     """Write a kanban DB with a VALID SQLite header but malformed page content.
 
     This is the corruption shape the integrity guard specifically targets
@@ -3155,7 +3155,7 @@ def _write_corrupt_db(path: Path) -> bytes:
     header += b"\x00\x00\x00\x0c\x00\x00\x23\x46\x00\x00\x00\x00"
     header = header.ljust(100, b"\x00")
     payload = b"definitely not a valid sqlite page \x00\x01\x02\x03" * 64
-    blob = header + payload
+    blob = header + payload + token.encode("utf-8")
     path.write_bytes(blob)
     return blob
 
@@ -3187,6 +3187,72 @@ def test_connect_refuses_corrupt_existing_file(tmp_path):
 
     with pytest.raises(kb.KanbanDbCorruptError):
         kb.connect(db_path=db_path)
+
+
+def test_corrupt_db_quarantine_is_idempotent_and_preserves_sidecars(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    original = _write_corrupt_db(db_path, token="first")
+    wal = tmp_path / "kanban.db-wal"
+    shm = tmp_path / "kanban.db-shm"
+    wal.write_bytes(b"wal-first")
+    shm.write_bytes(b"shm-first")
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbCorruptError) as first:
+        kb.init_db(db_path=db_path)
+
+    backup = first.value.backup_path
+    assert backup is not None
+    assert backup.exists()
+    assert backup.read_bytes() == original
+    assert kb._corrupt_db_marker_path(db_path).exists()
+
+    with pytest.raises(kb.KanbanDbCorruptError) as second:
+        kb.init_db(db_path=db_path)
+
+    assert second.value.backup_path == backup
+    assert "already quarantined" in str(second.value)
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 1
+
+
+def test_corrupt_db_quarantine_backup_retention_is_capped(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    wal = tmp_path / "kanban.db-wal"
+    shm = tmp_path / "kanban.db-shm"
+
+    for generation in range(kb.CORRUPT_DB_BACKUP_RETENTION + 2):
+        _write_corrupt_db(db_path, token=f"generation-{generation}")
+        wal.write_bytes(f"wal-{generation}".encode("utf-8"))
+        shm.write_bytes(f"shm-{generation}".encode("utf-8"))
+
+        with pytest.raises(kb.KanbanDbCorruptError):
+            kb.init_db(db_path=db_path)
+
+    backups = sorted(tmp_path.glob("kanban.db.corrupt.*.bak"))
+
+    assert len(backups) == kb.CORRUPT_DB_BACKUP_RETENTION
+
+    marker = kb._load_corrupt_db_marker(db_path)
+    assert marker is not None
+    assert marker["retention_limit"] == kb.CORRUPT_DB_BACKUP_RETENTION
+    assert Path(marker["backup_path"]).name in {backup.name for backup in backups}
+
+
+def test_prune_corrupt_db_backups_removes_stale_sidecars(tmp_path):
+    db_path = tmp_path / "kanban.db"
+
+    for generation in range(5):
+        backup = tmp_path / f"kanban.db.corrupt.20260525_13000{generation}.bak"
+        backup.write_text(f"backup-{generation}", encoding="utf-8")
+        Path(str(backup) + "-wal").write_text(f"wal-{generation}", encoding="utf-8")
+        Path(str(backup) + "-shm").write_text(f"shm-{generation}", encoding="utf-8")
+        time.sleep(0.01)
+
+    kb._prune_corrupt_db_backups(db_path, keep=2)
+
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak"))) == 2
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak-wal"))) == 2
+    assert len(list(tmp_path.glob("kanban.db.corrupt.*.bak-shm"))) == 2
 
 
 def test_locked_healthy_db_does_not_classify_as_corrupt(tmp_path, monkeypatch):
@@ -3338,4 +3404,3 @@ def test_maybe_emit_scratch_tip_skips_non_scratch_workspaces(kanban_home, caplog
                 "SELECT kind FROM task_events WHERE task_id = ?", (tid,),
             ).fetchall()
             assert "tip_scratch_workspace" not in [e["kind"] for e in events]
-

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -41,6 +41,17 @@ def _load_plugin_router():
     return mod.router
 
 
+def _write_integrity_corrupt_db(path: Path) -> bytes:
+    """Write a file that passes the header check but fails integrity_check."""
+    header = b"SQLite format 3\x00" + b"\x10\x00\x02\x02\x00\x40\x20\x20"
+    header += b"\x00\x00\x00\x0c\x00\x00\x23\x46\x00\x00\x00\x00"
+    header = header.ljust(100, b"\x00")
+    payload = b"broken sqlite page payload \x00\x01\x02\x03" * 64
+    blob = header + payload
+    path.write_bytes(blob)
+    return blob
+
+
 @pytest.fixture
 def kanban_home(tmp_path, monkeypatch):
     """Isolated HERMES_HOME with an empty kanban DB."""
@@ -191,6 +202,38 @@ def test_board_query_param_default_overrides_current_board_pointer(client):
     assert pinned_ids == {default_task["id"]}
 
 
+def test_get_board_corrupt_pinned_board_returns_clean_http_error(client):
+    """A stale browser pin to a malformed board DB must not surface as raw 500."""
+    kb.create_board("researchos")
+    kb.create_board("stale-corrupt")
+    kb.set_current_board("researchos")
+    kb.kanban_db_path(board="stale-corrupt").write_bytes(b"not a sqlite database")
+
+    r = client.get("/api/plugins/kanban/board?board=stale-corrupt")
+
+    assert r.status_code == 422
+    body = r.json()
+    assert body["detail"]["error"] == "kanban_board_unreadable"
+    assert body["detail"]["board"] == "stale-corrupt"
+    assert "stale-corrupt" in body["detail"]["message"]
+
+
+def test_get_board_integrity_corrupt_pinned_board_returns_clean_http_error(client):
+    """Integrity-check corruption should also surface as the clean 422 shape."""
+    kb.create_board("researchos")
+    kb.create_board("stale-integrity-corrupt")
+    kb.set_current_board("researchos")
+    _write_integrity_corrupt_db(kb.kanban_db_path(board="stale-integrity-corrupt"))
+
+    r = client.get("/api/plugins/kanban/board?board=stale-integrity-corrupt")
+
+    assert r.status_code == 422
+    body = r.json()
+    assert body["detail"]["error"] == "kanban_board_unreadable"
+    assert body["detail"]["board"] == "stale-integrity-corrupt"
+    assert "stale-integrity-corrupt" in body["detail"]["message"]
+
+
 def test_dashboard_select_filters_use_sdk_value_change_handler():
     """Tenant/assignee filters must work with the dashboard SDK Select API.
 
@@ -245,6 +288,21 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     assert "if (!storedBoard && !board && data && data.current)" in js
     assert "setBoard(data.current);" in js
     assert 'readSelectedBoard() || "default"' not in js
+
+
+def test_dashboard_stale_or_corrupt_stored_board_falls_back_to_backend_current():
+    """Bad localStorage board pins should heal to /boards current, not default."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "function fallbackToCurrentBoard(reason)" in js
+    assert "const fallback = currentBoardRef.current || \"default\";" in js
+    assert "SDK.fetchJSON(`${API}/boards`)" in js
+    assert "writeSelectedBoard(slug);" in js
+    assert "fallbackToCurrentBoard(err);" in js
+    assert "setBoard(\"default\");" not in js
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Harden Kanban handling for corrupt per-board SQLite databases.

Before this change, repeated access to the same corrupt board DB could create repeated `kanban.db.corrupt.*` backup files. This could grow unbounded across retries/restarts if a dashboard or dispatcher kept touching the same malformed board.

This patch makes corrupt-board handling idempotent and bounded.

## Changes

- Add durable corrupt-board quarantine state via `kanban.db.corrupt-quarantine.json`.
- Fingerprint corrupt DB files so repeated access to the same corrupt DB does not create new backups.
- Add `CORRUPT_DB_BACKUP_RETENTION = 3`.
- Prune old `.bak`, `.bak-wal`, and `.bak-shm` corrupt backup files.
- Clear stale quarantine markers after a healthy DB open/recovery.
- Extend dashboard/API handling to return clean unreadable-board diagnostics.
- Preserve dashboard fallback away from stale `hermes.kanban.selectedBoard`.
- Extend gateway dispatcher handling for quarantined corrupt boards.
- Add regression coverage for idempotent quarantine, retention, dashboard diagnostics, and dispatcher handling.

## Validation

```text
venv/bin/python -m pytest tests/plugins/test_kanban_dashboard_plugin.py
97 passed, 1 warning

venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -k "corrupt_db_quarantine or prune_corrupt_db_backups or init_db_refuses_corrupt_existing_file or connect_refuses_corrupt_existing_file or locked_healthy_db_does_not_classify_as_corrupt"
6 passed, 169 deselected

venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k "gateway_dispatcher_disables_corrupt_board_without_traceback or gateway_dispatcher_disables_quarantined_corrupt_board_without_traceback"
2 passed, 164 deselected
