### PR TITLE
feat(skills): add goal prompt pack workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 ---
 
+## Built-in Skill Workflows
+
+Hermes ships reusable skills for common agent workflows. This release adds a standalone **Goal Prompt Pack** workflow for preparing high-quality autonomous app-build prompts before any code is written.
+
+Use `/goal-prompt-pack` when you want Hermes to create the strongest possible long-running goal prompt for Codex Goal Mode, Hermes workers, or another coding agent. The workflow can start from a rough app idea and produce:
+
+- a product spec and screen-level UI spec;
+- high-fidelity UI mockup prompts, with optional generated mockup references;
+- a translation of selected mockups back into written UI requirements;
+- a final copy-paste-ready goal prompt with acceptance criteria, verification checks, blocker rules, stop rules, and final report format.
+
+For broader product exploration, use `/idea-superpowers-suite`. It now has an optional Goal Prompt Pack stage that can plug the same spec → mockups → autonomous goal prompt process into an idea package. The standalone skill remains independent: you can run `/goal-prompt-pack` directly without using the idea or Superpowers workflows.
+
+---
+
 ## Quick Install
 
 ### Linux, macOS, WSL2, Termux

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.14.0"
+version = "0.14.1"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/idea-workflow/idea-superpowers-suite/SKILL.md
+++ b/skills/idea-workflow/idea-superpowers-suite/SKILL.md
@@ -1,0 +1,477 @@
+---
+name: idea-superpowers-suite
+description: "Use when running the full idea workflow: capture a rough idea, expand it into design/UI/implementation docs, research similar products, and generate build-ready Markdown artifacts."
+version: 1.2.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [idea-workflow, note-taking, product-design, ui-design, implementation, research, superpowers]
+    related_skills: [idea-to-design-doc, idea-to-ui-design-brief, idea-to-implementation-doc, goal-prompt-pack, writing-plans]
+---
+# Idea Superpowers Suite
+
+This skill is a superpowers-style umbrella workflow for idea development.
+
+It coordinates the focused stages:
+- `idea-to-design-doc` for product/design thinking
+- `idea-to-ui-design-brief` for optional Full-mode UI direction and image-generation concepts
+- `idea-to-implementation-doc` for build-ready implementation planning
+
+Use this skill when the user wants a bigger, multi-step workflow that feels like a reusable system rather than a one-off prompt.
+
+## Purpose
+
+Turn a rough thought into a structured chain of artifacts:
+1. Idea capture — create or update a local idea note from the user's high-level concept.
+2. Clarifying interview — capture the rough plan, philosophy, target experience, and constraints.
+3. Design doc — flesh the idea into a full product/UX/technical design document.
+4. Optional UI design brief — in Full mode only, define screens, layout, visual direction, states, and optional image-generation concept prompts.
+5. Research pass — compare similar products and identify what to emulate or avoid.
+6. Implementation spec — translate the design into practical build strategy.
+7. Build handoff — produce one Markdown file with tasks, prompts, tests, acceptance criteria, and Superpowers handoff guidance.
+8. Optional Goal Prompt Pack — use standalone `goal-prompt-pack` when the user wants the video-style spec → UI mockups → final autonomous goal prompt workflow. This option can create the UI spec, generate or prepare actual mockups, translate them into written visual requirements, and produce a copy-paste-ready Codex Goal Mode / Hermes goal prompt. It does not require Superpowers and does not execute the build unless the user explicitly asks.
+9. Spec review — judge readiness before execution.
+
+## Design Philosophy
+
+This workflow should:
+- capture fast;
+- clarify deeply;
+- research before building;
+- separate product thinking from engineering thinking;
+- separate UI direction from implementation details when interface quality matters;
+- save every stage as its own Markdown artifact;
+- remain skippable and resilient when the user wants speed.
+
+The UI brief is optional. It improves interface-heavy projects, but it must not make Lite mode heavier or break existing design-doc → implementation-doc flow.
+
+## Mode Selection
+
+At the start, choose one of two modes unless the user explicitly picks one:
+
+- Lite mode — for sketches, small utilities, early thoughts, and ideas the user wants captured quickly.
+- Full mode — for serious app/product ideas that may later be built by an AI coding agent or Superpowers.
+
+Default to Lite mode when the idea is vague or exploratory. Default to Full mode when the user asks for a product spec, implementation plan, build handoff, research pass, UI/mockup direction, or agent-ready artifact.
+
+## Default File Layout
+
+Use local Markdown files first. If the user later wants Obsidian export, treat that as a separate step.
+
+### Lite mode layout
+
+```text
+ideas/<idea-slug>.md
+ideas/index.md
+```
+
+Optional only if requested:
+
+```text
+ideas/<idea-slug>.implementation.md
+ideas/<idea-slug>.build-prompt.md
+ideas/<idea-slug>.ui-brief.md
+```
+
+### Full mode layout with UI stage
+
+```text
+ideas/<idea-slug>/
+  README.md
+  00-idea-capture.md
+  01-design-doc.md
+  02-ui-design-brief.md
+  03-implementation-spec.md
+  04-agent-build-handoff.md
+  05-spec-review.md
+```
+
+Optional Goal Prompt Pack add-on:
+
+```text
+ideas/<idea-slug>/
+  05-goal-prompt-pack.md
+  06-spec-review.md
+```
+
+When adding the Goal Prompt Pack, move or create spec review after the prompt pack so it can judge the actual goal prompt readiness.
+
+### Full mode fallback layout when UI stage is skipped
+
+If the UI stage is skipped, preserve the previous simpler numbering:
+
+```text
+ideas/<idea-slug>/
+  README.md
+  00-idea-capture.md
+  01-design-doc.md
+  02-implementation-spec.md
+  03-agent-build-handoff.md
+  04-spec-review.md
+```
+
+Optional Goal Prompt Pack add-on when UI stage is skipped:
+
+```text
+ideas/<idea-slug>/
+  04-goal-prompt-pack.md
+  05-spec-review.md
+```
+
+Use whichever numbering is already established in a package. Keep the README artifact map consistent.
+
+## Workflow Stages
+
+### Stage 1: Capture
+
+When the user says they have an idea, create a working note with:
+- title;
+- short summary;
+- rough problem statement;
+- initial bullet points;
+- mode: Lite or Full.
+
+If needed, ask for a name, but prefer to proceed with a temporary title and refine later.
+
+### Stage 2: Interview
+
+Ask one question at a time. Use `references/interview-question-bank.md` for stronger prompts.
+
+In Lite mode, ask only enough to capture the idea clearly, then draft.
+
+In Full mode, cover:
+- target user and problem;
+- what the app should do;
+- desired behavior and product experience;
+- scope and non-goals;
+- main screens or sections;
+- what should be visible at a glance;
+- where users take action;
+- details that can be hidden until needed;
+- desired visual taste: minimal, playful, professional, dense, dashboard-like, calm, command-center, etc.;
+- empty, loading, error, success, first-run, and permission states where relevant;
+- data, integrations, and platform constraints;
+- data location and hosting preference;
+- platform targets: web, desktop, mobile web, iOS, Android, etc.;
+- topology: one app or multiple pieces such as desktop app + hosted web app + API + worker;
+- authentication, secrets, API keys, public/private sharing, and client/server boundaries;
+- what would make the result feel excellent, not merely functional.
+
+Do not push into stack decisions too early unless the user has made a technical constraint explicit. When technical planning starts, recommend practical defaults first, then let the user accept or change them.
+
+### Stage 3: Design Doc
+
+Write `01-design-doc.md` to capture product direction and enough technical shape to support planning.
+
+Suggested sections:
+- one-line summary;
+- problem / purpose;
+- product philosophy;
+- target user;
+- core concept;
+- desired behavior;
+- key features;
+- layout / information architecture;
+- UX notes;
+- technical shape;
+- data / integrations / platform needs;
+- hosting / data location / deployment preference;
+- platform targets;
+- recommended technical defaults and accepted/changed decisions;
+- non-goals;
+- open questions;
+- next steps.
+
+### Stage 4: Optional UI Design Brief
+
+This stage is Full-mode only by default. Do not add it to Lite mode unless the user explicitly asks for UI, mockups, generated images, or visual design direction.
+
+Load `idea-to-ui-design-brief` when this stage runs.
+
+Create `02-ui-design-brief.md` when interface quality matters. It should define:
+- purpose of the UI;
+- product feel and design principles;
+- primary screens/surfaces;
+- screen-by-screen notes;
+- layout and information architecture;
+- component inventory;
+- key user flows;
+- states to design: empty, loading, error, success, first-run, permissions;
+- visual direction;
+- accessibility and responsiveness;
+- content/copy notes;
+- optional image-generation concepts;
+- selected direction;
+- handoff notes for implementation.
+
+#### Optional image-generation pass
+
+Image generation is concept exploration, not the implementation source of truth.
+
+Use it when:
+- the user wants possible UI designs;
+- taste is ambiguous;
+- a dashboard/app/landing page needs visual exploration before code;
+- comparing 2-3 directions would help.
+
+Default concepts:
+1. Conservative — familiar, low-risk, easy to implement.
+2. Strong-fit — best interpretation of the product brief.
+3. Divergent — more distinctive, useful for taste discovery.
+
+If image generation is unavailable or skipped, write the prompts and continue text-only. If images are generated, use vision/manual review to translate them back into written requirements, component notes, and acceptance criteria. Do not ask Superpowers to copy an image blindly.
+
+### Stage 5: Research Pass
+
+For the specific idea, look for similar products and note:
+- what already exists;
+- what is common / commodity;
+- what is different;
+- what should be avoided;
+- where the idea fits.
+
+Keep this practical and bounded. Research should strengthen the spec, not become an endless market report.
+
+### Stage 6: Implementation Thinking
+
+Translate the idea into `03-implementation-spec.md` if the UI brief exists, otherwise `02-implementation-spec.md`.
+
+Include:
+- major system pieces;
+- data needs;
+- recommended database/storage choice and why;
+- hosting/deployment target;
+- platform target decisions;
+- app topology decisions;
+- frontend structure and how it respects the UI design brief if present;
+- backend/service needs;
+- recommended technical stack defaults;
+- security/secrets model;
+- integration points;
+- workflow/milestones;
+- risks and tradeoffs;
+- executable build tasks;
+- testing and verification plan;
+- acceptance criteria / done means;
+- a build sequence a developer or AI coding agent could follow.
+
+Use recommend-then-confirm for technical choices:
+1. infer sensible defaults from product constraints;
+2. present a concise recommendation table;
+3. ask whether the user accepts or changes items;
+4. record accepted defaults and explicit overrides;
+5. if unsure, proceed with defaults as assumptions.
+
+### Stage 7: Final Agent Build Handoff
+
+Create or update `README.md` using `templates/idea-package-readme-template.md`.
+
+Create the final handoff as:
+- `04-agent-build-handoff.md` if the UI brief exists;
+- `03-agent-build-handoff.md` if the UI brief was skipped.
+
+Load `idea-to-implementation-doc` when creating the handoff because the canonical handoff template lives there.
+
+The handoff must include:
+- mission;
+- product vision;
+- non-negotiable requirements;
+- UI/design direction or explicit UI assumptions;
+- out of scope;
+- technical architecture;
+- implementation phases;
+- build tasks;
+- testing requirements;
+- verification commands/checks;
+- acceptance criteria;
+- done means checklist;
+- prompt for the build agent;
+- explicit Superpowers handoff instructions.
+
+### Stage 8: Optional Goal Prompt Pack
+
+Run this stage when the user asks for a goal prompt, Codex Goal Mode prompt, autonomous build prompt, or the video-style workflow where the agent first creates a spec, then UI mockups, then the final goal prompt.
+
+Load `goal-prompt-pack`. This is a standalone skill and must remain usable without the idea workflow or Superpowers. Inside the idea workflow, treat it as an optional packaging stage that can consume existing design/UI/implementation artifacts, fill gaps, generate or prepare actual UI mockups, and produce the final copy-paste-ready goal prompt.
+
+Use this stage to create a file such as:
+
+- `05-goal-prompt-pack.md` if the UI brief exists and the previous handoff is `04-agent-build-handoff.md`.
+- `04-goal-prompt-pack.md` if the UI brief was skipped and the previous handoff is `03-agent-build-handoff.md`.
+
+The Goal Prompt Pack should include:
+- product spec summary;
+- UI spec or UI assumptions;
+- mockup generation prompts;
+- generated/selected mockup references when available;
+- mockup-to-written-requirement translation;
+- final Codex Goal Mode prompt, preferably starting with `/goal` when Codex is the target;
+- Hermes/generic variant notes when useful;
+- acceptance criteria;
+- blocker and stop rules;
+- final report format.
+
+Do not execute the goal prompt in this stage unless the user explicitly asks to start the build.
+
+### Stage 9: Spec Review / Readiness Gate
+
+Create:
+- `06-spec-review.md` if the UI brief and Goal Prompt Pack exist;
+- `05-spec-review.md` if the UI brief exists and Goal Prompt Pack is skipped;
+- `05-spec-review.md` if the UI brief is skipped but Goal Prompt Pack exists;
+- `04-spec-review.md` if both UI brief and Goal Prompt Pack are skipped.
+
+Review whether:
+- the product goal is clear;
+- UI/design expectations are clear enough for a fresh agent to avoid generic output;
+- requirements are testable;
+- unresolved product decisions remain;
+- unresolved technical decisions remain;
+- acceptance criteria are concrete;
+- done means is specific;
+- a fresh agent could build from the file without asking obvious questions;
+- testing and verification requirements are included;
+- non-goals prevent scope creep.
+
+Verdicts:
+- PASS — ready to feed into Superpowers.
+- PASS WITH CHANGES — mostly ready; patch listed issues first.
+- FAIL — too ambiguous or incomplete.
+
+### Stage 10: Review / Plan Review
+
+If the user wants a critique pass, review artifacts separately:
+- design doc stays product-focused;
+- UI brief gives concrete screen/style/state guidance without prescribing unnecessary code;
+- implementation doc stays build-focused;
+- final handoff is agent-ready;
+- spec review is honest about gaps;
+- package summary does not duplicate all focused docs.
+
+## Progression Rules and Override Phrase
+
+### Lite mode rules
+
+- Capture quickly; do not force research, UI brief, or implementation planning.
+- Ask at most 3-5 clarifying questions before drafting unless the user wants more.
+- Do not create `02-ui-design-brief.md`, implementation spec, build handoff, or spec review unless the user upgrades to Full mode or specifically asks for UI/mockup direction.
+- If the user says the idea is just a note, keep it as a note.
+
+### Full mode rules
+
+- Do not move from capture to design until target user, problem, and core behavior are clear enough to summarize.
+- Do not move from design to implementation if open product or UI questions would change architecture, MVP scope, or core interface.
+- Do not create final build handoff until implementation phases, testing requirements, acceptance criteria, and done means are present.
+- Do not mark spec review PASS if verification checks are missing, major product/technical decisions remain, or UI expectations are too vague for an interface-heavy app.
+- If the UI stage is skipped, carry UI assumptions forward instead of blocking.
+
+### User override phrase
+
+The user can force progression with this exact phrase:
+
+> GREENLIGHT NEXT STAGE
+
+When the user says it, move to the next stage. Briefly note the risk, carry unresolved items under Open Questions / Assumptions, and continue. This does not allow unsafe actions or credential exposure.
+
+## Operating Rules
+
+- Keep the workflow modular.
+- Prefer separate files for separate stages.
+- Save progress as Markdown.
+- Patch the working idea note when the user confirms product, architecture, or UI decisions.
+- Keep reusable skill content public-safe; do not embed private product plans or credentials.
+- If the user says stop, that's enough, enough for now, done, draft it, or write it up, stop questioning and draft immediately.
+- If the user wants a lighter experience, use Lite mode.
+- If a stage is skipped, continue with the previous workflow and record assumptions.
+
+## Cost-Aware Worker Delegation
+
+Default to GPT/orchestrator time for judgment, synthesis, user interaction, and quality gates; use cheaper bounded workers for the long middle of the workflow when delegation is available.
+
+Good tasks to delegate to cheaper DeepSeek/Gemini/macdaddy-style workers:
+- bounded public research on comparable products, patterns, constraints, and risks;
+- first-pass design doc drafts from captured notes;
+- UI brief variants, visual direction alternatives, and screen/state inventories;
+- first-pass implementation specs, milestone breakdowns, and test-plan drafts;
+- critique/spec-review passes that identify ambiguity, missing acceptance criteria, and scope risks;
+- mechanical Markdown cleanup, README artifact maps, and consistency checks.
+
+Keep GPT/orchestrator responsible for:
+- interpreting the user's actual intent;
+- asking clarifying questions;
+- deciding Lite vs Full mode and stage progression;
+- resolving product/architecture tradeoffs;
+- merging worker output into one coherent artifact set;
+- final build handoff quality and readiness verdicts.
+
+Delegation rules:
+1. Give each worker a narrow prompt, the current artifact text or summarized source notes, the target filename/stage, and a compact handoff contract.
+2. For cost-minimized build-readiness reviews, prefer a single bounded `architect-grunt` background run for the long middle: read source idea, draft/update implementation spec, final agent handoff, spec review, README/status map, and a compact worker report in a workspace folder. The orchestrator should only do setup, occasional stall checks if needed, and the final quality gate.
+3. Ask workers to report: what they did, sources/files used, key findings, recommended changes, risks/assumptions, blockers, verification performed, and next action.
+4. Do not expose private notes, credentials, customer data, or sensitive repo/log content to public web tools or external workers without explicit user approval.
+5. Treat worker drafts as input, not truth. The orchestrator must review, correct, and synthesize before saving or presenting final artifacts.
+6. Delegation is optional for Lite mode; use it only when it clearly saves cost/time or improves quality. In Full mode, prefer delegation for research, drafts, critiques, and mechanical checks.
+
+### Grunt-offloaded readiness review pattern
+
+When the user asks to use “almost 0 tokens,” “offload the whole process to grunt,” or similar, do not narrate a plan only. Start a background worker immediately if the source artifact can be found. Use a workspace such as `~/Hermes/FleetWorkspace/<idea-slug>-review/`, pass the source path, require no source-file mutation unless explicitly approved, and ask for these outputs: `README.md`, implementation spec, agent build handoff, spec review verdict, and `grunt-report.md`. Finalize by reading the worker report/artifacts and issuing the orchestrator's own PASS / PASS WITH CHANGES / FAIL decision before telling the user it is ready for Superpowers.
+
+For existing-app-vs-idea reviews, use the same pattern but make the worker explicitly read-only against the app source and frame the output around improving the existing app rather than greenfield design. If the app is on a worker machine, first confirm candidate paths, then launch grunt with both the app source path and any related idea/docs path. Useful outputs are: `01-app-review.md` (current state), `02-implementation-spec.md` (improvement plan), `03-agent-build-handoff.md` (next build pass), `04-spec-review.md` (readiness gate), and `grunt-report.md`.
+
+If the spec review returns PASS WITH CHANGES due only to small clarifications, run a narrow second grunt pass instead of resolving from memory. Ask it to create `05-clarifications.md` plus a compact `clarification-report.md` with recommended decisions, rationale, exact patch wording for the handoff, verdict impact, and residual risks. Then the orchestrator should patch the handoff/spec-review docs and update the verdict to PASS only after verifying the blockers are actually incorporated.
+
+For existing-app reviews, use `references/grunt-offloaded-app-review.md`: require the worker to maintain `status.txt`, run the worker in the background with `grunt-run.log`, optionally create a temporary no-agent cron watcher for Telegram/origin progress updates, remove the watcher when complete, and spot-check key source claims before presenting the final verdict.
+
+## Relationship to Focused Skills
+
+- Use `idea-to-design-doc` when the user only wants the design stage.
+- Use `idea-to-ui-design-brief` when the user wants UI direction, generated UI concepts, screen-by-screen mockup notes, or post-build UI redesign.
+- Use `idea-to-implementation-doc` when the user only wants implementation planning.
+- Use `goal-prompt-pack` when the user wants a standalone or plug-in package that creates the product/UI spec, UI mockup prompts or actual mockups, and the final autonomous build goal prompt for Codex Goal Mode, Hermes, or a generic coding agent. This skill does not require the idea workflow or Superpowers.
+- Use `idea-superpowers-suite` when the user wants the full system.
+
+## Relationship to Superpowers
+
+The idea workflow is the front-end product/spec pipeline. Superpowers is the execution discipline pipeline.
+
+Expected handoff:
+1. `idea-superpowers-suite` captures the idea and asks clarifying questions.
+2. `idea-to-design-doc` produces the design/spec document.
+3. `idea-to-ui-design-brief` optionally produces UI direction and image-generation concept prompts.
+4. `idea-to-implementation-doc` produces the build-ready Markdown handoff.
+5. Superpowers validates, plans, implements, tests, reviews, and verifies.
+
+The idea workflow should create high-quality input for Superpowers, not replace Superpowers execution.
+
+## Reference Files
+
+- `references/interview-question-bank.md` — reusable question bank for Lite and Full interviews.
+- `references/example-cli-tool-build-handoff.md` — generic example final handoff for a small developer CLI tool.
+- `references/example-saas-web-app-build-handoff.md` — generic example final handoff for a small SaaS/web app.
+- `references/example-automation-script-build-handoff.md` — generic example final handoff for a practical automation workflow.
+
+## Templates
+
+- `idea-to-implementation-doc/templates/agent-build-handoff-template.md` — required structure for final agent/Superpowers build handoff documents.
+- `templates/idea-package-readme-template.md` — README/status index for Full mode idea folders.
+
+## Common Pitfalls
+
+1. Making the UI stage mandatory. It is optional and Full-mode only by default.
+2. Letting generated images become the source of truth. Translate images into written UI requirements.
+3. Renumbering existing packages inconsistently. Preserve established numbering and update README maps.
+4. Overloading Lite mode. Keep Lite fast unless the user asks for UI or Full mode.
+5. Producing generic UI slop. Use product-specific screens, states, and actions.
+6. Moving into code before product and UI decisions that affect scope are clear.
+
+## Verification Checklist
+
+- [ ] Mode was chosen or inferred correctly.
+- [ ] Lite mode stayed lightweight unless explicitly upgraded.
+- [ ] Full mode artifacts are separated by stage.
+- [ ] UI brief exists only when useful/requested, or UI assumptions are carried forward.
+- [ ] Optional image-generation prompts are treated as concepts, not implementation truth.
+- [ ] README artifact map matches actual filenames and numbering.
+- [ ] Final handoff includes UI direction or explicit UI assumptions.
+- [ ] Spec review honestly reports unresolved product, UI, and technical gaps.

