### PR TITLE
feat: add /temp ephemeral session command

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -202,6 +202,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    temp_session: bool = False,
 ):
     """
     Initialize the AI Agent.
@@ -280,6 +281,7 @@ def init_agent(
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
+    agent.temp_session = temp_session
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1521,12 +1521,15 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 # Ephemeral session tool-block helper
 # ---------------------------------------------------------------------------
 # Tools whose write-side actions are blocked in /temp (ephemeral) sessions.
-# Read-only operations (memory view, skill list, cron list/poll/etc.) are fine.
+# Read-only operations (memory is read via system prompt, skill_view /
+# skills_list are separate tools, cron list/poll/run are fine) are unaffected.
 _TEMP_BLOCKED_TOOLS = {
-    # tool_name -> set of blocked actions, or None to block all actions
-    "memory": None,          # view is fine; add/replace/remove blocked
-    "skill_manage": None,    # view/skill_view fine; create/edit/delete/write_file/remove_file blocked
-    "cronjob": {"create"},  # only create blocked; list/poll/run/etc. are fine
+    # tool_name -> frozenset of blocked actions.
+    # Empty frozenset means "block this tool entirely" (no actions allowed).
+    # All listed actions must match the tool's schema enum exactly.
+    "memory": frozenset({"add", "replace", "remove"}),
+    "skill_manage": frozenset({"create", "edit", "patch", "delete", "write_file", "remove_file"}),
+    "cronjob": frozenset({"create"}),
 }
 
 
@@ -1539,11 +1542,11 @@ def _check_temp_session_block(function_name: str, function_args: dict) -> Option
         return None
 
     blocked_actions = _TEMP_BLOCKED_TOOLS[function_name]
-    # If None, all actions for this tool are blocked.
-    if blocked_actions is None:
+
+    # If the tool has no actions at all (empty frozenset), block entirely.
+    if not blocked_actions:
         return (
             f"Tool '{function_name}' is blocked in ephemeral session mode. "
-            "Memory writes and skill edits are disabled. "
             "Use /new or /reset to exit ephemeral mode."
         )
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1517,6 +1517,46 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     )
 
 
+# ---------------------------------------------------------------------------
+# Ephemeral session tool-block helper
+# ---------------------------------------------------------------------------
+# Tools whose write-side actions are blocked in /temp (ephemeral) sessions.
+# Read-only operations (memory view, skill list, cron list/poll/etc.) are fine.
+_TEMP_BLOCKED_TOOLS = {
+    # tool_name -> set of blocked actions, or None to block all actions
+    "memory": None,          # view is fine; add/replace/remove blocked
+    "skill_manage": None,    # view/skill_view fine; create/edit/delete/write_file/remove_file blocked
+    "cronjob": {"create"},  # only create blocked; list/poll/run/etc. are fine
+}
+
+
+def _check_temp_session_block(function_name: str, function_args: dict) -> Optional[str]:
+    """Return an error message string if the tool call is blocked in temp session mode.
+
+    Returns None if the call is allowed.
+    """
+    if function_name not in _TEMP_BLOCKED_TOOLS:
+        return None
+
+    blocked_actions = _TEMP_BLOCKED_TOOLS[function_name]
+    # If None, all actions for this tool are blocked.
+    if blocked_actions is None:
+        return (
+            f"Tool '{function_name}' is blocked in ephemeral session mode. "
+            "Memory writes and skill edits are disabled. "
+            "Use /new or /reset to exit ephemeral mode."
+        )
+
+    # Otherwise, check the specific action parameter.
+    action = function_args.get("action", "")
+    if action in blocked_actions:
+        return (
+            f"Tool '{function_name}' action '{action}' is blocked in ephemeral session mode. "
+            "Use /new or /reset to exit ephemeral mode."
+        )
+
+    return None
+
 
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,
                  tool_call_id: Optional[str] = None, messages: list = None,
@@ -1539,6 +1579,12 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             pass
     if block_message is not None:
         return json.dumps({"error": block_message}, ensure_ascii=False)
+
+    # Ephemeral session guard: block write-side tools in /temp mode.
+    if getattr(agent, "temp_session", False):
+        _blocked = _check_temp_session_block(function_name, function_args)
+        if _blocked:
+            return json.dumps({"error": _blocked}, ensure_ascii=False)
 
     if function_name == "todo":
         from tools.todo_tool import todo_tool as _todo_tool

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -315,8 +315,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if getattr(agent, "temp_session", False):
         volatile_parts.append(
             "EPHEMERAL SESSION: This session is ephemeral (/temp mode). "
-            "The memory, skill_manage, and cronjob (create) tools are BLOCKED — "
-            "do not attempt memory writes, skill edits, or cron creates. "
+            "The following tool actions are BLOCKED — do not attempt them:\n"
+            "- memory: add, replace, remove (reads via system prompt still work)\n"
+            "- skill_manage: create, edit, patch, delete, write_file, remove_file "
+            "(skill_view and skills_list still work)\n"
+            "- cronjob: create (list, poll, run, etc. still work)\n"
             "All other tools work normally. Inform the user if they ask about "
             "persisting information."
         )

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -311,6 +311,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nProvider: {agent.provider}"
     volatile_parts.append(timestamp_line)
 
+    # Ephemeral session notice — tell the model it can't write to memory/skills/cron
+    if getattr(agent, "temp_session", False):
+        volatile_parts.append(
+            "EPHEMERAL SESSION: This session is ephemeral (/temp mode). "
+            "The memory, skill_manage, and cronjob (create) tools are BLOCKED — "
+            "do not attempt memory writes, skill edits, or cron creates. "
+            "All other tools work normally. Inform the user if they ask about "
+            "persisting information."
+        )
+
     return {
         "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
         "context":  "\n\n".join(p.strip() for p in context_parts  if p and p.strip()),

--- a/cli.py
+++ b/cli.py
@@ -859,6 +859,7 @@ def _cleanup_all_browsers(*args, **kwargs):
 _cleanup_done = False
 # Weak reference to the active AIAgent for memory provider shutdown at exit
 _active_agent_ref = None
+_active_cli_ref = None  # Weak reference to HermesCLI for atexit ephemeral cleanup
 _deferred_agent_startup_done = False
 
 
@@ -953,6 +954,15 @@ def _run_cleanup():
                 _active_agent_ref.shutdown_memory_provider(_session_msgs)
             else:
                 _active_agent_ref.shutdown_memory_provider()
+    except Exception:
+        pass
+    # Purge ephemeral session on exit (covers crash/SIGTERM paths).
+    # The graceful /quit handler also calls this, but atexit ensures it
+    # runs even on unexpected process termination.
+    try:
+        _cli = _active_cli_ref
+        if _cli and getattr(_cli, '_temp_session', False):
+            _cli._cleanup_temp_session_if_active()
     except Exception:
         pass
 
@@ -4895,8 +4905,9 @@ class HermesCLI:
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
             )
             # Store reference for atexit memory provider shutdown
-            global _active_agent_ref
+            global _active_agent_ref, _active_cli_ref
             _active_agent_ref = self.agent
+            _active_cli_ref = self
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint

--- a/cli.py
+++ b/cli.py
@@ -3098,6 +3098,10 @@ class HermesCLI:
 
         # Deferred title: stored in memory until the session is created in the DB
         self._pending_title: Optional[str] = None
+
+        # Ephemeral session flag — /temp mode disables memory writes, skill
+        # edits, and cron creates; session is purged on /new, /reset, or exit.
+        self._temp_session: bool = False
         
         # Session ID: reuse existing one when resuming, otherwise generate fresh
         if resume:
@@ -4896,6 +4900,7 @@ class HermesCLI:
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
             self.agent._print_fn = _cprint
+            self.agent.temp_session = self._temp_session
             self._active_agent_route_signature = (
                 effective_model,
                 runtime.get("provider"),
@@ -6399,6 +6404,32 @@ class HermesCLI:
             else:
                 print("(^_^)v New session started!")
 
+    def _cleanup_temp_session_if_active(self) -> None:
+        """Purge the current ephemeral session from DB and disk if active.
+
+        Called before /new, /reset, or on exit when ``_temp_session`` is True.
+        Deletes the session row, messages, and any transcript files so no
+        trace remains.
+        """
+        if not self._temp_session:
+            return
+        old_id = self.session_id
+        if old_id and self._session_db:
+            try:
+                from hermes_constants import get_hermes_home
+                _sessions_dir = get_hermes_home() / "sessions"
+                deleted = self._session_db.delete_session(
+                    old_id,
+                    sessions_dir=_sessions_dir,
+                )
+                if deleted:
+                    logger.info("Ephemeral session %s purged from DB", old_id)
+                    _cprint(f"  🔒 Ephemeral session purged: {old_id}")
+            except Exception as exc:
+                logger.warning("Failed to purge ephemeral session %s: %s", old_id, exc)
+        # Reset the flag — the new session is regular unless /temp is used again.
+        self._temp_session = False
+
     def _handle_handoff_command(self, cmd_original: str) -> bool:
         """Handle ``/handoff <platform>`` — transfer this CLI session to a gateway platform.
 
