### PR TITLE
Allow reverse-proxied hostnames via dashboard --trusted-host allowlist

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10692,6 +10692,7 @@ def cmd_dashboard(args):
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
         embedded_chat=embedded_chat,
+        trusted_hosts=getattr(args, "trusted_hosts", None),
     )
 
 
@@ -13749,6 +13750,21 @@ Examples:
         "--insecure",
         action="store_true",
         help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",
+    )
+    dashboard_parser.add_argument(
+        "--trusted-host",
+        action="append",
+        default=[],
+        metavar="HOSTNAME",
+        dest="trusted_hosts",
+        help=(
+            "Additional hostname to accept in the Host header beyond the "
+            "bind-derived defaults. Repeatable. Use when a reverse proxy "
+            "(e.g. `tailscale serve`) forwards the public hostname against "
+            "a 127.0.0.1 bind — without this, the dashboard rejects the "
+            "request as a DNS-rebinding attempt. May also be set via "
+            "HERMES_DASHBOARD_TRUSTED_HOSTS (comma-separated)."
+        ),
     )
     dashboard_parser.add_argument(
         "--tui",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -160,7 +160,11 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+def _is_accepted_host(
+    host_header: str,
+    bound_host: str,
+    trusted_hosts: Optional[frozenset] = None,
+) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
@@ -168,6 +172,11 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     - Loopback aliases when bound to loopback
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
+    - Any name in ``trusted_hosts`` (operator-supplied allowlist for
+      reverse-proxied deployments — e.g. ``tailscale serve`` HTTPS in front
+      of a 127.0.0.1 bind: the proxy forwards the original hostname which
+      would otherwise be rejected as a rebinding attempt). Compared
+      case-insensitively after port stripping.
     """
     if not host_header:
         return False
@@ -188,6 +197,12 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
+
+    # Operator-supplied trusted hostnames take precedence over bind-derived
+    # checks. Used for reverse-proxied deployments where the proxy forwards
+    # the public hostname against a loopback bind (e.g. tailscale serve).
+    if trusted_hosts and host_only in trusted_hosts:
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
@@ -219,9 +234,10 @@ async def host_header_middleware(request: Request, call_next):
     # Store the bound host on app.state so this middleware can read it —
     # set by start_server() at listen time.
     bound_host = getattr(app.state, "bound_host", None)
+    trusted_hosts = getattr(app.state, "trusted_hosts", None)
     if bound_host:
         host_header = request.headers.get("host", "")
-        if not _is_accepted_host(host_header, bound_host):
+        if not _is_accepted_host(host_header, bound_host, trusted_hosts):
             return JSONResponse(
                 status_code=400,
                 content={
@@ -4665,8 +4681,21 @@ def start_server(
     allow_public: bool = False,
     *,
     embedded_chat: bool = False,
+    trusted_hosts: Optional[List[str]] = None,
 ):
-    """Start the web UI server."""
+    """Start the web UI server.
+
+    Parameters
+    ----------
+    trusted_hosts
+        Optional list of hostnames to accept in the ``Host`` header in
+        addition to the bind-derived defaults. Use this for reverse-proxied
+        deployments — e.g. when ``tailscale serve`` terminates HTTPS at
+        ``https://hermes.tailnet.ts.net`` and forwards to ``127.0.0.1:9119``;
+        the dashboard would otherwise reject the proxied request as a DNS
+        rebinding attempt because ``hermes.tailnet.ts.net`` isn't a loopback
+        alias. Operator vouches for the proxy chain.
+    """
     import uvicorn
 
     global _DASHBOARD_EMBEDDED_CHAT_ENABLED
@@ -4691,6 +4720,31 @@ def start_server(
     # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
+
+    # Normalise the trusted-hosts allowlist (lowercase, strip ports, drop
+    # blanks). Empty allowlist → no extra acceptance beyond bind-derived
+    # rules. We accept env-only entries to make systemd unit / docker /
+    # ansible-template ergonomics easier.
+    env_trusted = os.environ.get("HERMES_DASHBOARD_TRUSTED_HOSTS", "")
+    _raw = list(trusted_hosts or []) + [s for s in env_trusted.split(",") if s.strip()]
+    _norm: list[str] = []
+    for entry in _raw:
+        entry = entry.strip()
+        if not entry:
+            continue
+        # Strip optional port for normalised comparison.
+        if entry.startswith("["):
+            close = entry.find("]")
+            entry = entry[1:close] if close != -1 else entry.strip("[]")
+        else:
+            entry = entry.rsplit(":", 1)[0] if ":" in entry else entry
+        _norm.append(entry.lower())
+    app.state.trusted_hosts = frozenset(_norm) if _norm else None
+    if _norm:
+        _log.info(
+            "Dashboard accepting Host header from reverse-proxied "
+            "trusted hosts: %s", ", ".join(sorted(set(_norm))),
+        )
 
     if open_browser:
         import webbrowser

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -83,6 +83,37 @@ class TestHostHeaderValidator:
         assert _is_accepted_host("LOCALHOST", "127.0.0.1")
         assert _is_accepted_host("LocalHost:9119", "127.0.0.1")
 
+    def test_trusted_hosts_allowlist_accepts_proxied_hostname(self):
+        """Reverse-proxied deployments (e.g. `tailscale serve` HTTPS in
+        front of 127.0.0.1) forward the public hostname against a
+        loopback bind. The operator-supplied trusted_hosts set allows
+        those hostnames without losing the rebinding defence for any
+        hostname NOT on the allowlist."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        trusted = frozenset({"hermes.example.ts.net"})
+        # Trusted host accepted with and without port
+        assert _is_accepted_host("hermes.example.ts.net", "127.0.0.1", trusted)
+        assert _is_accepted_host("hermes.example.ts.net:443", "127.0.0.1", trusted)
+        # Case-insensitive
+        assert _is_accepted_host("HERMES.EXAMPLE.TS.NET", "127.0.0.1", trusted)
+        # Loopback aliases still work
+        assert _is_accepted_host("127.0.0.1", "127.0.0.1", trusted)
+        # Hostname NOT on the allowlist is still rejected — rebinding
+        # defence retained.
+        assert not _is_accepted_host("evil.example", "127.0.0.1", trusted)
+        assert not _is_accepted_host("hermes.example.ts.net.evil", "127.0.0.1", trusted)
+
+    def test_trusted_hosts_none_or_empty_behaves_like_before(self):
+        """Passing trusted_hosts=None or an empty frozenset must not
+        change the existing bind-derived behaviour."""
+        from hermes_cli.web_server import _is_accepted_host
+
+        assert _is_accepted_host("127.0.0.1", "127.0.0.1", None)
+        assert _is_accepted_host("127.0.0.1", "127.0.0.1", frozenset())
+        assert not _is_accepted_host("evil.example", "127.0.0.1", None)
+        assert not _is_accepted_host("evil.example", "127.0.0.1", frozenset())
+
 
 class TestHostHeaderMiddleware:
     """End-to-end test via the FastAPI app — verify the middleware
@@ -146,6 +177,38 @@ class TestHostHeaderMiddleware:
         resp = client.get("/api/status")
         # Should get through to the status endpoint, not a 400
         assert resp.status_code != 400
+
+    def test_trusted_hosts_proxied_request_accepted(self):
+        """End-to-end: when app.state.trusted_hosts contains a reverse-
+        proxy hostname, requests forwarded with that Host pass through
+        even with a 127.0.0.1 bind."""
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        app.state.bound_host = "127.0.0.1"
+        app.state.trusted_hosts = frozenset({"hermes.example.ts.net"})
+        try:
+            client = TestClient(app)
+            # Proxied request — public hostname, loopback bind
+            resp = client.get(
+                "/api/status",
+                headers={"Host": "hermes.example.ts.net"},
+            )
+            assert resp.status_code != 400 or (
+                "Invalid Host header" not in resp.json().get("detail", "")
+            )
+            # Still rejects non-allowlisted hostnames
+            resp = client.get(
+                "/api/status",
+                headers={"Host": "evil.example"},
+            )
+            assert resp.status_code == 400
+            assert "Invalid Host header" in resp.json()["detail"]
+        finally:
+            if hasattr(app.state, "bound_host"):
+                del app.state.bound_host
+            if hasattr(app.state, "trusted_hosts"):
+                del app.state.trusted_hosts
 
 
 class TestWebSocketHostOriginGuard:


### PR DESCRIPTION
## Summary

Adds a `--trusted-host HOSTNAME` flag (and matching `HERMES_DASHBOARD_TRUSTED_HOSTS` env var) to `hermes dashboard` so that operators behind a reverse proxy can name the hostnames they vouch for, without weakening the existing DNS-rebinding defence ([GHSA-ppp5-vxwm-4cf7](https://github.com/NousResearch/hermes-agent/security/advisories/GHSA-ppp5-vxwm-4cf7)) for everyone else.

## Motivation

The current Host-header validator in `hermes_cli/web_server.py` (`_is_accepted_host` / `host_header_middleware`) protects against DNS rebinding by requiring that the `Host` header match the interface the server bound to — loopback aliases when bound to loopback, exact match for explicit binds, no protection for `0.0.0.0` (since an operator who opts into that has effectively waived the defence).

That model breaks for one specific, very common deployment shape: **reverse-proxied HTTPS in front of a 127.0.0.1 bind**. The motivating example is `tailscale serve`:

```
tailscale serve  https://hermes.tailnet.ts.net    →    127.0.0.1:9119
```

The proxy terminates TLS, then forwards the request to the dashboard with `Host: hermes.tailnet.ts.net` (the public name the client used). The dashboard's loopback bind sees a non-loopback hostname and 400s the request as a rebinding attempt — which is the right call when there's no proxy, but the wrong call here. The operator-configured proxy chain is exactly what's vouching for the hostname.

Operators hitting this today have two bad options:

1. Bind to a non-loopback interface (`--insecure`), which is the situation the loopback bind exists to avoid in the first place — API keys served on the network without robust auth.
2. Disable the rebinding defence entirely (no current upstream flag does this; it would be a regression to add one).

This PR adds the third, correct option: let the operator name the hostnames their proxy chain forwards, the same shape as Django's `ALLOWED_HOSTS` or FastAPI's `TrustedHostMiddleware`.

## What changes

**`hermes_cli/web_server.py`**

- `_is_accepted_host(host_header, bound_host, trusted_hosts=None)` — new third arg. When provided and non-empty, a port-stripped, lowercased `Host` value that's in `trusted_hosts` is accepted regardless of the bind. Backwards compatible: `None` or empty set means existing behaviour.
- `host_header_middleware` reads `app.state.trusted_hosts` and passes it through.
- `start_server(..., trusted_hosts: Optional[List[str]] = None)` — new keyword arg, merges with `HERMES_DASHBOARD_TRUSTED_HOSTS` env var (comma-separated), normalises entries (strip whitespace, strip port, lowercase, drop blanks), stashes the frozen set on `app.state.trusted_hosts`. Logs the active allowlist at INFO when non-empty.

**`hermes_cli/main.py`**

- New `--trusted-host HOSTNAME` flag on the dashboard subparser. `action='append'`, repeatable, plumbed into `start_server(trusted_hosts=...)`.

**`tests/hermes_cli/test_web_server_host_header.py`**

- `test_trusted_hosts_allowlist_accepts_proxied_hostname` — unit-level: proxied hostnames accepted (with and without port, case-insensitive), loopback still works, non-allowlisted hostnames (including lookalikes like `hermes.example.ts.net.evil`) still rejected.
- `test_trusted_hosts_none_or_empty_behaves_like_before` — regression: `None` and empty `frozenset()` preserve original behaviour exactly.
- `test_trusted_hosts_proxied_request_accepted` — middleware integration: end-to-end via `TestClient` confirms the allowlisted Host passes and a non-allowlisted Host still 400s with the same error message.

All 14 tests in `tests/hermes_cli/test_web_server_host_header.py` pass against a fresh upstream checkout. The broader dashboard test surface (`tests/hermes_cli/` matching `dashboard or web_server or host_header`) — 205 tests — also passes with no regressions.

## Security posture

This is an opt-in widening of the accepted-Host set. With no flag and no env var, behaviour is unchanged — the rebinding defence still rejects every non-loopback Host header on a loopback bind. The allowlist only accepts hostnames the operator has explicitly named, so it can't be abused by a remote attacker without first compromising the operator's config. The threat model is the same as Django `ALLOWED_HOSTS`: the operator vouches for the proxy chain, and the application stops second-guessing that.

## Usage

```bash
# Single trusted host (the tailscale serve case)
hermes dashboard --trusted-host hermes.tailnet.ts.net

# Multiple
hermes dashboard --trusted-host hermes.example.com --trusted-host hermes-alt.example.com

# Env var (systemd / docker / ansible ergonomic)
HERMES_DASHBOARD_TRUSTED_HOSTS=hermes.tailnet.ts.net hermes dashboard
```

## Test plan

- [x] `tests/hermes_cli/test_web_server_host_header.py` — 14/14 pass
- [x] `tests/hermes_cli/` matching `dashboard or web_server or host_header` — 205/205 pass
- [x] Field-tested in production for ~3 days behind `tailscale serve` HTTPS → 127.0.0.1:9119 before this PR.