--- a/skills/idea-workflow/idea-superpowers-suite/references/example-automation-script-build-handoff.md
+++ b/skills/idea-workflow/idea-superpowers-suite/references/example-automation-script-build-handoff.md
@@ -1,0 +1,120 @@
+# Receipt Sorter Automation Agent Build Handoff
+
+## Mission
+
+Build an automation script that scans a local folder of receipt PDFs/images, extracts basic metadata, renames files consistently, and writes a CSV index.
+
+## Product Vision
+
+Turn a messy downloads folder into an organized, searchable receipt archive without requiring a full document-management system.
+
+## User Experience Goals
+
+- User points the script at an input folder.
+- Script processes supported files safely.
+- Original files are not destroyed.
+- Output names and CSV are predictable.
+
+## Non-Negotiable Requirements
+
+- Dry-run mode before modifying/copying files.
+- Never delete originals.
+- Produce a CSV index.
+- Handle extraction failures gracefully.
+- Log what happened.
+
+## Out of Scope
+
+- Cloud sync.
+- Accounting software integration.
+- Perfect OCR accuracy.
+- Multi-user workflow.
+
+## Technical Architecture
+
+- CLI/script with arguments for input folder, output folder, and dry-run.
+- File discovery layer.
+- Metadata extraction layer using available PDF/OCR tools in the repo/environment.
+- Rename/copy layer.
+- CSV writer and log output.
+
+## Data Model
+
+Receipt index row:
+- `original_path`
+- `new_path`
+- `vendor`
+- `date`
+- `amount`
+- `status`
+- `notes`
+
+## Integrations
+
+- Local filesystem.
+- Optional OCR/PDF library depending on environment.
+
+## Implementation Phases
+
+1. Inspect repo and available dependencies.
+2. Implement file discovery and dry-run reporting.
+3. Implement best-effort metadata extraction.
+4. Implement safe copy/rename.
+5. Implement CSV index and logging.
+6. Add tests with sample fixture files.
+
+## Build Tasks
+
+- Add tests for filename generation.
+- Add tests for CSV writing.
+- Add tests for dry-run no-write behavior.
+- Implement script arguments.
+- Implement processing pipeline.
+- Add README usage examples.
+
+## Testing Requirements
+
+- Unit tests for parsing and filename sanitization.
+- Tests proving dry-run does not create/copy output files.
+- Tests for duplicate filename handling.
+- Fixture-based test for at least one sample input.
+
+## Verification Commands / Checks
+
+- Run test suite.
+- Run dry-run on sample folder.
+- Run real mode on copied sample folder.
+- Confirm originals remain unchanged.
+- Confirm CSV contains one row per attempted file.
+
+## Acceptance Criteria
+
+- User can run dry-run and preview actions.
+- User can run real mode and get organized copies.
+- CSV index is created.
+- Failed extractions are recorded, not fatal.
+
+## Done Means
+
+- Tests pass.
+- Dry-run behavior is proven.
+- Manual sample run works.
+- README documents usage and safety behavior.
+
+## Known Risks
+
+- OCR quality varies.
+- Vendor/date/amount parsing should be best-effort for v1.
+
+## Open Questions
+
+- Should organized files be copied or moved by default? V1 should copy.
+- What filename format should be default: date-vendor-amount or vendor-date-amount?
+
+## Prompt for Build Agent
+
+Inspect the repository and dependencies first. Plan a safe implementation with dry-run tests before write behavior. Do not implement destructive file operations. Verify with fixture data before claiming done.
+
+## Superpowers Build Handoff
+
+Use the `superpowers-gpt` workflow on this document. Start with `superpowers-using-superpowers`, then `superpowers-writing-plans`, then execute, review, and verify with the appropriate Superpowers skills.

