### PR TITLE
fix(plugins): preserve cron registry from disk-cleanup auto-categorisation

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -481,7 +481,15 @@ def guess_category(path: Path) -> Optional[str]:
         }:
             return None
         if top == "cron" or top == "cronjobs":
-            return "cron-output"
+            # Only ``cron/output/**`` holds disposable run artifacts. The
+            # top level of ``cron/`` holds durable scheduler state
+            # (``jobs.json``, ``.tick.lock``) — auto-tracking those as
+            # ``cron-output`` makes the registry eligible for deletion
+            # during the next quick cleanup, which silently wipes all
+            # scheduled jobs (#32164).
+            if len(rel.parts) >= 2 and rel.parts[1] == "output":
+                return "cron-output"
+            return None
         if top == "cache":
             return "temp"
     except ValueError:

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -127,13 +127,46 @@ class TestGuessCategory:
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
-    def test_cron_subtree_categorised(self, _isolate_env):
+    def test_cron_output_subtree_categorised(self, _isolate_env):
+        # Only ``cron/output/**`` artifacts are disposable cron-output;
+        # tested via a typical per-job run artifact.
+        dg = _load_lib()
+        output_dir = _isolate_env / "cron" / "output" / "myjob"
+        output_dir.mkdir(parents=True)
+        p = output_dir / "run.md"
+        p.write_text("x")
+        assert dg.guess_category(p) == "cron-output"
+
+    def test_cron_registry_not_classified(self, _isolate_env):
+        # Regression for #32164: the live scheduler registry must never
+        # be auto-tracked as ``cron-output`` or quick cleanup will delete
+        # it and Hermes will then read missing-registry as zero jobs.
         dg = _load_lib()
         cron_dir = _isolate_env / "cron"
         cron_dir.mkdir()
-        p = cron_dir / "job_output.md"
-        p.write_text("x")
-        assert dg.guess_category(p) == "cron-output"
+        p = cron_dir / "jobs.json"
+        p.write_text("[]")
+        assert dg.guess_category(p) is None
+
+    def test_cron_tick_lock_not_classified(self, _isolate_env):
+        # ``cron/.tick.lock`` is also durable control-plane state; same
+        # invariant as ``jobs.json``.
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        p = cron_dir / ".tick.lock"
+        p.write_text("")
+        assert dg.guess_category(p) is None
+
+    def test_cronjobs_registry_not_classified(self, _isolate_env):
+        # ``cronjobs`` is the legacy alias for the same top-level dir;
+        # the same registry-preservation invariant must hold.
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cronjobs"
+        cron_dir.mkdir()
+        p = cron_dir / "jobs.json"
+        p.write_text("[]")
+        assert dg.guess_category(p) is None
 
     def test_ordinary_file_returns_none(self, _isolate_env):
         dg = _load_lib()


### PR DESCRIPTION
## What does this PR do?

`plugins/disk-cleanup`'s `guess_category()` classified every top-level path under `HERMES_HOME/cron/` (and the legacy `cronjobs/` alias) as `cron-output`. That is correct for the per-job run artifacts under `cron/output/<job>/`, but it also catches durable scheduler state — `cron/jobs.json` (the live job registry) and `cron/.tick.lock` (the tick mutex). Once the `post_tool_call` hook auto-tracks `jobs.json` under `cron-output`, the next `quick()` pass deletes the registry; Hermes then interprets the missing file as an empty schedule and the user's entire cron list silently disappears.

This PR narrows the `cron-output` branch to paths inside `cron/output/**` (and `cronjobs/output/**` for the legacy alias); top-level control-plane files now fall through to `None` and are never auto-tracked. The fix is the one written into the issue body verbatim, with regression tests for the three durable paths the issue calls out.

## Related Issue

Fixes #32164

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/disk-cleanup/disk_cleanup.py` — `guess_category()` now requires `rel.parts[1] == \"output\"` before returning `cron-output`; top-level cron files fall through to `None`.
- `tests/plugins/test_disk_cleanup_plugin.py` — reshape `test_cron_subtree_categorised` around the new `cron/output/<job>/run.md` layout; add `test_cron_registry_not_classified`, `test_cron_tick_lock_not_classified`, and `test_cronjobs_registry_not_classified` as regression guards.

## How to Test

1. Reproduce the bug on `main`: with the patch reverted, `guess_category(Path('~/.hermes/cron/jobs.json'))` returns `'cron-output'`, which means a single `post_tool_call` auto-track + quick cleanup pass (14 days later) deletes the registry.
2. With the patch applied: `guess_category(Path('~/.hermes/cron/jobs.json'))` returns `None`; `guess_category(Path('~/.hermes/cron/output/myjob/run.md'))` still returns `'cron-output'`.
3. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/plugins/test_disk_cleanup_plugin.py -v` → 41 passed locally.

Regression-guard pass: stashed `plugins/disk-cleanup/disk_cleanup.py` and re-ran the three new tests on the unpatched code — all three failed with `'cron-output' is None`, confirming they exercise the bug.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment explains the carve-out; existing module docstring is still accurate)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the path-parts check uses `Path.parts` so the same logic applies on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

> Audited siblings: scanned the rest of `guess_category()` for top-level dict entries that classify durable state. The other catch-all branches (`disk-cleanup`, `logs`, `memories`, `sessions`, `config.yaml`, etc.) already return `None`. `top == \"cache\"` returns `\"temp\"` but cache contents are regeneratable by definition — no known durable registry lives directly under `~/.hermes/cache/`. No additional widening is needed for this fix.