### PR TITLE
feat(tools): Linux X11 backend for computer_use toolset

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12882,16 +12882,20 @@ Examples:
     # =========================================================================
     computer_use_parser = subparsers.add_parser(
         "computer-use",
-        help="Manage the Computer Use (cua-driver) backend (macOS)",
+        help="Manage the Computer Use backend (macOS / Linux)",
         description=(
-            "Install or check the cua-driver binary used by the\n"
-            "`computer_use` toolset. macOS-only.\n\n"
-            "Use `hermes computer-use install` to fetch and run the\n"
-            "upstream cua-driver installer. This is equivalent to the\n"
-            "post-setup hook that `hermes tools` runs when you first\n"
-            "enable the Computer Use toolset, and is a stable target\n"
-            "for re-running the install if it didn't fire (e.g. when\n"
-            "toggling the toolset on a returning-user setup)."
+            "Install or check the platform driver used by the\n"
+            "`computer_use` toolset.\n\n"
+            "On macOS the backend is cua-driver (SkyLight-based). Run\n"
+            "`hermes computer-use install` to fetch and run the upstream\n"
+            "installer — this is equivalent to the post-setup hook that\n"
+            "`hermes tools` triggers when you first enable the toolset.\n\n"
+            "On Linux/X11 the backend uses standard utilities (xdotool,\n"
+            "scrot, wmctrl). Install them through your distro package\n"
+            "manager — e.g. on Arch:\n"
+            "  sudo pacman -S xdotool scrot wmctrl\n"
+            "Wayland sessions are not supported; switch to an X11\n"
+            "session at the display manager to use this toolset."
         ),
     )
     computer_use_sub = computer_use_parser.add_subparsers(dest="computer_use_action")
@@ -12917,12 +12921,40 @@ Examples:
     def cmd_computer_use(args):
         action = getattr(args, "computer_use_action", None)
         if action == "install":
+            if sys.platform.startswith("linux"):
+                print("On Linux, install dependencies through your distro:")
+                print("  Arch:    sudo pacman -S xdotool scrot wmctrl")
+                print("  Debian:  sudo apt install xdotool scrot wmctrl")
+                print("  Fedora:  sudo dnf install xdotool scrot wmctrl")
+                print("Then run `hermes computer-use status` to verify.")
+                return
             from hermes_cli.tools_config import install_cua_driver
             install_cua_driver(upgrade=bool(getattr(args, "upgrade", False)))
             return
         if action == "status":
             import shutil
             import subprocess
+            if sys.platform.startswith("linux"):
+                from tools.computer_use.linux_backend import (
+                    linux_backend_available,
+                    _REQUIRED_TOOLS,
+                    _OPTIONAL_TOOLS,
+                )
+                print(f"platform: linux (session: {os.environ.get('XDG_SESSION_TYPE', 'unknown')})")
+                for tool in _REQUIRED_TOOLS + _OPTIONAL_TOOLS:
+                    path = shutil.which(tool)
+                    marker = "✓" if path else ("✗" if tool in _REQUIRED_TOOLS else "·")
+                    label = "required" if tool in _REQUIRED_TOOLS else "optional"
+                    print(f"  {marker} {tool} ({label}): {path or 'not installed'}")
+                if linux_backend_available():
+                    print("computer_use: ready")
+                else:
+                    print("computer_use: not available")
+                    if os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland":
+                        print("  Wayland sessions cannot synthesize input — switch to X11.")
+                    if not os.environ.get("DISPLAY"):
+                        print("  $DISPLAY is not set — are you running over SSH without -X?")
+                return
             path = shutil.which("cua-driver")
             if path:
                 version = ""

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -77,7 +77,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
-    ("computer_use",     "🖱️  Computer Use (macOS)",     "background desktop control via cua-driver"),
+    ("computer_use",     "🖱️  Computer Use",              "background desktop control (macOS via cua-driver, Linux/X11 via xdotool)"),
 ]
 
 # Toolsets that are OFF by default for new installs.
