### PR TITLE
feat: add zai-coding provider for Z.AI GLM Coding Plan

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -262,6 +262,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         base_url_env_var="GLM_BASE_URL",
     ),
+    "zai-coding": ProviderConfig(
+        id="zai-coding",
+        name="Z.AI / GLM (Coding Plan)",
+        auth_type="api_key",
+        inference_base_url="https://api.z.ai/api/anthropic",
+        api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
+        base_url_env_var="GLM_BASE_URL",
+    ),
     "kimi-coding": ProviderConfig(
         id="kimi-coding",
         name="Kimi / Moonshot",
@@ -1422,6 +1430,7 @@ def resolve_provider(
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
+        "zai-coding": "zai-coding", "zai-coding-plan": "zai-coding", "glm-coding": "zai-coding", "z-ai-coding": "zai-coding",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
         "x-ai": "xai", "x.ai": "xai", "grok": "xai",
         "xai-oauth": "xai-oauth", "x-ai-oauth": "xai-oauth",

--- a/plugins/model-providers/zai-coding/__init__.py
+++ b/plugins/model-providers/zai-coding/__init__.py
@@ -1,0 +1,33 @@
+"""Z.AI GLM Coding Plan provider profile.
+
+Separate from the standard `zai` profile because the coding plan
+uses the Anthropic-compatible endpoint (api.z.ai/api/anthropic)
+instead of the OpenAI-compatible /api/paas/v4 endpoint.
+
+The coding plan quota is ONLY accessible via the Anthropic endpoint.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+zai_coding = ProviderProfile(
+    name="zai-coding",
+    aliases=("zai-coding-plan", "glm-coding", "z-ai-coding"),
+    api_mode="anthropic_messages",
+    env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
+    display_name="Z.AI (GLM Coding Plan)",
+    description="Z.AI GLM Coding Plan — Anthropic-compatible endpoint",
+    signup_url="https://z.ai/",
+    base_url="https://api.z.ai/api/anthropic",
+    auth_type="api_key",
+    fallback_models=(
+        "glm-5.1",
+        "glm-5-turbo",
+        "glm-4.7",
+        "glm-4.5-air",
+    ),
+    default_aux_model="glm-4.5-air",
+)
+
+register_provider(zai_coding)

--- a/plugins/model-providers/zai-coding/plugin.yaml
+++ b/plugins/model-providers/zai-coding/plugin.yaml
@@ -1,0 +1,5 @@
+name: zai-coding-provider
+kind: model-provider
+version: 1.0.0
+description: Z.AI GLM Coding Plan (Anthropic-compatible endpoint)
+author: Nous Research


### PR DESCRIPTION
## Summary

Adds a new `zai-coding` provider that routes through the Anthropic-compatible endpoint (`https://api.z.ai/api/anthropic`) instead of the OpenAI-compatible `/api/paas/v4` endpoint.

The Z.AI Coding Plan quota is **only accessible via the Anthropic endpoint** — the standard `/api/paas/v4` endpoint returns error 1113 (insufficient balance) even with a valid coding plan subscription.

## Changes

- **New plugin**: `plugins/model-providers/zai-coding/` with `api_mode="anthropic_messages"` and fallback models (glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air)
- **Registry**: Added `zai-coding` to `PROVIDER_REGISTRY` in `hermes_cli/auth.py` with `inference_base_url` pointing to the Anthropic endpoint
- **Aliases**: `zai-coding`, `zai-coding-plan`, `glm-coding`, `z-ai-coding`

## Usage

```bash
hermes config set model.provider zai-coding
hermes config set model.base_url https://api.z.ai/api/anthropic
hermes config set model.default glm-5.1
```

## How it works

The existing Anthropic transport (`anthropic_messages` api_mode) already handles third-party providers — the code in `agent_init.py` explicitly supports non-native Anthropic providers like GLM, sending the API key via `x-api-key` header and skipping OAuth/Claude identity injection.

The `_detect_api_mode_for_url()` in `runtime_provider.py` auto-detects `anthropic_messages` mode for URLs ending in `/anthropic`, so the transport routes correctly.

## Testing

- Verified the Anthropic endpoint accepts the coding plan key (HTTP 200)
- Confirmed `hermes -z` works with `--provider zai-coding -m glm-5.1`
- Confirmed runtime config persists via `hermes config set`

Co-Authored-By: Oz <oz-agent@warp.dev>