### PR TITLE
feat(skills): track usage by provenance key

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -269,6 +269,7 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
     for row in _u.agent_created_report():
         counts["checked"] += 1
         name = row["name"]
+        identity = row.get("usage_key") or name
         if row.get("pinned"):
             continue
 
@@ -282,15 +283,15 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
         current = row.get("state", _u.STATE_ACTIVE)
 
         if anchor <= archive_cutoff and current != _u.STATE_ARCHIVED:
-            ok, _msg = _u.archive_skill(name)
+            ok, _msg = _u.archive_skill(identity)
             if ok:
                 counts["archived"] += 1
         elif anchor <= stale_cutoff and current == _u.STATE_ACTIVE:
-            _u.set_state(name, _u.STATE_STALE)
+            _u.set_state(identity, _u.STATE_STALE)
             counts["marked_stale"] += 1
         elif anchor > stale_cutoff and current == _u.STATE_STALE:
             # Skill got used again after being marked stale — reactivate.
-            _u.set_state(name, _u.STATE_ACTIVE)
+            _u.set_state(identity, _u.STATE_ACTIVE)
             counts["reactivated"] += 1
 
     return counts
@@ -1353,8 +1354,10 @@ def _render_candidate_list() -> str:
         return "No agent-created skills to review."
     lines = [f"Agent-created skills ({len(rows)}):\n"]
     for r in rows:
+        identity = r.get("usage_key") or r["name"]
+        label = r["name"] if identity == r["name"] else f"{r['name']} ({identity})"
         lines.append(
-            f"- {r['name']}  "
+            f"- {label}  "
             f"state={r['state']}  "
             f"pinned={'yes' if r.get('pinned') else 'no'}  "
             f"activity={r.get('activity_count', 0)}  "

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -36,6 +36,16 @@ def _fmt_ts(ts: Optional[str]) -> str:
     return f"{secs // 86400}d ago"
 
 
+def _row_identity(row: dict) -> str:
+    return str(row.get("usage_key") or row.get("name") or "")
+
+
+def _row_label(row: dict) -> str:
+    identity = _row_identity(row)
+    name = str(row.get("name") or identity)
+    return name if identity == name else f"{name} ({identity})"
+
+
 def _cmd_status(args) -> int:
     from agent import curator
     from tools import skill_usage
@@ -78,6 +88,21 @@ def _cmd_status(args) -> int:
     print(f"  stale after:    {curator.get_stale_after_days()}d unused")
     print(f"  archive after:  {curator.get_archive_after_days()}d unused")
 
+    bundle_rows = skill_usage.bundle_usage_report()
+    if bundle_rows:
+        print(f"\nskill bundles: {len(bundle_rows)} total")
+        for r in bundle_rows[:5]:
+            source = r.get("source_repo") or "local"
+            print(
+                f"  {r.get('bundle_id', ''):32s}  "
+                f"skills={r.get('skill_count', 0):3d}  "
+                f"recorded={r.get('recorded_skill_count', 0):3d}  "
+                f"activity={r.get('activity_count', 0):3d}  "
+                f"use={r.get('use_count', 0):3d}  "
+                f"view={r.get('view_count', 0):3d}  "
+                f"source={source}"
+            )
+
     rows = skill_usage.agent_created_report()
     if not rows:
         print("\nno agent-created skills")
@@ -89,7 +114,7 @@ def _cmd_status(args) -> int:
         state_name = r.get("state", "active")
         by_state.setdefault(state_name, []).append(r)
         if r.get("pinned"):
-            pinned.append(r["name"])
+            pinned.append(_row_label(r))
 
     print(f"\nagent-created skills: {len(rows)} total")
     for state_name in ("active", "stale", "archived"):
@@ -111,7 +136,7 @@ def _cmd_status(args) -> int:
         for r in active:
             last = _fmt_ts(r.get("last_activity_at"))
             print(
-                f"  {r['name']:40s}  "
+                f"  {_row_label(r):40s}  "
                 f"activity={r.get('activity_count', 0):3d}  "
                 f"use={r.get('use_count', 0):3d}  "
                 f"view={r.get('view_count', 0):3d}  "
@@ -137,7 +162,7 @@ def _cmd_status(args) -> int:
             for r in most_active:
                 last = _fmt_ts(r.get("last_activity_at"))
                 print(
-                    f"  {r['name']:40s}  "
+                    f"  {_row_label(r):40s}  "
                     f"activity={r.get('activity_count', 0):3d}  "
                     f"use={r.get('use_count', 0):3d}  "
                     f"view={r.get('view_count', 0):3d}  "
@@ -154,7 +179,7 @@ def _cmd_status(args) -> int:
             for r in least_active:
                 last = _fmt_ts(r.get("last_activity_at"))
                 print(
-                    f"  {r['name']:40s}  "
+                    f"  {_row_label(r):40s}  "
                     f"activity={r.get('activity_count', 0):3d}  "
                     f"use={r.get('use_count', 0):3d}  "
                     f"view={r.get('view_count', 0):3d}  "
@@ -326,16 +351,16 @@ def _cmd_prune(args) -> int:
         idle = _idle_days(r)
         if idle is None or idle < days:
             continue
-        candidates.append((r["name"], idle))
+        candidates.append((_row_identity(r), _row_label(r), idle))
 
     if not candidates:
         print(f"curator: nothing to prune (no unpinned skills idle >= {days}d)")
         return 0
 
-    candidates.sort(key=lambda c: -c[1])
+    candidates.sort(key=lambda c: -c[2])
     print(f"curator: {len(candidates)} skill(s) idle >= {days}d:")
-    for name, idle in candidates:
-        print(f"  {name:40s} idle {idle}d")
+    for _identity, label, idle in candidates:
+        print(f"  {label:40s} idle {idle}d")
 
     if dry_run:
         print("\n(dry run — no changes made)")
@@ -353,12 +378,12 @@ def _cmd_prune(args) -> int:
 
     archived = 0
     failures = []
-    for name, _ in candidates:
-        ok, msg = skill_usage.archive_skill(name)
+    for identity, label, _idle in candidates:
+        ok, msg = skill_usage.archive_skill(identity)
         if ok:
             archived += 1
         else:
-            failures.append((name, msg))
+            failures.append((label, msg))
 
     print(f"\ncurator: archived {archived}/{len(candidates)}")
     if failures:

--- a/tests/hermes_cli/test_curator_status.py
+++ b/tests/hermes_cli/test_curator_status.py
@@ -48,6 +48,7 @@ def test_status_uses_last_activity_not_only_last_used(monkeypatch, capsys):
             "activity_count": 4,
         }
     ])
+    monkeypatch.setattr(skill_usage, "bundle_usage_report", lambda: [])
 
     assert curator_cli._cmd_status(SimpleNamespace()) == 0
     out = capsys.readouterr().out
@@ -92,10 +93,26 @@ def curator_status_env(tmp_path, monkeypatch):
             f"# {name}\n"
         )
 
