### PR TITLE
fix(kanban): close decomposer SQLite connections

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -36,6 +36,7 @@ Design notes
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -281,7 +282,7 @@ def decompose_task(
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
     """
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
@@ -370,7 +371,7 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect() as conn:
+        with contextlib.closing(kb.connect()) as conn:
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -439,7 +440,7 @@ def decompose_task(
         })
 
     try:
-        with kb.connect() as conn:
+        with contextlib.closing(kb.connect()) as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -467,7 +468,7 @@ def decompose_task(
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         rows = kb.list_tasks(
             conn,
             status="triage",

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -347,3 +347,32 @@ def test_decompose_no_aux_client_configured(kanban_home):
 
     assert outcome.ok is False
     assert "no auxiliary client" in outcome.reason
+
+
+def test_list_triage_ids_closes_kanban_connection(monkeypatch):
+    """The gateway auto-decomposer calls list_triage_ids once per tick.
+
+    sqlite3.Connection.__exit__ commits/rolls back but does not close the
+    database handle, so the helper must explicitly close kb.connect()'s result
+    instead of relying on ``with kb.connect()``.
+    """
+
+    class FakeConn:
+        def __init__(self):
+            self.closed = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def close(self):
+            self.closed = True
+
+    conn = FakeConn()
+    monkeypatch.setattr(decomp.kb, "connect", lambda: conn)
+    monkeypatch.setattr(decomp.kb, "list_tasks", lambda *args, **kwargs: [])
+
+    assert decomp.list_triage_ids() == []
+    assert conn.closed is True


### PR DESCRIPTION
## What does this PR do?

Fixes the embedded kanban decomposer path so its SQLite connections are closed deterministically instead of relying on `sqlite3.Connection.__exit__`.

`kanban_decompose.list_triage_ids()` runs on every gateway dispatcher tick. In the current implementation, `with kb.connect() as conn:` only commits/rolls back and leaves the SQLite handle open. Over time that accumulates `kanban.db` / `kanban.db-wal` file descriptors and eventually trips `Too many open files` / `unable to open database file` in long-lived gateway processes.

This patch switches the decomposer helpers to `contextlib.closing(kb.connect())` so the connection is always closed on block exit.

## Related Issue

Fixes #29610

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/kanban_decompose.py`
  - Replace `with kb.connect()` with `contextlib.closing(kb.connect())` in the decomposer helper paths, including `list_triage_ids()`.
- `tests/hermes_cli/test_kanban_decompose.py`
  - Add a regression test that proves `list_triage_ids()` closes the underlying connection.

## How to Test

1. Run the targeted regression suite:
   `uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/gateway/test_kanban_notifier.py -q -o 'addopts='
2. Verify the new regression passes:
   `uv run --extra dev python -m pytest tests/hermes_cli/test_kanban_decompose.py::test_list_triage_ids_closes_kanban_connection -q -o 'addopts='
3. Optional runtime check: repeatedly call `list_triage_ids()` in a live gateway and confirm `kanban.db` fd count stays flat.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted pytest suites above and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on macOS 26.3

### Documentation & Housekeeping

- [x] I've updated relevant docstrings — N/A for user-facing docs
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Relevant verification:
- Regression test passes
- Live gateway fd count dropped from 329 to 59 after restart and stayed flat across a dispatcher tick

## Notes

Related upstream work already in flight:
- #29525 appears to target the same decomposer SQLite fd leak class.
- This PR keeps the scope focused on the verified `kanban_decompose.py` hot path.