### PR TITLE
Add pre_system_prompt hook for plugins to modify system prompt before LLM call

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -154,6 +154,24 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # prompt) — build from scratch.
     agent._cached_system_prompt = agent._build_system_prompt(system_message)
 
+    # Plugin hook: pre_system_prompt — fired after system prompt is built
+    # but before it's persisted. Plugins can modify the system prompt
+    # (e.g. inject skill auto-load directives). The last non-None return
+    # value replaces the system prompt.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        results = _invoke_hook(
+            "pre_system_prompt",
+            system_prompt=agent._cached_system_prompt,
+            session_id=agent.session_id,
+            model=agent.model,
+            platform=getattr(agent, "platform", None) or "",
+        )
+        if results:
+            agent._cached_system_prompt = results[-1]
+    except Exception as exc:
+        logger.warning("pre_system_prompt hook failed: %s", exc)
+
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
     # to initialise session-scoped state (e.g. warm a memory cache).

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -143,6 +143,12 @@ _DEFAULT_PAYLOADS = {
     "on_session_end": {"session_id": "test-session"},
     "on_session_finalize": {"session_id": "test-session"},
     "on_session_reset": {"session_id": "test-session"},
+    "pre_system_prompt": {
+        "system_prompt": "You are a helpful assistant.",
+        "session_id": "test-session",
+        "model": "gpt-4",
+        "platform": "cli",
+    },
     "pre_api_request": {
         "session_id": "test-session",
         "task_id": "test-task",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -138,6 +138,10 @@ VALID_HOOKS: Set[str] = {
     "post_llm_call",
     "pre_api_request",
     "post_api_request",
+    # Allow plugins to modify the system prompt before it is sent.
+    # Plugins return the modified prompt string, or None to leave unchanged.
+    # Last non-None return wins. Useful for skill auto-loading.
+    "pre_system_prompt",
     "on_session_start",
     "on_session_end",
     "on_session_finalize",


### PR DESCRIPTION
Allow plugins to modify the system prompt before it is sent to the LLM. The hook fires after _build_system_prompt() and before on_session_start, giving plugins a window to inject directives (e.g. skill auto-loading).

- Add pre_system_prompt to VALID_HOOKS in hermes_cli/plugins.py
- Add default test payload in hermes_cli/hooks.py
- Insert hook invocation in agent/conversation_loop.py between system prompt build and on_session_start

Plugins return modified prompt string, or None to leave unchanged. Last non-None return from multiple plugins wins.

Tested: 3814/3818 pass, zero new failures.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