+    def _write_bundle_skill(bundle: str, name: str) -> None:
+        d = skills / bundle / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\n"
+            f"name: {name}\n"
+            "description: bundled test\n"
+            "metadata:\n"
+            "  hermes:\n"
+            f"    bundle_id: {bundle}\n"
+            "    source_repo: https://example.com/source.git\n"
+            "---\n"
+            f"# {name}\n"
+        )
+
     return {
         "home": home,
         "skills": skills,
         "make_skill": _write_skill,
+        "make_bundle_skill": _write_bundle_skill,
         "skill_usage": skill_usage,
         "curator_cli": curator_cli,
     }
@@ -166,6 +183,23 @@ def test_status_hides_most_active_when_all_zero(curator_status_env):
     assert "most active (top 5):" not in out
     # least-active still renders — it's part of the catalog overview
     assert "least active (top 5):" in out
+
+
+def test_status_shows_bundle_usage_summary(curator_status_env):
+    env = curator_status_env
+    env["make_bundle_skill"]("superpowers-zh", "using-superpowers")
+    env["make_bundle_skill"]("superpowers-zh", "verification-before-completion")
+    env["skill_usage"].bump_use("using-superpowers")
+    env["skill_usage"].bump_view("superpowers-zh/using-superpowers")
+
+    out = _capture_status(env["curator_cli"])
+
+    assert "skill bundles: 1 total" in out
+    assert "superpowers-zh" in out
+    assert "skills=  2" in out
+    assert "recorded=  1" in out
+    assert "activity=  2" in out
+    assert "source=https://example.com/source.git" in out
 
 
 def test_status_no_skills_produces_clean_empty_output(curator_status_env):

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -258,6 +258,26 @@ def test_agent_created_excludes_hub_installed(skills_home):
     assert "hub-skill" not in names
 
 
+def test_categorized_agent_created_skill_is_listed_and_reported(skills_home):
+    from tools.skill_usage import (
+        agent_created_report,
+        list_agent_created_skill_names,
+        load_usage,
+        mark_agent_created,
+    )
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "agent-made", category="devops")
+
+    mark_agent_created("agent-made")
+
+    usage = load_usage()
+    assert "devops/agent-made" in usage
+    assert "agent-made" in list_agent_created_skill_names()
+    report_by_name = {row["name"]: row for row in agent_created_report()}
+    assert report_by_name["agent-made"]["created_by"] == "agent"
+
+
 def test_agent_created_excludes_hub_installed_frontmatter_name(skills_home):
     from tools.skill_usage import (
         is_agent_created,
@@ -350,6 +370,282 @@ def test_archive_skill_moves_directory(skills_home):
     assert (skills_dir / ".archive" / "old-skill" / "SKILL.md").exists()
     assert get_record("old-skill")["state"] == "archived"
     assert get_record("old-skill")["archived_at"] is not None
+
+
+def test_archive_categorized_agent_created_skill_updates_canonical_record(skills_home):
+    from tools.skill_usage import archive_skill, bump_view, load_usage, mark_agent_created
+
+    skills_dir = skills_home / "skills"
+    skill_dir = _write_skill(skills_dir, "agent-made", category="devops")
+    mark_agent_created("agent-made")
+    bump_view("agent-made")
+
+    before = load_usage()
+    assert before["devops/agent-made"]["created_by"] == "agent"
+    assert before["devops/agent-made"]["state"] == "active"
+    assert before["devops/agent-made"]["view_count"] == 1
+
+    ok, msg = archive_skill("agent-made")
+    assert ok, msg
+
+    after = load_usage()
+    assert not skill_dir.exists()
+    assert (skills_dir / ".archive" / "agent-made" / "SKILL.md").exists()
+    assert "agent-made" not in after
+    assert after["devops/agent-made"]["created_by"] == "agent"
+    assert after["devops/agent-made"]["state"] == "archived"
+    assert after["devops/agent-made"]["view_count"] == 1
+    assert after["devops/agent-made"]["archived_at"] is not None
+
+
+def test_forget_categorized_agent_created_skill_removes_canonical_record(skills_home):
+    from tools.skill_usage import forget, load_usage, mark_agent_created
+
+    skills_dir = skills_home / "skills"
+    skill_dir = _write_skill(skills_dir, "agent-made", category="devops")
+    mark_agent_created("agent-made")
+    assert "devops/agent-made" in load_usage()
+
+    import shutil
+    shutil.rmtree(skill_dir)
+    forget("agent-made")
+
+    assert "devops/agent-made" not in load_usage()
+
+
+def test_forget_qualified_key_does_not_delete_other_namespace_suffix(skills_home):
+    from tools.skill_usage import forget, load_usage, save_usage
+
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        }
+    })
+
+    forget("devops/agent-made")
+
+    after = load_usage()
+    assert after["qa/agent-made"]["view_count"] == 7
+
+
+def test_mutate_qualified_key_does_not_update_other_namespace_suffix(skills_home):
+    from tools.skill_usage import bump_view, load_usage, save_usage
+
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        }
+    })
+
+    bump_view("devops/agent-made")
+
+    after = load_usage()
+    assert after["qa/agent-made"]["view_count"] == 7
+
+
+def test_get_record_qualified_key_does_not_read_other_namespace_suffix(skills_home):
+    from tools.skill_usage import get_record, save_usage
+
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        }
+    })
+
+    rec = get_record("devops/agent-made")
+
+    assert rec["view_count"] == 0
+
+
+def test_list_agent_created_does_not_use_other_namespace_suffix_record(skills_home):
+    from tools.skill_usage import list_agent_created_skill_names, save_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "agent-made", category="devops")
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        }
+    })
+
+    assert "agent-made" not in list_agent_created_skill_names()
+
+
+def test_agent_created_report_does_not_read_other_namespace_suffix_record(skills_home):
+    from tools.skill_usage import agent_created_report, save_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "agent-made", category="devops")
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        }
+    })
+
+    assert "agent-made" not in {row["name"] for row in agent_created_report()}
+
+
+def test_bundle_usage_report_does_not_count_other_namespace_suffix_record(skills_home):
+    from tools.skill_usage import bundle_usage_report, save_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "agent-made", category="devops")
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        }
+    })
+
+    by_bundle = {row["bundle_id"]: row for row in bundle_usage_report()}
+    assert by_bundle["devops"]["recorded_skill_count"] == 0
+    assert by_bundle["devops"]["view_count"] == 0
+
+
+def test_bundle_usage_report_does_not_double_count_same_suffix_record(skills_home):
+    from tools.skill_usage import bundle_usage_report, save_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "agent-made", category="devops")
+    _write_skill(skills_dir, "agent-made", category="qa")
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        }
+    })
+
+    by_bundle = {row["bundle_id"]: row for row in bundle_usage_report()}
+    assert by_bundle["qa"]["recorded_skill_count"] == 1
+    assert by_bundle["qa"]["view_count"] == 7
+    assert by_bundle["devops"]["recorded_skill_count"] == 0
+    assert by_bundle["devops"]["view_count"] == 0
+
+
+def test_restore_categorized_agent_created_skill_remains_reported(skills_home):
+    from tools.skill_usage import (
+        archive_skill,
+        agent_created_report,
+        list_agent_created_skill_names,
+        load_usage,
+        mark_agent_created,
+        restore_skill,
+    )
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "agent-made", category="devops")
+    mark_agent_created("agent-made")
+    archive_skill("agent-made")
+
+    ok, msg = restore_skill("agent-made")
+    assert ok, msg
+
+    usage = load_usage()
+    assert "devops/agent-made" not in usage
+    assert usage["agent-made"]["state"] == "active"
+    assert "agent-made" in list_agent_created_skill_names()
+    report_by_name = {row["name"]: row for row in agent_created_report()}
+    assert report_by_name["agent-made"]["state"] == "active"
+
+
+def test_agent_created_report_keeps_same_name_namespaces_distinct(skills_home):
+    from tools.skill_usage import agent_created_report, mark_agent_created, save_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "agent-made", category="devops")
+    _write_skill(skills_dir, "agent-made", category="qa")
+    save_usage({
+        "devops/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 3,
+        },
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        },
+    })
+
+    rows = agent_created_report()
+    by_key = {row["usage_key"]: row for row in rows}
+
+    assert set(by_key) == {"devops/agent-made", "qa/agent-made"}
+    assert by_key["devops/agent-made"]["name"] == "agent-made"
+    assert by_key["devops/agent-made"]["bundle_id"] == "devops"
+    assert by_key["devops/agent-made"]["view_count"] == 3
+    assert by_key["qa/agent-made"]["name"] == "agent-made"
+    assert by_key["qa/agent-made"]["bundle_id"] == "qa"
+    assert by_key["qa/agent-made"]["view_count"] == 7
+
+
+def test_archive_accepts_usage_key_for_same_name_namespace(skills_home):
+    from tools.skill_usage import archive_skill, load_usage, save_usage
+
+    skills_dir = skills_home / "skills"
+    devops_dir = _write_skill(skills_dir, "agent-made", category="devops")
+    qa_dir = _write_skill(skills_dir, "agent-made", category="qa")
+    save_usage({
+        "devops/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 3,
+        },
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "active",
+            "view_count": 7,
+        },
+    })
+
+    ok, msg = archive_skill("devops/agent-made")
+    assert ok, msg
+
+    usage = load_usage()
+    assert not devops_dir.exists()
+    assert qa_dir.exists()
+    assert usage["devops/agent-made"]["state"] == "archived"
+    assert usage["qa/agent-made"]["state"] == "active"
+
+
+def test_restore_does_not_migrate_other_namespace_unique_suffix_record(skills_home):
+    from tools.skill_usage import load_usage, restore_skill, save_usage
+
+    skills_dir = skills_home / "skills"
+    archive_dir = skills_dir / ".archive" / "agent-made"
+    archive_dir.mkdir(parents=True)
+    (archive_dir / "SKILL.md").write_text(
+        "---\nname: agent-made\ndescription: test\n---\n# body\n",
+        encoding="utf-8",
+    )
+    save_usage({
+        "qa/agent-made": {
+            "created_by": "agent",
+            "state": "archived",
+            "view_count": 7,
+        }
+    })
+
+    ok, msg = restore_skill("agent-made")
+    assert ok, msg
+
+    after = load_usage()
+    assert after["qa/agent-made"]["state"] == "archived"
+    assert after["qa/agent-made"]["view_count"] == 7
+    assert after["agent-made"]["state"] == "active"
+    assert after["agent-made"]["view_count"] == 0
 
 
 def test_archive_refuses_bundled_skill(skills_home):
