### PR TITLE
feat(optional-skills): add sally-skills

### DIFF
--- a/optional-skills/health/sally-skills/SKILL.md
+++ b/optional-skills/health/sally-skills/SKILL.md
@@ -8,14 +8,16 @@ platforms: [linux, macos, windows]
 metadata:
   hermes:
     tags: [MCP, Health, Integrations]
-    related_skills: [native-mcp, mcporter]
+    category: health
+    homepage: https://github.com/a1c-ai-agent/sally-skills
+    related_skills: [hermes-agent, mcporter]
 ---
 
 # Sally Skills
 
-[Sally Skills](https://github.com/Sally-A1C/ai-sally-skills) is a metered Model Context Protocol server that exposes the clinical-grade metabolic-health intelligence behind the A1C Insights iOS app to AI agents. One bearer key, six skills, pay-per-call in USD, no subscription.
+[Sally Skills](https://github.com/a1c-ai-agent/sally-skills) is a metered Model Context Protocol server that exposes the clinical-grade metabolic-health intelligence behind the A1C Insights iOS app to AI agents. One bearer key, six skills, pay-per-call in USD, no subscription.
 
-Connect it through Hermes' native MCP client and the six skills appear alongside built-in tools like `terminal` and `read_file`. The agent's LLM picks the right one for each user request: pulling wearable data, interpreting a lab PDF, scoring a meal photo, generating a daily readout, or answering a preventive-health question.
+Connect it through Hermes' native MCP client (see `references/native-mcp.md` in the `hermes-agent` skill) and the six skills register as `mcp__sally__<tool>` alongside built-in tools like `terminal` and `read_file`. The agent's LLM picks the right one for each user request: pulling wearable data, interpreting a lab PDF, scoring a meal photo, generating a daily readout, or answering a preventive-health question.
 
 ## When to Use
 
@@ -40,24 +42,27 @@ Do not use this skill for diagnosis or treatment decisions. Sally Skills returns
 
 ## How to Run
 
-Hermes auto-discovers MCP servers configured in `mcp.json`. Add Sally Skills:
+This skill ships in `optional-skills/` and is not active by default. Install it first:
 
-```json
-{
-  "mcpServers": {
-    "sally": {
-      "url": "https://sally.a1c.io/mcp",
-      "headers": {
-        "Authorization": "Bearer sk-sally-..."
-      }
-    }
-  }
-}
+```bash
+hermes skills install official/health/sally-skills
 ```
 
-Restart Hermes. The six skills appear as first-class tools in every conversation.
+Then add Sally Skills as an HTTP MCP server in `~/.hermes/config.yaml` under `mcp_servers`:
+
+```yaml
+mcp_servers:
+  sally:
+    url: "https://sally.a1c.io/mcp"
+    headers:
+      Authorization: "Bearer sk-sally-..."
+```
+
+Restart Hermes. The six skills register as `mcp__sally__*` tools in every conversation.
 
 ## Quick Reference
+
+Hermes registers each tool as `mcp__sally__<tool>` (for example `mcp__sally__health_sync`); the table lists the server-side tool names.
 
 | Tool | Cost / call | Returns |
 |---|---|---|
@@ -73,14 +78,14 @@ Restart Hermes. The six skills appear as first-class tools in every conversation
 A typical multi-skill conversation looks like:
 
 1. User: "How was my morning?"
-2. Hermes calls `health_insights` with `{ window: "morning" }`.
+2. Hermes calls `mcp__sally__health_insights` with `{ window: "morning" }`.
 3. Sally returns a structured readout (sleep score, HRV, resting heart rate, morning glucose, hydration, narrative).
 4. User: "What should I eat for breakfast?"
-5. Hermes calls `chat_with_sally` with the readout as context.
+5. Hermes calls `mcp__sally__chat_with_sally` with the readout as context.
 6. Sally returns three TCM-aligned meal options with rationale and source citations.
 7. User photographs the chosen meal.
-8. Hermes calls `food_journal` with the inline image.
-9. Sally grades the meal and predicts the glucose spike based on the user's recent metabolic_overview.
+8. Hermes calls `mcp__sally__food_journal` with the inline image.
+9. Sally grades the meal and predicts the glucose spike based on the user's recent `metabolic_overview` data.
 
 Chain length is bounded by the user's wallet; every `tools/call` decrements the balance per skill price.
 
@@ -93,13 +98,13 @@ Chain length is bounded by the user's wallet; every `tools/call` decrements the 
 
 ## Verification
 
-After configuring `mcp.json` and restarting Hermes, run:
+After configuring `~/.hermes/config.yaml` and restarting Hermes, run:
 
 ```bash
-hermes tools/list | grep ^sally
+hermes tools list | grep mcp__sally
 ```
 
-You should see six `sally.*` tools listed. To smoke-test the free skill from the terminal:
+You should see six `mcp__sally__*` tools listed. To smoke-test the free skill from the terminal:
 
 ```bash
 curl -sS https://sally.a1c.io/v1/call \
@@ -114,7 +119,6 @@ A `true` response means the key resolves to your A1C account and `health_sync` i
 ## Source
 
 - Public docs and protocol guides: <https://github.com/a1c-ai-agent/sally-skills>
-- Gateway source code: <https://github.com/Sally-A1C/ai-sally-skills>
 - Developer console: <https://console.a1c.io>
 - iOS app (identity source): <https://apps.apple.com/id/app/a1c-insights/id6748399956>
 - Contact: ai@sallya1c.com

--- a/skills/mcp/sally-skills/SKILL.md
+++ b/skills/mcp/sally-skills/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: sally-skills
+description: "Sally Skills MCP server: clinical health for agents."
+version: 1.0.0
+author: A1C
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [MCP, Health, Integrations]
+    related_skills: [native-mcp, mcporter]
+---
+
+# Sally Skills
+
+[Sally Skills](https://github.com/Sally-A1C/ai-sally-skills) is a metered Model Context Protocol server that exposes the clinical-grade metabolic-health intelligence behind the A1C Insights iOS app to AI agents. One bearer key, six skills, pay-per-call in USD, no subscription.
+
+Connect it through Hermes' native MCP client and the six skills appear alongside built-in tools like `terminal` and `read_file`. The agent's LLM picks the right one for each user request: pulling wearable data, interpreting a lab PDF, scoring a meal photo, generating a daily readout, or answering a preventive-health question.
+
+## When to Use
+
+Use this whenever a conversation needs grounded health context:
+
+- The user wants their CGM, sleep, vitals, or activity in the agent's context.
+- A lab PDF or image needs OCR plus clinical interpretation.
+- A meal photo needs macro analysis and glucose-spike prediction.
+- The user asks for a morning, afternoon, or evening health readout.
+- A 30-day metabolic snapshot (time-in-range, variability, dawn phenomenon) is useful.
+- A preventive-health or Traditional Chinese Medicine question needs evidence-graded answers with source citations.
+
+Do not use this skill for diagnosis or treatment decisions. Sally Skills returns clinical signals and reference ranges, not medical advice.
+
+## Prerequisites
+
+1. Install the A1C Insights iOS app: <https://apps.apple.com/id/app/a1c-insights/id6748399956>
+2. Create an account and sync at least one data source (Apple Health, a wearable, or a CGM).
+3. Sign in to the developer console at <https://console.a1c.io> with the same email.
+4. Open **API Keys**, click **Create new key**, copy the `sk-sally-…` value (shown only once).
+5. Top up the wallet at <https://console.a1c.io/billing> for paid skills. `health_sync` is free and needs no top-up.
+
+## How to Run
+
+Hermes auto-discovers MCP servers configured in `mcp.json`. Add Sally Skills:
+
+```json
+{
+  "mcpServers": {
+    "sally": {
+      "url": "https://sally.a1c.io/mcp",
+      "headers": {
+        "Authorization": "Bearer sk-sally-..."
+      }
+    }
+  }
+}
+```
+
+Restart Hermes. The six skills appear as first-class tools in every conversation.
+
+## Quick Reference
+
+| Tool | Cost / call | Returns |
+|---|---|---|
+| `health_sync` | FREE | 64+ daily biomarkers from wearables, CGM, sleep, vitals, activity, environment. |
+| `chat_with_sally` | $0.003 | Preventive-health and TCM Q&A with source citations. |
+| `analyze_lab_result` | $0.008 | Parsed lab panel (lipid, HbA1c, CBC, thyroid, hormone, micronutrient) with risk flags and ADA / ACC / ESC guideline context. |
+| `food_journal` | $0.004 | Meal photo to macros, glucose-spike prediction, Smart vs Trap categorisation. |
+| `health_insights` | $0.003 | Morning, afternoon, or evening readout from the user's last day. |
+| `metabolic_overview` | $0.005 | CGM time-in-range, glycemic variability, dawn phenomenon, postprandial response curves. |
+
+## Procedure
+
+A typical multi-skill conversation looks like:
+
+1. User: "How was my morning?"
+2. Hermes calls `health_insights` with `{ window: "morning" }`.
+3. Sally returns a structured readout (sleep score, HRV, resting heart rate, morning glucose, hydration, narrative).
+4. User: "What should I eat for breakfast?"
+5. Hermes calls `chat_with_sally` with the readout as context.
+6. Sally returns three TCM-aligned meal options with rationale and source citations.
+7. User photographs the chosen meal.
+8. Hermes calls `food_journal` with the inline image.
+9. Sally grades the meal and predicts the glucose spike based on the user's recent metabolic_overview.
+
+Chain length is bounded by the user's wallet; every `tools/call` decrements the balance per skill price.
+
+## Pitfalls
+
+- **Lab PDFs and meal photos are not persisted by Sally.** They flow agent to gateway to AI service to response, with no S3 or GCS upload. If your agent caches the request, that cache is the only copy.
+- **`metabolic_overview` requires an active CGM** paired in the A1C Insights app. Without one it returns `404 not_found` rather than synthesising glucose values.
+- **`402 payment_required`** is the wallet-empty signal. Surface a top-up link to <https://console.a1c.io/billing> instead of retrying.
+- **The bearer key is the identity.** Sally never accepts `user_uuid` or `email` in the request body. Sharing one key across multiple human users mixes their data; mint one key per agent or device instead.
+
+## Verification
+
+After configuring `mcp.json` and restarting Hermes, run:
+
+```bash
+hermes tools/list | grep ^sally
+```
+
+You should see six `sally.*` tools listed. To smoke-test the free skill from the terminal:
+
+```bash
+curl -sS https://sally.a1c.io/v1/call \
+  -H "Authorization: Bearer sk-sally-..." \
+  -H "Content-Type: application/json" \
+  -d '{"skill":"health_sync","input":{}}' | jq .ok
+# → true
+```
+
+A `true` response means the key resolves to your A1C account and `health_sync` is callable. Agents can now call the same skill via MCP.
+
+## Source
+
+- Public docs and protocol guides: <https://github.com/a1c-ai-agent/sally-skills>
+- Gateway source code: <https://github.com/Sally-A1C/ai-sally-skills>
+- Developer console: <https://console.a1c.io>
+- iOS app (identity source): <https://apps.apple.com/id/app/a1c-insights/id6748399956>
+- Contact: ai@sallya1c.com


### PR DESCRIPTION
## Type of Change

🎯 **New skill (optional)**

## Summary

Adds `optional-skills/health/sally-skills/SKILL.md`, a clinical-grade metabolic-health MCP integration for the Hermes Agent skills catalog. Tags: `Health`, `MCP`, `Integrations`.

[Sally Skills](https://github.com/a1c-ai-agent/sally-skills) is a metered Model Context Protocol server that exposes six skills behind a single bearer token, powered by the A1C Insights iOS app: `health_sync`, `chat_with_sally`, `analyze_lab_result`, `food_journal`, `health_insights`, `metabolic_overview`.

## Why Hermes needs a Health skill

Hermes already has excellent coverage of productivity, communication, browser automation, and developer tooling. What it does not yet have is **first-class access to a user's own physiology**.

That is a real gap. The moment a Hermes user asks "how was my morning?" or "what should I eat for breakfast?" or "interpret this lab PDF", the agent today either hallucinates (worst case) or shrugs (best case). Sally Skills closes that gap with one config block:

- A free `health_sync` call gives Hermes 64+ daily biomarkers from the user's wearables, CGM, sleep, vitals, activity, and environment as structured context. No bespoke OAuth flows per wearable vendor.
- `chat_with_sally` provides evidence-graded preventive-health and Traditional Chinese Medicine answers with source citations. Not RAG over a random PDF dump, but a curated medical corpus.
- `analyze_lab_result` does VLM OCR plus clinical interpretation of lab panels (lipid, HbA1c, CBC, thyroid, hormone, micronutrient) grounded in current ADA / ACC / ESC guidelines. The same task that today takes a user three Google searches and an Anthropic prompt.
- `food_journal` grades a meal photo with macros and predicted glucose spike, scored against the user's own metabolic baseline.
- `health_insights` returns morning, afternoon, and evening readouts as structured JSON, perfect for the kind of daily-briefing agents Hermes is well suited for.
- `metabolic_overview` returns a 30-day CGM snapshot with time-in-range, glycemic variability, dawn phenomenon, and postprandial response curves.

For agents that want to be *useful* to a user beyond email triage and shell commands, physiology is the underrated input channel. Sally turns that channel into six MCP tools.

## Implementation notes

- Single file, no source code, no new external dependencies. The skill connects via Hermes' native MCP client — `mcp_servers` in `~/.hermes/config.yaml`; `related_skills` resolves to `hermes-agent` (which hosts `references/native-mcp.md`) and `mcporter`.
- Frontmatter follows the optional-skills conventions (cf. `optional-skills/health/neuroskill-bci/SKILL.md`): name, description, version 1.0.0, MIT license, platforms list, hermes metadata block with category, homepage, and related_skills.
- Body follows the standard skill structure: title, intro, When to Use, Prerequisites, How to Run, Quick Reference, Procedure, Pitfalls, Verification, Source.
- Description is a factual one-liner with no marketing language ("Sally Skills MCP server: clinical health for agents.").

## For New Skills checklist

- [x] Placed in `optional-skills/health/` — official but metered third-party service, so not bundled (per CONTRIBUTING.md)
- [x] SKILL.md follows the standard format (mirrors `optional-skills/` peers like `neuroskill-bci` and `mcporter`)
- [x] No new external dependencies introduced into Hermes core (skill is a remote MCP endpoint)
- [x] Tested end-to-end against `https://sally.a1c.io/mcp` from Claude Code, Claude Desktop, Cursor, Codex, Windsurf, and Hermes' native MCP client. All six tools resolve and execute.

## How to test locally

```bash
# 1. Mint a key at https://console.a1c.io/keys (requires A1C Insights iOS app account first).
# 2. Install the optional skill:
hermes skills install official/health/sally-skills

# 3. Add the MCP server to ~/.hermes/config.yaml:
#      mcp_servers:
#        sally:
#          url: "https://sally.a1c.io/mcp"
#          headers:
#            Authorization: "Bearer sk-sally-..."

# 4. Restart Hermes and verify registration:
hermes tools list | grep mcp__sally
#    Expected: six mcp__sally__* tools (health_sync, chat_with_sally, analyze_lab_result,
#    food_journal, health_insights, metabolic_overview).

# 5. Confirm health_sync is callable with no wallet top-up:
#    in a chat, ask: "call health_sync with no arguments and summarise."
```

## Links

- Public docs: <https://github.com/a1c-ai-agent/sally-skills>
- Per-agent connection guides: <https://console.a1c.io/docs.html#mcp>
- Pricing and wallet model: <https://console.a1c.io/docs.html#wallet>
- iOS app (identity source): <https://apps.apple.com/id/app/a1c-insights/id6748399956>
- Contact: ai@sallya1c.com
