### PR TITLE
feat: add read-only skill cleaner audit

### DIFF
--- a/scripts/skill_cleaner_audit.py
+++ b/scripts/skill_cleaner_audit.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Run the report-only Hermes skill cleaner audit.
+
+This thin wrapper keeps the operator-facing command discoverable under scripts/
+while the implementation stays importable/testable in tools.skill_cleaner.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.skill_cleaner import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_skill_cleaner.py
+++ b/tests/tools/test_skill_cleaner.py
@@ -1,19 +1,23 @@
+import hashlib
 import json
 from pathlib import Path
 
-from tools.skill_cleaner import audit_skills, main, report_to_dict, write_report_files
+from tools.skill_cleaner import (
+    _canonical_skill_content_for_hash,
+    audit_skills,
+    main,
+    report_to_dict,
+    write_report_files,
+)
 
 
-def _write_skill(root: Path, rel: str, *, name: str, description: str, body: str) -> Path:
+def _write_skill(
+    root: Path, rel: str, *, name: str, description: str, body: str
+) -> Path:
     skill_dir = root / rel
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\n"
-        f"name: {name}\n"
-        f"description: {description}\n"
-        "---\n"
-        f"# {name}\n\n"
-        f"{body}\n",
+        f"---\nname: {name}\ndescription: {description}\n---\n# {name}\n\n{body}\n",
         encoding="utf-8",
     )
     return skill_dir
@@ -61,7 +65,9 @@ def test_audit_uses_active_profile_home_and_writes_report(tmp_path, monkeypatch)
     assert payload["summary"]["skill_count"] == 1
 
 