--- a/skills/idea-workflow/idea-superpowers-suite/references/example-cli-tool-build-handoff.md
+++ b/skills/idea-workflow/idea-superpowers-suite/references/example-cli-tool-build-handoff.md
@@ -1,0 +1,109 @@
+# DevLog CLI Agent Build Handoff
+
+## Mission
+
+Build a small command-line tool that lets a developer keep a local timestamped work log from the terminal.
+
+## Product Vision
+
+A fast, boring, reliable CLI for capturing short development notes without opening a project-management app.
+
+## User Experience Goals
+
+- Add a note in one command.
+- List recent notes quickly.
+- Search notes by text.
+- Store data locally in a human-readable file.
+
+## Non-Negotiable Requirements
+
+- Works offline.
+- Uses local storage only.
+- Has `add`, `list`, and `search` commands.
+- Includes automated tests for command behavior.
+
+## Out of Scope
+
+- Sync.
+- Accounts.
+- Web UI.
+- Team sharing.
+
+## Technical Architecture
+
+- CLI app in the target repo's primary language.
+- Local JSONL or SQLite storage.
+- Thin command parser layer over a small storage/service module.
+
+## Data Model
+
+Log entry:
+- `id`
+- `timestamp`
+- `project` optional
+- `text`
+- `tags` optional
+
+## Integrations
+
+None for v1.
+
+## Implementation Phases
+
+1. Create CLI skeleton and storage module.
+2. Implement `add`.
+3. Implement `list` with limit option.
+4. Implement `search`.
+5. Add tests and docs.
+
+## Build Tasks
+
+- Inspect existing repo conventions.
+- Add storage tests first.
+- Add command tests for `add`, `list`, and `search`.
+- Implement minimal behavior.
+- Document examples in README.
+
+## Testing Requirements
+
+- Unit tests for storage read/write.
+- CLI tests for successful commands.
+- Test missing/empty log file behavior.
+
+## Verification Commands / Checks
+
+- Run project test suite.
+- Manually run: `devlog add "fixed auth bug"`.
+- Manually run: `devlog list`.
+- Manually run: `devlog search auth`.
+
+## Acceptance Criteria
+
+- User can add a note from terminal.
+- User can list recent notes.
+- User can search existing notes.
+- Data persists across runs.
+
+## Done Means
+
+- Tests pass.
+- Manual commands work.
+- README includes usage examples.
+- No network or account requirement exists.
+
+## Known Risks
+
+- File path conventions may differ by OS.
+- Search can be simple substring search for v1.
+
+## Open Questions
+
+- Should default storage live in project directory or user config directory?
+
+## Prompt for Build Agent
+
+Inspect the repository first. Create a concise implementation plan with files, tests, commands, and expected results. Implement only the v1 CLI described here. Run automated and manual verification before claiming done.
+
+## Superpowers Build Handoff
+
+Use the `superpowers-gpt` workflow on this document. Start with `superpowers-using-superpowers`, then `superpowers-writing-plans`, then execute, review, and verify with the appropriate Superpowers skills.

--- a/skills/idea-workflow/idea-superpowers-suite/references/example-saas-web-app-build-handoff.md
+++ b/skills/idea-workflow/idea-superpowers-suite/references/example-saas-web-app-build-handoff.md
@@ -1,0 +1,123 @@
+# Team Pulse SaaS Agent Build Handoff
+
+## Mission
+
+Build a small web app where a team can submit weekly status updates and view a simple team pulse summary page.
+
+## Product Vision
+
+A lightweight alternative to bloated project-status tools: one weekly prompt, one summary page, minimal administration.
+
+## User Experience Goals
+
+- Team members submit a short weekly update in under two minutes.
+- Managers see blockers, morale, and priorities at a glance.
+- The app feels calm and low-friction.
+
+## Non-Negotiable Requirements
+
+- Users can create/edit their own weekly update.
+- Summary page groups updates by week.
+- Updates include priorities, blockers, confidence/mood, and notes.
+- Basic auth or single-user/team access must exist if deployed beyond localhost.
+
+## Out of Scope
+
+- Payroll/HR features.
+- Complex performance reviews.
+- Slack bot for v1.
+- Advanced analytics.
+
+## Technical Architecture
+
+- Web frontend with form and summary views.
+- Backend/API or full-stack framework depending on repo conventions.
+- Persistent database for users, weeks, and updates.
+- Server-rendered or simple client-rendered UI is acceptable.
+
+## Data Model
+
+User:
+- `id`
+- `name`
+- `email`
+
+WeeklyUpdate:
+- `id`
+- `user_id`
+- `week_start`
+- `priorities`
+- `blockers`
+- `confidence_score`
+- `notes`
+- `created_at`
+- `updated_at`
+
+## Integrations
+
+None required for v1.
+
+## Implementation Phases
+
+1. Inspect repo and choose existing app patterns.
+2. Create data model/migration.
+3. Build weekly update form.
+4. Build summary page grouped by week.
+5. Add auth/access handling appropriate to the project.
+6. Add tests and deployment docs.
+
+## Build Tasks
+
+- Identify framework, routing, database, and test conventions.
+- Add model/schema and persistence tests.
+- Add form validation tests.
+- Implement submission/edit flow.
+- Implement summary view.
+- Add seeded sample data if useful.
+
+## Testing Requirements
+
+- Model validation tests.
+- Form submission tests.
+- Summary page rendering tests.
+- Access-control checks where auth exists.
+
+## Verification Commands / Checks
+
+- Run the project test suite.
+- Start the app locally.
+- Submit an update as a user.
+- Edit the update.
+- Confirm the summary page shows the update under the correct week.
+
+## Acceptance Criteria
+
+- A user can submit one update per week.
+- A user can edit their current update.
+- Summary page summarizes current-week updates.
+- Blockers are easy to identify.
+
+## Done Means
+
+- Tests pass.
+- Manual local flow works end-to-end.
+- The summary page is usable with sample or real data.
+- Auth/access assumptions are documented.
+
+## Known Risks
+
+- Auth choices can expand scope.
+- Summary page complexity should stay minimal for v1.
+
+## Open Questions
+
+- Should managers see all users while members see only their own history?
+- Should week boundaries use local timezone or UTC?
+
+## Prompt for Build Agent
+
+Inspect the repository and current web stack first. Write an implementation plan with exact files, migrations, tests, and commands. Keep v1 simple and avoid adding integrations unless explicitly requested.
+
+## Superpowers Build Handoff
+
+Use the `superpowers-gpt` workflow on this document. Start with `superpowers-using-superpowers`, then `superpowers-writing-plans`, then execute, review, and verify with the appropriate Superpowers skills.

--- a/skills/idea-workflow/idea-superpowers-suite/references/grunt-offloaded-app-review.md
+++ b/skills/idea-workflow/idea-superpowers-suite/references/grunt-offloaded-app-review.md
@@ -1,0 +1,55 @@
+# Grunt-Offloaded App Review Pattern
+
+Use this reference when the user wants an existing app reviewed against the idea-workflow framework while keeping orchestrator token use low.
+
+## Purpose
+
+Run a read-only existing-app review through a cheaper worker, produce idea-workflow artifacts in a separate workspace, and keep the user updated through Telegram or the originating channel.
+
+## Proven workspace pattern
+
+- Create a separate review workspace, e.g. `~/Hermes/FleetWorkspace/<app-slug>-review/`.
+- Write a `worker-prompt.md` that includes:
+  - known source/app path(s)
+  - any related idea-note/doc path(s)
+  - read-only constraints
+  - output workspace path
+  - required artifact list
+  - required compact handoff report contract
+  - a `status.txt` path workers must update at meaningful checkpoints
+- Start the worker in the background with a wrapper script that logs to `grunt-run.log` and writes `DONE:` or `BLOCKED:` to `status.txt` on exit.
+- For Telegram progress updates, create a temporary no-agent cron watcher script that only emits when `status.txt` changes. Remove that watcher when the worker completes.
+
+## Artifact contract
+
+For existing-app reviews, ask for:
+
+- `README.md` — artifact map/status summary
+- `01-app-review.md` — current app/source review
+- `02-implementation-spec.md` — improvement plan and technical strategy
+- `03-agent-build-handoff.md` — coding-agent/Superpowers-ready handoff for the next pass
+- `04-spec-review.md` — PASS / PASS WITH CHANGES / FAIL readiness review
+- `grunt-report.md` — compact handoff packet
+
+## Worker prompt guardrails
+
+Require the worker to:
+
+- inspect source read-only
+- avoid `.env`, secrets, private keys, credential stores, and generated/vendor folders
+- avoid app mutation, commits, installs, and dependency changes unless explicitly approved
+- mark assumptions and uncertainty
+- report commands/files used, verification performed, blockers, and next action
+
+## Orchestrator verification before final answer
+
+Do not simply relay the worker verdict. Before presenting final recommendations:
+
+1. Read `grunt-report.md` and `04-spec-review.md`.
+2. Spot-check key factual claims against source with a cheap command, e.g. line counts, package scripts, component/test counts, key file existence.
+3. Remove any temporary progress watcher/cron job.
+4. Send a concise completion update with verdict, artifact path, verified key facts, and recommended next action.
+
+## Pitfall this prevents
+
+A background worker can finish silently or claim facts without evidence. The `status.txt` + watcher + orchestrator spot-check pattern keeps the user informed while preserving architect as the final quality gate.

--- a/skills/idea-workflow/idea-superpowers-suite/references/interview-question-bank.md
+++ b/skills/idea-workflow/idea-superpowers-suite/references/interview-question-bank.md
@@ -1,0 +1,156 @@
+# Idea Workflow Interview Question Bank
+
+Use this bank to ask better questions during idea capture. Ask one question at a time. Prefer the smallest question that unlocks the next useful artifact.
+
+## Mode selection
+
+- "Do you want this as a quick Lite capture, or should I take it through the Full build-ready workflow?"
+- "Is this something you may actually want built soon, or just an idea to save?"
+- "Should I optimize for speed or completeness?"
+
+## Lite mode: fast capture questions
+
+Use 3-5 of these, then draft.
+
+1. "What should we call this idea for now?"
+2. "What is the one-sentence version?"
+3. "Who is this for?"
+4. "What problem does it solve?"
+5. "What is the main thing it should do?"
+6. "What would make it feel useful enough to keep?"
+7. "What should it definitely not become?"
+8. "Do you want me to save this as a rough note now?"
+
+## Full mode: product philosophy
+
+- "What belief or frustration is behind this idea?"
+- "What should this product make easier, calmer, faster, safer, or more fun?"
+- "If this works perfectly, what changes for the user?"
+- "What should the product refuse to do, even if competitors do it?"
+- "Should this feel like a power tool, an assistant, an overview page, a notebook, a game, or something else?"
+- "What is the taste level: minimal, playful, professional, dense, visual, conversational, etc.?"
+
+## User and audience
+
+- "Who is the first real user?"
+- "Is this for you personally, a small group, a team, or a public audience?"
+- "What does the user already do today instead?"
+- "What is annoying, slow, fragile, or scattered about the current workflow?"
+- "How technical is the first user?"
+- "What does the user already know when they arrive?"
+
+## Core job and user flows
+
+- "What is the first job this product must do well?"
+- "Walk me through the main user flow from opening the app to getting value."
+- "What is the smallest successful session?"
+- "What should happen the first time a new user opens it?"
+- "What should happen on a normal repeat visit?"
+- "What action should always be one click or one command away?"
+- "What should the user never have to leave the product to do?"
+
+## Scope and MVP boundaries
+
+- "What is absolutely required for version one?"
+- "What sounds exciting but should wait?"
+- "What feature would make the project too big too early?"
+- "What can be manual behind the scenes for v1?"
+- "What can be mocked or stubbed for the first prototype?"
+- "What is the smallest version that would still prove the idea?"
+
+## UX and information architecture
+
+- "What are the main screens or areas?"
+- "Should the product organize around people, projects, tasks, time, files, objects, or something else?"
+- "What should be visible at a glance?"
+- "What details can be hidden until needed?"
+- "Where should the user take action?"
+- "What should the empty state teach or invite?"
+- "What would make the interface feel trustworthy?"
+
+## Data, integrations, and platform needs
+
+Ask these after product direction is clear.
+
+- "What data does the product need to store?"
+- "Where should that data live: local-only, self-hosted, Cloudflare, AWS, another cloud, or undecided for now?"
+- "If cloud-hosted, is the goal managed simplicity, low cost, portability, enterprise readiness, or something else?"
+- "What data comes from outside systems?"
+- "Does anything need to sync across devices or users?"
+- "Are there APIs, files, email accounts, calendars, devices, CLIs, or services it must connect to?"
+- "Does it need login/auth, or can it be local/single-user first?"
+- "Does it need real-time updates, or is refresh/polling fine?"
+- "What data would be sensitive or private?"
+
+## Platform targets
+
+Ask these before implementation planning so the build handoff does not assume the wrong app shape.
+
+- "Should this be web-only, or should it also have a Windows app, Mac app, or cross-platform desktop app?"
+- "Does this need a mobile app, or is responsive/mobile web enough?"
+- "If mobile is needed, is iOS, Android, or both required?"
+- "Does any platform need offline support, notifications, local filesystem access, menu bar/tray behavior, background processes, or native integrations?"
+- "Which platform is the first MVP target, and which platforms are explicitly later?"
+
+## App topology, auth, and secrets
+
+- "Is this one app, or multiple pieces such as desktop app + hosted web app + API + worker?"
+- "Which piece owns capture/input, storage, processing, viewing, sharing, and admin actions?"
+- "Who can log in: local admin only, multiple users, public viewers with links, teams, or no login?"
+- "What should public sharing allow, and what must remain admin-only?"
+- "Which secrets/API keys are needed, where should they live, and which clients must never receive them?"
+- "Are simple env-file credentials acceptable for an MVP, or should the default recommendation use a stronger auth/session model?"
+
+## Technical constraints
+
+- "Do you already have a preferred stack or hosting target?"
+- "Does this need to run locally, hosted, mobile, desktop, browser-only, or some combination?"
+- "Does it need offline support?"
+- "What should be cheap/simple to operate?"
+- "Are there existing repos, tools, scripts, or services this must fit into?"
+- "What would make maintenance painful later?"
+
+## Technical defaults: recommend, then confirm
+
+Use this section after product direction, data location, and platform targets are clear enough. Do not ask the user to pick every technology from a blank slate. First propose sensible defaults, then ask what they want to accept or change.
+
+Recommended prompt:
+
+"Based on the idea so far, my default technical recommendation is: <short stack summary>. Do you want to accept this as the default, or change any part of it?"
+
+Cover these areas as needed:
+
+- "Database/storage: I recommend <SQLite/Postgres/MySQL/DynamoDB/Cloudflare D1/KV/R2/S3/local files/no database> because <reason>. Accept or change?"
+- "Backend/runtime: I recommend <Node/Python/Go/serverless/local-only/etc.> because <reason>. Accept or change?"
+- "Frontend/UI: I recommend <React/Next/Vite/Svelte/native desktop/etc.> because <reason>. Accept or change?"
+- "Auth/users: I recommend <no auth/local auth/magic link/OAuth/provider> because <reason>. Accept or change?"
+- "Hosting/deployment: I recommend <local/Cloudflare/AWS/Vercel/Fly/self-hosted/etc.> because <reason>. Accept or change?"
+- "Files/objects: I recommend <local filesystem/S3/R2/database blobs/no file storage> because <reason>. Accept or change?"
+- "Background jobs/queues: I recommend <none/cron/worker queue/Cloudflare Queues/SQS/etc.> because <reason>. Accept or change?"
+- "Realtime/sync: I recommend <none/polling/WebSocket/SSE/platform realtime> because <reason>. Accept or change?"
+- "Search: I recommend <database search/SQLite FTS/Postgres FTS/Meilisearch/Algolia/none> because <reason>. Accept or change?"
+- "Observability/logging: I recommend <console logs/local logs/Sentry/OpenTelemetry/provider logs> because <reason>. Accept or change?"
+- "Testing: I recommend <unit/integration/e2e/manual demo script> because <reason>. Accept or change?"
+
+If the user says "use your suggestions" or seems unsure, record the recommendations as accepted defaults and continue. If the user overrides any item, preserve the override explicitly in the design doc and implementation handoff.
+
+## Quality, testing, and done criteria
+
+- "How will we know v1 works?"
+- "What should be tested manually before calling it done?"
+- "What should be covered by automated tests?"
+- "What failure would make the product untrustworthy?"
+- "What demo should the build agent be able to run at the end?"
+- "What must be true before someone can honestly say 'done'?"
+
+## Risks and open questions
+
+- "What is the riskiest assumption?"
+- "What part is most likely to be harder than it sounds?"
+- "What decision are you intentionally postponing?"
+- "What could make this not worth building?"
+- "What should the spec say if we do not know yet?"
+
+## Override phrase
+
+If the user says **GREENLIGHT NEXT STAGE**, stop asking questions and move to the next artifact. Carry unresolved issues forward under **Open Questions** or **Assumptions**.