@@ -637,3 +933,74 @@ def test_end_to_end_no_code_path_mutates_bundled_skill(skills_home):
     # The agent-created skill can still be mutated normally
     bump_view("mine")
     assert load_usage()["mine"]["view_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Bundle/package provenance and canonical usage keys
+# ---------------------------------------------------------------------------
+
+def test_usage_key_canonicalizes_nested_bundle_skill(skills_home):
+    from tools.skill_usage import bump_view, load_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "using-superpowers", category="superpowers-zh")
+
+    bump_view("using-superpowers")
+
+    data = load_usage()
+    assert "superpowers-zh/using-superpowers" in data
+    assert "using-superpowers" not in data
+    assert data["superpowers-zh/using-superpowers"]["view_count"] == 1
+
+
+def test_bundle_usage_report_groups_metadata_and_activity(skills_home):
+    from tools.skill_usage import bump_use, bump_view, bundle_usage_report
+
+    skills_dir = skills_home / "skills"
+    bundle_skill = skills_dir / "superpowers-zh" / "using-superpowers"
+    bundle_skill.mkdir(parents=True)
+    (bundle_skill / "SKILL.md").write_text(
+        """---
+name: using-superpowers
+description: test skill
+metadata:
+  hermes:
+    bundle_id: superpowers-zh
+    source_repo: https://example.com/superpowers-zh.git
+    source_ref: main
+    source_commit: abc123
+---
+
+# body
+""",
+        encoding="utf-8",
+    )
+    _write_skill(skills_dir, "verification-before-completion", category="superpowers-zh")
+
+    bump_use("using-superpowers")
+    bump_view("superpowers-zh/using-superpowers")
+
+    rows = bundle_usage_report()
+    by_bundle = {r["bundle_id"]: r for r in rows}
+    row = by_bundle["superpowers-zh"]
+    assert row["skill_count"] == 2
+    assert row["recorded_skill_count"] == 1
+    assert row["use_count"] == 1
+    assert row["view_count"] == 1
+    assert row["activity_count"] == 2
+    assert row["source_repo"] == "https://example.com/superpowers-zh.git"
+    assert row["source_ref"] == "main"
+    assert row["source_commit"] == "abc123"
+
+
+def test_canonical_bundled_alias_stays_off_limits(skills_home):
+    from tools.skill_usage import bump_view, load_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "bundled-skill", category="github")
+    (skills_dir / ".bundled_manifest").write_text(
+        "bundled-skill:abc\n", encoding="utf-8",
+    )
+
+    bump_view("github/bundled-skill")
+    assert "github/bundled-skill" not in load_usage()

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -551,6 +551,17 @@ class TestSkillView:
             skill["name"] for skill in list_result["skills"]
         ]
 
