### PR TITLE
feat: add AI radar brief helper

### DIFF
--- a/docs/plans/2026-05-26-ai-radar-brief.md
+++ b/docs/plans/2026-05-26-ai-radar-brief.md
@@ -1,0 +1,83 @@
+# AI Radar Brief Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a small local helper that turns manually collected or RSS-style AI/dev/community items into a Joe-style morning radar brief.
+
+**Architecture:** Keep the workflow reversible and standalone under `scripts/`: parse items from JSON/YAML or RSS XML, score them against Joe-relevant themes, and render a Traditional Chinese markdown brief with facts, hypotheses, and actions. Tests import the script module directly and cover parsing, ranking, rendering, and empty-report behavior.
+
+**Tech Stack:** Python stdlib + existing PyYAML dependency, pytest via `scripts/run_tests.sh`.
+
+---
+
+### Task 1: Add tests for item parsing and ranking
+
+**Objective:** Define the expected behavior before implementation.
+
+**Files:**
+- Create: `tests/scripts/test_ai_radar_brief.py`
+- Create: `scripts/ai_radar_brief.py`
+
+**Step 1: Write failing tests**
+
+Tests should assert:
+- RSS XML items are parsed into `RadarItem` objects with title/url/source/published fields.
+- Items matching Movement/BD/AI-agent themes rank above unrelated items.
+- Rendered markdown starts with `## TL;DR` and includes facts, hypotheses, actions, and source URLs.
+- Empty input returns `[SILENT]` when `silent_if_empty=True`.
+
+**Step 2: Run test to verify failure**
+
+Run: `scripts/run_tests.sh tests/scripts/test_ai_radar_brief.py -q`
+Expected: FAIL because `scripts/ai_radar_brief.py` does not exist yet.
+
+### Task 2: Implement minimal script API
+
+**Objective:** Make the tests pass with a small, dependency-light implementation.
+
+**Files:**
+- Create: `scripts/ai_radar_brief.py`
+
+**Step 1: Implement dataclass + parser helpers**
+
+Functions:
+- `RadarItem`
+- `parse_rss_xml(xml_text, source)`
+- `score_item(item, themes=DEFAULT_THEMES)`
+- `rank_items(items, limit=5)`
+- `render_brief(items, silent_if_empty=False)`
+
+**Step 2: Run focused tests**
+
+Run: `scripts/run_tests.sh tests/scripts/test_ai_radar_brief.py -q`
+Expected: PASS.
+
+### Task 3: Add CLI wrapper and smoke-check it
+
+**Objective:** Make the helper usable from cron/manual workflows.
+
+**Files:**
+- Modify: `scripts/ai_radar_brief.py`
+
+**Step 1: Add CLI**
+
+Arguments:
+- `--input PATH`: JSON/YAML list of items.
+- `--rss PATH_OR_URL`: RSS XML path or URL; repeatable.
+- `--limit N`
+- `--silent-if-empty`
+
+**Step 2: Verify CLI smoke**
+
+Run: `python scripts/ai_radar_brief.py --input <fixture-json>`
+Expected: Markdown brief with TL;DR and sources.
+
+### Task 4: Final verification and PR
+
+**Objective:** Keep nightly work reviewable.
+
+**Step 1:** Run focused test wrapper.
+
+**Step 2:** Commit with `feat: add AI radar brief helper`.
+
+**Step 3:** Push branch to Joe fork and open PR against `NousResearch/hermes-agent:main`.