@@ -6812,6 +6843,7 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = new_session_id
             self.agent.session_start = now
+            self.agent.temp_session = self._temp_session
             self.agent.reset_session_state()
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
@@ -8171,6 +8203,7 @@ class HermesCLI:
                 cmd_original=cmd_original,
             ) is None:
                 return
+            self._cleanup_temp_session_if_active()
             self.new_session(silent=True)
             _clear_output_history()
             # Clear terminal screen.  Inside the TUI, Rich's console.clear()
@@ -8295,7 +8328,7 @@ class HermesCLI:
         elif canonical == "new":
             # Strip inline-skip tokens (now/--yes/-y) before deriving the title
             # so "/new now My Session" yields title="My Session" instead of
-            # title="now My Session". See _split_destructive_skip.
+            # title="now My Session".  See _split_destructive_skip.
             _new_args, _ = self._split_destructive_skip(cmd_original)
             title = _new_args.strip() or None
             if self._confirm_destructive_slash(
@@ -8305,7 +8338,24 @@ class HermesCLI:
                 cmd_original=cmd_original,
             ) is None:
                 return
+            # If the current session is ephemeral, purge it before resetting.
+            self._cleanup_temp_session_if_active()
             self.new_session(title=title)
+        elif canonical == "temp":
+            if self._confirm_destructive_slash(
+                "temp",
+                "Start an ephemeral session?\n"
+                "Memory writes, skill edits, and cron creates will be blocked.\n"
+                "The session is auto-deleted when you /new, /reset, or exit.",
+                cmd_original=cmd_original,
+            ) is None:
+                return
+            # Purge any prior temp session first.
+            self._cleanup_temp_session_if_active()
+            self._temp_session = True
+            self.new_session(title="🔒 Ephemeral")
+            _cprint("  🔒 Ephemeral session — memory writes, skill edits, and cron creates are blocked.")
+            _cprint("  Session will be deleted on /new, /reset, or exit.")
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
         elif canonical == "sessions":
