### PR TITLE
fix(bluebubbles): fall back to /download/force when normal download fails

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -15,7 +15,7 @@ import os
 import re
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import quote
 
 import httpx
@@ -124,6 +124,23 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
+        # Force-download timeout: how long to wait for /download/force when an
+        # attachment hasn't been pulled from iCloud yet. The BlueBubbles server
+        # polls iCloud for up to 600s internally, but a 10-minute blocking wait
+        # on the inbound message path is a long time to hold the handler — a
+        # busy chat will pile up. Default to 300s (covers the common case);
+        # override per-deployment via extra["force_download_timeout_seconds"]
+        # or BLUEBUBBLES_FORCE_DOWNLOAD_TIMEOUT.
+        _raw_force_timeout = (
+            extra.get("force_download_timeout_seconds")
+            or os.getenv("BLUEBUBBLES_FORCE_DOWNLOAD_TIMEOUT")
+        )
+        try:
+            self.force_download_timeout = (
+                float(_raw_force_timeout) if _raw_force_timeout else 300.0
+            )
+        except (TypeError, ValueError):
+            self.force_download_timeout = 300.0
         self.client: Optional[httpx.AsyncClient] = None
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
@@ -700,8 +717,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         When ``force=True``, hits the Private-API-only ``/download/force``
         endpoint, which triggers macOS to pull the file from iCloud before
