### PR TITLE
harden: restrict markdown link schemes; parse untrusted XML with defusedxml

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -17,7 +17,11 @@ import logging
 import socket as _socket
 import time
 from typing import Any, Dict, List, Optional
-from xml.etree import ElementTree as ET
+# Security: parse untrusted, pre-auth request bodies (WeCom callbacks) with
+# defusedxml to block billion-laughs / entity-expansion (and XXE) DoS. The
+# parsing API (fromstring) is a drop-in for the stdlib calls used below;
+# response-building XML lives in wecom_crypto.py and is not parsed here.
+import defusedxml.ElementTree as ET
 
 try:
     from aiohttp import web

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -324,11 +324,24 @@ function InlineContent({
                 <HighlightedText text={node.content} terms={highlightTerms} />
               </em>
             );
-          case "link":
+          case "link": {
+            // Security: only render http(s)/mailto links. Other schemes
+            // (javascript:, data:, vbscript:) are dropped to plain text so a
+            // crafted link in agent/message content can't execute on click.
+            const href = node.href.trim();
+            if (!/^(https?:|mailto:)/i.test(href)) {
+              return (
+                <HighlightedText
+                  key={i}
+                  text={node.text}
+                  terms={highlightTerms}
+                />
+              );
+            }
             return (
               <a
                 key={i}
-                href={node.href}
+                href={href}
                 target="_blank"
                 rel="noreferrer"
                 className="text-primary underline underline-offset-2 decoration-primary/30 hover:decoration-primary/60 transition-colors"
@@ -336,6 +349,7 @@ function InlineContent({
                 {node.text}
               </a>
             );
+          }
           case "br":
             return <br key={i} />;
         }


### PR DESCRIPTION
## What

Two small defensive-hardening changes surfaced during an external review of the codebase. Minimal, source-only diff (2 files, +21/-3).

### 1. Dashboard — restrict markdown link schemes (`web/src/components/Markdown.tsx`)
The inline markdown renderer rendered link hrefs verbatim into `<a href>`. This renders an anchor only when the href matches `^(https?:|mailto:)` (case-insensitive, after trim); other schemes (`javascript:`, `data:`, `vbscript:`, …) are rendered as plain text instead. Prevents a crafted link in rendered (LLM/message-derived) content from executing on click. It's an allowlist, so scheme-obfuscation variants (leading whitespace, mixed case, embedded tab) are covered too.

### 2. WeCom callback — parse untrusted XML with `defusedxml` (`gateway/platforms/wecom_callback.py`)
`_decrypt_request` / `_build_event` parsed the inbound (pre-auth) callback body with `xml.etree.ElementTree`. The import is swapped to `defusedxml.ElementTree` (a drop-in for the `fromstring` parse path used here), blocking entity-expansion / billion-laughs (and XXE) on that endpoint before signature verification. `defusedxml` 0.7.1 is already a locked dependency. Response-building XML in `wecom_crypto.py` is intentionally left unchanged — it builds XML from trusted internal data and is never parsed from untrusted input.

## Verification
- **web**: `tsc --noEmit -p tsconfig.app.json` passes and `vite build` succeeds; the scheme allowlist correctly drops `javascript:`/`data:`/`vbscript:`/whitespace- and case-obfuscated variants while allowing `http(s)`/`mailto`.
- **wecom_callback**: imports cleanly with `defusedxml`; valid `<xml><Encrypt>…</Encrypt></xml>` envelopes still parse; an entity-expansion payload now raises `EntitiesForbidden`.

## Notes
- One small UX trade-off in (1): `tel:`/`ftp:`/`sms:` links are demoted to plain text; the allowlist can be widened if those schemes are wanted.
