### PR TITLE
feat(provider): add ByteDance Coding Plan as first-class provider

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -476,6 +476,16 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    "bytedance": [
+        "bytedance-seed-code",
+        "dola-seed-2.0-pro",
+        "dola-seed-2.0-lite",
+        "dola-seed-2.0-code",
+        "glm-5.1",
+        "glm-4.7",
+        "gpt-oss-120b",
+        "kimi-k2.5",
+    ],
 }
 
 # Vercel AI Gateway: derive the bare-model-id catalog from the curated
@@ -3557,6 +3567,47 @@ def validate_requested_model(
                     f"Note: `{requested}` was not found in the MiniMax catalog."
                     f"{suggestion_text}"
                     "\n  MiniMax does not expose a /models endpoint, so Hermes cannot verify the model name."
+                    "\n  The model may still work if it exists on the server."
+                ),
+            }
+
+    # ByteDance: the API's /models endpoint returns internal model IDs
+    # (e.g. seed-2-0-lite-260428) that differ from the user-facing names
+    # shown in the config panel (e.g. dola-seed-2.0-lite).  Validate
+    # against our static catalog instead of the live listing.
+    if normalized == "bytedance":
+        try:
+            catalog_models = provider_model_ids(normalized)
+        except Exception:
+            catalog_models = []
+        if catalog_models:
+            if requested_for_lookup in set(catalog_models):
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            auto = get_close_matches(requested_for_lookup, catalog_models, n=1, cutoff=0.9)
+            if auto:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": auto[0],
+                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                }
+            suggestions = get_close_matches(requested, catalog_models, n=3, cutoff=0.5)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in the ByteDance catalog."
+                    f"{suggestion_text}"
                     "\n  The model may still work if it exists on the server."
                 ),
             }

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -190,6 +190,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="TOKENHUB_BASE_URL",
     ),
+    "bytedance": HermesOverlay(
+        transport="openai_chat",
+        base_url_override="https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+        base_url_env_var="BYTEDANCE_BASE_URL",
+    ),
     "arcee": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://api.arcee.ai/api/v1",
@@ -353,6 +358,13 @@ ALIASES: Dict[str, str] = {
     # arcee
     "arcee-ai": "arcee",
     "arceeai": "arcee",
+
+    # bytedance
+    "byte-dance": "bytedance",
+    "byteplus": "bytedance",
+    "volcengine": "bytedance",
+    "doubao": "bytedance",
+    "volces": "bytedance",
 
     # gmi
     "gmi-cloud": "gmi",

--- a/plugins/model-providers/bytedance/__init__.py
+++ b/plugins/model-providers/bytedance/__init__.py
@@ -1,0 +1,34 @@
+"""ByteDance / BytePlus / Volcengine Coding Plan provider profile.
+
+Targets the international coding endpoint:
+  - Anthropic API: https://ark.ap-southeast.bytepluses.com/api/coding
+  - OpenAI API:    https://ark.ap-southeast.bytepluses.com/api/coding/v3
+
+This profile uses the OpenAI-compatible path by default.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+bytedance = ProviderProfile(
+    name="bytedance",
+    aliases=("byte-dance", "byteplus", "volcengine", "doubao"),
+    display_name="ByteDance Coding Plan",
+    description="ByteDance / BytePlus Coding Plan — Doubao & Seed models",
+    signup_url="https://www.byteplus.com/",
+    env_vars=("BYTEDANCE_API_KEY", "BYTEPLUS_API_KEY", "VOLCENGINE_API_KEY"),
+    base_url="https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+    auth_type="api_key",
+    fallback_models=(
+        "bytedance-seed-code",
+        "dola-seed-2.0-pro",
+        "dola-seed-2.0-lite",
+        "dola-seed-2.0-code",
+        "glm-5.1",
+        "glm-4.7",
+        "gpt-oss-120b",
+        "kimi-k2.5",
+    ),
+)
+
+register_provider(bytedance)

--- a/plugins/model-providers/bytedance/plugin.yaml
+++ b/plugins/model-providers/bytedance/plugin.yaml
@@ -1,0 +1,5 @@
+name: bytedance-provider
+kind: model-provider
+version: 1.0.0
+description: ByteDance / BytePlus / Volcengine Coding Plan
+author: tuancookiez-hub


### PR DESCRIPTION
## Summary

Adds ByteDance/Volcengine Coding Plan as a built-in provider, following the same pattern as `alibaba-coding-plan` and `kimi-coding-cn`.

ByteDance has launched a dedicated Coding Plan on ModelArk (Volcengine) with an OpenAI-compatible endpoint, offering models like Dola-Seed-2.0, ByteDance-Seed-Code, GLM-5.1, Kimi-K2.5, etc.

## Changes

| File | Change |
|------|--------|
| `plugins/model-providers/bytedance/__init__.py` | **New** — ProviderProfile registration with canonical endpoint, aliases, env vars |
| `plugins/model-providers/bytedance/plugin.yaml` | **New** — Plugin manifest |
| `hermes_cli/providers.py` | Add `HERMES_OVERLAYS` entry + 5 aliases (byte-dance, byteplus, volcengine, doubao, volces) |
| `hermes_cli/models.py` | Add static model catalog + model validation that handles ByteDance's internal-vs-user-facing model ID mismatch |

## Provider Details

- **Endpoint:** `https://ark.ap-southeast.bytepluses.com/api/coding/v3`
- **Auth env vars:** `BYTEDANCE_API_KEY`, `BYTEPLUS_API_KEY`, `VOLCENGINE_API_KEY`
- **Models:** `bytedance-seed-code`, `dola-seed-2.0-pro`, `dola-seed-2.0-lite`, `dola-seed-2.0-code`, `glm-5.1`, `glm-4.7`, `gpt-oss-120b`, `kimi-k2.5`

## Notes

The ByteDance API's `/models` endpoint returns internal model IDs (e.g. `seed-2-0-lite-260428`) that differ from the user-facing config panel names (e.g. `dola-seed-2.0-lite`). The model validation in `models.py` handles this by validating against the static catalog when the provider is `bytedance`, with auto-correction for close matches and fuzzy suggestions as fallback.