### PR TITLE
fix(cli): avoid return in voice cleanup finally

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10818,7 +10818,6 @@ class HermesCLI:
                     self._voice_continuous = False
                     self._no_speech_count = 0
                     _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
-                    return
             else:
                 self._no_speech_count = 0
 


### PR DESCRIPTION
Removes a return statement from a finally block in cli.py.

On Python 3.14, this emits a SyntaxWarning and fails when warnings are treated as errors. The behavior is preserved because _voice_continuous is already set to False before the auto-restart guard runs.

Tested:
- python -Werror::SyntaxWarning -m py_compile cli.py
- python -m compileall -q cli.py