### PR TITLE
fix(cli): harden local config and one-shot safety

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -37,11 +37,12 @@ import tempfile
 import time
 import uuid
 import textwrap
+import socket
 from collections import deque
 from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -173,6 +174,143 @@ from utils import base_url_host_matches, is_truthy_value
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
+
+
+def _single_query_slots_dir() -> Path:
+    return _hermes_home / "runtime" / "single-query-slots"
+
+
+def _pid_is_running(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _cleanup_stale_single_query_slot(slot_path: Path) -> bool:
+    try:
+        raw = slot_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    try:
+        payload = json.loads(raw) if raw.startswith("{") else {"pid": int(raw)}
+    except Exception:
+        payload = {}
+    pid = int(payload.get("pid") or 0)
+    if _pid_is_running(pid):
+        return False
+    try:
+        slot_path.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def _single_query_guard_config() -> tuple[int, float]:
+    limit = 0
+    wait_seconds = 0.0
+    try:
+        from hermes_cli.config import load_config as _load_full_config
+        _agent_cfg = ((_load_full_config() or {}).get("agent") or {})
+        limit = int(_agent_cfg.get("single_query_max_concurrency", 20) or 0)
+        wait_seconds = float(_agent_cfg.get("single_query_concurrency_wait_seconds", 0) or 0)
+    except Exception:
+        limit = 20
+        wait_seconds = 0.0
+
+    _env_limit = os.getenv("HERMES_SINGLE_QUERY_MAX_CONCURRENCY", "").strip()
+    if _env_limit:
+        try:
+            limit = int(_env_limit)
+        except ValueError:
+            pass
+    _env_wait = os.getenv("HERMES_SINGLE_QUERY_CONCURRENCY_WAIT_SECONDS", "").strip()
+    if _env_wait:
+        try:
+            wait_seconds = float(_env_wait)
+        except ValueError:
+            pass
+    return max(0, limit), max(0.0, wait_seconds)
+
+
+@contextmanager
+def _single_query_concurrency_guard(query_label: str = ""):
+    limit, wait_seconds = _single_query_guard_config()
+    if limit <= 0:
+        yield None
+        return
+
+    slots_dir = _single_query_slots_dir()
+    slots_dir.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + wait_seconds
+    slot_path = None
+    fd = None
+    meta = json.dumps(
+        {
+            "pid": os.getpid(),
+            "started_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "host": socket.gethostname(),
+            "query": (query_label or "")[:200],
+        },
+        ensure_ascii=False,
+    )
+
+    try:
+        while True:
+            for idx in range(limit):
+                candidate = slots_dir / f"slot-{idx}.lock"
+                try:
+                    fd = os.open(str(candidate), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                    os.write(fd, meta.encode("utf-8"))
+                    slot_path = candidate
+                    logger.info(
+                        "Single-query concurrency slot acquired: slot=%s limit=%s pid=%s query=%r",
+                        idx, limit, os.getpid(), (query_label or "")[:120],
+                    )
+                    yield slot_path
+                    return
+                except FileExistsError:
+                    if _cleanup_stale_single_query_slot(candidate):
+                        try:
+                            fd = os.open(str(candidate), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                            os.write(fd, meta.encode("utf-8"))
+                            slot_path = candidate
+                            logger.info(
+                                "Single-query concurrency slot acquired after stale cleanup: slot=%s limit=%s pid=%s query=%r",
+                                idx, limit, os.getpid(), (query_label or "")[:120],
+                            )
+                            yield slot_path
+                            return
+                        except OSError:
+                            pass
+                    continue
+                except OSError:
+                    continue
+
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"single-query concurrency limit reached ({limit}). "
+                    f"Set agent.single_query_max_concurrency / HERMES_SINGLE_QUERY_MAX_CONCURRENCY to adjust."
+                )
+            time.sleep(0.1)
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if slot_path is not None:
+            try:
+                slot_path.unlink()
+            except OSError:
+                pass
 
 
 _REASONING_TAGS = (
@@ -14946,133 +15084,137 @@ def main(
     # Handle single query mode
     if query or image:
         query, single_query_images = _collect_query_images(query, image)
-        if quiet:
-            # Quiet mode: suppress banner, spinner, tool previews.
-            # Only print the final response and parseable session info.
-            cli.tool_progress_mode = "off"
-            if cli._ensure_runtime_credentials():
-                effective_query: Any = query
-                if single_query_images:
-                    # Honour the same image-routing decision used by the
-                    # interactive path. With a vision-capable model (incl.
-                    # custom-provider models declared via
-                    # `model.supports_vision: true`), attach images natively
-                    # as image_url content parts. Otherwise fall back to the
-                    # text-pipeline (vision_analyze pre-description).
-                    _img_mode = "text"
-                    _build_parts = None
-                    try:
-                        from agent.image_routing import (
-                            build_native_content_parts as _build_parts,  # noqa: F811
-                        )
-                        from agent.image_routing import decide_image_input_mode
-                        from hermes_cli.config import load_config
-
-                        _img_mode = decide_image_input_mode(
-                            (cli.provider or "").strip(),
-                            (cli.model or "").strip(),
-                            load_config(),
-                        )
-                    except Exception:
-                        _img_mode = "text"
-
-                    if _img_mode == "native" and _build_parts is not None:
-                        try:
-                            _parts, _skipped = _build_parts(
-                                query if isinstance(query, str) else "",
-                                [str(p) for p in single_query_images],
-                            )
-                            if any(p.get("type") == "image_url" for p in _parts):
-                                effective_query = _parts
-                            else:
-                                # All images unreadable — text fallback.
-                                effective_query = cli._preprocess_images_with_vision(
-                                    query, single_query_images, announce=False,
+        _query_label = query or ("[image attached]" if single_query_images else "")
+        try:
+            with _single_query_concurrency_guard(_query_label):
+                if quiet:
+                    # Quiet mode: suppress banner, spinner, tool previews.
+                    # Only print the final response and parseable session info.
+                    cli.tool_progress_mode = "off"
+                    if cli._ensure_runtime_credentials():
+                        effective_query: Any = query
+                        if single_query_images:
+                            # Honour the same image-routing decision used by the
+                            # interactive path. With a vision-capable model (incl.
+                            # custom-provider models declared via
+                            # `model.supports_vision: true`), attach images natively
+                            # as image_url content parts. Otherwise fall back to the
+                            # text-pipeline (vision_analyze pre-description).
+                            _img_mode = "text"
+                            _build_parts = None
+                            try:
+                                from agent.image_routing import (
+                                    build_native_content_parts as _build_parts,  # noqa: F811
                                 )
-                        except Exception:
-                            effective_query = cli._preprocess_images_with_vision(
-                                query, single_query_images, announce=False,
+                                from agent.image_routing import decide_image_input_mode
+                                from hermes_cli.config import load_config
+
+                                _img_mode = decide_image_input_mode(
+                                    (cli.provider or "").strip(),
+                                    (cli.model or "").strip(),
+                                    load_config(),
+                                )
+                            except Exception:
+                                _img_mode = "text"
+
+                            if _img_mode == "native" and _build_parts is not None:
+                                try:
+                                    _parts, _skipped = _build_parts(
+                                        query if isinstance(query, str) else "",
+                                        [str(p) for p in single_query_images],
+                                    )
+                                    if any(p.get("type") == "image_url" for p in _parts):
+                                        effective_query = _parts
+                                    else:
+                                        # All images unreadable — text fallback.
+                                        effective_query = cli._preprocess_images_with_vision(
+                                            query, single_query_images, announce=False,
+                                        )
+                                except Exception:
+                                    effective_query = cli._preprocess_images_with_vision(
+                                        query, single_query_images, announce=False,
+                                    )
+                            else:
+                                effective_query = cli._preprocess_images_with_vision(
+                                    query,
+                                    single_query_images,
+                                    announce=False,
+                                )
+                        turn_route = cli._resolve_turn_agent_config(effective_query)
+                        if turn_route["signature"] != cli._active_agent_route_signature:
+                            cli.agent = None
+                        if cli._init_agent(
+                            model_override=turn_route["model"],
+                            runtime_override=turn_route["runtime"],
+                            request_overrides=turn_route.get("request_overrides"),
+                        ):
+                            cli.agent.quiet_mode = True
+                            cli.agent.suppress_status_output = True
+                            # Suppress streaming display callbacks so stdout stays
+                            # machine-readable (no styled "Hermes" box, no tool-gen
+                            # status lines).  The response is printed once below.
+                            cli.agent.stream_delta_callback = None
+                            cli.agent.tool_gen_callback = None
+                            result = cli.agent.run_conversation(
+                                user_message=effective_query,
+                                conversation_history=cli.conversation_history,
                             )
-                    else:
-                        effective_query = cli._preprocess_images_with_vision(
-                            query,
-                            single_query_images,
-                            announce=False,
-                        )
-                turn_route = cli._resolve_turn_agent_config(effective_query)
-                if turn_route["signature"] != cli._active_agent_route_signature:
-                    cli.agent = None
-                if cli._init_agent(
-                    model_override=turn_route["model"],
-                    runtime_override=turn_route["runtime"],
-                    request_overrides=turn_route.get("request_overrides"),
-                ):
-                    cli.agent.quiet_mode = True
-                    cli.agent.suppress_status_output = True
-                    # Suppress streaming display callbacks so stdout stays
-                    # machine-readable (no styled "Hermes" box, no tool-gen
-                    # status lines).  The response is printed once below.
-                    cli.agent.stream_delta_callback = None
-                    cli.agent.tool_gen_callback = None
-                    result = cli.agent.run_conversation(
-                        user_message=effective_query,
-                        conversation_history=cli.conversation_history,
-                    )
-                    # Sync session_id if mid-run compression created a
-                    # continuation session. The exit line below reports
-                    # session_id to stderr for automation wrappers; without
-                    # this sync it would point at the ended parent.
-                    if (
-                        getattr(cli.agent, "session_id", None)
-                        and cli.agent.session_id != cli.session_id
-                    ):
-                        cli.session_id = cli.agent.session_id
-                    response = result.get("final_response", "") if isinstance(result, dict) else str(result)
-                    # Surface backend errors that produced no visible output
-                    # (e.g. invalid model slug → provider 4xx). Mirrors the
-                    # interactive CLI path. Write to stderr so piped stdout
-                    # stays clean for automation wrappers.
-                    if (
-                        not response
-                        and isinstance(result, dict)
-                        and result.get("error")
-                        and (result.get("failed") or result.get("partial"))
-                    ):
-                        print(f"Error: {result['error']}", file=sys.stderr)
-                    elif response:
-                        print(response)
-                    # Session ID goes to stderr so piped stdout is clean.
-                    print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
-                    
-                    # Ensure proper exit code for automation wrappers
-                    sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
-            
-            # Exit with error code if credentials or agent init fails
+                            # Sync session_id if mid-run compression created a
+                            # continuation session. The exit line below reports
+                            # session_id to stderr for automation wrappers; without
+                            # this sync it would point at the ended parent.
+                            if (
+                                getattr(cli.agent, "session_id", None)
+                                and cli.agent.session_id != cli.session_id
+                            ):
+                                cli.session_id = cli.agent.session_id
+                            response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+                            # Surface backend errors that produced no visible output
+                            # (e.g. invalid model slug → provider 4xx). Mirrors the
+                            # interactive CLI path. Write to stderr so piped stdout
+                            # stays clean for automation wrappers.
+                            if (
+                                not response
+                                and isinstance(result, dict)
+                                and result.get("error")
+                                and (result.get("failed") or result.get("partial"))
+                            ):
+                                print(f"Error: {result['error']}", file=sys.stderr)
+                            elif response:
+                                print(response)
+                            # Session ID goes to stderr so piped stdout is clean.
+                            print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+
+                            # Ensure proper exit code for automation wrappers
+                            sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
+
+                    # Exit with error code if credentials or agent init fails
+                    sys.exit(1)
+                else:
+                    # Single-query mode (`hermes chat -q "…"`): skip the welcome
+                    # banner. Building the banner takes ~420 ms on cold start —
+                    # ~200 ms of that is the version-update check, the rest is
+                    # toolset / skill enumeration and Rich panel rendering. None
+                    # of that is useful for a one-shot query: the user already
+                    # picked the prompt, doesn't need a toolset reference, and
+                    # gets the session ID + resume hint from
+                    # ``_print_exit_summary()`` after the response prints.
+                    #
+                    # The fully-quiet ``-Q`` / ``--quiet`` machine-readable path
+                    # above was already banner-free; this brings the human-
+                    # facing single-query path in line so all non-interactive
+                    # invocations are fast.
+                    if _query_label:
+                        cli.console.print(f"[bold blue]Query:[/] {_query_label}")
+                    # Surface security advisories before the agent runs — short
+                    # banner, doesn't depend on the welcome banner being shown.
+                    cli._show_security_advisories()
+                    cli.chat(query, images=single_query_images or None)
+                    cli._print_exit_summary()
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)
-        else:
-            # Single-query mode (`hermes chat -q "…"`): skip the welcome
-            # banner. Building the banner takes ~420 ms on cold start —
-            # ~200 ms of that is the version-update check, the rest is
-            # toolset / skill enumeration and Rich panel rendering. None
-            # of that is useful for a one-shot query: the user already
-            # picked the prompt, doesn't need a toolset reference, and
-            # gets the session ID + resume hint from
-            # ``_print_exit_summary()`` after the response prints.
-            #
-            # The fully-quiet ``-Q`` / ``--quiet`` machine-readable path
-            # above was already banner-free; this brings the human-
-            # facing single-query path in line so all non-interactive
-            # invocations are fast.
-            _query_label = query or ("[image attached]" if single_query_images else "")
-            if _query_label:
-                cli.console.print(f"[bold blue]Query:[/] {_query_label}")
-            # Surface security advisories before the agent runs — short
-            # banner, doesn't depend on the welcome banner being shown.
-            cli._show_security_advisories()
-            cli.chat(query, images=single_query_images or None)
-            cli._print_exit_summary()
         return
-    
     # Run interactive mode
     cli.run()
 

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -629,7 +629,12 @@ def restore_quick_snapshot(
     """
     home = hermes_home or get_hermes_home()
     root = _quick_snapshot_root(home)
-    snap_dir = root / snapshot_id
+    try:
+        snap_dir = (root / snapshot_id).resolve()
+        snap_dir.relative_to(root.resolve())
+    except (OSError, ValueError):
+        logger.warning("Blocked quick snapshot restore outside snapshot root: %s", snapshot_id)
+        return False
 
     if not snap_dir.is_dir():
         return False
@@ -648,6 +653,11 @@ def restore_quick_snapshot(
             continue
 
         dst = home / rel
+        try:
+            dst.resolve().relative_to(home.resolve())
+        except (OSError, ValueError):
+            logger.warning("Blocked quick snapshot restore path outside Hermes home: %s", rel)
+            continue
         dst.parent.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -510,6 +510,15 @@ DEFAULT_CONFIG = {
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
+        # Global cap for one-shot `hermes chat -q ...` processes on this host.
+        # 0 disables the guard. Set conservatively by default because these
+        # single-query workers are the easiest path to accidental process storms
+        # from wrappers, web UIs, kanban dispatchers, or bad retry loops.
+        "single_query_max_concurrency": 20,
+        # Optional wait time (seconds) for a free single-query slot before the
+        # CLI exits with an error. 0 = fail fast immediately when the host is
+        # already at the concurrency cap.
+        "single_query_concurrency_wait_seconds": 0,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has
@@ -3183,13 +3192,20 @@ def _normalize_custom_provider_entry(
     if isinstance(models, dict) and models:
         normalized["models"] = models
     elif isinstance(models, list) and models:
-        # Hand-edited configs (and older Hermes versions) write ``models`` as
-        # a plain list of model ids. Preserve them by converting to the dict
-        # shape downstream code expects; otherwise normalize silently drops
-        # the list and /model shows the provider with (0) models.
-        normalized["models"] = {
-            str(m): {} for m in models if isinstance(m, str) and m.strip()
-        }
+        # Preserve both simple ``list[str]`` and enriched ``list[dict]`` forms.
+        # Older/local configs often store model metadata objects here; dropping
+        # them forces downstream pickers to fall back to incomplete endpoint
+        # /models listings.
+        normalized_models: Dict[str, Any] = {}
+        for item in models:
+            if isinstance(item, str) and item.strip():
+                normalized_models[item.strip()] = {}
+            elif isinstance(item, dict):
+                mid = item.get("id") or item.get("name")
+                if isinstance(mid, str) and mid.strip():
+                    normalized_models[mid.strip()] = item
+        if normalized_models:
+            normalized["models"] = normalized_models
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2253,6 +2253,7 @@ def select_provider_and_model(args=None):
                 "api_key": entry.get("api_key", ""),
                 "key_env": entry.get("key_env", ""),
                 "model": entry.get("model", ""),
+                "models": entry.get("models", {}) if isinstance(entry.get("models"), dict) else {},
                 "api_mode": entry.get("api_mode", ""),
                 "provider_key": provider_key,
                 "api_key_ref": _lookup_ref(
@@ -4422,6 +4423,14 @@ def _model_flow_named_custom(config, provider_info):
     if api_mode:
         fetch_kwargs["api_mode"] = api_mode
     models = fetch_api_models(api_key, base_url, **fetch_kwargs)
+    declared_models = []
+    raw_declared_models = provider_info.get("models")
+    if isinstance(raw_declared_models, dict) and raw_declared_models:
+        declared_models = [mid.strip() for mid in raw_declared_models.keys() if isinstance(mid, str) and mid.strip()]
+
+    if not models and declared_models:
+        models = declared_models
+        print(f"Endpoint /models unavailable; using {len(models)} configured model(s) from config.yaml.")
 
     if models:
         default_idx = 0

--- a/tests/hermes_cli/test_single_query_concurrency_guard.py
+++ b/tests/hermes_cli/test_single_query_concurrency_guard.py
@@ -1,0 +1,41 @@
+import cli
+
+
+def test_single_query_guard_disabled(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+    monkeypatch.setattr(cli, "_single_query_guard_config", lambda: (0, 0.0))
+
+    with cli._single_query_concurrency_guard("hello") as slot:
+        assert slot is None
+
+
+def test_single_query_guard_rejects_live_slot(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+    monkeypatch.setattr(cli, "_single_query_guard_config", lambda: (1, 0.0))
+    slot_dir = tmp_path / "runtime" / "single-query-slots"
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    (slot_dir / "slot-0.lock").write_text('{"pid": %d}' % cli.os.getpid(), encoding="utf-8")
+
+    try:
+        with cli._single_query_concurrency_guard("hello"):
+            raise AssertionError("expected RuntimeError")
+    except RuntimeError as exc:
+        assert "single-query concurrency limit reached (1)" in str(exc)
+
+
+def test_single_query_guard_reclaims_stale_slot(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "_hermes_home", tmp_path)
+    monkeypatch.setattr(cli, "_single_query_guard_config", lambda: (1, 0.0))
+    monkeypatch.setattr(cli, "_pid_is_running", lambda pid: False)
+    slot_dir = tmp_path / "runtime" / "single-query-slots"
+    slot_dir.mkdir(parents=True, exist_ok=True)
+    stale = slot_dir / "slot-0.lock"
+    stale.write_text('{"pid": 999999}', encoding="utf-8")
+
+    with cli._single_query_concurrency_guard("hello") as slot:
+        assert slot == stale
+        assert stale.exists()
+        payload = stale.read_text(encoding="utf-8")
+        assert str(cli.os.getpid()) in payload
+
+    assert not stale.exists()

--- a/tests/test_custom_provider_model_fallback.py
+++ b/tests/test_custom_provider_model_fallback.py
@@ -1,0 +1,110 @@
+import sys
+from types import SimpleNamespace
+
+from hermes_cli.main import _model_flow_named_custom
+
+
+class _MenuPickFirst:
+    def __init__(self, items, **kwargs):
+        self.items = items
+
+    def show(self):
+        return 0
+
+
+class _MenuChooseDefault:
+    last_items = None
+    last_cursor_index = None
+
+    def __init__(self, items, cursor_index=0, **kwargs):
+        self.items = items
+        self.cursor_index = cursor_index
+        _MenuChooseDefault.last_items = items
+        _MenuChooseDefault.last_cursor_index = cursor_index
+
+    def show(self):
+        return self.cursor_index
+
+
+def test_named_custom_provider_uses_declared_models_when_models_endpoint_unavailable(monkeypatch, capsys):
+    provider_info = {
+        "name": "cpa-codex",
+        "base_url": "http://127.0.0.1:8317/v1",
+        "api_key": "test-key",
+        "key_env": "",
+        "model": "gpt-5.4",
+        "models": {
+            "gpt-5.4": {},
+            "gpt-5.5": {},
+            "gpt-5.4-mini": {},
+        },
+        "api_mode": "chat_completions",
+        "provider_key": "",
+        "api_key_ref": "",
+    }
+
+    cfg = {"model": {}}
+    saved_models = []
+    saved_custom = []
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda new_cfg: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_models.append(model))
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: saved_custom.append((args, kwargs)))
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
+    monkeypatch.setitem(sys.modules, "simple_term_menu", SimpleNamespace(TerminalMenu=_MenuPickFirst))
+    monkeypatch.setattr("hermes_cli.curses_ui.flush_stdin", lambda: None)
+
+    _model_flow_named_custom({}, provider_info)
+
+    out = capsys.readouterr().out
+    assert "Endpoint /models unavailable; using 3 configured model(s) from config.yaml." in out
+    assert "Found 3 model(s):" in out
+    assert saved_models == ["gpt-5.4"]
+    assert cfg["model"]["provider"] == "custom"
+    assert cfg["model"]["base_url"] == "http://127.0.0.1:8317/v1"
+    assert cfg["model"]["api_key"] == "test-key"
+    assert saved_custom, "expected selected model to be persisted back to custom_providers"
+
+
+def test_named_custom_provider_preserves_declared_model_metadata_when_models_endpoint_unavailable(monkeypatch, capsys):
+    provider_info = {
+        "name": "cpa-codex",
+        "base_url": "http://127.0.0.1:8317/v1",
+        "api_key": "test-key",
+        "key_env": "",
+        "model": "gpt-5.5",
+        "models": {
+            "gpt-5.4": {"context_length": 128000},
+            "gpt-5.5": {"context_length": 256000, "supports_vision": True},
+            "gpt-5.4-mini": {"context_length": 64000},
+        },
+        "api_mode": "chat_completions",
+        "provider_key": "",
+        "api_key_ref": "",
+    }
+
+    cfg = {"model": {}}
+    saved_models = []
+    saved_custom = []
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda new_cfg: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_models.append(model))
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: saved_custom.append((args, kwargs)))
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: [])
+    monkeypatch.setitem(sys.modules, "simple_term_menu", SimpleNamespace(TerminalMenu=_MenuChooseDefault))
+    monkeypatch.setattr("hermes_cli.curses_ui.flush_stdin", lambda: None)
+
+    _model_flow_named_custom({}, provider_info)
+
+    out = capsys.readouterr().out
+    assert "Endpoint /models unavailable; using 3 configured model(s) from config.yaml." in out
+    assert saved_models == ["gpt-5.5"]
+    assert _MenuChooseDefault.last_cursor_index == 1
+    assert any("gpt-5.5 (current)" in item for item in _MenuChooseDefault.last_items)
+    assert saved_custom == [
+        (("http://127.0.0.1:8317/v1", "test-key", "gpt-5.5"), {"api_mode": "chat_completions"})
+    ]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -173,6 +173,26 @@ _SENSITIVE_PATH_PREFIXES = (
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
+_hermes_config_resolved: str | None = None
+_hermes_config_resolved_loaded = False
+
+
+def _get_hermes_config_resolved() -> str | None:
+    """Return the resolved absolute path of the Hermes config file (cached)."""
+    global _hermes_config_resolved, _hermes_config_resolved_loaded
+    if _hermes_config_resolved_loaded:
+        return _hermes_config_resolved
+    _hermes_config_resolved_loaded = True
+    try:
+        from hermes_cli.config import get_config_path
+        _hermes_config_resolved = str(get_config_path().resolve())
+    except Exception:
+        try:
+            _hermes_config_resolved = str(Path("~/.hermes/config.yaml").expanduser().resolve())
+        except Exception:
+            _hermes_config_resolved = None
+    return _hermes_config_resolved
+
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
@@ -190,6 +210,15 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
+    # Prevent agents from modifying the Hermes config file directly.
+    # approvals.mode and other control-plane settings live here; a malicious or
+    # prompt-injected agent could silently weaken security by editing config.yaml.
+    hermes_config = _get_hermes_config_resolved()
+    if hermes_config and (resolved == hermes_config or normalized == hermes_config):
+        return (
+            f"Refusing to modify Hermes config file directly: {filepath}\n"
+            "Use `hermes config set`, `hermes config edit`, or an explicit terminal command instead."
+        )
     return None
 
 


### PR DESCRIPTION
## Summary
- Add host-level concurrency guard for one-shot `hermes chat -q` runs
- Preserve declared custom-provider model metadata when `/models` is unavailable
- Harden quick snapshot restore path handling
- Block direct agent file edits to Hermes config.yaml in file tools

## Test Plan
- `python -m pytest -q -o addopts='' tests/hermes_cli/test_single_query_concurrency_guard.py tests/test_custom_provider_model_fallback.py`