--- a/scripts/ai_radar_brief.py
+++ b/scripts/ai_radar_brief.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Build a Joe-style AI/dev/community radar brief from local items or RSS.
+
+This is intentionally small and local-first: feed it manually collected JSON/YAML
+items or RSS XML exports, and it renders a concise Traditional Chinese morning
+brief with facts, hypotheses, action prompts, and source links.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import email.utils
+import html
+import json
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+try:  # PyYAML is already a Hermes core dependency.
+    import yaml
+except Exception:  # pragma: no cover - only hit in stripped environments.
+    yaml = None  # type: ignore[assignment]
+
+
+DEFAULT_THEMES: dict[str, tuple[str, ...]] = {
+    "ai agents": ("ai agent", "agentic", "agents", "coding agent", "workflow memory"),
+    "developer tooling": ("developer", "github", "pull request", "pr review", "issue triage", "open-source", "open source"),
+    "payments": ("payment", "payments", "checkout", "stablecoin", "merchant", "settlement"),
+    "fintech": ("neobank", "fintech", "wealth", "yield", "savings", "banking"),
+    "funding": ("raises", "raised", "series a", "seed", "funding", "round"),
+    "movement bd": ("move", "movement", "blockchain", "onchain", "defi", "wallet"),
+    "personal os": ("reminder", "habit", "body composition", "tracking", "personal os"),
+}
+
+
+@dataclass(frozen=True)
+class RadarItem:
+    """One external signal to rank and summarize."""
+
+    title: str
+    url: str = ""
+    source: str = ""
+    summary: str = ""
+    published: str = ""
+    score: int = 0
+    matched_themes: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _clean_text(value: Any) -> str:
+    text = html.unescape(str(value or ""))
+    return " ".join(text.split())
+
+
+def _child_text(element: ET.Element, names: Sequence[str]) -> str:
+    for name in names:
+        child = element.find(name)
+        if child is not None and child.text:
+            return _clean_text(child.text)
+    # Namespace-tolerant fallback for common RSS/Atom variants.
+    suffixes = tuple(f"}}{name}" for name in names)
+    for child in list(element):
+        if child.tag in names or child.tag.endswith(suffixes):
+            return _clean_text(child.text)
+    return ""
+
+
+def _normalize_date(value: str) -> str:
+    value = _clean_text(value)
+    if not value:
+        return ""
+    try:
+        parsed = email.utils.parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return value
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(dt.timezone.utc)
+    return parsed.date().isoformat()
+
+
+def parse_rss_xml(xml_text: str, source: str = "") -> list[RadarItem]:
+    """Parse RSS/Atom-ish XML into radar items.
+
+    The parser deliberately handles only standard feed fields so the helper stays
+    dependency-light and safe for cron usage.
+    """
+
+    root = ET.fromstring(xml_text)
+    channel_title = _child_text(root.find("channel") or root, ["title"])
+    feed_source = source or channel_title
+    items = root.findall(".//item") or root.findall(".//{http://www.w3.org/2005/Atom}entry")
+    parsed: list[RadarItem] = []
+    for item in items:
+        title = _child_text(item, ["title"])
+        url = _child_text(item, ["link"])
+        if not url:
+            for child in list(item):
+                if child.tag.endswith("}link") or child.tag == "link":
+                    url = child.attrib.get("href", "")
+                    break
+        summary = _child_text(item, ["description", "summary", "content"])
+        published = _normalize_date(_child_text(item, ["pubDate", "published", "updated"]))
+        if title or url or summary:
+            parsed.append(
+                RadarItem(
+                    title=title or url,
+                    url=url,
+                    source=feed_source,
+                    summary=summary,
+                    published=published,
+                )
+            )
+    return parsed
+
+
+def _item_text(item: RadarItem) -> str:
+    return f"{item.title} {item.summary} {item.source}".lower()
+
+
+def score_item(
+    item: RadarItem, themes: dict[str, tuple[str, ...]] = DEFAULT_THEMES
+) -> RadarItem:
+    """Return item annotated with deterministic score and matched themes."""
+
+    text = _item_text(item)
+    score = 0
+    matched: list[str] = []
+    for theme, keywords in themes.items():
+        hits = sum(1 for keyword in keywords if keyword.lower() in text)
+        if hits:
+            matched.append(theme)
+            score += 2 + hits
+    if item.url:
+        score += 1
+    if item.published:
+        score += 1
+    return replace(item, score=score, matched_themes=tuple(matched))
+
+
+def rank_items(items: Iterable[RadarItem], limit: int = 5) -> list[RadarItem]:
+    """Score and rank items for Joe's morning attention."""
+
+    scored = [score_item(item) for item in items]
+    return sorted(
+        scored,
+        key=lambda item: (item.score, item.published, item.title.lower()),
+        reverse=True,
+    )[:limit]
+
+
+def _fact_line(item: RadarItem) -> str:
+    parts = []
+    if item.source:
+        parts.append(item.source)
+    if item.published:
+        parts.append(item.published)
+    prefix = " / ".join(parts) if parts else "source provided"
+    return f"{prefix} — {item.summary or item.title}"
+
+
+def _hypothesis_line(item: RadarItem) -> str:
+    if item.matched_themes:
+        themes = ", ".join(item.matched_themes[:3])
+        return f"This may matter because it intersects Joe's {themes} radar."
+    return "Potentially low-signal unless it connects to Joe's side-project, BD, or personal-OS goals."
+
+
+def _action_line(item: RadarItem) -> str:
+    themes = set(item.matched_themes)
+    if {"payments", "fintech", "funding"} & themes:
+        return "Add to top-of-funnel BD watchlist; check whether Movement infra gives them distribution or technical leverage."
+    if {"ai agents", "developer tooling"} & themes:
+        return "Inspect for a reusable Hermes skill, cron workflow, or small PR idea; avoid rebuilding if the tool is already strong."
+    if "personal os" in themes:
+        return "Convert only if it reduces recurring friction with a measurable habit/reminder loop."
+    return "Skim once; promote only if a concrete next action appears."
+
+
+def render_brief(
+    items: Iterable[RadarItem], limit: int = 5, silent_if_empty: bool = False
+) -> str:
+    """Render a Traditional Chinese morning radar brief."""
+
+    ranked = rank_items(items, limit=limit)
+    if not ranked:
+        return "[SILENT]" if silent_if_empty else "## TL;DR\n- 沒有新的 radar item。"
+
+    lines = [
+        "## TL;DR",
+        f"- 今日整理 {len(ranked)} 個 AI/dev/community radar signals；優先看分數最高、最接近 Joe personal OS / Movement BD / side-project factory 的項目。",
+        "- 請把下面的 **Hypothesis** 當成待驗證假設，不是已證明結論。",
+        "",
+        "## Radar Items",
+    ]
+    for idx, item in enumerate(ranked, start=1):
+        themes = ", ".join(item.matched_themes) if item.matched_themes else "none"
+        lines.extend(
+            [
+                f"### {idx}. {item.title}",
+                f"- **Score:** {item.score}；**Themes:** {themes}",
+                f"- **Fact / verified:** {_fact_line(item)}",
+                f"- **Hypothesis:** {_hypothesis_line(item)}",
+                f"- **Action for Joe:** {_action_line(item)}",
+            ]
+        )
+        if item.url:
+            lines.append(f"- **Source:** {item.url}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _item_from_mapping(raw: dict[str, Any]) -> RadarItem:
+    return RadarItem(
+        title=_clean_text(raw.get("title")),
+        url=_clean_text(raw.get("url") or raw.get("link")),
+        source=_clean_text(raw.get("source")),
+        summary=_clean_text(raw.get("summary") or raw.get("description")),
+        published=_clean_text(raw.get("published") or raw.get("date") or raw.get("pubDate")),
+    )
+
+
+def load_items_file(path: Path) -> list[RadarItem]:
+    """Load radar items from JSON/YAML or RSS/XML file."""
+
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+    if suffix in {".xml", ".rss", ".atom"}:
+        return parse_rss_xml(text, source=path.stem)
+    if suffix in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to read YAML radar inputs")
+        data = yaml.safe_load(text) or []
+    else:
+        data = json.loads(text or "[]")
+    if isinstance(data, dict):
+        data = data.get("items", [])
+    if not isinstance(data, list):
+        raise ValueError(f"Expected list of items in {path}")
+    return [_item_from_mapping(item) for item in data if isinstance(item, dict)]
+
+
+def _read_url_or_path(value: str) -> str:
+    if value.startswith(("http://", "https://")):
+        with urllib.request.urlopen(value, timeout=20) as response:  # noqa: S310 - user-supplied CLI utility.
+            return response.read().decode("utf-8", errors="replace")
+    return Path(value).read_text(encoding="utf-8")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", action="append", type=Path, default=[], help="JSON/YAML/XML file with radar items; repeatable")
+    parser.add_argument("--rss", action="append", default=[], help="RSS/Atom URL or local XML path; repeatable")
+    parser.add_argument("--limit", type=int, default=5, help="Maximum items to render")
+    parser.add_argument("--silent-if-empty", action="store_true", help="Print exactly [SILENT] when no items are present")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    items: list[RadarItem] = []
+    for path in args.input:
+        items.extend(load_items_file(path))
+    for rss in args.rss:
+        items.extend(parse_rss_xml(_read_url_or_path(rss), source=rss))
+    sys.stdout.write(render_brief(items, limit=args.limit, silent_if_empty=args.silent_if_empty))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_ai_radar_brief.py
+++ b/tests/scripts/test_ai_radar_brief.py
@@ -1,0 +1,126 @@
+"""Tests for the Joe-style AI radar briefing helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "_ai_radar_brief_under_test",
+        Path(__file__).resolve().parents[2] / "scripts" / "ai_radar_brief.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_rss_xml_extracts_core_fields():
+    module = _load_module()
+    xml = """<?xml version="1.0"?>
+    <rss><channel><title>Builder Feed</title>
+      <item>
+        <title>New agentic coding workflow for GitHub PR reviews</title>
+        <link>https://example.com/agent-pr</link>
+        <pubDate>Tue, 26 May 2026 01:02:03 GMT</pubDate>
+        <description>Teams use AI agents to review pull requests.</description>
+      </item>
+    </channel></rss>
+    """
+
+    items = module.parse_rss_xml(xml, source="Builder Feed")
+
+    assert len(items) == 1
+    assert items[0].title == "New agentic coding workflow for GitHub PR reviews"
+    assert items[0].url == "https://example.com/agent-pr"
+    assert items[0].source == "Builder Feed"
+    assert "2026" in items[0].published
+    assert "AI agents" in items[0].summary
+
+
+def test_rank_items_prioritizes_joe_relevant_themes():
+    module = _load_module()
+    relevant = module.RadarItem(
+        title="Neobank raises Series A to launch stablecoin payment rails",
+        url="https://example.com/neobank-stablecoin",
+        source="Funding Feed",
+        summary="A fintech team is building payment and yield products for merchants.",
+    )
+    unrelated = module.RadarItem(
+        title="New mechanical keyboard colorway launches",
+        url="https://example.com/keyboard",
+        source="Gadget Feed",
+        summary="A keyboard vendor announced a limited run.",
+    )
+
+    ranked = module.rank_items([unrelated, relevant])
+
+    assert ranked[0].url == "https://example.com/neobank-stablecoin"
+    assert ranked[0].score > ranked[1].score
+    assert {"payments", "fintech", "funding"} <= set(ranked[0].matched_themes)
+
+
+def test_render_brief_uses_joe_morning_report_shape():
+    module = _load_module()
+    item = module.RadarItem(
+        title="Open-source AI agent adds workflow memory",
+        url="https://example.com/agent-memory",
+        source="GitHub Trending",
+        summary="The project stores reusable skills and improves coding workflows.",
+        published="2026-05-26",
+    )
+
+    brief = module.render_brief([item], limit=1)
+
+    assert brief.startswith("## TL;DR")
+    assert "### 1. Open-source AI agent adds workflow memory" in brief
+    assert "**Fact / verified:**" in brief
+    assert "**Hypothesis:**" in brief
+    assert "**Action for Joe:**" in brief
+    assert "https://example.com/agent-memory" in brief
+    assert "GitHub Trending" in brief
+
+
+def test_render_brief_can_suppress_empty_output():
+    module = _load_module()
+
+    assert module.render_brief([], silent_if_empty=True) == "[SILENT]"
+    assert "沒有新的 radar item" in module.render_brief([], silent_if_empty=False)
+
+
+def test_load_items_from_json_and_yaml_files(tmp_path):
+    module = _load_module()
+    json_path = tmp_path / "items.json"
+    json_path.write_text(
+        json.dumps(
+            [
+                {
+                    "title": "AI dev tool improves issue triage",
+                    "url": "https://example.com/triage",
+                    "source": "Example",
+                    "summary": "Uses agents to score issues and PRs.",
+                    "published": "2026-05-26",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "items.yaml"
+    yaml_path.write_text(
+        "- title: Stablecoin checkout startup raises seed\n"
+        "  url: https://example.com/checkout\n"
+        "  source: Funding Feed\n"
+        "  summary: Payments and merchant acquiring workflow.\n",
+        encoding="utf-8",
+    )
+
+    json_items = module.load_items_file(json_path)
+    yaml_items = module.load_items_file(yaml_path)
+
+    assert json_items[0].title == "AI dev tool improves issue triage"
+    assert yaml_items[0].url == "https://example.com/checkout"


### PR DESCRIPTION
## Summary
- Add `scripts/ai_radar_brief.py`, a local-first helper that ranks manually collected JSON/YAML or RSS/XML AI/dev/community signals against Joe-relevant themes.
- Render a Traditional Chinese morning brief with TL;DR, fact/hypothesis/action/source sections, and exact `[SILENT]` empty-output support for cron delivery.
- Add a spec plan under `docs/plans/` and focused tests for parsing, scoring, rendering, empty suppression, and JSON/YAML loading.

## Why
This gives Joe/Chrollo a small reusable primitive for nightly information-radar workflows without adding a live integration, sending messages, or depending on private data sources.

## Test Plan
- [x] `python -m pytest tests/scripts/test_ai_radar_brief.py -q -o 'addopts='`
- [x] `python -m py_compile scripts/ai_radar_brief.py tests/scripts/test_ai_radar_brief.py`
- [x] `python scripts/ai_radar_brief.py --input .tmp_ai_radar_items.json --limit 2`
- [x] `python scripts/ai_radar_brief.py --silent-if-empty`

## Notes
- `scripts/run_tests.sh tests/scripts/test_ai_radar_brief.py` currently fails before collection in this checkout because the wrapper passes `--timeout=30 --timeout-method=signal` but the active dev environment lacks the pytest-timeout plugin. Focused direct pytest fallback was used per AGENTS.md guidance.
