### PR TITLE
fix(telegram): strip markdown from auto-TTS voice caption (#32029)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3633,7 +3633,12 @@ class BasePlatformAdapter(ABC):
                             and text_content
                             and text_content[:1024] == text_content
                         ):
-                            telegram_tts_caption = text_content
+                            # Strip markdown for the voice caption: Telegram's
+                            # send_voice does not apply parse_mode here, so raw
+                            # markdown syntax (e.g. **bold**) would otherwise be
+                            # rendered literally in the caption. See #32029.
+                            from tools.tts_tool import _strip_markdown_for_tts
+                            telegram_tts_caption = _strip_markdown_for_tts(text_content)[:1024]
                         tts_result = await self.play_tts(
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -353,3 +353,36 @@ class TestTelegramAutoTtsCaptionDelivery:
                 "metadata": {"thread_id": "17585", "notify": True},
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_telegram_auto_tts_caption_strips_markdown(self, tmp_path):
+        """Regression for #32029: caption is sent without parse_mode, so raw
+        markdown syntax must be stripped before passing to send_voice — otherwise
+        the asterisks/underscores render literally in the Telegram caption.
+        """
+        adapter = DummyTelegramAdapter()
+        adapter._keep_typing = self._hold_typing()
+        adapter._should_auto_tts_for_chat = lambda _chat_id: True
+        adapter.play_tts = AsyncMock(return_value=SendResult(success=True, message_id="tts-1"))
+        markdown_reply = "Here is **bold** and *italic* text"
+        adapter.set_message_handler(
+            lambda _event: asyncio.sleep(0, result=markdown_reply)
+        )
+
+        tts_path = tmp_path / "reply.ogg"
+        tts_path.write_text("audio", encoding="utf-8")
+        event = self._make_voice_event()
+
+        with patch("tools.tts_tool.check_tts_requirements", return_value=True), patch(
+            "tools.tts_tool.text_to_speech_tool",
+            return_value=json.dumps({"file_path": str(tts_path)}),
+        ):
+            await adapter._process_message_background(
+                event, build_session_key(event.source)
+            )
+
+        adapter.play_tts.assert_awaited_once()
+        caption = adapter.play_tts.await_args.kwargs["caption"]
+        assert caption == "Here is bold and italic text"
+        assert "**" not in caption
+        assert adapter.sent == []


### PR DESCRIPTION
## Problem

When `voice.auto_tts` is enabled on Telegram and the bot replies to a voice message with text that fits in 1024 chars, the text is passed verbatim as the caption of the TTS audio. Telegram's `send_voice` here does **not** set `parse_mode`, so markdown syntax (e.g. `**bold**`, `*italic*`) shows up as literal asterisks in the caption bubble instead of rendering.

Fixes #32029.

## Root cause

In `gateway/platforms/base.py::_process_message_background` (~L3630), the caption is built directly from `text_content`:

```python
telegram_tts_caption = text_content   # raw markdown, never formatted
```

…and then handed to `play_tts` → `send_voice` with no `parse_mode`.

## Fix

Strip markdown from the caption before passing it on, reusing the existing `_strip_markdown_for_tts` helper from `tools/tts_tool.py`. This matches **Option B** from the issue author's proposed fix — the safer of the two options since plain-text captions never produce parse errors and captions rarely need rich formatting (the full formatted text still goes out via the normal text path when it can't fit in a caption).

## Files changed

- `gateway/platforms/base.py` — strip markdown via `_strip_markdown_for_tts` before assigning `telegram_tts_caption` (1 effective line + a comment + import).
- `tests/gateway/test_base_topic_sessions.py` — add regression test `test_telegram_auto_tts_caption_strips_markdown` covering the markdown-in-caption case.

## Testing

```
$ .venv/bin/python -m pytest tests/gateway/test_base_topic_sessions.py -v
...
11 passed in 0.92s

$ .venv/bin/python -m pytest tests/gateway/ -q -x --timeout=60 -k "voice or tts or caption"
277 passed, 1 skipped in 13.41s

$ .venv/bin/ruff check gateway/platforms/base.py tests/gateway/test_base_topic_sessions.py
All checks passed!
```

The three existing auto-TTS caption tests (`test_short_telegram_auto_tts_uses_caption_without_followup_text`, `test_long_telegram_auto_tts_keeps_followup_text_when_caption_would_truncate`, `test_telegram_auto_tts_send_failure_keeps_followup_text`) continue to pass — they use plain-text replies, which the strip is a no-op on.

## Caveats

- Truncation guard preserved: after stripping, the caption is still bounded with `[:1024]` for defensiveness even though the surrounding `text_content[:1024] == text_content` guard already ensures the input fits.
- The full markdown-formatted response is still delivered separately when needed (the existing 1024-char truncation branch is unchanged), so users don't lose formatting — they just don't see literal `**` in the audio bubble caption.