-        streaming it back. The server polls for up to 10 minutes, so the
-        client timeout has to be at least that long.
+        streaming it back. The wait is bounded by
+        ``self.force_download_timeout`` (see ``__init__``); requests still in
+        flight when that elapses are abandoned.
 
         Returns the bytes on success, None on any HTTP/network failure.
         """
@@ -709,9 +727,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return None
         encoded = quote(att_guid, safe="")
         suffix = "/force" if force else ""
-        # Force endpoint may block while the macOS helper pulls from iCloud;
-        # server-side poll window is 10 min. 60s is plenty for the cached path.
-        timeout = 660.0 if force else 60.0
+        timeout = self.force_download_timeout if force else 60.0
         try:
             resp = await self.client.get(
                 self._api_url(f"/api/v1/attachment/{encoded}/download{suffix}"),
@@ -729,34 +745,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             )
             return None
 
-    async def _download_attachment(
-        self, att_guid: str, att_meta: Dict[str, Any]
+    def _cache_attachment_bytes(
+        self, data: bytes, att_meta: Dict[str, Any]
     ) -> Optional[str]:
-        """Download an attachment from BlueBubbles and cache it locally.
-
-        Returns the local file path on success, None on failure.
-
-        Tries the normal ``/download`` endpoint first. If that fails (commonly
-        a 500 when the attachment hasn't been pulled from iCloud yet) and the
-        server has the Private API enabled, retries against
-        ``/download/force`` — which triggers the macOS helper to pull from
-        iCloud and then streams the bytes back. The Private-API endpoint
-        returns 500 when the helper isn't reachable, so gating on
-        ``self._private_api_enabled`` avoids a guaranteed second failure.
-        """
-        if not self.client:
-            return None
-
-        data = await self._fetch_attachment_bytes(att_guid, force=False)
-        if data is None and self._private_api_enabled:
-            logger.info(
-                "[bluebubbles] regular download failed for %s, trying force-download",
-                _redact(att_guid),
-            )
-            data = await self._fetch_attachment_bytes(att_guid, force=True)
-        if data is None:
-            return None
-
+        """Persist raw bytes to disk under the right media cache and return
+        the local file path. Returns None if the cache write fails."""
         try:
             mime = (att_meta.get("mimeType") or "").lower()
             transfer_name = att_meta.get("transferName", "")
@@ -787,17 +780,62 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 ext = ext_map.get(mime, ".mp3")
                 return cache_audio_from_bytes(data, ext)
 
-            # Videos, documents, and everything else
             filename = transfer_name or f"file_{uuid.uuid4().hex[:8]}"
             return cache_document_from_bytes(data, filename)
 
         except Exception as exc:
             logger.warning(
-                "[bluebubbles] failed to download attachment %s: %s",
-                _redact(att_guid),
+                "[bluebubbles] failed to cache attachment bytes (%s): %s",
+                (att_meta.get("mimeType") or "?"),
                 exc,
             )
             return None
+
+    async def _download_attachment(
+        self,
+        att_guid: str,
+        att_meta: Dict[str, Any],
+        *,
+        on_slow_path: Optional[Callable[[], Awaitable[None]]] = None,
+    ) -> Optional[str]:
+        """Download an attachment from BlueBubbles and cache it locally.
+
+        Returns the local file path on success, None on failure.
+
+        Tries the normal ``/download`` endpoint first. If that fails (commonly
+        a 500 when the attachment hasn't been pulled from iCloud yet) and the
+        server has the Private API enabled, retries against
+        ``/download/force`` — which triggers the macOS helper to pull from
+        iCloud and then streams the bytes back. The Private-API endpoint
+        returns 500 when the helper isn't reachable, so gating on
+        ``self._private_api_enabled`` avoids a guaranteed second failure.
+
+        ``on_slow_path`` is invoked once, just before the force-download
+        attempt, so the caller can surface a "fetching from iCloud" notice to
+        the user. Exceptions raised by the callback are swallowed.
+        """
+        if not self.client:
+            return None
+
+        data = await self._fetch_attachment_bytes(att_guid, force=False)
+        if data is None and self._private_api_enabled:
+            logger.info(
+                "[bluebubbles] regular download failed for %s, trying force-download",
+                _redact(att_guid),
+            )
+            if on_slow_path is not None:
+                try:
+                    await on_slow_path()
+                except Exception:
+                    logger.debug(
+                        "[bluebubbles] slow-path notification failed",
+                        exc_info=True,
+                    )
+            data = await self._fetch_attachment_bytes(att_guid, force=True)
+        if data is None:
+            return None
+
+        return self._cache_attachment_bytes(data, att_meta)
 
     # ------------------------------------------------------------------
     # Webhook handling
@@ -885,42 +923,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             or ""
         )
 
-        # --- Inbound attachment handling ---
-        attachments = record.get("attachments") or []
-        media_urls: List[str] = []
-        media_types: List[str] = []
-        msg_type = MessageType.TEXT
-
-        for att in attachments:
-            att_guid = att.get("guid", "")
-            if not att_guid:
-                continue
-            cached = await self._download_attachment(att_guid, att)
-            if cached:
-                mime = (att.get("mimeType") or "").lower()
-                media_urls.append(cached)
-                media_types.append(mime)
-                if mime.startswith("image/"):
-                    msg_type = MessageType.PHOTO
-                elif mime.startswith("audio/") or (att.get("uti") or "").endswith(
-                    "caf"
-                ):
-                    msg_type = MessageType.VOICE
-                elif mime.startswith("video/"):
-                    msg_type = MessageType.VIDEO
-                else:
-                    msg_type = MessageType.DOCUMENT
-
-        # With multiple attachments, prefer PHOTO if any images present
-        if len(media_urls) > 1:
-            mime_prefixes = {(m or "").split("/")[0] for m in media_types}
-            if "image" in mime_prefixes:
-                msg_type = MessageType.PHOTO
-
-        if not text and media_urls:
-            text = "(attachment)"
-        # --- End attachment handling ---
-
         chat_guid = self._value(
             record.get("chatGuid"),
             payload.get("chatGuid"),
@@ -928,8 +930,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             payload.get("chat_guid"),
             payload.get("guid"),
         )
-        # Fallback: BlueBubbles v1.9+ webhook payloads omit top-level chatGuid;
-        # the chat GUID is nested under data.chats[0].guid instead.
+        # BB v1.9+ webhook payloads omit top-level chatGuid; nested under data.chats[0].guid.
         if not chat_guid:
             _chats = record.get("chats") or []
             if _chats and isinstance(_chats[0], dict):
@@ -954,7 +955,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if not (chat_guid or chat_identifier) and sender:
             chat_identifier = sender
-        if not sender or not (chat_guid or chat_identifier) or not text:
+
+        attachments = record.get("attachments") or []
+        attachments_to_process = [att for att in attachments if att.get("guid")]
+
+        if (
+            not sender
+            or not (chat_guid or chat_identifier)
+            or not (text or attachments_to_process)
+        ):
             return web.json_response({"error": "missing message fields"}, status=400)
 
         session_chat_id = chat_guid or chat_identifier
@@ -967,9 +976,122 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             user_name=sender,
             chat_id_alt=chat_identifier,
         )
+
+        # Probe every attachment against the cached /download endpoint in
+        # parallel. Anything that comes back empty and has Private API
+        # available is queued for the slow /download/force path and handed
+        # off to a background task — the webhook handler must NOT block on
+        # iCloud pulls (up to self.force_download_timeout per attachment).
+        cached_pairs: List[Tuple[Dict[str, Any], bytes]] = []
+        need_force: List[Dict[str, Any]] = []
+
+        if attachments_to_process:
+            probe_results = await asyncio.gather(
+                *[
+                    self._fetch_attachment_bytes(att["guid"], force=False)
+                    for att in attachments_to_process
+                ],
+                return_exceptions=True,
+            )
+            for att, data in zip(attachments_to_process, probe_results):
+                if isinstance(data, BaseException) or data is None:
+                    if self._private_api_enabled:
+                        need_force.append(att)
+                    else:
+                        logger.warning(
+                            "[bluebubbles] dropping attachment %s: cached "
+                            "download failed and Private API is disabled",
+                            _redact(att.get("guid", "")),
+                        )
+                else:
+                    cached_pairs.append((att, data))
+
+        synced_media: List[Tuple[Dict[str, Any], str, str]] = []
+        for att, data in cached_pairs:
+            path = self._cache_attachment_bytes(data, att)
+            if path:
+                synced_media.append((att, path, (att.get("mimeType") or "").lower()))
+
+        if need_force:
+            if chat_guid:
+                try:
+                    await self.send(
+                        chat_guid,
+                        "📎 Fetching attachment from iCloud, this may take a minute…",
+                    )
+                except Exception:
+                    logger.debug(
+                        "[bluebubbles] slow-path notification failed",
+                        exc_info=True,
+                    )
+
+            task = asyncio.create_task(
+                self._deferred_deliver_message(
+                    text=text,
+                    cached_media=synced_media,
+                    need_force=need_force,
+                    source=source,
+                    record=record,
+                    payload=payload,
+                )
+            )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
+        else:
+            self._dispatch_message_event(
+                text=text,
+                synced_media=synced_media,
+                source=source,
+                record=record,
+                payload=payload,
+            )
+
+        # Fire-and-forget read receipt
+        if self.send_read_receipts and session_chat_id:
+            asyncio.create_task(self.mark_read(session_chat_id))
+
+        return web.Response(text="ok")
+
+    def _derive_attachment_msg_type(
+        self, synced_media: List[Tuple[Dict[str, Any], str, str]]
+    ) -> "MessageType":
+        """Pick the MessageType that best describes a set of cached attachments."""
+        if not synced_media:
+            return MessageType.TEXT
+        # Multiple attachments with any image → PHOTO (preserves prior behavior).
+        mimes = [mime for _, _, mime in synced_media]
+        if len(synced_media) > 1:
+            if "image" in {(m or "").split("/")[0] for m in mimes}:
+                return MessageType.PHOTO
+        att, _path, mime = synced_media[-1]
+        if mime.startswith("image/"):
+            return MessageType.PHOTO
+        if mime.startswith("audio/") or (att.get("uti") or "").endswith("caf"):
+            return MessageType.VOICE
+        if mime.startswith("video/"):
+            return MessageType.VIDEO
+        return MessageType.DOCUMENT
+
+    def _dispatch_message_event(
+        self,
+        *,
+        text: str,
+        synced_media: List[Tuple[Dict[str, Any], str, str]],
+        source: Any,
+        record: Dict[str, Any],
+        payload: Dict[str, Any],
+    ) -> None:
+        """Build a MessageEvent from cached attachments and schedule
+        ``handle_message`` as a tracked background task. No-op when there is
+        nothing to deliver (no text and no media)."""
+        media_urls = [path for _, path, _ in synced_media]
+        media_types = [mime for _, _, mime in synced_media]
+        effective_text = text or ("(attachment)" if media_urls else "")
+        if not effective_text:
+            return
         event = MessageEvent(
-            text=text,
-            message_type=msg_type,
+            text=effective_text,
+            message_type=self._derive_attachment_msg_type(synced_media),
             source=source,
             raw_message=payload,
             message_id=self._value(
@@ -988,8 +1110,45 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
-        # Fire-and-forget read receipt
-        if self.send_read_receipts and session_chat_id:
-            asyncio.create_task(self.mark_read(session_chat_id))
+    async def _deferred_deliver_message(
+        self,
+        *,
+        text: str,
+        cached_media: List[Tuple[Dict[str, Any], str, str]],
+        need_force: List[Dict[str, Any]],
+        source: Any,
+        record: Dict[str, Any],
+        payload: Dict[str, Any],
+    ) -> None:
+        """Force-fetch attachments that missed the cached path, then deliver
+        the full MessageEvent. Runs as a background task so the webhook
+        handler can return immediately and the user-facing
+        "📎 Fetching from iCloud…" notice arrives before the long wait."""
+        force_results = await asyncio.gather(
+            *[
+                self._fetch_attachment_bytes(att["guid"], force=True)
+                for att in need_force
+            ],
+            return_exceptions=True,
+        )
+        synced_media = list(cached_media)
+        for att, data in zip(need_force, force_results):
+            if isinstance(data, BaseException) or data is None:
+                logger.warning(
+                    "[bluebubbles] force-download failed for %s",
+                    _redact(att.get("guid", "")),
+                )
+                continue
+            path = self._cache_attachment_bytes(data, att)
+            if path:
+                synced_media.append(
+                    (att, path, (att.get("mimeType") or "").lower())
+                )
 
-        return web.Response(text="ok")
+        self._dispatch_message_event(
+            text=text,
+            synced_media=synced_media,
+            source=source,
+            record=record,
+            payload=payload,
+        )

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -693,25 +693,71 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Inbound attachment downloading (from #4588)
     # ------------------------------------------------------------------
 
+    async def _fetch_attachment_bytes(
+        self, att_guid: str, *, force: bool
+    ) -> Optional[bytes]:
+        """Fetch raw attachment bytes from BlueBubbles.
+
+        When ``force=True``, hits the Private-API-only ``/download/force``
+        endpoint, which triggers macOS to pull the file from iCloud before
+        streaming it back. The server polls for up to 10 minutes, so the
+        client timeout has to be at least that long.
+
+        Returns the bytes on success, None on any HTTP/network failure.
+        """
+        if not self.client:
+            return None
+        encoded = quote(att_guid, safe="")
+        suffix = "/force" if force else ""
+        # Force endpoint may block while the macOS helper pulls from iCloud;
+        # server-side poll window is 10 min. 60s is plenty for the cached path.
+        timeout = 660.0 if force else 60.0
+        try:
+            resp = await self.client.get(
+                self._api_url(f"/api/v1/attachment/{encoded}/download{suffix}"),
+                timeout=timeout,
+                follow_redirects=True,
+            )
+            resp.raise_for_status()
+            return resp.content
+        except Exception as exc:
+            logger.warning(
+                "[bluebubbles] %s attempt for %s failed: %s",
+                "force-download" if force else "download",
+                _redact(att_guid),
+                exc,
+            )
+            return None
+
     async def _download_attachment(
         self, att_guid: str, att_meta: Dict[str, Any]
     ) -> Optional[str]:
         """Download an attachment from BlueBubbles and cache it locally.
 
         Returns the local file path on success, None on failure.
+
+        Tries the normal ``/download`` endpoint first. If that fails (commonly
+        a 500 when the attachment hasn't been pulled from iCloud yet) and the
+        server has the Private API enabled, retries against
+        ``/download/force`` — which triggers the macOS helper to pull from
+        iCloud and then streams the bytes back. The Private-API endpoint
+        returns 500 when the helper isn't reachable, so gating on
+        ``self._private_api_enabled`` avoids a guaranteed second failure.
         """
         if not self.client:
             return None
-        try:
-            encoded = quote(att_guid, safe="")
-            resp = await self.client.get(
-                self._api_url(f"/api/v1/attachment/{encoded}/download"),
-                timeout=60,
-                follow_redirects=True,
-            )
-            resp.raise_for_status()
-            data = resp.content
 
+        data = await self._fetch_attachment_bytes(att_guid, force=False)
+        if data is None and self._private_api_enabled:
+            logger.info(
+                "[bluebubbles] regular download failed for %s, trying force-download",
+                _redact(att_guid),
+            )
+            data = await self._fetch_attachment_bytes(att_guid, force=True)
+        if data is None:
+            return None
+
+        try:
             mime = (att_meta.get("mimeType") or "").lower()
             transfer_name = att_meta.get("transferName", "")
 

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -1014,10 +1014,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         if need_force:
             if chat_guid:
+                n_force = len(need_force)
                 try:
                     await self.send(
                         chat_guid,
-                        "📎 Fetching attachment from iCloud, this may take a minute…",
+                        f"📎 Fetching {n_force} attachment"
+                        f"{'s' if n_force != 1 else ''} from iCloud, "
+                        f"this may take a minute…",
                     )
                 except Exception:
                     logger.debug(
@@ -1033,6 +1036,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                     source=source,
                     record=record,
                     payload=payload,
+                    chat_guid=chat_guid or "",
                 )
             )
             self._background_tasks.add(task)
@@ -1119,11 +1123,19 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         source: Any,
         record: Dict[str, Any],
         payload: Dict[str, Any],
+        chat_guid: str = "",
     ) -> None:
         """Force-fetch attachments that missed the cached path, then deliver
         the full MessageEvent. Runs as a background task so the webhook
         handler can return immediately and the user-facing
-        "📎 Fetching from iCloud…" notice arrives before the long wait."""
+        "📎 Fetching from iCloud…" notice arrives before the long wait.
+
+        After the fetch settles, posts a result notice to the chat (success,
+        partial, or full failure) and — when any attachment failed —
+        augments the agent-facing text with a ``[System: …]`` note so the
+        agent knows the user's message arrived incomplete and can respond
+        accordingly (e.g. ask the user to resend).
+        """
         force_results = await asyncio.gather(
             *[
                 self._fetch_attachment_bytes(att["guid"], force=True)
@@ -1132,21 +1144,71 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return_exceptions=True,
         )
         synced_media = list(cached_media)
+        failed_count = 0
         for att, data in zip(need_force, force_results):
             if isinstance(data, BaseException) or data is None:
                 logger.warning(
                     "[bluebubbles] force-download failed for %s",
                     _redact(att.get("guid", "")),
                 )
+                failed_count += 1
                 continue
             path = self._cache_attachment_bytes(data, att)
             if path:
                 synced_media.append(
                     (att, path, (att.get("mimeType") or "").lower())
                 )
+            else:
+                # bytes arrived but caching failed — treat as a failure for
+                # user/agent reporting so neither side is silently lied to.
+                failed_count += 1
+
+        total_slow = len(need_force)
+        ok_slow = total_slow - failed_count
+
+        # User-facing result notice: closes the loop opened by the
+        # "📎 Fetching…" message so the user knows what happened.
+        if chat_guid:
+            if failed_count == 0:
+                notice = "✅ Got it — processing your message…"
+            elif ok_slow == 0:
+                notice = (
+                    f"❌ Couldn't fetch attachment"
+                    f"{'s' if total_slow != 1 else ''} from iCloud — "
+                    f"processing your message text only."
+                )
+            else:
+                notice = (
+                    f"⚠️ Got {ok_slow} of {total_slow} attachments from "
+                    f"iCloud ({failed_count} failed) — processing what "
+                    f"came through."
+                )
+            try:
+                await self.send(chat_guid, notice)
+            except Exception:
+                logger.debug(
+                    "[bluebubbles] result notification failed",
+                    exc_info=True,
+                )
+
+        # Agent-facing context: append a system note so the agent doesn't
+        # silently lose track of dropped attachments. Without this, hermes
+        # would either see fewer media URLs than the user sent (and not
+        # know to apologize / ask for a resend) or — in the attachment-only
+        # all-fail case — receive no message at all because
+        # _dispatch_message_event drops empty events.
+        if failed_count > 0:
+            note = (
+                f"[System: {failed_count} of {total_slow} attachment"
+                f"{'s' if total_slow != 1 else ''} failed to download from "
+                f"iCloud. User may want to resend.]"
+            )
+            text_for_agent = f"{text}\n\n{note}" if text else note
+        else:
+            text_for_agent = text
 
         self._dispatch_message_event(
-            text=text,
+            text=text_for_agent,
             synced_media=synced_media,
             source=source,
             record=record,

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -613,9 +613,608 @@ class TestBlueBubblesAttachmentDownload:
         assert "/download/force" not in normal_url
         assert "/download/force" in force_url
         assert normal_timeout == 60.0
-        assert force_timeout >= 600.0, (
-            f"force timeout {force_timeout} too short; server polls for 10 min"
+        # Force timeout must exceed normal and match the configured default
+        # so a single cached attempt can't accidentally stretch into the
+        # iCloud-poll window.
+        assert force_timeout > normal_timeout
+        assert force_timeout == 300.0
+
+    def test_force_download_timeout_configurable_via_extra(self, monkeypatch):
+        """extra['force_download_timeout_seconds'] overrides the default."""
+        adapter = _make_adapter(
+            monkeypatch, force_download_timeout_seconds=120
         )
+        assert adapter.force_download_timeout == 120.0
+
+    def test_force_download_timeout_configurable_via_env(self, monkeypatch):
+        """BLUEBUBBLES_FORCE_DOWNLOAD_TIMEOUT env var overrides the default."""
+        monkeypatch.setenv("BLUEBUBBLES_FORCE_DOWNLOAD_TIMEOUT", "45")
+        # Reload via _make_adapter helper after env is set
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+        from gateway.config import PlatformConfig
+
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={"server_url": "http://localhost:1234", "password": "secret"},
+        )
+        adapter = BlueBubblesAdapter(cfg)
+        assert adapter.force_download_timeout == 45.0
+
+    def test_force_download_timeout_invalid_falls_back_to_default(
+        self, monkeypatch
+    ):
+        """Non-numeric override is ignored; default stands."""
+        adapter = _make_adapter(
+            monkeypatch, force_download_timeout_seconds="not-a-number"
+        )
+        assert adapter.force_download_timeout == 300.0
+
+    def test_on_slow_path_invoked_before_force_download(self, monkeypatch):
+        """on_slow_path callback fires once, just before /download/force."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        events = []
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            if "/download/force" in url:
+                events.append("force-get")
+                return SuccessResponse()
+            events.append("normal-get")
+            return FailingResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_image_from_bytes",
+            lambda data, ext: f"/tmp/x{ext}",
+        )
+
+        async def slow_cb():
+            events.append("slow-cb")
+
+        asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment(
+                "att-guid",
+                {"mimeType": "image/png"},
+                on_slow_path=slow_cb,
+            )
+        )
+
+        assert events == ["normal-get", "slow-cb", "force-get"]
+
+    def test_on_slow_path_not_invoked_on_normal_success(self, monkeypatch):
+        """Normal download succeeds → slow-path callback never fires."""
+        adapter = _make_adapter(monkeypatch)
+        import asyncio
+
+        events = []
+
+        class SuccessResponse:
+            content = b"ok"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            return SuccessResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_image_from_bytes",
+            lambda data, ext: f"/tmp/x{ext}",
+        )
+
+        async def slow_cb():
+            events.append("slow-cb")
+
+        asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment(
+                "att-guid",
+                {"mimeType": "image/png"},
+                on_slow_path=slow_cb,
+            )
+        )
+
+        assert events == []
+
+    def test_on_slow_path_exceptions_swallowed(self, monkeypatch):
+        """Raising callback doesn't crash the download flow."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            if "/download/force" in url:
+                return SuccessResponse()
+            return FailingResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_image_from_bytes",
+            lambda data, ext: f"/tmp/x{ext}",
+        )
+
+        async def bad_cb():
+            raise RuntimeError("boom")
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment(
+                "att-guid",
+                {"mimeType": "image/png"},
+                on_slow_path=bad_cb,
+            )
+        )
+
+        assert result == "/tmp/x.png"
+
+
+class TestBlueBubblesAttachmentLoopBehavior:
+    """End-to-end webhook handler tests for the cached-path probe + deferred
+    force-download delivery flow."""
+
+    def _webhook_request(self, payload):
+        from unittest.mock import MagicMock
+
+        req = MagicMock()
+        req.query = {"password": "secret"}
+        req.headers = {}
+
+        async def _read():
+            import json
+            return json.dumps(payload).encode("utf-8")
+
+        req.read = _read
+        return req
+
+    @staticmethod
+    def _drain_background(adapter):
+        import asyncio
+        pending = list(adapter._background_tasks)
+        if pending:
+            asyncio.get_event_loop().run_until_complete(
+                asyncio.gather(*pending, return_exceptions=True)
+            )
+
+    def _install_message_recorder(self, adapter, monkeypatch):
+        """Capture every outbound send() and every dispatched MessageEvent."""
+        import asyncio
+        sent_messages = []
+        delivered_events = []
+
+        async def fake_send(chat_id, content, **kwargs):
+            sent_messages.append((chat_id, content))
+            from gateway.platforms.base import SendResult
+            return SendResult(success=True, message_id="ok")
+
+        async def fake_handle_message(event):
+            delivered_events.append(event)
+
+        monkeypatch.setattr(adapter, "send", fake_send)
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(
+            adapter, "mark_read", lambda *a, **k: asyncio.sleep(0)
+        )
+        return sent_messages, delivered_events
+
+    def _install_http(self, adapter, monkeypatch, mock_get):
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_image_from_bytes",
+            lambda data, ext: f"/tmp/x{ext}",
+        )
+
+    def test_status_message_sent_inline_before_handler_returns(
+        self, monkeypatch
+    ):
+        """When any attachment misses the cached path, the '📎 Fetching…'
+        status is sent SYNCHRONOUSLY before the webhook returns OK. The
+        force-download is deferred to a background task so the message is
+        not yet delivered when the handler returns."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            if "/download/force" in url:
+                await asyncio.sleep(0.2)
+                return SuccessResponse()
+            return FailingResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-1",
+                "text": "hi",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [{"guid": "att-1", "mimeType": "image/png"}],
+            },
+        }
+        req = self._webhook_request(payload)
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(adapter._handle_webhook(req))
+
+        try:
+            notices = [m for _, m in sent_messages if "Fetching attachment" in m]
+            assert len(notices) == 1, sent_messages
+            assert delivered_events == [], (
+                "message must NOT be delivered before force-download completes"
+            )
+            assert len(adapter._background_tasks) >= 1, (
+                "expected a deferred background task to be tracked"
+            )
+        finally:
+            self._drain_background(adapter)
+
+        assert len(delivered_events) == 1
+        assert delivered_events[0].media_urls == ["/tmp/x.png"]
+
+    def test_status_message_sent_once_for_multiple_force_attachments(
+        self, monkeypatch
+    ):
+        """N un-cached attachments emit exactly ONE status notice, not N."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            if "/download/force" in url:
+                return SuccessResponse()
+            return FailingResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-2",
+                "text": "hi",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [
+                    {"guid": f"att-{i}", "mimeType": "image/png"}
+                    for i in range(3)
+                ],
+            },
+        }
+        req = self._webhook_request(payload)
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
+        self._drain_background(adapter)
+
+        notices = [m for _, m in sent_messages if "Fetching attachment" in m]
+        assert len(notices) == 1, (
+            f"expected 1 notice for 3 force-needed attachments, got "
+            f"{len(notices)}: {sent_messages}"
+        )
+        # All 3 attachments should have arrived in the deferred MessageEvent.
+        assert len(delivered_events) == 1
+        assert len(delivered_events[0].media_urls) == 3
+
+    def test_no_status_message_when_all_attachments_cached(self, monkeypatch):
+        """All attachments served from cache → zero status notices, inline
+        delivery (no deferred task spawned)."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        class SuccessResponse:
+            content = b"cached"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            return SuccessResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-3",
+                "text": "hi",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [{"guid": "att-1", "mimeType": "image/png"}],
+            },
+        }
+        req = self._webhook_request(payload)
+        asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
+        self._drain_background(adapter)
+
+        notices = [m for _, m in sent_messages if "Fetching attachment" in m]
+        assert notices == []
+        assert len(delivered_events) == 1
+        assert delivered_events[0].media_urls == ["/tmp/x.png"]
+
+    def test_force_downloads_run_concurrently_in_background(self, monkeypatch):
+        """Multiple un-cached attachments do not serialize their
+        force-download timeouts — total wall time is bounded by the slowest,
+        not the sum (measured across handler + background drain)."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+        import time
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        in_flight = {"force": 0, "max_concurrent_force": 0}
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            if "/download/force" in url:
+                in_flight["force"] += 1
+                in_flight["max_concurrent_force"] = max(
+                    in_flight["max_concurrent_force"], in_flight["force"]
+                )
+                await asyncio.sleep(0.05)
+                in_flight["force"] -= 1
+                return SuccessResponse()
+            return FailingResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-4",
+                "text": "hi",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [
+                    {"guid": "att-1", "mimeType": "image/png"},
+                    {"guid": "att-2", "mimeType": "image/png"},
+                    {"guid": "att-3", "mimeType": "image/png"},
+                ],
+            },
+        }
+        req = self._webhook_request(payload)
+
+        loop = asyncio.get_event_loop()
+        start = time.monotonic()
+        loop.run_until_complete(adapter._handle_webhook(req))
+        self._drain_background(adapter)
+        elapsed = time.monotonic() - start
+
+        # Three sequential force-downloads would be ≥ 3*0.05 = 0.15s.
+        # Concurrent should finish in roughly 0.05s + scheduling overhead.
+        assert elapsed < 0.13, (
+            f"attachments ran sequentially: {elapsed:.3f}s for 3 × 0.05s"
+        )
+        assert in_flight["max_concurrent_force"] >= 2, (
+            f"expected ≥2 concurrent force-downloads, "
+            f"observed peak {in_flight['max_concurrent_force']}"
+        )
+        assert len(delivered_events) == 1
+
+    def test_webhook_returns_before_force_download_completes(self, monkeypatch):
+        """The webhook handler must not block on /download/force. It returns
+        OK as soon as the status notice is sent; force-download finishes
+        later in the background."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        # 500ms force-download — long enough to clearly show the handler
+        # returning before it completes, short enough to not slow tests.
+        async def mock_get(url, **kwargs):
+            if "/download/force" in url:
+                await asyncio.sleep(0.5)
+                return SuccessResponse()
+            return FailingResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-5",
+                "text": "hi",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [{"guid": "att-1", "mimeType": "image/png"}],
+            },
+        }
+        req = self._webhook_request(payload)
+
+        import time
+        loop = asyncio.get_event_loop()
+        start = time.monotonic()
+        loop.run_until_complete(adapter._handle_webhook(req))
+        handler_elapsed = time.monotonic() - start
+
+        # Handler should return in well under the 500ms force-download.
+        assert handler_elapsed < 0.3, (
+            f"webhook handler blocked on force-download: {handler_elapsed:.3f}s"
+        )
+        # Message NOT yet delivered.
+        assert delivered_events == []
+        # Drain the background and verify it eventually lands.
+        self._drain_background(adapter)
+        assert len(delivered_events) == 1
+
+    def test_failed_force_download_still_delivers_text(self, monkeypatch):
+        """If the force-download fails entirely, the user's text is still
+        delivered (without the attachment) so the agent at least sees the
+        message."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        async def mock_get(url, **kwargs):
+            return FailingResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-6",
+                "text": "what is this?",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [{"guid": "att-1", "mimeType": "image/png"}],
+            },
+        }
+        req = self._webhook_request(payload)
+        asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
+        self._drain_background(adapter)
+
+        assert len(delivered_events) == 1
+        assert delivered_events[0].text == "what is this?"
+        assert delivered_events[0].media_urls == []
+
+    def test_attachment_only_message_passes_early_validation(self, monkeypatch):
+        """An attachment-only message (no text) must not be rejected as
+        'missing message fields' before the attachment is fetched."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        class SuccessResponse:
+            content = b"cached"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            return SuccessResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-7",
+                "text": "",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [{"guid": "att-1", "mimeType": "image/png"}],
+            },
+        }
+        req = self._webhook_request(payload)
+        asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
+        self._drain_background(adapter)
+
+        assert len(delivered_events) == 1
+        assert delivered_events[0].text == "(attachment)"
+        assert delivered_events[0].media_urls == ["/tmp/x.png"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -840,7 +840,8 @@ class TestBlueBubblesAttachmentLoopBehavior:
         """When any attachment misses the cached path, the '📎 Fetching…'
         status is sent SYNCHRONOUSLY before the webhook returns OK. The
         force-download is deferred to a background task so the message is
