### PR TITLE
fix(mattermost): accept leading-space slash commands

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -792,6 +792,8 @@ class MattermostAdapter(BasePlatformAdapter):
         # Determine message type.
         file_ids = post.get("file_ids") or []
         msg_type = MessageType.TEXT
+        if message_text[:1].isspace() and message_text.lstrip().startswith("/"):
+            message_text = message_text.lstrip()
         if message_text.startswith("/"):
             msg_type = MessageType.COMMAND
 

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
 
 
 # ---------------------------------------------------------------------------
@@ -365,6 +366,55 @@ class TestMattermostWebSocketParsing:
         assert self.adapter.handle_message.called
         msg_event = self.adapter.handle_message.call_args[0][0]
         assert msg_event.source.chat_type == "dm"
+
+    @pytest.mark.asyncio
+    async def test_leading_space_slash_command_is_command(self):
+        """Mattermost mobile suggests leading-space slash commands."""
+        post_data = {
+            "id": "post_cmd",
+            "user_id": "user_123",
+            "channel_id": "chan_dm",
+            "message": " /new",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/new"
+        assert msg_event.message_type is MessageType.COMMAND
+        assert msg_event.get_command() == "new"
+
+    @pytest.mark.asyncio
+    async def test_leading_space_normal_text_is_preserved(self):
+        """Only command-shaped mobile messages should be normalized."""
+        post_data = {
+            "id": "post_text",
+            "user_id": "user_123",
+            "channel_id": "chan_dm",
+            "message": " hello",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@bob",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == " hello"
+        assert msg_event.message_type is MessageType.TEXT
 
     @pytest.mark.asyncio
     async def test_thread_id_from_root_id(self):


### PR DESCRIPTION
Fixes #25184.

Mattermost mobile prevents users from sending messages that start with `/`, but suggests prefixing the message with a space. The Mattermost adapter previously checked message_text.startswith("/"), so " /new" was treated as plain text instead of a gateway command.

This normalizes only command-shaped leading-space messages before command detection, while preserving leading whitespace for ordinary text.

Tested:
- python -m pytest tests/gateway/test_mattermost.py -q
- python -m compileall -q plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py