### PR TITLE
fix(gateway): suppress shutdown notice on planned --replace takeover (#32008)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1680,6 +1680,7 @@ class GatewayRunner:
     _restart_task_started: bool = False
     _restart_detached: bool = False
     _restart_via_service: bool = False
+    _shutdown_notifications_suppressed: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
@@ -1723,6 +1724,7 @@ class GatewayRunner:
         self._restart_task_started = False
         self._restart_detached = False
         self._restart_via_service = False
+        self._shutdown_notifications_suppressed = False
         self._stop_task: Optional[asyncio.Task] = None
         
         # Track running agents per session for interrupt support
@@ -3443,6 +3445,18 @@ class GatewayRunner:
         messages can be delivered. Best-effort: individual send failures are
         logged and swallowed so they never block the shutdown sequence.
         """
+        # Skip user-facing shutdown notices when another gateway is taking
+        # over via `--replace`. Without this guard, a duplicate-LaunchAgent
+        # configuration where two services point at the same HERMES_HOME
+        # would cause every ~5s `--replace` teardown to broadcast the
+        # warning to active chats, producing an indefinite chat-spam loop
+        # (#32008). The replacing gateway emits its own startup notice.
+        if self._shutdown_notifications_suppressed:
+            logger.info(
+                "Shutdown notifications suppressed (planned --replace takeover)"
+            )
+            return
+
         active = self._snapshot_running_agents()
 
         action = "restarting" if self._restart_requested else "shutting down"
@@ -18845,6 +18859,10 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logger.debug("snapshot_shutdown_context failed: %s", _e)
 
         if planned_takeover:
+            # Mute the user-facing shutdown notice on the way out — the
+            # replacing gateway will be back online immediately and will
+            # emit its own startup/restart notification. See #32008.
+            runner._shutdown_notifications_suppressed = True
             logger.info(
                 "Received %s as a planned --replace takeover — exiting cleanly",
                 _shutdown_ctx["signal"] if _shutdown_ctx else "SIGTERM",

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -622,3 +622,74 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
         "⚠️ Gateway shutting down — Your current task will be interrupted.",
         metadata={"thread_id": "topic-7"},
     )
+
+
+# ── #32008: suppress shutdown notice on planned --replace takeover ──────
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_suppressed_on_planned_replace_takeover(caplog):
+    """A planned --replace takeover must not emit user-facing shutdown notices.
+
+    Issue #32008: a duplicate-LaunchAgent configuration where two services
+    point at the same HERMES_HOME causes the two gateways to flap-fight via
+    `--replace`, broadcasting the shutdown warning every ~5s. Setting
+    ``_shutdown_notifications_suppressed`` (done in the signal handler when
+    the takeover marker is consumed) must short-circuit the per-session and
+    home-channel send paths before any adapter call.
+    """
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="42")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=None)
+    runner._cache_session_source(session_key, source)
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-99",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    runner._shutdown_notifications_suppressed = True
+
+    with caplog.at_level("INFO", logger="gateway.run"):
+        await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_called()
+    suppressed_lines = [
+        r for r in caplog.records
+        if r.levelname == "INFO"
+        and "Shutdown notifications suppressed" in r.getMessage()
+        and "--replace takeover" in r.getMessage()
+    ]
+    assert suppressed_lines, (
+        "Expected INFO line noting the planned --replace takeover suppression; "
+        f"got records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_default_flag_is_false():
+    """Default behavior is unchanged: the suppression flag defaults to False so
+    normal/unexpected shutdowns still emit notifications. Guards against a
+    future refactor silently flipping the class-level default to True."""
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="55")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=None)
+    runner._cache_session_source(session_key, source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    # Sanity-check: the helper does not set this attribute, so it must come
+    # from the class-level default.
+    assert runner._shutdown_notifications_suppressed is False
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once_with(
+        "55",
+        "⚠️ Gateway shutting down — Your current task will be interrupted.",
+        metadata=None,
+    )


### PR DESCRIPTION
## What does this PR do?

Stops the user-facing `⚠️ Gateway shutting down` notice from being broadcast to active chats when the gateway is being torn down by a planned `--replace` takeover. The replacing gateway is back online within ~5s and emits its own startup/restart notification, so the outgoing instance's warning is pure noise — and in the duplicate-LaunchAgent flap loop described in #32008 (two services pointing at the same `HERMES_HOME`), it becomes indefinite chat spam.

`shutdown_signal_handler` in `gateway/run.py` already detects planned `--replace` takeovers via `consume_takeover_marker_for_self`. This PR threads that signal into a new `_shutdown_notifications_suppressed` flag on the runner so `_notify_active_sessions_of_shutdown` short-circuits before any adapter send. The flag is checked once at function entry and logged as INFO so the suppression is visible in shutdown forensics.

## Related Issue

Fixes #32008 (sub-bug 2: `--replace` flap loop spam).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — added `_shutdown_notifications_suppressed` class-level default + `__init__` reset, an early-return guard at the top of `_notify_active_sessions_of_shutdown`, and a one-liner in `shutdown_signal_handler`'s `planned_takeover` branch that sets the flag before `runner.stop()` is scheduled.
- `tests/gateway/test_restart_notification.py` — added two regression tests: (a) when the flag is set, neither active-session nor home-channel sends fire and an INFO line records the suppression; (b) the class-level default is `False`, so the existing normal-shutdown behavior is unchanged.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_restart_notification.py -v` — all 27 cases pass, including the 2 new ones.
2. Adjacent regression: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_restart_drain.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_shutdown_cache_cleanup.py -v` — all 88 cases pass.
3. Manual reproduction: configure two `LaunchAgent`s pointed at the same `HERMES_HOME`, both with `--replace` + `KeepAlive { SuccessfulExit: false }`. Before this fix, every ~5s `--replace` teardown sends `⚠️ Gateway shutting down…` to every active chat. After: nothing visible during the flap; once the duplicate plist is removed, the surviving gateway runs normally and emits its startup notification on the next legitimate boot.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; the new behavior is documented via in-source comment and INFO log line.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no new config key (this is automatic on a path the signal handler already detects).
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the takeover marker path is Unix-only in practice (Windows uses a different service manager that does not currently exercise `--replace`); the guard is a no-op on platforms that never set the flag.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A.

## Related / Positioning

- **Sub-bug 1 of #32008 (reboot SIGTERM burst across ~15 bots)** is **not** covered here. That path is an unexpected SIGTERM with no takeover marker, so the new guard never triggers — by design. It is the topic of #22113 (config option) and #26005 (env-var gate) which are both currently open and complementary. Reporter (`daimon-nous`) explicitly notes both as related-but-distinct in the issue thread.
- **Sub-bug 2 of #32008 (duplicate-LaunchAgent `--replace` flap)** is what this PR addresses.
- Distinct from `gateway_restart_notification: false` (existing per-platform config opt-out, kept intact) — that mutes all notifications globally per platform, whereas this guard auto-fires only on planned `--replace` takeover and leaves unexpected-SIGTERM warnings alone.

> Audited siblings: the only other call site of the warning text is `_send_restart_notification` (the "Gateway restarted" message from the *new* gateway, which is the intended user-facing replacement signal and must keep firing). No widening needed.