### PR TITLE
fix(tools): ignore anyio cleanup artifact during MCP HTTP reconnect

### DIFF
--- a/tests/tools/test_mcp_anyio_cleanup_artifact.py
+++ b/tests/tools/test_mcp_anyio_cleanup_artifact.py
@@ -1,0 +1,164 @@
+"""Regression tests for benign anyio cleanup artifacts during MCP reconnect.
+
+See #31987.  When ``async with streamable_http_client(...)`` unwinds for
+a planned reconnect on an HTTP/StreamableHTTP MCP server, anyio's
+TaskGroup teardown can raise ``RuntimeError("The current task is not
+holding this lock")`` even though the session shut down cleanly.  The
+previous reconnect loop treated this as a real connection failure and
+burned a slot in the reconnect budget, so every keepalive-driven
+reconnect cost one retry attempt and the server was permanently
+disconnected after ``_MAX_RECONNECT_RETRIES`` cleanup events.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+
+def test_anyio_cleanup_marker_matches_bare_runtime_error():
+    """``not holding this lock`` is recognized on a bare RuntimeError."""
+    from tools.mcp_tool import _is_anyio_cleanup_artifact
+
+    exc = RuntimeError("The current task is not holding this lock")
+    assert _is_anyio_cleanup_artifact(exc) is True
+
+
+def test_anyio_cleanup_marker_unwraps_exception_group():
+    """``ExceptionGroup`` wrapping the anyio RuntimeError still matches."""
+    from tools.mcp_tool import _is_anyio_cleanup_artifact
+
+    inner = RuntimeError("The current task is not holding this lock")
+    group = BaseExceptionGroup("unhandled errors in a TaskGroup", [inner])
+    assert _is_anyio_cleanup_artifact(group) is True
+
+
+def test_anyio_cleanup_marker_unwraps_nested_groups():
+    """Nested ``ExceptionGroup`` chains are walked, not just one level."""
+    from tools.mcp_tool import _is_anyio_cleanup_artifact
+
+    inner = RuntimeError("The current task is not holding this lock")
+    nested = BaseExceptionGroup("inner group", [inner])
+    outer = BaseExceptionGroup("outer group", [nested])
+    assert _is_anyio_cleanup_artifact(outer) is True
+
+
+def test_anyio_cleanup_marker_rejects_unrelated_runtime_error():
+    """Plain ``RuntimeError`` without the marker is not an anyio artifact."""
+    from tools.mcp_tool import _is_anyio_cleanup_artifact
+
+    assert _is_anyio_cleanup_artifact(RuntimeError("DNS resolution failed")) is False
+    assert _is_anyio_cleanup_artifact(ConnectionError("ECONNRESET")) is False
+
+
+def test_reconnect_loop_ignores_anyio_cleanup_artifact():
+    """Anyio cleanup error after the server is ready does not burn a retry.
+
+    Reproduces the #31987 failure mode: each reconnect causes a
+    ``RuntimeError`` from ``streamable_http_client.__aexit__``.  Without
+    the fix, the retry counter would exhaust quickly and the server
+    would be given up on.  With the fix, the loop treats it as benign
+    cleanup, resets backoff, and reconnects immediately.
+    """
+    from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+    call_count = 0
+
+    async def _run():
+        nonlocal call_count
+        server = MCPServerTask("test-anyio-cleanup")
+
+        # First call: succeed (marks server ready), then raise the anyio
+        # cleanup artifact several times in a row, then finally exit cleanly
+        # on shutdown.
+        async def fake_run_http(self_inner, config):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Mark as initially connected so subsequent failures hit
+                # the "session was ready" branch, not the initial-connect
+                # retry budget.
+                self_inner._ready.set()
+                raise RuntimeError("The current task is not holding this lock")
+            if call_count <= _MAX_RECONNECT_RETRIES + 2:
+                # More cleanup-artifact failures than the reconnect budget
+                # would normally tolerate.  Each must NOT count.
+                raise BaseExceptionGroup(
+                    "unhandled errors in a TaskGroup",
+                    [RuntimeError("The current task is not holding this lock")],
+                )
+            # Eventually exit cleanly on shutdown.
+            await self_inner._shutdown_event.wait()
+
+        _orig_sleep = asyncio.sleep
+
+        async def _instant_sleep(*_a, **_k):
+            await _orig_sleep(0)
+
+        with patch.object(MCPServerTask, "_run_http", fake_run_http), \
+             patch.object(MCPServerTask, "_is_http", lambda self_inner: True), \
+             patch("asyncio.sleep", new=_instant_sleep):
+            task = asyncio.ensure_future(server.run({"url": "https://example.test/mcp"}))
+            await server._ready.wait()
+
+            # Yield enough times for the cleanup-artifact failures to cycle.
+            for _ in range(_MAX_RECONNECT_RETRIES + 5):
+                await asyncio.sleep(0)
+
+            server._shutdown_event.set()
+            server._reconnect_event.set()
+            await task
+
+        # The loop survived more cleanup events than _MAX_RECONNECT_RETRIES
+        # would have permitted if they had counted as real failures.
+        assert call_count > _MAX_RECONNECT_RETRIES + 1, (
+            f"Expected >{_MAX_RECONNECT_RETRIES + 1} attempts (cleanup did not "
+            f"burn the retry budget); got {call_count}"
+        )
+        # And no error was latched onto the server.
+        assert server._error is None
+
+    asyncio.new_event_loop().run_until_complete(_run())
+
+
+def test_reconnect_loop_still_counts_real_failures():
+    """Non-anyio reconnect failures still count against the retry budget."""
+    from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+    call_count = 0
+
+    async def _run():
+        nonlocal call_count
+        server = MCPServerTask("test-real-failures")
+
+        async def fake_run_http(self_inner, config):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # Mark as initially connected, then start failing for real.
+                self_inner._ready.set()
+                raise ConnectionError("ECONNRESET")
+            raise ConnectionError("ECONNRESET")
+
+        _orig_sleep = asyncio.sleep
+
+        async def _instant_sleep(*_a, **_k):
+            await _orig_sleep(0)
+
+        with patch.object(MCPServerTask, "_run_http", fake_run_http), \
+             patch.object(MCPServerTask, "_is_http", lambda self_inner: True), \
+             patch("asyncio.sleep", new=_instant_sleep):
+            task = asyncio.ensure_future(server.run({"url": "https://example.test/mcp"}))
+            # Server should ready on first attempt, then exhaust retries.
+            await server._ready.wait()
+            await task
+
+        # Real failures should exhaust the reconnect budget — the first
+        # attempt sets ready then raises, and each subsequent failure
+        # increments ``retries`` until ``retries > _MAX_RECONNECT_RETRIES``
+        # triggers "give up".  That bounds total ``_run_http`` calls at
+        # ``_MAX_RECONNECT_RETRIES + 1``.
+        assert call_count == _MAX_RECONNECT_RETRIES + 1, (
+            f"Expected {_MAX_RECONNECT_RETRIES + 1} attempts on real "
+            f"failures; got {call_count}"
+        )
+
+    asyncio.new_event_loop().run_until_complete(_run())

--- a/tests/tools/test_mcp_anyio_cleanup_artifact.py
+++ b/tests/tools/test_mcp_anyio_cleanup_artifact.py
@@ -116,7 +116,7 @@ def test_reconnect_loop_ignores_anyio_cleanup_artifact():
         # And no error was latched onto the server.
         assert server._error is None
 
-    asyncio.new_event_loop().run_until_complete(_run())
+    asyncio.run(_run())
 
 
 def test_reconnect_loop_still_counts_real_failures():
@@ -161,4 +161,4 @@ def test_reconnect_loop_still_counts_real_failures():
             f"failures; got {call_count}"
         )
 
-    asyncio.new_event_loop().run_until_complete(_run())
+    asyncio.run(_run())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1923,6 +1923,11 @@ class MCPServerTask:
                         self.name, exc,
                     )
                     backoff = 1.0
+                    # Yield once before the next reconnect attempt so a
+                    # transport that fails synchronously inside its
+                    # ``__aenter__`` (no internal await) cannot starve the
+                    # event loop with a tight reconnect spin.
+                    await asyncio.sleep(0)
                     continue
 
                 retries += 1

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1909,6 +1909,22 @@ class MCPServerTask:
                     )
                     return
 
+                # Benign anyio cleanup artifact during reconnect tear-down:
+                # don't burn a reconnect-budget slot on it.  Without this,
+                # every keepalive-driven reconnect on an HTTP/Streamable
+                # MCP server raises ``RuntimeError("not holding this lock")``
+                # from ``streamable_http_client.__aexit__`` and the server is
+                # permanently disconnected after _MAX_RECONNECT_RETRIES
+                # cleanup events.  See #31987.
+                if _is_anyio_cleanup_artifact(exc):
+                    logger.debug(
+                        "MCP server '%s': anyio cleanup artifact during "
+                        "reconnect tear-down (not counting against retries): %s",
+                        self.name, exc,
+                    )
+                    backoff = 1.0
+                    continue
+
                 retries += 1
                 if retries > _MAX_RECONNECT_RETRIES:
                     logger.warning(
@@ -2239,6 +2255,39 @@ _SESSION_EXPIRED_MARKERS: tuple = (
     "broken pipe",
     "end of file",
 )
+
+
+# Substrings (lower-cased match) that identify anyio cleanup artifacts
+# raised from ``streamable_http_client.__aexit__`` during a planned
+# reconnect tear-down.  When ``async with streamable_http_client(...)``
+# unwinds while an anyio Lock is still held by a different coroutine
+# in the same TaskGroup (asyncio + anyio>=4.x), the exit raises
+# ``RuntimeError("The current task is not holding this lock")`` even
+# though the session shut down cleanly.  This is benign cleanup noise,
+# not a real connection failure — the next reconnect attempt will
+# succeed.  See #31987.
+_ANYIO_CLEANUP_MARKERS: tuple = (
+    "current task is not holding this lock",
+)
+
+
+def _is_anyio_cleanup_artifact(exc: BaseException) -> bool:
+    """Return True if ``exc`` is a benign anyio cleanup error.
+
+    Walks ``BaseExceptionGroup`` chains because the top-level error
+    from a ``streamable_http_client`` teardown is typically
+    ``ExceptionGroup("unhandled errors in a TaskGroup", [...])`` with
+    the real anyio RuntimeError nested inside.  See #31987.
+    """
+    stack: list[BaseException] = [exc]
+    while stack:
+        cur = stack.pop()
+        msg = str(cur).lower()
+        if msg and any(marker in msg for marker in _ANYIO_CLEANUP_MARKERS):
+            return True
+        if isinstance(cur, BaseExceptionGroup):
+            stack.extend(cur.exceptions)
+    return False
 
 
 def _is_session_expired_error(exc: BaseException) -> bool:


### PR DESCRIPTION
## What does this PR do?

When a Streamable HTTP MCP server tears down its session for a planned
reconnect (e.g. after the keepalive timer triggers, default 180s),
`async with streamable_http_client(...)` unwinds and anyio's TaskGroup
cleanup can raise `RuntimeError("The current task is not holding this
lock")` from a Lock that was acquired by a different coroutine inside
the TaskGroup. The session shut down cleanly, but the cleanup raises.

Previously the reconnect loop's `except Exception` treated this as a
real connection failure and burned a slot in the
`_MAX_RECONNECT_RETRIES` budget. Every keepalive-driven reconnect cost
one retry attempt, and after ~5 cleanup events the server was
permanently disconnected for the rest of the gateway lifetime.

Fix: add `_ANYIO_CLEANUP_MARKERS` + `_is_anyio_cleanup_artifact()` that
walk `BaseExceptionGroup` chains (the SDK wraps the inner
`RuntimeError` in an `ExceptionGroup("unhandled errors in a
TaskGroup", ...)`), and in the retry loop skip the retry-counter
increment when the artifact fires after the server was already ready.
The helper mirrors the existing `_SESSION_EXPIRED_MARKERS` design.

## Related Issue

Fixes #31987

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py` — add `_ANYIO_CLEANUP_MARKERS` + `_is_anyio_cleanup_artifact()` (walks `BaseExceptionGroup`), and short-circuit the reconnect retry counter when the artifact fires after `_ready` is set.
- `tests/tools/test_mcp_anyio_cleanup_artifact.py` — six regression tests: bare `RuntimeError` match, `ExceptionGroup` unwrap (one + nested levels), rejection of unrelated `RuntimeError`/`ConnectionError`, the full reconnect-loop scenario showing >_MAX_RECONNECT_RETRIES cleanup events survive, and a control test confirming real `ConnectionError` failures still exhaust the budget at `_MAX_RECONNECT_RETRIES + 1` attempts.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_mcp_anyio_cleanup_artifact.py -v` — 6 passed
2. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_mcp_reconnect_signal.py tests/tools/test_mcp_stability.py tests/tools/test_mcp_tool_session_expired.py tests/tools/test_mcp_cancelled_error_propagation.py tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_tool.py -v` — 239 passed, no regressions
3. Regression guard: with `tools/mcp_tool.py` reverted to `origin/main`, `test_reconnect_loop_ignores_anyio_cleanup_artifact` fails with `assert 6 > 6` (server gives up after 5 cleanup events) — confirms the test exercises the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the anyio/asyncio interaction is OS-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Reproduces the user-reported log from #31987:

```
keepalive failed, triggering reconnect
reconnect requested — tearing down HTTP session
connection lost (attempt 1/5): unhandled errors in a TaskGroup
...
failed after 5 reconnection attempts, giving up
```

With the fix, those `RuntimeError("not holding this lock")` cleanup
artifacts drop to DEBUG-level and don't consume the retry budget.

## Related / Positioning

- daimon-nous (issue commenter) suggested extending `_SESSION_EXPIRED_MARKERS` to cover this RuntimeError. I chose a separate `_ANYIO_CLEANUP_MARKERS` tuple + dedicated helper because (a) `_is_session_expired_error` is only consulted by tool-call handlers (`_handle_session_expired_and_retry` at lines 2422/2484/2544/2607/2678), not by the reconnect retry loop where the actual budget burn happens; (b) the failure mode is cleanup-after-clean-teardown, not the server rejecting a request — different semantics worth keeping distinct. The two could be merged later if more anyio cleanup signatures need handling.
- #28556 (`fix(tools): keep cua-driver MCP session task-local`) touches a related anyio cancel-scope problem in `tools/computer_use/cua_backend.py`. Different file, different code path; no overlap.

> Audited siblings: confirmed every `async with streamable_http_client(...)` block in `_run_http` shares the same outer reconnect retry loop in `run()`, so the single check in the `except Exception` handler covers all three call sites (lines 1463, plus the wrapping retries at 1594-1654 surface the same exception class). Stdio transport (`_run_stdio`) does not use `streamable_http_client`, so the artifact cannot fire from that path. No widening needed.