### PR TITLE
fix(tool_executor): pass session_id and tool_call_id to pre_tool_call hooks

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -127,7 +127,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
             block_message = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
+                function_name,
+                function_args,
+                task_id=effective_task_id or "",
+                session_id=agent.session_id or "",
+                tool_call_id=tool_call.id or "",
             )
         except Exception:
             block_message = None
@@ -502,7 +506,11 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         try:
             from hermes_cli.plugins import get_pre_tool_call_block_message
             _block_msg = get_pre_tool_call_block_message(
-                function_name, function_args, task_id=effective_task_id or "",
+                function_name,
+                function_args,
+                task_id=effective_task_id or "",
+                session_id=agent.session_id or "",
+                tool_call_id=tool_call.id or "",
             )
         except Exception:
             pass


### PR DESCRIPTION
## Summary

Both `execute_tool_calls_sequential` and `execute_tool_calls_concurrent` in `agent/tool_executor.py` call `get_pre_tool_call_block_message` with only `task_id`. The function signature already accepts `session_id` and `tool_call_id` (added in v0.13.0) but the callers were not forwarding these values.

This means plugin hooks implementing per-session rate limiting, per-call-id deduplication, or approval workflows never receive the full context needed for correct decisions.

## Changes

- Pass `session_id=agent.session_id or ""` and `tool_call_id=tool_call.id or ""` at both call sites in `tool_executor.py`

## Test plan

- [ ] Existing tests pass
- [ ] Plugin hooks implementing `pre_tool_call` now receive `session_id` and `tool_call_id` correctly