### PR TITLE
fix(codex): activity watchdog for codex_responses stale detector

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -363,7 +363,27 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
         # Stale-call detector: kill the connection if no response
         # arrives within the configured timeout.
-        if _elapsed > _stale_timeout:
+        #
+        # For codex_responses the request is internally streaming
+        # (``run_codex_stream`` consumes ``responses.create(..., stream=True)``
+        # SSE events under the hood of what looks like a non-streaming call
+        # to this layer). If any event has already arrived we treat the
+        # detector as an activity watchdog and measure staleness from the
+        # last event rather than from ``_call_start``. Without that,
+        # long-but-healthy turns
+        # (extended reasoning, multi-tool-call sequences) cross the
+        # wall-clock stale threshold while events are still flowing and
+        # get misreported as "No response from provider for Ns
+        # (non-streaming, ...)". The TTFB watchdog above already handles
+        # the zero-events case; this branch covers events-then-silence.
+        _last_event_ts = getattr(agent, "_codex_stream_last_event_ts", None)
+        _codex_has_events = (
+            agent.api_mode == "codex_responses" and _last_event_ts is not None
+        )
+        _stale_elapsed = (
+            time.time() - _last_event_ts if _codex_has_events else _elapsed
+        )
+        if _stale_elapsed > _stale_timeout:
             _est_ctx = estimate_request_context_tokens(api_kwargs)
             _silent_hint: Optional[str] = None
             _hint_fn = getattr(agent, "_codex_silent_hang_hint", None)
@@ -372,24 +392,38 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     _silent_hint = _hint_fn(model=api_kwargs.get("model"))
                 except Exception:
                     _silent_hint = None
-            logger.warning(
-                "Non-streaming API call stale for %.0fs (threshold %.0fs). "
-                "model=%s context=~%s tokens. Killing connection.",
-                _elapsed, _stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
-            )
-            if _silent_hint:
-                agent._emit_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
-                    f"{_silent_hint}"
+            if _codex_has_events:
+                logger.warning(
+                    "Codex Responses stream stale for %.0fs since last event "
+                    "(threshold %.0fs, total elapsed %.0fs). model=%s "
+                    "context=~%s tokens. Killing connection.",
+                    _stale_elapsed, _stale_timeout, _elapsed,
+                    api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
                 )
-            else:
                 agent._emit_status(
-                    f"⚠️ No response from provider for {int(_elapsed)}s "
-                    f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                    f"⚠️ No stream events from provider for {int(_stale_elapsed)}s "
+                    f"(codex stream, model: {api_kwargs.get('model', 'unknown')}). "
                     f"Aborting call."
                 )
+            else:
+                logger.warning(
+                    "Non-streaming API call stale for %.0fs (threshold %.0fs). "
+                    "model=%s context=~%s tokens. Killing connection.",
+                    _elapsed, _stale_timeout,
+                    api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+                )
+                if _silent_hint:
+                    agent._emit_status(
+                        f"⚠️ No response from provider for {int(_elapsed)}s "
+                        f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"{_silent_hint}"
+                    )
+                else:
+                    agent._emit_status(
+                        f"⚠️ No response from provider for {int(_elapsed)}s "
+                        f"(non-streaming, model: {api_kwargs.get('model', 'unknown')}). "
+                        f"Aborting call."
+                    )
             try:
                 if agent.api_mode == "anthropic_messages":
                     agent._anthropic_client.close()
@@ -404,7 +438,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
             if result["error"] is None and result["response"] is None:
