### PR TITLE
fix(hindsight): retain only new buffered turns

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1441,9 +1441,20 @@ class HindsightMemoryProvider(MemoryProvider):
                          self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
             return
 
-        logger.debug("sync_turn: retaining %d turns, total session content %d chars",
-                     len(self._session_turns), sum(len(t) for t in self._session_turns))
-        content = "[" + ",".join(self._session_turns) + "]"
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        if update_mode == "append":
+            # Modern Hindsight appends to the server-side document, so retain
+            # only the turns buffered since the previous retain. Re-sending
+            # prior turns would make Hindsight re-extract duplicate facts.
+            turns_to_retain = list(self._session_turns)
+            self._session_turns = []
+        else:
+            # Legacy Hindsight replaces the document on each retain. Keep the
+            # cumulative resend so earlier turns are not overwritten/lost.
+            turns_to_retain = list(self._session_turns)
+        logger.debug("sync_turn: retaining %d buffered turns, content %d chars, mode=%s",
+                     len(turns_to_retain), sum(len(t) for t in turns_to_retain), update_mode)
+        content = "[" + ",".join(turns_to_retain) + "]"
 
         lineage_tags: list[str] = []
         if self._session_id:
@@ -1454,11 +1465,10 @@ class HindsightMemoryProvider(MemoryProvider):
         # Snapshot the state needed for the retain. The writer may run after
         # _session_turns / _turn_index are mutated by a later sync_turn().
         metadata_snapshot = self._build_metadata(
-            message_count=len(self._session_turns) * 2,
+            message_count=len(turns_to_retain) * 2,
             turn_index=self._turn_index,
         )
-        num_turns = len(self._session_turns)
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        num_turns = len(turns_to_retain)
         bank_id = self._bank_id
         retain_async_flag = self._retain_async
         retain_context = self._retain_context

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -756,8 +756,12 @@ class TestSyncTurn:
         assert item["metadata"]["turn_index"] == "3"
         assert item["metadata"]["message_count"] == "6"
 
-    def test_sync_turn_accumulates_full_session(self, provider_with_config):
-        """Each retain sends the ENTIRE session, not just the latest batch."""
+    def test_sync_turn_append_mode_retains_only_new_buffered_turns(self, provider_with_config, monkeypatch):
+        """Append-capable APIs get only new turns, not the already-retained session."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *a, **kw: True,
+        )
         p = provider_with_config(retain_every_n_turns=2)
 
         p.sync_turn("turn1-user", "turn1-asst")
@@ -771,7 +775,35 @@ class TestSyncTurn:
         p._retain_queue.join()
 
         content = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
-        # Should contain ALL turns from the session
+        # Previously-retained turns must not be sent again, otherwise
+        # Hindsight extracts duplicate facts on every retain.
+        assert "turn1-user" not in content
+        assert "turn2-user" not in content
+        assert "turn3-user" in content
+        assert "turn4-user" in content
+
+    def test_sync_turn_legacy_replace_mode_keeps_cumulative_session(self, provider_with_config, monkeypatch):
+        """Legacy APIs replace documents, so each retain must resend prior turns."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_api_supports_update_mode_append",
+            lambda *a, **kw: False,
+        )
+        p = provider_with_config(retain_every_n_turns=2)
+
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn3-user", "turn3-asst")
+        p.sync_turn("turn4-user", "turn4-asst")
+        p._retain_queue.join()
+
+        call_kwargs = p._client.aretain_batch.call_args.kwargs
+        content = call_kwargs["items"][0]["content"]
+        assert call_kwargs["document_id"].startswith("test-session-")
+        assert "update_mode" not in call_kwargs["items"][0]
         assert "turn1-user" in content
         assert "turn2-user" in content
         assert "turn3-user" in content


### PR DESCRIPTION
## Summary
- change Hindsight auto-retain to send only newly buffered turns instead of the full cumulative session on each retain for append-capable APIs
- preserve cumulative resend behavior for legacy replace-mode APIs so prior turns are not overwritten
- update provider tests for both append and legacy replace behavior

## Why
Re-sending the full cumulative session to append-capable APIs causes Hindsight to re-extract already-retained facts on every turn/batch, producing near-duplicate memories in recall. Legacy replace-mode APIs still need cumulative resend to avoid turn loss.

## Test Plan
- .venv/bin/python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='