--- a/skills/idea-workflow/idea-superpowers-suite/templates/idea-package-readme-template.md
+++ b/skills/idea-workflow/idea-superpowers-suite/templates/idea-package-readme-template.md
@@ -1,0 +1,54 @@
+# <Idea Name> Package README
+
+Status: Draft | In Review | Ready for Superpowers | Building | Complete | Parked
+Mode: Lite | Full
+Current verdict: Not reviewed | PASS | PASS WITH CHANGES | FAIL
+Last updated: <YYYY-MM-DD>
+
+## One-line summary
+
+<What this idea is in one sentence.>
+
+## Current next action
+
+<The next concrete action: answer open questions, write design doc, create implementation spec, run spec review, hand to Superpowers, etc.>
+
+## Artifact map
+
+- `00-idea-capture.md` — raw idea, goals, philosophy, and interview notes.
+- `01-design-doc.md` — product, UX, and high-level technical design.
+- `02-implementation-spec.md` — implementation strategy, system pieces, phases, risks, and testing plan.
+- `03-agent-build-handoff.md` — single-file source of truth for a build agent or Superpowers.
+- `04-spec-review.md` — readiness review and PASS / PASS WITH CHANGES / FAIL verdict.
+
+## Handoff file
+
+Use this file for the build handoff:
+
+`03-agent-build-handoff.md`
+
+## Open decisions
+
+- [ ] <Decision needed before build or before PASS.>
+
+## Assumptions
+
+- <Assumption carried forward because it is not yet confirmed.>
+
+## Non-goals
+
+- <What this idea is intentionally not doing.>
+
+## Superpowers readiness
+
+- [ ] Product goal is clear.
+- [ ] Requirements are testable.
+- [ ] Technical approach is specific enough to plan.
+- [ ] Testing requirements are included.
+- [ ] Verification checks/commands are included.
+- [ ] Done Means is specific.
+- [ ] Spec review verdict is PASS or accepted PASS WITH CHANGES.
+
+## Notes
+
+<Any context a future session needs.>

--- a/skills/idea-workflow/idea-to-design-doc/SKILL.md
+++ b/skills/idea-workflow/idea-to-design-doc/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: idea-to-design-doc
+description: "Use when turning a rough idea into a focused product/design Markdown doc through guided questions, without moving into implementation too early."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [idea-workflow, note-taking, product-design, design-doc, brainstorming]
+    related_skills: [idea-superpowers-suite, idea-to-implementation-doc]
+---
+# Idea to Design Doc Workflow
+
+Use this skill when the user says things like:
+- "I have an idea for an app"
+- "I have an idea for a physical product / 3D-printable product / digital-download design"
+- "Help me flesh out this product"
+- "Turn this thought into a design doc"
+- "Make me a list of ideas and link each one to a note"
+
+## Goal
+
+Convert a rough idea into a structured design document with:
+1. A master ideas index
+2. One markdown note per idea
+3. A guided interview that stops when the user says `stop`, `that's enough`, or `done`
+4. The product idea, philosophy, intended experience, and practical technical shape needed to understand the app
+
+This workflow starts with *product thinking* and only moves into technical aspects after the concept/philosophy is clear. The design doc should capture what the user wants and enough technical direction to support a later build plan.
+
+## Important constraints
+
+- Do **not** push into backend, frameworks, database design, or code architecture too early.
+- First capture product intent, behavior, audience, layout, features, UX, and philosophy.
+- Then, when drafting the design doc, include the relevant technical aspects: platform assumptions, major system components, data needs, integrations, constraints, and likely architecture questions.
+- For Full mode or build-bound ideas, recommend sensible technical defaults first, then let the user accept or change them. Cover database/storage, hosting/deployment, backend/runtime, frontend/UI, auth, platform targets, and other technical pieces only after the product direction is clear.
+- Ask one question at a time when possible.
+- If the user gives a short answer, follow up with a narrower question.
+- If the user says to stop, immediately draft the note from what you have.
+- For cost-aware runs, cheaper workers may draft, critique, or research supporting material, but the orchestrator remains responsible for interpreting user intent, asking questions, and final synthesis. Follow `idea-superpowers-suite` Cost-Aware Worker Delegation rules when available.
+
+## Default storage layout
+
+Save files locally first, rather than directly into the Obsidian vault.
+
+Recommended local folder structure:
+
+- `./ideas/Ideas Index.md`
+- `./ideas/<idea-title>.md`
+
+If the user later wants Obsidian export, treat that as a separate export step.
+
+## Lite vs Full mode
+
+Use **Lite mode** for quick idea capture: ask only enough to produce a useful note. Use **Full mode** when the user wants a durable design doc or eventual implementation handoff.
+
+The user can force the next stage with the exact phrase **GREENLIGHT NEXT STAGE**. If they use it, stop questioning, draft with current information, and record gaps under **Open questions**.
+
+## Interview flow
+
+Ask questions in this order, adapting to the user's answers. For stronger prompts, use `idea-superpowers-suite/references/interview-question-bank.md`.
+
+## Interview flow
+
+Ask questions in this order, adapting to the user's answers. For stronger prompts, use `idea-superpowers-suite/references/interview-question-bank.md`:
+
+1. **Working title**
+   - "What should we call this idea for now?"
+2. **Problem / purpose**
+   - "What problem does it solve, or what is it for?"
+3. **Audience**
+   - "Who is it for?"
+4. **Core behavior**
+   - "What should it do when someone uses it?"
+5. **Primary user flow**
+   - "What is the main thing a user should be able to do from start to finish?"
+6. **Key features**
+   - "What are the must-have features?"
+7. **Layout / organization**
+   - "How should the main parts be arranged or grouped?"
+8. **Physical/digital-product specifics when relevant**
+   - For 3D-printable, hardware, or physical-product ideas, ask about variants/models supported, materials, manufacturing/printing method, fit/tolerance needs, access/serviceability, safety, packaging/deliverables, sales channel, and validation/test-print criteria before moving into app-style hosting/platform questions.
+9. **Data location / hosting preference**
+   - "Should the data stay local, be self-hosted, go to Cloudflare/AWS/another cloud, or is that undecided?"
+10. **Platform targets**
+   - "Should this be web-only, or should it also have a Windows app, Mac app, cross-platform desktop app, mobile app, or responsive mobile web?"
+11. **Recommended technical defaults**
+   - "Based on this idea, I recommend these technical defaults: <short stack summary>. Do you want to accept them or change any part?"
+12. **Preferences / feel**
+   - "Should it feel simple, playful, serious, fast, calm, etc.?"
+13. **Non-goals**
+    - "What should this *not* do?"
+14. **Success criteria**
+    - "How will you know this idea is good enough to move forward?"
+
+## Interview style
+
+Use prompts like:
+- "Tell me more about that part."
+- "What would happen next?"
+- "Can you give an example?"
+- "Is that a must-have or a nice-to-have?"
+- "Do you want it to be simple or more feature-rich?"
+
+If the user is unsure, offer lightweight options instead of open-ended pressure:
+- "Do you want this to be more like a list app, an overview page, or a single-focus tool?"
+- "Should users see everything at once, or step through it one section at a time?"
+
+## Stop condition
+
+If the user says any of the following, stop interviewing and draft immediately:
+- stop
+- that's enough
+- enough for now
+- done
+- draft it
+- write it up
+- GREENLIGHT NEXT STAGE
+
+## Output format
+
+When drafting, produce a markdown note with this structure:
+
+```markdown
+# <Idea Title>
+
+## One-line summary
+
+## Problem / purpose
+
+## Product philosophy
+
+## Target user
+
+## Core concept
+
+## Desired behavior
+
+## Key features
+
+## Layout / information architecture
+
+## UX / product notes
+
+## Technical shape
+
+## Data / integrations / platform needs
+
+## Hosting / data location
+
+## Platform targets
+
+## Recommended technical defaults
+
+## Non-goals
+
+## Open questions
+
+## Next steps
+```
+
+## Master index format
+
+Maintain `Ideas Index.md` as a simple bullet list of idea notes:
+
+```markdown
+# Ideas Index
+
+- [[Idea Title]] — short one-line summary
+- [[Another Idea]] — short one-line summary
+```
+
+If the index file exists, append the new idea in alphabetical or newest-first order, but stay consistent.
+
+## Suggested response behavior
+
+During the interview:
+- Be conversational and concise.
+- Ask a question, then wait for the user's answer.
+- Keep the scope on product/design thinking.
+
+When the user stops:
+- Summarize the idea clearly.
+- Capture uncertainties under **Open questions**.
+- Save the note locally.
+- Add/update the local index.
+- Give the user the local note path.
+
+## Quality bar
+
+A good result should make it easy to revisit the idea later and immediately understand:
+- what it is
+- who it is for
+- how it should behave
+- what matters most
+- what is intentionally out of scope

--- a/skills/idea-workflow/idea-to-design-doc/references/physical-product-design-capture.md
+++ b/skills/idea-workflow/idea-to-design-doc/references/physical-product-design-capture.md
@@ -1,0 +1,64 @@
+# Physical Product / 3D-Printable Product Design Capture
+
+Use this reference when a rough idea is not an app/software product but a physical object, printable accessory, hardware-adjacent concept, or sellable digital design file.
+
+## Interview adaptation
+
+Do not push the standard app/platform/backend questions too early. First capture:
+
+1. **Product purpose and differentiation**
+   - What existing product or workaround is unsatisfying?
+   - What should feel better, cleaner, thinner, safer, cheaper, or more premium?
+   - Is the goal personal use, sellable files, sellable finished product, or validation first?
+
+2. **Target object/device compatibility**
+   - Which model(s) are supported first?
+   - Should model selection be a customer-facing variant?
+   - Are dimensions, tolerances, buttons, ports, cameras, sensors, magnets, or accessories involved?
+
+3. **Variants and options**
+   - Capture product-family variants separately from visual-style variants.
+   - Example: slim case vs card-pocket case vs insert; hidden vs visible retention style.
+   - Ask which variant is V1 and which should remain exploratory.
+
+4. **Physical constraints**
+   - Material assumptions: TPU, PLA, PETG, resin, hybrid, non-printed components.
+   - Fit/retention method: press-fit, snap cap, sliding door, screw cover, flexible lip, insert.
+   - Thickness, bulk, weight, durability, protection, access, and maintenance tradeoffs.
+   - If an object is thick, ask whether the desired design is truly thinner or simply better integrated into the profile.
+
+5. **Manufacturability / printability**
+   - Intended print process and material.
+   - Orientation/supports, tolerances, flexible vs rigid parts, overhangs, post-processing.
+   - Whether the user owns a printer or needs viewable files/renders and third-party printing.
+
+6. **Commercial packaging**
+   - If the user wants to sell: downloadable files, printed units, or both.
+   - Required deliverables: STL/3MF, source CAD/STEP, renders, README, print settings, model matrix, disclaimers, license.
+   - Capture marketplace assumptions: Etsy, Printables, MakerWorld, Thangs, Cults3D, own site, undecided.
+
+7. **Brand/IP/listing risks**
+   - Avoid official-brand implication, logos, and confusing affiliation.
+   - For accessories around branded products, note trademark-sensitive wording for later review.
+   - Keep this practical and non-legalistic unless the user asks for legal review.
+
+## Output additions for physical-product notes
+
+In the design doc, add or emphasize these sections when relevant:
+
+- Product family / variants
+- Supported models / compatibility matrix
+- Physical constraints
+- Materials and print process
+- Retention / access mechanism
+- Fit, tolerance, and validation plan
+- Commercial packaging and deliverables
+- Marketplace / licensing assumptions
+- IP and listing cautions
+
+## Pitfalls
+
+- Do not treat a 3D-printable product like a software app. Backend, auth, hosting, and app platform targets may be irrelevant.
+- Do not collapse exploration too early into one geometry. If the user wants all design options explored before final design, preserve options and identify a likely first prototype separately.
+- Do not assume the user can print at home. Ask whether they need renders/source files and third-party printability.
+- Do not imply compatibility with branded ecosystems without noting that listings and naming may need careful wording.

