### PR TITLE
fix(kanban): resolve worktree defaults from board root

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3948,8 +3948,11 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         return p
     if kind == "worktree":
         if not task.workspace_path:
-            # Default: .worktrees/<id>/ under CWD.  Worker skill creates it.
-            return Path.cwd() / ".worktrees" / task.id
+            # Default: worktree dir under the board's workspaces root.
+            # This mirrors the scratch pattern above and ensures the path
+            # resolves to the board-managed workspace directory rather than
+            # cwd/.worktrees/<id> when the dispatcher runs from another root.
+            return workspaces_root(board=board) / task.id
         p = Path(task.workspace_path).expanduser()
         if not p.is_absolute():
             raise ValueError(


### PR DESCRIPTION
## Summary
- Fixes Kanban worktree default path resolution to use the board-managed workspace root instead of the dispatcher's current working directory.
- Prevents shared Hermes/board dispatchers from resolving worker worktrees inside the Hermes agent repo when no explicit `workspace_path` is set.

## Root cause
`resolve_workspace()` fell back to `Path.cwd() / ".worktrees" / task.id` for worktree tasks without `workspace_path`. When the dispatcher runs from `~/.hermes/hermes-agent`, the worker workspace resolves under the Hermes repo rather than the board/product workspace root.

## Verification
- `python3 -m py_compile hermes_cli/kanban_db.py`
- `python3 -m pytest tests/hermes_cli/test_kanban_db.py -x -q` -> 172 passed
- `python3 -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_cli.py -x -q` -> 211 passed
- `git diff --check -- hermes_cli/kanban_db.py`

## Scope
- One source file only: `hermes_cli/kanban_db.py`
- No secrets, logs, generated artifacts, memory files, or unrelated dirty local changes included.
