### PR TITLE
fix(telegram): format auto-TTS voice caption as MarkdownV2

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3438,6 +3438,15 @@ class TelegramAdapter(BasePlatformAdapter):
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Audio", audio_path))
             
+            # Telegram renders captions as plain text unless parse_mode is set,
+            # so convert standard markdown (**bold**, *italic*, ...) to
+            # MarkdownV2 the same way text messages are formatted. Without this
+            # the auto-TTS voice reply caption shows raw syntax characters
+            # (see issue #32029). Truncate before formatting so the 1024-char
+            # cap is applied to the source text, not mid-escape-sequence.
+            formatted_caption = self.format_message(caption[:1024]) if caption else None
+            caption_parse_mode = ParseMode.MARKDOWN_V2 if formatted_caption else None
+
             with open(audio_path, "rb") as audio_file:
                 ext = os.path.splitext(audio_path)[1].lower()
                 # .ogg / .opus files -> send as voice (round playable bubble)
@@ -3456,7 +3465,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         {
                             "chat_id": int(chat_id),
                             "voice": audio_file,
-                            "caption": caption[:1024] if caption else None,
+                            "caption": formatted_caption,
+                            "parse_mode": caption_parse_mode,
                             "reply_to_message_id": reply_to_id,
                             **voice_thread_kwargs,
                             **self._notification_kwargs(metadata),
@@ -3482,7 +3492,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         {
                             "chat_id": int(chat_id),
                             "audio": audio_file,
-                            "caption": caption[:1024] if caption else None,
+                            "caption": formatted_caption,
+                            "parse_mode": caption_parse_mode,
                             "reply_to_message_id": reply_to_id,
                             **audio_thread_kwargs,
                             **self._notification_kwargs(metadata),

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -575,6 +575,75 @@ class TestSendVoice:
         connected_adapter._bot.send_audio.assert_awaited_once()
         connected_adapter._bot.send_document.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_voice_caption_formatted_with_markdown_v2(self, connected_adapter, tmp_path):
+        """Regression #32029: voice caption must be MarkdownV2-formatted, not raw."""
+        from gateway.platforms import telegram as tg_mod
+
+        audio_file = tmp_path / "reply.ogg"
+        audio_file.write_bytes(b"OggS" + b"\x00" * 32)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 201
+        connected_adapter._bot.send_voice = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_voice(
+            chat_id="12345",
+            audio_path=str(audio_file),
+            caption="Here is **bold** text",
+        )
+
+        assert result.success is True
+        kwargs = connected_adapter._bot.send_voice.await_args.kwargs
+        # Raw markdown must be converted to MarkdownV2 (bold: **x** -> *x*)
+        assert "**" not in kwargs["caption"]
+        assert "*bold*" in kwargs["caption"]
+        assert kwargs["parse_mode"] == tg_mod.ParseMode.MARKDOWN_V2
+
+    @pytest.mark.asyncio
+    async def test_audio_caption_formatted_with_markdown_v2(self, connected_adapter, tmp_path):
+        """The mp3/m4a audio path must format its caption the same way."""
+        from gateway.platforms import telegram as tg_mod
+
+        audio_file = tmp_path / "reply.mp3"
+        audio_file.write_bytes(b"ID3" + b"\x00" * 32)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 202
+        connected_adapter._bot.send_audio = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_voice(
+            chat_id="12345",
+            audio_path=str(audio_file),
+            caption="Here is **bold** text",
+        )
+
+        assert result.success is True
+        kwargs = connected_adapter._bot.send_audio.await_args.kwargs
+        assert "**" not in kwargs["caption"]
+        assert "*bold*" in kwargs["caption"]
+        assert kwargs["parse_mode"] == tg_mod.ParseMode.MARKDOWN_V2
+
+    @pytest.mark.asyncio
+    async def test_voice_without_caption_sets_no_parse_mode(self, connected_adapter, tmp_path):
+        """No caption → caption and parse_mode both None (avoid empty MarkdownV2)."""
+        audio_file = tmp_path / "reply.ogg"
+        audio_file.write_bytes(b"OggS" + b"\x00" * 32)
+
+        mock_msg = MagicMock()
+        mock_msg.message_id = 203
+        connected_adapter._bot.send_voice = AsyncMock(return_value=mock_msg)
+
+        result = await connected_adapter.send_voice(
+            chat_id="12345",
+            audio_path=str(audio_file),
+        )
+
+        assert result.success is True
+        kwargs = connected_adapter._bot.send_voice.await_args.kwargs
+        assert kwargs["caption"] is None
+        assert kwargs["parse_mode"] is None
+
 
 # ---------------------------------------------------------------------------
 # TestSendDocument — outbound file attachment delivery


### PR DESCRIPTION
## What does this PR do?

When `voice.auto_tts` is enabled, the bot's Telegram reply is delivered as the caption of a TTS audio bubble. The `send_voice`/`send_audio` calls passed that caption with no `parse_mode`, so Telegram rendered the standard markdown as plain text with raw syntax characters visible (`**bold**` appeared literally). This converts the caption through the adapter's existing `format_message()` (standard markdown → MarkdownV2) and sets `parse_mode=ParseMode.MARKDOWN_V2`, so the caption renders with formatting applied — the same way every other text path in the Telegram adapter already works.

The issue proposed two options: strip markdown at the source in `base.py` (Option B), or format the caption in the adapter (Option A). I went with Option A because the reporter's stated expected behavior is "formatted text visible in telegram with format applied" — stripping would only remove the stray asterisks and lose the formatting entirely. Formatting also belongs in the platform adapter (which owns MarkdownV2 translation), keeping `base.py` platform-neutral. The caption is truncated to 1024 chars *before* formatting so the limit applies to the source text rather than a half-written escape sequence; if Telegram ever rejects the formatted caption, the existing `except` already falls back to the base adapter's plain send.

## Related Issue

Fixes #32029

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: in `send_voice()`, format the caption via `format_message()` and pass `parse_mode=ParseMode.MARKDOWN_V2` for both the `.ogg`/`.opus` voice path and the `.mp3`/`.m4a` audio path (no caption → both stay `None`).
- `tests/gateway/test_telegram_documents.py`: add regression tests asserting the voice and audio captions are MarkdownV2-formatted with `parse_mode` set, and that a missing caption sends no `parse_mode`.

## How to Test

1. Set `voice.auto_tts: true` (or `/voice on` in chat) with `streaming.enabled: false`.
2. Send a voice message to the bot and let it reply with text ≤ 1024 chars containing markdown (e.g. `**bold**`).
3. The audio bubble's caption now renders with formatting applied instead of showing literal `**` asterisks.
4. Automated: `pytest tests/gateway/test_telegram_documents.py -q` (see `TestSendVoice::test_voice_caption_formatted_with_markdown_v2` and siblings).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS on darwin-arm64 (local)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config or docs change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific APIs touched; `scripts/check-windows-footguns.py` clean

<!-- autocontrib:worker-id=issue-new-751c7833 kind=pr-open -->