@@ -14532,6 +14582,12 @@ class HermesCLI:
                             _cprint(f"  {_DIM}✗ Session {_escape(_sid)} not found for deletion{_RST}")
                     except (Exception, KeyboardInterrupt) as e:
                         logger.debug("Could not delete session on exit: %s", e)
+                # Ephemeral session cleanup — purges temp traces on exit.
+                if getattr(self, '_temp_session', False):
+                    try:
+                        self._cleanup_temp_session_if_active()
+                    except (Exception, KeyboardInterrupt) as e:
+                        logger.debug("Could not purge ephemeral session on exit: %s", e)
             # Plugin hook: on_session_end — safety net for interrupted exits.
             # run_conversation() already fires this per-turn on normal completion,
             # so only fire here if the agent was mid-turn (_agent_running) when

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6020,6 +6020,15 @@ class GatewayRunner:
                     _db.close()
                 except Exception as _e:
                     logger.debug("SessionDB close error: %s", _e)
+
+            # Purge any ephemeral (/temp) sessions before closing DB.
+            try:
+                _purged = self._purge_all_temp_sessions()
+                if _purged:
+                    logger.info("Shutdown: purged %d ephemeral session(s)", _purged)
+            except Exception as _e:
+                logger.debug("Ephemeral session purge error: %s", _e)
+
             logger.info(
                 "Shutdown phase: SessionDB close done at +%.2fs",
                 _phase_elapsed(),
@@ -9383,6 +9392,24 @@ class GatewayRunner:
 
         header = "🔒 Ephemeral session started — memory writes, skill edits, and cron creates are blocked."
         return EphemeralReply(f"{header}\nSession will be deleted on /new, /reset, or exit.")
+
+    def _purge_all_temp_sessions(self) -> int:
+        """Purge all ephemeral sessions from DB and disk. Returns count purged.
+
+        Called on gateway shutdown to clean up any /temp sessions that weren't
+        explicitly ended with /new or /reset.
+        """
+        purged = 0
+        for _key, entry in list(getattr(self, 'session_store', None)._entries.items() if getattr(self, 'session_store', None) else []):
+            if getattr(entry, 'temp_session', False):
+                try:
+                    _sid = getattr(entry, 'session_id', None)
+                    if _sid and getattr(self, '_session_db', None):
+                        self._session_db.delete_session(_sid, sessions_dir=self.config.sessions_dir)
+                        purged += 1
+                except Exception:
+                    pass
+        return purged
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7350,6 +7350,21 @@ class GatewayRunner:
                 execute=_do_reset,
             )
 
