### PR TITLE
【功能】新增 Hermes Linear AIG receiver 與多 app profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,41 @@ export HERMES_LINEAR_AIG_PROVIDER="..."    # optional
 export HERMES_LINEAR_AIG_TOOLSETS="..."    # optional comma-separated list
 ```
 
+Kilo Code, MiniMax, and Windsurf can run through the same Linear AIG receiver
+using app profiles. Profiles set provider defaults where Hermes has a matching
+provider and allow separate Linear app credentials without changing code:
+
+```bash
+export HERMES_LINEAR_AIG_APP="kilocode"
+export HERMES_LINEAR_AIG_KILOCODE_ACCESS_TOKEN="..."
+export HERMES_LINEAR_AIG_KILOCODE_WEBHOOK_SECRET="..."
+export HERMES_LINEAR_AIG_KILOCODE_TASK_MODE="oneshot"
+```
+
+```bash
+export HERMES_LINEAR_AIG_APP="minimax"
+export HERMES_LINEAR_AIG_MINIMAX_ACCESS_TOKEN="..."
+export HERMES_LINEAR_AIG_MINIMAX_WEBHOOK_SECRET="..."
+export HERMES_LINEAR_AIG_MINIMAX_TASK_MODE="oneshot"
+```
+
+The MiniMax app profile uses the `minimax-oauth` provider by default. Windsurf
+has separate app credentials but no built-in provider default yet; set
+`HERMES_LINEAR_AIG_WINDSURF_PROVIDER` if you route it through a configured
+provider.
+
+```bash
+export HERMES_LINEAR_AIG_APP="windsurf"
+export HERMES_LINEAR_AIG_WINDSURF_ACCESS_TOKEN="..."
+export HERMES_LINEAR_AIG_WINDSURF_WEBHOOK_SECRET="..."
+export HERMES_LINEAR_AIG_WINDSURF_TASK_MODE="oneshot"
+export HERMES_LINEAR_AIG_WINDSURF_PROVIDER="..." # optional configured provider
+```
+
+Supported app profiles are `hermes`, `kilocode`, `minimax`, and `windsurf`.
+Generic `HERMES_LINEAR_AIG_*` values still work; app-specific values take
+precedence when `HERMES_LINEAR_AIG_APP` or `--app` is set.
+
 ---
 
 ## Skip the API-key collection — Nous Portal

--- a/README.md
+++ b/README.md
@@ -81,6 +81,41 @@ hermes doctor       # Diagnose any issues
 
 ---
 
+## Linear Agent App Preview
+
+Hermes can run a Linear Agent Session webhook receiver for early Linear AIG app
+testing. Configure a Linear OAuth app installation with `actor=app`, request the
+`app:assignable` and `app:mentionable` scopes, enable Agent session event
+webhooks, then point the webhook URL at `/linear/aig` on your public Hermes
+receiver.
+
+Set credentials in your shell or secret manager; do not commit them:
+
+```bash
+export HERMES_LINEAR_AIG_ACCESS_TOKEN="..."
+export HERMES_LINEAR_AIG_WEBHOOK_SECRET="..."
+export HERMES_LINEAR_AIG_HOST="0.0.0.0"
+export HERMES_LINEAR_AIG_PORT="8667"
+```
+
+Validate without starting the server:
+
+```bash
+hermes linear-aig check-config
+```
+
+Start the receiver:
+
+```bash
+hermes linear-aig serve
+```
+
+The MVP receiver validates Linear webhook signatures, acknowledges
+`AgentSessionEvent` webhooks quickly, and emits Agent Activities back to Linear.
+Full Hermes task execution wiring is still separate from this preview receiver.
+
+---
+
 ## Skip the API-key collection — Nous Portal
 
 Hermes works with whatever provider you want — that's not changing. But if you'd rather not collect five separate API keys for the model, web search, image generation, TTS, and a cloud browser, **[Nous Portal](https://portal.nousresearch.com)** covers all of them under one subscription:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,16 @@ hermes linear-aig serve
 
 The MVP receiver validates Linear webhook signatures, acknowledges
 `AgentSessionEvent` webhooks quickly, and emits Agent Activities back to Linear.
-Full Hermes task execution wiring is still separate from this preview receiver.
+By default it runs in `bridge` mode, which is useful for webhook smoke tests
+because it responds transparently without starting a full Hermes task. To route
+Linear sessions through Hermes oneshot execution, set:
+
+```bash
+export HERMES_LINEAR_AIG_TASK_MODE="oneshot"
+export HERMES_LINEAR_AIG_MODEL="..."       # optional
+export HERMES_LINEAR_AIG_PROVIDER="..."    # optional
+export HERMES_LINEAR_AIG_TOOLSETS="..."    # optional comma-separated list
+```
 
 ---
 

--- a/hermes_cli/linear_aig.py
+++ b/hermes_cli/linear_aig.py
@@ -41,6 +41,14 @@ TASK_MODE_ENV = "HERMES_LINEAR_AIG_TASK_MODE"
 MODEL_ENV = "HERMES_LINEAR_AIG_MODEL"
 PROVIDER_ENV = "HERMES_LINEAR_AIG_PROVIDER"
 TOOLSETS_ENV = "HERMES_LINEAR_AIG_TOOLSETS"
+APP_ENV = "HERMES_LINEAR_AIG_APP"
+
+APP_PROFILE_DEFAULTS: dict[str, dict[str, str]] = {
+    "hermes": {},
+    "kilocode": {"provider": "kilocode"},
+    "minimax": {"provider": "minimax-oauth"},
+    "windsurf": {},
+}
 
 TASK_MODE_BRIDGE = "bridge"
 TASK_MODE_ONESHOT = "oneshot"
@@ -65,6 +73,7 @@ class AgentSessionEvent:
 class LinearAIGRuntimeConfig:
     access_token: str
     webhook_secret: str
+    app: str = "hermes"
     host: str = DEFAULT_HOST
     port: int = DEFAULT_PORT
     graphql_url: str = LINEAR_GRAPHQL_URL
@@ -206,6 +215,18 @@ def _env(env: Mapping[str, str], name: str) -> str:
     return str(env.get(name) or "").strip()
 
 
+def _app_env_name(app: str, env_name: str) -> str:
+    suffix = env_name.removeprefix("HERMES_LINEAR_AIG_")
+    app_key = app.upper().replace("-", "_")
+    return f"HERMES_LINEAR_AIG_{app_key}_{suffix}"
+
+
+def _env_for_app(env: Mapping[str, str], app: str, env_name: str) -> str:
+    if app == "hermes":
+        return _env(env, env_name)
+    return _env(env, _app_env_name(app, env_name)) or _env(env, env_name)
+
+
 def _parse_port(value: str | int | None, *, default: int) -> int:
     if value in (None, ""):
         return default
@@ -219,28 +240,43 @@ def _parse_port(value: str | int | None, *, default: int) -> int:
 
 
 def load_runtime_config(args: Any, env: Mapping[str, str]) -> LinearAIGRuntimeConfig:
+    app = (
+        str(getattr(args, "app", "") or "").strip()
+        or _env(env, APP_ENV)
+        or "hermes"
+    ).lower()
+    if app not in APP_PROFILE_DEFAULTS:
+        raise ValueError(
+            "Linear AIG app must be one of: "
+            + ", ".join(sorted(APP_PROFILE_DEFAULTS))
+        )
+    profile_defaults = APP_PROFILE_DEFAULTS[app]
     access_token = (
         str(getattr(args, "access_token", "") or "").strip()
-        or _env(env, ACCESS_TOKEN_ENV)
+        or _env_for_app(env, app, ACCESS_TOKEN_ENV)
     )
     webhook_secret = (
         str(getattr(args, "webhook_secret", "") or "").strip()
-        or _env(env, WEBHOOK_SECRET_ENV)
+        or _env_for_app(env, app, WEBHOOK_SECRET_ENV)
     )
-    host = str(getattr(args, "host", "") or "").strip() or _env(env, HOST_ENV) or DEFAULT_HOST
+    host = (
+        str(getattr(args, "host", "") or "").strip()
+        or _env_for_app(env, app, HOST_ENV)
+        or DEFAULT_HOST
+    )
     port = _parse_port(
-        getattr(args, "port", None) or _env(env, PORT_ENV),
+        getattr(args, "port", None) or _env_for_app(env, app, PORT_ENV),
         default=DEFAULT_PORT,
     )
     graphql_url = (
         str(getattr(args, "graphql_url", "") or "").strip()
-        or _env(env, GRAPHQL_URL_ENV)
+        or _env_for_app(env, app, GRAPHQL_URL_ENV)
         or LINEAR_GRAPHQL_URL
     )
     ack_only = bool(getattr(args, "ack_only", False))
     task_mode = (
         str(getattr(args, "task_mode", "") or "").strip()
-        or _env(env, TASK_MODE_ENV)
+        or _env_for_app(env, app, TASK_MODE_ENV)
         or TASK_MODE_BRIDGE
     ).lower()
     if task_mode not in TASK_MODES:
@@ -248,23 +284,29 @@ def load_runtime_config(args: Any, env: Mapping[str, str]) -> LinearAIGRuntimeCo
             "Linear AIG task mode must be one of: "
             + ", ".join(sorted(TASK_MODES))
         )
-    model = str(getattr(args, "model", "") or "").strip() or _env(env, MODEL_ENV) or None
+    model = (
+        str(getattr(args, "model", "") or "").strip()
+        or _env_for_app(env, app, MODEL_ENV)
+        or profile_defaults.get("model")
+        or None
+    )
     provider = (
         str(getattr(args, "provider", "") or "").strip()
-        or _env(env, PROVIDER_ENV)
+        or _env_for_app(env, app, PROVIDER_ENV)
+        or profile_defaults.get("provider")
         or None
     )
     toolsets = (
         str(getattr(args, "toolsets", "") or "").strip()
-        or _env(env, TOOLSETS_ENV)
+        or _env_for_app(env, app, TOOLSETS_ENV)
         or None
     )
 
     missing = []
     if not access_token:
-        missing.append(ACCESS_TOKEN_ENV)
+        missing.append(_app_env_name(app, ACCESS_TOKEN_ENV) if app != "hermes" else ACCESS_TOKEN_ENV)
     if not webhook_secret:
-        missing.append(WEBHOOK_SECRET_ENV)
+        missing.append(_app_env_name(app, WEBHOOK_SECRET_ENV) if app != "hermes" else WEBHOOK_SECRET_ENV)
     if missing:
         raise ValueError(
             "Linear AIG is missing required environment variables: "
@@ -274,6 +316,7 @@ def load_runtime_config(args: Any, env: Mapping[str, str]) -> LinearAIGRuntimeCo
     return LinearAIGRuntimeConfig(
         access_token=access_token,
         webhook_secret=webhook_secret,
+        app=app,
         host=host,
         port=port,
         graphql_url=graphql_url,
@@ -289,6 +332,7 @@ def describe_runtime_config(config: LinearAIGRuntimeConfig) -> str:
     return "\n".join(
         [
             "Linear AIG runtime config:",
+            f"  app: {config.app}",
             f"  {ACCESS_TOKEN_ENV}: {_redact(config.access_token)}",
             f"  {WEBHOOK_SECRET_ENV}: {_redact(config.webhook_secret)}",
             f"  host: {config.host}",

--- a/hermes_cli/linear_aig.py
+++ b/hermes_cli/linear_aig.py
@@ -29,6 +29,14 @@ except ImportError:  # pragma: no cover - exercised in environments without aioh
 
 LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
 DEFAULT_REPLAY_TOLERANCE_MS = 60_000
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8667
+
+ACCESS_TOKEN_ENV = "HERMES_LINEAR_AIG_ACCESS_TOKEN"
+WEBHOOK_SECRET_ENV = "HERMES_LINEAR_AIG_WEBHOOK_SECRET"
+HOST_ENV = "HERMES_LINEAR_AIG_HOST"
+PORT_ENV = "HERMES_LINEAR_AIG_PORT"
+GRAPHQL_URL_ENV = "HERMES_LINEAR_AIG_GRAPHQL_URL"
 
 ActivitySender = Callable[[str, dict[str, Any]], Awaitable[None]]
 TaskDispatcher = Callable[["AgentSessionEvent"], Awaitable[str | None]]
@@ -43,6 +51,16 @@ class AgentSessionEvent:
     issue_identifier: str | None = None
     issue_title: str | None = None
     comment_body: str | None = None
+
+
+@dataclass(frozen=True)
+class LinearAIGRuntimeConfig:
+    access_token: str
+    webhook_secret: str
+    host: str = DEFAULT_HOST
+    port: int = DEFAULT_PORT
+    graphql_url: str = LINEAR_GRAPHQL_URL
+    ack_only: bool = False
 
 
 def _header(headers: Mapping[str, str], name: str) -> str:
@@ -164,6 +182,86 @@ def build_activity_content(kind: str, body: str, **extra: Any) -> dict[str, Any]
     return content
 
 
+def _redact(value: str) -> str:
+    if not value:
+        return "<missing>"
+    if len(value) <= 8:
+        return "<set>"
+    return f"{value[:4]}...{value[-4:]}"
+
+
+def _env(env: Mapping[str, str], name: str) -> str:
+    return str(env.get(name) or "").strip()
+
+
+def _parse_port(value: str | int | None, *, default: int) -> int:
+    if value in (None, ""):
+        return default
+    try:
+        port = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Linear AIG port must be an integer") from exc
+    if port <= 0 or port > 65535:
+        raise ValueError("Linear AIG port must be between 1 and 65535")
+    return port
+
+
+def load_runtime_config(args: Any, env: Mapping[str, str]) -> LinearAIGRuntimeConfig:
+    access_token = (
+        str(getattr(args, "access_token", "") or "").strip()
+        or _env(env, ACCESS_TOKEN_ENV)
+    )
+    webhook_secret = (
+        str(getattr(args, "webhook_secret", "") or "").strip()
+        or _env(env, WEBHOOK_SECRET_ENV)
+    )
+    host = str(getattr(args, "host", "") or "").strip() or _env(env, HOST_ENV) or DEFAULT_HOST
+    port = _parse_port(
+        getattr(args, "port", None) or _env(env, PORT_ENV),
+        default=DEFAULT_PORT,
+    )
+    graphql_url = (
+        str(getattr(args, "graphql_url", "") or "").strip()
+        or _env(env, GRAPHQL_URL_ENV)
+        or LINEAR_GRAPHQL_URL
+    )
+    ack_only = bool(getattr(args, "ack_only", False))
+
+    missing = []
+    if not access_token:
+        missing.append(ACCESS_TOKEN_ENV)
+    if not webhook_secret:
+        missing.append(WEBHOOK_SECRET_ENV)
+    if missing:
+        raise ValueError(
+            "Linear AIG is missing required environment variables: "
+            + ", ".join(missing)
+        )
+
+    return LinearAIGRuntimeConfig(
+        access_token=access_token,
+        webhook_secret=webhook_secret,
+        host=host,
+        port=port,
+        graphql_url=graphql_url,
+        ack_only=ack_only,
+    )
+
+
+def describe_runtime_config(config: LinearAIGRuntimeConfig) -> str:
+    return "\n".join(
+        [
+            "Linear AIG runtime config:",
+            f"  {ACCESS_TOKEN_ENV}: {_redact(config.access_token)}",
+            f"  {WEBHOOK_SECRET_ENV}: {_redact(config.webhook_secret)}",
+            f"  host: {config.host}",
+            f"  port: {config.port}",
+            f"  graphql_url: {config.graphql_url}",
+            f"  ack_only: {config.ack_only}",
+        ]
+    )
+
+
 def build_agent_activity_input(
     agent_session_id: str,
     content: Mapping[str, Any],
@@ -220,6 +318,30 @@ async def send_agent_activity(
             raise RuntimeError("Linear agentActivityCreate did not return success")
 
     await asyncio.to_thread(_post)
+
+
+def build_activity_sender(
+    *,
+    access_token: str,
+    graphql_url: str = LINEAR_GRAPHQL_URL,
+) -> ActivitySender:
+    async def _sender(agent_session_id: str, content: dict[str, Any]) -> None:
+        await send_agent_activity(
+            api_key=access_token,
+            agent_session_id=agent_session_id,
+            content=content,
+            graphql_url=graphql_url,
+        )
+
+    return _sender
+
+
+async def ack_only_dispatcher(event: AgentSessionEvent) -> str:
+    target = f" for {event.issue_identifier}" if event.issue_identifier else ""
+    return (
+        f"Hermes Linear AIG bridge received the session{target}. "
+        "Full task execution is not wired in this runtime yet."
+    )
 
 
 class LinearAIGReceiver:
@@ -295,3 +417,50 @@ def create_app(receiver: LinearAIGReceiver) -> Any:
     app.router.add_post("/linear/aig", receiver.handle_request)
     app.router.add_get("/linear/aig/health", health)
     return app
+
+
+def run_server(config: LinearAIGRuntimeConfig) -> None:
+    if not AIOHTTP_AVAILABLE:
+        raise RuntimeError(
+            "aiohttp is required for the Linear AIG receiver. Install with: "
+            "pip install 'hermes-agent[messaging]' or `pip install aiohttp`."
+        )
+
+    receiver = LinearAIGReceiver(
+        signing_secret=config.webhook_secret,
+        activity_sender=build_activity_sender(
+            access_token=config.access_token,
+            graphql_url=config.graphql_url,
+        ),
+        task_dispatcher=None if config.ack_only else ack_only_dispatcher,
+    )
+    app = create_app(receiver)
+    web.run_app(app, host=config.host, port=config.port)
+
+
+def linear_aig_command(args: Any) -> int:
+    import os
+
+    subcommand = getattr(args, "linear_aig_action", None)
+    if not subcommand:
+        print("Usage: hermes linear-aig {serve|check-config}")
+        return 2
+
+    try:
+        config = load_runtime_config(args, os.environ)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    if subcommand == "check-config":
+        print(describe_runtime_config(config))
+        return 0
+
+    if subcommand == "serve":
+        print(describe_runtime_config(config))
+        print(f"Listening on http://{config.host}:{config.port}/linear/aig")
+        run_server(config)
+        return 0
+
+    print(f"Unknown linear-aig command: {subcommand}")
+    return 2

--- a/hermes_cli/linear_aig.py
+++ b/hermes_cli/linear_aig.py
@@ -37,6 +37,14 @@ WEBHOOK_SECRET_ENV = "HERMES_LINEAR_AIG_WEBHOOK_SECRET"
 HOST_ENV = "HERMES_LINEAR_AIG_HOST"
 PORT_ENV = "HERMES_LINEAR_AIG_PORT"
 GRAPHQL_URL_ENV = "HERMES_LINEAR_AIG_GRAPHQL_URL"
+TASK_MODE_ENV = "HERMES_LINEAR_AIG_TASK_MODE"
+MODEL_ENV = "HERMES_LINEAR_AIG_MODEL"
+PROVIDER_ENV = "HERMES_LINEAR_AIG_PROVIDER"
+TOOLSETS_ENV = "HERMES_LINEAR_AIG_TOOLSETS"
+
+TASK_MODE_BRIDGE = "bridge"
+TASK_MODE_ONESHOT = "oneshot"
+TASK_MODES = {TASK_MODE_BRIDGE, TASK_MODE_ONESHOT}
 
 ActivitySender = Callable[[str, dict[str, Any]], Awaitable[None]]
 TaskDispatcher = Callable[["AgentSessionEvent"], Awaitable[str | None]]
@@ -61,6 +69,10 @@ class LinearAIGRuntimeConfig:
     port: int = DEFAULT_PORT
     graphql_url: str = LINEAR_GRAPHQL_URL
     ack_only: bool = False
+    task_mode: str = TASK_MODE_BRIDGE
+    model: str | None = None
+    provider: str | None = None
+    toolsets: str | None = None
 
 
 def _header(headers: Mapping[str, str], name: str) -> str:
@@ -226,6 +238,27 @@ def load_runtime_config(args: Any, env: Mapping[str, str]) -> LinearAIGRuntimeCo
         or LINEAR_GRAPHQL_URL
     )
     ack_only = bool(getattr(args, "ack_only", False))
+    task_mode = (
+        str(getattr(args, "task_mode", "") or "").strip()
+        or _env(env, TASK_MODE_ENV)
+        or TASK_MODE_BRIDGE
+    ).lower()
+    if task_mode not in TASK_MODES:
+        raise ValueError(
+            "Linear AIG task mode must be one of: "
+            + ", ".join(sorted(TASK_MODES))
+        )
+    model = str(getattr(args, "model", "") or "").strip() or _env(env, MODEL_ENV) or None
+    provider = (
+        str(getattr(args, "provider", "") or "").strip()
+        or _env(env, PROVIDER_ENV)
+        or None
+    )
+    toolsets = (
+        str(getattr(args, "toolsets", "") or "").strip()
+        or _env(env, TOOLSETS_ENV)
+        or None
+    )
 
     missing = []
     if not access_token:
@@ -245,6 +278,10 @@ def load_runtime_config(args: Any, env: Mapping[str, str]) -> LinearAIGRuntimeCo
         port=port,
         graphql_url=graphql_url,
         ack_only=ack_only,
+        task_mode=task_mode,
+        model=model,
+        provider=provider,
+        toolsets=toolsets,
     )
 
 
@@ -258,6 +295,10 @@ def describe_runtime_config(config: LinearAIGRuntimeConfig) -> str:
             f"  port: {config.port}",
             f"  graphql_url: {config.graphql_url}",
             f"  ack_only: {config.ack_only}",
+            f"  task_mode: {config.task_mode}",
+            f"  model: {config.model or '<configured default>'}",
+            f"  provider: {config.provider or '<configured default>'}",
+            f"  toolsets: {config.toolsets or '<configured default>'}",
         ]
     )
 
@@ -342,6 +383,64 @@ async def ack_only_dispatcher(event: AgentSessionEvent) -> str:
         f"Hermes Linear AIG bridge received the session{target}. "
         "Full task execution is not wired in this runtime yet."
     )
+
+
+def build_oneshot_prompt(event: AgentSessionEvent) -> str:
+    parts = [
+        "You are Hermes responding to a Linear Agent Session.",
+        f"Action: {event.action}",
+    ]
+    if event.issue_identifier:
+        parts.append(f"Issue: {event.issue_identifier}")
+    if event.issue_title:
+        parts.append(f"Issue title: {event.issue_title}")
+    if event.comment_body:
+        parts.append(f"Comment: {event.comment_body}")
+    if event.prompt:
+        parts.append("")
+        parts.append(event.prompt)
+    return "\n".join(parts).strip()
+
+
+def run_hermes_oneshot(
+    prompt: str,
+    *,
+    model: str | None = None,
+    provider: str | None = None,
+    toolsets: str | None = None,
+) -> str:
+    from hermes_cli.oneshot import _run_agent
+
+    return _run_agent(
+        prompt,
+        model=model,
+        provider=provider,
+        toolsets=toolsets,
+        use_config_toolsets=toolsets is None,
+    )
+
+
+def build_task_dispatcher(config: LinearAIGRuntimeConfig) -> TaskDispatcher | None:
+    if config.ack_only:
+        return None
+    if config.task_mode == TASK_MODE_BRIDGE:
+        return ack_only_dispatcher
+    if config.task_mode == TASK_MODE_ONESHOT:
+        async def _dispatch(event: AgentSessionEvent) -> str:
+            prompt = build_oneshot_prompt(event)
+            if not prompt:
+                return "Hermes Linear AIG received an empty Agent Session prompt."
+            response = await asyncio.to_thread(
+                run_hermes_oneshot,
+                prompt,
+                model=config.model,
+                provider=config.provider,
+                toolsets=config.toolsets,
+            )
+            return response or "Hermes completed the Linear Agent Session without a final response."
+
+        return _dispatch
+    raise ValueError(f"Unsupported Linear AIG task mode: {config.task_mode}")
 
 
 class LinearAIGReceiver:
@@ -432,7 +531,7 @@ def run_server(config: LinearAIGRuntimeConfig) -> None:
             access_token=config.access_token,
             graphql_url=config.graphql_url,
         ),
-        task_dispatcher=None if config.ack_only else ack_only_dispatcher,
+        task_dispatcher=build_task_dispatcher(config),
     )
     app = create_app(receiver)
     web.run_app(app, host=config.host, port=config.port)

--- a/hermes_cli/linear_aig.py
+++ b/hermes_cli/linear_aig.py
@@ -1,0 +1,297 @@
+"""Linear AIG webhook receiver primitives for Hermes.
+
+This module keeps the Linear Agent Session wiring isolated from Hermes'
+generic webhook adapter. Linear AIG has stricter timing and payload semantics:
+webhook handlers must acknowledge quickly, then emit Agent Activities back to
+the Agent Session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Mapping
+
+import httpx
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised in environments without aiohttp
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+
+LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+DEFAULT_REPLAY_TOLERANCE_MS = 60_000
+
+ActivitySender = Callable[[str, dict[str, Any]], Awaitable[None]]
+TaskDispatcher = Callable[["AgentSessionEvent"], Awaitable[str | None]]
+
+
+@dataclass(frozen=True)
+class AgentSessionEvent:
+    action: str
+    agent_session_id: str
+    prompt_context: str
+    prompt: str
+    issue_identifier: str | None = None
+    issue_title: str | None = None
+    comment_body: str | None = None
+
+
+def _header(headers: Mapping[str, str], name: str) -> str:
+    lower_name = name.lower()
+    for key, value in headers.items():
+        if key.lower() == lower_name:
+            return value
+    return ""
+
+
+def verify_linear_signature(
+    *,
+    raw_body: bytes,
+    headers: Mapping[str, str],
+    signing_secret: str,
+    payload: Mapping[str, Any] | None = None,
+    now_ms: int | None = None,
+    replay_tolerance_ms: int = DEFAULT_REPLAY_TOLERANCE_MS,
+) -> bool:
+    """Validate Linear's HMAC signature and webhook timestamp."""
+    if not signing_secret:
+        return False
+
+    signature = _header(headers, "Linear-Signature").strip()
+    if signature.startswith("sha256="):
+        signature = signature.removeprefix("sha256=")
+    if not signature:
+        return False
+
+    try:
+        expected = hmac.new(
+            signing_secret.encode("utf-8"),
+            raw_body,
+            hashlib.sha256,
+        ).hexdigest()
+    except Exception:
+        return False
+
+    if not hmac.compare_digest(expected, signature):
+        return False
+
+    if replay_tolerance_ms <= 0:
+        return True
+
+    body = payload
+    if body is None:
+        try:
+            body = json.loads(raw_body.decode("utf-8"))
+        except Exception:
+            return False
+
+    timestamp = body.get("webhookTimestamp")
+    if not isinstance(timestamp, (int, float)):
+        return False
+
+    current_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    return abs(current_ms - int(timestamp)) <= replay_tolerance_ms
+
+
+def parse_agent_session_event(payload: Mapping[str, Any]) -> AgentSessionEvent:
+    """Extract the fields Hermes needs from a Linear AgentSessionEvent."""
+    action = str(payload.get("action") or "").strip()
+    agent_session = payload.get("agentSession")
+    if not isinstance(agent_session, Mapping):
+        data = payload.get("data")
+        agent_session = data.get("agentSession") if isinstance(data, Mapping) else None
+    if not isinstance(agent_session, Mapping):
+        agent_session = {}
+
+    agent_session_id = str(
+        agent_session.get("id") or payload.get("agentSessionId") or ""
+    ).strip()
+    if not action:
+        raise ValueError("Linear AgentSessionEvent is missing action")
+    if not agent_session_id:
+        raise ValueError("Linear AgentSessionEvent is missing agentSession.id")
+
+    agent_activity = payload.get("agentActivity")
+    if not isinstance(agent_activity, Mapping):
+        agent_activity = {}
+
+    issue = agent_session.get("issue")
+    if not isinstance(issue, Mapping):
+        issue = {}
+
+    data = payload.get("data")
+    if not isinstance(data, Mapping):
+        data = {}
+
+    prompt_context = str(
+        payload.get("promptContext")
+        or data.get("promptContext")
+        or agent_session.get("promptContext")
+        or ""
+    )
+    comment_body = str(agent_activity.get("body") or "")
+    prompt = prompt_context or comment_body
+
+    return AgentSessionEvent(
+        action=action,
+        agent_session_id=agent_session_id,
+        prompt_context=prompt_context,
+        prompt=prompt,
+        issue_identifier=(str(issue.get("identifier")) if issue.get("identifier") else None),
+        issue_title=(str(issue.get("title")) if issue.get("title") else None),
+        comment_body=comment_body or None,
+    )
+
+
+def build_activity_content(kind: str, body: str, **extra: Any) -> dict[str, Any]:
+    if kind not in {"thought", "elicitation", "action", "response", "error"}:
+        raise ValueError(f"Unsupported Linear Agent Activity type: {kind}")
+    content: dict[str, Any] = {"type": kind}
+    if kind == "action":
+        content["action"] = body
+    else:
+        content["body"] = body
+    content.update({key: value for key, value in extra.items() if value is not None})
+    return content
+
+
+def build_agent_activity_input(
+    agent_session_id: str,
+    content: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "agentSessionId": agent_session_id,
+        "content": dict(content),
+    }
+
+
+async def send_agent_activity(
+    *,
+    api_key: str,
+    agent_session_id: str,
+    content: Mapping[str, Any],
+    graphql_url: str = LINEAR_GRAPHQL_URL,
+    timeout_seconds: float = 10.0,
+) -> None:
+    """Send a Linear Agent Activity using GraphQL."""
+    if not api_key:
+        raise ValueError("Linear API key is required to send Agent Activities")
+
+    mutation = """
+    mutation AgentActivityCreate($input: AgentActivityCreateInput!) {
+      agentActivityCreate(input: $input) {
+        success
+      }
+    }
+    """
+    payload = {
+        "query": mutation,
+        "variables": {
+            "input": build_agent_activity_input(agent_session_id, content),
+        },
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    def _post() -> None:
+        response = httpx.post(
+            graphql_url,
+            headers=headers,
+            json=payload,
+            timeout=timeout_seconds,
+        )
+        response.raise_for_status()
+        data = response.json()
+        errors = data.get("errors")
+        if errors:
+            raise RuntimeError(f"Linear GraphQL error: {errors}")
+        if not data.get("data", {}).get("agentActivityCreate", {}).get("success"):
+            raise RuntimeError("Linear agentActivityCreate did not return success")
+
+    await asyncio.to_thread(_post)
+
+
+class LinearAIGReceiver:
+    """Small aiohttp-compatible receiver for Linear AgentSessionEvent webhooks."""
+
+    def __init__(
+        self,
+        *,
+        signing_secret: str,
+        activity_sender: ActivitySender,
+        task_dispatcher: TaskDispatcher | None = None,
+    ) -> None:
+        self.signing_secret = signing_secret
+        self.activity_sender = activity_sender
+        self.task_dispatcher = task_dispatcher
+
+    async def handle_request(self, request: Any) -> Any:
+        raw_body = await request.read()
+        try:
+            payload = json.loads(raw_body.decode("utf-8"))
+        except Exception:
+            return web.json_response({"error": "invalid_json"}, status=400)
+
+        if not verify_linear_signature(
+            raw_body=raw_body,
+            headers=request.headers,
+            signing_secret=self.signing_secret,
+            payload=payload,
+        ):
+            return web.json_response({"error": "invalid_signature"}, status=401)
+
+        try:
+            event = parse_agent_session_event(payload)
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+        asyncio.create_task(self.process_event(event))
+        return web.json_response({"ok": True})
+
+    async def process_event(self, event: AgentSessionEvent) -> None:
+        await self.activity_sender(
+            event.agent_session_id,
+            build_activity_content(
+                "thought",
+                f"Hermes received Linear Agent Session `{event.action}` and is starting.",
+            ),
+        )
+        if not self.task_dispatcher:
+            return
+        try:
+            result = await self.task_dispatcher(event)
+        except Exception as exc:
+            await self.activity_sender(
+                event.agent_session_id,
+                build_activity_content("error", f"Hermes failed: {exc}"),
+            )
+            return
+        if result:
+            await self.activity_sender(
+                event.agent_session_id,
+                build_activity_content("response", result),
+            )
+
+
+def create_app(receiver: LinearAIGReceiver) -> Any:
+    if not AIOHTTP_AVAILABLE:
+        raise RuntimeError("aiohttp is required for the Linear AIG receiver")
+
+    async def health(_request: Any) -> Any:
+        return web.json_response({"ok": True})
+
+    app = web.Application()
+    app.router.add_post("/linear/aig", receiver.handle_request)
+    app.router.add_get("/linear/aig/health", health)
+    return app

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12013,6 +12013,16 @@ def main():
     )
     for _linear_aig_sub in (linear_aig_check, linear_aig_serve):
         _linear_aig_sub.add_argument(
+            "--app",
+            choices=["hermes", "kilocode", "minimax", "windsurf"],
+            default="",
+            help=(
+                "Linear AIG app profile. Defaults to HERMES_LINEAR_AIG_APP or "
+                "hermes. App profiles can use app-specific env vars such as "
+                "HERMES_LINEAR_AIG_KILOCODE_ACCESS_TOKEN."
+            ),
+        )
+        _linear_aig_sub.add_argument(
             "--access-token",
             default="",
             help=(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12055,6 +12055,36 @@ def main():
                 "bridge response used by the MVP smoke path."
             ),
         )
+        _linear_aig_sub.add_argument(
+            "--task-mode",
+            choices=["bridge", "oneshot"],
+            default="",
+            help=(
+                "How to process Linear sessions. Defaults to "
+                "HERMES_LINEAR_AIG_TASK_MODE or bridge."
+            ),
+        )
+        _linear_aig_sub.add_argument(
+            "--model",
+            default="",
+            help="Model override for oneshot mode. Defaults to HERMES_LINEAR_AIG_MODEL.",
+        )
+        _linear_aig_sub.add_argument(
+            "--provider",
+            default="",
+            help=(
+                "Provider override for oneshot mode. Defaults to "
+                "HERMES_LINEAR_AIG_PROVIDER."
+            ),
+        )
+        _linear_aig_sub.add_argument(
+            "--toolsets",
+            default="",
+            help=(
+                "Comma-separated toolsets for oneshot mode. Defaults to "
+                "HERMES_LINEAR_AIG_TOOLSETS or configured CLI toolsets."
+            ),
+        )
     linear_aig_parser.set_defaults(func=cmd_linear_aig)
 
     # =========================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6146,6 +6146,15 @@ def cmd_webhook(args):
     webhook_command(args)
 
 
+def cmd_linear_aig(args):
+    """Linear Agent Interaction Guidelines receiver."""
+    from hermes_cli.linear_aig import linear_aig_command
+
+    rc = linear_aig_command(args)
+    if isinstance(rc, int) and rc != 0:
+        raise SystemExit(rc)
+
+
 def cmd_portal(args):
     """Nous Portal status and Tool Gateway routing surface."""
     from hermes_cli.portal_cli import portal_command
@@ -11979,6 +11988,74 @@ def main():
     )
 
     webhook_parser.set_defaults(func=cmd_webhook)
+
+    # =========================================================================
+    # linear-aig command
+    # =========================================================================
+    linear_aig_parser = subparsers.add_parser(
+        "linear-aig",
+        help="Run a Linear Agent Session webhook receiver",
+        description=(
+            "Receive Linear AgentSessionEvent webhooks and emit Agent Activities "
+            "back to Linear."
+        ),
+    )
+    linear_aig_subparsers = linear_aig_parser.add_subparsers(
+        dest="linear_aig_action"
+    )
+    linear_aig_check = linear_aig_subparsers.add_parser(
+        "check-config",
+        help="Validate Linear AIG environment without starting the server",
+    )
+    linear_aig_serve = linear_aig_subparsers.add_parser(
+        "serve",
+        help="Start the Linear AIG webhook receiver",
+    )
+    for _linear_aig_sub in (linear_aig_check, linear_aig_serve):
+        _linear_aig_sub.add_argument(
+            "--access-token",
+            default="",
+            help=(
+                "Linear app OAuth access token. Defaults to "
+                "HERMES_LINEAR_AIG_ACCESS_TOKEN."
+            ),
+        )
+        _linear_aig_sub.add_argument(
+            "--webhook-secret",
+            default="",
+            help=(
+                "Linear webhook signing secret. Defaults to "
+                "HERMES_LINEAR_AIG_WEBHOOK_SECRET."
+            ),
+        )
+        _linear_aig_sub.add_argument(
+            "--host",
+            default="",
+            help="Host to bind. Defaults to HERMES_LINEAR_AIG_HOST or 0.0.0.0.",
+        )
+        _linear_aig_sub.add_argument(
+            "--port",
+            default=None,
+            type=int,
+            help="Port to bind. Defaults to HERMES_LINEAR_AIG_PORT or 8667.",
+        )
+        _linear_aig_sub.add_argument(
+            "--graphql-url",
+            default="",
+            help=(
+                "Linear GraphQL endpoint. Defaults to "
+                "HERMES_LINEAR_AIG_GRAPHQL_URL or Linear production."
+            ),
+        )
+        _linear_aig_sub.add_argument(
+            "--ack-only",
+            action="store_true",
+            help=(
+                "Only emit the immediate thought activity; skip the transparent "
+                "bridge response used by the MVP smoke path."
+            ),
+        )
+    linear_aig_parser.set_defaults(func=cmd_linear_aig)
 
     # =========================================================================
     # portal command — Nous Portal status + Tool Gateway routing

--- a/tests/hermes_cli/test_linear_aig.py
+++ b/tests/hermes_cli/test_linear_aig.py
@@ -40,6 +40,7 @@ def _payload(**overrides):
 def _args(**overrides):
     defaults = {
         "linear_aig_action": "check-config",
+        "app": "",
         "access_token": "",
         "webhook_secret": "",
         "host": "",
@@ -127,6 +128,79 @@ def test_load_runtime_config_cli_args_override_environment():
     assert config.model == "arg-model"
     assert config.provider == "arg-provider"
     assert config.toolsets == "arg-tools"
+
+
+def test_load_runtime_config_uses_app_specific_credentials_and_provider_default():
+    config = linear_aig.load_runtime_config(
+        _args(app="kilocode"),
+        {
+            "HERMES_LINEAR_AIG_KILOCODE_ACCESS_TOKEN": "kilo_token",
+            "HERMES_LINEAR_AIG_KILOCODE_WEBHOOK_SECRET": "kilo_secret",
+            "HERMES_LINEAR_AIG_KILOCODE_PORT": "8668",
+        },
+    )
+
+    assert config.app == "kilocode"
+    assert config.access_token == "kilo_token"
+    assert config.webhook_secret == "kilo_secret"
+    assert config.port == 8668
+    assert config.provider == "kilocode"
+
+
+def test_load_runtime_config_app_specific_values_override_generic_env():
+    config = linear_aig.load_runtime_config(
+        _args(app="minimax"),
+        {
+            linear_aig.ACCESS_TOKEN_ENV: "generic_token",
+            linear_aig.WEBHOOK_SECRET_ENV: "generic_secret",
+            linear_aig.PROVIDER_ENV: "generic-provider",
+            "HERMES_LINEAR_AIG_MINIMAX_ACCESS_TOKEN": "minimax_token",
+            "HERMES_LINEAR_AIG_MINIMAX_WEBHOOK_SECRET": "minimax_secret",
+        },
+    )
+
+    assert config.app == "minimax"
+    assert config.access_token == "minimax_token"
+    assert config.webhook_secret == "minimax_secret"
+    assert config.provider == "generic-provider"
+
+
+def test_minimax_app_defaults_to_oauth_provider():
+    config = linear_aig.load_runtime_config(
+        _args(app="minimax"),
+        {
+            "HERMES_LINEAR_AIG_MINIMAX_ACCESS_TOKEN": "minimax_token",
+            "HERMES_LINEAR_AIG_MINIMAX_WEBHOOK_SECRET": "minimax_secret",
+        },
+    )
+
+    assert config.provider == "minimax-oauth"
+
+
+def test_windsurf_app_uses_app_specific_credentials_without_provider_default():
+    config = linear_aig.load_runtime_config(
+        _args(app="windsurf"),
+        {
+            "HERMES_LINEAR_AIG_WINDSURF_ACCESS_TOKEN": "windsurf_token",
+            "HERMES_LINEAR_AIG_WINDSURF_WEBHOOK_SECRET": "windsurf_secret",
+        },
+    )
+
+    assert config.app == "windsurf"
+    assert config.access_token == "windsurf_token"
+    assert config.webhook_secret == "windsurf_secret"
+    assert config.provider is None
+
+
+def test_load_runtime_config_rejects_unknown_app():
+    with pytest.raises(ValueError, match="app"):
+        linear_aig.load_runtime_config(
+            _args(app="unknown"),
+            {
+                linear_aig.ACCESS_TOKEN_ENV: "lin_access_token",
+                linear_aig.WEBHOOK_SECRET_ENV: "signing_secret",
+            },
+        )
 
 
 def test_load_runtime_config_requires_token_and_webhook_secret():

--- a/tests/hermes_cli/test_linear_aig.py
+++ b/tests/hermes_cli/test_linear_aig.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import json
+from argparse import Namespace
 
 import pytest
 
@@ -36,6 +37,20 @@ def _payload(**overrides):
     return payload
 
 
+def _args(**overrides):
+    defaults = {
+        "linear_aig_action": "check-config",
+        "access_token": "",
+        "webhook_secret": "",
+        "host": "",
+        "port": None,
+        "graphql_url": "",
+        "ack_only": False,
+    }
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
 def test_verify_linear_signature_accepts_valid_signature():
     payload = _payload()
     raw_body = _body(payload)
@@ -47,6 +62,127 @@ def test_verify_linear_signature_accepts_valid_signature():
         payload=payload,
         now_ms=NOW_MS,
     )
+
+
+def test_load_runtime_config_uses_environment_defaults():
+    config = linear_aig.load_runtime_config(
+        _args(),
+        {
+            linear_aig.ACCESS_TOKEN_ENV: "lin_access_token",
+            linear_aig.WEBHOOK_SECRET_ENV: "signing_secret",
+            linear_aig.HOST_ENV: "127.0.0.1",
+            linear_aig.PORT_ENV: "9999",
+            linear_aig.GRAPHQL_URL_ENV: "https://linear.test/graphql",
+        },
+    )
+
+    assert config.access_token == "lin_access_token"
+    assert config.webhook_secret == "signing_secret"
+    assert config.host == "127.0.0.1"
+    assert config.port == 9999
+    assert config.graphql_url == "https://linear.test/graphql"
+
+
+def test_load_runtime_config_cli_args_override_environment():
+    config = linear_aig.load_runtime_config(
+        _args(
+            access_token="arg_token",
+            webhook_secret="arg_secret",
+            host="localhost",
+            port=8668,
+            graphql_url="https://override.test/graphql",
+            ack_only=True,
+        ),
+        {
+            linear_aig.ACCESS_TOKEN_ENV: "env_token",
+            linear_aig.WEBHOOK_SECRET_ENV: "env_secret",
+            linear_aig.PORT_ENV: "9999",
+        },
+    )
+
+    assert config.access_token == "arg_token"
+    assert config.webhook_secret == "arg_secret"
+    assert config.host == "localhost"
+    assert config.port == 8668
+    assert config.graphql_url == "https://override.test/graphql"
+    assert config.ack_only is True
+
+
+def test_load_runtime_config_requires_token_and_webhook_secret():
+    with pytest.raises(ValueError, match=linear_aig.ACCESS_TOKEN_ENV):
+        linear_aig.load_runtime_config(_args(), {})
+
+
+def test_describe_runtime_config_redacts_sensitive_values():
+    config = linear_aig.LinearAIGRuntimeConfig(
+        access_token="lin_very_secret_token",
+        webhook_secret="webhook_secret_value",
+        host="127.0.0.1",
+        port=8667,
+    )
+
+    description = linear_aig.describe_runtime_config(config)
+
+    assert "lin_very_secret_token" not in description
+    assert "webhook_secret_value" not in description
+    assert "lin_...oken" in description
+    assert "webh...alue" in description
+
+
+def test_linear_aig_command_check_config_prints_redacted_config(monkeypatch, capsys):
+    monkeypatch.setenv(linear_aig.ACCESS_TOKEN_ENV, "lin_very_secret_token")
+    monkeypatch.setenv(linear_aig.WEBHOOK_SECRET_ENV, "webhook_secret_value")
+
+    rc = linear_aig.linear_aig_command(_args(linear_aig_action="check-config"))
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Linear AIG runtime config" in out
+    assert "lin_very_secret_token" not in out
+    assert "webhook_secret_value" not in out
+
+
+def test_linear_aig_command_fails_when_config_missing(monkeypatch, capsys):
+    monkeypatch.delenv(linear_aig.ACCESS_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(linear_aig.WEBHOOK_SECRET_ENV, raising=False)
+
+    rc = linear_aig.linear_aig_command(_args(linear_aig_action="check-config"))
+
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert linear_aig.ACCESS_TOKEN_ENV in out
+    assert linear_aig.WEBHOOK_SECRET_ENV in out
+
+
+def test_run_server_builds_receiver_and_starts_aiohttp(monkeypatch):
+    calls = []
+
+    class FakeWeb:
+        @staticmethod
+        def run_app(app, *, host, port):
+            calls.append({"app": app, "host": host, "port": port})
+
+    app = object()
+
+    monkeypatch.setattr(linear_aig, "AIOHTTP_AVAILABLE", True)
+    monkeypatch.setattr(linear_aig, "web", FakeWeb)
+    monkeypatch.setattr(linear_aig, "create_app", lambda receiver: app)
+
+    linear_aig.run_server(
+        linear_aig.LinearAIGRuntimeConfig(
+            access_token="lin_token",
+            webhook_secret="webhook_secret",
+            host="127.0.0.1",
+            port=8668,
+            graphql_url="https://linear.test/graphql",
+            ack_only=True,
+        )
+    )
+
+    assert calls
+    assert calls[0]["app"] is app
+    assert calls[0]["host"] == "127.0.0.1"
+    assert calls[0]["port"] == 8668
 
 
 def test_verify_linear_signature_accepts_sha256_prefix():

--- a/tests/hermes_cli/test_linear_aig.py
+++ b/tests/hermes_cli/test_linear_aig.py
@@ -1,0 +1,266 @@
+import hashlib
+import hmac
+import json
+
+import pytest
+
+from hermes_cli import linear_aig
+
+
+SECRET = "linear-signing-secret"
+NOW_MS = 1_770_000_000_000
+
+
+def _body(payload: dict) -> bytes:
+    return json.dumps(payload, separators=(",", ":")).encode("utf-8")
+
+
+def _signature(raw_body: bytes, secret: str = SECRET) -> str:
+    return hmac.new(secret.encode("utf-8"), raw_body, hashlib.sha256).hexdigest()
+
+
+def _payload(**overrides):
+    payload = {
+        "action": "created",
+        "webhookTimestamp": NOW_MS,
+        "agentSession": {
+            "id": "ags_123",
+            "promptContext": "Implement WHO-192",
+            "issue": {
+                "identifier": "WHO-192",
+                "title": "Implement Hermes Linear AIG webhook receiver",
+            },
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_verify_linear_signature_accepts_valid_signature():
+    payload = _payload()
+    raw_body = _body(payload)
+
+    assert linear_aig.verify_linear_signature(
+        raw_body=raw_body,
+        headers={"Linear-Signature": _signature(raw_body)},
+        signing_secret=SECRET,
+        payload=payload,
+        now_ms=NOW_MS,
+    )
+
+
+def test_verify_linear_signature_accepts_sha256_prefix():
+    payload = _payload()
+    raw_body = _body(payload)
+
+    assert linear_aig.verify_linear_signature(
+        raw_body=raw_body,
+        headers={"linear-signature": f"sha256={_signature(raw_body)}"},
+        signing_secret=SECRET,
+        payload=payload,
+        now_ms=NOW_MS,
+    )
+
+
+def test_verify_linear_signature_rejects_bad_signature():
+    payload = _payload()
+
+    assert not linear_aig.verify_linear_signature(
+        raw_body=_body(payload),
+        headers={"Linear-Signature": "0" * 64},
+        signing_secret=SECRET,
+        payload=payload,
+        now_ms=NOW_MS,
+    )
+
+
+def test_verify_linear_signature_rejects_stale_timestamp():
+    payload = _payload(webhookTimestamp=NOW_MS - 90_000)
+    raw_body = _body(payload)
+
+    assert not linear_aig.verify_linear_signature(
+        raw_body=raw_body,
+        headers={"Linear-Signature": _signature(raw_body)},
+        signing_secret=SECRET,
+        payload=payload,
+        now_ms=NOW_MS,
+    )
+
+
+def test_verify_linear_signature_rejects_missing_timestamp():
+    payload = _payload()
+    payload.pop("webhookTimestamp")
+    raw_body = _body(payload)
+
+    assert not linear_aig.verify_linear_signature(
+        raw_body=raw_body,
+        headers={"Linear-Signature": _signature(raw_body)},
+        signing_secret=SECRET,
+        payload=payload,
+        now_ms=NOW_MS,
+    )
+
+
+def test_parse_agent_session_event_extracts_issue_and_prompt_context():
+    event = linear_aig.parse_agent_session_event(_payload())
+
+    assert event.action == "created"
+    assert event.agent_session_id == "ags_123"
+    assert event.prompt == "Implement WHO-192"
+    assert event.issue_identifier == "WHO-192"
+    assert event.issue_title == "Implement Hermes Linear AIG webhook receiver"
+
+
+def test_parse_agent_session_event_accepts_nested_data_shape():
+    event = linear_aig.parse_agent_session_event(
+        {
+            "action": "created",
+            "data": {
+                "promptContext": "Nested prompt",
+                "agentSession": {"id": "ags_nested"},
+            },
+        }
+    )
+
+    assert event.agent_session_id == "ags_nested"
+    assert event.prompt_context == "Nested prompt"
+
+
+def test_parse_agent_session_event_requires_action_and_session_id():
+    with pytest.raises(ValueError, match="missing action"):
+        linear_aig.parse_agent_session_event({"agentSession": {"id": "ags_123"}})
+
+    with pytest.raises(ValueError, match="missing agentSession.id"):
+        linear_aig.parse_agent_session_event({"action": "created"})
+
+
+def test_build_activity_content_supports_linear_content_types():
+    assert linear_aig.build_activity_content("thought", "Starting") == {
+        "type": "thought",
+        "body": "Starting",
+    }
+    assert linear_aig.build_activity_content("action", "checkout", url=None) == {
+        "type": "action",
+        "action": "checkout",
+    }
+
+    with pytest.raises(ValueError, match="Unsupported"):
+        linear_aig.build_activity_content("note", "Nope")
+
+
+@pytest.mark.asyncio
+async def test_process_event_emits_start_and_response_activity():
+    sent = []
+
+    async def sender(agent_session_id, content):
+        sent.append((agent_session_id, content))
+
+    async def dispatcher(event):
+        assert event.issue_identifier == "WHO-192"
+        return "Ready for review."
+
+    receiver = linear_aig.LinearAIGReceiver(
+        signing_secret=SECRET,
+        activity_sender=sender,
+        task_dispatcher=dispatcher,
+    )
+
+    await receiver.process_event(linear_aig.parse_agent_session_event(_payload()))
+
+    assert sent == [
+        (
+            "ags_123",
+            {
+                "type": "thought",
+                "body": "Hermes received Linear Agent Session `created` and is starting.",
+            },
+        ),
+        ("ags_123", {"type": "response", "body": "Ready for review."}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_event_emits_error_activity_on_dispatch_failure():
+    sent = []
+
+    async def sender(agent_session_id, content):
+        sent.append((agent_session_id, content))
+
+    async def dispatcher(_event):
+        raise RuntimeError("boom")
+
+    receiver = linear_aig.LinearAIGReceiver(
+        signing_secret=SECRET,
+        activity_sender=sender,
+        task_dispatcher=dispatcher,
+    )
+
+    await receiver.process_event(linear_aig.parse_agent_session_event(_payload()))
+
+    assert sent[-1] == ("ags_123", {"type": "error", "body": "Hermes failed: boom"})
+
+
+@pytest.mark.asyncio
+async def test_send_agent_activity_posts_graphql_payload(monkeypatch):
+    calls = []
+
+    class Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": {"agentActivityCreate": {"success": True}}}
+
+    def post(url, *, headers, json, timeout):
+        calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "json": json,
+                "timeout": timeout,
+            }
+        )
+        return Response()
+
+    monkeypatch.setattr(linear_aig.httpx, "post", post)
+
+    await linear_aig.send_agent_activity(
+        api_key="lin_api_key",
+        agent_session_id="ags_123",
+        content={"type": "response", "body": "Done"},
+        graphql_url="https://linear.test/graphql",
+        timeout_seconds=3,
+    )
+
+    assert calls[0]["url"] == "https://linear.test/graphql"
+    assert calls[0]["headers"] == {
+        "Authorization": "Bearer lin_api_key",
+        "Content-Type": "application/json",
+    }
+    assert "agentActivityCreate" in calls[0]["json"]["query"]
+    assert calls[0]["json"]["variables"] == {
+        "input": {
+            "agentSessionId": "ags_123",
+            "content": {"type": "response", "body": "Done"},
+        },
+    }
+    assert calls[0]["timeout"] == 3
+
+
+@pytest.mark.asyncio
+async def test_send_agent_activity_raises_on_graphql_error(monkeypatch):
+    class Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"errors": [{"message": "bad input"}]}
+
+    monkeypatch.setattr(linear_aig.httpx, "post", lambda *args, **kwargs: Response())
+
+    with pytest.raises(RuntimeError, match="Linear GraphQL error"):
+        await linear_aig.send_agent_activity(
+            api_key="lin_api_key",
+            agent_session_id="ags_123",
+            content={"type": "response", "body": "Done"},
+        )

--- a/tests/hermes_cli/test_linear_aig.py
+++ b/tests/hermes_cli/test_linear_aig.py
@@ -46,6 +46,10 @@ def _args(**overrides):
         "port": None,
         "graphql_url": "",
         "ack_only": False,
+        "task_mode": "",
+        "model": "",
+        "provider": "",
+        "toolsets": "",
     }
     defaults.update(overrides)
     return Namespace(**defaults)
@@ -73,6 +77,10 @@ def test_load_runtime_config_uses_environment_defaults():
             linear_aig.HOST_ENV: "127.0.0.1",
             linear_aig.PORT_ENV: "9999",
             linear_aig.GRAPHQL_URL_ENV: "https://linear.test/graphql",
+            linear_aig.TASK_MODE_ENV: "oneshot",
+            linear_aig.MODEL_ENV: "model-a",
+            linear_aig.PROVIDER_ENV: "provider-a",
+            linear_aig.TOOLSETS_ENV: "linear,git",
         },
     )
 
@@ -81,6 +89,10 @@ def test_load_runtime_config_uses_environment_defaults():
     assert config.host == "127.0.0.1"
     assert config.port == 9999
     assert config.graphql_url == "https://linear.test/graphql"
+    assert config.task_mode == "oneshot"
+    assert config.model == "model-a"
+    assert config.provider == "provider-a"
+    assert config.toolsets == "linear,git"
 
 
 def test_load_runtime_config_cli_args_override_environment():
@@ -92,11 +104,16 @@ def test_load_runtime_config_cli_args_override_environment():
             port=8668,
             graphql_url="https://override.test/graphql",
             ack_only=True,
+            task_mode="bridge",
+            model="arg-model",
+            provider="arg-provider",
+            toolsets="arg-tools",
         ),
         {
             linear_aig.ACCESS_TOKEN_ENV: "env_token",
             linear_aig.WEBHOOK_SECRET_ENV: "env_secret",
             linear_aig.PORT_ENV: "9999",
+            linear_aig.TASK_MODE_ENV: "oneshot",
         },
     )
 
@@ -106,11 +123,26 @@ def test_load_runtime_config_cli_args_override_environment():
     assert config.port == 8668
     assert config.graphql_url == "https://override.test/graphql"
     assert config.ack_only is True
+    assert config.task_mode == "bridge"
+    assert config.model == "arg-model"
+    assert config.provider == "arg-provider"
+    assert config.toolsets == "arg-tools"
 
 
 def test_load_runtime_config_requires_token_and_webhook_secret():
     with pytest.raises(ValueError, match=linear_aig.ACCESS_TOKEN_ENV):
         linear_aig.load_runtime_config(_args(), {})
+
+
+def test_load_runtime_config_rejects_unknown_task_mode():
+    with pytest.raises(ValueError, match="task mode"):
+        linear_aig.load_runtime_config(
+            _args(task_mode="launch"),
+            {
+                linear_aig.ACCESS_TOKEN_ENV: "lin_access_token",
+                linear_aig.WEBHOOK_SECRET_ENV: "signing_secret",
+            },
+        )
 
 
 def test_describe_runtime_config_redacts_sensitive_values():
@@ -127,6 +159,7 @@ def test_describe_runtime_config_redacts_sensitive_values():
     assert "webhook_secret_value" not in description
     assert "lin_...oken" in description
     assert "webh...alue" in description
+    assert "task_mode: bridge" in description
 
 
 def test_linear_aig_command_check_config_prints_redacted_config(monkeypatch, capsys):
@@ -183,6 +216,65 @@ def test_run_server_builds_receiver_and_starts_aiohttp(monkeypatch):
     assert calls[0]["app"] is app
     assert calls[0]["host"] == "127.0.0.1"
     assert calls[0]["port"] == 8668
+
+
+def test_build_oneshot_prompt_includes_linear_context():
+    prompt = linear_aig.build_oneshot_prompt(linear_aig.parse_agent_session_event(_payload()))
+
+    assert "Linear Agent Session" in prompt
+    assert "Action: created" in prompt
+    assert "Issue: WHO-192" in prompt
+    assert "Issue title: Implement Hermes Linear AIG webhook receiver" in prompt
+    assert "Implement WHO-192" in prompt
+
+
+@pytest.mark.asyncio
+async def test_oneshot_dispatcher_runs_hermes_agent(monkeypatch):
+    calls = []
+
+    def fake_run(prompt, *, model, provider, toolsets):
+        calls.append(
+            {
+                "prompt": prompt,
+                "model": model,
+                "provider": provider,
+                "toolsets": toolsets,
+            }
+        )
+        return "Hermes result"
+
+    monkeypatch.setattr(linear_aig, "run_hermes_oneshot", fake_run)
+    dispatcher = linear_aig.build_task_dispatcher(
+        linear_aig.LinearAIGRuntimeConfig(
+            access_token="lin_token",
+            webhook_secret="webhook_secret",
+            task_mode="oneshot",
+            model="model-a",
+            provider="provider-a",
+            toolsets="linear,git",
+        )
+    )
+
+    result = await dispatcher(linear_aig.parse_agent_session_event(_payload()))
+
+    assert result == "Hermes result"
+    assert calls[0]["model"] == "model-a"
+    assert calls[0]["provider"] == "provider-a"
+    assert calls[0]["toolsets"] == "linear,git"
+    assert "Implement WHO-192" in calls[0]["prompt"]
+
+
+def test_build_task_dispatcher_respects_ack_only():
+    dispatcher = linear_aig.build_task_dispatcher(
+        linear_aig.LinearAIGRuntimeConfig(
+            access_token="lin_token",
+            webhook_secret="webhook_secret",
+            ack_only=True,
+            task_mode="oneshot",
+        )
+    )
+
+    assert dispatcher is None
 
 
 def test_verify_linear_signature_accepts_sha256_prefix():


### PR DESCRIPTION
【摘要】
新增 Hermes Linear AIG receiver，並把同一套 Linear Agent App 架構擴充到 Hermes / Kilo / MiniMax OAuth / Windsurf app profile。

【意圖】
讓 WHO-192 可以用穩定 webhook receiver 承接 Linear Agent Session，並讓 WHO-40 的 Kilo、MiniMax、Windsurf 後續不用複製多套 receiver，只需切換 app profile 與 credentials。

【流程變更】
- 原本：Linear AIG receiver 只吃一組通用 `HERMES_LINEAR_AIG_*` 設定
- 現在：可用 `HERMES_LINEAR_AIG_APP` 或 `--app` 選擇 `hermes`、`kilocode`、`minimax`、`windsurf`
- 原本：receiver 可 bridge / oneshot，但 app credentials 混在同一組 env
- 現在：app-specific env 會優先，例如 `HERMES_LINEAR_AIG_KILOCODE_ACCESS_TOKEN`、`HERMES_LINEAR_AIG_MINIMAX_WEBHOOK_SECRET`

【系統變更】
- 新增 `hermes_cli.linear_aig` isolated module
- 驗證 `Linear-Signature` HMAC-SHA256 與 `webhookTimestamp` replay window
- 解析 Linear Agent Session payload，包括 nested `data.agentSession` shape
- 建立 `thought` / `response` / `error` / `action` 等 Agent Activity content payload
- 新增 `agentActivityCreate` GraphQL helper
- 新增 aiohttp-compatible `/linear/aig` 與 `/linear/aig/health` app factory
- 新增 `hermes linear-aig check-config|serve`
- 新增 `--app` profile 選項
- Kilo profile 預設 provider：`kilocode`
- MiniMax profile 預設 provider：`minimax-oauth`（只保留 OAuth 方向）
- Windsurf profile 保留獨立 Linear app credentials，provider 需用 `HERMES_LINEAR_AIG_WINDSURF_PROVIDER` 指到已配置 provider
- README 補上 app profile 設定範例

【部署 / Tunnel 狀態】
- 本機 Cloudflare named tunnel `openclaw` 已新增 DNS route：`linear.whoasked.vip`
- 本機 cloudflared config 已新增 `linear.whoasked.vip -> http://localhost:8667`
- 用 smoke receiver 驗證過 `https://linear.whoasked.vip/linear/aig/health` 可回 `200 {"ok": true}`
- 正式收斂仍需要管理員權限重啟 Windows `cloudflared` service，並設定正式 Linear app token / webhook secret

