### PR TITLE
fix(skills): reject symlinks in skill bundles before install

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1913,3 +1913,50 @@ class TestInstallPathSafety:
         assert ok is False
         assert victim.exists()
         assert (victim / "important").read_text() == "don't delete me"
+
+    def test_install_from_quarantine_rejects_symlinks(self, tmp_path):
+        """Skill install must not follow symlinks that leak file contents
+        from outside the quarantine directory."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: bad-skill\n---\n")
+
+        secret = tmp_path / "secret.txt"
+        secret.write_text("data exfiltration payload\n")
+
+        leak = q_dir / "leak.txt"
+        try:
+            leak.symlink_to(secret)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        bundle = hub.SkillBundle(
+            name="bad-skill",
+            files={"SKILL.md": "---\nname: bad-skill\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="bad-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="symlink"):
+                hub.install_from_quarantine(
+                    q_dir, "bad-skill", "", bundle, scan_result,
+                )
+
+        assert not (skills_dir / "bad-skill" / "leak.txt").exists()
+        assert secret.read_text() == "data exfiltration payload\n"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3040,6 +3040,21 @@ def install_from_quarantine(
         except OSError:
             pass
 
+    # Reject symlinks inside the quarantined skill before moving it.
+    # A malicious skill bundle could include a symlink pointing outside the
+    # skills tree; its target contents would then be copied into skills/ and
+    # leaked to the agent on the next skill_view call.
+    for entry in quarantine_path.rglob("*"):
+        if not _is_path_redirect(entry):
+            continue
+        try:
+            rel = entry.relative_to(quarantine_resolved)
+        except ValueError:
+            rel = entry
+        raise ValueError(
+            f"Installed skill contains symlinks, which is not allowed: {rel}"
+        )
+
     install_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(quarantine_path), str(install_dir))
 


### PR DESCRIPTION
## Summary
Adds symlink guard to the skill install path, as suggested in the review of #21938.

---

## Root cause
`install_from_quarantine` in `tools/skills_hub.py` called `shutil.move` without checking whether the quarantined skill bundle contained symlinks pointing outside the quarantine directory. A malicious skill bundle could include such a symlink; its target contents would then be copied into `~/.hermes/skills/` and leaked to the agent on the next `skill_view` call.

---

## What changed

**`tools/skills_hub.py`**
- Added a symlink check in `install_from_quarantine` before `shutil.move`. Uses the existing `_is_path_redirect` helper (which covers both symlinks and Windows junctions) to scan all entries in the quarantine directory. Raises `ValueError` if any redirect is found, aborting the install.

This is the install-time equivalent of `_reject_distribution_symlinks` added to profile distributions in #25292 (merged).

---

## What is NOT changed
- Runtime skill discovery is unaffected. The intentional dev-workflow pattern of symlinking `~/.hermes/skills/<name>` to a checked-out repo elsewhere on disk continues to work.

---

## Tests
1 new test `test_install_from_quarantine_rejects_symlinks` in `TestInstallPathSafety`. All 15 tests in the class pass with no regressions.

Follows up on #21938 (closed). Addresses the install-time layer as suggested by @teknium1.