-                if _silent_hint:
+                if _codex_has_events:
+                    result["error"] = TimeoutError(
+                        f"Codex Responses stream stalled: no new event for "
+                        f"{int(_stale_elapsed)}s (threshold: {int(_stale_timeout)}s)"
+                    )
+                elif _silent_hint:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "
                         f"with no response (threshold: {int(_stale_timeout)}s). "

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1335,6 +1335,7 @@ AUTHOR_MAP = {
     "timothy.b.dixon@gmail.com": "Codename-11",  # PR #29302 (API server session controls — sessions/chat/fork/stream)
     "jpschwartz2@uwalumni.com": "Schwartz10",  # PR #29302 sub-PR (multimodal media in session chat API)
     "JohnC1009@users.noreply.github.com": "JohnC1009",  # PR #32020 salvage (auth: global auth.json fallback in _load_provider_state)
+    "4436110+zqchris@users.noreply.github.com": "zqchris",  # PR #32131 (codex stream activity watchdog)
 }
 
 

--- a/tests/agent/test_codex_stream_activity_watchdog.py
+++ b/tests/agent/test_codex_stream_activity_watchdog.py
@@ -1,0 +1,198 @@
+"""Regression tests for the Codex Responses stream activity watchdog.
+
+The TTFB watchdog (see test_codex_ttfb_watchdog.py) handles the case where the
+backend accepts a connection but never emits a single stream event. Once *any*
+event has arrived, the connection is healthy and the stale-call detector
+takes over.
+
+The bug this file covers: prior to the activity-watchdog fix, that stale
+detector measured against ``_call_start`` even for ``codex_responses``, which
+streams events under the hood of what looks like a single non-streaming call.
+So a long-but-healthy turn (extended reasoning, multi-tool-call sequences)
+crossed the wall-clock stale threshold while events were still flowing and
+got misreported as ``No response from provider for Ns (non-streaming, ...)``.
+
+The fix: when ``api_mode == "codex_responses"`` and a stream event has been
+observed, measure staleness from ``agent._codex_stream_last_event_ts`` rather
+than from the call start. Non-codex modes keep wall-clock semantics.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+# Stub optional heavy imports so run_agent imports cleanly in isolation.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+def _make_codex_agent(tmp_path, monkeypatch, *, stale_timeout: float = 1.0):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model="gpt-5.5",
+        provider="openai-codex",
+        api_key="sk-dummy",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="cli",
+    )
+    agent.api_mode = "codex_responses"
+    # Disable TTFB so this file exclusively exercises the activity watchdog.
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0")
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: stale_timeout
+    )
+    agent._emitted_status: list = []
+    monkeypatch.setattr(
+        agent, "_emit_status", lambda msg: agent._emitted_status.append(msg)
+    )
+    return agent
+
+
+def _wire_client_closes(agent, monkeypatch):
+    """Capture every connection-close reason so the test can assert on them."""
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent, "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent, "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    return closes
+
+
+def test_stale_kicks_in_when_events_stop_flowing(tmp_path, monkeypatch):
+    """Events arrived (so TTFB does not apply), then the stream went silent
+    for longer than the stale timeout — the activity watchdog kills the call
+    and the surfaced error/status reflect "no new event" rather than the
+    legacy "non-streaming, no response" wording."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch, stale_timeout=1.0)
+    closes = _wire_client_closes(agent, monkeypatch)
+
+    stop = {"flag": False}
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        # Stream a single event, then go silent until either killed or 30s pass.
+        agent._codex_stream_last_event_ts = time.time()
+        deadline = time.time() + 30
+        while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
+            time.sleep(0.02)
+        raise RuntimeError("connection closed")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    t0 = time.time()
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+        elapsed = time.time() - t0
+        assert "no new event" in str(excinfo.value).lower()
+        assert "stale_call_kill" in closes
+        # Must fire near the 1s threshold + 2s join grace — well under 30s.
+        assert elapsed < 10, f"activity watchdog took {elapsed:.1f}s"
+        # The user-facing status must say "stream events", not "non-streaming".
+        emitted = " ".join(agent._emitted_status)
+        assert "stream events" in emitted
+        assert "non-streaming" not in emitted
+    finally:
+        stop["flag"] = True
+
+
+def test_long_healthy_stream_is_not_killed(tmp_path, monkeypatch):
+    """Events keep flowing past the wall-clock stale threshold — total elapsed
+    > stale_timeout, but the gap between the last event and now is always
+    short, so the watchdog must NOT kill the connection."""
+    from agent import chat_completion_helpers as h
+
+    # 0.4s stale window; we will run ~1.2s of streaming with ~50ms event gap.
+    agent = _make_codex_agent(tmp_path, monkeypatch, stale_timeout=0.4)
+    closes = _wire_client_closes(agent, monkeypatch)
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        # 24 events × 50ms = 1.2s real elapsed, but the last-event gap is
+        # always ~50ms — well under the 0.4s stale window.
+        for _ in range(24):
+            agent._codex_stream_last_event_ts = time.time()
+            time.sleep(0.05)
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    t0 = time.time()
+    resp = h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+    elapsed = time.time() - t0
+    assert resp is sentinel
+    assert "stale_call_kill" not in closes
+    assert elapsed >= 1.0, "fake stream should have run > 1s"
+    # No timeout status should have been emitted while events were flowing.
+    assert not any("stream events" in m for m in agent._emitted_status)
+
+
+def test_non_codex_mode_keeps_wall_clock_semantics(tmp_path, monkeypatch):
+    """The activity watchdog is gated on ``codex_responses``. Other api_modes
+    (chat_completions non-stream, anthropic, bedrock) have no stream-event
+    signal and must continue to fire stale based on wall-clock elapsed."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch, stale_timeout=1.0)
+    agent.api_mode = "chat_completions"  # NOT codex_responses
+    closes = _wire_client_closes(agent, monkeypatch)
+
+    # Even if some other code path stamped this marker, it must not influence
+    # non-codex_responses requests. Set it to "now" — under codex rules the
+    # call would be considered freshly alive; under wall-clock it still dies.
+    agent._codex_stream_last_event_ts = time.time()
+
+    stop = {"flag": False}
+
+    def fake_blocking_call(*a, **k):
+        deadline = time.time() + 30
+        while time.time() < deadline and not stop["flag"] and not agent._interrupt_requested:
+            # Keep refreshing the codex marker so a buggy activity check would
+            # see the call as "healthy" and never fire.
+            agent._codex_stream_last_event_ts = time.time()
+            time.sleep(0.05)
+        raise RuntimeError("connection closed")
+
+    # interruptible_api_call falls through to the chat_completions branch and
+    # calls openai_client.chat.completions.create(**api_kwargs); we stub that.
+    fake_openai = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=fake_blocking_call)
+        )
+    )
+    monkeypatch.setattr(agent, "openai_client", fake_openai, raising=False)
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: fake_openai)
+
+    t0 = time.time()
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}]})
+        elapsed = time.time() - t0
+        # Wall-clock path: message must say "non-streaming", not "no new event".
+        assert "non-streaming" in str(excinfo.value).lower()
+        assert "no new event" not in str(excinfo.value).lower()
+        # Should still fire near the 1s threshold + 2s join grace.
+        assert elapsed < 10, f"wall-clock watchdog took {elapsed:.1f}s"
+    finally:
+        stop["flag"] = True


### PR DESCRIPTION
## Summary

- Make the non-stream stale detector in `interruptible_api_call` measure staleness **from the last stream event** when `api_mode == codex_responses`, not from `_call_start`.
- Once any event has arrived, long-but-healthy turns (extended reasoning, multi-tool-call sequences) stay alive; the TTFB watchdog from #32042 still handles the zero-events case.
- Non-codex api_modes (chat_completions non-stream, anthropic_messages, bedrock_converse) are explicitly excluded and keep wall-clock semantics.

## Problem

`codex_responses` requests look "non-streaming" to `interruptible_api_call`, but under the hood `run_codex_stream` iterates `responses.stream(...)` events. The stale detector currently measures `_elapsed = time.time() - _call_start`, i.e. a wall-clock deadline on the entire turn. With the stale defaults lowered to 90 / 150 / 240s by context tier in #31967 (2d422720b), it is now easy for a healthy long reasoning / multi-tool run to cross that threshold **while events are still arriving**, and get killed with the misleading

```
⚠️ No response from provider for 120s (non-streaming, model: gpt-5.5). Aborting call.
```

#32042 already stamps `agent._codex_stream_last_event_ts` on every event in `run_codex_stream`, but only the TTFB watchdog reads it — and only checks whether it's still `None`. Once the first event arrives, TTFB stops applying and there's no activity-based supervisor left. The wall-clock detector takes over with the wrong semantics for an internally-streaming path.

This PR closes that gap by turning the stale detector into a true activity watchdog for `codex_responses` once at least one event has been observed.

## Why this isn't already covered by recent fixes

| PR / commit | Covers | Doesn't cover |
|---|---|---|
| #31967 (2d422720b) — context-shape estimator + tier defaults | Right-sizing the wall-clock budget for Responses-API payloads | Events-then-silence (still wall-clock) |
| #32024 (b1adb9503) — silent-hang hint | gpt-5.5 family zero-event silent-reject, actionable text | Events-then-silence (only fires on the same wall-clock path) |
| #32042 — TTFB watchdog | Connection accepted, **zero** events ever | Events flow then stop |

This PR is the missing fourth tile.

## Relationship to prior work

- **#19359 (closed, unmerged)** took the same event-based watchdog approach but was closed by its author after extensive force-pushes against a moving base; the code paths it touched (`run_agent.py` directly) have since been refactored into `agent/chat_completion_helpers.py` and `agent/codex_runtime.py`. This PR is the post-refactor version of the same idea, gated more narrowly (only `codex_responses`, only after a first event), with a smaller diff.
- **#8027 (open)** is orthogonal: it adds `_touch_activity()` calls inside `run_codex_stream` / fallback so the **cron inactivity tracker** stays fresh during active streaming. This PR doesn't change that path — both could land independently. The marker this PR reads (`_codex_stream_last_event_ts`) was added by #32042, not #8027.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Zero events for >TTFB cutoff | TTFB kill (#32042) | TTFB kill (unchanged) |
| Events flow, total wall-clock > stale_timeout but recent events | **killed**, "non-streaming, no response" | **not killed** (activity watchdog) |
| Events flow then go silent > stale_timeout | killed with confusing "non-streaming" wording | killed with `⚠️ No stream events from provider for Ns (codex stream, ...). Aborting call.` |
| Other api_modes (chat_completions non-stream, anthropic, bedrock) | wall-clock | wall-clock (unchanged) |

Error text changes:
- `TimeoutError("Codex Responses stream stalled: no new event for Ns (threshold: ...)")` for the events-then-silence path
- Existing `Non-streaming API call timed out after Ns ...` (with optional silent-hang hint) for non-codex / zero-event paths

## Tests

- `tests/agent/test_codex_stream_activity_watchdog.py` (new) — 3 cases:
  - events stop flowing → killed at activity threshold with "no new event" wording, status says "stream events" not "non-streaming"
  - events keep flowing past wall-clock stale → not killed, completes normally
  - non-codex api_mode → wall-clock semantics unchanged (sanity gate, prevents regression in chat_completions / anthropic / bedrock)
- Existing `tests/agent/test_codex_ttfb_watchdog.py`, `test_non_stream_stale_timeout.py`, and `test_codex_silent_hang_hint.py` continue to pass (28/28 in the targeted suite).

## Test plan

- [x] `pytest tests/agent/test_codex_stream_activity_watchdog.py tests/agent/test_codex_ttfb_watchdog.py tests/agent/test_non_stream_stale_timeout.py tests/run_agent/test_codex_silent_hang_hint.py` — 28 passed
- [ ] (Reviewer / CI) full test suite
- [ ] Optional manual: long codex_responses turn on a large context where wall-clock stale would previously have fired (verify it now completes)

Refs #21444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)