### PR TITLE
fix: convert TTS audio to OGG Opus for Feishu voice bubbles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11354,8 +11354,11 @@ class GatewayRunner:
         import uuid as _uuid
         audio_path = None
         actual_path = None
+        converted_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import (
+                text_to_speech_tool, _strip_markdown_for_tts, _convert_to_opus,
+            )
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
@@ -11408,9 +11411,17 @@ class GatewayRunner:
                     thread_meta["notify"] = True
                 else:
                     thread_meta = {"notify": True}
+
+                # Feishu requires OGG Opus for voice bubbles — convert if needed.
+                send_path = actual_path
+                if event.source.platform == "feishu" and not actual_path.lower().endswith((".ogg", ".opus")):
+                    converted_path = _convert_to_opus(actual_path)
+                    if converted_path:
+                        send_path = converted_path
+
                 send_kwargs: Dict[str, Any] = {
                     "chat_id": event.source.chat_id,
-                    "audio_path": actual_path,
+                    "audio_path": send_path,
                     "reply_to": reply_anchor,
                     "metadata": thread_meta,
                 }
@@ -11418,7 +11429,7 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:
-            for p in {audio_path, actual_path} - {None}:
+            for p in {audio_path, actual_path, converted_path} - {None}:
                 try:
                     os.unlink(p)
                 except OSError:


### PR DESCRIPTION
Auto voice replies (TTS) were sent as MP3 file attachments in Feishu instead of voice bubbles because _resolve_outbound_file_routing only maps .ogg/.opus to msg_type=audio; all other extensions (including .mp3) fall through to msg_type=file.

This change adds Feishu-specific OGG conversion in _send_voice_reply:
- After TTS generates the audio file, check if the platform is feishu
- If the file is not .ogg/.opus, convert it using _convert_to_opus (ffmpeg)
- Use the converted path when calling send_voice

The conversion temporary file is tracked and cleaned up in the finally block.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

