### PR TITLE
fix(gateway): send 'back online' broadcast after OS reboot / external relaunch

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -734,6 +734,36 @@ def _restart_notification_pending() -> bool:
     return (_hermes_home / ".restart_notify.json").exists()
 
 
+# Marker written when a shutdown/restart broadcast was actually delivered to
+# users (active sessions or home channels).  Consumed on the next gateway
+# startup to send a matching "back online" home-channel notice so the user
+# isn't left wondering whether the gateway came back after an OS reboot or
+# external `systemctl restart`.  See `_notify_active_sessions_of_shutdown`
+# (writer) and `_should_broadcast_startup` (reader).
+_SHUTDOWN_BROADCAST_MARKER = ".shutdown_broadcast_pending"
+
+
+def _shutdown_broadcast_pending() -> bool:
+    """Return True when a prior shutdown broadcast went out and hasn't been acked."""
+    return (_hermes_home / _SHUTDOWN_BROADCAST_MARKER).exists()
+
+
+def _clear_shutdown_broadcast_marker() -> None:
+    try:
+        (_hermes_home / _SHUTDOWN_BROADCAST_MARKER).unlink()
+    except FileNotFoundError:
+        pass
+    except Exception:  # pragma: no cover — best-effort cleanup
+        pass
+
+
+def _write_shutdown_broadcast_marker() -> None:
+    try:
+        (_hermes_home / _SHUTDOWN_BROADCAST_MARKER).touch()
+    except Exception:  # pragma: no cover — best-effort
+        pass
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -3502,6 +3532,13 @@ class GatewayRunner:
                     e,
                 )
 
+        # Record that we just broadcast shutdown/restart messages so the next
+        # gateway startup can send a matching "back online" notice — even when
+        # the trigger wasn't /restart (OS reboot, external `systemctl
+        # restart`, etc.).  Only write when at least one delivery succeeded.
+        if notified:
+            _write_shutdown_broadcast_marker()
+
     def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
             try:
@@ -4326,17 +4363,31 @@ class GatewayRunner:
         delivered_restart_target = await self._send_restart_notification()
 
         # Broadcast a lightweight "gateway is back" message to configured
-        # home channels only when this startup is resuming from /restart. If a
-        # /restart requester already received a direct completion notice in the
-        # same chat, skip the generic broadcast there to avoid duplicates while
-        # still allowing a home-channel fallback when the direct send fails.
-        if restart_notification_pending or delivered_restart_target is not None:
+        # home channels when this startup is resuming from /restart, OR when
+        # the previous gateway sent a shutdown broadcast (OS reboot, external
+        # `systemctl restart`, etc.).  In those latter cases users already
+        # got a "shutting down" notice on Telegram/Discord/etc. and expect a
+        # matching "back online" signal.  If a /restart requester already
+        # received a direct completion notice in the same chat, skip the
+        # generic broadcast there to avoid duplicates while still allowing a
+        # home-channel fallback when the direct send fails.
+        shutdown_broadcast_was_pending = _shutdown_broadcast_pending()
+        if (
+            restart_notification_pending
+            or delivered_restart_target is not None
+            or shutdown_broadcast_was_pending
+        ):
             skip_home_targets = (
                 {delivered_restart_target} if delivered_restart_target else None
             )
             await self._send_home_channel_startup_notifications(
                 skip_targets=skip_home_targets,
             )
+        # Always clear the marker after a startup attempt — whether we
+        # broadcast or not — so a single stale marker can't cause repeated
+        # spurious "back online" notices on subsequent restarts.
+        if shutdown_broadcast_was_pending:
+            _clear_shutdown_broadcast_marker()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -623,3 +623,57 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
         "⚠️ Gateway shutting down — Your current task will be interrupted.",
         metadata={"thread_id": "topic-7"},
     )