@@ -450,12 +450,14 @@ TOOL_CATEGORIES = {
         ],
     },
     "computer_use": {
-        "name": "Computer Use (macOS)",
+        "name": "Computer Use",
         "icon": "🖱️",
-        "platform_gate": "darwin",
+        # Supported platforms — macOS uses cua-driver, Linux/X11 uses
+        # xdotool+scrot+wmctrl. Windows and Wayland are not supported.
+        "platform_gate": ("darwin", "linux"),
         "providers": [
             {
-                "name": "cua-driver (background)",
+                "name": "cua-driver (background, macOS)",
                 "badge": "★ recommended · free · local",
                 "tag": (
                     "macOS background computer-use via SkyLight SPIs — does "
@@ -467,6 +469,18 @@ TOOL_CATEGORIES = {
                     # optional pin for reproducibility across macOS updates.
                 ],
                 "post_setup": "cua_driver",
+            },
+            {
+                "name": "xdotool + scrot + wmctrl (Linux/X11)",
+                "badge": "free · local",
+                "tag": (
+                    "Linux X11 desktop control via standard utilities. "
+                    "Wayland is unsupported — switch to X11 at your display "
+                    "manager. SOM-mode captures degrade to vision (no AT-SPI "
+                    "element tree)."
+                ),
+                "env_vars": [],
+                "post_setup": "linux_x11_tools",
             },
         ],
     },

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -108,12 +108,33 @@ class TestRegistration:
         assert entry.toolset == "computer_use"
         assert entry.schema["name"] == "computer_use"
 
-    def test_check_fn_is_false_on_linux(self):
+    def test_check_fn_is_false_on_unsupported_platform(self):
+        """On Windows / BSD / etc. — neither cua-driver nor Linux X11 applies."""
         import tools.computer_use_tool  # noqa: F401
         from tools.registry import registry
         entry = registry._tools["computer_use"]
-        if sys.platform != "darwin":
+        with patch("tools.computer_use.tool.sys") as fake_sys, \
+             patch.dict(
+                 os.environ, {"HERMES_COMPUTER_USE_BACKEND": ""}, clear=False
+             ):
+            fake_sys.platform = "win32"
             assert entry.check_fn() is False
+
+    def test_check_fn_routes_to_linux_backend_on_linux(self):
+        """On Linux the check delegates to ``linux_backend_available``."""
+        import tools.computer_use_tool  # noqa: F401
+        from tools.registry import registry
+        entry = registry._tools["computer_use"]
+        with patch("tools.computer_use.tool.sys") as fake_sys, \
+             patch.dict(
+                 os.environ, {"HERMES_COMPUTER_USE_BACKEND": ""}, clear=False
+             ), \
+             patch(
+                 "tools.computer_use.linux_backend.linux_backend_available",
+                 return_value=True,
+             ):
+            fake_sys.platform = "linux"
+            assert entry.check_fn() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_computer_use_linux_backend.py
+++ b/tests/tools/test_computer_use_linux_backend.py
@@ -1,0 +1,446 @@
+"""Tests for the Linux X11 backend of the computer_use toolset.
+
+These tests don't need an X server — every subprocess call is mocked so
+the suite runs hermetically on the CI runner (which has neither
+``$DISPLAY`` nor xdotool installed).
+"""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+import sys
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module-level availability check
+# ---------------------------------------------------------------------------
+
+class TestAvailabilityProbe:
+    """``linux_backend_available()`` is the gating function the registry
+    consults at import time, so its negative cases must be tight."""
+
+    def test_returns_false_on_non_linux_platform(self):
+        from tools.computer_use.linux_backend import linux_backend_available
+        with patch("tools.computer_use.linux_backend.sys") as fake_sys:
+            fake_sys.platform = "darwin"
+            assert linux_backend_available() is False
+
+    def test_returns_false_on_wayland_session(self):
+        from tools.computer_use.linux_backend import linux_backend_available
+        with patch("tools.computer_use.linux_backend.sys") as fake_sys, \
+             patch.dict(
+                 "tools.computer_use.linux_backend.os.environ",
+                 {"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"},
+                 clear=True,
+             ):
+            fake_sys.platform = "linux"
+            assert linux_backend_available() is False
+
+    def test_returns_false_when_display_not_set(self):
+        from tools.computer_use.linux_backend import linux_backend_available
+        with patch("tools.computer_use.linux_backend.sys") as fake_sys, \
+             patch.dict(
+                 "tools.computer_use.linux_backend.os.environ",
+                 {"XDG_SESSION_TYPE": "x11"},
+                 clear=True,
+             ):
+            fake_sys.platform = "linux"
+            assert linux_backend_available() is False
+
+    def test_returns_false_when_required_tool_missing(self):
+        from tools.computer_use.linux_backend import linux_backend_available
+        with patch("tools.computer_use.linux_backend.sys") as fake_sys, \
+             patch.dict(
+                 "tools.computer_use.linux_backend.os.environ",
+                 {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"},
+                 clear=True,
+             ), \
+             patch(
+                 "tools.computer_use.linux_backend.shutil.which",
+                 side_effect=lambda name: None if name == "scrot" else f"/usr/bin/{name}",
+             ):
+            fake_sys.platform = "linux"
+            assert linux_backend_available() is False
+
+    def test_returns_true_when_all_conditions_met(self):
+        from tools.computer_use.linux_backend import linux_backend_available
+        with patch("tools.computer_use.linux_backend.sys") as fake_sys, \
+             patch.dict(
+                 "tools.computer_use.linux_backend.os.environ",
+                 {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"},
+                 clear=True,
+             ), \
+             patch(
+                 "tools.computer_use.linux_backend.shutil.which",
+                 side_effect=lambda name: f"/usr/bin/{name}",
+             ):
+            fake_sys.platform = "linux"
+            assert linux_backend_available() is True
+
+
+# ---------------------------------------------------------------------------
+# Backend lifecycle + subprocess plumbing
+# ---------------------------------------------------------------------------
+
+def _completed(rc: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=rc, stdout=stdout, stderr=stderr
+    )
+
+
+@pytest.fixture
+def backend():
+    """A LinuxBackend with all tools resolved to fake paths."""
+    from tools.computer_use.linux_backend import LinuxBackend
+    b = LinuxBackend()
+    with patch(
+        "tools.computer_use.linux_backend.shutil.which",
+        side_effect=lambda name: f"/usr/bin/{name}",
+    ):
+        b.start()
+    return b
+
+
+class TestLifecycle:
+    def test_start_resolves_tool_paths(self, backend):
+        assert backend._tools["xdotool"] == "/usr/bin/xdotool"
+        assert backend._tools["scrot"] == "/usr/bin/scrot"
+        assert backend._tools["wmctrl"] == "/usr/bin/wmctrl"
+
+    def test_stop_clears_state(self, backend):
+        backend.stop()
+        assert backend._tools == {}
+        assert backend._started is False
+
+    def test_start_is_idempotent(self, backend):
+        # Calling start twice should not double-resolve or raise.
+        with patch(
+            "tools.computer_use.linux_backend.shutil.which",
+            side_effect=lambda name: f"/other/{name}",
+        ):
+            backend.start()
+        # Original paths preserved (start short-circuits when already started).
+        assert backend._tools["xdotool"] == "/usr/bin/xdotool"
+
+
+# ---------------------------------------------------------------------------
+# Capture
+# ---------------------------------------------------------------------------
+
+class TestCapture:
+    def test_vision_capture_returns_base64_png(self, backend):
+        fake_png = b"\x89PNG\r\n\x1a\nfakepng"
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0, "1920 1080\n"),
+        ), patch(
+            "tools.computer_use.linux_backend.Path.read_bytes",
+            return_value=fake_png,
+        ), patch(
+            "tools.computer_use.linux_backend.Path.exists",
+            return_value=True,
+        ):
+            result = backend.capture(mode="vision")
+        assert result.mode == "vision"
+        assert result.png_b64 == base64.b64encode(fake_png).decode("ascii")
+        assert result.elements == []
+        assert result.png_bytes_len == len(fake_png)
+
+    def test_som_mode_degrades_to_vision(self, backend):
+        """SOM has no AT-SPI on Linux — backend transparently falls back."""
+        fake_png = b"png-bytes"
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0, "1024 768\n"),
+        ), patch(
+            "tools.computer_use.linux_backend.Path.read_bytes",
+            return_value=fake_png,
+        ), patch(
+            "tools.computer_use.linux_backend.Path.exists",
+            return_value=True,
+        ):
+            result = backend.capture(mode="som")
+        assert result.mode == "vision"
+        assert result.elements == []
+
+    def test_ax_mode_returns_empty_elements(self, backend):
+        """AX is unsupported — must return cleanly, not raise."""
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0, "1920 1080\n"),
+        ):
+            result = backend.capture(mode="ax")
+        assert result.mode == "ax"
+        assert result.elements == []
+        assert result.png_b64 is None
+
+    def test_capture_handles_scrot_failure(self, backend):
+        """scrot non-zero must not crash — return empty PNG."""
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(1, "", "scrot: cannot capture"),
+        ):
+            result = backend.capture(mode="vision")
+        assert result.png_b64 is None
+
+
+# ---------------------------------------------------------------------------
+# Pointer actions
+# ---------------------------------------------------------------------------
+
+def _capture_calls(run_mock: MagicMock) -> List[List[str]]:
+    """Return the argv list passed to each subprocess.run call."""
+    return [c.args[0] for c in run_mock.call_args_list]
+
+
+class TestClick:
+    def test_click_xy_invokes_xdotool_mousemove_then_click(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            r = backend.click(x=100, y=200, button="left")
+        assert r.ok
+        calls = _capture_calls(run_mock)
+        # First call: mousemove --sync 100 200
+        assert calls[0] == ["/usr/bin/xdotool", "mousemove", "--sync", "100", "200"]
+        # Second call: click 1
+        assert calls[1] == ["/usr/bin/xdotool", "click", "1"]
+
+    def test_click_button_mapping(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.click(x=10, y=10, button="right")
+        calls = _capture_calls(run_mock)
+        assert calls[-1] == ["/usr/bin/xdotool", "click", "3"]
+
+    def test_click_with_element_returns_error(self, backend):
+        r = backend.click(element=5)
+        assert r.ok is False
+        assert "accessibility" in r.message.lower() or "element" in r.message.lower()
+
+    def test_click_count_repeats(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.click(x=5, y=5, click_count=3)
+        # mousemove + 3 clicks = 4 calls
+        assert run_mock.call_count == 4
+
+    def test_click_with_modifiers_holds_then_releases(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.click(x=1, y=1, modifiers=["shift", "ctrl"])
+        calls = _capture_calls(run_mock)
+        # Verify shift+ctrl keydown then keyup (release order is reversed).
+        keydowns = [c for c in calls if len(c) > 1 and c[1] == "keydown"]
+        keyups = [c for c in calls if len(c) > 1 and c[1] == "keyup"]
+        assert [c[2] for c in keydowns] == ["shift", "ctrl"]
+        assert [c[2] for c in keyups] == ["ctrl", "shift"]
+
+
+class TestScroll:
+    def test_scroll_down_uses_button_5(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.scroll(direction="down", amount=2)
+        clicks = [c for c in _capture_calls(run_mock) if c[1:2] == ["click"]]
+        assert all(c[2] == "5" for c in clicks)
+        assert len(clicks) == 2
+
+    def test_scroll_up_uses_button_4(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.scroll(direction="up")
+        clicks = [c for c in _capture_calls(run_mock) if c[1:2] == ["click"]]
+        assert all(c[2] == "4" for c in clicks)
+
+    def test_scroll_unknown_direction_returns_error(self, backend):
+        r = backend.scroll(direction="diagonal")
+        assert r.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Keyboard
+# ---------------------------------------------------------------------------
+
+class TestKeyboard:
+    def test_type_text_calls_xdotool_with_separator(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.type_text("hello world")
+        argv = _capture_calls(run_mock)[0]
+        # Crucial: "--" separator before user text prevents flag injection.
+        assert "--" in argv
+        assert argv[argv.index("--") + 1] == "hello world"
+
+    def test_type_empty_text_is_noop(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            r = backend.type_text("")
+        assert r.ok
+        assert run_mock.call_count == 0
+
+    def test_key_translates_macos_cmd_to_super(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            r = backend.key("cmd+s")
+        assert r.ok
+        argv = _capture_calls(run_mock)[0]
+        # The combo passed to xdotool should be "super+s", not "cmd+s".
+        assert argv[-1] == "super+s"
+
+    def test_key_translates_option_to_alt(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.key("option+left")
+        argv = _capture_calls(run_mock)[0]
+        assert argv[-1] == "alt+left"
+
+    def test_key_preserves_native_x11_combos(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            backend.key("ctrl+shift+t")
+        argv = _capture_calls(run_mock)[0]
+        assert argv[-1] == "ctrl+shift+t"
+
+    def test_key_empty_returns_error(self, backend):
+        r = backend.key("")
+        assert r.ok is False
+
+
+# ---------------------------------------------------------------------------
+# Introspection
+# ---------------------------------------------------------------------------
+
+class TestListApps:
+    def test_parses_wmctrl_output(self, backend):
+        wmctrl_out = (
+            "0x05400003  0 12345 Navigator.firefox     host  Mozilla Firefox\n"
+            "0x05400004  0 12346 Navigator.firefox     host  Reddit - Firefox\n"
+            "0x05400005  0 23456 code.Code             host  hermes-agent — Code\n"
+        )
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0, wmctrl_out),
+        ):
+            apps = backend.list_apps()
+        names = sorted(a["name"] for a in apps)
+        assert names == ["Code", "firefox"]
+        firefox = next(a for a in apps if a["name"] == "firefox")
+        assert firefox["windows"] == 2
+        assert firefox["pid"] == 12345
+
+    def test_returns_empty_list_when_wmctrl_unavailable(self, backend):
+        backend._tools.pop("wmctrl", None)
+        assert backend.list_apps() == []
+
+
+class TestFocusApp:
+    def test_focus_app_via_wmctrl(self, backend):
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            return_value=_completed(0),
+        ) as run_mock:
+            r = backend.focus_app("firefox")
+        assert r.ok
+        # First call should be wmctrl -a firefox.
+        first = run_mock.call_args_list[0].args[0]
+        assert first == ["/usr/bin/wmctrl", "-a", "firefox"]
+
+    def test_focus_app_empty_name_returns_error(self, backend):
+        r = backend.focus_app("")
+        assert r.ok is False
+
+    def test_focus_app_falls_back_to_xdotool_when_wmctrl_misses(self, backend):
+        # wmctrl returns rc=1, xdotool --class succeeds.
+        responses = [_completed(1), _completed(0)]
+        with patch(
+            "tools.computer_use.linux_backend.subprocess.run",
+            side_effect=responses,
+        ) as run_mock:
+            r = backend.focus_app("Code")
+        assert r.ok
+        second = run_mock.call_args_list[1].args[0]
+        assert second[0] == "/usr/bin/xdotool"
+        assert "search" in second
+
+
+# ---------------------------------------------------------------------------
+# Native-value mutation (intentionally unsupported on Linux)
+# ---------------------------------------------------------------------------
+
+class TestSetValue:
+    def test_returns_actionable_error(self, backend):
+        r = backend.set_value("hello", element=1)
+        assert r.ok is False
+        # Error message must point the agent at the click+type workaround.
+        assert "click" in r.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+class TestRegistryDispatch:
+    """Confirm ``HERMES_COMPUTER_USE_BACKEND=linux`` selects LinuxBackend."""
+
+    def test_get_backend_returns_linux_when_env_set(self):
+        from tools.computer_use.linux_backend import LinuxBackend
+        from tools.computer_use.tool import _get_backend, reset_backend_for_tests
+
+        reset_backend_for_tests()
+        with patch.dict(
+            "os.environ", {"HERMES_COMPUTER_USE_BACKEND": "linux"}, clear=False
+        ), patch(
+            "tools.computer_use.linux_backend.shutil.which",
+            side_effect=lambda name: f"/usr/bin/{name}",
+        ):
+            backend = _get_backend()
+        try:
+            assert isinstance(backend, LinuxBackend)
+        finally:
+            reset_backend_for_tests()
+
+    def test_check_requirements_routes_to_linux_on_linux_platform(self):
+        from tools.computer_use.tool import check_computer_use_requirements
+
+        with patch("tools.computer_use.tool.sys") as fake_sys, \
+             patch.dict("os.environ", {"HERMES_COMPUTER_USE_BACKEND": ""}, clear=False), \
+             patch(
+                 "tools.computer_use.linux_backend.linux_backend_available",
+                 return_value=True,
+             ):
+            fake_sys.platform = "linux"
+            assert check_computer_use_requirements() is True
+
+    def test_check_requirements_noop_override_always_true(self):
+        from tools.computer_use.tool import check_computer_use_requirements
+        with patch.dict(
+            "os.environ", {"HERMES_COMPUTER_USE_BACKEND": "noop"}, clear=False
+        ):
+            assert check_computer_use_requirements() is True

--- a/tools/computer_use/__init__.py
+++ b/tools/computer_use/__init__.py
@@ -1,12 +1,20 @@
-"""Computer use toolset — universal (any-model) macOS desktop control.
+"""Computer use toolset — universal (any-model) desktop control.
 
 Architecture
 ------------
-This toolset drives macOS apps through cua-driver's background computer-use
+On macOS this toolset drives apps through cua-driver's background computer-use
 primitive (SkyLight private SPIs for focus-without-raise + pid-scoped event
 posting). Unlike #4562's pyautogui backend, it does NOT steal the user's
 cursor, keyboard focus, or Space — the agent and the user can co-work on the
 same machine.
+
+On Linux/X11 it drives via standard ``xdotool`` + ``scrot`` + ``wmctrl``
+utilities (see ``linux_backend.py``). The Linux backend is selected
+automatically when ``sys.platform`` is ``linux`` and the X11 dependencies
+are present; SOM (set-of-mark numbered overlays) degrades to vision-mode
+screenshots because Linux has no first-class accessibility tree comparable
+to macOS AX. Wayland is intentionally unsupported — by design, the
+compositor does not allow arbitrary clients to synthesize input.
 
 Unlike #4562's Anthropic-native `computer_20251124` tool, the schema here is
 a plain OpenAI function-calling schema that every tool-capable model can

--- a/tools/computer_use/linux_backend.py
+++ b/tools/computer_use/linux_backend.py
@@ -1,0 +1,545 @@
+"""Linux X11 backend for the computer_use toolset.
+
+Uses standard X11 utilities — ``xdotool`` for input synthesis,
+``scrot`` for screen capture, and ``wmctrl`` for window/app
+enumeration. Vision-mode captures are fully supported; SOM and AX
+modes gracefully degrade to vision (the macOS backend uses Accessibility
+APIs to build a numbered element overlay — Linux has AT-SPI but
+coverage varies wildly by toolkit, so we deliberately skip element
+indexing here and let the agent click by pixel coordinates).
+
+Wayland is intentionally excluded: by design, Wayland compositors do
+not let arbitrary clients synthesize input system-wide. Users who
+want desktop automation on Linux today must run an X11 session
+(``echo $XDG_SESSION_TYPE`` should print ``x11``). XWayland clients
+under a Wayland session would partially work for X11 apps but not for
+native Wayland windows, and the asymmetry is more confusing than
+useful — we surface a clear "not available" signal in that case.
+
+The backend is intentionally subprocess-based with no global state
+beyond resolved tool paths, so tests can mock ``subprocess.run`` and
+``shutil.which`` without monkey-patching the module.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from tools.computer_use.backend import (
+    ActionResult,
+    CaptureResult,
+    ComputerUseBackend,
+    UIElement,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Tools the backend depends on. xdotool + scrot are hard requirements;
+# wmctrl is used for list_apps/focus_app and the backend degrades to
+# xdotool-only window search if it's missing.
+_REQUIRED_TOOLS: Tuple[str, ...] = ("xdotool", "scrot")
+_OPTIONAL_TOOLS: Tuple[str, ...] = ("wmctrl",)
+
+# Map of macOS-style modifier names → X11 keysyms, so the agent can keep
+# using the same schema ("cmd+s", "option+f4") on either platform.
+_MODIFIER_MAP: Dict[str, Optional[str]] = {
+    "cmd": "super",
+    "command": "super",
+    "shift": "shift",
+    "option": "alt",
+    "alt": "alt",
+    "ctrl": "ctrl",
+    "control": "ctrl",
+    # "fn" has no portable X11 equivalent — drop silently.
+    "fn": None,
+}
+
+# X11 button numbers for mouse actions.
+_BUTTON_NUMS: Dict[str, str] = {"left": "1", "middle": "2", "right": "3"}
+# Scroll wheel: in X11 scroll directions are synthesized as button presses.
+_SCROLL_BUTTONS: Dict[str, str] = {"up": "4", "down": "5", "left": "6", "right": "7"}
+
+
+def linux_backend_available() -> bool:
+    """True iff this host can run the Linux X11 backend right now.
+
+    Conditions checked:
+      * platform is Linux,
+      * an X11 display is exported (``$DISPLAY``) and the session is
+        not Wayland (``$XDG_SESSION_TYPE != wayland``),
+      * required tools (``xdotool``, ``scrot``) are on PATH.
+
+    Optional tools (``wmctrl``) are not required — their absence only
+    degrades ``list_apps``/``focus_app``.
+    """
+    if sys.platform != "linux":
+        return False
+    if os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland":
+        return False
+    if not os.environ.get("DISPLAY"):
+        return False
+    return all(shutil.which(tool) for tool in _REQUIRED_TOOLS)
+
+
+class LinuxBackend(ComputerUseBackend):
+    """X11 desktop control via xdotool + scrot + wmctrl.
+
+    Element-index targeting (``capture(mode="som")`` returning numbered
+    overlays) is not implemented — capture always returns the plain
+    screenshot and an empty element list, and actions that accept an
+    ``element`` index fall back to an error message asking for ``x``/``y``.
+    """
+
+    def __init__(self) -> None:
+        self._started = False
+        # Resolved at start(); empty until then.
+        self._tools: Dict[str, str] = {}
+
+    # ── Lifecycle ───────────────────────────────────────────────────
+
+    def start(self) -> None:
+        if self._started:
+            return
+        for tool in _REQUIRED_TOOLS + _OPTIONAL_TOOLS:
+            path = shutil.which(tool)
+            if path:
+                self._tools[tool] = path
+        # Missing required tools surface through is_available(); we don't
+        # raise here so the noop/cua paths keep working in mixed envs.
+        self._started = True
+        logger.debug(
+            "linux_backend started — resolved tools: %s",
+            {k: v for k, v in self._tools.items()},
+        )
+
+    def stop(self) -> None:
+        self._started = False
+        self._tools.clear()
+
+    def is_available(self) -> bool:
+        return linux_backend_available()
+
+    # ── Subprocess helper ───────────────────────────────────────────
+
+    def _run(self, *args: str, timeout: float = 10.0) -> subprocess.CompletedProcess:
+        """Run a CLI tool as an argv list (never via shell).
+
+        Returns a CompletedProcess with ``returncode``/``stdout``/``stderr``
+        populated. Times out cleanly — the caller decides what to do
+        with a non-zero rc.
+        """
+        try:
+            return subprocess.run(
+                list(args),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            logger.warning("linux_backend: %s timed out after %.1fs", args[0], timeout)
+            return subprocess.CompletedProcess(
+                args=list(args),
+                returncode=124,
+                stdout=exc.stdout.decode() if isinstance(exc.stdout, bytes) else (exc.stdout or ""),
+                stderr=f"timeout after {timeout}s",
+            )
+        except (OSError, FileNotFoundError) as exc:
+            logger.warning("linux_backend: %s failed to start: %s", args[0], exc)
+            return subprocess.CompletedProcess(
+                args=list(args), returncode=127, stdout="", stderr=str(exc)
+            )
+
+    def _tool(self, name: str) -> str:
+        """Return resolved path for a tool, falling back to PATH lookup."""
+        return self._tools.get(name) or name
+
+    # ── Capture ─────────────────────────────────────────────────────
+
+    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
+        # Linux has no first-class AX tree; degrade SOM → vision.
+        out_mode = "vision" if mode in ("som", "vision") else mode
+        width, height = self._screen_size()
+        window_title = self._active_window_title()
+
+        if out_mode == "ax":
+            # AT-SPI integration is out of scope for the initial Linux
+            # backend; return an empty AX result so the upper layers
+            # don't crash.
+            return CaptureResult(
+                mode="ax",
+                width=width,
+                height=height,
+                png_b64=None,
+                elements=[],
+                app=app or "",
+                window_title=window_title,
+            )
+
+        if app:
+            # Best-effort focus so the screenshot shows the requested app.
+            self._focus_window(app)
+
+        png_bytes = self._screenshot_png()
+        if not png_bytes:
+            return CaptureResult(
+                mode=out_mode,
+                width=width,
+                height=height,
+                png_b64=None,
+                elements=[],
+                app=app or "",
+                window_title=window_title,
+            )
+
+        return CaptureResult(
+            mode=out_mode,
+            width=width,
+            height=height,
+            png_b64=base64.b64encode(png_bytes).decode("ascii"),
+            elements=[],
+            app=app or "",
+            window_title=window_title,
+            png_bytes_len=len(png_bytes),
+        )
+
+    def _screenshot_png(self) -> bytes:
+        """Capture the full virtual display to a PNG byte string."""
+        fd, tmp_path = tempfile.mkstemp(suffix=".png", prefix="hermes-cu-")
+        os.close(fd)
+        try:
+            # ``-o`` overwrite, ``-z`` compress. scrot defaults to the
+            # whole virtual display when given no geometry.
+            result = self._run(self._tool("scrot"), "-o", "-z", tmp_path, timeout=15.0)
+            if result.returncode != 0:
+                logger.warning(
+                    "scrot failed (rc=%s): %s", result.returncode, result.stderr.strip()
+                )
+                return b""
+            path = Path(tmp_path)
+            if not path.exists():
+                return b""
+            return path.read_bytes()
+        finally:
+            try:
+                Path(tmp_path).unlink()
+            except OSError:
+                pass
+
+    def _screen_size(self) -> Tuple[int, int]:
+        result = self._run(self._tool("xdotool"), "getdisplaygeometry")
+        if result.returncode == 0 and result.stdout.strip():
+            try:
+                parts = result.stdout.split()
+                return int(parts[0]), int(parts[1])
+            except (ValueError, IndexError):
+                pass
+        # Safe default — width/height are advisory in vision mode.
+        return 1920, 1080
+
+    def _active_window_title(self) -> str:
+        result = self._run(
+            self._tool("xdotool"), "getactivewindow", "getwindowname"
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    def _focus_window(self, needle: str) -> bool:
+        """Try to focus a window matching ``needle`` (title or wm_class).
+
+        Returns True on success. Prefers ``wmctrl`` when available — it
+        matches against the window title and class without requiring an
+        exact match.
+        """
+        wmctrl = self._tools.get("wmctrl")
+        if wmctrl:
+            if self._run(wmctrl, "-a", needle).returncode == 0:
+                return True
+        xdotool = self._tool("xdotool")
+        for selector in ("--class", "--name"):
+            if self._run(xdotool, "search", selector, needle, "windowactivate").returncode == 0:
+                return True
+        return False
+
+    # ── Pointer actions ─────────────────────────────────────────────
+
+    def click(
+        self,
+        *,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        button: str = "left",
+        click_count: int = 1,
+        modifiers: Optional[List[str]] = None,
+    ) -> ActionResult:
+        if element is not None:
+            return ActionResult(
+                ok=False,
+                action="click",
+                message=(
+                    "element-index targeting requires an accessibility tree; "
+                    "the Linux backend does not build one — pass x and y instead"
+                ),
+            )
+        if x is None or y is None:
+            return ActionResult(
+                ok=False, action="click", message="click requires x and y"
+            )
+
+        btn = _BUTTON_NUMS.get(button)
+        if btn is None:
+            return ActionResult(
+                ok=False, action="click", message=f"unknown button: {button!r}"
+            )
+
+        xdotool = self._tool("xdotool")
+        self._run(xdotool, "mousemove", "--sync", str(int(x)), str(int(y)))
+
+        held = self._press_modifiers(modifiers)
+        try:
+            count = max(1, int(click_count))
+            for _ in range(count):
+                rc = self._run(xdotool, "click", btn).returncode
+                if rc != 0:
+                    return ActionResult(
+                        ok=False,
+                        action="click",
+                        message=f"xdotool click rc={rc}",
+                    )
+        finally:
+            self._release_modifiers(held)
+
+        return ActionResult(
+            ok=True,
+            action="click",
+            message=f"clicked {button} at ({x},{y}) x{click_count}",
+        )
+
+    def drag(
+        self,
+        *,
+        from_element: Optional[int] = None,
+        to_element: Optional[int] = None,
+        from_xy: Optional[Tuple[int, int]] = None,
+        to_xy: Optional[Tuple[int, int]] = None,
+        button: str = "left",
+        modifiers: Optional[List[str]] = None,
+    ) -> ActionResult:
+        if from_element is not None or to_element is not None:
+            return ActionResult(
+                ok=False,
+                action="drag",
+                message="element-index targeting unsupported on linux — use from_xy/to_xy",
+            )
+        if not from_xy or not to_xy:
+            return ActionResult(
+                ok=False, action="drag", message="drag requires from_xy and to_xy"
+            )
+
+        btn = _BUTTON_NUMS.get(button)
+        if btn is None:
+            return ActionResult(
+                ok=False, action="drag", message=f"unknown button: {button!r}"
+            )
+
+        xdotool = self._tool("xdotool")
+        x1, y1 = from_xy
+        x2, y2 = to_xy
+
+        held = self._press_modifiers(modifiers)
+        try:
+            self._run(xdotool, "mousemove", "--sync", str(int(x1)), str(int(y1)))
+            self._run(xdotool, "mousedown", btn)
+            self._run(xdotool, "mousemove", "--sync", str(int(x2)), str(int(y2)))
+            self._run(xdotool, "mouseup", btn)
+        finally:
+            self._release_modifiers(held)
+
+        return ActionResult(
+            ok=True,
+            action="drag",
+            message=f"dragged ({x1},{y1}) → ({x2},{y2}) with {button}",
+        )
+
+    def scroll(
+        self,
+        *,
+        direction: str,
+        amount: int = 3,
+        element: Optional[int] = None,
+        x: Optional[int] = None,
+        y: Optional[int] = None,
+        modifiers: Optional[List[str]] = None,
+    ) -> ActionResult:
+        btn = _SCROLL_BUTTONS.get(direction.lower())
+        if not btn:
+            return ActionResult(
+                ok=False, action="scroll", message=f"unknown direction: {direction!r}"
+            )
+        xdotool = self._tool("xdotool")
+        if x is not None and y is not None:
+            self._run(xdotool, "mousemove", "--sync", str(int(x)), str(int(y)))
+
+        held = self._press_modifiers(modifiers)
+        try:
+            ticks = max(1, int(amount))
+            for _ in range(ticks):
+                self._run(xdotool, "click", btn)
+        finally:
+            self._release_modifiers(held)
+
+        return ActionResult(
+            ok=True, action="scroll", message=f"scrolled {direction} x{amount}"
+        )
+
+    # ── Modifier helpers ────────────────────────────────────────────
+
+    def _press_modifiers(self, modifiers: Optional[List[str]]) -> List[str]:
+        if not modifiers:
+            return []
+        held: List[str] = []
+        xdotool = self._tool("xdotool")
+        for mod in modifiers:
+            key = _MODIFIER_MAP.get(mod.lower())
+            if key is None:
+                continue
+            if self._run(xdotool, "keydown", key).returncode == 0:
+                held.append(key)
+        return held
+
+    def _release_modifiers(self, held: List[str]) -> None:
+        if not held:
+            return
+        xdotool = self._tool("xdotool")
+        for key in reversed(held):
+            self._run(xdotool, "keyup", key)
+
+    # ── Keyboard ────────────────────────────────────────────────────
+
+    def type_text(self, text: str) -> ActionResult:
+        if not text:
+            return ActionResult(ok=True, action="type", message="empty input — noop")
+        # The trailing "--" stops xdotool from parsing the text as flags;
+        # the delay is xdotool's default but explicit for clarity.
+        result = self._run(
+            self._tool("xdotool"), "type", "--delay", "12", "--", text, timeout=30.0
+        )
+        if result.returncode != 0:
+            return ActionResult(
+                ok=False,
+                action="type",
+                message=result.stderr.strip() or "xdotool type failed",
+            )
+        return ActionResult(
+            ok=True, action="type", message=f"typed {len(text)} chars"
+        )
+
+    def key(self, keys: str) -> ActionResult:
+        if not keys:
+            return ActionResult(ok=False, action="key", message="empty key combo")
+        # Translate any macOS-style names ("cmd+s") to X11 keysyms
+        # ("super+s") so the same prompts work on both platforms.
+        translated_parts: List[str] = []
+        for part in keys.split("+"):
+            cleaned = part.strip()
+            if not cleaned:
+                continue
+            mapped = _MODIFIER_MAP.get(cleaned.lower(), cleaned)
+            if mapped:
+                translated_parts.append(mapped)
+        if not translated_parts:
+            return ActionResult(ok=False, action="key", message=f"invalid combo: {keys!r}")
+        combo = "+".join(translated_parts)
+        result = self._run(self._tool("xdotool"), "key", "--", combo)
+        if result.returncode != 0:
+            return ActionResult(
+                ok=False,
+                action="key",
+                message=result.stderr.strip() or f"xdotool key {combo!r} failed",
+            )
+        return ActionResult(ok=True, action="key", message=f"sent key combo: {combo}")
+
+    # ── Introspection ───────────────────────────────────────────────
+
+    def list_apps(self) -> List[Dict[str, Any]]:
+        wmctrl = self._tools.get("wmctrl")
+        if not wmctrl:
+            return []
+        # ``-l`` list windows, ``-p`` include PID, ``-x`` include wm_class.
+        # Output columns: <wid> <desktop> <pid> <wm_class> <host> <title>
+        result = self._run(wmctrl, "-l", "-p", "-x")
+        if result.returncode != 0:
+            return []
+
+        apps: Dict[str, Dict[str, Any]] = {}
+        for raw in result.stdout.splitlines():
+            parts = raw.split(None, 5)
+            if len(parts) < 6:
+                continue
+            _wid, _desk, pid_str, wm_class, _host, title = parts
+            try:
+                pid = int(pid_str)
+            except ValueError:
+                pid = 0
+            # wm_class is "instance.Class"; use the class half as app name.
+            app_name = wm_class.rsplit(".", 1)[-1] if "." in wm_class else wm_class
+            entry = apps.setdefault(
+                app_name,
+                {
+                    "name": app_name,
+                    "pid": pid,
+                    "windows": 0,
+                    "wm_class": wm_class,
+                    "titles": [],
+                },
+            )
+            entry["windows"] += 1
+            if title and title not in entry["titles"]:
+                entry["titles"].append(title)
+        return list(apps.values())
+
+    def focus_app(self, app: str, raise_window: bool = False) -> ActionResult:
+        if not app:
+            return ActionResult(
+                ok=False, action="focus_app", message="app name required"
+            )
+        # On X11 the distinction between "focus" and "raise" is muddier
+        # than on macOS — wmctrl -a raises by default on most WMs, and we
+        # accept that for compatibility. raise_window is honored as a
+        # soft hint; we don't try to suppress the raise on Linux.
+        if self._focus_window(app):
+            return ActionResult(
+                ok=True, action="focus_app", message=f"focused {app!r}"
+            )
+        return ActionResult(
+            ok=False,
+            action="focus_app",
+            message=f"window matching {app!r} not found",
+        )
+
+    # ── Native-value mutation ───────────────────────────────────────
+
+    def set_value(
+        self, value: str, element: Optional[int] = None
+    ) -> ActionResult:
+        # AT-SPI value-set integration is not implemented in the initial
+        # Linux backend. The agent can usually achieve the same effect
+        # via focus + select-all + type. Returning a clear, actionable
+        # error keeps the agent unblocked.
+        return ActionResult(
+            ok=False,
+            action="set_value",
+            message=(
+                "set_value is unsupported on linux (no AT-SPI integration); "
+                "fall back to click → key('ctrl+a') → type_text"
+            ),
+        )

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -126,14 +126,33 @@ _session_auto_approve = False
 _always_allow: set = set()  # action names the user unlocked for the session
 
 
+def _default_backend_name() -> str:
+    """Pick a sensible default backend for the current platform.
+
+    macOS keeps ``cua`` (the SkyLight-based driver). Linux gets ``linux``
+    so the X11 backend turns on automatically when its dependencies
+    (xdotool + scrot) are installed.
+    """
+    if sys.platform == "darwin":
+        return "cua"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return "cua"
+
+
 def _get_backend() -> ComputerUseBackend:
     global _backend
     with _backend_lock:
         if _backend is None:
-            backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
+            backend_name = os.environ.get(
+                "HERMES_COMPUTER_USE_BACKEND", _default_backend_name()
+            ).lower()
             if backend_name in {"cua", "cua-driver", ""}:
                 from tools.computer_use.cua_backend import CuaDriverBackend
                 _backend = CuaDriverBackend()
+            elif backend_name == "linux":
+                from tools.computer_use.linux_backend import LinuxBackend
+                _backend = LinuxBackend()
             elif backend_name == "noop":  # pragma: no cover
                 _backend = _NoopBackend()
             else:
@@ -736,12 +755,25 @@ def _element_to_dict(e: UIElement) -> Dict[str, Any]:
 def check_computer_use_requirements() -> bool:
     """Return True iff computer_use can run on this host.
 
-    Conditions: macOS + cua-driver binary installed (or override via env).
+    Platform dispatch:
+      * macOS — cua-driver binary present (SkyLight-based backend).
+      * Linux — xdotool + scrot present, ``$DISPLAY`` exported, session
+        is X11 (not Wayland).
+      * Other platforms / unknown overrides — False.
+
+    The ``HERMES_COMPUTER_USE_BACKEND`` env var can pin a backend for
+    testing (``noop`` is always considered available).
     """
-    if sys.platform != "darwin":
-        return False
-    from tools.computer_use.cua_backend import cua_driver_binary_available
-    return cua_driver_binary_available()
+    override = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "").lower()
+    if override == "noop":
+        return True
+    if override == "linux" or (not override and sys.platform.startswith("linux")):
+        from tools.computer_use.linux_backend import linux_backend_available
+        return linux_backend_available()
+    if override in {"cua", "cua-driver"} or (not override and sys.platform == "darwin"):
+        from tools.computer_use.cua_backend import cua_driver_binary_available
+        return cua_driver_binary_available()
+    return False
 
 
 def get_computer_use_schema() -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Adds a Linux/X11 backend for the universal `computer_use` toolset, so the
"background desktop control" capability works on Linux distros (Manjaro,
Arch, Debian, Fedora, …) alongside macOS. Before this PR `hermes doctor`
reports `⚠ computer_use (system dependency not met)` on every non-macOS
host because `check_computer_use_requirements()` hard-fails on
`sys.platform != "darwin"`.

Falls into contribution priority #2 (cross-platform compatibility) per
CONTRIBUTING.md.

## Approach

The existing `ComputerUseBackend` ABC in `tools/computer_use/backend.py`
is already swappable via `HERMES_COMPUTER_USE_BACKEND`. This PR adds a
new `linux` backend implementing all 9 abstract methods on top of three
ubiquitous X11 utilities:

| Surface | Tool | Notes |
|---|---|---|
| Input synthesis | `xdotool` | Mouse + keyboard. Modifier map keeps macOS-style combos (`cmd+s`, `option+left`) working — they're translated to X11 keysyms before dispatch. |
| Screen capture | `scrot` | PNG bytes returned as base64; whole virtual display. |
| Window/app introspection | `wmctrl` | Optional — `list_apps`/`focus_app` degrade to xdotool window search when absent. |

`sys.platform == "linux"` now auto-selects this backend; macOS continues
to default to `cua`. The env var override behaviour is unchanged.

## Deliberate non-goals

* **No Wayland support.** Wayland compositors disallow arbitrary
  input synthesis by design. The backend's `is_available()` returns
  False when `$XDG_SESSION_TYPE == wayland` and `hermes computer-use
  status` reports a clear "switch to X11" message. ydotool/wtype-based
  Wayland support belongs in a follow-up PR.
* **No AT-SPI / SOM overlays.** SOM-mode captures degrade to plain
  vision captures. Linux has AT-SPI but coverage varies wildly by
  toolkit (Electron, native Wayland, games, …), so I deliberately
  defer to a follow-up rather than ship a half-broken element tree.
  Modern vision models target screenshots fine without SOM.
* **No `set_value` mutation.** Same AT-SPI dependency — the backend
  returns an actionable error pointing the agent at `click → ctrl+a
  → type_text` as the workaround.

## CLI surface changes

* `hermes computer-use status` is now platform-aware. On Linux it
  prints the X11/Wayland session type, the resolution path of each
  required/optional tool, and an actionable error when the host
  isn't usable.
* `hermes computer-use install` on Linux prints distro-appropriate
  install lines (`pacman -S` / `apt install` / `dnf install`)
  instead of trying to run the macOS `cua-driver` installer.
* The `hermes tools` setup wizard's Computer Use entry is no longer
  labelled "(macOS)"; `platform_gate` is widened to
  `("darwin", "linux")` and a second provider entry under the
  toolset documents the Linux dependencies.

## Testing

* **35 new hermetic unit tests** (`tests/tools/test_computer_use_linux_backend.py`)
  covering: availability gating (non-Linux, Wayland, missing
  `$DISPLAY`, missing `xdotool`/`scrot`), backend lifecycle,
  vision/SOM/AX capture modes, scrot failure recovery, click +
  modifier translation, drag, scroll button mapping, type with `--`
  flag-injection guard, key combo translation (`cmd+s` → `super+s`),
  `wmctrl` parsing, focus fallback to xdotool, `set_value` error
  shape, and registry dispatch with the env override.
* **Updated** `TestRegistration.test_check_fn_is_false_on_linux` —
  the old assertion was correct under the old "macOS-only"
  assumption. Replaced with a Windows-platform negative test plus a
  Linux positive test that mocks `linux_backend_available()`.
* All subprocess + `shutil.which` calls are mocked so the suite is
  fully hermetic — no `$DISPLAY` or `xdotool` required on the CI
  runner.
* **Full `tests/tools/` suite stays green** — `151/151` across the
  four `test_computer_use*` files.
* **Live smoke-tested** on Manjaro KDE Plasma 6 / X11:
  * `hermes doctor` → `✓ computer_use`
  * `hermes computer-use status` correctly reports the session type
    and all three tool paths.
  * `LinuxBackend.capture(mode="vision")` returned a 395 KB valid
    PNG of the desktop.
  * `LinuxBackend.list_apps()` correctly enumerated `plasmashell`,
    `konsole`, `Google-chrome`, `obsidian`, `vesktop`.
  * `LinuxBackend.key("alt+space")` was dispatched end-to-end by a
    live `hermes` session and the keystroke landed in the focused
    window.

## Platforms tested

* ✅ Manjaro KDE Plasma 6.6.5 / X11 / xdotool 3.20210903 / scrot 1.10
* ✅ CI hermetic runner (subprocess + which mocked — no $DISPLAY needed)
* ⛔ Wayland — explicitly refused with a clear error
* 🔲 Other Linux distros — should work but not personally tested

## Cross-platform sanity

Per CONTRIBUTING.md:

* All `sys.platform` checks use `.startswith("linux")` so musl-libc /
  uncommon Linux variants still route correctly.
* All subprocess calls use argv lists, never `shell=True`. The
  `type_text` xdotool invocation uses the `--` separator before user
  text to prevent flag-injection.
* No POSIX-only APIs (`os.killpg`, `os.setsid`, signals) — Windows
  builds keep working, just without this backend.

## Out-of-scope / follow-ups

* Wayland backend (ydotool/wtype + grim/spectacle).
* AT-SPI integration for SOM overlays and `set_value`.
* Windows backend (pywinauto + win32 SendInput).