-        not yet delivered when the handler returns."""
+        not yet delivered when the handler returns. After the fetch
+        completes, a '✅ Got it' notice closes the loop."""
         adapter = _make_adapter(monkeypatch)
         adapter._private_api_enabled = True
         import asyncio
@@ -885,8 +886,12 @@ class TestBlueBubblesAttachmentLoopBehavior:
         loop.run_until_complete(adapter._handle_webhook(req))
 
         try:
-            notices = [m for _, m in sent_messages if "Fetching attachment" in m]
-            assert len(notices) == 1, sent_messages
+            fetching = [m for _, m in sent_messages if "Fetching" in m]
+            got_it = [m for _, m in sent_messages if "Got it" in m]
+            assert len(fetching) == 1, sent_messages
+            assert got_it == [], (
+                "success notice must arrive AFTER force-download completes"
+            )
             assert delivered_events == [], (
                 "message must NOT be delivered before force-download completes"
             )
@@ -896,8 +901,15 @@ class TestBlueBubblesAttachmentLoopBehavior:
         finally:
             self._drain_background(adapter)
 
+        got_it = [m for _, m in sent_messages if "Got it" in m]
+        assert len(got_it) == 1, (
+            f"expected one '✅ Got it' notice after success: {sent_messages}"
+        )
         assert len(delivered_events) == 1
         assert delivered_events[0].media_urls == ["/tmp/x.png"]