+
+
+# ── shutdown-broadcast marker (drives "back online" on next startup) ────────
+
+
+def test_shutdown_broadcast_marker_helpers_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    assert gateway_run._shutdown_broadcast_pending() is False
+
+    gateway_run._write_shutdown_broadcast_marker()
+    assert gateway_run._shutdown_broadcast_pending() is True
+    assert (tmp_path / gateway_run._SHUTDOWN_BROADCAST_MARKER).exists()
+
+    gateway_run._clear_shutdown_broadcast_marker()
+    assert gateway_run._shutdown_broadcast_pending() is False
+
+
+def test_clear_shutdown_broadcast_marker_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    # Should not raise even when the marker doesn't exist.
+    gateway_run._clear_shutdown_broadcast_marker()
+    gateway_run._clear_shutdown_broadcast_marker()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_broadcast_writes_marker_when_delivery_succeeds(tmp_path, monkeypatch):
+    """After a successful shutdown broadcast, leave a marker for next startup."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="42")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="bye"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert gateway_run._shutdown_broadcast_pending() is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_broadcast_skips_marker_when_no_delivery(tmp_path, monkeypatch):
+    """No active sessions and no home channel → no broadcast → no marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_called()
+    assert gateway_run._shutdown_broadcast_pending() is False


### PR DESCRIPTION
## Problem

The shutdown broadcast — `⚠️ Gateway shutting down — Your current task will be interrupted.` — fires from `_notify_active_sessions_of_shutdown()` on **any** clean stop: `/restart`, `hermes gateway restart`, SIGTERM from systemd/launchd, OS-upgrade reboot, etc.

But the matching home-channel comeback broadcast (`♻️ Gateway online — Hermes is back and ready.`) in `start()` is gated solely on the `/restart` markers:

```python
if restart_notification_pending or delivered_restart_target is not None:
    await self._send_home_channel_startup_notifications(...)
```

Result for users: they see "shutting down" on Telegram/Discord before an OS-upgrade reboot or a systemd-triggered relaunch, and then… silence. No confirmation the gateway came back.

I hit this myself on a macOS upgrade reboot — saw the shutdown notice, never got the comeback notice.

## Fix

Add a small on-disk marker (`~/.hermes/.shutdown_broadcast_pending`) that mirrors the shutdown broadcast:

- **Writer** (`_notify_active_sessions_of_shutdown`) — when at least one shutdown notification was successfully delivered (to active sessions or home channels), drop the marker. No marker is written if there was nothing to broadcast (cold start with no active sessions and no home channels) — keeps the cold-start path silent.
- **Reader** (`start()`) — treat the marker as a third trigger for the comeback broadcast, alongside the existing `/restart` pending and direct-delivery triggers.
- The marker is **always cleared after a startup attempt** so a stale file can't cause repeated spurious notices on subsequent restarts.

Why not just key off `.clean_shutdown` absence? Because that marker is written on *every* graceful stop (including SIGTERM), so "no clean marker" ≠ "shutdown broadcast went out". A dedicated marker tied to the actual broadcast keeps the signals aligned 1:1: every "shutting down" notice now gets a matching "back online" notice.

## Tests

Added to `tests/gateway/test_restart_notification.py`:

- `test_shutdown_broadcast_marker_helpers_roundtrip` — write/read/clear cycle
- `test_clear_shutdown_broadcast_marker_is_idempotent` — clearing a missing marker is a no-op
- `test_shutdown_broadcast_writes_marker_when_delivery_succeeds` — marker IS written when an active-session notification succeeds
- `test_shutdown_broadcast_skips_marker_when_no_delivery` — marker is NOT written when there's nothing to broadcast

All 126 existing tests across `test_restart_notification.py`, `test_clean_shutdown_marker.py`, `test_restart_resume_pending.py`, `test_restart_drain.py`, and `test_shutdown_cache_cleanup.py` still pass.

## Behavior summary

| Trigger | Shutdown broadcast | Comeback (before) | Comeback (after) |
|---|---|---|---|
| `/restart` from chat | yes | yes | yes |
| `hermes gateway restart` | yes | no | yes |
| systemd/launchd SIGTERM (OS-upgrade relaunch) | yes | no | yes |
| Cold start (no prior shutdown broadcast) | n/a | no | no (unchanged) |
