### PR TITLE
Clarify App-specific Service Account Email requirements for Google Chat

### DIFF
--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -101,6 +101,8 @@ On the **topic** (not the subscription), add an IAM principal:
 Without this, Google Chat cannot publish events to your topic and your bot will
 never receive anything.
 
+In addition to the above standard principal, refer to Step 7 and the Chat App specific Service Account Email.
+
 ---
 
 ## Step 6: IAM binding on the subscription
@@ -130,6 +132,11 @@ Go to **APIs & Services → Google Chat API → Configuration**.
   to everyone while you're testing.
 
 Save.
+
+Next to **Connection settings** an app specific Service account email will be shown:
+If this is *not* identical to `chat-api-push@system.gserviceaccount.com` then add another IAM Binding for this Service account to the topic 
+- Principal: **Service account email** as generated here
+- Role: `Pub/Sub Publisher`
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Added clarification on Service Account Email for Google Chat integration.

For Cloud Pub/Sub connection setting, google generates an app specific Service account.



Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