--- a/skills/idea-workflow/idea-to-implementation-doc/SKILL.md
+++ b/skills/idea-workflow/idea-to-implementation-doc/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: idea-to-implementation-doc
+description: "Use when reviewing one specific idea/design doc, researching similar products, and producing a separate technical implementation plan or roadmap."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [idea-workflow, implementation, roadmap, research, planning]
+    related_skills: [idea-superpowers-suite, idea-to-design-doc, writing-plans]
+---
+# Idea to Implementation Doc Workflow
+
+Use this skill when the user wants to take *one specific idea note* and turn it into a technical implementation document.
+
+This is **not** the top-level ideas index workflow. It works on a *single idea file* and produces a separate implementation plan.
+
+## Goal
+
+Given a specific idea/design doc, create a detailed implementation document that:
+- reviews the idea carefully
+- researches similar products or existing apps
+- identifies gaps or overlap with existing solutions
+- proposes a concrete build approach
+- outlines the system design, major components, and development phases
+- converts the plan into an executable set of tasks and/or prompts for Hermes, Claude Code, Codex, OpenClaw, or another coding agent
+- includes testing, verification, and acceptance criteria so “done” means the program works and is ready to use
+- produces a single markdown file that can be handed to an agent as the build source of truth
+
+For physical-product, hardware-accessory, 3D-printable, or digital STL/3MF ideas, adapt the implementation plan away from app/database/backend defaults and use `references/physical-product-cad-workflow.md` for CAD, material, tolerance, export, prototype, and validation planning.
+
+## Important constraints
+
+- Focus on *implementation strategy*, not just product brainstorming.
+- Research existing apps only to the extent needed to avoid reinventing something obvious.
+- Do not over-engineer the stack. Choose the simplest viable approach.
+- Keep the output practical and actionable.
+- If the user asks for the doc to stay non-technical, stop at product-level architecture and planning.
+- If the user wants code-level detail, include it in a separate section rather than mixing it into the product description.
+
+## Inputs
+
+Primary input:
+- one specific idea note, e.g. `ideas/my-app.md`
+
+Optional input:
+- associated design doc, if it exists separately
+- user constraints about stack, hosting, or platform
+- deployment/data-location preference: local-only, self-hosted, Cloudflare, AWS, another cloud, or undecided
+- platform targets: browser/web-only, Windows desktop, Mac desktop, cross-platform desktop, mobile web, iOS, Android, or explicitly no mobile
+- accepted technical defaults or overrides for database, backend/runtime, frontend, auth, file/object storage, queues/jobs, realtime/sync, search, observability/logging, tests, and deployment/CI
+
+## Workflow
+
+### 1) Read the source note
+
+Review the target idea/design doc and extract:
+- the core problem
+- intended user
+- must-have behavior
+- non-goals
+- any unresolved questions
+
+### 2) Research similar products
+
+Look for apps/products with similar goals or workflows.
+
+Identify:
+- comparable products
+- what they do similarly
+- where the user’s idea differs
+- what this idea should avoid copying or duplicating
+
+Treat this as lightweight product reconnaissance, not exhaustive market analysis.
+
+### 3) Convert to an implementation strategy
+
+Translate the idea into an implementation plan covering:
+- product scope
+- main user flows
+- data model / database needs
+- recommended database/storage default and accepted/changed decision
+- hosting/deployment target and where data should live
+- front end structure
+- backend/service needs
+- platform target decisions: web-only, desktop apps, mobile apps, responsive web, and which are MVP vs later
+- recommended technical defaults for frontend, backend/runtime, auth, storage, queues/jobs, realtime/sync, search, observability/logging, tests, and deployment/CI
+- integration points
+- file/module organization
+- development phases
+- executable task breakdown
+- agent-ready prompts or handoff instructions
+- testing and verification strategy
+- acceptance criteria and “done means” checklist
+- risks and open questions
+
+### 4) Produce implementation spec and final handoff docs
+
+Save the implementation work near the source note using the staged idea-workflow layout when appropriate:
+
+- `README.md` — status/index page for the full idea package.
+- `02-implementation-spec.md` — the detailed implementation strategy.
+- `03-agent-build-handoff.md` — the final single-file handoff for a coding agent or Superpowers.
+- `04-spec-review.md` — readiness review before execution.
+
+For lightweight ideas, a single `<idea-name>.implementation.md` file is acceptable, but full app builds should use the staged layout.
+
+Suggested naming:
+- `ideas/<idea-slug>/README.md`
+- `ideas/<idea-slug>/02-implementation-spec.md`
+- `ideas/<idea-slug>/03-agent-build-handoff.md`
+- `ideas/<idea-slug>/04-spec-review.md`
+
+## Recommended output structure
+
+```markdown
+# <Idea Title> Implementation Plan
+
+## Summary
+
+## Source Idea Review
+
+## Similar Products / Market Check
+
+## Product Scope
+
+## System Overview
+
+## Data Model
+
+## Database / Storage Recommendation
+
+## Hosting / Data Location / Deployment
+
+## Technical Stack Recommendation
+
+## Frontend Plan
+
+## Platform Targets
+
+## Backend / Services Plan
+
+## Key Workflows
+
+## Milestones / Phases
+
+## Build Tasks
+
+## Agent Build Prompt
+
+## Testing and Verification Plan
+
+## Acceptance Criteria / Done Means
+
+## Risks and Tradeoffs
+
+## Open Questions
+
+## Next Build Prompt
+```
+
+## Final agent handoff format
+
+After the implementation spec is drafted, create `03-agent-build-handoff.md` using this required structure:
+
+```markdown
+# <Project Name> Agent Build Handoff
+
+## Mission
+
+## Product Vision
+
+## User Experience Goals
+
+## Non-Negotiable Requirements
+
+## Out of Scope
+
+## Technical Architecture
+
+## Data Model
+
+## Database / Storage Recommendation
+
+State the recommended database/storage approach, why it fits the product, and whether the user accepted it or overrode it. Mention relevant alternatives considered when helpful.
+
+## Hosting / Data Location / Deployment
+
+Specify whether data stays local, is self-hosted, uses Cloudflare, AWS, another cloud, or remains undecided. If undecided, list the assumptions used for the MVP and what would change later.
+
+## Platform Targets
+
+Specify whether the MVP is browser/web-only, Windows desktop, Mac desktop, cross-platform desktop, mobile web, iOS, Android, or a combination. Explicitly separate MVP platforms from future platforms.
+
+## Technical Stack Recommendation
+
+List recommended defaults and user overrides for frontend, backend/runtime, auth, database, file/object storage, queues/jobs, realtime/sync, search, observability/logging, testing, and deployment/CI. The handoff should not require the build agent to guess these choices unless the spec explicitly marks them as flexible.
+
+## Integrations
+
+## Implementation Phases
+
+## Build Tasks
+
+## Testing Requirements
+
+## Verification Commands / Checks
+
+## Acceptance Criteria
+
+## Done Means
+
+## Known Risks
+
+## Open Questions
+
+## Prompt for Build Agent
+Use a prompt that asks the build agent to inspect the project, preserve scope, create or follow an implementation plan, run tests, and verify evidence before claiming done. Do not duplicate Superpowers' detailed planning protocol; hand off to it.
+
+## Superpowers Build Handoff
+Use the `superpowers-gpt` workflow on this document.
+
+Start with:
+1. `superpowers-using-superpowers` to route the work.
+2. `superpowers-writing-plans` to inspect the target repo and turn this handoff into exact implementation tasks, files, commands, tests, and expected results.
+3. `superpowers-executing-plans` or `superpowers-subagent-driven-development` to implement the approved plan without scope drift.
+4. `superpowers-requesting-code-review` to review the implementation.
+5. `superpowers-verification-before-completion` to prove the work satisfies the acceptance criteria before claiming completion.
+
+The goal is to convert this spec into an executable implementation plan, build it with tests, review the result, and verify before claiming completion.
+```
+
+## Spec review gate
+
+Before saying the handoff is ready, create `04-spec-review.md` with this verdict structure:
+
+```markdown
+# <Project Name> Spec Review
+
+Verdict: PASS | PASS WITH CHANGES | FAIL
+
+## Summary
+
+## Readiness Checklist
+- [ ] Product goal is clear
+- [ ] Requirements are testable
+- [ ] Product decisions are resolved or explicitly listed
+- [ ] Technical decisions are resolved or explicitly listed
+- [ ] Database/storage recommendation is present or explicitly unnecessary
+- [ ] Recommended technical defaults are documented, with user overrides if any
+- [ ] Acceptance criteria are concrete
+- [ ] Done Means is specific
+- [ ] A fresh agent could build from the handoff without obvious missing context
+- [ ] Testing requirements are included
+- [ ] Verification commands/checks are included
+- [ ] Non-goals prevent likely scope creep
+
+## Required Changes Before Build
+
+## Optional Improvements
+
+## Superpowers Handoff Recommendation
+```
+
+Only use `PASS` when the build handoff is ready to feed into Superpowers without major clarification.
+
+
+## Lite vs Full mode and progression rules
+
+If this skill is invoked for a lightweight idea, a single `<idea-name>.implementation.md` may be enough. Do not force the full handoff package unless the user asks for build readiness.
+
+For Full mode, follow these rules:
+- Do not move to implementation if unresolved product questions would change architecture or MVP scope.
+- Do not create `03-agent-build-handoff.md` until testing requirements, verification checks, acceptance criteria, and Done Means are concrete.
+- Do not mark `04-spec-review.md` as `PASS` when major product or technical choices are still unstated.
+
+The user can override completeness gates with the exact phrase **GREENLIGHT NEXT STAGE**. When they do, proceed to the next artifact, record unresolved items as assumptions/open questions, and continue.
+
+## Research guidance
+
+When researching similar products, answer:
+- What existing apps already solve this problem?
+- Which parts are commodity features?
+- Which parts are unique or differentiated?
+- Is the idea actually a variation of a well-known product category?
+- What would make users choose this over existing tools?
+
+If the idea appears very close to an existing app, note that clearly and suggest repositioning or narrowing scope.
+
+## Review guidance
+
+When reviewing the idea doc, explicitly check for:
+- ambiguity
+- scope creep
+- missing user flows
+- unclear data ownership
+- missing hosting/data-location choice
+- missing platform target decisions for web, desktop, and mobile
+- missing database/storage recommendation
+- missing technical default recommendations or user overrides
+- vague success criteria
+- hidden assumptions
+- duplicate features that already exist elsewhere
+
+## Implementation planning guidance
+
+For the technical plan:
+- Be concrete about likely components.
+- Prefer a simple architecture first.
+- Explain why a database is or is not needed.
+- Recommend a default technical stack first, then allow the user to accept or change it. Do not make the user pick every technical component from scratch.
+- Cover database/storage, backend/runtime, frontend/UI, auth, file/object storage, queues/jobs, realtime/sync, search, observability/logging, tests, and deployment/CI when relevant.
+- Record accepted defaults as decisions and user changes as explicit overrides.
+- If the app is small, mention a minimal viable architecture rather than a full enterprise stack.
+- If the app needs auth, persistence, search, sync, or real-time features, call that out.
+- For cost-aware runs, cheaper workers may handle bounded research, first-pass implementation specs, task breakdowns, and critique/spec-review passes, but the orchestrator must resolve tradeoffs and approve the final handoff. Follow `idea-superpowers-suite` Cost-Aware Worker Delegation rules when available.
+
+## Stop conditions
+
+If the user says to stop or only wants a high-level review, produce whatever you have and mark remaining uncertainty clearly.
+
+## Behavior when invoked
+
+This skill is intended to be run as a task or by explicit request after the idea doc already exists.
+
+Typical response style:
+- concise summary of what the idea is
+- similar products found
+- implementation strategy
+- file path to the new implementation doc
+
+## Quality bar
+
+A good implementation doc should let a developer or AI coding agent immediately understand:
+- what to build
+- why this approach makes sense
+- what the major system pieces are
+- how to start building without guessing
+- what existing products to compare against
+- which tasks to complete in what order
+- what tests to run
+- how to verify the app actually works
+- what must be true before the agent can honestly say “it’s done”

