### PR TITLE
fix(cli): prevent stale behind-count in banner update check

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -192,7 +192,11 @@ def _check_via_rev(local_rev: str) -> Optional[int]:
 
 
 def _check_via_local_git(repo_dir: Path) -> Optional[int]:
-    """Count commits behind origin/main in a local checkout."""
+    """Count commits behind origin/main in a local checkout.
+
+    Returns None when the fetch fails — a stale zero is worse than
+    no information, because it silently hides real updates.
+    """
     origin_url = _git_stdout(["remote", "get-url", "origin"], cwd=repo_dir)
     if _is_official_ssh_remote(origin_url):
         head_rev = _git_stdout(["rev-parse", "HEAD"], cwd=repo_dir)
@@ -217,13 +221,15 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         if is_shallow:
             fetch_args += ["--depth", "1"]
         fetch_args.append("--quiet")
-        subprocess.run(
+        result = subprocess.run(
             fetch_args,
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
         )
+        if result.returncode != 0:
+            return None
     except Exception:
-        pass  # Offline or timeout — use stale refs, that's fine
+        return None  # Offline or timeout — can't trust stale refs
 
     if is_shallow:
         # No history to count across the shallow boundary. `origin/main` may not
@@ -360,9 +366,12 @@ def check_for_updates() -> Optional[int]:
             behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(
-            json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION})
-        )
+        # Only cache non-None results — a failed fetch should retry next
+        # startup, not get locked into the 6-hour cache as "no info."
+        if behind is not None:
+            cache_file.write_text(
+                json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "ver": VERSION})
+            )
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -372,3 +372,95 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()
+
+
+def test_check_via_local_git_failed_fetch_returns_none(tmp_path):
+    """A non-zero fetch return code must return None, not count stale refs.
+
+    Regression: previously the fetch return code was ignored, so a failed
+    fetch (network error, auth failure) silently fell through to counting
+    stale local refs — which could report '0 behind' and hide real updates.
+    """
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd[:2] == ["git", "fetch"]:
+            # Simulate a failed fetch (network error, auth failure, etc.)
+            return MagicMock(returncode=1, stdout="")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result is None
+
+
+def test_check_via_local_git_fetch_timeout_returns_none(tmp_path):
+    """A fetch timeout (subprocess exception) must also return None."""
+    import subprocess as _subprocess
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd[:2] == ["git", "fetch"]:
+            raise _subprocess.TimeoutExpired(cmd, 10)
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner._check_via_local_git(repo_dir)
+
+    assert result is None
+
+
+def test_check_for_updates_does_not_cache_none(tmp_path, monkeypatch):
+    """When the fetch fails (behind=None), no cache entry must be written.
+
+    Regression: a failed fetch cached as None would be returned for the full
+    6-hour TTL, suppressing the retry that should happen on the next startup.
+    """
+    import hermes_cli.banner as banner
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "remote", "get-url", "origin"]:
+            return MagicMock(returncode=0, stdout="https://github.com/NousResearch/hermes-agent.git\n")
+        if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+            return MagicMock(returncode=0, stdout="false\n")
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=1, stdout="")
+        raise AssertionError(f"unexpected git command: {cmd!r}")
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    # Point __file__ at the temp repo so check_for_updates finds the .git
+    fake_banner = tmp_path / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run):
+        result = banner.check_for_updates()
+
+    assert result is None
+    # No cache file should exist — None must not be persisted.
+    assert not cache_file.exists()


### PR DESCRIPTION
## Summary

Prevents stale behind-count in the banner update check by:

1. **Checking `git fetch` return code** — returns `None` on non-zero exit instead of silently falling through to counting stale local refs, which could report '0 behind' and hide real updates.
2. **Skipping cache write when `behind is None`** — a failed fetch retries on next startup instead of being locked into the 6-hour cache.
3. **Preserving all existing branches** — SSH remote, shallow-clone (with `--depth 1`), and full-clone paths all get return-code handling.
4. **Leaving `format_banner_version_label()` intact** — revision-label UI separation preserved.

## Test Plan

- [x] `python3 -m pytest tests/hermes_cli/test_update_check.py -v` — 18/18 pass (15 existing + 3 new)
- [x] New: `test_check_via_local_git_failed_fetch_returns_none` — non-zero fetch return → None
- [x] New: `test_check_via_local_git_fetch_timeout_returns_none` — fetch timeout → None
- [x] New: `test_check_for_updates_does_not_cache_none` — None result not cached

## Changes from teknium1's review

- ✅ Preserve `ver: VERSION` in cache schema (already present on current main)
- ✅ Keep current SSH and shallow-clone branches, add return-code handling to their fetch path
- ✅ Leave `format_banner_version_label()` revision-label UI intact
- ✅ Add regression coverage for non-zero fetch return and absence of cache write

Rebased onto current main (was 5,773 commits behind).
