### PR TITLE
fix(cron): use get_default_hermes_root for JOBS_FILE so profile-scoped agents don't orphan jobs (fixes #32091)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -16,7 +16,7 @@ import re
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ except ImportError:
 # Configuration
 # =============================================================================
 
-HERMES_DIR = get_hermes_home().resolve()
+HERMES_DIR = get_default_hermes_root().resolve()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
 


### PR DESCRIPTION
## What does this PR do?

Fixes #32091: Cron jobs created from a profile-scoped agent session (e.g. `hermes -p corpusiq-agent chat`) were written to the profile-local `cron/jobs.json` and never seen by the gateway scheduler, which reads only the root `~/.hermes/cron/jobs.json`. Jobs looked healthy from the agent\'s POV but never fired.

## Root cause

`cron/jobs.py` used `get_hermes_home()` to compute `JOBS_FILE`. This is profile-aware -- when the agent runs under a named profile, it resolves to `~/.hermes/profiles/<name>/cron/jobs.json`. The gateway scheduler runs without a profile and reads from `~/.hermes/cron/jobs.json`.

## Fix

Changed `cron/jobs.py` to use `get_default_hermes_root()` instead of `get_hermes_home()` for the storage paths. This function always resolves to the root Hermes directory (default `~/.hermes`) regardless of active profile. Per-job `profile` field (already supported by the scheduler\'s `_job_profile_context`) is the correct mechanism for execution-context scoping -- the storage location shouldn't also be profile-scoped.

## Changes

- `cron/jobs.py`: import `get_default_hermes_root` and use it for `HERMES_DIR`/CRON_DIR/JOBS_FILE instead of `get_hermes_home`

## Tests

```bash
pytest tests/cron/ -q
# 383 passed
```

## Related issue

Closes #32091