### PR TITLE
feat(discord): auto-join voice for allowed users

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -700,6 +700,15 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#   voice:
+#     auto_join:
+#       enabled: false               # Auto-join a configured voice channel when a trigger user joins
+#       channel_id: ""               # Voice channel ID to join (preferred over channel_name)
+#       channel_name: ""             # Fallback match if channel_id is unset, e.g. "General"
+#       text_channel_id: ""          # Text channel for transcripts/replies; falls back to DISCORD_HOME_CHANNEL
+#       user_ids: []                 # Optional trigger-user IDs; empty = any authorized Discord user
+#     idle_timeout_seconds: 300       # 0 disables silence-based disconnect
+#     empty_timeout_seconds: 300      # Leave after no non-bot humans remain
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1895,37 +1895,23 @@ class GatewayRunner:
         except OSError as e:
             logger.warning("Failed to save voice modes: %s", e)
 
-    def _set_adapter_auto_tts_disabled(self, adapter, chat_id: str, disabled: bool) -> None:
-        """Update an adapter's in-memory auto-TTS suppression set if present."""
-        disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
-        if not isinstance(disabled_chats, set):
-            return
-        if disabled:
-            disabled_chats.add(chat_id)
-            # ``/voice off`` also clears any explicit enable — it's a hard override.
-            enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-            if isinstance(enabled_chats, set):
-                enabled_chats.discard(chat_id)
-        else:
-            disabled_chats.discard(chat_id)
-
-    def _set_adapter_auto_tts_enabled(self, adapter, chat_id: str, enabled: bool) -> None:
-        """Update an adapter's per-chat auto-TTS opt-in set if present.
-
-        Used for ``/voice on``/``/voice tts`` where the user explicitly wants
-        auto-TTS even when ``voice.auto_tts`` is False globally.
-        """
+    def _set_adapter_auto_tts(self, adapter, chat_id: str, *, enabled: bool) -> None:
+        """Update adapter in-memory auto-TTS overrides for one chat."""
+        chat_id = str(chat_id)
         enabled_chats = getattr(adapter, "_auto_tts_enabled_chats", None)
-        if not isinstance(enabled_chats, set):
-            return
+        disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
         if enabled:
-            enabled_chats.add(chat_id)
-            # An explicit opt-in clears any stale /voice off for this chat.
-            disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
+            if isinstance(enabled_chats, set):
+                enabled_chats.add(chat_id)
             if isinstance(disabled_chats, set):
+                # An explicit opt-in clears any stale /voice off for this chat.
                 disabled_chats.discard(chat_id)
         else:
-            enabled_chats.discard(chat_id)
+            if isinstance(disabled_chats, set):
+                disabled_chats.add(chat_id)
+            if isinstance(enabled_chats, set):
+                # ``/voice off`` is a hard override and clears any explicit enable.
+                enabled_chats.discard(chat_id)
 
     def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
         """Restore persisted /voice state into a live platform adapter.
@@ -1970,6 +1956,12 @@ class GatewayRunner:
                 key[len(prefix):] for key, mode in self._voice_mode.items()
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
+
+    def _run_adapter_post_sync_startup(self, adapter) -> None:
+        """Run adapter startup hooks that depend on runner-owned state sync."""
+        schedule_reconcile = getattr(adapter, "schedule_voice_auto_join_reconcile", None)
+        if callable(schedule_reconcile):
+            schedule_reconcile()
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.
@@ -3977,6 +3969,7 @@ class GatewayRunner:
                 if success:
                     self.adapters[platform] = adapter
                     self._sync_voice_mode_state_to_adapter(adapter)
+                    self._run_adapter_post_sync_startup(adapter)
                     connected_count += 1
                     self._update_platform_runtime_status(
                         platform.value,
@@ -5581,6 +5574,7 @@ class GatewayRunner:
                     if success:
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)
+                        self._run_adapter_post_sync_startup(adapter)
                         self.delivery_router.adapters = self.adapters
                         del self._failed_platforms[platform]
                         self._update_platform_runtime_status(
@@ -10853,6 +10847,31 @@ class GatewayRunner:
             return raw.guild.id
         return None
 
+    def _set_discord_voice_join_mode(
+        self,
+        adapter,
+        platform: Platform,
+        chat_id: str,
+        *,
+        tts_enabled: bool,
+    ) -> None:
+        """Persist the chat-side mode created by a Discord VC join.
+
+        When top-level ``voice.auto_tts`` is false, Hermes remains in the voice channel and
+        listens, but replies in text only.  This is represented as voice mode
+        ``off`` plus an explicit adapter auto-TTS suppression so the BaseAdapter
+        does not synthesize speech for voice-originated turns.
+        """
+        chat_id = str(chat_id)
+        self._voice_mode[self._voice_key(platform, chat_id)] = "all" if tts_enabled else "off"
+        self._save_voice_modes()
+        self._set_adapter_auto_tts(adapter, chat_id, enabled=tts_enabled)
+
+    @staticmethod
+    def _discord_voice_join_tts_enabled(adapter) -> bool:
+        """Return the existing global ``voice.auto_tts`` default pushed to the adapter."""
+        return getattr(adapter, "_auto_tts_default", False) is True
+
     async def _handle_voice_command(self, event: MessageEvent) -> str:
         """Handle /voice [on|off|tts|channel|leave|status] command."""
         args = event.get_command_args().strip().lower()
@@ -10866,19 +10885,19 @@ class GatewayRunner:
             self._voice_mode[voice_key] = "voice_only"
             self._save_voice_modes()
             if adapter:
-                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                self._set_adapter_auto_tts(adapter, chat_id, enabled=True)
             return t("gateway.voice.enabled_voice_only")
         elif args in {"off", "disable"}:
             self._voice_mode[voice_key] = "off"
             self._save_voice_modes()
             if adapter:
-                self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+                self._set_adapter_auto_tts(adapter, chat_id, enabled=False)
             return t("gateway.voice.disabled_text")
         elif args == "tts":
             self._voice_mode[voice_key] = "all"
             self._save_voice_modes()
             if adapter:
-                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                self._set_adapter_auto_tts(adapter, chat_id, enabled=True)
             return t("gateway.voice.tts_enabled")
         elif args in {"channel", "join"}:
             return await self._handle_voice_channel_join(event)
@@ -10914,14 +10933,25 @@ class GatewayRunner:
                 self._voice_mode[voice_key] = "voice_only"
                 self._save_voice_modes()
                 if adapter:
-                    self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+                    self._set_adapter_auto_tts(adapter, chat_id, enabled=True)
                 return t("gateway.voice.enabled_short")
             else:
                 self._voice_mode[voice_key] = "off"
                 self._save_voice_modes()
                 if adapter:
-                    self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+                    self._set_adapter_auto_tts(adapter, chat_id, enabled=False)
                 return t("gateway.voice.disabled_short")
+
+    def _wire_discord_voice_callbacks(self, adapter) -> None:
+        """Wire Discord voice callbacks before joining a voice channel."""
+        adapter._voice_input_callback = self._handle_voice_channel_input
+        adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+
+    @staticmethod
+    def _clear_discord_voice_callbacks(adapter) -> None:
+        """Clear callbacks after a failed or completed Discord voice join."""
+        adapter._voice_input_callback = None
+        adapter._on_voice_disconnect = None
 
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
@@ -10941,16 +10971,13 @@ class GatewayRunner:
 
         # Wire callbacks BEFORE join so voice input arriving immediately
         # after connection is not lost.
-        if hasattr(adapter, "_voice_input_callback"):
-            adapter._voice_input_callback = self._handle_voice_channel_input
-        if hasattr(adapter, "_on_voice_disconnect"):
-            adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
+        self._wire_discord_voice_callbacks(adapter)
 
         try:
             success = await adapter.join_voice_channel(voice_channel)
         except Exception as e:
             logger.warning("Failed to join voice channel: %s", e)
-            adapter._voice_input_callback = None
+            self._clear_discord_voice_callbacks(adapter)
             err_lower = str(e).lower()
             if "pynacl" in err_lower or "nacl" in err_lower or "davey" in err_lower:
                 return (
@@ -10959,20 +10986,119 @@ class GatewayRunner:
                 )
             return f"Failed to join voice channel: {e}"
 
-        if success:
-            adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
-            if hasattr(adapter, "_voice_sources"):
-                adapter._voice_sources[guild_id] = event.source.to_dict()
-            self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
-            self._save_voice_modes()
-            self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
-            return (
-                f"Joined voice channel **{voice_channel.name}**.\n"
-                f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
+        if not success:
+            self._clear_discord_voice_callbacks(adapter)
+            return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
+
+        voice_text_channels = getattr(adapter, "_voice_text_channels")
+        voice_sources = getattr(adapter, "_voice_sources")
+        voice_text_channels[guild_id] = int(event.source.chat_id)
+        voice_sources[guild_id] = event.source.to_dict()
+        tts_enabled = self._discord_voice_join_tts_enabled(adapter)
+        self._set_discord_voice_join_mode(
+            adapter,
+            event.source.platform,
+            event.source.chat_id,
+            tts_enabled=tts_enabled,
+        )
+        suffix = (
+            "I'll speak my replies and listen to you. Use /voice leave to disconnect."
+            if tts_enabled
+            else "I'll listen here and reply in text. Use /voice tts to enable spoken replies, "
+            "or /voice leave to disconnect."
+        )
+        return f"Joined voice channel **{voice_channel.name}**.\n{suffix}"
+
+    async def _handle_discord_voice_auto_join(self, adapter, member, channel, text_channel_id: str) -> None:
+        """Join a configured Discord VC when an authorized trigger user enters it."""
+        guild = getattr(channel, "guild", None) or getattr(member, "guild", None)
+        if guild is None:
+            return
+        guild_id = int(guild.id)
+        text_channel_id = str(text_channel_id)
+
+        try:
+            text_channel_id_int = int(text_channel_id)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Discord voice auto-join needs a numeric text channel id; got %r",
+                text_channel_id,
             )
-        # Join failed — clear callback
-        adapter._voice_input_callback = None
-        return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
+            return
+
+        text_channel = None
+        client = getattr(adapter, "_client", None)
+        if client is not None:
+            get_channel = getattr(client, "get_channel", None)
+            if callable(get_channel):
+                text_channel = get_channel(text_channel_id_int)
+        if text_channel is None:
+            logger.warning(
+                "Discord voice auto-join text channel %s was not found; refusing to join voice without reply routing",
+                text_channel_id,
+            )
+            return
+        text_guild = getattr(text_channel, "guild", None)
+        text_guild_id = getattr(text_guild, "id", None)
+        if text_guild_id is not None:
+            try:
+                text_guild_id_int = int(text_guild_id)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Discord voice auto-join text channel %s has invalid guild id %r",
+                    text_channel_id,
+                    text_guild_id,
+                )
+                return
+            if text_guild_id_int != guild_id:
+                logger.warning(
+                    "Discord voice auto-join text channel %s belongs to guild %s, not voice guild %s",
+                    text_channel_id,
+                    text_guild_id,
+                    guild_id,
+                )
+                return
+
+        # Wire callbacks BEFORE join so voice input arriving immediately after
+        # connection is not lost.
+        self._wire_discord_voice_callbacks(adapter)
+
+        try:
+            success = await adapter.join_voice_channel(channel)
+        except Exception:
+            logger.warning("Discord voice auto-join failed", exc_info=True)
+            success = False
+        if not success:
+            self._clear_discord_voice_callbacks(adapter)
+            return
+
+        voice_text_channels = getattr(adapter, "_voice_text_channels")
+        voice_sources = getattr(adapter, "_voice_sources")
+        voice_text_channels[guild_id] = text_channel_id_int
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=text_channel_id,
+            user_id=str(getattr(member, "id", "")),
+            user_name=getattr(member, "display_name", None) or str(getattr(member, "id", "")),
+            chat_name=getattr(text_channel, "name", None) or text_channel_id,
+            chat_type="channel",
+        )
+        voice_sources[guild_id] = source.to_dict()
+
+        tts_enabled = self._discord_voice_join_tts_enabled(adapter)
+        self._set_discord_voice_join_mode(
+            adapter,
+            Platform.DISCORD,
+            text_channel_id,
+            tts_enabled=tts_enabled,
+        )
+        logger.info(
+            "Auto-joined Discord voice channel %s (%s) for user %s; voice_auto_tts=%s",
+            getattr(channel, "name", text_channel_id),
+            getattr(channel, "id", "?"),
+            getattr(member, "id", "?"),
+            tts_enabled,
+        )
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
         """Leave the Discord voice channel."""
@@ -10992,9 +11118,8 @@ class GatewayRunner:
         # Always clean up state even if leave raised an exception
         self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "off"
         self._save_voice_modes()
-        self._set_adapter_auto_tts_disabled(adapter, event.source.chat_id, disabled=True)
-        if hasattr(adapter, "_voice_input_callback"):
-            adapter._voice_input_callback = None
+        self._set_adapter_auto_tts(adapter, event.source.chat_id, enabled=False)
+        self._clear_discord_voice_callbacks(adapter)
         return "Left voice channel."
 
     def _handle_voice_timeout_cleanup(self, chat_id: str) -> None:
@@ -11005,7 +11130,7 @@ class GatewayRunner:
         self._voice_mode[self._voice_key(Platform.DISCORD, chat_id)] = "off"
         self._save_voice_modes()
         adapter = self.adapters.get(Platform.DISCORD)
-        self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+        self._set_adapter_auto_tts(adapter, chat_id, enabled=False)
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
         """Suppress repeated STT outputs for the same recent utterance.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1382,6 +1382,20 @@ DEFAULT_CONFIG = {
         # real memory cost. Default 32 MiB matches the historical hardcoded
         # cap. Set to 0 for no cap. Env override: DISCORD_MAX_ATTACHMENT_BYTES.
         "max_attachment_bytes": 33554432,
+        # Discord voice-channel auto-join. Manual `/voice join` still works when
+        # disabled. Set channel/user IDs from Discord's Developer Mode. Env
+        # overrides use DISCORD_VOICE_* names (see docs).
+        "voice": {
+            "auto_join": {
+                "enabled": False,
+                "channel_id": "",      # Voice channel ID to join (preferred over name)
+                "channel_name": "",    # Fallback match when no channel_id is set
+                "text_channel_id": "", # Text channel for transcripts/replies (fallback: DISCORD_HOME_CHANNEL)
+                "user_ids": [],         # Optional trigger-user allowlist; empty = any authorized user
+            },
+            "idle_timeout_seconds": 300,   # 0 disables silence-based disconnect
+            "empty_timeout_seconds": 300,  # Leave after channel has no non-bot humans
+        },
     },
 
     # WhatsApp platform settings (gateway mode)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -51,7 +51,7 @@ from gateway.config import Platform, PlatformConfig
 import re
 
 from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
-from utils import atomic_json_write
+from utils import atomic_json_write, env_bool, env_int
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -83,6 +83,12 @@ def _clean_discord_id(entry: str) -> str:
     if entry.lower().startswith("user:"):
         entry = entry[5:]
     return entry.strip()
+
+
+def _parse_csv_env(name: str) -> List[str]:
+    """Return non-empty comma-separated env entries as stripped strings."""
+    raw = os.getenv(name, "")
+    return [part.strip() for part in raw.split(",") if part.strip()]
 
 
 def check_discord_requirements() -> bool:
