### PR TITLE
test(auxiliary): stabilize Codex stream timeout test

### DIFF
--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -2516,6 +2517,8 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert response.choices[0].message.content == "summary"
 
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
+        closed = threading.Event()
+
         class SlowAliveStream:
             def __enter__(self):
                 return self
@@ -2524,8 +2527,11 @@ class TestCodexAuxiliaryAdapterTimeout:
                 return False
 
             def __iter__(self):
-                for _ in range(5):
-                    time.sleep(0.03)
+                # Keep emitting progress well past the requested timeout, but
+                # use short sleeps so the test exercises total-timeout behavior
+                # without depending on a narrow wall-clock margin under xdist.
+                for _ in range(100):
+                    time.sleep(0.005)
                     yield SimpleNamespace(type="response.in_progress")
 
             def get_final_response(self):
@@ -2541,7 +2547,7 @@ class TestCodexAuxiliaryAdapterTimeout:
             def stream(self, **kwargs):
                 return SlowAliveStream()
 
-        fake_client = SimpleNamespace(responses=FakeResponses(), close=lambda: None)
+        fake_client = SimpleNamespace(responses=FakeResponses(), close=closed.set)
         adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
 
         started = time.monotonic()
@@ -2551,7 +2557,8 @@ class TestCodexAuxiliaryAdapterTimeout:
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        assert closed.is_set()
+        assert time.monotonic() - started < 0.2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Stabilizes the Codex auxiliary total-timeout regression test.

The production timeout behavior was already correct: the adapter starts a total-timeout timer, closes the client on timeout, and raises `TimeoutError` when the stream keeps emitting progress events. The flaky test used five 30ms real sleeps and asserted the whole call completed under 140ms, leaving only ~10ms of scheduler margin on a contended xdist/full-baseline run. This made the assertion timing-sensitive even when the timeout contract held.

This PR keeps the contract intact but makes the test less scheduler-sensitive:

- stream continues emitting progress events well past the 50ms timeout
- shorter per-event sleeps avoid a narrow wall-clock margin
- fake client `close()` is now observable via `threading.Event`
- test asserts timeout closes the client and returns promptly

## Validation

- `uv run --no-sync pytest -o addopts='' tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events --tb=long`
  - `1 passed in 0.22s`
- 20 repeated targeted runs:
  - `20 repeated targeted runs passed`
- `uv run --no-sync pytest -o addopts='' tests/agent/test_auxiliary_client.py --tb=short`
  - `176 passed, 1 warning in 3.51s`
- `uv run --no-sync pytest -o addopts='' -n auto tests/agent/test_auxiliary_client.py --tb=short`
  - `176 passed, 8 warnings in 1.85s`