+        if canonical == "temp":
+            async def _do_temp():
+                return await self._handle_temp_command(event)
+            return await self._maybe_confirm_destructive_slash(
+                event=event,
+                command="temp",
+                title="/temp",
+                detail=(
+                    "Start an ephemeral session? Memory writes, skill edits, "
+                    "and cron creates will be blocked. The session is "
+                    "auto-deleted on /new, /reset, or exit."
+                ),
+                execute=_do_temp,
+            )
+
         if canonical == "topic":
             return await self._handle_topic_command(event)
         
@@ -9175,6 +9190,18 @@ class GatewayRunner:
         session_key = self._session_key_for_source(source)
         self._invalidate_session_run_generation(session_key, reason="session_reset")
 
+        # If the current session is ephemeral (/temp), purge it from DB+disk.
+        _pre_entry = self.session_store._entries.get(session_key)
+        if _pre_entry and getattr(_pre_entry, 'temp_session', False):
+            try:
+                if self._session_db:
+                    self._session_db.delete_session(
+                        _pre_entry.session_id,
+                        sessions_dir=self.config.sessions_dir,
+                    )
+            except Exception:
+                logger.debug("Could not purge ephemeral session %s on reset", getattr(_pre_entry, 'session_id', '?'))
+
         # Snapshot the old entry so on_session_finalize can report the
         # expiring session id before reset_session() rotates it.
         old_entry = self.session_store._entries.get(session_key)
@@ -9314,6 +9341,48 @@ class GatewayRunner:
         if session_info:
             return EphemeralReply(f"{header}\n\n{session_info}{_tip_line}")
         return EphemeralReply(f"{header}{_tip_line}")
+
+    async def _handle_temp_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
+        """Handle /temp command — start an ephemeral session.
+
+        Memory writes, skill edits, and cron creates are blocked. The session
+        is auto-deleted on /new, /reset, or exit.
+        """
+        source = event.source
+        session_key = self._session_key_for_source(source)
+
+        # Purge any prior temp session for this key
+        old_entry = self.session_store._entries.get(session_key)
+        if old_entry and getattr(old_entry, 'temp_session', False):
+            try:
+                if self._session_db:
+                    self._session_db.delete_session(
+                        old_entry.session_id,
+                        sessions_dir=self.config.sessions_dir,
+                    )
+            except Exception:
+                logger.debug("Could not purge previous temp session %s", getattr(old_entry, 'session_id', '?'))
+
+        # Create a new session, marking it as temp
+        new_entry = self.session_store.reset_session(session_key)
+        if new_entry is None:
+            new_entry = self.session_store.get_or_create_session(source, force_new=True)
+
+        # Mark the session entry as ephemeral
+        if new_entry is not None:
+            new_entry.temp_session = True  # type: ignore[attr-defined]
+
+        # Mark cached agent as temp too
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache_lock and _cache is not None:
+            with _cache_lock:
+                cached = _cache.get(session_key)
+                if cached and isinstance(cached, tuple) and cached[0] is not None:
+                    cached[0].temp_session = True
+
+        header = "🔒 Ephemeral session started — memory writes, skill edits, and cron creates are blocked."
+        return EphemeralReply(f"{header}\nSession will be deleted on /new, /reset, or exit.")
 
     async def _handle_profile_command(self, event: MessageEvent) -> str:
         """Handle /profile — show active profile name and home directory."""