@@ -550,6 +556,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
+    # Auto-disconnect when a joined voice channel has no non-bot members.
+    VOICE_EMPTY_TIMEOUT = 300
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -569,6 +577,15 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
         self._voice_sources: Dict[int, Dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
         self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
+        self._voice_timeout_seconds = env_int(
+            "DISCORD_VOICE_IDLE_TIMEOUT_SECONDS",
+            self.VOICE_TIMEOUT,
+        )
+        self._voice_empty_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> empty-channel timeout task
+        self._voice_empty_timeout_seconds = env_int(
+            "DISCORD_VOICE_EMPTY_TIMEOUT_SECONDS",
+            self.VOICE_EMPTY_TIMEOUT,
+        )
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
@@ -583,6 +600,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
+        self._voice_auto_join_reconcile_task: Optional[asyncio.Task] = None
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
@@ -815,15 +833,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
             @self._client.event
             async def on_voice_state_update(member, before, after):
-                """Track voice channel join/leave events."""
-                # Only track channels where the bot is connected
-                bot_guild_ids = set(adapter_self._voice_clients.keys())
-                if not bot_guild_ids:
-                    return
-                guild_id = member.guild.id
-                if guild_id not in bot_guild_ids:
-                    return
-                # Ignore the bot itself
+                """Track voice channel join/leave events and opt-in auto-join."""
+                # Ignore the bot itself.
                 if member == adapter_self._client.user:
                     return
 
@@ -834,17 +845,41 @@ class DiscordAdapter(BasePlatformAdapter):
                     and after.channel is not None
                     and before.channel != after.channel
                 )
+                if not (joined or left or switched):
+                    return
 
-                if joined or left or switched:
-                    logger.info(
-                        "Voice state: %s (%d) %s (guild %d)",
-                        member.display_name,
-                        member.id,
-                        "joined " + after.channel.name if joined
-                        else "left " + before.channel.name if left
-                        else f"moved {before.channel.name} -> {after.channel.name}",
+                guild_id = member.guild.id
+                if env_bool("DISCORD_VOICE_AUTO_JOIN", False) or guild_id in adapter_self._voice_clients:
+                    if joined:
+                        action = f"joined {getattr(after.channel, 'name', after.channel)}"
+                    elif left:
+                        action = f"left {getattr(before.channel, 'name', before.channel)}"
+                    else:
+                        action = (
+                            f"moved {getattr(before.channel, 'name', before.channel)} -> "
+                            f"{getattr(after.channel, 'name', after.channel)}"
+                        )
+                    logger.debug(
+                        "Voice state relevant to voice handling: %s (%s) %s (guild %s)",
+                        getattr(member, "display_name", member),
+                        getattr(member, "id", ""),
+                        action,
                         guild_id,
                     )
+
+                left_with_trigger = await adapter_self._maybe_auto_leave_voice_channel_for_trigger(
+                    member,
+                    before.channel,
+                    after.channel,
+                )
+                if left_with_trigger:
+                    return
+
+                if after.channel is not None:
+                    await adapter_self._maybe_auto_join_voice_channel(member, after.channel)
+
+                if guild_id in adapter_self._voice_clients:
+                    adapter_self._reset_empty_voice_timeout(guild_id)
 
             # Register slash commands
             if self._slash_commands:
@@ -890,10 +925,18 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        if self._voice_auto_join_reconcile_task and not self._voice_auto_join_reconcile_task.done():
+            self._voice_auto_join_reconcile_task.cancel()
+            try:
+                await self._voice_auto_join_reconcile_task
+            except asyncio.CancelledError:
+                pass
+
         self._running = False
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._voice_auto_join_reconcile_task = None
 
         self._release_platform_lock()
 
@@ -1888,8 +1931,145 @@ class DiscordAdapter(BasePlatformAdapter):
             return await super().send_voice(chat_id, audio_path, caption, reply_to, metadata=metadata)
 
     # ------------------------------------------------------------------
-    # Voice channel methods (join / leave / play)
+    # Voice channel methods (auto-join / join / leave / play)
     # ------------------------------------------------------------------
+
+    def _voice_auto_join_channel_matches(self, channel) -> bool:
+        configured_channel_id = os.getenv("DISCORD_VOICE_AUTO_JOIN_CHANNEL_ID", "").strip()
+        configured_channel_name = os.getenv("DISCORD_VOICE_AUTO_JOIN_CHANNEL_NAME", "").strip()
+        if configured_channel_id:
+            return str(getattr(channel, "id", "")) == configured_channel_id
+        if configured_channel_name:
+            return getattr(channel, "name", "") == configured_channel_name
+        logger.warning("DISCORD_VOICE_AUTO_JOIN is enabled but no channel id/name is configured")
+        return False
+
+    def _voice_auto_join_text_channel_id(self) -> str:
+        return os.getenv("DISCORD_VOICE_TEXT_CHANNEL_ID", "").strip() or os.getenv("DISCORD_HOME_CHANNEL", "").strip()
+
+    async def _maybe_auto_leave_voice_channel_for_trigger(self, member, before_channel, after_channel) -> bool:
+        """Leave when a configured auto-join trigger user leaves our connected VC.
+
+        ``empty_timeout_seconds`` is a safety net for channels that become
+        empty.  When ``auto_join.user_ids`` is configured, the more useful
+        behavior is to follow the trigger user's presence exactly: if they
+        leave or move out of the channel Hermes joined for them, Hermes leaves
+        immediately instead of waiting for the empty-channel grace timer.
+        """
+        if not env_bool("DISCORD_VOICE_AUTO_JOIN", False):
+            return False
+        if getattr(member, "bot", False):
+            return False
+        trigger_user_ids = set(_parse_csv_env("DISCORD_VOICE_AUTO_JOIN_USER_IDS"))
+        if not trigger_user_ids or str(getattr(member, "id", "")) not in trigger_user_ids:
+            return False
+        if before_channel is None:
+            return False
+
+        guild = getattr(member, "guild", None) or getattr(before_channel, "guild", None)
+        if guild is None:
+            return False
+        guild_id = int(guild.id)
+        vc = self._voice_clients.get(guild_id)
+        if not vc or not vc.is_connected():
+            return False
+        connected_channel = getattr(vc, "channel", None)
+        if connected_channel is None:
+            return False
+        if str(getattr(before_channel, "id", "")) != str(getattr(connected_channel, "id", "")):
+            return False
+        if after_channel is not None and str(getattr(after_channel, "id", "")) == str(getattr(connected_channel, "id", "")):
+            return False
+
+        logger.info(
+            "Leaving Discord voice channel %s (%s) because trigger user %s left/moved",
+            getattr(connected_channel, "name", connected_channel),
+            getattr(connected_channel, "id", ""),
+            getattr(member, "id", ""),
+        )
+        await self._leave_voice_channel_for_timeout(
+            guild_id,
+            "Left voice channel (trigger user left).",
+        )
+        return True
+
+    async def _maybe_auto_join_voice_channel(self, member, channel) -> None:
+        """Auto-join a configured voice channel when an allowed user joins it."""
+        if not env_bool("DISCORD_VOICE_AUTO_JOIN", False):
+            return
+        if not self.gateway_runner:
+            return
+        if getattr(member, "bot", False):
+            return
+        guild = getattr(member, "guild", None) or getattr(channel, "guild", None)
+        if guild is None:
+            return
+        guild_id = int(guild.id)
+        if self.is_in_voice_channel(guild_id):
+            return
+        if not self._voice_auto_join_channel_matches(channel):
+            return
+
+        allowed_trigger_users = set(_parse_csv_env("DISCORD_VOICE_AUTO_JOIN_USER_IDS"))
+        if allowed_trigger_users and str(member.id) not in allowed_trigger_users:
+            return
+        if not self._is_allowed_user(str(member.id), member, guild=guild, is_dm=False):
+            return
+
+        text_channel_id = self._voice_auto_join_text_channel_id()
+        if not text_channel_id:
+            logger.warning("Discord voice auto-join needs DISCORD_VOICE_TEXT_CHANNEL_ID or DISCORD_HOME_CHANNEL")
+            return
+
+        handler = getattr(self.gateway_runner, "_handle_discord_voice_auto_join", None)
+        if handler is None:
+            return
+        try:
+            await handler(self, member, channel, text_channel_id)
+        except Exception:
+            logger.warning("Discord voice auto-join failed", exc_info=True)
+
+    def schedule_voice_auto_join_reconcile(self) -> None:
+        """Schedule startup auto-join after the gateway has synced voice config."""
+        if not env_bool("DISCORD_VOICE_AUTO_JOIN", False):
+            return
+        if self._voice_auto_join_reconcile_task and not self._voice_auto_join_reconcile_task.done():
+            self._voice_auto_join_reconcile_task.cancel()
+        self._voice_auto_join_reconcile_task = asyncio.create_task(
+            self._reconcile_voice_auto_join()
+        )
+
+    async def _reconcile_voice_auto_join(self) -> None:
+        """Join the configured voice channel on startup if a trigger user is already there."""
+        if not env_bool("DISCORD_VOICE_AUTO_JOIN", False):
+            return
+        client = self._client
+        if not client or not self.gateway_runner:
+            return
+        bot_user = getattr(self._client, "user", None)
+        for guild in getattr(client, "guilds", []) or []:
+            if self._client is not client:
+                return
+            is_closed = getattr(client, "is_closed", None)
+            if callable(is_closed) and is_closed():
+                return
+            if self.is_in_voice_channel(int(guild.id)):
+                continue
+            for channel in getattr(guild, "voice_channels", []) or []:
+                if self._client is not client:
+                    return
+                if not self._voice_auto_join_channel_matches(channel):
+                    continue
+                for member in getattr(channel, "members", []) or []:
+                    if self._client is not client:
+                        return
+                    if getattr(member, "bot", False) or member == bot_user:
+                        continue
+                    await self._maybe_auto_join_voice_channel(member, channel)
+                    if self.is_in_voice_channel(int(guild.id)):
+                        break
+                if self.is_in_voice_channel(int(guild.id)):
+                    break
 
     async def join_voice_channel(self, channel) -> bool:
         """Join a Discord voice channel. Returns True on success."""
@@ -1903,14 +2083,17 @@ class DiscordAdapter(BasePlatformAdapter):
             if existing and existing.is_connected():
                 if existing.channel.id == channel.id:
                     self._reset_voice_timeout(guild_id)
+                    self._reset_empty_voice_timeout(guild_id)
                     return True
                 await existing.move_to(channel)
                 self._reset_voice_timeout(guild_id)
+                self._reset_empty_voice_timeout(guild_id)
                 return True
 
             vc = await channel.connect()
             self._voice_clients[guild_id] = vc
             self._reset_voice_timeout(guild_id)
+            self._reset_empty_voice_timeout(guild_id)
 
             # Start voice receiver (Phase 2: listen to users)
             try:
@@ -1942,6 +2125,9 @@ class DiscordAdapter(BasePlatformAdapter):
             task = self._voice_timeout_tasks.pop(guild_id, None)
             if task:
                 task.cancel()
+            empty_task = self._voice_empty_timeout_tasks.pop(guild_id, None)
+            if empty_task:
+                empty_task.cancel()
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
 
@@ -2004,23 +2190,84 @@ class DiscordAdapter(BasePlatformAdapter):
         return member.voice.channel
 
     def _reset_voice_timeout(self, guild_id: int) -> None:
-        """Reset the auto-disconnect inactivity timer."""
+        """Reset the auto-disconnect inactivity timer.
+
+        ``DISCORD_VOICE_IDLE_TIMEOUT_SECONDS=0`` disables the silence-based
+        timeout so Hermes can stay connected/listening while everyone is muted.
+        Empty-channel cleanup is handled separately by
+        ``_reset_empty_voice_timeout``.
+        """
         task = self._voice_timeout_tasks.pop(guild_id, None)
         if task:
             task.cancel()
+        if self._voice_timeout_seconds <= 0:
+            return
         self._voice_timeout_tasks[guild_id] = asyncio.ensure_future(
             self._voice_timeout_handler(guild_id)
         )
 
     async def _voice_timeout_handler(self, guild_id: int) -> None:
-        """Auto-disconnect after VOICE_TIMEOUT seconds of inactivity."""
+        """Auto-disconnect after configured seconds of voice inactivity."""
         try:
-            await asyncio.sleep(self.VOICE_TIMEOUT)
+            await asyncio.sleep(self._voice_timeout_seconds)
         except asyncio.CancelledError:
             return
+        await self._leave_voice_channel_for_timeout(
+            guild_id,
+            "Left voice channel (inactivity timeout).",
+        )
+
+    def _voice_channel_has_humans(self, guild_id: int) -> bool:
+        """Return True when the connected VC still contains non-bot members."""
+        vc = self._voice_clients.get(guild_id)
+        if not vc or not vc.is_connected():
+            return False
+        channel = getattr(vc, "channel", None)
+        if channel is None:
+            return False
+        client = getattr(self, "_client", None)
+        bot_user = getattr(client, "user", None) if client else None
+        bot_id = getattr(bot_user, "id", None)
+        return any(
+            not getattr(member, "bot", False)
+            and (bot_id is None or getattr(member, "id", None) != bot_id)
+            for member in (getattr(channel, "members", []) or [])
+        )
+
+    def _reset_empty_voice_timeout(self, guild_id: int) -> None:
+        """Reset/cancel the leave-on-empty-channel timer for a guild."""
+        task = self._voice_empty_timeout_tasks.pop(guild_id, None)
+        if task:
+            task.cancel()
+        if self._voice_empty_timeout_seconds <= 0:
+            return
+        if self._voice_channel_has_humans(guild_id):
+            return
+        vc = self._voice_clients.get(guild_id)
+        if not vc or not vc.is_connected():
+            return
+        self._voice_empty_timeout_tasks[guild_id] = asyncio.ensure_future(
+            self._voice_empty_timeout_handler(guild_id)
+        )
+
+    async def _voice_empty_timeout_handler(self, guild_id: int) -> None:
+        """Leave the voice channel if it remains empty for the grace period."""
+        try:
+            await asyncio.sleep(self._voice_empty_timeout_seconds)
+        except asyncio.CancelledError:
+            return
+        if self._voice_channel_has_humans(guild_id):
+            return
+        await self._leave_voice_channel_for_timeout(
+            guild_id,
+            "Left voice channel (empty channel timeout).",
+        )
+
+    async def _leave_voice_channel_for_timeout(self, guild_id: int, notification: str) -> None:
+        """Disconnect for an adapter-owned timeout and clean runner state."""
         text_ch_id = self._voice_text_channels.get(guild_id)
         await self.leave_voice_channel(guild_id)
-        # Notify the runner so it can clean up voice_mode state
+        # Notify the runner so it can clean up voice_mode state.
         if self._on_voice_disconnect and text_ch_id:
             try:
                 self._on_voice_disconnect(str(text_ch_id))
@@ -2030,7 +2277,7 @@ class DiscordAdapter(BasePlatformAdapter):
             ch = self._client.get_channel(text_ch_id)
             if ch:
                 try:
-                    await ch.send("Left voice channel (inactivity timeout).")
+                    await ch.send(notification)
                 except Exception:
                     pass
 
@@ -2149,6 +2396,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         is_dm=False,
                     ):
                         continue