--- a/skills/idea-workflow/idea-to-implementation-doc/references/physical-product-cad-workflow.md
+++ b/skills/idea-workflow/idea-to-implementation-doc/references/physical-product-cad-workflow.md
@@ -1,0 +1,91 @@
+# Physical Product / 3D-Printable CAD Workflow Reference
+
+Use this reference when an idea is a physical product, 3D-printable object, hardware accessory, or digital STL/3MF product rather than a software app.
+
+## Core shift
+
+Do not force app-centric implementation sections like database, auth, backend, and deployment when they do not apply. Replace them with CAD/manufacturing/product-validation concerns.
+
+## Recommended implementation sections
+
+For physical-product ideas, cover:
+
+- CAD source-of-truth choice
+- Parametric model structure
+- Dimension/reference data needed
+- Model variants/SKUs
+- Materials and manufacturing/printing process
+- Tolerances and clearances
+- Safety, fit, serviceability, and access
+- Export/package formats
+- Prototype phases
+- Physical validation plan
+- Marketplace/listing assets if it is a digital product
+- Legal/trademark/disclaimer notes when compatibility with branded products matters
+
+## CAD tool defaults
+
+For parametric 3D-printable products:
+
+- Use CadQuery or OpenSCAD when a coding agent should generate repeatable variants.
+- Use Fusion 360 or Onshape for human industrial-design refinement and polished commercial geometry.
+- Use FreeCAD as an open-source edit/view fallback.
+- Use Blender for renders/marketing visuals, not as the dimension-critical source of truth.
+
+## Material planning defaults
+
+Start with a material test matrix, not a single unsupported claim. Include:
+
+- Target material for the first real prototype
+- Easier rigid materials for fit gauges only when appropriate
+- Secondary materials for later tests
+- Print/service constraints and customer printability if files will be sold
+
+Example pattern from a phone-case/AirTag product:
+
+- Target final case material: TPU 95A
+- Softer TPU variants: later comfort/flex tests
+- PLA/PETG: rough fit gauges only, not final daily-use case
+- Professional flexible printing: later if selling physical units
+
+## Prototype phase pattern
+
+1. Reference geometry: product envelope, keep-out zones, mating parts, dummy inserts.
+2. Placement/layout comparison: explore all plausible layouts before choosing one.
+3. Rough shell/body: simple printable shape, not final surfacing.
+4. Functional cavity/mechanism: retention, access, serviceability.
+5. Visual variants: hidden/subtle/alternate exterior treatments.
+6. Export review package: STL/STEP/3MF plus screenshots/renders.
+7. Physical test print or prototype.
+8. Tolerance revision based on real fit.
+9. Marketplace/manufacturing package.
+
+## Agent handoff guidance
+
+A coding agent can usually build:
+
+- Parametric CAD project skeleton
+- YAML/JSON dimension configs
+- Variant/export scripts
+- Basic STL/STEP exports
+- README/print settings/test plan docs
+
+A human or physical test loop is still needed for:
+
+- Ergonomic feel
+- Premium surfacing judgment
+- Exact tolerances
+- Real-world fit and durability
+- Commercial-quality validation photos
+
+## Acceptance tests before claiming sellable
+
+For a downloadable physical product, require real-world validation before commercial claims:
+
+- At least one real prototype/test print in the target material
+- Fit and function checks against the actual object/device
+- Material-specific printability notes
+- Clear model compatibility list
+- Export files open in common slicers/viewers
+- Marketplace readme/disclaimers are present
+- Branded compatibility language avoids implying official affiliation

--- a/skills/idea-workflow/idea-to-implementation-doc/templates/agent-build-handoff-template.md
+++ b/skills/idea-workflow/idea-to-implementation-doc/templates/agent-build-handoff-template.md
@@ -1,0 +1,149 @@
+# <Project Name> Agent Build Handoff
+
+## Mission
+State exactly what the build agent should create in one or two paragraphs.
+
+## Product Vision
+Explain why this product exists, who it serves, and what experience it should deliver.
+
+## User Experience Goals
+- Goal 1
+- Goal 2
+- Goal 3
+
+## Non-Negotiable Requirements
+These are mandatory. The build is not complete unless all are satisfied.
+
+- Requirement 1
+- Requirement 2
+- Requirement 3
+
+## Out of Scope
+Prevent scope creep by naming what should not be built in this pass.
+
+- Out-of-scope item 1
+- Out-of-scope item 2
+
+## Technical Architecture
+Describe the intended architecture, major components, and how they interact.
+
+## App Topology / Surfaces
+State whether this is one app or multiple pieces, such as desktop app, web app, API, background worker, upload agent, mobile app, or CLI. Define what each piece owns and how they communicate.
+
+## Data Model
+List entities, fields, relationships, storage needs, and persistence assumptions.
+
+## Database / Storage Recommendation
+State the recommended database/storage choice, why it fits this build, whether the user accepted it or changed it, and any important alternatives considered. If no database is needed, say so explicitly.
+
+## Hosting / Data Location / Deployment
+State where data and services should live for this build: local-only, self-hosted, Cloudflare, AWS, another cloud/provider, or explicitly undecided. Include deployment assumptions, operational constraints, and what must not leave the local machine if applicable.
+
+## Platform Targets
+State the required app platforms for this build: browser/web-only, Windows desktop, Mac desktop, cross-platform desktop, mobile web, iOS, Android, or some combination. Separate MVP targets from future targets and explicitly say if desktop or mobile apps are out of scope.
+
+## Technical Stack Recommendation
+List recommended defaults and user overrides for frontend/UI, backend/runtime, auth, database, file/object storage, queues/jobs, realtime/sync, search, observability/logging, testing, and deployment/CI. The build agent should not have to guess these choices unless this section explicitly marks them flexible.
+
+## Auth / Secrets / Sharing Model
+State how admin login, public/private access, shareable links, API keys, environment variables, and client/server secret boundaries should work. Never include real secrets. Say which credentials must remain server-side/local-only and what must not be exposed to public clients.
+
+## Integrations
+List external tools, APIs, CLIs, SDKs, local services, agents, or platforms involved.
+
+## Implementation Phases
+
+### Phase 1: <Name>
+Goal:
+Tasks:
+Verification:
+
+### Phase 2: <Name>
+Goal:
+Tasks:
+Verification:
+
+## Build Tasks
+Each task should be executable by an AI coding agent.
+
+### Task 1: <Small objective>
+Objective:
+Files/areas likely involved:
+Steps:
+Verification:
+Expected result:
+
+### Task 2: <Small objective>
+Objective:
+Files/areas likely involved:
+Steps:
+Verification:
+Expected result:
+
+## Testing Requirements
+Describe required tests by level.
+
+- Unit tests:
+- Integration tests:
+- End-to-end tests:
+- Manual checks:
+- Regression checks:
+
+## Verification Commands / Checks
+Use exact commands when known. If unknown, specify discovery steps.
+
+```bash
+# example
+npm test
+npm run build
+```
+
+## Acceptance Criteria
+The implementation is acceptable when:
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Done Means
+The agent may only say “done” when:
+
+- [ ] The implementation satisfies all non-negotiable requirements.
+- [ ] Required tests pass with fresh output.
+- [ ] Build/lint/typecheck checks pass where applicable.
+- [ ] Manual verification steps have been completed or explicitly marked unavailable.
+- [ ] Known limitations are documented.
+- [ ] Any generated artifacts or files are present at the expected paths.
+
+## Known Risks
+- Risk 1 — mitigation
+- Risk 2 — mitigation
+
+## Open Questions
+List unresolved questions. If any question blocks implementation, the spec review should not be PASS.
+
+- Question 1
+- Question 2
+
+## Prompt for Build Agent
+Use this prompt to start implementation. It intentionally aligns with Superpowers rather than replacing it:
+
+```text
+You are implementing <Project Name> from this build handoff.
+
+First, read the entire document and inspect the target repository. Do not start coding immediately. Create or follow an implementation plan that names files, tests, commands, expected results, and risks. Preserve the scope and non-goals in this handoff. Build incrementally, verify each task, request review, and do not claim completion until the Verification Commands / Checks, Acceptance Criteria, and Done Means checklist pass with fresh evidence.
+
+If Superpowers skills are available, use the Superpowers Build Handoff sequence below instead of inventing your own process.
+```
+
+## Superpowers Build Handoff
+Use the `superpowers-gpt` workflow on this document.
+
+Start with:
+1. `superpowers-using-superpowers` to route the work.
+2. `superpowers-writing-plans` to inspect the target repo and turn this handoff into exact implementation tasks, files, commands, tests, and expected results.
+3. `superpowers-executing-plans` or `superpowers-subagent-driven-development` to implement the approved plan without scope drift.
+4. `superpowers-requesting-code-review` to review the implementation.
+5. `superpowers-verification-before-completion` to prove the work satisfies the acceptance criteria before claiming completion.
+
+The goal is to convert this spec into an executable implementation plan, build it with tests, review the result, and verify before claiming completion.

--- a/skills/idea-workflow/idea-to-ui-design-brief/SKILL.md
+++ b/skills/idea-workflow/idea-to-ui-design-brief/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: idea-to-ui-design-brief
+description: "Use when turning a product/design doc into a focused UI design brief, optional AI image-generation concept prompts, and implementation-ready UI direction without replacing the main idea workflow."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [idea-workflow, ui-design, ux, image-generation, product-design, superpowers]
+    related_skills: [idea-superpowers-suite, idea-to-design-doc, idea-to-implementation-doc, claude-design]
+---
+# Idea to UI Design Brief
+
+## Overview
+
+Use this skill as an optional Full-mode stage inside the idea workflow. It converts a product/design direction into a practical UI design brief that can guide image-generation concepts, HTML prototypes, or later Superpowers implementation work.
+
+This skill should not run in Lite mode unless the user explicitly asks for UI design. Lite mode should keep the previous simple idea-capture behavior.
+
+The UI brief is a bridge between product thinking and implementation. It should define what the interface should look, feel, and behave like without forcing premature code architecture.
+
+## When to Use
+
+Use when the user asks to:
+
+- explore possible UI designs for an idea;
+- add a dedicated UI/design stage to the idea workflow;
+- generate image prompts for app screenshots, dashboards, landing pages, or product surfaces;
+- create a UI brief before giving the idea to a coding agent;
+- critique or redesign an already-built app after screenshots exist;
+- turn a design doc into screen-by-screen UI requirements.
+
+Do not use when:
+
+- the user only wants a quick Lite idea note;
+- the idea is not yet clear enough to identify target users and core behavior;
+- the user wants production frontend code immediately — use implementation skills after the UI direction is chosen;
+- the user wants a formal token spec only — use `design-md` if available.
+
+## Artifact Placement
+
+For Full mode idea packages, add this artifact after the design doc and before implementation planning:
+
+```text
+ideas/<idea-slug>/
+  README.md
+  00-idea-capture.md
+  01-design-doc.md
+  02-ui-design-brief.md
+  03-implementation-spec.md
+  04-agent-build-handoff.md
+  05-spec-review.md
+```
+
+Fallback rule: if the user skips this stage, preserve the old workflow numbering and behavior, or mark UI decisions as assumptions in the implementation spec. Do not block the workflow merely because no UI brief exists.
+
+## Required Inputs
+
+Before writing the UI brief, collect or infer:
+
+- product purpose and target user;
+- core user flow;
+- main screens or surfaces;
+- platform target: web, desktop, mobile web, native mobile, or multi-surface;
+- desired feel: calm, command-center, playful, professional, dense, minimal, etc.;
+- visual constraints: brand, existing repo/design system, accessibility needs, dark/light mode;
+- important states: empty, loading, error, success, first-run, repeat-use.
+
+If these are missing and the user has not forced progression, ask one concise question at a time.
+
+## UI Brief Structure
+
+Create `02-ui-design-brief.md` with:
+
+```markdown
+# <Idea Title> — UI Design Brief
+
+## Purpose
+
+## Product Feel
+
+## Design Principles
+
+## Primary Surfaces / Screens
+
+## Screen-by-Screen Notes
+
+## Layout / Information Architecture
+
+## Component Inventory
+
+## Key User Flows
+
+## States to Design
+
+## Visual Direction
+
+## Accessibility and Responsiveness
+
+## Content / Copy Notes
+
+## Optional Image-Generation Concepts
+
+## Selected Direction
+
+## Open Questions
+
+## Handoff Notes for Implementation
+```
+
+## Optional Image-Generation Pass
+
+Image generation is optional and should be treated as concept exploration, not the implementation source of truth.
+
+Use image generation when:
+
+- the user wants possible visual directions;
+- taste is ambiguous;
+- an app/dashboard/landing page needs visual exploration before code;
+- the workflow benefits from comparing 2-3 directions.
+
+Default to three concept prompts:
+
+1. **Conservative** — familiar, low-risk, easy to implement.
+2. **Strong-fit** — best interpretation of the product brief.
+3. **Divergent** — more distinctive, useful for discovering taste boundaries.
+
+Each prompt should specify:
+
+- product category and target user;
+- screen type and platform;
+- information hierarchy;
+- density and interaction posture;
+- visual style and theme;
+- what should not appear;
+- that the result is a UI concept screenshot, not marketing art.
+
+## Image Prompt Template
+
+```text
+Create a high-fidelity UI concept screenshot for <product>. Platform: <desktop web/mobile/etc>. Screen: <main dashboard/onboarding/settings/etc>. Target user: <user>. Product feel: <feel>. Layout: <key layout>. Must show: <components/data/actions>. Avoid: generic SaaS filler, fake irrelevant metrics, stock photos, excessive gradients, unreadable tiny text. Style: <visual direction>. The image should be a realistic product UI mockup suitable for turning into a design brief.
+```
+
+## After Images Are Generated
+
+If image artifacts are generated:
+
+1. Save or reference each image path/URL in the UI brief.
+2. Use vision analysis or manual review to extract what works and what does not.
+3. Update `Selected Direction` with the chosen layout, components, and visual rules.
+4. Do not ask the build agent to copy the image blindly. Convert the image into text requirements, components, tokens, and acceptance criteria.
+
+## Post-Build Redesign Loop
+
+After Superpowers or another coding agent builds the app, this skill can run again as a UI polish loop:
+
+1. Capture screenshots of the built app.
+2. Compare screenshots to the UI brief and product design doc.
+3. Identify UI gaps: hierarchy, spacing, navigation, copy, state handling, responsiveness.
+4. Optionally generate alternate UI concepts.
+5. Produce a focused redesign brief and implementation task list.
+6. Hand the task list to Superpowers with the constraint: improve UI only, avoid backend behavior changes unless explicitly approved.
+
+## Integration Rules
+
+- This stage is Full-mode only by default.
+- It must not make the workflow mandatory or brittle.
+- If skipped, continue with the old design-doc → implementation-spec → handoff sequence.
+- If the user wants speed, fold only a short `UI / UX Notes` section into the design doc instead.
+- If image generation is unavailable, write image prompts and continue with a text-only UI brief.
+- If an existing repo exists, inspect current UI/components before inventing a new design direction.
+- If retrofitting an existing idea package that already has a Superpowers handoff, use the handoff as the compressed source, add the UI brief as an addendum, and preserve existing filenames unless the user asks for a clean regeneration. See `references/retrofitting-ui-briefs.md`.
+- For cost-aware runs, cheaper workers may produce UI direction variants, state inventories, image prompts, or critique passes, but the orchestrator must choose/synthesize the final brief. Follow `idea-superpowers-suite` Cost-Aware Worker Delegation rules when available.
+
+## Common Pitfalls
+
+1. **Letting images become the spec.** Images are inspiration. The written UI brief and implementation handoff are the source of truth.
+2. **Overcomplicating Lite mode.** Do not add this stage to quick idea capture unless requested.
+3. **Generic dashboard slop.** Avoid fake metrics, irrelevant charts, and decorative cards unless the product actually needs them.
+4. **Skipping states.** Empty, loading, error, success, first-run, and mobile states matter for build quality.
+5. **Breaking artifact numbering.** If adding this stage to a package, update README artifact maps and subsequent stage numbers consistently.
+6. **Copying proprietary references.** Transform style principles; do not clone distinctive third-party UI.
+
+## Verification Checklist
+
+- [ ] The workflow is Full mode or the user explicitly requested UI design.
+- [ ] The product/design direction is clear enough for screen-level UI decisions.
+- [ ] `02-ui-design-brief.md` exists if this stage was run.
+- [ ] Optional image prompts are stored in the brief even if image generation is skipped.
+- [ ] Generated images, if any, are treated as references and translated into text requirements.
+- [ ] Implementation handoff references the selected UI direction or explicitly states that UI is an assumption.
+- [ ] If the stage is skipped, the old workflow still proceeds without blockage.