【測試】
- `.\.venv\Scripts\python.exe -m pytest -o addopts= tests\hermes_cli\test_linear_aig.py` → 29 passed
- `.\.venv\Scripts\python.exe -m ruff check hermes_cli\linear_aig.py hermes_cli\main.py tests\hermes_cli\test_linear_aig.py` → passed
- `git diff --check` → passed
- `hermes linear-aig check-config` smoke：MiniMax profile 顯示 provider `minimax-oauth`
- `hermes linear-aig check-config` smoke：Windsurf profile 可讀 app-specific credentials 與 explicit provider

【風險】
- 尚未接正式 Linear app webhooks 與 signing secret
- `linear.whoasked.vip` 的穩定 connector 需要管理員權限重啟 `cloudflared` service 才能完全收斂
- Windsurf 目前沒有內建 Hermes model provider；只先完成 Linear app profile 與 credentials isolation
- Windows 測試需清掉 repo 預設 pytest timeout addopts，因 `signal` 模式依賴 POSIX `SIGALRM`

【後續】
- 設定正式 Hermes / Kilo / MiniMax / Windsurf Linear app credentials
- 管理員 PowerShell 執行 `Restart-Service cloudflared`
- 啟動正式 receiver：`hermes linear-aig serve --app hermes|kilocode|minimax|windsurf`
- 補正式 Linear sandbox webhook smoke test