### PR TITLE
fix(kanban): forbid clarify in worker guidance — use kanban_block instead

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -253,7 +253,11 @@ KANBAN_GUIDANCE = (
     "specialist profile.\n"
     "- Do not call `delegate_task` as a board substitute. `delegate_task` is "
     "for short reasoning subtasks inside your own run; board tasks are for "
-    "cross-agent handoffs that outlive one API loop."
+    "cross-agent handoffs that outlive one API loop.\n"
+    "- Do not call `clarify`. There is no live user on the other end — the "
+    "call will time out and the task will hang in `running`. If you need a "
+    "human decision, use `kanban_comment` for context then `kanban_block` "
+    "with the specific question."
 )
 
 TOOL_USE_ENFORCEMENT_GUIDANCE = (

--- a/skills/devops/kanban-worker/SKILL.md
+++ b/skills/devops/kanban-worker/SKILL.md
@@ -170,6 +170,7 @@ You can configure the gateway to receive cross-profile Kanban task notifications
 - Modify files outside `$HERMES_KANBAN_WORKSPACE` unless the task body says to.
 - Create follow-up tasks assigned to yourself — assign to the right specialist.
 - Complete a task you didn't actually finish. Block it instead.
+- Call `clarify` — there is no live user to answer. Use `kanban_comment` for context, then `kanban_block` with the specific question.
 
 ## Pitfalls
 


### PR DESCRIPTION
## Summary

Closes #32167.

Kanban workers run headless with no live user on the other end. When a worker calls `clarify()`, the call always times out (~120s), the task hangs in `running` with no visible indicator, and no notification reaches the operator.

## Changes

Two-line fix across two files:

1. **`agent/prompt_builder.py`** — Added a "Do not call `clarify`" bullet to the `## Do NOT` section of `KANBAN_GUIDANCE`. Every kanban worker sees this in their system prompt.

2. **`skills/devops/kanban-worker/SKILL.md`** — Added the same rule to the skill-level `## Do NOT` section for deeper reference.

Both entries tell workers to use `kanban_comment` + `kanban_block` instead, which is the existing documented pattern for requesting human input.

## Testing

- All 3 existing kanban guidance tests pass:
  - `test_kanban_guidance_prompt_size_bounded` — guidance is 3,969 chars, under the 4,096 cap
  - `test_kanban_guidance_in_worker_prompt` — guidance injected for kanban workers
  - `test_kanban_guidance_not_in_normal_prompt` — guidance not injected for normal sessions
- Verified `"clarify"` appears in the updated `KANBAN_GUIDANCE` text

## Why this approach

The issue reporter suggested exactly these two locations. The `kanban_comment` + `kanban_block` pattern is already documented and tested — workers just need an explicit rule to never reach for `clarify`.