### PR TITLE
docs(config): explain current paste-collapse thresholds

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1270,6 +1270,17 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 
+## Paste Collapse
+
+When you paste multi-line text into the CLI or TUI, Hermes can collapse it into a short file reference instead of flooding the prompt with the full content. Two top-level keys tune this:
+
+```yaml
+paste_collapse_threshold: 5            # Collapse a bracketed paste into a file reference once it spans at least this many lines (0 = never). Safe: the reference is appended to whatever you have already typed.
+paste_collapse_threshold_fallback: 0   # Same threshold for terminals without bracketed-paste support. That path replaces the entire input buffer (destructive), so it is disabled by default. 0 = disabled.
+```
+
+Both thresholds count the lines in the pasted block and trigger when the count is at or above the threshold. Pasted text whose first non-whitespace character is `/` (a slash command) is never collapsed, so commands always reach the parser intact.
+
 ## Privacy
 
 ```yaml

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2170,6 +2170,20 @@ Signal is listed as a valid platform key because the setting can be saved per pl
 
 `show_commentary` (default `true`) controls Codex Responses models' commentary channel — the polished progress narration these models produce alongside their private reasoning. When enabled, each completed commentary message is delivered as a visible mid-turn update (on the gateway this also requires `interim_assistant_messages`). Set it to `false` if the extra narration annoys you: commentary then falls back to the reasoning channel and is only shown when `show_reasoning` is enabled.
 
+## Paste Collapse
+
+Large text pastes can be displayed as a compact reference instead of filling the input. Configure these top-level keys:
+
+```yaml
+paste_collapse_threshold: 5          # Bracketed-paste size threshold; also used by the TUI
+paste_collapse_threshold_fallback: 5 # Classic CLI fallback for terminals without bracketed paste
+paste_collapse_char_threshold: 2000  # Character threshold for both paths and the TUI
+```
+
+Collapse triggers when either enabled size threshold is reached. The classic CLI counts newline characters for the first two keys; the TUI counts lines for `paste_collapse_threshold`. Setting a threshold to `0` disables only that check. Set all three keys to `0` to disable size-based paste collapse across these paths.
+
+In the classic CLI, bracketed paste inserts a file reference at the cursor and preserves existing input. It skips collapse when the **existing buffer**, after trimming whitespace, begins with `/`; a pasted slash command is not universally exempt. The fallback detects paste-like input changes, evaluates the whole buffer, and replaces it with a file reference. It skips buffers that start directly with `/`.
+
 ## Privacy
 
 ```yaml

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1259,6 +1259,17 @@ display:
 
 `interim_assistant_messages` 仅限 gateway。启用后，Hermes 将已完成的轮次中 assistant 更新作为单独的聊天消息发送。这与 `tool_progress` 无关，不需要 gateway 流式传输。
 
+## 粘贴折叠
+
+当你向 CLI 或 TUI 粘贴多行文本时，Hermes 可以将其折叠为简短的文件引用，而不是用完整内容淹没提示。两个顶层键用于调节此行为：
+
+```yaml
+paste_collapse_threshold: 5            # 当 bracketed paste 的行数达到或超过该值时，折叠为文件引用（0 = 从不折叠）。安全：引用会追加到你已输入的内容之后。
+paste_collapse_threshold_fallback: 0   # 针对不支持 bracketed paste 的终端使用的同类阈值。该路径会替换整个输入缓冲区（破坏性），因此默认禁用。0 = 禁用。
+```
+
+两个阈值都按粘贴块的行数计数，当行数达到或超过阈值时触发。首个非空白字符为 `/` 的粘贴文本（斜杠命令）永不折叠，因此命令始终完整传递给解析器。
+
 ## 隐私
 
 ```yaml

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1303,6 +1303,20 @@ display:
 
 `interim_assistant_messages` 仅限 gateway。启用后，Hermes 将已完成的轮次中 assistant 更新作为单独的聊天消息发送。这与 `tool_progress` 无关，不需要 gateway 流式传输。
 
+## 粘贴折叠
+
+较大的文本粘贴可以显示为简短引用，而不是占满输入框。使用以下顶层配置键：
+
+```yaml
+paste_collapse_threshold: 5          # Bracketed paste 的大小阈值；TUI 也使用此键
+paste_collapse_threshold_fallback: 5 # 经典 CLI 在终端不支持 bracketed paste 时的回退阈值
+paste_collapse_char_threshold: 2000  # 两种路径和 TUI 共用的字符数阈值
+```
+
+达到任一已启用的大小阈值即触发折叠。经典 CLI 的前两个键统计换行符数量；TUI 的 `paste_collapse_threshold` 统计行数。将某个阈值设为 `0` 只禁用对应检查；将三个键都设为 `0` 可关闭这些路径中按大小触发的粘贴折叠。
+
+在经典 CLI 中，bracketed paste 会在光标处插入文件引用，保留原有输入。如果**已有输入缓冲区**去除首尾空白后以 `/` 开头，则不折叠；粘贴的斜杠命令并非一律豁免。回退路径检测类似粘贴的输入变化，对整个缓冲区判断阈值，并用文件引用替换整个缓冲区；缓冲区直接以 `/` 开头时不折叠。
+
 ## 隐私
 
 ```yaml


### PR DESCRIPTION
Document the three paste-collapse settings in English and Chinese, with current defaults: bracketed threshold `5`, fallback threshold `5`, and character threshold `2000`.

Either enabled size check can trigger collapse, so zero disables only that check. The descriptions distinguish the classic CLI's newline count from the TUI's line count, explain insertion versus whole-buffer replacement, and limit the slash-command exemption to the actual classic CLI buffer guards.

Addresses all three review points and rebases the documentation onto current main. Verified against `hermes_cli/config_defaults.py`, both paste handlers in `hermes_cli/cli_tui_mixin.py`, and TUI config/composer code. Complete two-file documentation diff reviewed; `git diff --check` passed.
