### PR TITLE
feat(tools): add native search router and exact session recall

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1590,6 +1590,21 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             db=session_db,
             current_session_id=agent.session_id,
         )
+    elif function_name == "session_search_exact":
+        session_db = agent._get_session_db_for_recall()
+        if not session_db:
+            from hermes_state import format_session_db_unavailable
+            return json.dumps({"success": False, "error": format_session_db_unavailable()})
+        from tools.session_search_exact_tool import session_search_exact as _session_search_exact
+        return _session_search_exact(
+            query=function_args.get("query", ""),
+            role_filter=function_args.get("role_filter") or None,
+            source_filter=function_args.get("source_filter") or None,
+            limit=function_args.get("limit", 10),
+            group_by_session=function_args.get("group_by_session", True),
+            match_mode=function_args.get("match_mode", "auto"),
+            db=session_db,
+        )
     elif function_name == "memory":
         target = function_args.get("target", "memory")
         from tools.memory_tool import memory_tool as _memory_tool

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -627,6 +627,25 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_duration = time.time() - tool_start_time
             if agent._should_emit_quiet_tool_messages():
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
+        elif function_name == "session_search_exact":
+            session_db = agent._get_session_db_for_recall()
+            if not session_db:
+                from hermes_state import format_session_db_unavailable
+                function_result = json.dumps({"success": False, "error": format_session_db_unavailable()})
+            else:
+                from tools.session_search_exact_tool import session_search_exact as _session_search_exact
+                function_result = _session_search_exact(
+                    query=function_args.get("query", ""),
+                    role_filter=function_args.get("role_filter") or None,
+                    source_filter=function_args.get("source_filter") or None,
+                    limit=function_args.get("limit", 10),
+                    group_by_session=function_args.get("group_by_session", True),
+                    match_mode=function_args.get("match_mode", "auto"),
+                    db=session_db,
+                )
+            tool_duration = time.time() - tool_start_time
+            if agent._should_emit_quiet_tool_messages():
+                agent._vprint(f"  {_get_cute_tool_message_impl('session_search_exact', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
             target = function_args.get("target", "memory")
             from tools.memory_tool import memory_tool as _memory_tool

--- a/tests/tools/test_search_router_tool.py
+++ b/tests/tools/test_search_router_tool.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+from tools.search_router_tool import (
+    DEFAULT_SEARCH_WORKER_TIMEOUT_SECONDS,
+    _build_prompt,
+    _run_worker,
+    _select_worker_python,
+    _summarize_packet,
+    search_router_tool,
+)
+
+
+def test_search_router_tool_success(monkeypatch):
+    packet = {
+        "query_intent": "确认官方文档入口",
+        "searches_performed": [{"tool": "web_search", "query": "Hermes Agent docs"}],
+        "sources": [{"title": "Official Docs", "url": "https://hermes-agent.nousresearch.com/docs/", "source_type": "official"}],
+        "key_findings": ["官方文档入口存在"],
+        "conflicts": [],
+        "unknowns": [],
+        "recommended_next_step": "如需更细节，继续抽子页面",
+    }
+
+    def fake_run_worker(prompt: str, profile: str, provider: str, model: str):
+        assert "任务目标" in prompt
+        assert profile == "search-worker"
+        assert provider == "ctyun"
+        assert model == "DeepSeek-V4-Flash"
+        return SimpleNamespace(returncode=0, stdout="前言\n```json\n" + json.dumps(packet, ensure_ascii=False) + "\n```", stderr="")
+
+    monkeypatch.setattr("tools.search_router_tool._run_worker", fake_run_worker)
+    payload = json.loads(search_router_tool(task_goal="确认官方文档入口"))
+
+    assert payload["success"] is True
+    assert payload["packet"]["query_intent"] == "确认官方文档入口"
+    assert payload["issues"] == []
+    assert "stdout 在 JSON 前包含额外文本" in payload["warnings"]
+    assert "stdout 在 JSON 后包含额外文本" in payload["warnings"]
+    assert "**结论**" in payload["assistant_brief"]
+    assert "Official Docs" in payload["assistant_brief"]
+
+
+def test_search_router_tool_success_when_output_is_bare_json(monkeypatch):
+    packet = {
+        "query_intent": "确认官方文档入口",
+        "searches_performed": [{"tool": "web_search", "query": "Hermes Agent docs"}],
+        "sources": [{"title": "Official Docs", "url": "https://hermes-agent.nousresearch.com/docs/", "source_type": "official"}],
+        "key_findings": ["官方文档入口存在"],
+        "conflicts": [],
+        "unknowns": [],
+        "recommended_next_step": "如需更细节，继续抽子页面",
+    }
+
+    def fake_run_worker(prompt: str, profile: str, provider: str, model: str):
+        return SimpleNamespace(returncode=0, stdout=json.dumps(packet, ensure_ascii=False), stderr="")
+
+    monkeypatch.setattr("tools.search_router_tool._run_worker", fake_run_worker)
+    payload = json.loads(search_router_tool(task_goal="确认官方文档入口"))
+
+    assert payload["success"] is True
+    assert payload["issues"] == []
+
+
+def test_search_router_tool_worker_failure(monkeypatch):
+    def fake_run_worker(prompt: str, profile: str, provider: str, model: str):
+        return SimpleNamespace(returncode=9, stdout="oops", stderr="boom")
+
+    monkeypatch.setattr("tools.search_router_tool._run_worker", fake_run_worker)
+    payload = json.loads(search_router_tool(task_goal="确认官方文档入口"))
+
+    assert payload["success"] is False
+    assert payload["error_type"] == "worker_process_failed"
+    assert payload["exit_code"] == 9
+
+
+def test_search_router_tool_parse_failure(monkeypatch):
+    def fake_run_worker(prompt: str, profile: str, provider: str, model: str):
+        return SimpleNamespace(returncode=0, stdout="没有json", stderr="")
+
+    monkeypatch.setattr("tools.search_router_tool._run_worker", fake_run_worker)
+    payload = json.loads(search_router_tool(task_goal="确认官方文档入口"))
+
+    assert payload["success"] is False
+    assert payload["error_type"] == "json_extract_or_parse_failed"
+
+
+def test_search_router_tool_worker_timeout(monkeypatch):
+    def fake_run_worker(prompt: str, profile: str, provider: str, model: str):
+        raise subprocess.TimeoutExpired(
+            cmd=["hermes", "chat"], timeout=DEFAULT_SEARCH_WORKER_TIMEOUT_SECONDS, output="partial out", stderr="partial err"
+        )
+
+    monkeypatch.setattr("tools.search_router_tool._run_worker", fake_run_worker)
+    payload = json.loads(search_router_tool(task_goal="确认官方文档入口"))
+
+    assert payload["success"] is False
+    assert payload["error_type"] == "worker_timeout"
+    assert payload["worker_profile"] == "search-worker"
+    assert payload["worker_provider"] == "ctyun"
+    assert payload["worker_model"] == "DeepSeek-V4-Flash"
+    assert payload["stdout_head"] == "partial out"
+    assert payload["stderr_tail"] == "partial err"
+
+
+def test_build_prompt_enforces_stop_conditions():
+    prompt = _build_prompt("确认官方文档入口", "官方源 + 中文公开讨论", 2)
+
+    assert "达到 min_sources 且已有官方/一手源时，优先停止" in prompt
+    assert "不要为了“更完整”而无限追加相近来源" in prompt
+    assert "不要自行继续扩题" in prompt
+    assert "如果输出任何 JSON 之外的前言、总结、解释、markdown 代码块或围栏，视为失败" in prompt
+
+
+def test_summarize_packet_flattens_dicts():
+    brief = _summarize_packet(
+        {
+            "key_findings": [{"a": "结论A", "b": "结论B"}],
+            "sources": [{"title": "源1", "url": "https://x", "source_type": "official"}],
+            "conflicts": [{"desc": "口径不同"}],
+            "unknowns": [{"u": "版本号未确认"}],
+            "recommended_next_step": {"n": "继续查 release"},
+        }
+    )
+
+    assert "结论A" in brief
+    assert "结论B" in brief
+    assert "口径不同" in brief
+    assert "版本号未确认" in brief
+    assert "继续查 release" in brief
+
+
+def test_select_worker_python_prefers_venv_then_dotvenv_then_sys_executable(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    venv_python = repo_root / "venv" / "bin" / "python"
+    dotvenv_python = repo_root / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    dotvenv_python.parent.mkdir(parents=True)
+    venv_python.write_text("#!/bin/sh\n")
+    dotvenv_python.write_text("#!/bin/sh\n")
+
+    monkeypatch.setattr("tools.search_router_tool.os.access", lambda path, mode: True)
+    monkeypatch.setattr("tools.search_router_tool.sys.executable", "/fallback/python")
+
+    assert _select_worker_python(repo_root) == str(venv_python)
+
+    venv_python.unlink()
+    assert _select_worker_python(repo_root) == str(dotvenv_python)
+
+    dotvenv_python.unlink()
+    assert _select_worker_python(repo_root) == "/fallback/python"
+
+
+def test_run_worker_sanitizes_empty_profile_provider_and_model(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile_dir = root / "profiles" / "search-worker"
+    profile_dir.mkdir(parents=True)
+
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, env, timeout):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["timeout"] = timeout
+        return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr("tools.search_router_tool.get_default_hermes_root", lambda: root)
+    monkeypatch.setattr("tools.search_router_tool.subprocess.run", fake_run)
+    monkeypatch.setattr("tools.search_router_tool._select_worker_python", lambda: "/repo/venv/bin/python")
+
+    _run_worker(prompt="只输出{}", profile="", provider="", model="")
+
+    assert captured["cmd"] == [
+        "/repo/venv/bin/python",
+        "-m",
+        "hermes_cli.main",
+        "chat",
+        "-q",
+        "只输出{}",
+        "-Q",
+    ]
+    assert captured["env"]["HERMES_HOME"] == str(profile_dir)
+    assert captured["timeout"] == DEFAULT_SEARCH_WORKER_TIMEOUT_SECONDS
+
+
+def test_run_worker_includes_provider_and_model_only_when_non_empty(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile_dir = root / "profiles" / "search-worker"
+    profile_dir.mkdir(parents=True)
+
+    captured = {}
+
+    def fake_run(cmd, capture_output, text, env, timeout):
+        captured["cmd"] = cmd
+        captured["env"] = env
+        captured["timeout"] = timeout
+        return SimpleNamespace(returncode=0, stdout="{}", stderr="")
+
+    monkeypatch.setattr("tools.search_router_tool.get_default_hermes_root", lambda: root)
+    monkeypatch.setattr("tools.search_router_tool.subprocess.run", fake_run)
+    monkeypatch.setattr("tools.search_router_tool._select_worker_python", lambda: "/repo/venv/bin/python")
+
+    _run_worker(prompt="只输出{}", profile="search-worker", provider="ctyun", model="DeepSeek-V4-Flash")
+
+    assert captured["cmd"] == [
+        "/repo/venv/bin/python",
+        "-m",
+        "hermes_cli.main",
+        "chat",
+        "-q",
+        "只输出{}",
+        "-Q",
+        "--provider",
+        "ctyun",
+        "-m",
+        "DeepSeek-V4-Flash",
+    ]
+    assert captured["env"]["HERMES_HOME"] == str(profile_dir)
+    assert captured["timeout"] == DEFAULT_SEARCH_WORKER_TIMEOUT_SECONDS

--- a/tests/tools/test_session_search_exact_tool.py
+++ b/tests/tools/test_session_search_exact_tool.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    db_path = tmp_path / "test_state.db"
+    session_db = SessionDB(db_path=db_path)
+    yield session_db
+    session_db.close()
+
+
+def test_exact_token_hit_returns_raw_snippet(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    db.create_session(session_id="s1", source="feishu")
+    db.append_message("s1", role="assistant", content="management key is c61f7999114fe65e099f5c0ca7af851e")
+
+    payload = json.loads(session_search_exact(query="c61f7999114fe65e099f5c0ca7af851e", db=db))
+
+    assert payload["success"] is True
+    assert payload["mode"] == "exact"
+    assert payload["count"] == 1
+    assert payload["results"][0]["session_id"] == "s1"
+    assert "c61f7999114fe65e099f5c0ca7af851e" in payload["results"][0]["snippet"]
+
+
+def test_group_by_session_false_preserves_multiple_hits(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    db.create_session(session_id="s1", source="cli")
+    db.append_message("s1", role="user", content="uuid 123e4567-e89b-12d3-a456-426614174000")
+    db.append_message("s1", role="assistant", content="same uuid 123e4567-e89b-12d3-a456-426614174000 again")
+
+    payload = json.loads(
+        session_search_exact(
+            query="123e4567-e89b-12d3-a456-426614174000",
+            group_by_session=False,
+            limit=10,
+            db=db,
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["count"] >= 2
+    assert all(item["session_id"] == "s1" for item in payload["results"])
+
+
+def test_group_by_session_true_dedupes_session_hits(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    db.create_session(session_id="s1", source="cli")
+    db.append_message("s1", role="user", content="remote-management.secret-key is enabled")
+    db.append_message("s1", role="assistant", content="I repeated remote-management.secret-key for validation")
+
+    payload = json.loads(
+        session_search_exact(
+            query='"remote-management.secret-key"',
+            group_by_session=True,
+            limit=10,
+            db=db,
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["count"] == 1
+    assert payload["results"][0]["session_id"] == "s1"
+
+
+def test_source_and_role_filters_apply(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    db.create_session(session_id="s1", source="feishu")
+    db.append_message("s1", role="assistant", content="error path /var/log/app/error.log")
+
+    db.create_session(session_id="s2", source="cli")
+    db.append_message("s2", role="user", content="error path /var/log/app/error.log")
+
+    payload = json.loads(
+        session_search_exact(
+            query="/var/log/app/error.log",
+            source_filter="feishu",
+            role_filter="assistant",
+            db=db,
+        )
+    )
+
+    assert payload["success"] is True
+    assert payload["count"] == 1
+    assert payload["match_mode"] == "substring"
+    assert payload["results"][0]["source"] == "feishu"
+    assert payload["results"][0]["role"] == "assistant"
+
+
+def test_auto_mode_prefers_real_content_over_query_echo_noise(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    db.create_session(session_id="s1", source="feishu")
+    db.append_message("s1", role="assistant", content="real key c61f7999114fe65e099f5c0ca7af851e stored here")
+    db.append_message("s1", role="assistant", content="")
+
+    payload = json.loads(session_search_exact(query="c61f7999114fe65e099f5c0ca7af851e", db=db))
+
+    assert payload["success"] is True
+    assert payload["count"] >= 1
+    assert any(
+        "real key c61f7999114fe65e099f5c0ca7af851e" in (
+            (item.get("snippet") or "")
+            .replace(">>>", "")
+            .replace("<<<", "")
+            or (item.get("content") or "")
+            or " ".join(ctx.get("content", "") for ctx in item.get("context") or [])
+        )
+        for item in payload["results"]
+    )
+
+
+def test_ranking_demotes_tool_call_echoes(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    db.create_session(session_id="s1", source="feishu")
+    db.append_message("s1", role="assistant", content='[{"id":"call_1","function":{"name":"session_search","arguments":"{\\"query\\":\\"c61f7999114fe65e099f5c0ca7af851e\\"}"}}]')
+    db.append_message("s1", role="assistant", content="管理密钥就是 c61f7999114fe65e099f5c0ca7af851e")
+
+    payload = json.loads(session_search_exact(query="c61f7999114fe65e099f5c0ca7af851e", group_by_session=False, db=db))
+
+    assert payload["success"] is True
+    assert payload["count"] >= 1
+    top = payload["results"][0]
+    top_text = (top.get("snippet") or "") + " " + (top.get("content") or "")
+    assert "管理密钥就是" in top_text
+
+
+def test_invalid_match_mode_returns_error(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    payload = json.loads(session_search_exact(query="docker", match_mode="boom", db=db))
+    assert payload["success"] is False
+    assert "match_mode must be one of" in payload["error"]
+
+
+def test_missing_query_returns_error(db):
+    from tools.session_search_exact_tool import session_search_exact
+
+    payload = json.loads(session_search_exact(query="", db=db))
+    assert payload["success"] is False
+    assert "query is required" in payload["error"]

--- a/tools/search_router_tool.py
+++ b/tools/search_router_tool.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Native search-router tool for Hermes.
+
+Routes public/external search tasks to the dedicated ``search-worker`` profile,
+normalizes its output into a validated evidence packet, and returns both the raw
+packet and a compact assistant brief for the parent agent to synthesize.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from hermes_constants import get_default_hermes_root
+from tools.registry import registry, tool_error, tool_result
+
+REQUIRED_KEYS = [
+    "query_intent",
+    "searches_performed",
+    "sources",
+    "key_findings",
+    "conflicts",
+    "unknowns",
+    "recommended_next_step",
+]
+
+DEFAULT_SEARCH_WORKER_TIMEOUT_SECONDS = 120
+
+_DEF_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_QUOTA_PATTERNS = (
+    r"HTTP\s*432",
+    r"usage limit exceeded",
+    r"exceeds your plan(?:'s)? set usage limit",
+    r"plan usage limit",
+    r"quota exhausted",
+    r"quota exceeded",
+)
+
+
+SEARCH_ROUTER_SCHEMA = {
+    "name": "search_router",
+    "description": (
+        "Route a public/external search task to the dedicated search-worker profile and return "
+        "a normalized evidence packet plus a compact Chinese brief. Use this as the DEFAULT "
+        "tool for broad web research, official-source checks, multi-source evidence gathering, "
+        "and tasks needing official + community / Chinese + international cross-checks. Prefer "
+        "this over direct web_search/web_extract when the task is not a trivial one-shot lookup."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_goal": {
+                "type": "string",
+                "description": "What the search-worker should find or verify.",
+            },
+            "coverage": {
+                "type": "string",
+                "description": "Coverage requirements such as official source + Chinese public discussion.",
+            },
+            "min_sources": {
+                "type": "integer",
+                "description": "Minimum number of sources required.",
+                "default": 2,
+            },
+            "model": {
+                "type": "string",
+                "description": "Optional worker model override. Defaults to DeepSeek-V4-Flash.",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Optional worker provider override. Defaults to ctyun.",
+            },
+            "profile": {
+                "type": "string",
+                "description": "Worker profile name. Defaults to search-worker.",
+            },
+            "debug": {
+                "type": "boolean",
+                "description": "Include debug fields such as prompt and raw stdout snippets.",
+                "default": False,
+            },
+        },
+        "required": ["task_goal"],
+    },
+}
+
+
+def check_search_router_requirements() -> bool:
+    """Expose the tool unconditionally; runtime errors are returned explicitly."""
+    return True
+
+
+def _build_prompt(task_goal: str, coverage: str, min_sources: int) -> str:
+    coverage = (coverage or "").strip() or "至少覆盖 1 条官方/一手来源；如主题涉及中文公开讨论，也覆盖至少 1 条中文公开来源；已知 URL/正文抽取/多页抓取优先走 Firecrawl，docs/code/security/英文技术资料 first-pass 优先 AnySearch。"
+    min_sources = max(1, int(min_sources or 2))
+    return (
+        "你是 search-worker。\n\n"
+        f"任务目标：\n{task_goal.strip()}\n\n"
+        "搜索约束：\n"
+        "- 中文实时/国内信息：优先用本地百度搜索脚本；必要时补 Tavily / AnySearch / 官方站点，但不要默认先走 AnySearch 或 Firecrawl。\n"
+        "- docs / code / security / URL extract / 英文技术资料 first-pass：优先 AnySearch；但如果任务明显会很快进入正文抽取、官网页面读取或多页抓取，尽早切 Firecrawl。\n"
+        "- Firecrawl 已在当前体系验证可用，优先把它用于：URL extract / 已知站点正文 / multi-page crawl / extract-heavy research / docs discovery 后大概率还要拉正文。\n"
+        "- 强规则：只要任务已进入 URL extract / 已知站点正文 / docs discovery 后马上要拉正文 这类场景，默认必须先尝试 Firecrawl 抽取；只有 Firecrawl 失败、被目标站点拦截、或证据明确不足时，才回退 AnySearch extract / 其他抽取链。\n"
+        "- 通用公网未知问题：优先走 Tavily 做 first-hop；拿到候选 URL 后尽快切抽取链，不要在同一问题上长时间重复 search。\n"
+        "- 如果需要平台/CLI 搜索，可通过 terminal 调本机工具，但只限搜索/读取/抽取相关命令。\n"
+        "- 对 academic 主研究链、中文主搜索链、平台原生搜索，不要默认让 AnySearch 或 Firecrawl 抢 first-hop。\n"
+        "- 默认不要上 browser；只有静态搜索不足时，才把升级建议写进 recommended_next_step。\n"
+        "- 当 Firecrawl 被使用时，在 searches_performed 里明确记录 web_search(firecrawl)、web_extract(firecrawl)、web_crawl(firecrawl) 或等价描述，避免主 agent 无法判断是否真的命中该路由。\n\n"
+        "- 成本纪律：默认串行取证，同一轮不要并发开多个搜索/抽取工具调用；先做 1 次 first-hop，再决定下一步。\n"
+        "- 预算纪律：除非任务天然需要宽覆盖，单任务默认控制在 最多 3 次 search + 2 次 extract 的量级。\n"
+        "- 达到 min_sources 且已有官方/一手源后优先停止，不要继续横向扩张相近来源。\n"
+        "- 如果 2~3 条高质量来源已经足够支撑核心判断，直接收口；剩余缺口写进 unknowns / recommended_next_step。\n\n"
+        "结果要求：\n"
+        "- 只输出 evidence packet 所需内容。\n"
+        f"- 必须覆盖：{coverage}\n"
+        "- 如果证据不足，不要硬下结论，把缺口写进 unknowns。\n"
+        "- 如果有冲突来源，把冲突写进 conflicts。\n"
+        "- 必须输出严格 JSON，对象字段固定为：\n"
+        "  query_intent, searches_performed, sources, key_findings, conflicts, unknowns, recommended_next_step\n"
+        "- 如果输出任何 JSON 之外的前言、总结、解释、markdown 代码块或围栏，视为失败。\n\n"
+        "质量要求：\n"
+        "- 尽量包含一手源/官方源\n"
+        "- 找到链接不等于完成验证，能抽正文就抽正文\n"
+        f"- sources 至少 {min_sources} 条\n"
+        "- 达到 min_sources 且已有官方/一手源时，优先停止，不继续横向扩张。\n"
+        "- 不要为了“更完整”而无限追加相近来源。\n"
+        "- 不要为了“更完整”把同类型 search 连续铺开；每多一次 search/extract 都要有明确新增价值。\n"
+        "- 如果还需深挖，把缺口写进 recommended_next_step，不要自行继续扩题。\n"
+        "- 结果交给主 agent，不需要替最终用户拍板\n"
+    ).strip()
+
+
+def _extract_first_json_object(text: str) -> str:
+    start = text.find("{")
+    if start == -1:
+        raise ValueError("stdout 中未找到 JSON 起始符 {")
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+    raise ValueError("stdout 中找到 { 但未找到完整闭合 JSON 对象")
+
+
+def _detect_non_json_wrapper_text(text: str, json_text: str) -> List[str]:
+    start = text.find(json_text)
+    if start == -1:
+        return []
+    prefix = text[:start].strip()
+    suffix = text[start + len(json_text) :].strip()
+    issues: List[str] = []
+    if prefix:
+        issues.append("stdout 在 JSON 前包含额外文本")
+    if suffix:
+        issues.append("stdout 在 JSON 后包含额外文本")
+    return issues
+
+
+def _validate_packet(obj: Dict[str, Any]) -> List[str]:
+    missing = [k for k in REQUIRED_KEYS if k not in obj]
+    type_errors = []
+    if "searches_performed" in obj and not isinstance(obj["searches_performed"], list):
+        type_errors.append("searches_performed 不是数组")
+    if "sources" in obj and not isinstance(obj["sources"], list):
+        type_errors.append("sources 不是数组")
+    if "key_findings" in obj and not isinstance(obj["key_findings"], list):
+        type_errors.append("key_findings 不是数组")
+    if "conflicts" in obj and not isinstance(obj["conflicts"], list):
+        type_errors.append("conflicts 不是数组")
+    if "unknowns" in obj and not isinstance(obj["unknowns"], list):
+        type_errors.append("unknowns 不是数组")
+    if "recommended_next_step" in obj and not isinstance(obj["recommended_next_step"], (str, dict, list)):
+        type_errors.append("recommended_next_step 类型不合法")
+    return missing + type_errors
+
+
+def _looks_like_quota_exhausted(*texts: Any) -> bool:
+    parts: List[str] = []
+    for t in texts:
+        if isinstance(t, bytes):
+            parts.append(t.decode("utf-8", errors="ignore"))
+        elif isinstance(t, str):
+            parts.append(t)
+    haystack = "\n".join(parts).lower()
+    if not haystack:
+        return False
+    return any(re.search(pattern, haystack, flags=re.IGNORECASE) for pattern in _QUOTA_PATTERNS)
+
+
+def _bulletize(item: Any) -> List[str]:
+    if isinstance(item, str):
+        text = item.strip()
+        return [text] if text else []
+    if isinstance(item, dict):
+        vals = [str(v).strip() for v in item.values() if str(v).strip()]
+        return vals or [json.dumps(item, ensure_ascii=False)]
+    if isinstance(item, list):
+        out: List[str] = []
+        for x in item:
+            out.extend(_bulletize(x))
+        return out
+    text = str(item).strip()
+    return [text] if text else []
+
+
+def _summarize_packet(packet: Dict[str, Any]) -> str:
+    lines: List[str] = ["**结论**"]
+    bullets: List[str] = []
+    for item in (packet.get("key_findings") or [])[:6]:
+        bullets.extend(_bulletize(item))
+    if bullets:
+        for item in bullets[:6]:
+            lines.append(f"- {item}")
+    else:
+        lines.append("- 暂无足够结论")
+
+    srcs = packet.get("sources") or []
+    if srcs:
+        lines.extend(["", "**关键信源**"])
+        for s in srcs[:5]:
+            if isinstance(s, dict):
+                title = s.get("title", "未命名来源")
+                stype = s.get("source_type", "")
+                url = s.get("url", "")
+                lines.append(f"- {title}｜{stype}｜{url}")
+            else:
+                lines.append(f"- {s}")
+
+    conflict_bullets: List[str] = []
+    for item in (packet.get("conflicts") or [])[:4]:
+        conflict_bullets.extend(_bulletize(item))
+    if conflict_bullets:
+        lines.extend(["", "**冲突/注意点**"])
+        for item in conflict_bullets[:4]:
+            lines.append(f"- {item}")
+
+    unknown_bullets: List[str] = []
+    for item in (packet.get("unknowns") or [])[:4]:
+        unknown_bullets.extend(_bulletize(item))
+    if unknown_bullets:
+        lines.extend(["", "**未确认**"])
+        for item in unknown_bullets[:4]:
+            lines.append(f"- {item}")
+
+    next_bullets = _bulletize(packet.get("recommended_next_step"))[:4]
+    if next_bullets:
+        lines.extend(["", "**建议下一步**"])
+        for item in next_bullets:
+            lines.append(f"- {item}")
+    return "\n".join(lines).strip()
+
+
+def _select_worker_python(repo_root: Path = _DEF_REPO_ROOT) -> str:
+    candidates = [
+        repo_root / "venv" / "bin" / "python",
+        repo_root / ".venv" / "bin" / "python",
+    ]
+    for candidate in candidates:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return sys.executable
+
+
+def _run_worker(
+    prompt: str,
+    profile: str,
+    provider: str,
+    model: str,
+    timeout_seconds: int = DEFAULT_SEARCH_WORKER_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess:
+    root = get_default_hermes_root()
+    profile = (profile or "").strip() or "search-worker"
+    provider = (provider or "").strip()
+    model = (model or "").strip()
+
+    profile_dir = root / "profiles" / profile
+    if not profile_dir.exists():
+        raise FileNotFoundError(f"search-worker profile 不存在: {profile_dir}")
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(root / "profiles" / profile)
+
+    worker_python = _select_worker_python()
+
+    cmd = [
+        worker_python,
+        "-m",
+        "hermes_cli.main",
+        "chat",
+        "-q",
+        prompt,
+        "-Q",
+    ]
+    if provider:
+        cmd.extend(["--provider", provider])
+    if model:
+        cmd.extend(["-m", model])
+    return subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=timeout_seconds)
+
+
+def search_router_tool(
+    task_goal: str,
+    coverage: str = None,
+    min_sources: int = 2,
+    model: str = "DeepSeek-V4-Flash",
+    provider: str = "ctyun",
+    profile: str = "search-worker",
+    debug: bool = False,
+) -> str:
+    task_goal = (task_goal or "").strip()
+    if not task_goal:
+        return tool_error("task_goal is required", success=False)
+
+    prompt = _build_prompt(task_goal, coverage or "", min_sources)
+
+    try:
+        proc = _run_worker(prompt=prompt, profile=profile, provider=provider, model=model)
+    except FileNotFoundError as e:
+        return tool_error(str(e), success=False, error_type="profile_missing")
+    except subprocess.TimeoutExpired as e:
+        stdout_head = ((e.stdout or "")[:2000] if isinstance(e.stdout, str) else "")
+        stderr_tail = ((e.stderr or "")[-1000:] if isinstance(e.stderr, str) else "")
+        quota_exhausted = _looks_like_quota_exhausted(stdout_head, stderr_tail, str(e))
+        return tool_result(
+            success=False,
+            error_type="quota_exhausted" if quota_exhausted else "worker_timeout",
+            message=str(e),
+            stdout_head=stdout_head,
+            stderr_tail=stderr_tail,
+            worker_profile=profile,
+            worker_provider=provider,
+            worker_model=model,
+            quota_exhausted=quota_exhausted,
+            recommended_fallback=(
+                "Install/use ddgs or configure searxng/exa/firecrawl/parallel; avoid hard-locking search_backend=tavily"
+                if quota_exhausted
+                else "Inspect worker logs / provider rate limits / backend availability"
+            ),
+        )
+    except Exception as e:
+        return tool_error(f"search-worker 调用失败: {e}", success=False, error_type="spawn_failed")
+
+    if proc.returncode != 0:
+        stdout_head = (proc.stdout or "")[:2000]
+        stderr_tail = (proc.stderr or "")[-2000:]
+        quota_exhausted = _looks_like_quota_exhausted(stdout_head, stderr_tail)
+        return tool_result(
+            success=False,
+            error_type="quota_exhausted" if quota_exhausted else "worker_process_failed",
+            exit_code=proc.returncode,
+            stderr=stderr_tail,
+            stdout_head=stdout_head,
+            quota_exhausted=quota_exhausted,
+            recommended_fallback=(
+                "Install/use ddgs or configure searxng/exa/firecrawl/parallel; avoid hard-locking search_backend=tavily"
+                if quota_exhausted
+                else "Inspect worker stderr/stdout and router-vs-profile runtime"
+            ),
+        )
+
+    try:
+        json_text = _extract_first_json_object(proc.stdout or "")
+        obj = json.loads(json_text)
+        validation_issues = _validate_packet(obj)
+        wrapper_warnings = _detect_non_json_wrapper_text(proc.stdout or "", json_text)
+        payload: Dict[str, Any] = {
+            "success": len(validation_issues) == 0,
+            "issues": validation_issues,
+            "warnings": wrapper_warnings,
+            "packet": obj,
+            "assistant_brief": _summarize_packet(obj),
+            "worker_profile": profile,
+            "worker_provider": provider,
+            "worker_model": model,
+        }
+        if debug:
+            payload["debug"] = {
+                "prompt": prompt,
+                "raw_stdout_head": (proc.stdout or "")[:2000],
+                "raw_stderr_tail": (proc.stderr or "")[-1000:],
+            }
+        return tool_result(payload)
+    except Exception as e:
+        return tool_result(
+            success=False,
+            error_type="json_extract_or_parse_failed",
+            message=str(e),
+            stdout_head=(proc.stdout or "")[:2000],
+            stderr_tail=(proc.stderr or "")[-1000:],
+        )
+
+
+registry.register(
+    name="search_router",
+    toolset="web",
+    schema=SEARCH_ROUTER_SCHEMA,
+    handler=lambda args, **kw: search_router_tool(
+        task_goal=args.get("task_goal", ""),
+        coverage=args.get("coverage"),
+        min_sources=args.get("min_sources", 2),
+        model=args.get("model", "DeepSeek-V4-Flash"),
+        provider=args.get("provider", "ctyun"),
+        profile=args.get("profile", "search-worker"),
+        debug=bool(args.get("debug", False)),
+    ),
+    check_fn=check_search_router_requirements,
+    emoji="🧭",
+)

--- a/tools/session_search_exact_tool.py
+++ b/tools/session_search_exact_tool.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Session Search Exact Tool - Cross-Session Exact Recall
+
+Returns raw message-level or session-grouped hits from the SQLite session store
+without any LLM summarization. This is the exact-recall complement to
+``session_search``: use it for keys, hashes, UUIDs, long paths, long error
+strings, and exact quoted phrases that must be recovered verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import sqlite3
+
+from tools.registry import registry, tool_error
+
+
+_MATCH_MODES = {"auto", "fts", "substring"}
+
+
+def _score_hit(result: Dict[str, Any], query: str) -> tuple:
+    snippet = str(result.get("snippet") or "")
+    role = str(result.get("role") or "")
+    source = str(result.get("source") or "")
+    content = str(result.get("content") or "")
+    text = content or snippet
+    lower = text.lower()
+    q = query.lower()
+
+    plain_text_bonus = 0
+    if q in lower:
+        plain_text_bonus += 4
+    if "\\\"query\\\"" in snippet or '"function"' in snippet or 'call_' in snippet:
+        plain_text_bonus -= 5
+    if snippet.lstrip().startswith("[") or snippet.lstrip().startswith("{"):
+        plain_text_bonus -= 3
+    if "session_search" in lower or "session_search_exact" in lower:
+        plain_text_bonus -= 3
+    if "当前能搜到的历史会话里，没找到" in text:
+        plain_text_bonus -= 4
+    if "key_plaintext" in text or "remote-management.secret-key" in text:
+        plain_text_bonus += 2
+    if role == "user":
+        plain_text_bonus += 2
+    elif role == "assistant":
+        plain_text_bonus += 1
+    elif role == "tool":
+        plain_text_bonus -= 2
+    if source == "feishu":
+        plain_text_bonus += 1
+    return (plain_text_bonus, float(result.get("timestamp") or 0.0), int(result.get("id") or 0))
+
+
+def _split_csv(value: Optional[str]) -> Optional[List[str]]:
+    if value is None:
+        return None
+    parts = [p.strip() for p in str(value).split(",") if p and p.strip()]
+    return parts or None
+
+
+def _format_exact_hit(result: Dict[str, Any], match_mode: str) -> Dict[str, Any]:
+    return {
+        "message_id": result.get("id"),
+        "session_id": result.get("session_id"),
+        "role": result.get("role"),
+        "source": result.get("source"),
+        "model": result.get("model"),
+        "when": result.get("timestamp"),
+        "session_started": result.get("session_started"),
+        "snippet": result.get("snippet") or (result.get("content") or "")[:240],
+        "content": result.get("content") or "",
+        "tool_name": result.get("tool_name"),
+        "context": result.get("context") if isinstance(result.get("context"), list) else [],
+        "match_type": match_mode,
+    }
+
+
+def _search_messages_substring(
+    db,
+    query: str,
+    source_filter: Optional[List[str]],
+    role_filter: Optional[List[str]],
+    limit: int,
+) -> List[Dict[str, Any]]:
+    escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    where = ["m.content LIKE ? ESCAPE '\\'"]
+    params: List[Any] = [f"%{escaped}%"]
+    if source_filter is not None:
+        where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+        params.extend(source_filter)
+    if role_filter:
+        where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+        params.extend(role_filter)
+    sql = f"""
+        SELECT m.id, m.session_id, m.role,
+               substr(m.content, max(1, instr(m.content, ?) - 40), 160) AS snippet,
+               m.content, m.timestamp, m.tool_name,
+               s.source, s.model, s.started_at AS session_started
+        FROM messages m
+        JOIN sessions s ON s.id = m.session_id
+        WHERE {' AND '.join(where)}
+        ORDER BY m.timestamp DESC
+        LIMIT ?
+    """
+    bind = [query] + params + [limit]
+    with db._lock:
+        cursor = db._conn.execute(sql, bind)
+        matches = [dict(row) for row in cursor.fetchall()]
+    for match in matches:
+        match.setdefault("context", [])
+    return matches
+
+
+def check_session_search_exact_requirements() -> bool:
+    try:
+        from hermes_state import DEFAULT_DB_PATH
+        return DEFAULT_DB_PATH.parent.exists()
+    except ImportError:
+        return False
+
+
+def session_search_exact(
+    query: str,
+    role_filter: str = None,
+    source_filter: str = None,
+    limit: int = 10,
+    group_by_session: bool = True,
+    match_mode: str = "auto",
+    db=None,
+) -> str:
+    if db is None:
+        return tool_error("Session database not available.", success=False)
+
+    query = (query or "").strip()
+    if not query:
+        return tool_error("query is required for session_search_exact.", success=False)
+
+    if not isinstance(limit, int):
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 10
+    limit = max(1, min(limit, 50))
+
+    if not isinstance(group_by_session, bool):
+        group_by_session = bool(group_by_session)
+
+    match_mode = str(match_mode or "auto").strip().lower()
+    if match_mode not in _MATCH_MODES:
+        return tool_error(
+            "match_mode must be one of: auto, fts, substring",
+            success=False,
+        )
+
+    role_list = _split_csv(role_filter)
+    source_list = _split_csv(source_filter)
+
+    def _normalize_substring_query(value: str) -> str:
+        stripped = value.strip()
+        if stripped.startswith('"') and stripped.endswith('"') and len(stripped) >= 2:
+            return stripped[1:-1]
+        return stripped
+
+    fetch_limit = limit if not group_by_session else min(max(limit * 3, limit), 200)
+
+    try:
+        primary_query = _normalize_substring_query(query) if match_mode == "substring" else query
+        raw_results = db.search_messages(
+            query=primary_query,
+            source_filter=source_list,
+            role_filter=role_list,
+            limit=fetch_limit,
+            offset=0,
+        )
+        effective_match_mode = match_mode
+        if match_mode == "auto" and not raw_results:
+            fallback_query = _normalize_substring_query(query)
+            raw_results = _search_messages_substring(
+                db=db,
+                query=fallback_query,
+                source_filter=source_list,
+                role_filter=role_list,
+                limit=fetch_limit,
+            )
+            if raw_results:
+                effective_match_mode = "substring"
+        elif match_mode == "substring":
+            raw_results = _search_messages_substring(
+                db=db,
+                query=_normalize_substring_query(query),
+                source_filter=source_list,
+                role_filter=role_list,
+                limit=fetch_limit,
+            )
+            effective_match_mode = "substring"
+    except (sqlite3.Error, Exception) as e:
+        return tool_error(f"Exact session search failed: {e}", success=False)
+
+    ranked_rows = sorted(raw_results or [], key=lambda row: _score_hit(row, query), reverse=True)
+
+    results: List[Dict[str, Any]] = []
+    seen_sessions = set()
+    for row in ranked_rows:
+        item = _format_exact_hit(row, effective_match_mode)
+        if group_by_session:
+            sid = item.get("session_id")
+            if sid in seen_sessions:
+                continue
+            seen_sessions.add(sid)
+        results.append(item)
+        if len(results) >= limit:
+            break
+
+    return json.dumps(
+        {
+            "success": True,
+            "query": query,
+            "mode": "exact",
+            "match_mode": effective_match_mode,
+            "group_by_session": group_by_session,
+            "results": results,
+            "count": len(results),
+            "message": "No exact matches found." if not results else None,
+        },
+        ensure_ascii=False,
+    )
+
+
+SESSION_SEARCH_EXACT_SCHEMA = {
+    "name": "session_search_exact",
+    "description": (
+        "Cross-session exact recall for raw strings and message-level evidence. "
+        "Use this for keys, hashes, UUIDs, long paths, long error strings, and quoted phrases "
+        "when you need the original snippet, not a summary. Unlike session_search, this tool does "
+        "NOT summarize with an LLM — it returns exact hits from the session database."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Exact string, phrase, path, key, hash, UUID, or search expression to recover from past sessions.",
+            },
+            "role_filter": {
+                "type": "string",
+                "description": "Optional roles to search, comma-separated. Example: 'user,assistant'.",
+            },
+            "source_filter": {
+                "type": "string",
+                "description": "Optional session sources to search, comma-separated. Example: 'feishu,cli'.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max exact hits to return (default 10, max 50).",
+                "default": 10,
+            },
+            "group_by_session": {
+                "type": "boolean",
+                "description": "When true (default), return the best hit per session. When false, return message-level hits.",
+                "default": True,
+            },
+            "match_mode": {
+                "type": "string",
+                "description": "Search mode hint: 'auto' (default), 'fts', or 'substring'.",
+                "enum": ["auto", "fts", "substring"],
+                "default": "auto",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+registry.register(
+    name="session_search_exact",
+    toolset="session_search",
+    schema=SESSION_SEARCH_EXACT_SCHEMA,
+    handler=lambda args, **kw: session_search_exact(
+        query=args.get("query") or "",
+        role_filter=args.get("role_filter"),
+        source_filter=args.get("source_filter"),
+        limit=args.get("limit", 10),
+        group_by_session=args.get("group_by_session", True),
+        match_mode=args.get("match_mode", "auto"),
+        db=kw.get("db"),
+    ),
+    check_fn=check_session_search_exact_requirements,
+    emoji="🧷",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,9 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "search_router",
+    # File/config safety helpers
+    "hermes_config_safe_update", "hermes_env_safe_update", "hermes_runtime_effect_check",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -49,7 +51,7 @@ _HERMES_CORE_TOOLS = [
     # Planning & memory
     "todo", "memory",
     # Session history search
-    "session_search",
+    "session_search", "session_search_exact",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
@@ -378,7 +380,7 @@ TOOLSETS = {
             # Planning & memory
             "todo", "memory",
             # Session history search
-            "session_search",
+            "session_search", "session_search_exact",
             # Code execution + delegation
             "execute_code", "delegate_task",
             # Cronjob management


### PR DESCRIPTION
## Summary
- Add native `search_router` tool for search-worker mediated evidence packets
- Add `session_search_exact` for raw cross-session exact recall
- Wire both tools into agent execution paths and core toolsets

## Test Plan
- `python -m pytest -q -o addopts='' tests/tools/test_search_router_tool.py tests/tools/test_session_search_exact_tool.py`
- Verified hermes-cli toolset exposes `search_router` and `session_search_exact`; nonexistent local-only helper tool names are filtered by registry availability.