@@ -16539,6 +16608,10 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+
+            # Propagate ephemeral session flag from session entry
+            _cur_entry = self.session_store._entries.get(session_key)
+            agent.temp_session = getattr(_cur_entry, 'temp_session', False) if _cur_entry else False
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -468,6 +468,10 @@ class SessionEntry:
     # See issue #6508.
     is_fresh_reset: bool = False
     
+    # Set when the session is ephemeral (/temp) — memory writes, skill edits,
+    # and cron creates are blocked; session is purged on /new, /reset, or exit.
+    temp_session: bool = False
+    
     # Set by the background expiry watcher after it finalizes an expired
     # session (invoking on_session_finalize hooks and evicting the cached
     # agent).  Persisted to sessions.json so the flag survives gateway

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -65,7 +65,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Session
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
-    CommandDef("temp", "Start an ephemeral session — no memory writes, auto-deleted on /new or exit", "Session"),
+    CommandDef("temp", "Start an ephemeral session — write tools blocked, auto-deleted on /new, /reset, or exit", "Session"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -65,6 +65,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Session
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
+    CommandDef("temp", "Start an ephemeral session — no memory writes, auto-deleted on /new or exit", "Session"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
                gateway_only=True, args_hint="[off|help|session-id]"),
     CommandDef("clear", "Clear screen and start a new session", "Session",

--- a/run_agent.py
+++ b/run_agent.py
@@ -413,6 +413,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        temp_session: bool = False,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -482,6 +483,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            temp_session=temp_session,
         )
 
     def _get_session_db_for_recall(self):


### PR DESCRIPTION
## Summary

Adds a `/temp` slash command that starts an **ephemeral session** — a fully functional chat session where write-side persistence tools are blocked and the entire session is auto-deleted on `/new`, `/reset`, `/clear`, or exit.

### Blocked tools in ephemeral mode
| Tool | What's blocked |
|---|---|
| `memory` | All write actions (add/replace/remove) |
| `skill_manage` | All write actions (create/edit/patch/delete/write_file/remove_file) |
| `cronjob` | `create` only (list/poll/run/update/pause/resume/remove still work) |

All other tools (web_search, browse, terminal, file read/write, send_message, session_search, delegate_task, todo, vision, etc.) work normally.

### Key behaviors
- **System prompt injection**: A volatile-tier note tells the model it's in ephemeral mode so it doesn't waste turns attempting blocked operations
- **Tool-level enforcement**: `_check_temp_session_block()` in `agent_runtime_helpers.py` intercepts blocked tool calls before execution and returns a clear error message
- **DB + disk purge**: On session exit/reset, `_cleanup_temp_session_if_active()` calls `SessionDB.delete_session()` with `sessions_dir` to wipe the session row, messages, and transcript files
- **Works in both CLI and gateway**: `/temp` is registered in `COMMAND_REGISTRY` and handled in both `cli.py` and `gateway/run.py`
- **Session flag propagation**: `temp_session` flag flows from CLI → AIAgent → system prompt and tool dispatch

### Files changed (8)
- `hermes_cli/commands.py` — Command registry entry
- `cli.py` — `/temp` handler, `_temp_session` flag, cleanup logic
- `run_agent.py` + `agent/agent_init.py` — `temp_session` param on AIAgent
- `agent/agent_runtime_helpers.py` — Tool blocking logic
- `agent/system_prompt.py` — Ephemeral session notice
- `gateway/run.py` — Gateway `/temp` handler + reset cleanup
- `gateway/session.py` — `temp_session` field on SessionEntry