### PR TITLE
fix(config): prevent config.yaml write-race via defense-in-depth

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -86,7 +86,7 @@ from gateway.platforms.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
-from utils import atomic_replace
+from utils import atomic_replace, config_file_lock
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _TELEGRAM_IMAGE_MIME_TO_EXT = {
@@ -1349,7 +1349,8 @@ class TelegramAdapter(BasePlatformAdapter):
                         _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
                         f.flush()
                         os.fsync(f.fileno())
-                    atomic_replace(tmp_path, config_path)
+                    with config_file_lock(config_path):
+                        atomic_replace(tmp_path, config_path)
                 except BaseException:
                     try:
                         os.unlink(tmp_path)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -258,6 +258,88 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     return None
 
 
+def _check_hermes_config_path(filepath: str, task_id: str = "default") -> str | None:
+    """Refuse direct writes/patches to any Hermes profile's ``config.yaml``.
+
+    ``config.yaml`` is mutated concurrently by the gateway, TUI, telegram
+    adapter, onboarding flow, and CLI ``hermes config set``. A torn write
+    from this tool produces a corrupt file on line 1, after which the
+    gateway falls back to the default config (provider: openrouter), the
+    user's keys stop working, and authentication starts failing silently.
+
+    Route through ``utils.atomic_roundtrip_yaml_update`` (single key) or
+    ``utils.atomic_yaml_write`` inside ``utils.config_file_lock`` (full
+    rewrite) — both serialize cross-process writers via ``fcntl.flock``
+    and preserve comments/quoting.
+    """
+    try:
+        resolved = Path(_resolve_path_for_task(filepath, task_id)).resolve()
+    except (OSError, ValueError):
+        try:
+            resolved = Path(os.path.expanduser(filepath)).resolve()
+        except (OSError, ValueError):
+            return None
+
+    if resolved.name != "config.yaml":
+        return None
+
+    # Hermes config lives at one of:
+    #   ~/.hermes/config.yaml                       (default profile)
+    #   ~/.hermes/profiles/<name>/config.yaml       (named profile)
+    #   $HERMES_HOME/config.yaml                    (env override)
+    candidate_homes: set[Path] = set()
+    try:
+        from hermes_constants import get_hermes_home
+        candidate_homes.add(Path(get_hermes_home()).resolve())
+    except Exception:
+        pass
+    hermes_home_env = os.environ.get("HERMES_HOME")
+    if hermes_home_env:
+        try:
+            candidate_homes.add(Path(hermes_home_env).expanduser().resolve())
+        except (OSError, ValueError):
+            pass
+    try:
+        candidate_homes.add((Path.home() / ".hermes").resolve())
+    except (OSError, ValueError):
+        pass
+
+    parent = resolved.parent
+    is_hermes_config = False
+    # Direct child of any candidate home, or under <home>/profiles/<name>/.
+    for home in candidate_homes:
+        try:
+            if parent == home:
+                is_hermes_config = True
+                break
+            if parent.parent == home / "profiles":
+                is_hermes_config = True
+                break
+        except (OSError, ValueError):
+            continue
+
+    if not is_hermes_config:
+        return None
+
+    return (
+        f"Refusing to write to Hermes config: {resolved}\n"
+        "This file is mutated concurrently by the gateway, TUI, telegram "
+        "adapter, onboarding, and `hermes config set`. A torn write from "
+        "this tool corrupts line 1 and silently drops the gateway onto "
+        "the default config (provider: openrouter), breaking auth.\n\n"
+        "Use one of these instead (both serialize writers and preserve "
+        "comments/quoting):\n"
+        "  • Single key:\n"
+        "      from utils import atomic_roundtrip_yaml_update\n"
+        "      atomic_roundtrip_yaml_update(path, 'model.provider', 'copilot')\n"
+        "  • Full rewrite:\n"
+        "      from utils import atomic_yaml_write, config_file_lock\n"
+        "      with config_file_lock(path):\n"
+        "          atomic_yaml_write(path, new_config)\n"
+        "Run them via the `execute_code` tool."
+    )
+
+
 def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | None:
     """Return a cross-profile warning string when ``filepath`` lands in
     another Hermes profile's skills/plugins/cron/memories directory.
@@ -959,6 +1041,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
         return tool_error(sensitive_err)
+    hermes_config_err = _check_hermes_config_path(path, task_id)
+    if hermes_config_err:
+        return tool_error(hermes_config_err)
     if not cross_profile:
         cross_warning = _check_cross_profile_path(path, task_id)
         if cross_warning:
@@ -1061,6 +1146,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
             return tool_error(sensitive_err)
+        hermes_config_err = _check_hermes_config_path(_p, task_id)
+        if hermes_config_err:
+            return tool_error(hermes_config_err)
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import is_truthy_value
+from utils import atomic_yaml_write, config_file_lock, is_truthy_value
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -681,11 +681,10 @@ def _load_cfg() -> dict:
 
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime, _cfg_path
-    import yaml
 
     path = _hermes_home / "config.yaml"
-    with open(path, "w", encoding="utf-8") as f:
-        yaml.safe_dump(cfg, f)
+    with config_file_lock(path):
+        atomic_yaml_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         _cfg_path = path

--- a/utils.py
+++ b/utils.py
@@ -1,17 +1,40 @@
 """Shared utility functions for hermes-agent."""
 
+import contextlib
 import json
 import logging
 import os
 import stat
 import tempfile
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Iterator, Union
 from urllib.parse import urlparse
 
 import yaml
 
+try:
+    import fcntl as _fcntl  # type: ignore
+except ImportError:  # pragma: no cover - non-POSIX
+    _fcntl = None  # type: ignore
+
 logger = logging.getLogger(__name__)
+
+
+# Per-thread reentrance set so atomic_yaml_write/atomic_roundtrip_yaml_update
+# can safely call each other (or run inside an outer config_file_lock) without
+# deadlocking on the advisory flock.
+import threading as _threading
+_LOCK_REENTRY = _threading.local()
+
+
+def _in_config_lock(path) -> bool:
+    held = getattr(_LOCK_REENTRY, "held", None)
+    if not held:
+        return False
+    try:
+        return str(Path(path).expanduser().resolve()) in held
+    except (OSError, ValueError):
+        return False
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
@@ -148,7 +171,78 @@ def atomic_json_write(
         raise
 
 
+def _is_hermes_config_path(path: Union[str, Path]) -> bool:
+    """Return True when ``path`` resolves to a Hermes profile's ``config.yaml``.
+
+    Hermes config lives at one of:
+      * ``$HERMES_HOME/config.yaml`` (env override)
+      * ``~/.hermes/config.yaml`` (default profile)
+      * ``~/.hermes/profiles/<name>/config.yaml`` (named profile)
+
+    The atomic-write helpers use this to auto-acquire ``config_file_lock``
+    so that call-sites can't forget the cross-process lock and produce a
+    torn write (which corrupts line 1 and silently drops the gateway onto
+    the default config, e.g. provider: openrouter, breaking auth).
+    """
+    try:
+        resolved = Path(path).expanduser().resolve()
+    except (OSError, ValueError):
+        return False
+    if resolved.name != "config.yaml":
+        return False
+
+    candidate_homes: set[Path] = set()
+    hermes_home_env = os.environ.get("HERMES_HOME")
+    if hermes_home_env:
+        try:
+            candidate_homes.add(Path(hermes_home_env).expanduser().resolve())
+        except (OSError, ValueError):
+            pass
+    try:
+        candidate_homes.add((Path.home() / ".hermes").resolve())
+    except (OSError, ValueError):
+        pass
+
+    parent = resolved.parent
+    for home in candidate_homes:
+        try:
+            if parent == home:
+                return True
+            if parent.parent == home / "profiles":
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
 def atomic_yaml_write(
+    path: Union[str, Path],
+    data: Any,
+    *,
+    default_flow_style: bool = False,
+    sort_keys: bool = False,
+    extra_content: str | None = None,
+) -> None:
+    # Auto-acquire cross-process lock for Hermes config.yaml so concurrent
+    # writers (gateway, TUI, CLI, agent) can't produce torn writes that
+    # corrupt line 1 and drop the gateway onto the default config.
+    if _is_hermes_config_path(path) and not _in_config_lock(path):
+        with config_file_lock(path):
+            return _atomic_yaml_write_impl(
+                path, data,
+                default_flow_style=default_flow_style,
+                sort_keys=sort_keys,
+                extra_content=extra_content,
+            )
+    return _atomic_yaml_write_impl(
+        path, data,
+        default_flow_style=default_flow_style,
+        sort_keys=sort_keys,
+        extra_content=extra_content,
+    )
+
+
+def _atomic_yaml_write_impl(
     path: Union[str, Path],
     data: Any,
     *,
@@ -201,6 +295,18 @@ def atomic_yaml_write(
 
 
 def atomic_roundtrip_yaml_update(
+    path: Union[str, Path],
+    key_path: str,
+    value: Any,
+) -> None:
+    # Auto-acquire cross-process lock for Hermes config.yaml.
+    if _is_hermes_config_path(path) and not _in_config_lock(path):
+        with config_file_lock(path):
+            return _atomic_roundtrip_yaml_update_impl(path, key_path, value)
+    return _atomic_roundtrip_yaml_update_impl(path, key_path, value)
+
+
+def _atomic_roundtrip_yaml_update_impl(
     path: Union[str, Path],
     key_path: str,
     value: Any,
@@ -262,6 +368,83 @@ def atomic_roundtrip_yaml_update(
         except OSError:
             pass
         raise
+
+
+@contextlib.contextmanager
+def config_file_lock(
+    config_path: Union[str, Path],
+    *,
+    timeout: float = 10.0,
+) -> Iterator[None]:
+    """Serialize cross-process writes to a shared YAML config file.
+
+    Multiple Hermes components (TUI gateway, telegram adapter, CLI ``hermes
+    config set``, agent runtime) all mutate ``~/.hermes/config.yaml``.  When
+    two writers interleave, the file can be left half-written — a YAML
+    parse error on line 1 that drops the gateway back onto the default
+    config (e.g. provider: openrouter instead of the user's choice).
+
+    This advisory ``fcntl.flock`` on a sibling ``.lock`` file makes every
+    cooperating writer wait its turn.  On non-POSIX platforms the lock is
+    a no-op — atomic_yaml_write still prevents torn writes within a single
+    process; only cross-process races require the lock.
+
+    Use as::
+
+        with config_file_lock(cfg_path):
+            data = yaml.safe_load(cfg_path.read_text()) or {}
+            data["foo"] = "bar"
+            atomic_yaml_write(cfg_path, data)
+    """
+    config_path = Path(config_path)
+    lock_path = config_path.with_suffix(config_path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if _fcntl is None:
+        yield
+        return
+
+    import time
+
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        deadline = time.monotonic() + max(0.0, timeout)
+        while True:
+            try:
+                _fcntl.flock(fd, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+                break
+            except (BlockingIOError, OSError):
+                if time.monotonic() >= deadline:
+                    logger.warning(
+                        "config_file_lock: timeout after %.1fs waiting for %s; "
+                        "proceeding without lock (writes may race).",
+                        timeout, lock_path,
+                    )
+                    break
+                time.sleep(0.05)
+
+        held = getattr(_LOCK_REENTRY, "held", None)
+        if held is None:
+            held = set()
+            _LOCK_REENTRY.held = held
+        try:
+            _resolved = str(config_path.expanduser().resolve())
+        except (OSError, ValueError):
+            _resolved = str(config_path)
+        held.add(_resolved)
+        try:
+            yield
+        finally:
+            held.discard(_resolved)
+    finally:
+        try:
+            _fcntl.flock(fd, _fcntl.LOCK_UN)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass
 
 
 # ─── JSON Helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When the gateway and the agent both write to `~/.hermes/config.yaml` concurrently (e.g. agent uses `patch`/`write_file` while gateway is persisting state), the file can end up torn — yielding a YAML parse error like `r1c23`. The fallback path then demotes the configured provider to the default (`openrouter`), producing silent auth failures downstream.

Reproduced locally: agent's own patch tool ran on config.yaml at 09:07 + 09:28 while the gateway was also writing, producing a torn file.

## Fix — two layers of defense

1. **`tools/file_tools.py`**: `write_file` and `patch` tools now refuse any path matching `*/[.hermes|profiles/*]/config.yaml`, pointing callers at `utils.atomic_roundtrip_yaml_update`. Prevents accidental future regressions where an agent-side tool bypasses the safe path.

2. **`utils.py`**: `atomic_yaml_write` and `atomic_roundtrip_yaml_update` auto-acquire `config_file_lock` when the target is a Hermes config.yaml. Reentrance is tracked via `threading.local` so callers that already hold the lock don't deadlock. All 15 existing call sites are now safe without per-site changes.

## Verification

- 233 tests passing (132 in atomic-yaml suite + 101 in file-safety / write-deny suites)
- Fresh 5-proc × 20-write stress run left the file valid with all worker keys present

## Notes

The deny-list in `file_tools.py` is a guardrail, not a barrier — `atomic_roundtrip_yaml_update` remains the single safe writer. Happy to adjust the path-matching glob if you prefer a different convention.