+    def test_view_exposes_canonical_usage_key_for_bundle_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "using-superpowers", category="superpowers-zh")
+            raw = skill_view("superpowers-zh/using-superpowers")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["name"] == "using-superpowers"
+        assert result["usage_key"] == "superpowers-zh/using-superpowers"
+        assert result["bundle_id"] == "superpowers-zh"
+
 
 class TestSkillViewSecureSetupOnLoad:
     def test_requests_missing_required_env_and_continues(self, tmp_path, monkeypatch):

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -1,8 +1,9 @@
 """Skill usage telemetry + provenance tracking for the Curator feature.
 
 Tracks per-skill usage metadata in a sidecar JSON file (~/.hermes/skills/.usage.json)
-keyed by skill name. Counters are bumped by the existing skill tools (skill_view,
-skill_manage); the curator orchestrator reads the derived activity timestamp to
+keyed by canonical skill name (including bundle namespace when known). Counters
+are bumped by the existing skill tools (skill_view, skill_manage); the curator
+orchestrator reads the derived activity timestamp to
 decide lifecycle transitions.
 
 Design notes:
@@ -176,7 +177,7 @@ def _read_bundled_manifest_names() -> Set[str]:
                 names.add(name)
     except OSError as e:
         logger.debug("Failed to read bundled manifest: %s", e)
-    return names
+    return _expand_known_skill_aliases(names)
 
 
 def _read_hub_installed_names() -> Set[str]:
@@ -210,11 +211,71 @@ def _read_hub_installed_names() -> Set[str]:
                         continue
                     skill_md = resolved / "SKILL.md"
                     if skill_md.exists():
-                        names.add(_read_skill_name(skill_md, fallback=resolved.name))
+                        actual_name = _read_skill_name(skill_md, fallback=resolved.name)
+                        names.add(actual_name)
+                        names.add(skill_usage_key_for_path(
+                            skill_md,
+                            root=skills_dir,
+                            skill_name=actual_name,
+                        ).get("usage_key") or actual_name)
+                        try:
+                            names.add(str(resolved.relative_to(skills_dir.resolve())).strip("/"))
+                        except (OSError, ValueError):
+                            pass
                 return names
     except (OSError, json.JSONDecodeError) as e:
         logger.debug("Failed to read hub lock file: %s", e)
     return set()
+
+
+def _iter_agent_created_skill_entries() -> List[Dict[str, Any]]:
+    """Enumerate curator-managed skills with canonical identity metadata."""
+    base = _skills_dir()
+    if not base.exists():
+        return []
+    off_limits = _read_bundled_manifest_names() | _read_hub_installed_names()
+    usage = load_usage()
+    entries: List[Dict[str, Any]] = []
+    seen_keys: Set[str] = set()
+
+    for skill_md in base.rglob("SKILL.md"):
+        if is_excluded_skill_path(skill_md):
+            continue
+        try:
+            skill_md.relative_to(base)
+        except ValueError:
+            continue
+        frontmatter = _read_skill_frontmatter(skill_md)
+        name = _clean_str(frontmatter.get("name")) or skill_md.parent.name
+        provenance = skill_usage_key_for_path(
+            skill_md,
+            root=base,
+            skill_name=name,
+            frontmatter=frontmatter,
+        )
+        usage_key = str(provenance.get("usage_key") or name)
+        try:
+            rel_name = str(skill_md.parent.resolve().relative_to(base.resolve())).strip("/")
+        except (OSError, ValueError):
+            rel_name = skill_md.parent.name
+        if {str(name), usage_key, rel_name} & off_limits:
+            continue
+        rec = _record_for_usage_key(usage, usage_key, str(name))
+        if not _is_curator_managed_record(rec):
+            continue
+        if usage_key in seen_keys:
+            continue
+        seen_keys.add(usage_key)
+        entries.append({
+            "name": str(name),
+            "usage_key": usage_key,
+            "bundle_id": provenance.get("bundle_id"),
+            "source_repo": provenance.get("source_repo"),
+            "source_ref": provenance.get("source_ref"),
+            "source_commit": provenance.get("source_commit"),
+            "skill_md": skill_md,
+        })
+    return sorted(entries, key=lambda e: (str(e.get("usage_key") or ""), str(e.get("name") or "")))
 
 
 def list_agent_created_skill_names() -> List[str]:
@@ -226,31 +287,7 @@ def list_agent_created_skill_names() -> List[str]:
     Bundled / hub skills are maintained by their upstream sources and must
     never be pruned here.
     """
-    base = _skills_dir()
-    if not base.exists():
-        return []
-    bundled = _read_bundled_manifest_names()
-    hub = _read_hub_installed_names()
-    off_limits = bundled | hub
-    usage = load_usage()
-
-    names: List[str] = []
-    # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
-    for skill_md in base.rglob("SKILL.md"):
-        # Skip Hermes metadata, VCS, virtualenv/dependency, and cache dirs
-        if is_excluded_skill_path(skill_md):
-            continue
-        try:
-            rel = skill_md.relative_to(base)
-        except ValueError:
-            continue
-        name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
-        if name in off_limits:
-            continue
-        if not _is_curator_managed_record(usage.get(name)):
-            continue
-        names.append(name)
-    return sorted(set(names))
+    return sorted({entry["name"] for entry in _iter_agent_created_skill_entries()})
 
 
 def list_archived_skill_names() -> List[str]:
@@ -287,10 +324,296 @@ def _read_skill_name(skill_md: Path, fallback: str) -> str:
     return fallback
 
 
