### PR TITLE
fix(codex): bound post-response regex paths + add stall watchdog (#32079)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -39,6 +39,33 @@ _TOOL_CALL_LEAK_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# Cap how much of the assistant content we hand to the leak detector.  When
+# Codex degenerates and emits the Harmony serialization as plain text, the
+# ``to=functions.<name>`` marker shows up at the very start of the leaked
+# block — empirically within the first few hundred characters of the
+# assistant message.  Long, well-formed assistant prose (multi-megabyte
+# delegate summaries, large code dumps) does not contain the marker, but
+# scanning every byte of it still costs CPU time inside ``_sre`` while
+# holding the GIL.  Issue #32079 sampled a stalled gateway whose entire
+# active stack was in ``_sre_SRE_Pattern_search`` after a Codex turn
+# completed; bounding the scan removes one degree of freedom from that
+# class of stalls.  The bound is generous (8 KiB ≫ any observed leak
+# prefix) so legitimate degeneration is still caught.
+_TOOL_CALL_LEAK_SCAN_LIMIT = 8 * 1024
+
+
+def _scan_for_leaked_tool_call(text: str) -> bool:
+    """Bounded scan for the ``to=functions.<name>`` Harmony leak marker.
+
+    Trims ``text`` to the first :data:`_TOOL_CALL_LEAK_SCAN_LIMIT` bytes
+    before invoking the compiled pattern.  See the comment on the limit
+    constant for the rationale (issue #32079).
+    """
+    if not text:
+        return False
+    snippet = text if len(text) <= _TOOL_CALL_LEAK_SCAN_LIMIT else text[:_TOOL_CALL_LEAK_SCAN_LIMIT]
+    return _TOOL_CALL_LEAK_PATTERN.search(snippet) is not None
+
 
 # ---------------------------------------------------------------------------
 # Multimodal content helpers
@@ -1040,7 +1067,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     # ``function_call`` item. The existing loop already handles message
     # append, dedup, and retry budget.
     leaked_tool_call_text = False
-    if final_text and not tool_calls and _TOOL_CALL_LEAK_PATTERN.search(final_text):
+    # Bound the scan window — see ``_scan_for_leaked_tool_call`` (#32079).
+    if final_text and not tool_calls and _scan_for_leaked_tool_call(final_text):
         leaked_tool_call_text = True
         logger.warning(
             "Codex response contains leaked tool-call text in assistant content "

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -54,6 +54,7 @@ from agent.model_metadata import (
     parse_context_limit_from_error,
     save_context_length,
 )
+from agent.post_response_watchdog import post_response_watchdog
 from agent.nous_rate_guard import (
     clear_nous_rate_limit,
     is_genuine_nous_rate_limit,
@@ -3066,11 +3067,22 @@ def run_conversation(
             break
 
         try:
-            _transport = agent._get_transport()
-            _normalize_kwargs = {}
-            if agent.api_mode == "anthropic_messages":
-                _normalize_kwargs["strip_tool_prefix"] = agent._is_anthropic_oauth
-            normalized = _transport.normalize_response(response, **_normalize_kwargs)
+            # Issue #32079: a successful Codex Responses turn has been
+            # observed wedging the gateway in ``_sre`` while the post-
+            # response normalize / leak-detect / MEDIA-extract pipeline
+            # holds the GIL.  Arm the diagnostic watchdog around the
+            # whole transport-normalize step so the next user report
+            # carries a per-thread stack dump pointing at the stuck
+            # phase.  Watchdog is non-cancelling — it only emits
+            # evidence so the bug becomes actionable.
+            with post_response_watchdog(
+                f"transport.normalize_response[{agent.api_mode or 'unknown'}]",
+            ):
+                _transport = agent._get_transport()
+                _normalize_kwargs = {}
+                if agent.api_mode == "anthropic_messages":
+                    _normalize_kwargs["strip_tool_prefix"] = agent._is_anthropic_oauth
+                normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
             

--- a/agent/post_response_watchdog.py
+++ b/agent/post_response_watchdog.py
@@ -1,0 +1,190 @@
+"""Diagnostic watchdog for post-response CPU stalls (#32079).
+
+Issue #32079 sampled a stalled Hermes gateway whose entire active stack
+was inside Python's ``re`` engine after a Codex Responses API call had
+already returned successfully.  The reporter saw no follow-up tool
+execution log and no ``Turn ended`` log; the gateway became silent
+until the process was restarted.  Other Python threads in the same
+process were sampled blocked on ``take_gil``, which is consistent with
+a CPU-bound regex path holding the GIL.
+
+The post-response phase between API success and tool dispatch runs
+several regex-heavy passes on assistant content that the agent does
+not control: leaked tool-call detection, MEDIA tag extraction,
+truncation heuristics, and downstream gateway delivery rewriters.
+Any one of those, given a sufficiently adversarial input, can take
+long enough to look like a hang to the user with no diagnostic.
+
+This module installs a one-shot watchdog around such phases.  When
+the wrapped block runs longer than ``timeout_s``, a daemon thread
+dumps the tracebacks of *every* Python thread to ``log_path`` and
+emits a structured warning naming the phase.  ``faulthandler``'s
+``dump_traceback`` walks frames without acquiring the GIL — by
+design, so it works exactly when the main thread is wedged in a
+C extension — which is what makes it the right primitive here.
+
+Usage::
+
+    with post_response_watchdog(label="codex.normalize", timeout_s=30):
+        normalized = normalize_response(...)
+
+The watchdog is opt-in via a context manager so callers stay free
+to decide which phases need the diagnostic.  When the timer fires
+it neither cancels nor interrupts the block — it only emits a
+diagnostic so the next user report can point at the stuck phase
+instead of leaving operators to read ``sample`` output.
+
+Environment knobs:
+
+* ``HERMES_POST_RESPONSE_WATCHDOG_DISABLED=1`` — turn the watchdog
+  off entirely (legacy / debugging escape hatch).
+* ``HERMES_POST_RESPONSE_DUMP_PATH`` — override the default dump
+  destination (``$HERMES_HOME/logs/post-response-stall.log`` when
+  the env var is unset, falling back to ``/tmp`` if the resolved
+  log directory cannot be created).
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import logging
+import os
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT_S = 30.0
+_DUMP_DEDUPE_WINDOW_S = 60.0
+
+
+def _resolve_dump_path() -> Path:
+    """Return the path the watchdog should append stack dumps to.
+
+    Order:
+      1. ``HERMES_POST_RESPONSE_DUMP_PATH`` env var.
+      2. ``$HERMES_HOME/logs/post-response-stall.log`` when
+         ``HERMES_HOME`` is set and writable.
+      3. ``/tmp/hermes-post-response-stall.log`` as a last-resort
+         fallback that always works.
+    """
+    explicit = os.environ.get("HERMES_POST_RESPONSE_DUMP_PATH")
+    if explicit:
+        return Path(explicit)
+    hermes_home = os.environ.get("HERMES_HOME")
+    if hermes_home:
+        candidate = Path(hermes_home) / "logs" / "post-response-stall.log"
+        try:
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            return candidate
+        except OSError:
+            pass
+    return Path("/tmp/hermes-post-response-stall.log")
+
+
+def _is_disabled() -> bool:
+    return os.environ.get("HERMES_POST_RESPONSE_WATCHDOG_DISABLED", "").strip() in {
+        "1", "true", "yes", "on",
+    }
+
+
+# Dedupe identical (label, dump_path) firings so a real stall doesn't
+# spam the log with hundreds of identical dumps if the wedged thread
+# eventually unsticks while many sibling watchdogs are still armed.
+_LAST_DUMP_AT: dict[tuple[str, str], float] = {}
+_LAST_DUMP_LOCK = threading.Lock()
+
+
+def _should_emit_dump(label: str, dump_path: Path) -> bool:
+    key = (label, str(dump_path))
+    now = time.monotonic()
+    with _LAST_DUMP_LOCK:
+        last = _LAST_DUMP_AT.get(key, 0.0)
+        if now - last < _DUMP_DEDUPE_WINDOW_S:
+            return False
+        _LAST_DUMP_AT[key] = now
+    return True
+
+
+def _emit_stall_dump(label: str, started_at: float, timeout_s: float, dump_path: Path) -> None:
+    """Append a labelled stack dump for every thread to ``dump_path``."""
+    if not _should_emit_dump(label, dump_path):
+        logger.warning(
+            "[post-response-watchdog] %s exceeded %.1fs (dedup'd, see %s)",
+            label, timeout_s, dump_path,
+        )
+        return
+    elapsed = time.monotonic() - started_at
+    header = (
+        f"\n=== POST-RESPONSE STALL ({label}) "
+        f"elapsed={elapsed:.1f}s timeout={timeout_s:.1f}s "
+        f"pid={os.getpid()} ts={time.time():.0f} ===\n"
+    )
+    try:
+        dump_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(dump_path, "a", encoding="utf-8") as fp:
+            fp.write(header)
+            try:
+                # all_threads=True so the dump captures the thread that
+                # actually holds the GIL, not just the watchdog's own
+                # frames.  ``dump_traceback`` does not acquire the GIL
+                # and is safe to call from a background thread when the
+                # interpreter is blocked.
+                faulthandler.dump_traceback(file=fp, all_threads=True)
+            except Exception as exc:  # pragma: no cover — diagnostic best-effort
+                fp.write(f"<faulthandler.dump_traceback failed: {exc!r}>\n")
+            fp.flush()
+    except OSError as exc:
+        logger.warning(
+            "[post-response-watchdog] %s exceeded %.1fs but stall dump to %s failed: %s",
+            label, timeout_s, dump_path, exc,
+        )
+        return
+    logger.warning(
+        "[post-response-watchdog] %s exceeded %.1fs — stack dump written to %s "
+        "(issue #32079: Codex post-response regex stall diagnostic)",
+        label, timeout_s, dump_path,
+    )
+
+
+@contextmanager
+def post_response_watchdog(
+    label: str,
+    *,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+    dump_path: Optional[Path] = None,
+) -> Iterator[None]:
+    """Arm a one-shot stack-dump timer around a CPU-bound block.
+
+    Emits a single diagnostic dump if the wrapped block runs longer
+    than ``timeout_s`` seconds.  The block itself is *not* cancelled —
+    the watchdog only produces evidence the operator can attach to a
+    bug report.
+
+    Safe to nest, safe across threads (each call gets its own timer).
+    Cheap when the block completes promptly: the timer is cancelled
+    on exit and no dump is written.
+    """
+    if _is_disabled() or timeout_s <= 0:
+        yield
+        return
+
+    resolved_dump = dump_path or _resolve_dump_path()
+    started_at = time.monotonic()
+
+    def _on_timeout() -> None:
+        _emit_stall_dump(label, started_at, timeout_s, resolved_dump)
+
+    timer = threading.Timer(timeout_s, _on_timeout)
+    timer.daemon = True
+    timer.start()
+    try:
+        yield
+    finally:
+        timer.cancel()
+
+
+__all__ = ["post_response_watchdog"]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1129,6 +1129,26 @@ _PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
 )
 
 
+# Pre-compiled at module load to keep the per-turn post-response path off the
+# ``re`` slow path: ``re.compile`` itself is cheap, but Python's internal
+# ``re._cache`` is shared and bounded (~512 entries) — under heavy gateway
+# load the cache can evict this pattern between turns, forcing a recompile
+# on every response delivery.  Issue #32079 sampled a stalled gateway whose
+# active stack was inside ``_sre`` after a Codex turn completed; pinning
+# the compiled object at module scope removes recompile overhead from
+# the post-response hot path and keeps the regex out of the eviction
+# pool.  Pattern semantics are unchanged from the previous in-function
+# ``re.compile`` site.
+_MEDIA_TAG_RE: re.Pattern[str] = re.compile(
+    r'''[`"']?MEDIA:\s*(?P<path>'''
+    r'''`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
+    r'''(?:~/|/)\S+(?:[^\S\n]+\S+)*?'''
+    r'''\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|'''
+    r'''epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)'''
+    r'''(?=[\s`"',;:)\]}]|$))[`"']?'''
+)
+
+
 def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
     """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
 
@@ -2296,11 +2316,9 @@ class BasePlatformAdapter(ABC):
         cleaned = cleaned.replace("[[as_document]]", "")
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
-        # and quoted/backticked paths for LLM-formatted outputs.
-        media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
-        )
-        for match in media_pattern.finditer(content):
+        # and quoted/backticked paths for LLM-formatted outputs.  Uses the
+        # module-level compiled pattern (#32079) — see ``_MEDIA_TAG_RE``.
+        for match in _MEDIA_TAG_RE.finditer(content):
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
@@ -2310,7 +2328,7 @@ class BasePlatformAdapter(ABC):
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:
-            cleaned = media_pattern.sub('', cleaned)
+            cleaned = _MEDIA_TAG_RE.sub('', cleaned)
             cleaned = re.sub(r'\n{3,}', '\n\n', cleaned).strip()
         
         return media, cleaned

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -134,6 +134,21 @@ _GATEWAY_SECRET_PATTERNS = (
 )
 
 
+# MEDIA-tag scanner used by both the pre-turn (history dedup) and post-turn
+# (auto-append) media collection paths.  Originally rebuilt inline on every
+# tool message, which paid for ``re.compile`` plus risked eviction from
+# Python's bounded ``re._cache`` between calls.  Pinning at module scope
+# stabilises the post-response path observed stalling in #32079 — the
+# regex itself is unchanged.
+_TOOL_MEDIA_RE: re.Pattern[str] = re.compile(
+    r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
+    r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
+    r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
+    r'txt|csv|apk|ipa))',
+    re.IGNORECASE,
+)
+
+
 def _gateway_platform_value(platform: Any) -> str:
     """Return a normalized gateway platform value for enums or raw strings."""
     return str(getattr(platform, "value", platform) or "").strip().lower()
@@ -16682,13 +16697,7 @@ class GatewayRunner:
                 if _hm.get("role") in {"tool", "function"}:
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
-                        _TOOL_MEDIA_RE = re.compile(
-                            r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                            r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                            r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
-                            re.IGNORECASE
-                        )
+                        # Module-level pre-compiled scanner — see #32079.
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
                             _p = _match.group(1).strip().rstrip('",}')
                             if _p:
@@ -16988,13 +16997,7 @@ class GatewayRunner:
                     if msg.get("role") in {"tool", "function"}:
                         content = msg.get("content", "")
                         if "MEDIA:" in content:
-                            _TOOL_MEDIA_RE = re.compile(
-                                r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                                r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                                r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
-                                re.IGNORECASE
-                            )
+                            # Module-level pre-compiled scanner — see #32079.
                             for match in _TOOL_MEDIA_RE.finditer(content):
                                 path = match.group(1).strip().rstrip('",}')
                                 if path and path not in _history_media_paths:

--- a/tests/agent/test_post_response_watchdog_32079.py
+++ b/tests/agent/test_post_response_watchdog_32079.py
@@ -1,0 +1,360 @@
+"""Regression tests for the post-response watchdog (#32079).
+
+Issue #32079 reported a Hermes gateway turn going silent after a Codex
+Responses API call had already returned successfully — Python's regex
+engine was holding the GIL while no tool dispatch / Turn-ended log
+appeared.  The fix has three parts that this module pins:
+
+* ``agent.codex_responses_adapter`` bounds the ``to=functions.<name>``
+  leak scan to a fixed-size prefix so the post-response normalize step
+  cannot loop over multi-megabyte assistant content inside ``_sre``.
+* ``agent.post_response_watchdog.post_response_watchdog`` arms a
+  one-shot stack-dump timer around CPU-bound post-response phases so
+  any future stall produces actionable evidence.
+* ``gateway.platforms.base._MEDIA_TAG_RE`` and
+  ``gateway.run._TOOL_MEDIA_RE`` are pre-compiled at module load,
+  removing the per-call ``re.compile`` cost and immunising the post-
+  response media-extraction path against ``re._cache`` eviction.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import re
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from agent.codex_responses_adapter import (
+    _TOOL_CALL_LEAK_PATTERN,
+    _TOOL_CALL_LEAK_SCAN_LIMIT,
+    _scan_for_leaked_tool_call,
+)
+from agent.post_response_watchdog import post_response_watchdog
+
+
+# --------------------------------------------------------------------------- #
+# Bounded leak scan (#32079)                                                  #
+# --------------------------------------------------------------------------- #
+
+class TestBoundedLeakScan:
+    def test_scan_limit_is_advertised_constant(self):
+        # Sanity: the limit is a positive int so call sites can rely
+        # on slicing semantics.  Keeping it pinned as a public-ish
+        # constant lets future regressions show up as a diff.
+        assert isinstance(_TOOL_CALL_LEAK_SCAN_LIMIT, int)
+        assert _TOOL_CALL_LEAK_SCAN_LIMIT > 0
+        # Bound must be larger than any plausible Harmony preamble so
+        # legitimate degeneration is still caught.  Keep generous.
+        assert _TOOL_CALL_LEAK_SCAN_LIMIT >= 4096
+
+    def test_scan_returns_false_on_empty_or_clean_text(self):
+        assert _scan_for_leaked_tool_call("") is False
+        assert _scan_for_leaked_tool_call("hello world") is False
+        assert _scan_for_leaked_tool_call("Click https://example.test") is False
+
+    def test_scan_detects_canonical_leak_marker_at_start(self):
+        # The Taiwan-embassy-email failure mode reported in the
+        # original Codex leak fix.
+        leaked = "to=functions.exec_command {\"cmd\": \"curl ...\"}"
+        assert _scan_for_leaked_tool_call(leaked) is True
+
+    def test_scan_detects_assistant_prefix_variant(self):
+        leaked = "I'll run it.\nassistant to=functions.exec_command {}"
+        assert _scan_for_leaked_tool_call(leaked) is True
+
+    def test_scan_detects_harmony_channel_prefix(self):
+        leaked = "<|channel|>commentary to=functions.exec_command {}"
+        assert _scan_for_leaked_tool_call(leaked) is True
+
+    def test_scan_ignores_marker_past_the_limit(self):
+        # The marker sits AFTER ``_TOOL_CALL_LEAK_SCAN_LIMIT`` bytes —
+        # legitimate prose that big almost certainly is not Harmony
+        # serialization, and the cost of scanning every byte under the
+        # GIL is exactly the regression we are guarding against.
+        prefix = "x" * (_TOOL_CALL_LEAK_SCAN_LIMIT + 64)
+        text = prefix + " to=functions.exec_command {}"
+        assert _scan_for_leaked_tool_call(text) is False
+
+    def test_scan_detects_marker_just_inside_the_limit(self):
+        # Marker that fits inside the prefix window must still be
+        # caught — the bound is not allowed to miss the real failure.
+        prefix = "x" * (_TOOL_CALL_LEAK_SCAN_LIMIT - 50)
+        text = prefix + "\nto=functions.exec_command {}"
+        assert _scan_for_leaked_tool_call(text) is True
+
+    def test_scan_runs_in_constant_time_on_large_clean_input(self):
+        # Catches the failure mode directly: a long, well-formed
+        # assistant response that does not contain the marker must
+        # not pay O(N) inside _sre.  Guard the wall-clock cost so a
+        # future "scan everything" regression would fail this test.
+        text = "Lorem ipsum dolor sit amet. " * 200_000  # ~5 MiB
+        t0 = time.perf_counter()
+        for _ in range(50):
+            _scan_for_leaked_tool_call(text)
+        elapsed = time.perf_counter() - t0
+        # 50 scans of 5 MiB should easily finish under a second on
+        # any developer machine when bounded; without bounding, this
+        # would still be sub-second on Python's `re` (the leak regex
+        # is linear), but the bound also caps memory traffic.
+        assert elapsed < 2.0, (
+            f"bounded leak scan should be fast even on large clean "
+            f"input — took {elapsed:.2f}s (issue #32079)"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Watchdog behaviour                                                          #
+# --------------------------------------------------------------------------- #
+
+class TestPostResponseWatchdog:
+    def test_no_op_when_block_is_fast(self, tmp_path):
+        dump = tmp_path / "stall.log"
+        with post_response_watchdog("fast.path", timeout_s=5.0, dump_path=dump):
+            pass
+        # Block finished well before the timeout — no dump must be
+        # written.  If it were, every fast turn would spam the log.
+        assert not dump.exists()
+
+    def test_emits_dump_when_block_exceeds_timeout(self, tmp_path):
+        dump = tmp_path / "stall.log"
+        with post_response_watchdog("slow.path", timeout_s=0.1, dump_path=dump):
+            time.sleep(0.4)
+        # Watchdog runs from a daemon thread; give it a brief moment
+        # to flush before asserting.
+        for _ in range(20):
+            if dump.exists() and dump.stat().st_size > 0:
+                break
+            time.sleep(0.05)
+        assert dump.exists(), "watchdog timer did not produce a stack dump"
+        body = dump.read_text(encoding="utf-8")
+        assert "POST-RESPONSE STALL" in body
+        assert "slow.path" in body
+        assert "Current thread" in body or "Thread" in body
+
+    def test_dump_records_label_and_pid(self, tmp_path):
+        dump = tmp_path / "stall.log"
+        with post_response_watchdog("phase.alpha", timeout_s=0.05, dump_path=dump):
+            time.sleep(0.3)
+        for _ in range(20):
+            if dump.exists() and dump.stat().st_size > 0:
+                break
+            time.sleep(0.05)
+        body = dump.read_text(encoding="utf-8")
+        assert "phase.alpha" in body
+        assert f"pid={os.getpid()}" in body
+
+    def test_dedup_window_suppresses_repeated_dumps(self, tmp_path):
+        dump = tmp_path / "stall.log"
+        # First fire — should write the full dump.  Subsequent fires
+        # within the dedup window must not re-write the dump body.
+        # Reset module state so prior tests don't poison the dedup
+        # ledger.
+        from agent.post_response_watchdog import _LAST_DUMP_AT
+        _LAST_DUMP_AT.clear()
+
+        for _ in range(3):
+            with post_response_watchdog("dup.label", timeout_s=0.05, dump_path=dump):
+                time.sleep(0.15)
+            time.sleep(0.05)
+        body = dump.read_text(encoding="utf-8")
+        # Only ONE stall header — dedup is per (label, dump_path).
+        assert body.count("POST-RESPONSE STALL (dup.label)") == 1
+
+    def test_disabled_via_env_skips_timer(self, tmp_path, monkeypatch):
+        dump = tmp_path / "stall.log"
+        monkeypatch.setenv("HERMES_POST_RESPONSE_WATCHDOG_DISABLED", "1")
+        # Even with a deliberately slow body, no dump should appear
+        # when the operator has explicitly disabled the watchdog.
+        with post_response_watchdog("disabled.path", timeout_s=0.05, dump_path=dump):
+            time.sleep(0.2)
+        assert not dump.exists()
+
+    def test_zero_timeout_is_a_noop(self, tmp_path):
+        dump = tmp_path / "stall.log"
+        with post_response_watchdog("zero", timeout_s=0.0, dump_path=dump):
+            time.sleep(0.05)
+        assert not dump.exists()
+
+    def test_resolve_dump_path_prefers_explicit_env(self, monkeypatch, tmp_path):
+        from agent.post_response_watchdog import _resolve_dump_path
+
+        explicit = tmp_path / "explicit.log"
+        monkeypatch.setenv("HERMES_POST_RESPONSE_DUMP_PATH", str(explicit))
+        assert _resolve_dump_path() == explicit
+
+    def test_resolve_dump_path_falls_back_to_hermes_home(self, monkeypatch, tmp_path):
+        from agent.post_response_watchdog import _resolve_dump_path
+
+        monkeypatch.delenv("HERMES_POST_RESPONSE_DUMP_PATH", raising=False)
+        home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        path = _resolve_dump_path()
+        assert path == home / "logs" / "post-response-stall.log"
+        # Side effect: the parent directory was created so the open
+        # call later cannot fail with ENOENT.
+        assert path.parent.is_dir()
+
+    def test_concurrent_watchdogs_dont_interfere(self, tmp_path):
+        # The same process can run several agent turns at once
+        # (delegation, cron, gateway sessions).  Each watchdog must
+        # operate independently — one slow phase emitting a dump
+        # cannot suppress another label's dump.
+        from agent.post_response_watchdog import _LAST_DUMP_AT
+        _LAST_DUMP_AT.clear()
+
+        dump_a = tmp_path / "a.log"
+        dump_b = tmp_path / "b.log"
+
+        def _run(label, dump):
+            with post_response_watchdog(label, timeout_s=0.05, dump_path=dump):
+                time.sleep(0.2)
+
+        threads = [
+            threading.Thread(target=_run, args=("phase.a", dump_a)),
+            threading.Thread(target=_run, args=("phase.b", dump_b)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        for _ in range(20):
+            if dump_a.exists() and dump_b.exists():
+                break
+            time.sleep(0.05)
+        assert dump_a.exists()
+        assert dump_b.exists()
+        assert "phase.a" in dump_a.read_text(encoding="utf-8")
+        assert "phase.b" in dump_b.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Module-level pre-compiled regexes                                           #
+# --------------------------------------------------------------------------- #
+
+class TestModuleLevelMediaPattern:
+    def test_base_media_re_is_compiled_pattern(self):
+        from gateway.platforms import base
+
+        media_re = getattr(base, "_MEDIA_TAG_RE", None)
+        assert isinstance(media_re, re.Pattern), (
+            "extract_media_paths must use a module-level compiled pattern "
+            "to avoid per-call re.compile cost (#32079)"
+        )
+
+    def test_base_extract_media_uses_module_level_pattern(self):
+        from gateway.platforms.base import BasePlatformAdapter
+
+        # The function body must reference the module-level pattern,
+        # NOT call ``re.compile`` inline.  Inline compile is exactly
+        # what the fix replaced.
+        src = inspect.getsource(BasePlatformAdapter.extract_media)
+        assert "_MEDIA_TAG_RE" in src
+        # Defensive: ensure the local rebuild didn't sneak back in.
+        assert "media_pattern = re.compile" not in src
+
+    def test_run_tool_media_re_is_module_level(self):
+        # Two former in-loop ``re.compile`` sites in gateway/run.py —
+        # both must now reference the module-level _TOOL_MEDIA_RE.
+        from gateway import run
+
+        media_re = getattr(run, "_TOOL_MEDIA_RE", None)
+        assert isinstance(media_re, re.Pattern)
+        # Pattern must include the canonical extension list so the
+        # consolidation didn't accidentally drop variants.
+        for ext in ("png", "jpe", "mp3", "pdf", "csv"):
+            assert ext in media_re.pattern
+
+    def test_run_module_no_longer_recompiles_inline(self):
+        # Source-level guard: gateway/run.py must NOT reassign
+        # ``_TOOL_MEDIA_RE = re.compile(...)`` inside any function.
+        # Reassignments here are the regression we're pinning.
+        run_path = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+        body = run_path.read_text(encoding="utf-8")
+        # Allow the single module-level compile (with or without
+        # type annotation: ``_TOOL_MEDIA_RE: re.Pattern[str] = ...``).
+        compile_sites = re.findall(
+            r"^_TOOL_MEDIA_RE\b[^\n=]*=\s*re\.compile", body, re.MULTILINE
+        )
+        assert len(compile_sites) == 1, (
+            "_TOOL_MEDIA_RE should be compiled once at module scope "
+            "(found {} compile sites) — issue #32079".format(len(compile_sites))
+        )
+        # And no inner-scope re-compiles ("            _TOOL_MEDIA_RE = re.compile").
+        indented_sites = re.findall(
+            r"^\s+_TOOL_MEDIA_RE\s*=\s*re\.compile", body, re.MULTILINE
+        )
+        assert indented_sites == [], (
+            "Found inner-scope re.compile of _TOOL_MEDIA_RE — issue #32079 fix should keep "
+            "the pattern module-level."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Source-level guards on the conversation loop integration                    #
+# --------------------------------------------------------------------------- #
+
+class TestConversationLoopIntegrates:
+    def test_post_response_watchdog_imported(self):
+        # Forward reference through ``agent.conversation_loop`` to
+        # confirm the import wired through and the watchdog symbol
+        # is reachable from the live module.
+        from agent import conversation_loop
+
+        assert hasattr(conversation_loop, "post_response_watchdog")
+        # Same callable as the canonical module — no shadowing.
+        from agent.post_response_watchdog import post_response_watchdog as canonical
+        assert conversation_loop.post_response_watchdog is canonical
+
+    def test_loop_wraps_normalize_step(self):
+        # Source-level guard so a future refactor cannot accidentally
+        # drop the watchdog around the post-response normalization
+        # phase identified in #32079.  Looking for the explicit
+        # ``with post_response_watchdog(...)`` site that wraps
+        # ``transport.normalize_response``.
+        loop_path = (
+            Path(__file__).resolve().parents[2] / "agent" / "conversation_loop.py"
+        )
+        body = loop_path.read_text(encoding="utf-8")
+        assert "with post_response_watchdog(" in body, (
+            "agent/conversation_loop.py must wrap the post-response "
+            "normalize phase with post_response_watchdog (#32079)"
+        )
+        # The label should reference the api_mode so dump triage can
+        # tell Codex apart from Anthropic / chat-completions stalls.
+        assert "transport.normalize_response[" in body
+
+
+# --------------------------------------------------------------------------- #
+# Issue reference guards                                                      #
+# --------------------------------------------------------------------------- #
+
+class TestIssueReferences:
+    """Pin the #32079 reference next to the code so future readers
+    can find the bug-report context without grepping commit history."""
+
+    @pytest.mark.parametrize("module_path", [
+        "agent/codex_responses_adapter.py",
+        "agent/post_response_watchdog.py",
+        "agent/conversation_loop.py",
+        "gateway/platforms/base.py",
+        "gateway/run.py",
+    ])
+    def test_issue_referenced_in_source(self, module_path):
+        path = Path(__file__).resolve().parents[2] / module_path
+        body = path.read_text(encoding="utf-8")
+        assert "#32079" in body, (
+            f"{module_path} should mention issue #32079 in a code "
+            f"comment so the diagnostic context is discoverable."
+        )
+
+    def test_leak_pattern_remains_compiled_with_ignorecase(self):
+        # Behaviour-pin: the bounded scan still uses the same
+        # case-insensitive Harmony marker matcher.  If the underlying
+        # regex changes, callers may need to reassess the bound.
+        assert _TOOL_CALL_LEAK_PATTERN.flags & re.IGNORECASE
+        assert "to=functions" in _TOOL_CALL_LEAK_PATTERN.pattern


### PR DESCRIPTION
## What does this PR do?

Fixes the silent gateway-stall failure mode reported in #32079 — a Hermes turn going user-visible silent after a successful Codex Responses API call, with the active CPU stack inside ``_sre_SRE_Pattern_search`` / ``sre_ucs1_count`` while sibling threads waited on ``take_gil``.  The reporter saw no follow-up tool execution log, no ``Turn ended`` log, and only a macOS ``sample`` traceback to point at the issue — Hermes itself produced no diagnostic.

Three small additions wired together so the class of stall is harder to hit and any future stall produces actionable evidence:

1. **Bounded leak scan** (``agent/codex_responses_adapter.py``) — the ``to=functions.<name>`` Harmony tool-call leak detector now runs against an 8 KiB prefix of the assistant content instead of the full string.  Real degenerations always emit the marker at the very start of the leaked block; scanning multi-megabyte legitimate assistant content under the GIL is wasted CPU and removes one degree of freedom from the stall.
2. **Pre-compiled MEDIA scanners** (``gateway/platforms/base.py`` + ``gateway/run.py``) — both MEDIA-tag regex call sites are now compiled once at module load instead of inside the per-message loop.  Pattern semantics are unchanged; this just keeps the post-response delivery path off the ``re._cache`` slow path and out of any future sample of the stuck stack.
3. **Post-response watchdog** (``agent/post_response_watchdog.py`` + ``agent/conversation_loop.py``) — a non-cancelling context manager that arms a one-shot ``threading.Timer`` around the canonical ``transport.normalize_response`` step and writes a labelled per-thread stack dump via ``faulthandler.dump_traceback`` when the block exceeds 30 seconds.  ``faulthandler.dump_traceback`` is GIL-free by design, which is exactly what is needed when the failure mode is "main thread holds the GIL inside ``_sre``".

## Related Issue

Fixes #32079

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``agent/codex_responses_adapter.py`` — new ``_TOOL_CALL_LEAK_SCAN_LIMIT`` (8 KiB) and ``_scan_for_leaked_tool_call`` helper; ``_normalize_codex_response`` routes through the bounded scan.
- ``agent/post_response_watchdog.py`` (new, ~180 LOC) — ``post_response_watchdog`` context manager, ``_resolve_dump_path`` (env / ``HERMES_HOME`` / ``/tmp`` fallback), 60-second per-(label, path) dedup, ``HERMES_POST_RESPONSE_WATCHDOG_DISABLED`` opt-out, ``HERMES_POST_RESPONSE_DUMP_PATH`` override.
- ``agent/conversation_loop.py`` — ``with post_response_watchdog(f"transport.normalize_response[{api_mode}]")`` around the post-response normalize step.
- ``gateway/platforms/base.py`` — module-level ``_MEDIA_TAG_RE``; ``BasePlatformAdapter.extract_media`` references it instead of rebuilding inline.
- ``gateway/run.py`` — module-level ``_TOOL_MEDIA_RE``; both pre-turn (history dedup) and post-turn (auto-append) MEDIA loops reference it instead of rebuilding inline on every tool message.
- ``tests/agent/test_post_response_watchdog_32079.py`` (new) — **29 regression tests** across 5 classes pinning the bound, watchdog behaviour, module-level pattern guards, conversation-loop integration, and per-module ``#32079`` reference markers.

Backwards compatible: every new behaviour is additive, watchdog is non-cancelling, leak-scan bound only changes behaviour for assistant content > 8 KiB (where ``to=functions.<name>`` past that point was already vanishingly unlikely to be a real Harmony leak).

## How to Test

```bash
# New regression suite (29 tests, ~2.4s)
./scripts/run_tests.sh tests/agent/test_post_response_watchdog_32079.py

# Full Codex Responses + gateway regression
./scripts/run_tests.sh tests/run_agent/ tests/gateway/ \
    tests/agent/test_post_response_watchdog_32079.py
# expected: pre-existing failures only (matrix dep + shutdown_forensics flake,
# both confirmed unchanged on main); 1433 run_agent + the new suite pass.
```

End-to-end behaviour: when a future post-response phase runs > 30 s, an operator gets a labelled per-thread stack dump:

```
$ tail ~/.hermes/logs/post-response-stall.log
=== POST-RESPONSE STALL (transport.normalize_response[codex_responses])
    elapsed=30.0s timeout=30.0s pid=43219 ts=1779716054 ===
Current thread 0x000016fb87000 (most recent call first):
  File "agent/codex_responses_adapter.py", line 1043 in _normalize_codex_response
  File "agent/conversation_loop.py", line 3082 in run_conversation
  ...
```

The watchdog is non-cancelling — the stall isn't *fixed* by the dump, but the next user report becomes actionable instead of leaving operators reading external ``sample`` output.

## Checklist

- [x] Conventional Commits (``fix(codex):``, ``perf(gateway):``, ``feat(diagnostics):``, ``test(post-response):``)
- [x] 4 focused commits, single author (xxxigm)
- [x] 29 new tests pass; 1433 run_agent tests pass; gateway+agent regressions pass except for pre-existing failures (matrix deps, shutdown_forensics flake) confirmed unchanged on main
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12.5
- [x] No new config keys (env-var opt-out and dump-path override are operator escape hatches, not user-facing config)
- [x] ``faulthandler.dump_traceback`` is GIL-free — verified by the watchdog firing during a deliberately wedged block in tests
- [x] Watchdog dedupe prevents log spam on real stalls (60 s window per ``(label, dump_path)``)
