### PR TITLE
fix(cli): keep skin status bar transparent

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -890,13 +890,18 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
         "prompt": prompt,
         "prompt-working": f"{dim} italic",
         "hint": f"{dim} italic",
-        "status-bar": f"bg:{status_bg} {status_text}",
-        "status-bar-strong": f"bg:{status_bg} {status_strong} bold",
-        "status-bar-dim": f"bg:{status_bg} {status_dim}",
-        "status-bar-good": f"bg:{status_bg} {status_good} bold",
-        "status-bar-warn": f"bg:{status_bg} {status_warn} bold",
-        "status-bar-bad": f"bg:{status_bg} {status_bad} bold",
-        "status-bar-critical": f"bg:{status_bg} {status_critical} bold",
+        # Keep the runtime footer/status bar transparent.  The bar should
+        # inherit the user's terminal background; forcing bg:<color> creates
+        # a visible filled strip (black in dark defaults, white in light skins)
+        # inside SSH/tmux/zellij stacks.  Floating overlays below intentionally
+        # keep explicit backgrounds for legibility.
+        "status-bar": status_text,
+        "status-bar-strong": f"{status_strong} bold",
+        "status-bar-dim": status_dim,
+        "status-bar-good": f"{status_good} bold",
+        "status-bar-warn": f"{status_warn} bold",
+        "status-bar-bad": f"{status_bad} bold",
+        "status-bar-critical": f"{status_critical} bold",
         "input-rule": input_rule,
         "image-badge": f"{label} bold",
         "completion-menu": f"bg:{menu_bg} {text}",

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -374,15 +374,9 @@ class TestCliBrandingHelpers:
         overrides = get_prompt_toolkit_style_overrides()
         assert overrides["prompt"] == skin.get_color("prompt")
         assert overrides["input-rule"] == skin.get_color("input_rule")
-        assert overrides["status-bar"] == (
-            f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('status_bar_text')}"
-        )
-        assert overrides["status-bar-strong"] == (
-            f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('status_bar_strong')} bold"
-        )
-        assert overrides["status-bar-critical"] == (
-            f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('status_bar_critical')} bold"
-        )
+        assert overrides["status-bar"] == skin.get_color("status_bar_text")
+        assert overrides["status-bar-strong"] == f"{skin.get_color('status_bar_strong')} bold"
+        assert overrides["status-bar-critical"] == f"{skin.get_color('status_bar_critical')} bold"
         assert overrides["clarify-title"] == f"{skin.get_color('banner_title')} bold"
         assert overrides["sudo-prompt"] == f"{skin.get_color('ui_error')} bold"
         assert overrides["approval-title"] == f"{skin.get_color('ui_warn')} bold"
@@ -390,5 +384,26 @@ class TestCliBrandingHelpers:
         set_active_skin("daylight")
         skin = get_active_skin()
         overrides = get_prompt_toolkit_style_overrides()
-        assert overrides["status-bar"] == f"bg:{skin.get_color('status_bar_bg')} {skin.get_color('banner_text')}"
+        assert overrides["status-bar"] == skin.get_color("banner_text")
         assert overrides["voice-status"] == f"bg:{skin.get_color('voice_status_bg')} {skin.get_color('ui_label')}"
+
+    def test_status_bar_styles_are_transparent_foreground_only(self):
+        from hermes_cli.skin_engine import set_active_skin, get_prompt_toolkit_style_overrides
+
+        set_active_skin("default")
+        overrides = get_prompt_toolkit_style_overrides()
+        status_keys = [
+            "status-bar",
+            "status-bar-strong",
+            "status-bar-dim",
+            "status-bar-good",
+            "status-bar-warn",
+            "status-bar-bad",
+            "status-bar-critical",
+        ]
+        for key in status_keys:
+            assert "bg:" not in overrides[key]
+
+        # Floating overlays still need explicit backgrounds for legibility.
+        assert "bg:" in overrides["completion-menu"]
+        assert "bg:" in overrides["voice-status"]


### PR DESCRIPTION
## Summary
- Keep prompt_toolkit runtime footer/status-bar styles foreground-only so skins inherit the terminal background.
- Preserve explicit backgrounds for floating overlays like completion menus and voice badges.
- Add a regression test ensuring status-bar classes do not emit `bg:`.

## Why
Custom light skins such as `spacemacs-light` previously exposed a dark/black strip when status bars fell back to the dark default background. Setting a light background only changed the bug from black to white. The intended behavior is transparent.

## Tests
- `venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_skin_engine.py -q`
- Result: `34 passed in 1.25s`