--- a/skills/idea-workflow/idea-to-ui-design-brief/references/retrofitting-ui-briefs.md
+++ b/skills/idea-workflow/idea-to-ui-design-brief/references/retrofitting-ui-briefs.md
@@ -1,0 +1,42 @@
+# Retrofitting UI Briefs Into Existing Idea Packages
+
+Use this reference when an existing Full-mode idea package was already produced before the optional UI design brief stage existed.
+
+## Key Learning
+
+Do not rerun the whole idea workflow or renumber every artifact just to add UI design. The fastest low-risk path is to run the new UI stage against the existing handoff/design docs and treat the result as an additive UI/design addendum.
+
+## Recommended Procedure
+
+1. Load `idea-superpowers-suite` and `idea-to-ui-design-brief`.
+2. Locate the existing package, especially:
+   - `README.md`
+   - `01-design-doc.md`
+   - implementation spec
+   - agent/Superpowers handoff
+3. Read the existing handoff first if the user's goal is to prepare for Superpowers. It is usually the most token-efficient source because it already compresses product, scope, tasks, and acceptance criteria.
+4. Generate a new UI brief from the existing documents.
+5. Prefer adding `02-ui-design-brief.md` as an addendum if `02-implementation-spec.md` already exists.
+6. Do not rename `02-implementation-spec.md` to `03-implementation-spec.md` unless the user explicitly wants a clean regenerated package. Renaming can break existing references and handoff links.
+7. Patch `README.md` artifact map to mention the UI brief and state that old numbering was preserved.
+8. Patch the handoff file with a short `UI / Design Addendum` section that points to the UI brief.
+9. Keep the original handoff as the build source of truth; the UI brief is design guidance, not scope expansion.
+
+## Example Additive Layout
+
+```text
+ideas/<idea-slug>/
+  README.md
+  00-idea-capture.md
+  01-design-doc.md
+  02-ui-design-brief.md        # new additive UI brief
+  02-implementation-spec.md    # old filename preserved
+  03-agent-build-handoff.md    # still main Superpowers source
+  04-spec-review.md
+```
+
+This intentionally duplicates the `02-` prefix. It is acceptable for a retrofit if the README explains why.
+
+## Image Generation Rule
+
+Add image-generation prompts as optional concept exploration. The written UI brief remains the source of truth. If images are generated later, review them and translate the useful parts into components, tokens, and acceptance criteria before asking Superpowers to implement.

--- a/skills/software-development/goal-prompt-pack/SKILL.md
+++ b/skills/software-development/goal-prompt-pack/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: goal-prompt-pack
+description: "Use when creating the strongest possible long-running goal prompt for Codex Goal Mode, Hermes workers, or another autonomous coding agent; can independently create product specs, UI specs, UI mockup prompts/images, acceptance criteria, and the final build goal without requiring the idea or Superpowers workflows."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [goal-prompt, codex, hermes, autonomous-agents, ui-mockups, prompt-engineering, app-builds]
+    related_skills: [youtube-content, idea-superpowers-suite, idea-to-ui-design-brief, idea-to-implementation-doc]
+---
+# Goal Prompt Pack
+
+## Overview
+
+This skill creates a **Goal Prompt Pack**: a complete, self-contained package for launching a long-running autonomous app build in Codex Goal Mode, Hermes, Claude Code, OpenCode, or a similar coding agent.
+
+It is standalone. It does **not** require the idea workflow, Superpowers, or an existing design doc. If those artifacts exist, use them as inputs. If they do not exist, create the needed product spec, UI spec, mockup prompts, selected mockup notes, and final goal prompt directly inside this workflow.
+
+The goal is to make the final prompt as strong as possible by giving the build agent a bounded, visible, testable finish line.
+
+Core method:
+
+1. Define the app/product target.
+2. Write a compact but complete product spec.
+3. Write a screen-level UI spec.
+4. Generate or prepare high-fidelity UI mockups from that UI spec.
+5. Review the mockups and translate them back into written visual requirements.
+6. Create the final autonomous goal prompt with hard requirements, non-goals, acceptance criteria, blocker rules, stop rules, verification requirements, and final report format.
+
+## When to Use
+
+Use this skill when the user asks for:
+
+- a goal prompt;
+- a Codex Goal Mode prompt;
+- an autonomous build prompt;
+- a prompt pack to create an app;
+- the spec → UI mockups → goal prompt workflow;
+- a polished multi-screen app prompt where UI quality matters;
+- a prompt that includes UI mockups and a full build prompt;
+- a reusable standalone process for creating the best possible app-building prompt;
+- a Hermes worker goal prompt with visual references and acceptance criteria.
+
+Also use it when the user gives only a rough app idea but wants to end with a build-ready goal prompt.
+
+## When Not to Use
+
+Do not use this skill when:
+
+- the user only wants a quick product note;
+- the task is a bug with unknown root cause;
+- there is no clear finish line and the user wants open-ended exploration;
+- the user wants you to immediately build the app rather than prepare the goal prompt;
+- the app has no UI and a normal implementation plan is enough, unless the user explicitly asks for a goal prompt;
+- the target is unsafe, credential-harvesting, deceptive, or otherwise inappropriate.
+
+## Output Modes
+
+Choose one mode up front.
+
+### Standalone Mode
+
+Use when no idea/design artifacts exist or the user wants the video-style workflow from scratch.
+
+Produce a self-contained Goal Prompt Pack with:
+
+- product spec;
+- UI spec;
+- mockup generation prompts;
+- optional generated mockup image paths/URLs;
+- selected mockup analysis;
+- final autonomous goal prompt.
+
+### Plug-in Mode
+
+Use when an existing idea/design/implementation package exists.
+
+Read the available artifacts, fill gaps, then create a Goal Prompt Pack as an additional artifact. Do not require or invoke the idea workflow unless the user explicitly wants that broader process.
+
+### Text-only Mode
+
+Use when image generation is unavailable or the user does not want to generate images yet.
+
+Still produce:
+
+- high-fidelity mockup prompts;
+- a visual target description;
+- placeholders such as `[ATTACH SELECTED MOCKUPS HERE]` in the final goal prompt;
+- explicit instructions that the final prompt becomes stronger after mockups are generated and attached.
+
+### Image-backed Mode
+
+Use when image generation is available through Codex, Hermes, GPT-5.5, or another tool.
+
+Generate or instruct generation of mockups, then analyze the mockups and incorporate them into the final goal prompt as visual targets.
+
+## Required Inputs
+
+Minimum input:
+
+- app/product idea;
+- target platform, or permission to recommend one;
+- whether visual fidelity matters.
+
+Strong preferred inputs:
+
+- target users;
+- core workflow;
+- must-have screens;
+- desired visual feel;
+- stack preference;
+- data/storage requirements;
+- integrations;
+- auth/privacy constraints;
+- examples of apps/styles to emulate or avoid;
+- target executor: Codex Goal Mode, Hermes, Claude Code, OpenCode, generic coding agent.
+
+If critical inputs are missing, ask concise questions. If the user wants speed, make sensible assumptions and label them.
+
+## Hard Gates
+
+- Do not write the final goal prompt until the app purpose, primary user flow, and MVP scope are clear enough to state in one paragraph.
+- Do not let generated mockups become the only source of truth. Convert them into written UI requirements.
+- Do not claim the Goal Prompt Pack is build-ready unless it contains testable acceptance criteria.
+- Do not omit blocker and stop rules for long-running agents.
+- Do not ask an agent to “match exactly” without defining acceptable fidelity and when to stop.
+- Do not execute the build unless the user explicitly asks to start execution after the pack is created.
+
+## Protocol
+
+### 1. Select target executor
+
+Identify the intended build agent:
+
+- Codex Goal Mode — preferred when the user wants OpenAI Codex goal behavior and strong built-in image generation.
+- Hermes — useful when the goal prompt will be run by a Hermes worker or GPT-5.5-backed process.
+- Generic coding agent — use neutral language and include all context inline.
+
+If unknown, write the final prompt in Codex Goal Mode style and add a Hermes/generic variant note.
+
+### 2. Capture or synthesize the product spec
+
+Write a concise product spec with:
+
+- app name / working title;
+- one-line summary;
+- target user;
+- core problem;
+- MVP user flow;
+- functional requirements;
+- data/persistence needs;
+- platform target;
+- technical constraints or recommended defaults;
+- non-goals;
+- open questions / assumptions.
+
+### 3. Create the UI spec
+
+For UI-bearing apps, write a screen-level UI spec:
+
+- product feel;
+- design principles;
+- navigation model;
+- screen list;
+- screen-by-screen layout;
+- component inventory;
+- visual style: color, typography, spacing, density, motion if relevant;
+- states: empty, loading, error, success, first-run, permissions;
+- accessibility and responsiveness;
+- copy/content notes;
+- visual non-goals.
+
+For non-UI tools, replace this with a CLI/API/output-experience spec.
+
+### 4. Create mockup generation prompts
+
+Create prompts for the minimum set of screens needed to define the visual target.
+
+Default app mockup set:
+
+1. Primary/home screen.
+2. Main workflow/action screen.
+3. Library/detail/settings screen, whichever is core.
+4. Secondary output/result screen.
+
+For each prompt, specify:
+
+- platform and device/frame;
+- screen purpose;
+- target user;
+- exact content/components to show;
+- layout and hierarchy;
+- visual direction;
+- density/spacing;
+- things to avoid;
+- that it should be a realistic product UI screenshot, not marketing art.
+
+Default prompt shape:
+
+```text
+Create a high-fidelity <platform> app UI mockup for <app name>.
+Screen: <screen name>.
+Target user: <target user>.
+Purpose: <what this screen helps the user do>.
+Layout: <specific layout/hierarchy>.
+Must show: <components, labels, sample data, actions>.
+Visual style: <colors, typography, density, mood>.
+Avoid: generic SaaS filler, irrelevant metrics, stock photos, unreadable text, decorative-only cards, redesigned navigation, extra screens.
+The result should look like a real app screenshot that a coding agent can implement.
+```
+
+### 5. Generate mockups when available
+
+If image generation is available and the user wants actual mockups:
+
+- Generate the selected screens.
+- Save or reference image paths/URLs.
+- If using Codex because of stronger image generation, instruct the user or agent to run the mockup prompts in Codex before using the final goal prompt.
+- If using Hermes image generation, use available image tools and record the returned paths/URLs.
+
+If image generation is unavailable, continue in Text-only Mode and mark image attachment as a recommended next step.
+
+### 6. Review mockups and translate them to written requirements
+
+For each generated or selected mockup, extract:
+
+- screen name;
+- layout structure;
+- visible components;
+- hierarchy;
+- spacing/density;
+- color/style rules;
+- content examples;
+- deviations from the UI spec;
+- implementation notes.
+
+If the mockups are generic, inconsistent, ugly, or contradict the spec, revise the UI spec and regenerate or update the mockup prompts before producing the final goal prompt.
+
+### 7. Define acceptance criteria
+
+Create acceptance criteria covering:
+
+- functional behavior;
+- screen coverage;
+- visual fidelity;
+- data persistence;
+- platform/build requirements;
+- testing/lint/typecheck/build commands;
+- screenshot evidence;
+- known non-goals.
+
+Each criterion must be checkable by a future agent or human.
+
+### 8. Write blocker and stop rules
+
+Long-running goals need explicit failure behavior.
+
+Include rules for:
+
+- missing credentials;
+- failed dependency install;
+- simulator/browser/device failure;
+- blocked external services;
+- ambiguous requirements;
+- impossible visual fidelity;
+- repeated failing verification;
+- maximum passes/turns before stopping.
+
+### 9. Create the final goal prompt
+
+Write the final prompt as a copy-paste-ready block for the selected executor.
+
+For Codex, start with `/goal` when appropriate.
+
+The final goal prompt must include:
+
+- mission;
+- source artifacts or pasted source content;
+- attached mockup references;
+- priority order;
+- functional requirements;
+- UI fidelity requirements;
+- technical requirements;
+- non-goals;
+- verification requirements;
+- blocker rule;
+- stop/loop rule;
+- final report format.
+
+### 10. Produce readiness verdict
+
+End with:
+
+- `READY` — complete enough to run;
+- `READY AFTER MOCKUPS` — text pack is ready, but actual image mockups should be generated/attached first;
+- `NEEDS CLARIFICATION` — missing decisions would materially change the app;
+- `NOT SUITABLE FOR GOAL MODE` — finish line is not bounded/testable or the task is exploratory/unknown.
+
+## Artifact Contract
+
+A complete Goal Prompt Pack should contain:
+
+```markdown
+# <App Name> Goal Prompt Pack
+
+Verdict: READY | READY AFTER MOCKUPS | NEEDS CLARIFICATION | NOT SUITABLE FOR GOAL MODE
+Target executor: Codex Goal Mode | Hermes | Generic coding agent
+Mode: Standalone | Plug-in | Text-only | Image-backed
+
+## 1. Product Spec
+
+## 2. UI Spec
+
+## 3. Mockup Generation Prompts
+
+### Mockup 1 — <Screen>
+
+### Mockup 2 — <Screen>
+
+### Mockup 3 — <Screen>
+
+### Mockup 4 — <Screen>
+
+## 4. Mockup References
+
+## 5. Mockup-to-Requirement Translation
+
+## 6. Acceptance Criteria
+
+## 7. Blocker and Stop Rules
+
+## 8. Final Goal Prompt
+
+```text
+/goal
+...
+```
+
+## 9. Hermes / Generic Variant Notes
+
+## 10. Open Questions and Assumptions
+```
+
+## Final Goal Prompt Template
+
+```text
+/goal
+
+Build <app name> as a <platform/stack> app.
+
+You must treat the written spec and attached mockups as the build target.
+
+Source of truth:
+1. Product spec: <path, paste, or section below>
+2. UI spec: <path, paste, or section below>
+3. Mockups: <attach/list image paths or say ATTACH SELECTED MOCKUPS HERE>
+
+Priority order:
+1. Non-negotiable product requirements
+2. Functional correctness
+3. Screen-by-screen UI fidelity to the mockups
+4. Tests/build verification
+5. Polish
+
+If the mockups and written spec conflict, follow the written spec for behavior and the mockups for visual layout/style. Report the conflict in the final answer.
+
+Do not reinterpret, simplify, merge screens, redesign, create a generic version, or add unrelated features.
+
+Functional requirements:
+- <requirement>
+
+UI fidelity requirements:
+- Implement every required screen from the UI spec.
+- Match the attached mockups for layout, hierarchy, component inventory, color direction, spacing, density, and content structure.
+- Preserve screen-specific navigation and actions.
+- Implement required empty/loading/error/success states.
+- If exact pixel parity is impossible, get as close as practical and explain the deviation.
+
+Technical requirements:
+- <stack/platform>
+- <data/storage>
+- <auth/integrations>
+- <project constraints>
+
+Non-goals:
+- Do not <non-goal>.
+
+Acceptance criteria:
+- <criterion>
+
+Verification requirements:
+- Run <command> and inspect the result.
+- Run <command> and inspect the result.
+- Capture screenshots for <screens>.
+- Compare implemented screenshots against the mockups.
+- Do another focused pass for meaningful visual or functional gaps before finalizing.
+
+Blocker rule:
+If blocked by external tooling, missing credentials, unavailable simulator/browser/device, dependency failure, unsupported API, repeated failing verification, or ambiguous requirements, stop and report:
+1. exact blocker;
+2. command/error/output;
+3. what you tried;
+4. what human action is needed;
+5. whether the goal can resume afterward.
+
+Loop/stop rule:
+Continue iterating until the acceptance checklist passes or a real blocker is reached. Stop after <N> substantial passes/turns if still blocked or if remaining differences are minor pixel-level deltas that do not affect product quality. Do not continue indefinitely.
+
+Final answer format:
+1. Summary of what was built
+2. Files changed/created
+3. Commands run and results
+4. Screenshot evidence paths
+5. Screen-by-screen fidelity review
+6. Acceptance checklist with PASS/PARTIAL/FAIL
+7. Known deviations
+8. Remaining limitations
+9. Recommended next step
+```
+
+## Target Executor Notes
+
+### Codex Goal Mode
+
+Use Codex when the user wants the closest match to the video workflow or wants Codex's image generation and Goal Mode loop.
+
+Recommendations:
+
+- Generate the UI spec first as a normal prompt, not as a goal.
+- Generate mockups from the UI spec next, also not as a goal.
+- Review/select the mockups.
+- Attach or reattach the selected mockups when launching the final `/goal`.
+- Include max-pass/blocked-stop instructions.
+
+### Hermes
+
+Use Hermes when the prompt pack will feed a Hermes worker, GPT-5.5-backed workflow, or local orchestration.
+
+Recommendations:
+
+- If using Hermes image generation, include generated image paths in the pack.
+- If not using image generation, produce mockup prompts and tell the user to generate/attach images before execution.
+- Include verification commands and evidence requirements because Hermes final synthesis should not trust worker self-reports blindly.
+
+### Generic Coding Agent
+
+If the target agent does not support persistent goal mode, keep the prompt usable by instructing it to:
+
+- create a plan;
+- implement in passes;
+- run verification after each pass;
+- stop and report blockers;
+- produce final evidence.
+
+## Common Pitfalls
+
+1. **Vague finish line.** “Build a polished app” is not a goal. Define screens, behaviors, states, checks, and done criteria.
+2. **Mockups without written requirements.** Images help, but agents need text criteria to verify against.
+3. **No stop rule.** Visual fidelity loops can run too long chasing tiny differences.
+4. **Generic UI slop.** Mockup prompts must include real content, specific screens, and product-specific hierarchy.
+5. **Conflicting sources.** Decide whether written spec or mockups win for each kind of conflict.
+6. **No evidence requirement.** Require commands, screenshots, and PASS/PARTIAL/FAIL acceptance reporting.
+7. **Premature execution.** This skill creates the prompt pack; do not build until explicitly asked.
+
+## Verification Checklist
+
+- [ ] Target executor is identified.
+- [ ] Product spec is clear enough to summarize the app and MVP.
+- [ ] UI spec covers required screens and states.
+- [ ] Mockup prompts are specific and image-generation-ready.
+- [ ] Generated mockups, if present, are referenced and translated into written requirements.
+- [ ] Final goal prompt includes requirements, non-goals, acceptance criteria, verification, blocker rules, stop rules, and final report format.
+- [ ] Readiness verdict is honest.
+- [ ] The pack can stand alone without requiring the idea or Superpowers workflows.

