### PR TITLE
fix(gateway): clear model/reasoning boundary state on resume and branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,6 +103,8 @@ jobs:
       # ---------------------------------------------------------------------
       - name: Install uv (for docker tests)
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          github-token: ${{ github.token }}
 
       - name: Set up Python 3.11 (for docker tests)
         run: uv python install 3.11

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install ruff + ty
         run: |
@@ -171,6 +173,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          github-token: ${{ github.token }}
 
       - name: Install ruff
         run: uv tool install ruff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          github-token: ${{ github.token }}
 
       - name: Set up Python 3.11
         run: uv python install 3.11
@@ -161,6 +163,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          github-token: ${{ github.token }}
 
       - name: Set up Python 3.11
         run: uv python install 3.11

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6
+        with:
+          github-token: ${{ github.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4

--- a/.github/workflows/uv-lockfile-check.yml
+++ b/.github/workflows/uv-lockfile-check.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+        with:
+          github-token: ${{ github.token }}
 
       # `uv lock --check` re-resolves the project from pyproject.toml and
       # compares the result to uv.lock, exiting non-zero if they disagree.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15110,9 +15110,18 @@ class GatewayRunner:
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:
-        """Clear per-session control state that must not survive a boundary switch."""
+        """Clear per-session state that must not survive a boundary switch."""
         if not session_key:
             return
+
+        session_model_overrides = getattr(self, "_session_model_overrides", None)
+        if isinstance(session_model_overrides, dict):
+            session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+
+        pending_model_notes = getattr(self, "_pending_model_notes", None)
+        if isinstance(pending_model_notes, dict):
+            pending_model_notes.pop(session_key, None)
 
         pending_skills_reload_notes = getattr(
             self, "_pending_skills_reload_notes", None

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -127,6 +127,18 @@ async def test_resume_clears_session_scoped_approval_and_yolo_state():
     runner, session_key = _make_resume_runner()
     other_key = "agent:main:telegram:dm:other-chat"
 
+    runner._session_model_overrides = {
+        session_key: {"model": "gpt-5.4", "provider": "openai"},
+        other_key: {"model": "claude-sonnet-4-6", "provider": "anthropic"},
+    }
+    runner._session_reasoning_overrides = {
+        session_key: {"enabled": True, "effort": "high"},
+        other_key: {"enabled": True, "effort": "low"},
+    }
+    runner._pending_model_notes = {
+        session_key: "[Note: switched to gpt-5.4.]",
+        other_key: "[Note: switched to claude-sonnet-4-6.]",
+    }
     runner._pending_skills_reload_notes = {
         session_key: "[USER INITIATED SKILLS RELOAD: target]",
         other_key: "[USER INITIATED SKILLS RELOAD: other]",
@@ -145,11 +157,17 @@ async def test_resume_clears_session_scoped_approval_and_yolo_state():
     assert "Resumed session" in result
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
+    assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_model_notes
     assert session_key not in runner._pending_approvals
     assert session_key not in runner._update_prompt_pending
     assert session_key not in runner._pending_skills_reload_notes
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
+    assert other_key in runner._session_model_overrides
+    assert other_key in runner._session_reasoning_overrides
+    assert other_key in runner._pending_model_notes
     assert other_key in runner._pending_approvals
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes
@@ -160,6 +178,18 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     runner, session_key = _make_branch_runner()
     other_key = "agent:main:telegram:dm:other-chat"
 
+    runner._session_model_overrides = {
+        session_key: {"model": "gpt-5.4", "provider": "openai"},
+        other_key: {"model": "claude-sonnet-4-6", "provider": "anthropic"},
+    }
+    runner._session_reasoning_overrides = {
+        session_key: {"enabled": True, "effort": "high"},
+        other_key: {"enabled": True, "effort": "low"},
+    }
+    runner._pending_model_notes = {
+        session_key: "[Note: switched to gpt-5.4.]",
+        other_key: "[Note: switched to claude-sonnet-4-6.]",
+    }
     runner._pending_skills_reload_notes = {
         session_key: "[USER INITIATED SKILLS RELOAD: target]",
         other_key: "[USER INITIATED SKILLS RELOAD: other]",
@@ -178,11 +208,17 @@ async def test_branch_clears_session_scoped_approval_and_yolo_state():
     assert "Branched to" in result
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
+    assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_model_notes
     assert session_key not in runner._pending_approvals
     assert session_key not in runner._update_prompt_pending
     assert session_key not in runner._pending_skills_reload_notes
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
+    assert other_key in runner._session_model_overrides
+    assert other_key in runner._session_reasoning_overrides
+    assert other_key in runner._pending_model_notes
     assert other_key in runner._pending_approvals
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes
@@ -221,7 +257,7 @@ async def test_branch_preserves_persisted_assistant_metadata():
 
 
 def test_clear_session_boundary_security_state_is_scoped():
-    """The helper must wipe only the target session's approval/yolo state.
+    """The helper must wipe only the target session's boundary state.
 
     Also exercises the /new reset path indirectly: /new calls this helper,
     so if the helper is scoped correctly, /new's clearing is correct too.
@@ -229,6 +265,9 @@ def test_clear_session_boundary_security_state_is_scoped():
     from gateway.run import GatewayRunner
 
     runner = object.__new__(GatewayRunner)
+    runner._session_model_overrides = {}
+    runner._session_reasoning_overrides = {}
+    runner._pending_model_notes = {}
     runner._pending_approvals = {}
     runner._update_prompt_pending = {}
     runner._pending_skills_reload_notes = {}
@@ -241,6 +280,26 @@ def test_clear_session_boundary_security_state_is_scoped():
     approve_session(other_key, "recursive delete")
     enable_session_yolo(session_key)
     enable_session_yolo(other_key)
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-5.4",
+        "provider": "openai",
+    }
+    runner._session_model_overrides[other_key] = {
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+    }
+    runner._session_reasoning_overrides[session_key] = {
+        "enabled": True,
+        "effort": "high",
+    }
+    runner._session_reasoning_overrides[other_key] = {
+        "enabled": True,
+        "effort": "low",
+    }
+    runner._pending_model_notes[session_key] = "[Note: switched to gpt-5.4.]"
+    runner._pending_model_notes[other_key] = (
+        "[Note: switched to claude-sonnet-4-6.]"
+    )
     runner._pending_approvals[session_key] = {"command": "rm -rf /tmp/demo"}
     runner._pending_approvals[other_key] = {"command": "rm -rf /tmp/other"}
     runner._update_prompt_pending[session_key] = True
@@ -266,6 +325,9 @@ def test_clear_session_boundary_security_state_is_scoped():
     # Target session cleared
     assert is_approved(session_key, "recursive delete") is False
     assert is_session_yolo_enabled(session_key) is False
+    assert session_key not in runner._session_model_overrides
+    assert session_key not in runner._session_reasoning_overrides
+    assert session_key not in runner._pending_model_notes
     assert session_key not in runner._pending_approvals
     assert session_key not in runner._update_prompt_pending
     assert session_key not in runner._pending_skills_reload_notes
@@ -273,6 +335,9 @@ def test_clear_session_boundary_security_state_is_scoped():
     # Other session untouched
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
+    assert other_key in runner._session_model_overrides
+    assert other_key in runner._session_reasoning_overrides
+    assert other_key in runner._pending_model_notes
     assert other_key in runner._pending_approvals
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes


### PR DESCRIPTION

## Summary
This change clears session-scoped model overrides, reasoning overrides, and pending model-switch notes when a conversation crosses a session boundary via `/resume` or `/branch`.

It fixes a real state-leak bug where a newly resumed or branched session could continue with stale model/provider/reasoning state from the previous session.

## Changes
- Extend `_clear_session_boundary_security_state()` to clear:
  - `_session_model_overrides`
  - `_session_reasoning_overrides`
  - `_pending_model_notes`
- Add regression coverage to verify `/resume` and `/branch` clear only the target session’s boundary state and leave unrelated sessions untouched.

## Test Results
- `tests/gateway/test_session_boundary_security_state.py`
- `tests/gateway/test_session_model_reset.py`
- `tests/gateway/test_resume_command.py`

Result: 22 passed

- `tests/gateway/test_session_boundary_hooks.py`

Result: 6 passed

- `tests/gateway/test_session_model_override_routing.py`

Result: 4 passed

Total: 32 passed