+def _clean_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _read_skill_frontmatter(skill_md: Path) -> Dict[str, Any]:
+    """Read SKILL.md frontmatter with nested metadata support."""
+    try:
+        text = skill_md.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return {}
+    try:
+        from agent.skill_utils import parse_frontmatter
+
+        frontmatter, _ = parse_frontmatter(text)
+    except Exception:
+        return {}
+    return frontmatter if isinstance(frontmatter, dict) else {}
+
+
+
+def _containing_skill_root(skill_md: Path) -> Optional[Path]:
+    """Return the configured skills root that contains *skill_md*."""
+    try:
+        from agent.skill_utils import get_all_skills_dirs
+
+        roots = get_all_skills_dirs()
+    except Exception:
+        roots = [_skills_dir()]
+    for root in roots:
+        try:
+            skill_md.resolve().relative_to(root.resolve())
+            return root
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def skill_usage_key_for_path(
+    skill_md: Path,
+    *,
+    root: Optional[Path] = None,
+    skill_name: Optional[str] = None,
+    frontmatter: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Return provenance and the canonical sidecar key for a SKILL.md path.
+
+    ``metadata.hermes.bundle_id`` wins. When absent, a nested path such as
+    ``superpowers-zh/using-superpowers/SKILL.md`` is treated as a package-like
+    namespace and produces ``superpowers-zh/using-superpowers``.
+    """
+    if frontmatter is None:
+        frontmatter = _read_skill_frontmatter(skill_md)
+    if skill_name is None:
+        skill_name = _clean_str(frontmatter.get("name")) or skill_md.parent.name
+
+    metadata = frontmatter.get("metadata") if isinstance(frontmatter, dict) else None
+    hermes_meta = metadata.get("hermes") if isinstance(metadata, dict) else None
+    if not isinstance(hermes_meta, dict):
+        hermes_meta = {}
+
+    bundle_id = _clean_str(hermes_meta.get("bundle_id"))
+    source_repo = _clean_str(hermes_meta.get("source_repo"))
+    source_ref = _clean_str(hermes_meta.get("source_ref"))
+    source_commit = _clean_str(hermes_meta.get("source_commit"))
+
+    if root is None:
+        root = _containing_skill_root(skill_md)
+
+    rel_parts: Tuple[str, ...] = ()
+    if root is not None:
+        try:
+            rel_parts = skill_md.resolve().relative_to(root.resolve()).parts
+        except (OSError, ValueError):
+            try:
+                rel_parts = skill_md.relative_to(root).parts
+            except ValueError:
+                rel_parts = ()
+
+    if not bundle_id and len(rel_parts) >= 3 and rel_parts[-1] == "SKILL.md":
+        bundle_id = rel_parts[0]
+
+    usage_key = str(skill_name)
+    if bundle_id:
+        if not usage_key.startswith(f"{bundle_id}/") and not usage_key.startswith(f"{bundle_id}:"):
+            usage_key = f"{bundle_id}/{usage_key}"
+
+    return {
+        "skill_name": str(skill_name),
+        "usage_key": usage_key,
+        "bundle_id": bundle_id,
+        "source_repo": source_repo,
+        "source_ref": source_ref,
+        "source_commit": source_commit,
+    }
+
+
+def _iter_skill_files_under(root: Path):
+    try:
+        from agent.skill_utils import iter_skill_index_files
+
+        yield from iter_skill_index_files(root, "SKILL.md")
+        return
+    except Exception:
+        pass
+    if root.exists():
+        for skill_md in sorted(root.rglob("SKILL.md")):
+            if not is_excluded_skill_path(skill_md):
+                yield skill_md
+
+
+def _find_skill_file_candidates(skill_name: str) -> List[Path]:
+    """Find SKILL.md files matching a bare or canonical skill identifier."""
+    if not skill_name:
+        return []
+    bare = skill_name.rsplit("/", 1)[-1]
+    candidates: List[Path] = []
+    seen: Set[Path] = set()
+    try:
+        from agent.skill_utils import get_all_skills_dirs
+
+        roots = get_all_skills_dirs()
+    except Exception:
+        roots = [_skills_dir()]
+    for root in roots:
+        if not root.exists():
+            continue
+        for skill_md in _iter_skill_files_under(root):
+            frontmatter = _read_skill_frontmatter(skill_md)
+            actual = _clean_str(frontmatter.get("name")) or skill_md.parent.name
+            provenance = skill_usage_key_for_path(
+                skill_md,
+                root=root,
+                skill_name=actual,
+                frontmatter=frontmatter,
+            )
+            try:
+                rel_parent = str(skill_md.parent.resolve().relative_to(root.resolve()))
+            except (OSError, ValueError):
+                rel_parent = str(skill_md.parent.name)
+            identifiers = {
+                str(actual),
+                skill_md.parent.name,
+                provenance.get("usage_key") or str(actual),
+                rel_parent.strip("/"),
+            }
+            if skill_name in identifiers or ("/" not in skill_name and bare in identifiers):
+                try:
+                    key = skill_md.resolve()
+                except OSError:
+                    key = skill_md
+                if key not in seen:
+                    seen.add(key)
+                    candidates.append(skill_md)
+    return candidates
+
+
+def canonicalize_usage_key(skill_name: str) -> str:
+    """Canonicalize a telemetry key, adding a bundle namespace when unique."""
+    skill_name = str(skill_name or "").strip()
+    if not skill_name or ":" in skill_name:
+        return skill_name
+    if "/" in skill_name:
+        return skill_name.strip("/")
+    candidates = _find_skill_file_candidates(skill_name)
+    if len(candidates) != 1:
+        return skill_name
+    actual = skill_name if candidates[0].parent.name == skill_name else _read_skill_name(
+        candidates[0], fallback=candidates[0].parent.name
+    )
+    return skill_usage_key_for_path(candidates[0], skill_name=actual).get("usage_key") or skill_name
+
+
+def _known_key_variants(skill_name: str) -> Set[str]:
+    raw = str(skill_name or "").strip().strip("/")
+    if not raw:
+        return set()
+    variants = {raw}
+    if "/" in raw:
+        variants.add(raw.rsplit("/", 1)[-1])
+    canonical = canonicalize_usage_key(raw)
+    if canonical:
+        variants.add(canonical)
+    return variants
+
+
+def _existing_usage_keys_for_name(
+    skill_name: str,
+    data: Dict[str, Dict[str, Any]],
+) -> List[str]:
+    """Find existing sidecar keys that refer to *skill_name*.
+
+    Bare names may use a unique suffix fallback (``agent-made`` ->
+    ``devops/agent-made``) for post-move/delete cleanup. Explicit qualified
+    keys are exact/canonical only; ``devops/agent-made`` must never match a
+    different namespace such as ``qa/agent-made``.
+    """
+    raw = str(skill_name or "").strip().strip("/")
+    if not raw:
+        return []
+    candidates: List[str] = []
+
+    def _add(key: Optional[str]) -> None:
+        if key and key in data and key not in candidates:
+            candidates.append(key)
+
+    _add(raw)
+    _add(canonicalize_usage_key(raw))
+    if "/" in raw:
+        return candidates
+    bare = raw.rsplit("/", 1)[-1]
+    if bare:
+        for key in data.keys():
+            if key.rsplit("/", 1)[-1] == bare and key not in candidates:
+                candidates.append(key)
+    return candidates
+
+
+def _select_usage_key_for_mutation(
+    skill_name: str,
+    data: Dict[str, Dict[str, Any]],
+) -> Optional[str]:
+    raw = str(skill_name or "").strip().strip("/")
+    if not raw:
+        return None
+    existing = _existing_usage_keys_for_name(raw, data)
+    if len(existing) == 1:
+        return existing[0]
+    canonical = canonicalize_usage_key(raw)
+    if canonical and (canonical != raw or not existing or canonical in data):
+        return canonical
+    if raw in data or not existing:
+        return raw
+    # Ambiguous suffix-only matches; avoid creating or mutating the wrong record.
+    return None
+
+
+def _usage_keys_to_forget(
+    skill_name: str,
+    data: Dict[str, Dict[str, Any]],
+) -> Set[str]:
+    raw = str(skill_name or "").strip().strip("/")
+    if not raw:
+        return set()
+    keys: Set[str] = set()
+    canonical = canonicalize_usage_key(raw)
+    for key in {raw, canonical}:
+        if key in data:
+            keys.add(key)
+    if "/" in raw:
+        return keys
+    existing = _existing_usage_keys_for_name(raw, data)
+    if len(existing) == 1:
+        keys.add(existing[0])
+    return keys
+
+
+def _expand_known_skill_aliases(names: Set[str]) -> Set[str]:
+    """Add canonical bundle/path aliases for known off-limit skill names."""
+    out = {str(n) for n in names if str(n).strip()}
+    if not out:
+        return out
+    base = _skills_dir()
+    if not base.exists():
+        return out
+    for skill_md in _iter_skill_files_under(base):
+        actual = _read_skill_name(skill_md, fallback=skill_md.parent.name)
+        if actual not in out and skill_md.parent.name not in out:
+            continue
+        provenance = skill_usage_key_for_path(
+            skill_md,
+            root=base,
+            skill_name=actual,
+        )
+        key = provenance.get("usage_key")
+        if key:
+            out.add(str(key))
+        try:
+            out.add(str(skill_md.parent.resolve().relative_to(base.resolve())).strip("/"))
+        except (OSError, ValueError):
+            pass
+    return out
+
+
 def is_agent_created(skill_name: str) -> bool:
     """Whether *skill_name* is neither bundled nor hub-installed."""
     off_limits = _read_bundled_manifest_names() | _read_hub_installed_names()
-    return skill_name not in off_limits
+    return _known_key_variants(skill_name).isdisjoint(off_limits)
 
 
 def _is_curator_managed_record(record: Any) -> bool:
@@ -366,8 +689,17 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
 
 def get_record(skill_name: str) -> Dict[str, Any]:
     """Return the record for *skill_name*, creating a fresh one if missing."""
+    key = canonicalize_usage_key(skill_name)
     data = load_usage()
-    rec = data.get(skill_name)
+    rec = data.get(key)
+    if not isinstance(rec, dict) and key != skill_name:
+        # Legacy sidecars may have been keyed by bare frontmatter name before
+        # bundle-aware canonicalization existed.
+        rec = data.get(skill_name)
+    if not isinstance(rec, dict):
+        existing = _existing_usage_keys_for_name(skill_name, data)
+        if len(existing) == 1:
+            rec = data.get(existing[0])
     if not isinstance(rec, dict):
         return _empty_record()
     # Backfill any missing keys so callers don't need to handle old files
@@ -391,11 +723,20 @@ def _mutate(skill_name: str, mutator) -> None:
             return
         with _usage_file_lock():
             data = load_usage()
-            rec = data.get(skill_name)
+            skill_key = _select_usage_key_for_mutation(skill_name, data)
+            if not skill_key:
+                return
+            rec = data.get(skill_key)
+            if not isinstance(rec, dict):
+                canonical = canonicalize_usage_key(skill_name)
+                if canonical != skill_key and isinstance(data.get(canonical), dict):
+                    rec = data.pop(canonical)
+                elif skill_key != skill_name and isinstance(data.get(skill_name), dict):
+                    rec = data.pop(skill_name)
             if not isinstance(rec, dict):
                 rec = _empty_record()
             mutator(rec)
-            data[skill_name] = rec
+            data[skill_key] = rec
             save_usage(data)
     except Exception as e:
         logger.debug("skill_usage._mutate(%s) failed: %s", skill_name, e, exc_info=True)
@@ -468,8 +809,13 @@ def forget(skill_name: str) -> None:
     try:
         with _usage_file_lock():
             data = load_usage()
-            if skill_name in data:
-                del data[skill_name]
+            keys = _usage_keys_to_forget(skill_name, data)
+            removed = False
+            for key in keys:
+                if key in data:
+                    del data[key]
+                    removed = True
+            if removed:
                 save_usage(data)
     except Exception as e:
         logger.debug("skill_usage.forget(%s) failed: %s", skill_name, e, exc_info=True)
@@ -478,6 +824,80 @@ def forget(skill_name: str) -> None:
 # ---------------------------------------------------------------------------
 # Archive / restore
 # ---------------------------------------------------------------------------
+
+def _archive_usage_key_file(skill_dir: Path) -> Path:
+    return skill_dir / ".usage_key"
+
+
+def _read_archive_usage_key(skill_dir: Path) -> Optional[str]:
+    marker = _archive_usage_key_file(skill_dir)
+    try:
+        value = marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def _write_archive_usage_key(skill_dir: Path, usage_key: str) -> None:
+    if not usage_key:
+        return
+    try:
+        _archive_usage_key_file(skill_dir).write_text(usage_key + "\n", encoding="utf-8")
+    except OSError as e:
+        logger.debug("Failed to write archive usage key for %s: %s", skill_dir, e)
+
+
+def _remove_archive_usage_key(skill_dir: Path) -> None:
+    try:
+        _archive_usage_key_file(skill_dir).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.debug("Failed to remove archive usage key for %s: %s", skill_dir, e)
+
+
+def _mutate_usage_key_exact(skill_key: str, mutator) -> None:
+    """Mutate an exact sidecar key without canonical/suffix fallback."""
+    if not skill_key:
+        return
+    try:
+        with _usage_file_lock():
+            data = load_usage()
+            rec = data.get(skill_key)
+            if not isinstance(rec, dict):
+                rec = _empty_record()
+            mutator(rec)
+            data[skill_key] = rec
+            save_usage(data)
+    except Exception as e:
+        logger.debug(
+            "skill_usage._mutate_usage_key_exact(%s) failed: %s",
+            skill_key,
+            e,
+            exc_info=True,
+        )
+
+
+def _migrate_archived_usage_key(old_key: Optional[str], target_key: str) -> None:
+    """Move a trusted archived usage key to *target_key* after restore."""
+    if not old_key or not target_key or old_key == target_key:
+        return
+    try:
+        with _usage_file_lock():
+            data = load_usage()
+            rec = data.pop(old_key, None)
+            if isinstance(rec, dict):
+                data[target_key] = rec
+                save_usage(data)
+    except Exception as e:
+        logger.debug(
+            "skill_usage._migrate_archived_usage_key(%s -> %s) failed: %s",
+            old_key,
+            target_key,
+            e,
+            exc_info=True,
+        )
+
 
 def archive_skill(skill_name: str) -> Tuple[bool, str]:
     """Move an agent-created skill directory to ~/.hermes/skills/.archive/.
@@ -490,7 +910,13 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
 
     skill_dir = _find_skill_dir(skill_name)
     if skill_dir is None:
-        return False, f"skill '{skill_name}' not found"
+        return False, f"skill '{skill_name}' not found or ambiguous; use usage_key for same-name namespaces"
+    skill_md = skill_dir / "SKILL.md"
+    archived_usage_key = skill_usage_key_for_path(
+        skill_md,
+        root=_skills_dir(),
+        skill_name=_read_skill_name(skill_md, fallback=skill_dir.name),
+    ).get("usage_key") or skill_name
 
     archive_root = _archive_dir()
     try:
@@ -514,7 +940,11 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
         except Exception as e2:
             return False, f"failed to archive: {e2}"
 
-    set_state(skill_name, STATE_ARCHIVED)
+    _write_archive_usage_key(dest, str(archived_usage_key))
+    def _mark_archived(rec: Dict[str, Any]) -> None:
+        rec["state"] = STATE_ARCHIVED
+        rec["archived_at"] = _now_iso()
+    _mutate_usage_key_exact(str(archived_usage_key), _mark_archived)
     return True, f"archived to {dest}"
 
 
@@ -550,6 +980,7 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
         return False, f"skill '{skill_name}' not found in archive"
 
     src = candidates[0]
+    archived_usage_key = _read_archive_usage_key(src)
     dest = _skills_dir() / skill_name
     if dest.exists():
         return False, f"destination already exists: {dest}"
@@ -563,24 +994,54 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
         except Exception as e:
             return False, f"failed to restore: {e}"
 
-    set_state(skill_name, STATE_ACTIVE)
+    target_key = canonicalize_usage_key(skill_name)
+    _migrate_archived_usage_key(archived_usage_key, target_key)
+    _remove_archive_usage_key(dest)
+    def _mark_active(rec: Dict[str, Any]) -> None:
+        rec["state"] = STATE_ACTIVE
+        rec["archived_at"] = None
+    _mutate_usage_key_exact(target_key, _mark_active)
     return True, f"restored to {dest}"
 
 
 def _find_skill_dir(skill_name: str) -> Optional[Path]:
-    """Locate the directory for a skill by its frontmatter `name:` field.
+    """Locate a skill directory by usage key, relative path, or bare name.
 
-    Handles both flat (~/.hermes/skills/<skill>/SKILL.md) and category-nested
-    (~/.hermes/skills/<category>/<skill>/SKILL.md) layouts.
+    Qualified identities (``bundle/skill``) are matched exactly against the
+    canonical usage key or directory-relative path. Bare names keep the legacy
+    frontmatter-name lookup but refuse ambiguous same-name namespaces.
     """
     base = _skills_dir()
     if not base.exists():
         return None
+    raw = str(skill_name or "").strip().strip("/")
+    if not raw:
+        return None
+    candidates: List[Path] = []
     for skill_md in base.rglob("SKILL.md"):
         if is_excluded_skill_path(skill_md):
             continue
-        if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:
-            return skill_md.parent
+        frontmatter = _read_skill_frontmatter(skill_md)
+        name = _clean_str(frontmatter.get("name")) or skill_md.parent.name
+        provenance = skill_usage_key_for_path(
+            skill_md,
+            root=base,
+            skill_name=name,
+            frontmatter=frontmatter,
+        )
+        usage_key = str(provenance.get("usage_key") or name)
+        try:
+            rel_name = str(skill_md.parent.resolve().relative_to(base.resolve())).strip("/")
+        except (OSError, ValueError):
+            rel_name = skill_md.parent.name
+        if "/" in raw:
+            matched = raw in {usage_key, rel_name}
+        else:
+            matched = raw in {str(name), skill_md.parent.name}
+        if matched:
+            candidates.append(skill_md.parent)
+    if len(candidates) == 1:
+        return candidates[0]
     return None
 
 
@@ -589,20 +1050,150 @@ def _find_skill_dir(skill_name: str) -> Optional[Path]:
 # ---------------------------------------------------------------------------
 
 def agent_created_report() -> List[Dict[str, Any]]:
-    """Return a list of {name, state, pinned, last_activity_at, ...}
-    records for every agent-created skill. Missing usage records are backfilled
-    with defaults so callers can always index fields."""
+    """Return curator-managed skill records keyed by canonical ``usage_key``.
+
+    ``name`` is a display label and may collide across namespaces; callers that
+    mutate lifecycle state should use ``usage_key`` when present.
+    """
     data = load_usage()
     rows: List[Dict[str, Any]] = []
-    for name in list_agent_created_skill_names():
-        rec = data.get(name)
+    for entry in _iter_agent_created_skill_entries():
+        name = str(entry["name"])
+        key = str(entry["usage_key"])
+        rec = _record_for_usage_key(data, key, name)
         if not isinstance(rec, dict):
             rec = _empty_record()
         base = _empty_record()
         for k, v in base.items():
             rec.setdefault(k, v)
-        row = {"name": name, **rec}
+        row = {
+            "name": name,
+            "usage_key": key,
+            "bundle_id": entry.get("bundle_id"),
+            "source_repo": entry.get("source_repo"),
+            "source_ref": entry.get("source_ref"),
+            "source_commit": entry.get("source_commit"),
+            **rec,
+        }
         row["last_activity_at"] = latest_activity_at(row)
         row["activity_count"] = activity_count(row)
         rows.append(row)
     return rows
+
+
+def _record_for_usage_key(
+    usage: Dict[str, Dict[str, Any]],
+    usage_key: str,
+    legacy_name: str,
+) -> Optional[Dict[str, Any]]:
+    """Return exact canonical record or exact legacy bare-name record only.
+
+    Reporting paths must not suffix-match ``*/legacy_name``: a record for
+    ``qa/agent-made`` does not belong to ``devops/agent-made``.
+    """
+    rec = usage.get(usage_key)
+    if isinstance(rec, dict):
+        return rec
+    rec = usage.get(legacy_name)
+    if isinstance(rec, dict):
+        return rec
+    return None
+
+
+def bundle_usage_report() -> List[Dict[str, Any]]:
+    """Aggregate usage telemetry by skill package / bundle namespace.
+
+    Groups are discovered from ``metadata.hermes.bundle_id`` when present, or
+    from the first path segment for nested skill packages such as
+    ``superpowers-zh/<skill>/SKILL.md``. Counts include legacy bare-name usage
+    records so older sidecars are still reflected in package totals.
+    """
+    usage = load_usage()
+    bundles: Dict[str, Dict[str, Any]] = {}
+    try:
+        from agent.skill_utils import get_all_skills_dirs
+
+        roots = get_all_skills_dirs()
+    except Exception:
+        roots = [_skills_dir()]
+
+    seen_files: Set[Path] = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        for skill_md in _iter_skill_files_under(root):
+            try:
+                file_key = skill_md.resolve()
+            except OSError:
+                file_key = skill_md
+            if file_key in seen_files:
+                continue
+            seen_files.add(file_key)
+
+            frontmatter = _read_skill_frontmatter(skill_md)
+            skill_name = _clean_str(frontmatter.get("name")) or skill_md.parent.name
+            provenance = skill_usage_key_for_path(
+                skill_md,
+                root=root,
+                skill_name=skill_name,
+                frontmatter=frontmatter,
+            )
+            bundle_id = provenance.get("bundle_id")
+            if not bundle_id:
+                continue
+
+            row = bundles.setdefault(
+                str(bundle_id),
+                {
+                    "bundle_id": str(bundle_id),
+                    "source_repo": None,
+                    "source_ref": None,
+                    "source_commit": None,
+                    "skill_count": 0,
+                    "recorded_skill_count": 0,
+                    "use_count": 0,
+                    "view_count": 0,
+                    "patch_count": 0,
+                    "activity_count": 0,
+                    "last_activity_at": None,
+                    "skills": [],
+                },
+            )
+            row["skill_count"] += 1
+            row["skills"].append(provenance.get("usage_key") or str(skill_name))
+            for field in ("source_repo", "source_ref", "source_commit"):
+                if not row.get(field) and provenance.get(field):
+                    row[field] = provenance.get(field)
+
+            rec = _record_for_usage_key(
+                usage,
+                str(provenance.get("usage_key") or skill_name),
+                str(skill_name),
+            )
+            if not isinstance(rec, dict):
+                continue
+            row["recorded_skill_count"] += 1
+            base = _empty_record()
+            merged = {**base, **rec}
+            for field in ("use_count", "view_count", "patch_count"):
+                try:
+                    row[field] += int(merged.get(field) or 0)
+                except (TypeError, ValueError):
+                    pass
+            row["activity_count"] += activity_count(merged)
+            last = latest_activity_at(merged)
+            if last:
+                if not row["last_activity_at"]:
+                    row["last_activity_at"] = last
+                else:
+                    current = _parse_iso_timestamp(row["last_activity_at"])
+                    candidate = _parse_iso_timestamp(last)
+                    if candidate and (current is None or candidate > current):
+                        row["last_activity_at"] = last
+
+    for row in bundles.values():
+        row["skills"] = sorted(set(row["skills"]))
+    return sorted(
+        bundles.values(),
+        key=lambda r: (-(r.get("activity_count") or 0), str(r.get("bundle_id") or "")),
+    )

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1298,6 +1298,32 @@ def skill_view(
         skill_name = frontmatter.get(
             "name", skill_md.stem if not skill_dir else skill_dir.name
         )
+        usage_root = None
+        for candidate_root in all_dirs:
+            try:
+                skill_md.resolve().relative_to(candidate_root.resolve())
+                usage_root = candidate_root
+                break
+            except (OSError, ValueError):
+                continue
+        try:
+            from tools.skill_usage import skill_usage_key_for_path
+
+            provenance = skill_usage_key_for_path(
+                skill_md,
+                root=usage_root or SKILLS_DIR,
+                skill_name=str(skill_name),
+                frontmatter=frontmatter,
+            )
+        except Exception:
+            provenance = {
+                "skill_name": str(skill_name),
+                "usage_key": str(skill_name),
+                "bundle_id": None,
+                "source_repo": None,
+                "source_ref": None,
+                "source_commit": None,
+            }
         legacy_env_vars, _ = _collect_prerequisite_values(frontmatter)
         required_env_vars = _get_required_environment_variables(
             frontmatter, legacy_env_vars
@@ -1382,6 +1408,11 @@ def skill_view(
         result = {
             "success": True,
             "name": skill_name,
+            "usage_key": provenance.get("usage_key") or str(skill_name),
+            "bundle_id": provenance.get("bundle_id"),
+            "source_repo": provenance.get("source_repo"),
+            "source_ref": provenance.get("source_ref"),
+            "source_commit": provenance.get("source_commit"),
             "description": frontmatter.get("description", ""),
             "tags": tags,
             "related_skills": related_skills,
@@ -1544,7 +1575,7 @@ def _skill_view_with_bump(args, **kw):
         if isinstance(parsed, dict) and parsed.get("success"):
             # Use the resolved skill name from the payload when present —
             # qualified forms ("plugin:skill") return with the canonical name.
-            resolved = parsed.get("name") or name
+            resolved = parsed.get("usage_key") or parsed.get("name") or name
             if resolved:
                 from tools.skill_usage import bump_use, bump_view
                 bump_view(str(resolved))


### PR DESCRIPTION
## Summary
- Track skill usage records by canonical provenance-aware `usage_key` so third-party namespaces remain distinct.
- Make curator status/prune/automatic transitions use `usage_key` for lifecycle mutations while keeping readable labels.
- Add bundle/source usage reporting and regression coverage for same-name skills in different namespaces.

## Test Plan
- `PYTHONPATH=$PWD python3 -m pytest -q -o addopts='' tests/tools/test_skill_usage.py tests/tools/test_skills_tool.py tests/hermes_cli/test_curator_status.py tests/hermes_cli/test_curator_archive_prune.py tests/agent/test_curator.py` → 213 passed
- `PYTHONPATH=$PWD python3 -m pytest -q -o addopts=''` → blocked during collection by missing optional `acp` package in this environment (`ModuleNotFoundError: No module named 'acp'`)
- `PYTHONPATH=$PWD python3 -m pytest -q -o addopts='' --ignore=tests/acp --ignore=tests/acp_adapter` → timed out after 600s in this environment
- `git diff --check` → passed