-def test_verified_card_contract_flags_thin_missing_metadata(tmp_path, monkeypatch):
+def test_documented_frontmatter_contract_flags_thin_missing_metadata(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-b"))
     skill_dir = tmp_path / "profile-b" / "skills" / "bad-card"
     skill_dir.mkdir(parents=True)
@@ -73,8 +79,41 @@ def test_verified_card_contract_flags_thin_missing_metadata(tmp_path, monkeypatc
     assert "missing_frontmatter" in codes
     assert "missing_description" in codes
     assert "thin_body" in codes
-    assert "missing_skill_card" in codes
+    assert "missing_skill_card" not in codes
     assert report.finding_counts["error"] >= 2
+
+
+def test_optional_skill_card_hash_excludes_its_own_field(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-hash"))
+    skill_dir = tmp_path / "profile-hash" / "skills" / "hash-audit"
+    skill_dir.mkdir(parents=True)
+    template = (
+        "---\n"
+        "name: hash-audit\n"
+        "description: Verify optional content hashes.\n"
+        "skill_card:\n"
+        "  verification:\n"
+        "    content_sha256: HASH_PLACEHOLDER\n"
+        "---\n"
+        "# hash-audit\n\n" + _healthy_body("content hashes") + "\n"
+    )
+    digest = hashlib.sha256(
+        _canonical_skill_content_for_hash(template).encode("utf-8")
+    ).hexdigest()
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(template.replace("HASH_PLACEHOLDER", digest), encoding="utf-8")
+
+    report = audit_skills()
+    codes = {finding.code for finding in report.skills[0].card_findings}
+    assert "content_hash_mismatch" not in codes
+
+    skill_md.write_text(
+        skill_md.read_text(encoding="utf-8") + "Changed after review.\n",
+        encoding="utf-8",
+    )
+    changed_report = audit_skills()
+    changed_codes = {finding.code for finding in changed_report.skills[0].card_findings}
+    assert "content_hash_mismatch" in changed_codes
 
 
 def test_audit_includes_configured_external_skill_dirs(tmp_path, monkeypatch):
@@ -114,7 +153,10 @@ def test_duplicate_detection_can_include_bundled_root(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(active_home))
     monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_root))
 
-    duplicate_body = _healthy_body("duplicate skill overlap") + "\nshared terraform dns deployment audit approval gate " * 8
+    duplicate_body = (
+        _healthy_body("duplicate skill overlap")
+        + "\nshared terraform dns deployment audit approval gate " * 8
+    )
     _write_skill(
         active_home / "skills",
         "operations/dns-audit",
@@ -139,28 +181,64 @@ def test_duplicate_detection_can_include_bundled_root(tmp_path, monkeypatch):
     assert with_bundled.duplicates[0].similarity >= 0.8
 
 
-def test_session_artifact_detection_ignores_numeric_date_references(tmp_path, monkeypatch):
+def test_session_artifact_detection_ignores_dates_and_durable_sha_pins(
+    tmp_path, monkeypatch
+):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-dates"))
     _write_skill(
         tmp_path / "profile-dates" / "skills",
         "ops/date-reference",
         name="date-reference",
         description="Audit dated reference names without false SHA matches.",
-        body=_healthy_body("dated references") + "\nOpen references/report-20260525.md when needed.",
+        body=_healthy_body("dated references")
+        + "\nOpen references/report-20260525.md when needed.",
     )
     _write_skill(
         tmp_path / "profile-dates" / "skills",
         "ops/sha-reference",
         name="sha-reference",
-        description="Audit real SHA-like artifacts.",
-        body=_healthy_body("SHA references") + "\nMove stale detail for deadbee when found.",
+        description="Audit durable SHA-pinned dependencies.",
+        body=_healthy_body("SHA references")
+        + "\nUse actions/checkout@deadbeef1234567890 for the pinned dependency.",
+    )
+    _write_skill(
+        tmp_path / "profile-dates" / "skills",
+        "ops/pr-reference",
+        name="pr-reference",
+        description="Audit stale pull request references.",
+        body=_healthy_body("PR references")
+        + "\nMove stale detail from PR #1234 to references.",
     )
 
     report = audit_skills()
-    findings_by_name = {skill.name: {finding.code for finding in skill.card_findings} for skill in report.skills}
+    findings_by_name = {
+        skill.name: {finding.code for finding in skill.card_findings}
+        for skill in report.skills
+    }
 
     assert "session_artifact" not in findings_by_name["date-reference"]
-    assert "session_artifact" in findings_by_name["sha-reference"]
+    assert "session_artifact" not in findings_by_name["sha-reference"]
+    assert "session_artifact" in findings_by_name["pr-reference"]
+
+
+def test_prompt_footprint_measures_rendered_index_not_full_body(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-index"))
+    _write_skill(
+        tmp_path / "profile-index" / "skills",
+        "ops/large-reference",
+        name="large-reference",
+        description="A deliberately long description that the real prompt builder truncates before rendering.",
+        body=_healthy_body("large references") + ("\nDetailed procedure text." * 1000),
+    )
+
+    report = audit_skills()
+    skill = report.skills[0]
+    codes = {finding.code for finding in skill.card_findings}
+
+    assert skill.char_count > 20_000
+    assert skill.estimated_tokens < 30
+    assert "prompt_bloat" not in codes
+    assert "large_card" not in codes
 
 
 def test_cli_no_write_json_smoke(tmp_path, monkeypatch, capsys):

--- a/tests/tools/test_skill_cleaner.py
+++ b/tests/tools/test_skill_cleaner.py
@@ -1,0 +1,180 @@
+import json
+from pathlib import Path
+
+from tools.skill_cleaner import audit_skills, main, report_to_dict, write_report_files
+
+
+def _write_skill(root: Path, rel: str, *, name: str, description: str, body: str) -> Path:
+    skill_dir = root / rel
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        f"name: {name}\n"
+        f"description: {description}\n"
+        "---\n"
+        f"# {name}\n\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def _healthy_body(topic: str) -> str:
+    return f"""
+Use when auditing {topic} skills for reusable operating guidance.
+
+## Workflow
+1. Inspect the card frontmatter and body.
+2. Compare the procedure against related skills.
+3. Record report-only findings for Glen approval.
+
+## Verification
+Validate the output artifact and do not mutate skills during the audit.
+"""
+
+
+def test_audit_uses_active_profile_home_and_writes_report(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+    skills_root = tmp_path / "profile-a" / "skills"
+    _write_skill(
+        skills_root,
+        "ops/test-audit",
+        name="test-audit",
+        description="Audit skill for report-only cleaner tests.",
+        body=_healthy_body("Hermes"),
+    )
+
+    report = audit_skills()
+    data = report_to_dict(report)
+
+    assert report.hermes_home == str(tmp_path / "profile-a")
+    assert report.scanned_roots == [str(skills_root)]
+    assert data["summary"]["skill_count"] == 1
+    assert report.skills[0].name == "test-audit"
+    assert report.skills[0].source == "active-profile"
+
+    md_path, json_path = write_report_files(report)
+    assert md_path.is_file()
+    assert json_path.is_file()
+    assert str(tmp_path / "profile-a" / "reports" / "skill-cleaner") in str(md_path)
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["summary"]["skill_count"] == 1
+
+
+def test_verified_card_contract_flags_thin_missing_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-b"))
+    skill_dir = tmp_path / "profile-b" / "skills" / "bad-card"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Bad\n\nToo short.\n", encoding="utf-8")
+
+    report = audit_skills()
+    codes = {finding.code for finding in report.skills[0].card_findings}
+
+    assert "missing_frontmatter" in codes
+    assert "missing_description" in codes
+    assert "thin_body" in codes
+    assert "missing_skill_card" in codes
+    assert report.finding_counts["error"] >= 2
+
+
+def test_audit_includes_configured_external_skill_dirs(tmp_path, monkeypatch):
+    home = tmp_path / "profile-external"
+    external_root = tmp_path / "external-skills"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "skills:\n  external_dirs:\n    - " + str(external_root) + "\n",
+        encoding="utf-8",
+    )
+    _write_skill(
+        home / "skills",
+        "ops/local-audit",
+        name="local-audit",
+        description="Local audit skill.",
+        body=_healthy_body("local"),
+    )
+    _write_skill(
+        external_root,
+        "ops/external-audit",
+        name="external-audit",
+        description="External audit skill.",
+        body=_healthy_body("external"),
+    )
+
+    report = audit_skills()
+
+    assert str(home / "skills") in report.scanned_roots
+    assert str(external_root) in report.scanned_roots
+    assert {skill.source for skill in report.skills} == {"active-profile", "external"}
+
+
+def test_duplicate_detection_can_include_bundled_root(tmp_path, monkeypatch):
+    active_home = tmp_path / "profile-c"
+    bundled_root = tmp_path / "bundled-skills"
+    monkeypatch.setenv("HERMES_HOME", str(active_home))
+    monkeypatch.setenv("HERMES_BUNDLED_SKILLS", str(bundled_root))
+
+    duplicate_body = _healthy_body("duplicate skill overlap") + "\nshared terraform dns deployment audit approval gate " * 8
+    _write_skill(
+        active_home / "skills",
+        "operations/dns-audit",
+        name="dns-audit",
+        description="Audit DNS deployment gates and approvals.",
+        body=duplicate_body,
+    )
+    _write_skill(
+        bundled_root,
+        "operations/dns-audit-copy",
+        name="dns-audit-copy",
+        description="Audit DNS deployment gates and approvals.",
+        body=duplicate_body,
+    )
+
+    without_bundled = audit_skills(include_bundled=False, similarity_threshold=0.8)
+    with_bundled = audit_skills(include_bundled=True, similarity_threshold=0.8)
+
+    assert len(without_bundled.skills) == 1
+    assert len(with_bundled.skills) == 2
+    assert with_bundled.duplicates
+    assert with_bundled.duplicates[0].similarity >= 0.8
+
+
+def test_session_artifact_detection_ignores_numeric_date_references(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-dates"))
+    _write_skill(
+        tmp_path / "profile-dates" / "skills",
+        "ops/date-reference",
+        name="date-reference",
+        description="Audit dated reference names without false SHA matches.",
+        body=_healthy_body("dated references") + "\nOpen references/report-20260525.md when needed.",
+    )
+    _write_skill(
+        tmp_path / "profile-dates" / "skills",
+        "ops/sha-reference",
+        name="sha-reference",
+        description="Audit real SHA-like artifacts.",
+        body=_healthy_body("SHA references") + "\nMove stale detail for deadbee when found.",
+    )
+
+    report = audit_skills()
+    findings_by_name = {skill.name: {finding.code for finding in skill.card_findings} for skill in report.skills}
+
+    assert "session_artifact" not in findings_by_name["date-reference"]
+    assert "session_artifact" in findings_by_name["sha-reference"]
+
+
+def test_cli_no_write_json_smoke(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-d"))
+    _write_skill(
+        tmp_path / "profile-d" / "skills",
+        "ops/test-audit",
+        name="test-audit",
+        description="Audit skill for CLI smoke tests.",
+        body=_healthy_body("CLI"),
+    )
+
+    assert main(["--no-write", "--json"]) == 0
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert payload["summary"]["skill_count"] == 1
+    assert "artifacts" not in payload

--- a/tools/skill_cleaner.py
+++ b/tools/skill_cleaner.py
@@ -1,9 +1,9 @@
 """Report-only Hermes skill cleaner/audit helpers.
 
-This module intentionally performs **no mutations**. It inventories skill cards,
-runs the existing skills guard, checks a minimal verified-card contract, estimates
-prompt bloat, and reports likely duplicate/overlapping skills so a human/curator
-can decide what to consolidate.
+This module intentionally performs **no mutations**. It inventories skills,
+runs the existing skills guard, checks the documented skill frontmatter, estimates
+the rendered prompt-index footprint, and reports likely duplicate/overlapping
+skills so a human/curator can decide what to consolidate.
 """
 
 from __future__ import annotations
@@ -17,17 +17,28 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files, parse_frontmatter
-from hermes_constants import display_hermes_home, get_bundled_skills_dir, get_hermes_home, get_skills_dir
+from agent.skill_utils import (
+    extract_skill_description,
+    get_all_skills_dirs,
+    iter_skill_index_files,
+    parse_frontmatter,
+)
+from hermes_constants import (
+    display_hermes_home,
+    get_bundled_skills_dir,
+    get_hermes_home,
+    get_skills_dir,
+)
 from tools.skills_guard import scan_skill
 
 _TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9_-]{2,}")
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
 _NUMBERED_STEP_RE = re.compile(r"(?m)^\s*\d+\.\s+\S+")
 _SESSION_ARTIFACT_RE = re.compile(
-    r"\b(?:PR\s*#?\d+|pull request\s*#?\d+|issue\s*#?\d+|(?=[0-9a-f]{7,40}\b)(?=[0-9a-f]*[a-f])[0-9a-f]{7,40})\b",
+    r"\b(?:PR\s*#?\d+|pull request\s*#?\d+|issue\s*#?\d+)\b",
     re.IGNORECASE,
 )
+_CONTENT_HASH_FIELD_RE = re.compile(r"^\s*content_sha256\s*:")
 
 
 @dataclass
@@ -93,8 +104,25 @@ def _estimate_tokens(text: str) -> int:
 
 def _token_set(text: str) -> set[str]:
     stop = {
-        "the", "and", "for", "with", "that", "this", "when", "from", "into", "your",
-        "skill", "skills", "hermes", "agent", "use", "using", "will", "must", "should",
+        "the",
+        "and",
+        "for",
+        "with",
+        "that",
+        "this",
+        "when",
+        "from",
+        "into",
+        "your",
+        "skill",
+        "skills",
+        "hermes",
+        "agent",
+        "use",
+        "using",
+        "will",
+        "must",
+        "should",
     }
     return {tok.lower() for tok in _TOKEN_RE.findall(text) if tok.lower() not in stop}
 
@@ -140,118 +168,179 @@ def _nested_get(data: dict[str, Any], dotted: str) -> Any:
     return cur
 
 
-def _check_required_card_field(findings: list[CardFinding], card: dict[str, Any], dotted: str) -> None:
-    value = _nested_get(card, dotted)
-    missing = value is None or value == "" or value == [] or value == {}
-    if missing:
-        findings.append(CardFinding("warning", "missing_skill_card_field", f"skill_card.{dotted} is required by the verified-card contract."))
+def _canonical_skill_content_for_hash(raw: str) -> str:
+    """Return SKILL.md content with its frontmatter content hash field omitted.
+
+    The hash cannot cover its own value. Preserve every other byte so the digest
+    changes when the actual skill content or other frontmatter changes.
+    """
+    lines = raw.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return raw
+
+    frontmatter_end: int | None = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            frontmatter_end = index
+            break
+    if frontmatter_end is None:
+        return raw
+
+    return "".join(
+        line
+        for index, line in enumerate(lines)
+        if not (index < frontmatter_end and _CONTENT_HASH_FIELD_RE.match(line))
+    )
 
 
 def _skill_card_findings(card: Any, raw: str) -> list[CardFinding]:
     findings: list[CardFinding] = []
+    if card is None:
+        return findings
     if not isinstance(card, dict):
         return [
             CardFinding(
                 "warning",
-                "missing_skill_card",
-                "Add skill_card provenance/risk/scope/verification/dependency metadata before trusting this skill as verified.",
+                "invalid_skill_card",
+                "Optional skill_card metadata must be a mapping when present.",
             )
         ]
 
-    required_fields = (
-        "card_version",
-        "source.origin",
-        "source.upstream_url",
-        "source.author",
-        "source.imported_at",
-        "scope.summary",
-        "scope.allowed_surfaces",
-        "scope.denied_surfaces",
-        "risk.level",
-        "risk.reasons",
-        "risk.approval_required_for",
-        "verification.reviewed_by",
-        "verification.reviewed_at",
-        "verification.spec_reference",
-        "verification.content_sha256",
-        "verification.modified_since_review",
-        "dependencies.required_env_vars",
-        "dependencies.required_commands",
-        "dependencies.network_access",
-    )
-    for field_name in required_fields:
-        _check_required_card_field(findings, card, field_name)
-
-    level = str(_nested_get(card, "risk.level") or "").strip().lower()
-    if level and level not in {"low", "medium", "high", "critical"}:
-        findings.append(CardFinding("warning", "invalid_risk_level", "skill_card.risk.level must be low, medium, high, or critical."))
-
-    for dotted in (
-        "scope.allowed_surfaces",
-        "scope.denied_surfaces",
-        "risk.reasons",
-        "risk.approval_required_for",
-        "dependencies.required_env_vars",
-        "dependencies.required_commands",
-    ):
-        value = _nested_get(card, dotted)
-        if value is not None and not isinstance(value, list):
-            findings.append(CardFinding("warning", "invalid_skill_card_field", f"skill_card.{dotted} should be a list."))
-
-    modified = _nested_get(card, "verification.modified_since_review")
-    if modified is True:
-        findings.append(CardFinding("warning", "modified_since_review", "Skill card says content changed since review; re-review before trusting."))
-
+    # There is no repository-wide skill_card schema. Treat it as optional and
+    # validate only an explicit integrity claim, without inventing required
+    # provenance, risk, scope, or dependency fields.
     expected_hash = _nested_get(card, "verification.content_sha256")
-    if isinstance(expected_hash, str) and len(expected_hash.strip()) == 64:
-        actual_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    if isinstance(expected_hash, str) and re.fullmatch(
+        r"[0-9a-fA-F]{64}", expected_hash.strip()
+    ):
+        canonical = _canonical_skill_content_for_hash(raw)
+        actual_hash = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
         if expected_hash.strip().lower() != actual_hash:
-            findings.append(CardFinding("warning", "content_hash_mismatch", "skill_card verification hash does not match current SKILL.md content."))
+            findings.append(
+                CardFinding(
+                    "warning",
+                    "content_hash_mismatch",
+                    "skill_card verification hash does not match current SKILL.md content.",
+                )
+            )
+    elif expected_hash is not None:
+        findings.append(
+            CardFinding(
+                "warning",
+                "invalid_content_hash",
+                "skill_card verification hash must be a 64-character SHA-256 digest.",
+            )
+        )
 
     return findings
 
 
-def _card_contract_findings(frontmatter: dict[str, Any], body: str, raw: str, skill_dir: Path) -> list[CardFinding]:
+def _card_contract_findings(
+    frontmatter: dict[str, Any], body: str, raw: str, skill_dir: Path
+) -> list[CardFinding]:
     findings: list[CardFinding] = []
     name = str(frontmatter.get("name") or skill_dir.name).strip()
     description = str(frontmatter.get("description") or "").strip()
 
     if not raw.startswith("---"):
-        findings.append(CardFinding("error", "missing_frontmatter", "SKILL.md must start with YAML frontmatter."))
+        findings.append(
+            CardFinding(
+                "error",
+                "missing_frontmatter",
+                "SKILL.md must start with YAML frontmatter.",
+            )
+        )
     if not name or not _NAME_RE.match(name):
-        findings.append(CardFinding("error", "invalid_name", "Frontmatter `name` must be lowercase kebab/underscore identifier."))
+        findings.append(
+            CardFinding(
+                "error",
+                "invalid_name",
+                "Frontmatter `name` must be lowercase kebab/underscore identifier.",
+            )
+        )
     if not description:
-        findings.append(CardFinding("error", "missing_description", "Frontmatter `description` is required for discoverability."))
+        findings.append(
+            CardFinding(
+                "error",
+                "missing_description",
+                "Frontmatter `description` is required for discoverability.",
+            )
+        )
     elif len(description) > 220:
-        findings.append(CardFinding("warning", "long_description", "Description is too long for a compact skill card."))
+        findings.append(
+            CardFinding(
+                "warning",
+                "long_description",
+                "Description is too long for a compact skill card.",
+            )
+        )
 
     lower_body = body.lower()
     if len(body.strip()) < 400:
-        findings.append(CardFinding("warning", "thin_body", "Body is thin; class-level skills need actionable workflow detail."))
-    if not any(marker in lower_body for marker in ("when to use", "trigger", "use when", "scope")):
-        findings.append(CardFinding("warning", "missing_trigger", "Add trigger/when-to-use guidance."))
-    if not (_NUMBERED_STEP_RE.search(body) or any(marker in lower_body for marker in ("steps", "workflow", "procedure"))):
-        findings.append(CardFinding("warning", "missing_workflow", "Add concrete workflow steps or a procedure section."))
-    if not any(marker in lower_body for marker in ("verify", "verification", "validate", "checks", "tests")):
-        findings.append(CardFinding("warning", "missing_verification", "Add verification/checks guidance."))
+        findings.append(
+            CardFinding(
+                "warning",
+                "thin_body",
+                "Body is thin; class-level skills need actionable workflow detail.",
+            )
+        )
+    if not any(
+        marker in lower_body
+        for marker in ("when to use", "trigger", "use when", "scope")
+    ):
+        findings.append(
+            CardFinding(
+                "warning", "missing_trigger", "Add trigger/when-to-use guidance."
+            )
+        )
+    if not (
+        _NUMBERED_STEP_RE.search(body)
+        or any(marker in lower_body for marker in ("steps", "workflow", "procedure"))
+    ):
+        findings.append(
+            CardFinding(
+                "warning",
+                "missing_workflow",
+                "Add concrete workflow steps or a procedure section.",
+            )
+        )
+    if not any(
+        marker in lower_body
+        for marker in ("verify", "verification", "validate", "checks", "tests")
+    ):
+        findings.append(
+            CardFinding(
+                "warning", "missing_verification", "Add verification/checks guidance."
+            )
+        )
     if _SESSION_ARTIFACT_RE.search(body):
-        findings.append(CardFinding("warning", "session_artifact", "Body appears to include PR/issue/SHA session artifacts; move stale detail to references or remove."))
-
-    estimated_tokens = _estimate_tokens(raw)
-    if estimated_tokens > 4000:
-        findings.append(CardFinding("error", "prompt_bloat", f"Estimated {estimated_tokens:,} tokens; split details into references/templates/scripts."))
-    elif estimated_tokens > 2000:
-        findings.append(CardFinding("warning", "large_card", f"Estimated {estimated_tokens:,} tokens; review for prompt bloat."))
+        findings.append(
+            CardFinding(
+                "warning",
+                "session_artifact",
+                "Body appears to include PR/issue session artifacts; move stale detail to references or remove.",
+            )
+        )
 
     return findings
 
 
-def _scan_one(skill_md: Path, root: Path, source: str) -> tuple[SkillCardReport, set[str]]:
+def _rendered_index_entry(name: str, description: str) -> str:
+    """Mirror the name/description payload rendered by build_skills_system_prompt."""
+    return f"- {name}: {description}" if description else f"- {name}"
+
+
+def _scan_one(
+    skill_md: Path, root: Path, source: str
+) -> tuple[SkillCardReport, set[str]]:
     raw = skill_md.read_text(encoding="utf-8")
     frontmatter, body = parse_frontmatter(raw)
     skill_dir = skill_md.parent
     name = str(frontmatter.get("name") or skill_dir.name).strip() or skill_dir.name
-    guard = scan_skill(skill_dir, source="official" if source == "bundled" else "agent-created")
+    description = extract_skill_description(frontmatter)
+    guard = scan_skill(
+        skill_dir, source="official" if source == "bundled" else "agent-created"
+    )
     rel = _relative_to_root(skill_dir, root)
     card_findings = _card_contract_findings(frontmatter, body, raw, skill_dir)
     card_findings.extend(_skill_card_findings(frontmatter.get("skill_card"), raw))
@@ -261,8 +350,8 @@ def _scan_one(skill_md: Path, root: Path, source: str) -> tuple[SkillCardReport,
         path=str(skill_dir),
         rel_path=rel,
         char_count=len(raw),
-        estimated_tokens=_estimate_tokens(raw),
-        description=str(frontmatter.get("description") or "").strip(),
+        estimated_tokens=_estimate_tokens(_rendered_index_entry(name, description)),
+        description=description,
         guard_verdict=guard.verdict,
         guard_findings=len(guard.findings),
         card_findings=card_findings,
@@ -271,7 +360,9 @@ def _scan_one(skill_md: Path, root: Path, source: str) -> tuple[SkillCardReport,
     return report, tokens
 
 
-def audit_skills(*, include_bundled: bool = False, similarity_threshold: float = 0.42) -> SkillCleanerReport:
+def audit_skills(
+    *, include_bundled: bool = False, similarity_threshold: float = 0.42
+) -> SkillCleanerReport:
     """Build a read-only skill-cleaner report for the active Hermes profile."""
     reports: list[SkillCardReport] = []
     token_sets: dict[str, set[str]] = {}
@@ -294,11 +385,27 @@ def audit_skills(*, include_bundled: bool = False, similarity_threshold: float =
     for idx, (left_key, left) in enumerate(keyed):
         for right_key, right in keyed[idx + 1 :]:
             if left.name == right.name and left.path != right.path:
-                duplicates.append(DuplicateCandidate(left.name, right.name, 1.0, "same skill name in multiple locations"))
+                duplicates.append(
+                    DuplicateCandidate(
+                        left.name,
+                        right.name,
+                        1.0,
+                        "same skill name in multiple locations",
+                    )
+                )
                 continue
-            sim = _jaccard(token_sets.get(left_key, set()), token_sets.get(right_key, set()))
+            sim = _jaccard(
+                token_sets.get(left_key, set()), token_sets.get(right_key, set())
+            )
             if sim >= similarity_threshold:
-                duplicates.append(DuplicateCandidate(left.name, right.name, round(sim, 3), "high content-term overlap"))
+                duplicates.append(
+                    DuplicateCandidate(
+                        left.name,
+                        right.name,
+                        round(sim, 3),
+                        "high content-term overlap",
+                    )
+                )
 
     duplicates.sort(key=lambda d: d.similarity, reverse=True)
     reports.sort(key=lambda s: (s.estimated_tokens, s.name), reverse=True)
@@ -322,7 +429,9 @@ def report_to_dict(report: SkillCleanerReport) -> dict[str, Any]:
     return data
 
 
-def format_markdown_report(report: SkillCleanerReport, *, duplicate_limit: int = 30, finding_limit: int = 80) -> str:
+def format_markdown_report(
+    report: SkillCleanerReport, *, duplicate_limit: int = 30, finding_limit: int = 80
+) -> str:
     counts = report.finding_counts
     lines = [
         "# Hermes Skill Cleaner Report",
@@ -331,15 +440,15 @@ def format_markdown_report(report: SkillCleanerReport, *, duplicate_limit: int =
         "",
         f"- Generated: `{report.generated_at}`",
         f"- Hermes home: `{report.hermes_home}`",
-        f"- Scanned roots: {', '.join(f'`{r}`' for r in report.scanned_roots) or '(none)' }",
+        f"- Scanned roots: {', '.join(f'`{r}`' for r in report.scanned_roots) or '(none)'}",
         f"- Skills scanned: **{len(report.skills)}**",
-        f"- Estimated loaded skill-card tokens: **{report.total_estimated_tokens:,}**",
+        f"- Estimated rendered skill-index entry tokens: **{report.total_estimated_tokens:,}**",
         f"- Card findings: errors={counts.get('error', 0)}, warnings={counts.get('warning', 0)}, info={counts.get('info', 0)}",
         f"- Duplicate candidates: **{len(report.duplicates)}**",
         "",
-        "## Largest skill cards",
+        "## Largest rendered skill-index entries",
         "",
-        "| Skill | Source | Est. tokens | Guard | Path |",
+        "| Skill | Source | Est. index tokens | Guard | Path |",
         "|---|---:|---:|---|---|",
     ]
     for skill in report.skills[:20]:
@@ -348,20 +457,24 @@ def format_markdown_report(report: SkillCleanerReport, *, duplicate_limit: int =
             f"{skill.guard_verdict} ({skill.guard_findings}) | `{skill.rel_path}` |"
         )
 
-    lines.extend(["", "## Verified skill-card findings", ""])
+    lines.extend(["", "## Skill findings", ""])
     emitted = 0
     for skill in report.skills:
         for finding in skill.card_findings:
             if emitted >= finding_limit:
                 break
-            lines.append(f"- **{finding.severity.upper()}** `{skill.name}` `{finding.code}` — {finding.message}")
+            lines.append(
+                f"- **{finding.severity.upper()}** `{skill.name}` `{finding.code}` — {finding.message}"
+            )
             emitted += 1
         if emitted >= finding_limit:
             break
     if emitted == 0:
-        lines.append("- No verified-card findings.")
+        lines.append("- No skill findings.")
     elif sum(len(s.card_findings) for s in report.skills) > emitted:
-        lines.append(f"- ...truncated at {finding_limit} findings; see JSON for all findings.")
+        lines.append(
+            f"- ...truncated at {finding_limit} findings; see JSON for all findings."
+        )
 
     lines.extend(["", "## Duplicate / consolidation candidates", ""])
     if not report.duplicates:
@@ -369,9 +482,13 @@ def format_markdown_report(report: SkillCleanerReport, *, duplicate_limit: int =
     else:
         lines.extend(["| Similarity | Left | Right | Reason |", "|---:|---|---|---|"])
         for dup in report.duplicates[:duplicate_limit]:
-            lines.append(f"| {dup.similarity:.3f} | `{dup.left}` | `{dup.right}` | {dup.reason} |")
+            lines.append(
+                f"| {dup.similarity:.3f} | `{dup.left}` | `{dup.right}` | {dup.reason} |"
+            )
         if len(report.duplicates) > duplicate_limit:
-            lines.append(f"\n_Truncated at {duplicate_limit} duplicate candidates; see JSON for all pairs._")
+            lines.append(
+                f"\n_Truncated at {duplicate_limit} duplicate candidates; see JSON for all pairs._"
+            )
 
     lines.extend([
         "",
@@ -383,7 +500,9 @@ def format_markdown_report(report: SkillCleanerReport, *, duplicate_limit: int =
     return "\n".join(lines)
 
 
-def write_report_files(report: SkillCleanerReport, output_dir: Path | None = None) -> tuple[Path, Path]:
+def write_report_files(
+    report: SkillCleanerReport, output_dir: Path | None = None
+) -> tuple[Path, Path]:
     """Write markdown and JSON report artifacts under the active profile reports dir."""
     if output_dir is None:
         output_dir = get_hermes_home() / "reports" / "skill-cleaner"
@@ -392,7 +511,10 @@ def write_report_files(report: SkillCleanerReport, output_dir: Path | None = Non
     md_path = output_dir / f"skill-cleaner-{stamp}.md"
     json_path = output_dir / f"skill-cleaner-{stamp}.json"
     md_path.write_text(format_markdown_report(report), encoding="utf-8")
-    json_path.write_text(json.dumps(report_to_dict(report), indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    json_path.write_text(
+        json.dumps(report_to_dict(report), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
     return md_path, json_path
 
 

--- a/tools/skill_cleaner.py
+++ b/tools/skill_cleaner.py
@@ -1,0 +1,459 @@
+"""Report-only Hermes skill cleaner/audit helpers.
+
+This module intentionally performs **no mutations**. It inventories skill cards,
+runs the existing skills guard, checks a minimal verified-card contract, estimates
+prompt bloat, and reports likely duplicate/overlapping skills so a human/curator
+can decide what to consolidate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files, parse_frontmatter
+from hermes_constants import display_hermes_home, get_bundled_skills_dir, get_hermes_home, get_skills_dir
+from tools.skills_guard import scan_skill
+
+_TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9_-]{2,}")
+_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+_NUMBERED_STEP_RE = re.compile(r"(?m)^\s*\d+\.\s+\S+")
+_SESSION_ARTIFACT_RE = re.compile(
+    r"\b(?:PR\s*#?\d+|pull request\s*#?\d+|issue\s*#?\d+|(?=[0-9a-f]{7,40}\b)(?=[0-9a-f]*[a-f])[0-9a-f]{7,40})\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class CardFinding:
+    severity: str
+    code: str
+    message: str
+
+
+@dataclass
+class SkillCardReport:
+    name: str
+    source: str
+    path: str
+    rel_path: str
+    char_count: int
+    estimated_tokens: int
+    description: str = ""
+    guard_verdict: str = "safe"
+    guard_findings: int = 0
+    card_findings: list[CardFinding] = field(default_factory=list)
+
+
+@dataclass
+class DuplicateCandidate:
+    left: str
+    right: str
+    similarity: float
+    reason: str
+
+
+@dataclass
+class SkillCleanerReport:
+    generated_at: str
+    hermes_home: str
+    scanned_roots: list[str]
+    skills: list[SkillCardReport]
+    duplicates: list[DuplicateCandidate]
+
+    @property
+    def total_estimated_tokens(self) -> int:
+        return sum(s.estimated_tokens for s in self.skills)
+
+    @property
+    def finding_counts(self) -> dict[str, int]:
+        counts = {"error": 0, "warning": 0, "info": 0}
+        for skill in self.skills:
+            for finding in skill.card_findings:
+                counts[finding.severity] = counts.get(finding.severity, 0) + 1
+        return counts
+
+
+@dataclass(frozen=True)
+class _SkillSource:
+    label: str
+    root: Path
+
+
+def _estimate_tokens(text: str) -> int:
+    # Cheap prompt-size approximation; intentionally deterministic and dependency-free.
+    return max(1, (len(text) + 3) // 4)
+
+
+def _token_set(text: str) -> set[str]:
+    stop = {
+        "the", "and", "for", "with", "that", "this", "when", "from", "into", "your",
+        "skill", "skills", "hermes", "agent", "use", "using", "will", "must", "should",
+    }
+    return {tok.lower() for tok in _TOKEN_RE.findall(text) if tok.lower() not in stop}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def _relative_to_root(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _source_roots(include_bundled: bool) -> list[_SkillSource]:
+    active_root = get_skills_dir().resolve()
+    roots: list[_SkillSource] = []
+    seen: set[Path] = set()
+    for root in get_all_skills_dirs():
+        resolved = root.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        label = "active-profile" if resolved == active_root else "external"
+        roots.append(_SkillSource(label, resolved))
+    if include_bundled:
+        repo_default = Path(__file__).resolve().parent.parent / "skills"
+        bundled = get_bundled_skills_dir(default=repo_default).resolve()
+        if bundled not in seen:
+            roots.append(_SkillSource("bundled", bundled))
+    return roots
+
+
+def _nested_get(data: dict[str, Any], dotted: str) -> Any:
+    cur: Any = data
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _check_required_card_field(findings: list[CardFinding], card: dict[str, Any], dotted: str) -> None:
+    value = _nested_get(card, dotted)
+    missing = value is None or value == "" or value == [] or value == {}
+    if missing:
+        findings.append(CardFinding("warning", "missing_skill_card_field", f"skill_card.{dotted} is required by the verified-card contract."))
+
+
+def _skill_card_findings(card: Any, raw: str) -> list[CardFinding]:
+    findings: list[CardFinding] = []
+    if not isinstance(card, dict):
+        return [
+            CardFinding(
+                "warning",
+                "missing_skill_card",
+                "Add skill_card provenance/risk/scope/verification/dependency metadata before trusting this skill as verified.",
+            )
+        ]
+
+    required_fields = (
+        "card_version",
+        "source.origin",
+        "source.upstream_url",
+        "source.author",
+        "source.imported_at",
+        "scope.summary",
+        "scope.allowed_surfaces",
+        "scope.denied_surfaces",
+        "risk.level",
+        "risk.reasons",
+        "risk.approval_required_for",
+        "verification.reviewed_by",
+        "verification.reviewed_at",
+        "verification.spec_reference",
+        "verification.content_sha256",
+        "verification.modified_since_review",
+        "dependencies.required_env_vars",
+        "dependencies.required_commands",
+        "dependencies.network_access",
+    )
+    for field_name in required_fields:
+        _check_required_card_field(findings, card, field_name)
+
+    level = str(_nested_get(card, "risk.level") or "").strip().lower()
+    if level and level not in {"low", "medium", "high", "critical"}:
+        findings.append(CardFinding("warning", "invalid_risk_level", "skill_card.risk.level must be low, medium, high, or critical."))
+
+    for dotted in (
+        "scope.allowed_surfaces",
+        "scope.denied_surfaces",
+        "risk.reasons",
+        "risk.approval_required_for",
+        "dependencies.required_env_vars",
+        "dependencies.required_commands",
+    ):
+        value = _nested_get(card, dotted)
+        if value is not None and not isinstance(value, list):
+            findings.append(CardFinding("warning", "invalid_skill_card_field", f"skill_card.{dotted} should be a list."))
+
+    modified = _nested_get(card, "verification.modified_since_review")
+    if modified is True:
+        findings.append(CardFinding("warning", "modified_since_review", "Skill card says content changed since review; re-review before trusting."))
+
+    expected_hash = _nested_get(card, "verification.content_sha256")
+    if isinstance(expected_hash, str) and len(expected_hash.strip()) == 64:
+        actual_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        if expected_hash.strip().lower() != actual_hash:
+            findings.append(CardFinding("warning", "content_hash_mismatch", "skill_card verification hash does not match current SKILL.md content."))
+
+    return findings
+
+
+def _card_contract_findings(frontmatter: dict[str, Any], body: str, raw: str, skill_dir: Path) -> list[CardFinding]:
+    findings: list[CardFinding] = []
+    name = str(frontmatter.get("name") or skill_dir.name).strip()
+    description = str(frontmatter.get("description") or "").strip()
+
+    if not raw.startswith("---"):
+        findings.append(CardFinding("error", "missing_frontmatter", "SKILL.md must start with YAML frontmatter."))
+    if not name or not _NAME_RE.match(name):
+        findings.append(CardFinding("error", "invalid_name", "Frontmatter `name` must be lowercase kebab/underscore identifier."))
+    if not description:
+        findings.append(CardFinding("error", "missing_description", "Frontmatter `description` is required for discoverability."))
+    elif len(description) > 220:
+        findings.append(CardFinding("warning", "long_description", "Description is too long for a compact skill card."))
+
+    lower_body = body.lower()
+    if len(body.strip()) < 400:
+        findings.append(CardFinding("warning", "thin_body", "Body is thin; class-level skills need actionable workflow detail."))
+    if not any(marker in lower_body for marker in ("when to use", "trigger", "use when", "scope")):
+        findings.append(CardFinding("warning", "missing_trigger", "Add trigger/when-to-use guidance."))
+    if not (_NUMBERED_STEP_RE.search(body) or any(marker in lower_body for marker in ("steps", "workflow", "procedure"))):
+        findings.append(CardFinding("warning", "missing_workflow", "Add concrete workflow steps or a procedure section."))
+    if not any(marker in lower_body for marker in ("verify", "verification", "validate", "checks", "tests")):
+        findings.append(CardFinding("warning", "missing_verification", "Add verification/checks guidance."))
+    if _SESSION_ARTIFACT_RE.search(body):
+        findings.append(CardFinding("warning", "session_artifact", "Body appears to include PR/issue/SHA session artifacts; move stale detail to references or remove."))
+
+    estimated_tokens = _estimate_tokens(raw)
+    if estimated_tokens > 4000:
+        findings.append(CardFinding("error", "prompt_bloat", f"Estimated {estimated_tokens:,} tokens; split details into references/templates/scripts."))
+    elif estimated_tokens > 2000:
+        findings.append(CardFinding("warning", "large_card", f"Estimated {estimated_tokens:,} tokens; review for prompt bloat."))
+
+    return findings
+
+
+def _scan_one(skill_md: Path, root: Path, source: str) -> tuple[SkillCardReport, set[str]]:
+    raw = skill_md.read_text(encoding="utf-8")
+    frontmatter, body = parse_frontmatter(raw)
+    skill_dir = skill_md.parent
+    name = str(frontmatter.get("name") or skill_dir.name).strip() or skill_dir.name
+    guard = scan_skill(skill_dir, source="official" if source == "bundled" else "agent-created")
+    rel = _relative_to_root(skill_dir, root)
+    card_findings = _card_contract_findings(frontmatter, body, raw, skill_dir)
+    card_findings.extend(_skill_card_findings(frontmatter.get("skill_card"), raw))
+    report = SkillCardReport(
+        name=name,
+        source=source,
+        path=str(skill_dir),
+        rel_path=rel,
+        char_count=len(raw),
+        estimated_tokens=_estimate_tokens(raw),
+        description=str(frontmatter.get("description") or "").strip(),
+        guard_verdict=guard.verdict,
+        guard_findings=len(guard.findings),
+        card_findings=card_findings,
+    )
+    tokens = _token_set(f"{name} {report.description}\n{body}")
+    return report, tokens
+
+
+def audit_skills(*, include_bundled: bool = False, similarity_threshold: float = 0.42) -> SkillCleanerReport:
+    """Build a read-only skill-cleaner report for the active Hermes profile."""
+    reports: list[SkillCardReport] = []
+    token_sets: dict[str, set[str]] = {}
+    roots = _source_roots(include_bundled)
+
+    for source in roots:
+        if not source.root.is_dir():
+            continue
+        for skill_md in iter_skill_index_files(source.root, "SKILL.md"):
+            try:
+                report, tokens = _scan_one(skill_md, source.root, source.label)
+            except (OSError, UnicodeDecodeError):
+                continue
+            key = f"{report.source}:{report.rel_path}:{report.name}"
+            reports.append(report)
+            token_sets[key] = tokens
+
+    duplicates: list[DuplicateCandidate] = []
+    keyed = [(f"{r.source}:{r.rel_path}:{r.name}", r) for r in reports]
+    for idx, (left_key, left) in enumerate(keyed):
+        for right_key, right in keyed[idx + 1 :]:
+            if left.name == right.name and left.path != right.path:
+                duplicates.append(DuplicateCandidate(left.name, right.name, 1.0, "same skill name in multiple locations"))
+                continue
+            sim = _jaccard(token_sets.get(left_key, set()), token_sets.get(right_key, set()))
+            if sim >= similarity_threshold:
+                duplicates.append(DuplicateCandidate(left.name, right.name, round(sim, 3), "high content-term overlap"))
+
+    duplicates.sort(key=lambda d: d.similarity, reverse=True)
+    reports.sort(key=lambda s: (s.estimated_tokens, s.name), reverse=True)
+    return SkillCleanerReport(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        hermes_home=display_hermes_home(),
+        scanned_roots=[str(s.root) for s in roots if s.root.is_dir()],
+        skills=reports,
+        duplicates=duplicates,
+    )
+
+
+def report_to_dict(report: SkillCleanerReport) -> dict[str, Any]:
+    data = asdict(report)
+    data["summary"] = {
+        "skill_count": len(report.skills),
+        "total_estimated_tokens": report.total_estimated_tokens,
+        "finding_counts": report.finding_counts,
+        "duplicate_candidates": len(report.duplicates),
+    }
+    return data
+
+
+def format_markdown_report(report: SkillCleanerReport, *, duplicate_limit: int = 30, finding_limit: int = 80) -> str:
+    counts = report.finding_counts
+    lines = [
+        "# Hermes Skill Cleaner Report",
+        "",
+        "Read-only audit. No skills were modified, archived, deleted, or rewritten.",
+        "",
+        f"- Generated: `{report.generated_at}`",
+        f"- Hermes home: `{report.hermes_home}`",
+        f"- Scanned roots: {', '.join(f'`{r}`' for r in report.scanned_roots) or '(none)' }",
+        f"- Skills scanned: **{len(report.skills)}**",
+        f"- Estimated loaded skill-card tokens: **{report.total_estimated_tokens:,}**",
+        f"- Card findings: errors={counts.get('error', 0)}, warnings={counts.get('warning', 0)}, info={counts.get('info', 0)}",
+        f"- Duplicate candidates: **{len(report.duplicates)}**",
+        "",
+        "## Largest skill cards",
+        "",
+        "| Skill | Source | Est. tokens | Guard | Path |",
+        "|---|---:|---:|---|---|",
+    ]
+    for skill in report.skills[:20]:
+        lines.append(
+            f"| `{skill.name}` | {skill.source} | {skill.estimated_tokens:,} | "
+            f"{skill.guard_verdict} ({skill.guard_findings}) | `{skill.rel_path}` |"
+        )
+
+    lines.extend(["", "## Verified skill-card findings", ""])
+    emitted = 0
+    for skill in report.skills:
+        for finding in skill.card_findings:
+            if emitted >= finding_limit:
+                break
+            lines.append(f"- **{finding.severity.upper()}** `{skill.name}` `{finding.code}` — {finding.message}")
+            emitted += 1
+        if emitted >= finding_limit:
+            break
+    if emitted == 0:
+        lines.append("- No verified-card findings.")
+    elif sum(len(s.card_findings) for s in report.skills) > emitted:
+        lines.append(f"- ...truncated at {finding_limit} findings; see JSON for all findings.")
+
+    lines.extend(["", "## Duplicate / consolidation candidates", ""])
+    if not report.duplicates:
+        lines.append("- No duplicate candidates above threshold.")
+    else:
+        lines.extend(["| Similarity | Left | Right | Reason |", "|---:|---|---|---|"])
+        for dup in report.duplicates[:duplicate_limit]:
+            lines.append(f"| {dup.similarity:.3f} | `{dup.left}` | `{dup.right}` | {dup.reason} |")
+        if len(report.duplicates) > duplicate_limit:
+            lines.append(f"\n_Truncated at {duplicate_limit} duplicate candidates; see JSON for all pairs._")
+
+    lines.extend([
+        "",
+        "## Recommended next action",
+        "",
+        "Use this as scout data only. Consolidation, archive, delete, profile changes, or prompt-loader changes still require Workman approval gates.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def write_report_files(report: SkillCleanerReport, output_dir: Path | None = None) -> tuple[Path, Path]:
+    """Write markdown and JSON report artifacts under the active profile reports dir."""
+    if output_dir is None:
+        output_dir = get_hermes_home() / "reports" / "skill-cleaner"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    md_path = output_dir / f"skill-cleaner-{stamp}.md"
+    json_path = output_dir / f"skill-cleaner-{stamp}.json"
+    md_path.write_text(format_markdown_report(report), encoding="utf-8")
+    json_path.write_text(json.dumps(report_to_dict(report), indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return md_path, json_path
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run a read-only Hermes skill cleaner audit for the active profile.",
+    )
+    parser.add_argument(
+        "--include-bundled",
+        action="store_true",
+        help="Also scan bundled repo/package skills in addition to the active profile skills.",
+    )
+    parser.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=0.42,
+        help="Jaccard token-overlap threshold for duplicate candidates (default: 0.42).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for markdown+JSON artifacts (default: <HERMES_HOME>/reports/skill-cleaner).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print JSON summary instead of markdown after writing artifacts.",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Print the report only; do not write artifacts.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    report = audit_skills(
+        include_bundled=args.include_bundled,
+        similarity_threshold=args.similarity_threshold,
+    )
+
+    md_path: Path | None = None
+    json_path: Path | None = None
+    if not args.no_write:
+        md_path, json_path = write_report_files(report, output_dir=args.output_dir)
+
+    if args.json:
+        payload = report_to_dict(report)
+        if md_path and json_path:
+            payload["artifacts"] = {"markdown": str(md_path), "json": str(json_path)}
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(format_markdown_report(report))
+        if md_path and json_path:
+            print(f"\nArtifacts written:\n- {md_path}\n- {json_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through CLI smoke tests
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a read-only Hermes skill cleaner/audit tool that scans active/external/bundled skill roots using profile-aware Hermes home helpers.
- Add an operator wrapper that writes Markdown/JSON audit reports under the active Hermes reports directory.
- Add tests for report generation, verified skill-card metadata findings, duplicate detection, external/bundled root handling, and numeric date artifact false-positive protection.

## Validation
- `venv/bin/python -m py_compile tools/skill_cleaner.py scripts/skill_cleaner_audit.py` — passed
- `git diff --check -- tools/skill_cleaner.py scripts/skill_cleaner_audit.py tests/tools/test_skill_cleaner.py` — passed
- `scripts/run_tests.sh tests/tools/test_skill_cleaner.py tests/tools/test_skills_guard.py` — passed: 69 tests passed, 0 failed
- `venv/bin/python scripts/skill_cleaner_audit.py --json` — passed and generated report artifacts locally

## Safety
- Read-only audit tooling only.
- No skill deletion, archive, import, rewrite automation, deploy, DNS, indexing, email/social send, production/customer data mutation, secrets change, or merge performed.
- Profile-aware path handling is used so the active Hermes home is respected.