+                    self._reset_voice_timeout(guild_id)
                     await self._process_voice_input(guild_id, user_id, pcm_data)
         except asyncio.CancelledError:
             pass
@@ -6133,6 +6381,34 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     if _discord_rtm is not None and not os.getenv("DISCORD_REPLY_TO_MODE"):
         _rtm_str = "off" if _discord_rtm is False else str(_discord_rtm).lower()
         os.environ["DISCORD_REPLY_TO_MODE"] = _rtm_str
+
+    # Discord voice-channel options.  These live under the Discord platform
+    # block (``discord.voice``) because they identify Discord channel/user IDs
+    # and adapter-owned timeout behaviour; generic STT/TTS provider settings
+    # remain under top-level ``stt`` / ``tts`` / ``voice``.  Whether joined
+    # voice sessions speak replies is controlled by existing ``voice.auto_tts``.
+    def _set_voice_env_if_absent(env_key: str, value) -> None:
+        if value is None or os.getenv(env_key):
+            return
+        if isinstance(value, bool):
+            os.environ[env_key] = str(value).lower()
+        elif isinstance(value, (list, tuple, set)):
+            os.environ[env_key] = ",".join(str(v) for v in value)
+        else:
+            os.environ[env_key] = str(value)
+
+    voice_cfg = discord_cfg.get("voice")
+    if isinstance(voice_cfg, dict):
+        auto_join_cfg = voice_cfg.get("auto_join")
+        if isinstance(auto_join_cfg, dict):
+            _set_voice_env_if_absent("DISCORD_VOICE_AUTO_JOIN", auto_join_cfg.get("enabled"))
+            _set_voice_env_if_absent("DISCORD_VOICE_AUTO_JOIN_CHANNEL_ID", auto_join_cfg.get("channel_id"))
+            _set_voice_env_if_absent("DISCORD_VOICE_AUTO_JOIN_CHANNEL_NAME", auto_join_cfg.get("channel_name"))
+            _set_voice_env_if_absent("DISCORD_VOICE_TEXT_CHANNEL_ID", auto_join_cfg.get("text_channel_id"))
+            _set_voice_env_if_absent("DISCORD_VOICE_AUTO_JOIN_USER_IDS", auto_join_cfg.get("user_ids"))
+        _set_voice_env_if_absent("DISCORD_VOICE_IDLE_TIMEOUT_SECONDS", voice_cfg.get("idle_timeout_seconds"))
+        _set_voice_env_if_absent("DISCORD_VOICE_EMPTY_TIMEOUT_SECONDS", voice_cfg.get("empty_timeout_seconds"))
+
     return None  # all settings flow through env; nothing to merge into extras
 
 

