### PR TITLE
fix(acp): make resume skip history replay

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -977,12 +977,12 @@ class HermesACPAgent(acp.Agent):
         ).strip()
 
     async def _replay_session_history(self, state: SessionState) -> None:
-        """Replay persisted user/assistant history during session/load or session/resume.
+        """Replay persisted user/assistant history during session/load.
 
-        Invoked inline (``await``) from both ``load_session`` and
-        ``resume_session`` so that spec-compliant ACP clients receive the
-        full transcript within the request's lifetime — see the comment at
-        the call sites for the rationale and prior-art citations.
+        Invoked inline (``await``) from ``load_session`` so that
+        spec-compliant ACP clients receive the full transcript within the
+        request's lifetime — see the comment at the call site for the
+        rationale and prior-art citations.
 
         Replays the conversation as user/assistant chunks, thinking-mode
         thought chunks, plus reconstructed tool-call start/completion
@@ -1140,18 +1140,9 @@ class HermesACPAgent(acp.Agent):
             state = self.session_manager.create_session(cwd=cwd)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Resumed session %s", state.session_id)
-        # See `load_session` above for the spec rationale — replay must
-        # complete before the response so clients receive the full transcript
-        # within the request's lifetime.
-        try:
-            await self._replay_session_history(state)
-        except Exception:
-            logger.warning(
-                "ACP history replay raised during session/resume for %s — "
-                "resume will still succeed, partial transcript may be missing",
-                state.session_id,
-                exc_info=True,
-            )
+        # ACP ``session/resume`` reattaches to an existing runtime session and
+        # intentionally does not replay prior transcript history. Clients that
+        # need to hydrate a transcript should use ``session/load`` instead.
         self._schedule_available_commands_update(state.session_id)
         self._schedule_usage_update(state)
         return ResumeSessionResponse(

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -476,7 +476,7 @@ class TestSessionOps:
         assert [entry.status for entry in plan.entries] == ["in_progress"]
 
     @pytest.mark.asyncio
-    async def test_resume_session_replays_persisted_history_to_client(self, agent):
+    async def test_resume_session_does_not_replay_persisted_history_to_client(self, agent):
         mock_conn = MagicMock(spec=acp.Client)
         mock_conn.session_update = AsyncMock()
         agent._conn = mock_conn
@@ -491,12 +491,20 @@ class TestSessionOps:
         await asyncio.sleep(0)
 
         assert isinstance(resp, ResumeSessionResponse)
-        updates = [call.kwargs["update"] for call in mock_conn.session_update.await_args_list]
-        assert any(
-            isinstance(update, UserMessageChunk)
-            and update.content.text == "So tell me the current state"
-            for update in updates
-        )
+        replay_kinds = [
+            getattr(call.kwargs.get("update"), "session_update", None)
+            for call in mock_conn.session_update.await_args_list
+            if getattr(call.kwargs.get("update"), "session_update", None)
+            in {
+                "user_message_chunk",
+                "agent_message_chunk",
+                "agent_thought_chunk",
+                "tool_call",
+                "tool_call_update",
+                "plan",
+            }
+        ]
+        assert replay_kinds == []
 
     @pytest.mark.asyncio
     async def test_load_session_replays_reasoning_thought_before_message(self, agent):
@@ -732,8 +740,8 @@ class TestSessionOps:
         assert events == ["replay", "returned"]
 
     @pytest.mark.asyncio
-    async def test_resume_session_replays_history_before_returning_response(self, agent):
-        """Same spec rationale as ``load_session`` — replay before responding."""
+    async def test_resume_session_does_not_replay_history_before_returning_response(self, agent):
+        """Per ACP resume semantics, resume should not replay transcript history."""
         new_resp = await agent.new_session(cwd="/tmp")
         state = agent.session_manager.get_session(new_resp.session_id)
         state.history = [{"role": "user", "content": "hello from history"}]
@@ -747,7 +755,7 @@ class TestSessionOps:
             events.append("returned")
 
         assert isinstance(resp, ResumeSessionResponse)
-        assert events == ["replay", "returned"]
+        assert events == ["returned"]
 
     @pytest.mark.asyncio
     async def test_load_session_survives_replay_helper_exception(self, agent, caplog):
@@ -774,8 +782,8 @@ class TestSessionOps:
         assert "history replay raised during session/load" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_resume_session_survives_replay_helper_exception(self, agent, caplog):
-        """Same guarantee as ``load_session`` for the resume path."""
+    async def test_resume_session_does_not_invoke_replay_helper(self, agent, caplog):
+        """No-replay resume semantics should bypass replay helpers entirely."""
         new_resp = await agent.new_session(cwd="/tmp")
         state = agent.session_manager.get_session(new_resp.session_id)
         state.history = [{"role": "user", "content": "hi"}]
@@ -788,7 +796,7 @@ class TestSessionOps:
                 resp = await agent.resume_session(cwd="/tmp", session_id=new_resp.session_id)
 
         assert isinstance(resp, ResumeSessionResponse)
-        assert "history replay raised during session/resume" in caplog.text
+        assert "history replay raised during session/resume" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_resume_session_creates_new_if_missing(self, agent):


### PR DESCRIPTION
## What does this PR do?

`session/resume` now follows no-history resume semantics instead of behaving like `session/load`.

Hermes already advertises ACP `sessionCapabilities.resume`, but `resume_session(...)` previously called `_replay_session_history(state)` just like `load_session(...)`. That meant clients using resume to reattach/continue could receive prior transcript `session/update` notifications and duplicate or re-render history.

This PR keeps `session/load` as the transcript-hydration path and makes `session/resume` restore/reuse session state without replaying persisted transcript history.

## Related Issue

Fixes #32201

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`
  - Remove the `_replay_session_history(state)` call from `resume_session(...)`.
  - Keep existing resume behavior for cwd updates, missing-session fallback, MCP registration, available-command updates, usage updates, and `ResumeSessionResponse` construction.
  - Narrow `_replay_session_history(...)` documentation to `session/load`.
- `tests/acp/test_server.py`
  - Update resume regression coverage so `session/resume` does not replay persisted user/assistant/thought/tool/plan history.
  - Assert the resume path does not invoke the replay helper.
  - Preserve `session/load` tests that require replay before returning.

## How to Test

1. Confirm the previous behavior is reproduced by the updated tests before the implementation change:
   - `scripts/run_tests.sh tests/acp/test_server.py`
   - RED result before the fix: 3 resume no-replay assertions failed.
2. Run focused ACP server tests:
   - `scripts/run_tests.sh tests/acp/test_server.py`
   - Result: 78 passed.
3. Run focused MCP/session integration coverage:
   - `scripts/run_tests.sh tests/acp/test_mcp_e2e.py`
   - Result: 8 passed.
4. Run the ACP test suite:
   - `scripts/run_tests.sh tests/acp`
   - Result: 275 passed.
5. Check whitespace:
   - `git diff --check`
   - Result: clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Arch)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add or modify a skill.

## Screenshots / Logs

Focused test output summary:

```text
scripts/run_tests.sh tests/acp
=== Summary: 12 files, 275 tests passed, 0 failed (100% complete) in 4.0s (64 workers) ===
```

No interactive editor/client smoke test was run.