--- a/skills/software-development/goal-prompt-pack/templates/codex-goal-prompt-template.md
+++ b/skills/software-development/goal-prompt-pack/templates/codex-goal-prompt-template.md
@@ -1,0 +1,72 @@
+/goal
+
+Build <app name> as a <platform/stack> app.
+
+You must treat the written spec and attached mockups as the build target.
+
+Source of truth:
+1. Product spec: <path, paste, or section below>
+2. UI spec: <path, paste, or section below>
+3. Mockups: <attach/list image paths or say ATTACH SELECTED MOCKUPS HERE>
+
+Priority order:
+1. Non-negotiable product requirements
+2. Functional correctness
+3. Screen-by-screen UI fidelity to the mockups
+4. Tests/build verification
+5. Polish
+
+If the mockups and written spec conflict, follow the written spec for behavior and the mockups for visual layout/style. Report the conflict in the final answer.
+
+Do not reinterpret, simplify, merge screens, redesign, create a generic version, or add unrelated features.
+
+Functional requirements:
+- <requirement>
+
+UI fidelity requirements:
+- Implement every required screen from the UI spec.
+- Match the attached mockups for layout, hierarchy, component inventory, color direction, spacing, density, and content structure.
+- Preserve screen-specific navigation and actions.
+- Implement required empty/loading/error/success states.
+- If exact pixel parity is impossible, get as close as practical and explain the deviation.
+
+Technical requirements:
+- <stack/platform>
+- <data/storage>
+- <auth/integrations>
+- <project constraints>
+
+Non-goals:
+- Do not <non-goal>.
+
+Acceptance criteria:
+- <criterion>
+
+Verification requirements:
+- Run <command> and inspect the result.
+- Run <command> and inspect the result.
+- Capture screenshots for <screens>.
+- Compare implemented screenshots against the mockups.
+- Do another focused pass for meaningful visual or functional gaps before finalizing.
+
+Blocker rule:
+If blocked by external tooling, missing credentials, unavailable simulator/browser/device, dependency failure, unsupported API, repeated failing verification, or ambiguous requirements, stop and report:
+1. exact blocker;
+2. command/error/output;
+3. what you tried;
+4. what human action is needed;
+5. whether the goal can resume afterward.
+
+Loop/stop rule:
+Continue iterating until the acceptance checklist passes or a real blocker is reached. Stop after <N> substantial passes/turns if still blocked or if remaining differences are minor pixel-level deltas that do not affect product quality. Do not continue indefinitely.
+
+Final answer format:
+1. Summary of what was built
+2. Files changed/created
+3. Commands run and results
+4. Screenshot evidence paths
+5. Screen-by-screen fidelity review
+6. Acceptance checklist with PASS/PARTIAL/FAIL
+7. Known deviations
+8. Remaining limitations
+9. Recommended next step

--- a/skills/software-development/goal-prompt-pack/templates/goal-prompt-pack-template.md
+++ b/skills/software-development/goal-prompt-pack/templates/goal-prompt-pack-template.md
@@ -1,0 +1,108 @@
+# <App Name> Goal Prompt Pack
+
+Verdict: READY | READY AFTER MOCKUPS | NEEDS CLARIFICATION | NOT SUITABLE FOR GOAL MODE
+Target executor: Codex Goal Mode | Hermes | Generic coding agent
+Mode: Standalone | Plug-in | Text-only | Image-backed
+
+## 1. Product Spec
+
+### Working title
+
+### One-line summary
+
+### Target user
+
+### Problem / purpose
+
+### MVP user flow
+
+### Functional requirements
+
+### Data / persistence
+
+### Platform / stack recommendation
+
+### Non-goals
+
+### Assumptions / open questions
+
+## 2. UI Spec
+
+### Product feel
+
+### Design principles
+
+### Navigation model
+
+### Required screens
+
+### Screen-by-screen UI requirements
+
+### Component inventory
+
+### States to design
+
+### Accessibility / responsiveness
+
+### Visual non-goals
+
+## 3. Mockup Generation Prompts
+
+### Mockup 1 — <Screen>
+
+```text
+Create a high-fidelity <platform> app UI mockup for <app name>.
+Screen: <screen name>.
+Target user: <target user>.
+Purpose: <what this screen helps the user do>.
+Layout: <specific layout/hierarchy>.
+Must show: <components, labels, sample data, actions>.
+Visual style: <colors, typography, density, mood>.
+Avoid: generic SaaS filler, irrelevant metrics, stock photos, unreadable text, decorative-only cards, redesigned navigation, extra screens.
+The result should look like a real app screenshot that a coding agent can implement.
+```
+
+### Mockup 2 — <Screen>
+
+### Mockup 3 — <Screen>
+
+### Mockup 4 — <Screen>
+
+## 4. Mockup References
+
+- <image/path/url> — <screen>
+
+## 5. Mockup-to-Requirement Translation
+
+For each mockup:
+- layout structure;
+- visible components;
+- hierarchy;
+- spacing/density;
+- color/style rules;
+- content examples;
+- implementation notes;
+- deviations from the written spec.
+
+## 6. Acceptance Criteria
+
+### Functional
+
+### UI fidelity
+
+### Technical/build
+
+### Evidence/reporting
+
+## 7. Blocker and Stop Rules
+
+## 8. Final Goal Prompt
+
+```text
+/goal
+...
+```
+
+## 9. Hermes / Generic Variant Notes
+
+## 10. Open Questions and Assumptions

--- a/uv.lock
+++ b/uv.lock
@@ -1589,7 +1589,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Summary
- add standalone goal-prompt-pack skill for Codex Goal Mode, Hermes workers, and generic autonomous coding agents
- add idea-workflow skills and plug-in Goal Prompt Pack stage to idea-superpowers-suite v1.2.0
- document the new workflow in README and bump hermes-agent to 0.14.1

## Test Plan
- python3 YAML/frontmatter validation for new SKILL.md files
- uv run --with pytest-timeout python -m pytest tests/tools/test_skill_manager_tool.py tests/tools/test_skill_size_limits.py tests/website/test_generate_skill_docs.py
- git diff --cached --check
- staged secret-pattern scan