--- a/tests/gateway/test_discord_race_polish.py
+++ b/tests/gateway/test_discord_race_polish.py
@@ -23,6 +23,9 @@ def _make_adapter():
     adapter._voice_receivers = {}
     adapter._voice_listen_tasks = {}
     adapter._voice_timeout_tasks = {}
+    adapter._voice_timeout_seconds = DiscordAdapter.VOICE_TIMEOUT
+    adapter._voice_empty_timeout_tasks = {}
+    adapter._voice_empty_timeout_seconds = DiscordAdapter.VOICE_EMPTY_TIMEOUT
     adapter._voice_text_channels = {}
     adapter._voice_sources = {}
     adapter._client = MagicMock()
@@ -60,11 +63,14 @@ async def test_concurrent_joins_do_not_double_connect():
     channel.guild.id = 42
     channel.connect = lambda: slow_connect(channel)
 
+    def fake_ensure_future(coro):
+        coro.close()
+        return asyncio.create_task(asyncio.sleep(0))
+
     from plugins.platforms.discord import adapter as discord_mod
     with patch.object(discord_mod, "VoiceReceiver",
                       MagicMock(return_value=MagicMock(start=lambda: None))):
-        with patch.object(discord_mod.asyncio, "ensure_future",
-                          lambda _c: asyncio.create_task(asyncio.sleep(0))):
+        with patch.object(discord_mod.asyncio, "ensure_future", fake_ensure_future):
             t1 = asyncio.create_task(adapter.join_voice_channel(channel))
             t2 = asyncio.create_task(adapter.join_voice_channel(channel))
             await asyncio.sleep(0.05)

