### PR TITLE
fix(vision): allow Gemini 2.x native media results

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -52,8 +52,15 @@ class TestSupportsMediaInToolResults:
     def test_gemini_3_yes(self):
         assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
 
-    def test_gemini_2_no(self):
-        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+    @pytest.mark.parametrize(
+        "model",
+        ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
+    )
+    def test_gemini_2_0_and_2_5_yes(self, model):
+        assert _supports_media_in_tool_results("google", model) is True
+
+    def test_older_gemini_no(self):
+        assert _supports_media_in_tool_results("google", "gemini-1.5-pro") is False
 
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -429,8 +429,8 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         ``image_url`` parts.
       * OpenAI Responses (``openai-codex``): ``function_call_output.output``
         accepts an array of ``input_text``/``input_image`` items.
-      * Gemini 3 (and proxied via aggregators): supports multimodal tool
-        results. Older Gemini does NOT.
+      * Gemini 2.0+ (and proxied via aggregators): supports multimodal tool
+        results.
 
     For unknown / legacy providers we conservatively return False — the
     caller falls back to the legacy aux-LLM text path.
@@ -461,12 +461,18 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support
-    # multimodal functionResponse. Gemini 3.x does.
+    # multimodal functionResponse. Gemini 2.0+ does.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:
         if not isinstance(model, str):
             return False
         m = model.strip().lower()
-        if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
+        if (
+            "gemini-3" in m
+            or "gemini-pro-3" in m
+            or "gemini-flash-3" in m
+            or "gemini-2.5" in m
+            or "gemini-2.0" in m
+        ):
             return True
         return False
 


### PR DESCRIPTION
Fixes #30704.

Gemini 2.0 and 2.5 models support multimodal tool results through the OpenAI-compatible endpoint, but _supports_media_in_tool_results only allowed Gemini 3.x models.

This updates the Gemini allowlist so gemini-2.0-* and gemini-2.5-* use the native vision fast path, while keeping older Gemini models conservative.

Tested:
- python -m pytest tests/tools/test_vision_native_fast_path.py -q