+        assert delivered_events[0].text == "hi", (
+            "no failures → text must NOT be augmented"
+        )
 
     def test_status_message_sent_once_for_multiple_force_attachments(
         self, monkeypatch
@@ -948,12 +960,19 @@ class TestBlueBubblesAttachmentLoopBehavior:
         asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
         self._drain_background(adapter)
 
-        notices = [m for _, m in sent_messages if "Fetching attachment" in m]
-        assert len(notices) == 1, (
-            f"expected 1 notice for 3 force-needed attachments, got "
-            f"{len(notices)}: {sent_messages}"
+        fetching = [m for _, m in sent_messages if "Fetching" in m]
+        assert len(fetching) == 1, (
+            f"expected 1 fetching notice for 3 force-needed attachments, "
+            f"got {len(fetching)}: {sent_messages}"
         )
-        # All 3 attachments should have arrived in the deferred MessageEvent.
+        assert "3 attachments" in fetching[0], (
+            f"fetching notice should pluralize: {fetching[0]!r}"
+        )
+        got_it = [m for _, m in sent_messages if "Got it" in m]
+        assert len(got_it) == 1, (
+            f"expected exactly one success notice after all 3 succeeded: "
+            f"{sent_messages}"
+        )
         assert len(delivered_events) == 1
         assert len(delivered_events[0].media_urls) == 3
 
@@ -994,8 +1013,14 @@ class TestBlueBubblesAttachmentLoopBehavior:
         asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
         self._drain_background(adapter)
 
-        notices = [m for _, m in sent_messages if "Fetching attachment" in m]
-        assert notices == []
+        fetching = [m for _, m in sent_messages if "Fetching" in m]
+        got_it = [m for _, m in sent_messages if "Got it" in m]
+        failed = [m for _, m in sent_messages if "Couldn't fetch" in m]
+        assert fetching == []
+        assert got_it == [], (
+            "cached path must not send the deferred-success notice"
+        )
+        assert failed == []
         assert len(delivered_events) == 1
         assert delivered_events[0].media_urls == ["/tmp/x.png"]
 
@@ -1134,10 +1159,13 @@ class TestBlueBubblesAttachmentLoopBehavior:
         self._drain_background(adapter)
         assert len(delivered_events) == 1
 
-    def test_failed_force_download_still_delivers_text(self, monkeypatch):
-        """If the force-download fails entirely, the user's text is still
-        delivered (without the attachment) so the agent at least sees the
-        message."""
+    def test_failed_force_download_still_delivers_text_with_note(
+        self, monkeypatch
+    ):
+        """Force-download fails entirely → user's text is delivered, but
+        with a [System: …] note appended so the agent knows attachments
+        dropped and can ask the user to resend. User also gets a
+        '❌ Couldn't fetch' notice."""
         adapter = _make_adapter(monkeypatch)
         adapter._private_api_enabled = True
         import asyncio
@@ -1172,8 +1200,140 @@ class TestBlueBubblesAttachmentLoopBehavior:
         self._drain_background(adapter)
 
         assert len(delivered_events) == 1
-        assert delivered_events[0].text == "what is this?"
+        delivered_text = delivered_events[0].text
+        assert delivered_text.startswith("what is this?"), delivered_text
+        assert "[System:" in delivered_text, delivered_text
+        assert "1 of 1 attachment failed" in delivered_text, delivered_text
+        assert "resend" in delivered_text.lower(), delivered_text
         assert delivered_events[0].media_urls == []
+
+        failed_notices = [m for _, m in sent_messages if "Couldn't fetch" in m]
+        got_it_notices = [m for _, m in sent_messages if "Got it" in m]
+        assert len(failed_notices) == 1, (
+            f"expected one user-facing failure notice: {sent_messages}"
+        )
+        assert got_it_notices == [], (
+            "no success notice when all attachments failed"
+        )
+
+    def test_attachment_only_all_force_fail_delivers_note_to_agent(
+        self, monkeypatch
+    ):
+        """Attachment-only message where ALL force-downloads fail must NOT
+        be silently dropped. The agent receives the [System: …] note as
+        the message body so hermes can ask the user to resend, instead of
+        the conversation going dark."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        async def mock_get(url, **kwargs):
+            return FailingResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-att-only-fail",
+                "text": "",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [{"guid": "att-1", "mimeType": "image/png"}],
+            },
+        }
+        req = self._webhook_request(payload)
+        asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
+        self._drain_background(adapter)
+
+        assert len(delivered_events) == 1, (
+            "attachment-only all-fail must NOT be silently dropped"
+        )
+        delivered_text = delivered_events[0].text
+        assert delivered_text.startswith("[System:"), delivered_text
+        assert "failed to download" in delivered_text, delivered_text
+        assert delivered_events[0].media_urls == []
+
+        failed_notices = [m for _, m in sent_messages if "Couldn't fetch" in m]
+        assert len(failed_notices) == 1, sent_messages
+
+    def test_partial_failure_notice_and_text_augmentation(self, monkeypatch):
+        """Some attachments succeed, some fail → user gets a partial
+        notice with the count, agent gets text + failure note + the media
+        that did come through."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        sent_messages, delivered_events = self._install_message_recorder(
+            adapter, monkeypatch
+        )
+
+        forced_calls = {"n": 0}
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            if "/download/force" in url:
+                # Succeed on the second forced attempt, fail on others.
+                forced_calls["n"] += 1
+                if forced_calls["n"] == 2:
+                    return SuccessResponse()
+                raise httpx.HTTPError("500")
+            return FailingResponse()
+
+        self._install_http(adapter, monkeypatch, mock_get)
+
+        payload = {
+            "type": "new-message",
+            "data": {
+                "guid": "msg-partial",
+                "text": "see these",
+                "chatGuid": "iMessage;-;+15551234567",
+                "handle": {"address": "+15551234567"},
+                "isFromMe": False,
+                "attachments": [
+                    {"guid": "att-1", "mimeType": "image/png"},
+                    {"guid": "att-2", "mimeType": "image/png"},
+                    {"guid": "att-3", "mimeType": "image/png"},
+                ],
+            },
+        }
+        req = self._webhook_request(payload)
+        asyncio.get_event_loop().run_until_complete(adapter._handle_webhook(req))
+        self._drain_background(adapter)
+
+        assert len(delivered_events) == 1
+        delivered_text = delivered_events[0].text
+        assert delivered_text.startswith("see these"), delivered_text
+        assert "2 of 3 attachments failed" in delivered_text, delivered_text
+        assert len(delivered_events[0].media_urls) == 1
+
+        partial_notices = [
+            m for _, m in sent_messages if m.startswith("⚠️")
+        ]
+        assert len(partial_notices) == 1, sent_messages
+        assert "1 of 3" in partial_notices[0], partial_notices[0]
+        assert "2 failed" in partial_notices[0], partial_notices[0]
 
     def test_attachment_only_message_passes_early_validation(self, monkeypatch):
         """An attachment-only message (no text) must not be rejected as

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -416,6 +416,207 @@ class TestBlueBubblesAttachmentDownload:
         )
         assert result is None
 
+    def test_force_download_fallback_on_500(self, monkeypatch):
+        """Regular /download fails + private API enabled → /download/force is tried."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        called_urls = []
+
+        class FailingResponse:
+            status_code = 500
+
+            def raise_for_status(self):
+                raise httpx.HTTPError("500 Server Error")
+
+        class SuccessResponse:
+            status_code = 200
+            content = b"\x89PNG\r\n\x1a\nforced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            called_urls.append(url)
+            if "/download/force" in url:
+                return SuccessResponse()
+            return FailingResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+
+        cached = {}
+
+        def mock_cache_image(data, ext):
+            cached["data"] = data
+            cached["ext"] = ext
+            return f"/tmp/forced{ext}"
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_image_from_bytes",
+            mock_cache_image,
+        )
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment(
+                "att-guid-force", {"mimeType": "image/png"}
+            )
+        )
+
+        assert result == "/tmp/forced.png"
+        assert cached["data"] == b"\x89PNG\r\n\x1a\nforced"
+        assert len(called_urls) == 2
+        assert "/download/force" not in called_urls[0]
+        assert "/download/force" in called_urls[1]
+
+    def test_force_download_not_tried_on_normal_success(self, monkeypatch):
+        """Normal /download succeeds → /download/force is NOT called."""
+        adapter = _make_adapter(monkeypatch)
+        import asyncio
+
+        called_urls = []
+
+        class SuccessResponse:
+            status_code = 200
+            content = b"ok-bytes"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            called_urls.append(url)
+            return SuccessResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_image_from_bytes",
+            lambda data, ext: f"/tmp/normal{ext}",
+        )
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment("att-guid", {"mimeType": "image/png"})
+        )
+
+        assert result == "/tmp/normal.png"
+        assert len(called_urls) == 1
+        assert "/download/force" not in called_urls[0]
+
+    def test_both_downloads_fail_returns_none(self, monkeypatch):
+        """Both /download and /download/force fail → returns None, no crash."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        called_urls = []
+
+        class FailingResponse:
+            status_code = 500
+
+            def raise_for_status(self):
+                raise httpx.HTTPError("500 Server Error")
+
+        async def mock_get(url, **kwargs):
+            called_urls.append(url)
+            return FailingResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment("att-guid", {"mimeType": "image/png"})
+        )
+
+        assert result is None
+        assert len(called_urls) == 2
+        assert "/download/force" in called_urls[1]
+
+    def test_force_download_skipped_when_private_api_disabled(self, monkeypatch):
+        """Regular /download fails + private API disabled → no fallback call."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = False
+        import asyncio
+        import httpx
+
+        called_urls = []
+
+        class FailingResponse:
+            status_code = 500
+
+            def raise_for_status(self):
+                raise httpx.HTTPError("500 Server Error")
+
+        async def mock_get(url, **kwargs):
+            called_urls.append(url)
+            return FailingResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment("att-guid", {"mimeType": "image/png"})
+        )
+
+        assert result is None
+        assert len(called_urls) == 1
+        assert "/download/force" not in called_urls[0]
+
+    def test_force_download_uses_longer_timeout(self, monkeypatch):
+        """Force endpoint uses ≥600s timeout for iCloud poll window."""
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        import asyncio
+        import httpx
+
+        captured_timeouts = []
+
+        class FailingResponse:
+            def raise_for_status(self):
+                raise httpx.HTTPError("500")
+
+        class SuccessResponse:
+            content = b"forced"
+
+            def raise_for_status(self):
+                pass
+
+        async def mock_get(url, **kwargs):
+            captured_timeouts.append((url, kwargs.get("timeout")))
+            if "/download/force" in url:
+                return SuccessResponse()
+            return FailingResponse()
+
+        adapter.client = type(
+            "MockClient", (), {"get": staticmethod(mock_get)}
+        )()
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_document_from_bytes",
+            lambda data, filename: f"/tmp/{filename}",
+        )
+
+        asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment(
+                "att-guid", {"mimeType": "application/pdf", "transferName": "f.pdf"}
+            )
+        )
+
+        normal_url, normal_timeout = captured_timeouts[0]
+        force_url, force_timeout = captured_timeouts[1]
+        assert "/download/force" not in normal_url
+        assert "/download/force" in force_url
+        assert normal_timeout == 60.0
+        assert force_timeout >= 600.0, (
+            f"force timeout {force_timeout} too short; server polls for 10 min"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Webhook registration


### PR DESCRIPTION
## Problem

Downloading inbound BlueBubbles attachments via the regular endpoint

```
GET /api/v1/attachment/{guid}/download
```

returns **500** when the attachment hasn't been pulled from iCloud yet. Hermes errors that it cannot download the attachment.

## Fix

BlueBubbles-server exposes a Private-API endpoint that asks the macOS helper to download the file from iCloud first, then streams the bytes back:

```
GET /api/v1/attachment/{guid}/download/force
```

On any failure of the normal endpoint, [`_download_attachment`](gateway/platforms/bluebubbles.py) transparently retries against `/download/force` — **only when the server reports the Private API as enabled** (`server/info: private_api=true` at connect time). The Private-API endpoint returns 500 when the helper isn't reachable, so gating on `self._private_api_enabled` avoids a guaranteed second failure when pAPI is off.

## Changes

**[`gateway/platforms/bluebubbles.py`](gateway/platforms/bluebubbles.py)**
- New `_fetch_attachment_bytes(att_guid, *, force)` helper that does the actual HTTP call with per-endpoint timeout (60 s normal, 660 s force — matches the BlueBubbles server's internal 10-minute iCloud poll window).
- `_download_attachment` now: try normal → if it failed *and* `self._private_api_enabled`, try force → return cached file or `None`. MIME → cache routing (image / audio / document) is unchanged.

**[`tests/gateway/test_bluebubbles.py`](tests/gateway/test_bluebubbles.py)** — five new regression tests:
- `test_force_download_fallback_on_500` — normal fails + pAPI on → force succeeds → bytes routed through image cache.
- `test_force_download_not_tried_on_normal_success` — normal succeeds → no fallback call.
- `test_both_downloads_fail_returns_none` — both fail → returns `None` gracefully.
- `test_force_download_skipped_when_private_api_disabled` — normal fails + pAPI off → **no** fallback call (the new gate).
- `test_force_download_uses_longer_timeout` — pins the timeout contract (`force ≥ 600 s`).

## Reference

[BlueBubbles Postman docs — Force Download](https://documenter.getpostman.com/view/765844/UV5RnfwM#0eb1d6d7-781e-452d-956f-cbf6562bcb82) ([upstream route](https://github.com/BlueBubblesApp/bluebubbles-server/blob/95204ac18513fffcbb76cafed26008952e8346b3/packages/server/src/server/api/http/api/v1/httpRoutes.ts#L247-L257))

## Verification

```
python -m pytest tests/gateway/test_bluebubbles.py
============================== 55 passed in 0.88s ==============================
```

All 55 tests pass (48 pre-existing + 5 new). LSP diagnostics on both modified files are clean — the remaining errors are pre-existing on unchanged lines.