--- a/tests/gateway/test_discord_voice_auto_join.py
+++ b/tests/gateway/test_discord_voice_auto_join.py
@@ -1,0 +1,509 @@
+"""Tests for Discord voice auto-join and listen-only defaults."""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from plugins.platforms.discord.adapter import DiscordAdapter, _apply_yaml_config
+
+
+class _FakeTask:
+    def __init__(self):
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+class _FakeReceiver:
+    def __init__(self, completed):
+        self._running = True
+        self._completed = list(completed)
+
+    def check_silence(self):
+        self._running = False
+        completed, self._completed = self._completed, []
+        return completed
+
+
+class _FakeGuild:
+    def __init__(self, guild_id=111):
+        self.id = guild_id
+        self.voice_channels = []
+
+    def get_member(self, user_id):
+        return None
+
+
+class _FakeMember:
+    def __init__(self, user_id=333, *, bot=False, guild=None, display_name="Edward"):
+        self.id = user_id
+        self.bot = bot
+        self.guild = guild or _FakeGuild()
+        self.display_name = display_name
+        self.roles = []
+
+
+class _FakeVoiceChannel:
+    def __init__(self, channel_id=222, name="General", guild=None, members=None):
+        self.id = channel_id
+        self.name = name
+        self.guild = guild or _FakeGuild()
+        self.members = list(members or [])
+
+
+class _FakeVoiceClient:
+    def __init__(self, channel):
+        self.channel = channel
+        self.disconnected = False
+
+    def is_connected(self):
+        return not self.disconnected
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+def _make_adapter(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_VOICE_AUTO_JOIN", "true")
+    monkeypatch.setenv("DISCORD_VOICE_AUTO_JOIN_CHANNEL_NAME", "General")
+    monkeypatch.setenv("DISCORD_VOICE_TEXT_CHANNEL_ID", "444")
+    monkeypatch.delenv("DISCORD_VOICE_AUTO_JOIN_CHANNEL_ID", raising=False)
+    monkeypatch.delenv("DISCORD_VOICE_AUTO_JOIN_USER_IDS", raising=False)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="x"))
+    adapter.gateway_runner = SimpleNamespace(_handle_discord_voice_auto_join=AsyncMock())
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_auto_join_invokes_runner_for_configured_channel(monkeypatch, tmp_path):
+    adapter = _make_adapter(monkeypatch, tmp_path)
+    member = _FakeMember(guild=_FakeGuild(111))
+    channel = _FakeVoiceChannel(guild=member.guild)
+
+    await adapter._maybe_auto_join_voice_channel(member, channel)
+
+    adapter.gateway_runner._handle_discord_voice_auto_join.assert_awaited_once_with(
+        adapter,
+        member,
+        channel,
+        "444",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_join_ignores_unconfigured_channel(monkeypatch, tmp_path):
+    adapter = _make_adapter(monkeypatch, tmp_path)
+    monkeypatch.setenv("DISCORD_VOICE_AUTO_JOIN_CHANNEL_NAME", "Not General")
+
+    await adapter._maybe_auto_join_voice_channel(_FakeMember(), _FakeVoiceChannel())
+
+    adapter.gateway_runner._handle_discord_voice_auto_join.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_reconciliation_auto_joins_when_user_already_in_target_channel(monkeypatch, tmp_path):
+    adapter = _make_adapter(monkeypatch, tmp_path)
+    monkeypatch.setenv("DISCORD_VOICE_AUTO_JOIN_CHANNEL_ID", "222")
+    monkeypatch.setenv("DISCORD_VOICE_AUTO_JOIN_USER_IDS", "333")
+    guild = _FakeGuild(111)
+    member = _FakeMember(333, guild=guild)
+    channel = _FakeVoiceChannel(222, "General", guild=guild, members=[member])
+    guild.voice_channels = [channel]
+    adapter._client = SimpleNamespace(guilds=[guild], user=SimpleNamespace(id=999))
+
+    await adapter._reconcile_voice_auto_join()
+
+    adapter.gateway_runner._handle_discord_voice_auto_join.assert_awaited_once_with(
+        adapter,
+        member,
+        channel,
+        "444",
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_startup_reconciliation(monkeypatch, tmp_path):
+    adapter = _make_adapter(monkeypatch, tmp_path)
+    never = asyncio.Event()
+
+    async def wait_forever():
+        await never.wait()
+
+    task = asyncio.create_task(wait_forever())
+    adapter._voice_auto_join_reconcile_task = task
+
+    await adapter.disconnect()
+
+    assert task.cancelled() is True
+    assert adapter._voice_auto_join_reconcile_task is None
+
+
+@pytest.mark.asyncio
+async def test_trigger_user_leave_disconnects_immediately(monkeypatch, tmp_path):
+    adapter = _make_adapter(monkeypatch, tmp_path)
+    monkeypatch.setenv("DISCORD_VOICE_AUTO_JOIN_USER_IDS", "333")
+    guild = _FakeGuild(111)
+    member = _FakeMember(333, guild=guild)
+    channel = _FakeVoiceChannel(222, "General", guild=guild)
+    vc = _FakeVoiceClient(channel)
+    text_channel = SimpleNamespace(send=AsyncMock())
+    adapter._client = SimpleNamespace(get_channel=MagicMock(return_value=text_channel), user=SimpleNamespace(id=999))
+    adapter._voice_clients[111] = vc
+    adapter._voice_text_channels[111] = 444
+    adapter._on_voice_disconnect = MagicMock()
+
+    left = await adapter._maybe_auto_leave_voice_channel_for_trigger(member, channel, None)
+
+    assert left is True
+    assert vc.disconnected is True
+    assert 111 not in adapter._voice_clients
+    adapter._on_voice_disconnect.assert_called_once_with("444")
+    text_channel.send.assert_awaited_once_with("Left voice channel (trigger user left).")
+
+
+@pytest.mark.asyncio
+async def test_non_trigger_user_leave_keeps_voice_connected(monkeypatch, tmp_path):
+    adapter = _make_adapter(monkeypatch, tmp_path)
+    monkeypatch.setenv("DISCORD_VOICE_AUTO_JOIN_USER_IDS", "333")
+    guild = _FakeGuild(111)
+    member = _FakeMember(444, guild=guild)
+    channel = _FakeVoiceChannel(222, "General", guild=guild)
+    vc = _FakeVoiceClient(channel)
+    adapter._voice_clients[111] = vc
+
+    left = await adapter._maybe_auto_leave_voice_channel_for_trigger(member, channel, None)
+
+    assert left is False
+    assert vc.disconnected is False
+    assert adapter._voice_clients[111] is vc
+
+
+def test_idle_timeout_zero_disables_timeout_task(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_VOICE_IDLE_TIMEOUT_SECONDS", "0")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="x"))
+
+    adapter._reset_voice_timeout(111)
+
+    assert adapter._voice_timeout_tasks == {}
+
+
+def test_empty_channel_timeout_schedules_when_no_humans(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_VOICE_EMPTY_TIMEOUT_SECONDS", "60")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="x"))
+    channel = _FakeVoiceChannel(members=[SimpleNamespace(id=999, bot=True)])
+    adapter._voice_clients[111] = _FakeVoiceClient(channel)
+    scheduled_task = _FakeTask()
+
+    def fake_ensure_future(coro):
+        coro.close()
+        return scheduled_task
+
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.ensure_future", fake_ensure_future)
+
+    adapter._reset_empty_voice_timeout(111)
+
+    assert adapter._voice_empty_timeout_tasks[111] is scheduled_task
+
+
+def test_empty_channel_timeout_cancelled_when_human_present(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_VOICE_EMPTY_TIMEOUT_SECONDS", "60")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="x"))
+    channel = _FakeVoiceChannel(members=[SimpleNamespace(id=333, bot=False)])
+    adapter._voice_clients[111] = _FakeVoiceClient(channel)
+    task = _FakeTask()
+    adapter._voice_empty_timeout_tasks[111] = task
+
+    adapter._reset_empty_voice_timeout(111)
+
+    assert task.cancelled is True
+    assert adapter._voice_empty_timeout_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_voice_input_resets_idle_timeout(monkeypatch, tmp_path):
+    adapter = _make_adapter(monkeypatch, tmp_path)
+    adapter._allowed_user_ids = {"333"}
+    adapter._voice_receivers[111] = _FakeReceiver([(333, b"pcm")])  # type: ignore[assignment]
+    adapter._client = SimpleNamespace(get_guild=MagicMock(return_value=_FakeGuild(111)))
+    adapter._reset_voice_timeout = MagicMock()
+    adapter._process_voice_input = AsyncMock()
+
+    await adapter._voice_listen_loop(111)
+
+    adapter._reset_voice_timeout.assert_called_once_with(111)
+    adapter._process_voice_input.assert_awaited_once_with(111, 333, b"pcm")
+
+
+def test_yaml_config_bridge_exports_discord_voice_env(monkeypatch):
+    for key in (
+        "DISCORD_VOICE_AUTO_JOIN",
+        "DISCORD_VOICE_AUTO_JOIN_CHANNEL_ID",
+        "DISCORD_VOICE_AUTO_JOIN_CHANNEL_NAME",
+        "DISCORD_VOICE_TEXT_CHANNEL_ID",
+        "DISCORD_VOICE_AUTO_JOIN_USER_IDS",
+        "DISCORD_VOICE_IDLE_TIMEOUT_SECONDS",
+        "DISCORD_VOICE_EMPTY_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    _apply_yaml_config({}, {
+        "voice": {
+            "auto_join": {
+                "enabled": True,
+                "channel_id": "222",
+                "channel_name": "General",
+                "text_channel_id": "444",
+                "user_ids": ["333"],
+            },
+            "idle_timeout_seconds": 0,
+            "empty_timeout_seconds": 120,
+        }
+    })
+
+    assert os.environ["DISCORD_VOICE_AUTO_JOIN"] == "true"
+    assert os.environ["DISCORD_VOICE_AUTO_JOIN_CHANNEL_ID"] == "222"
+    assert os.environ["DISCORD_VOICE_AUTO_JOIN_CHANNEL_NAME"] == "General"
+    assert os.environ["DISCORD_VOICE_TEXT_CHANNEL_ID"] == "444"
+    assert os.environ["DISCORD_VOICE_AUTO_JOIN_USER_IDS"] == "333"
+    assert os.environ["DISCORD_VOICE_IDLE_TIMEOUT_SECONDS"] == "0"
+    assert os.environ["DISCORD_VOICE_EMPTY_TIMEOUT_SECONDS"] == "120"
+
+
+def test_gateway_schedules_startup_reconcile_after_voice_auto_tts_sync(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"voice": {"auto_tts": True}},
+    )
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._voice_mode = {}
+    observed = []
+    adapter = SimpleNamespace(
+        platform=Platform.DISCORD,
+        _auto_tts_default=False,
+        _auto_tts_enabled_chats=set(),
+        _auto_tts_disabled_chats=set(),
+    )
+
+    def schedule_reconcile():
+        observed.append(adapter._auto_tts_default)
+
+    adapter.schedule_voice_auto_join_reconcile = schedule_reconcile
+
+    runner._sync_voice_mode_state_to_adapter(adapter)
+    runner._run_adapter_post_sync_startup(adapter)
+
+    assert observed == [True]
+
+
+@pytest.mark.asyncio
+async def test_runner_auto_join_wires_text_only_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._VOICE_MODE_PATH = tmp_path / "gateway_voice_mode.json"
+    runner.session_store = MagicMock()
+    runner._session_db = None
+
+    adapter = MagicMock()
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._auto_tts_default = False
+    adapter._auto_tts_enabled_chats = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=SimpleNamespace(name="general", guild=_FakeGuild(111)))
+    )
+    member = _FakeMember(333, guild=_FakeGuild(111))
+    channel = _FakeVoiceChannel(guild=member.guild)
+
+    await runner._handle_discord_voice_auto_join(adapter, member, channel, "444")
+
+    assert adapter._voice_text_channels[111] == 444
+    assert runner._voice_mode["discord:444"] == "off"
+    assert "444" not in adapter._auto_tts_enabled_chats
+    assert "444" in adapter._auto_tts_disabled_chats
+    adapter.join_voice_channel.assert_awaited_once_with(channel)
+
+
+@pytest.mark.asyncio
+async def test_runner_auto_join_wires_tts_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._VOICE_MODE_PATH = tmp_path / "gateway_voice_mode.json"
+    runner.session_store = MagicMock()
+    runner._session_db = None
+
+    adapter = MagicMock()
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._auto_tts_default = True
+    adapter._auto_tts_enabled_chats = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=SimpleNamespace(name="general", guild=_FakeGuild(111)))
+    )
+    member = _FakeMember(333, guild=_FakeGuild(111))
+    channel = _FakeVoiceChannel(guild=member.guild)
+
+    await runner._handle_discord_voice_auto_join(adapter, member, channel, "444")
+
+    assert adapter._voice_text_channels[111] == 444
+    assert runner._voice_mode["discord:444"] == "all"
+    assert "444" in adapter._auto_tts_enabled_chats
+    assert "444" not in adapter._auto_tts_disabled_chats
+    adapter.join_voice_channel.assert_awaited_once_with(channel)
+
+
+@pytest.mark.asyncio
+async def test_runner_auto_join_failure_clears_callbacks(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._voice_mode = {}
+    runner._VOICE_MODE_PATH = tmp_path / "gateway_voice_mode.json"
+    runner.session_store = MagicMock()
+    runner._session_db = None
+
+    adapter = MagicMock()
+    adapter.join_voice_channel = AsyncMock(return_value=False)
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._voice_input_callback = MagicMock()
+    adapter._on_voice_disconnect = MagicMock()
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=SimpleNamespace(name="general", guild=_FakeGuild(111)))
+    )
+    member = _FakeMember(333, guild=_FakeGuild(111))
+    channel = _FakeVoiceChannel(guild=member.guild)
+
+    await runner._handle_discord_voice_auto_join(adapter, member, channel, "444")
+
+    assert adapter._voice_input_callback is None
+    assert adapter._on_voice_disconnect is None
+    assert adapter._voice_text_channels == {}
+
+
+@pytest.mark.asyncio
+async def test_runner_auto_join_rejects_bad_text_channel_before_join(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._voice_mode = {}
+    runner._VOICE_MODE_PATH = tmp_path / "gateway_voice_mode.json"
+    runner.session_store = MagicMock()
+    runner._session_db = None
+
+    adapter = MagicMock()
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._client = SimpleNamespace(get_channel=MagicMock())
+    member = _FakeMember(333, guild=_FakeGuild(111))
+    channel = _FakeVoiceChannel(guild=member.guild)
+
+    await runner._handle_discord_voice_auto_join(adapter, member, channel, "not-a-number")
+
+    adapter.join_voice_channel.assert_not_awaited()
+    assert adapter._voice_text_channels == {}
+
+
+@pytest.mark.asyncio
+async def test_manual_voice_join_honors_voice_auto_tts_false(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._voice_mode = {}
+    runner._VOICE_MODE_PATH = tmp_path / "gateway_voice_mode.json"
+    runner.session_store = MagicMock()
+    runner._session_db = None
+
+    adapter = MagicMock()
+    adapter.get_user_voice_channel = AsyncMock()
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._auto_tts_default = False
+    adapter._auto_tts_enabled_chats = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._voice_input_callback = None
+    adapter._on_voice_disconnect = None
+    guild = _FakeGuild(111)
+    channel = _FakeVoiceChannel(guild=guild)
+    adapter.get_user_voice_channel.return_value = channel
+    runner.adapters = {Platform.DISCORD: adapter}
+
+    source = SessionSource(platform=Platform.DISCORD, chat_id="444", user_id="333")
+    event = MessageEvent(text="/voice join", message_type=MessageType.TEXT, source=source)
+    event.raw_message = SimpleNamespace(guild_id=111)
+
+    result = await runner._handle_voice_channel_join(event)
+
+    assert adapter._voice_text_channels[111] == 444
+    assert runner._voice_mode["discord:444"] == "off"
+    assert "444" not in adapter._auto_tts_enabled_chats
+    assert "444" in adapter._auto_tts_disabled_chats
+    assert "text" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_manual_voice_join_honors_voice_auto_tts_true(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._voice_mode = {}
+    runner._VOICE_MODE_PATH = tmp_path / "gateway_voice_mode.json"
+    runner.session_store = MagicMock()
+    runner._session_db = None
+
+    adapter = MagicMock()
+    adapter.get_user_voice_channel = AsyncMock()
+    adapter.join_voice_channel = AsyncMock(return_value=True)
+    adapter._voice_text_channels = {}
+    adapter._voice_sources = {}
+    adapter._auto_tts_default = True
+    adapter._auto_tts_enabled_chats = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._voice_input_callback = None
+    adapter._on_voice_disconnect = None
+    guild = _FakeGuild(111)
+    channel = _FakeVoiceChannel(guild=guild)
+    adapter.get_user_voice_channel.return_value = channel
+    runner.adapters = {Platform.DISCORD: adapter}
+
+    source = SessionSource(platform=Platform.DISCORD, chat_id="444", user_id="333")
+    event = MessageEvent(text="/voice join", message_type=MessageType.TEXT, source=source)
+    event.raw_message = SimpleNamespace(guild_id=111)
+
+    result = await runner._handle_voice_channel_join(event)
+
+    assert adapter._voice_text_channels[111] == 444
+    assert runner._voice_mode["discord:444"] == "all"
+    assert "444" in adapter._auto_tts_enabled_chats
+    assert "444" not in adapter._auto_tts_disabled_chats
+    assert "speak" in result.lower()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -523,6 +523,9 @@ class TestDiscordPlayTtsSkip:
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
         adapter._voice_timeout_tasks = {}
+        adapter._voice_timeout_seconds = DiscordAdapter.VOICE_TIMEOUT
+        adapter._voice_empty_timeout_tasks = {}
+        adapter._voice_empty_timeout_seconds = DiscordAdapter.VOICE_EMPTY_TIMEOUT
         adapter._voice_receivers = {}
         adapter._voice_listen_tasks = {}
         adapter._client = None
@@ -816,7 +819,8 @@ class TestVoiceChannelCommands:
         result = await runner._handle_voice_channel_join(event)
         assert "joined" in result.lower()
         assert "General" in result
-        assert runner._voice_mode["discord:123"] == "all"
+        assert runner._voice_mode["discord:123"] == "off"
+        assert "reply in text" in result.lower()
         assert mock_adapter._voice_sources[111]["chat_id"] == "123"
         assert mock_adapter._voice_sources[111]["chat_type"] == "group"
 
@@ -1079,6 +1083,9 @@ class TestDiscordVoiceChannelMethods:
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
         adapter._voice_timeout_tasks = {}
+        adapter._voice_timeout_seconds = DiscordAdapter.VOICE_TIMEOUT
+        adapter._voice_empty_timeout_tasks = {}
+        adapter._voice_empty_timeout_seconds = DiscordAdapter.VOICE_EMPTY_TIMEOUT
         adapter._voice_receivers = {}
         adapter._voice_listen_tasks = {}
         adapter._voice_input_callback = None
@@ -1355,19 +1362,21 @@ class TestCallbackWiringOrder:
 
     def test_callback_set_before_join(self):
         """_handle_voice_channel_join wires callback before calling join."""
-        import ast, inspect
+        import inspect
         from gateway.run import GatewayRunner
         source = inspect.getsource(GatewayRunner._handle_voice_channel_join)
         lines = source.split("\n")
         callback_line = None
         join_line = None
         for i, line in enumerate(lines):
-            if "_voice_input_callback" in line and "=" in line and "None" not in line:
-                if callback_line is None:
-                    callback_line = i
+            if "_wire_discord_voice_callbacks" in line:
+                callback_line = i
             if "join_voice_channel" in line and "await" in line:
                 join_line = i
-        assert callback_line is not None, "callback wiring not found"
+        helper_source = inspect.getsource(GatewayRunner._wire_discord_voice_callbacks)
+        assert "_voice_input_callback" in helper_source, "callback wiring not found"
+        assert "_on_voice_disconnect" in helper_source, "disconnect callback wiring not found"
+        assert callback_line is not None, "callback wiring call not found"
         assert join_line is not None, "join_voice_channel call not found"
         assert callback_line < join_line, (
             f"callback must be wired (line {callback_line}) BEFORE "
@@ -1387,6 +1396,7 @@ class TestCallbackWiringOrder:
         )
         mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
         mock_adapter._voice_input_callback = None
+        mock_adapter._on_voice_disconnect = None
 
         event = _make_event("/voice channel")
         event.raw_message = SimpleNamespace(guild_id=111, guild=None)
@@ -1395,6 +1405,7 @@ class TestCallbackWiringOrder:
         result = await runner._handle_voice_channel_join(event)
         assert "failed" in result.lower()
         assert mock_adapter._voice_input_callback is None
+        assert mock_adapter._on_voice_disconnect is None
 
     @pytest.mark.asyncio
     async def test_join_returns_false_clears_callback(self, tmp_path):
@@ -1407,6 +1418,7 @@ class TestCallbackWiringOrder:
         mock_adapter.join_voice_channel = AsyncMock(return_value=False)
         mock_adapter.get_user_voice_channel = AsyncMock(return_value=mock_channel)
         mock_adapter._voice_input_callback = None
+        mock_adapter._on_voice_disconnect = None
 
         event = _make_event("/voice channel")
         event.raw_message = SimpleNamespace(guild_id=111, guild=None)
@@ -1415,6 +1427,7 @@ class TestCallbackWiringOrder:
         result = await runner._handle_voice_channel_join(event)
         assert "failed" in result.lower()
         assert mock_adapter._voice_input_callback is None
+        assert mock_adapter._on_voice_disconnect is None
 
 
 # =====================================================================
@@ -1437,6 +1450,7 @@ class TestLeaveExceptionHandling:
             side_effect=RuntimeError("Connection reset")
         )
         mock_adapter._voice_input_callback = MagicMock()
+        mock_adapter._on_voice_disconnect = MagicMock()
 
         event = _make_event("/voice leave")
         event.raw_message = SimpleNamespace(guild_id=111, guild=None)
@@ -1447,6 +1461,7 @@ class TestLeaveExceptionHandling:
         assert "left" in result.lower()
         assert runner._voice_mode["telegram:123"] == "off"
         assert mock_adapter._voice_input_callback is None
+        assert mock_adapter._on_voice_disconnect is None
 
     @pytest.mark.asyncio
     async def test_leave_clears_callback(self, runner):
@@ -1455,6 +1470,7 @@ class TestLeaveExceptionHandling:
         mock_adapter.is_in_voice_channel = MagicMock(return_value=True)
         mock_adapter.leave_voice_channel = AsyncMock()
         mock_adapter._voice_input_callback = MagicMock()
+        mock_adapter._on_voice_disconnect = MagicMock()
 
         event = _make_event("/voice leave")
         event.raw_message = SimpleNamespace(guild_id=111, guild=None)
@@ -1463,6 +1479,7 @@ class TestLeaveExceptionHandling:
 
         await runner._handle_voice_channel_leave(event)
         assert mock_adapter._voice_input_callback is None
+        assert mock_adapter._on_voice_disconnect is None
 
 
 # =====================================================================
@@ -1861,6 +1878,9 @@ class TestVoiceTimeoutCleansRunnerState:
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
         adapter._voice_timeout_tasks = {}
+        adapter._voice_timeout_seconds = DiscordAdapter.VOICE_TIMEOUT
+        adapter._voice_empty_timeout_tasks = {}
+        adapter._voice_empty_timeout_seconds = DiscordAdapter.VOICE_EMPTY_TIMEOUT
         adapter._voice_receivers = {}
         adapter._voice_listen_tasks = {}
         adapter._voice_input_callback = None
@@ -1952,6 +1972,9 @@ class TestPlaybackTimeout:
         adapter._voice_text_channels = {}
         adapter._voice_sources = {}
         adapter._voice_timeout_tasks = {}
+        adapter._voice_timeout_seconds = DiscordAdapter.VOICE_TIMEOUT
+        adapter._voice_empty_timeout_tasks = {}
+        adapter._voice_empty_timeout_seconds = DiscordAdapter.VOICE_EMPTY_TIMEOUT
         adapter._voice_receivers = {}
         adapter._voice_listen_tasks = {}
         adapter._voice_input_callback = None

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -345,7 +345,7 @@ Useful when you want private interaction without server-channel mention behavior
 
 This is the most advanced mode.
 
-Hermes joins a Discord VC, listens to user speech, transcribes it, runs the normal agent pipeline, and speaks replies back into the channel.
+Hermes joins a Discord VC, listens to user speech, transcribes it, runs the normal agent pipeline, and replies in the associated text channel. If the existing top-level `voice.auto_tts` setting is enabled, it also speaks replies back into the channel.
 
 ## Required Discord permissions
 
@@ -369,12 +369,36 @@ In a Discord text channel where the bot is present:
 /voice status
 ```
 
+By default, `/voice join` uses the same listen-only behavior as auto-join: Hermes stays in the VC, posts transcripts, and replies in text. Set top-level `voice.auto_tts: true` if you want it to speak replies immediately after joining.
+
+## Automatic Discord VC auto-join
+
+Hermes can auto-join a configured voice channel when an authorized trigger user joins it. This is useful for a personal server where you want Hermes to appear in `General` whenever you enter.
+
+```yaml
+# ~/.hermes/config.yaml
+discord:
+  voice:
+    auto_join:
+      enabled: true
+      channel_id: "123456789012345678"      # voice channel ID, preferred
+      # channel_name: "General"             # fallback if channel_id is unset
+      text_channel_id: "234567890123456789" # transcripts/replies; falls back to DISCORD_HOME_CHANNEL
+      user_ids: ["345678901234567890"]      # optional; empty = any authorized Discord user
+    idle_timeout_seconds: 0                  # 0 disables silence-based disconnect
+    empty_timeout_seconds: 300               # leave after no non-bot humans remain
+```
+
+Equivalent environment variables are `DISCORD_VOICE_AUTO_JOIN`, `DISCORD_VOICE_AUTO_JOIN_CHANNEL_ID`, `DISCORD_VOICE_AUTO_JOIN_CHANNEL_NAME`, `DISCORD_VOICE_TEXT_CHANNEL_ID`, `DISCORD_VOICE_AUTO_JOIN_USER_IDS`, `DISCORD_VOICE_IDLE_TIMEOUT_SECONDS`, and `DISCORD_VOICE_EMPTY_TIMEOUT_SECONDS`.
+
+On gateway startup, Hermes also reconciles the configured channel and joins if a trigger user is already present.
+
 ### What happens when joined
 
 - users speak in the VC
 - Hermes detects speech boundaries
 - transcripts are posted in the associated text channel
-- Hermes responds in text and audio
+- Hermes responds in text; if `voice.auto_tts` or `/voice tts` is enabled, it also responds in audio
 - the text channel is the one where `/voice join` was issued
 
 ### Best practices for Discord VC use

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -677,7 +677,8 @@ Hermes Agent supports Discord voice messages:
 
 - **Incoming voice messages** are automatically transcribed using the configured STT provider: local `faster-whisper` (no key), Groq Whisper (`GROQ_API_KEY`), or OpenAI Whisper (`VOICE_TOOLS_OPENAI_KEY`).
 - **Text-to-speech**: Use `/voice tts` to have the bot send spoken audio responses alongside text replies.
-- **Discord voice channels**: Hermes can also join a voice channel, listen to users speaking, and talk back in the channel.
+- **Discord voice channels**: Hermes can join a voice channel, listen to users speaking, post transcripts to a linked text channel, and optionally speak replies in the channel.
+- **Discord VC auto-join**: set `discord.voice.auto_join.enabled: true` in `~/.hermes/config.yaml` (or `DISCORD_VOICE_AUTO_JOIN=true`) to join a configured VC when an authorized trigger user enters. Configure `channel_id`, `text_channel_id`, optional `user_ids`, `idle_timeout_seconds`, and `empty_timeout_seconds` under `discord.voice`. Spoken replies use the existing top-level `voice.auto_tts` setting. Hermes also reconciles this on gateway startup if the trigger user is already in the target VC.
 
 For the full setup and operational guide, see:
 - [Voice Mode](/docs/user-guide/features/voice-mode)


### PR DESCRIPTION
## Summary
- Add Discord voice auto-join config bridging and docs so Hermes can join a configured VC when an allowed user is present.
- Default joined voice sessions to listen-and-reply-in-text via the existing top-level `voice.auto_tts` setting instead of adding a Discord-specific TTS knob.
- Add startup reconciliation after runner voice-mode sync, trigger-user leave cleanup, shutdown-safe reconciliation task cancellation, and pre-join text-channel routing validation.
- Add regression tests for auto-join filtering, startup reconciliation ordering, listen-only defaults, `voice.auto_tts` opt-in behavior, idle/empty timeouts, and malformed text-channel config.

## Test Plan
- [x] `python -m pytest tests/gateway/test_discord_voice_auto_join.py -q -o 'addopts='` — 18 passed
- [x] `python -m pytest tests/gateway/test_voice_command.py tests/gateway/test_discord*.py -q -o 'addopts='` — 557 passed
- [x] `git diff --check`
- [x] Static scan of added lines for hardcoded secrets, shell injection, eval/exec, unsafe pickle, and SQL string formatting
- [x] Independent pre-commit review passed
