### PR TITLE
fix(webhook): suppress delivery when [SILENT] appears anywhere in response

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -238,6 +238,22 @@ class WebhookAdapter(BasePlatformAdapter):
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 
+        # Monitoring-style webhook subscriptions (e.g. Home Assistant alert
+        # triage, GitHub event filters) often need the same semantics as
+        # cron watchdogs: reason about every inbound event, but stay quiet
+        # when nothing warrants interrupting the user.  Suppress responses
+        # containing the [SILENT] sentinel before any cross-platform delivery.
+        # Matches the substring-in-uppercase check used in cron.scheduler so
+        # the agent can append [SILENT] anywhere in the response (or return
+        # the bare token) and stop delivery uniformly.
+        from cron.scheduler import SILENT_MARKER
+
+        if SILENT_MARKER in content.strip().upper():
+            logger.info(
+                "[webhook] Suppressed %s response for %s", SILENT_MARKER, chat_id
+            )
+            return SendResult(success=True)
+
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
             return SendResult(success=True)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -1032,3 +1032,88 @@ class TestInsecureNoAuthSafetyRail:
         finally:
             await adapter.disconnect()
 
+
+# ===================================================================
+# [SILENT] sentinel suppression
+# ===================================================================
+
+
+class TestSilentSentinelSuppression:
+    """``send()`` must drop responses carrying the [SILENT] sentinel.
+
+    Webhook subscriptions used for monitoring/triage (HA alerts, GitHub
+    event filters, etc.) follow the same "stay quiet unless noteworthy"
+    convention as cron watchdogs.  The cron scheduler suppresses delivery
+    when SILENT_MARKER is present anywhere in the agent's response; this
+    test class enforces the same behaviour for the webhook adapter so a
+    triage prompt that returns ``[SILENT]`` does not leak the literal
+    sentinel to Telegram / Discord / Slack / etc.
+    """
+
+    def _setup(self, deliver_type="telegram"):
+        adapter = _make_adapter()
+        chat_id = "webhook:triage:d-1"
+        adapter._delivery_info[chat_id] = {
+            "deliver": deliver_type,
+            "deliver_extra": {"chat_id": "12345"},
+            "payload": {"x": 1},
+        }
+        adapter._delivery_info_created[chat_id] = time.time()
+        mock_target = AsyncMock()
+        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_runner = MagicMock()
+        if deliver_type == "log":
+            mock_runner.adapters = {}
+        else:
+            mock_runner.adapters = {Platform(deliver_type): mock_target}
+        mock_runner.config.get_home_channel.return_value = None
+        adapter.gateway_runner = mock_runner
+        return adapter, chat_id, mock_target
+
+    @pytest.mark.asyncio
+    async def test_bare_silent_suppressed(self):
+        adapter, chat_id, mock_target = self._setup()
+        result = await adapter.send(chat_id, "[SILENT]")
+        assert result.success is True
+        mock_target.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_silent_with_trailing_explanation_suppressed(self):
+        """Agent may append [SILENT] after an explanation (cron behaviour)."""
+        adapter, chat_id, mock_target = self._setup()
+        result = await adapter.send(
+            chat_id, "Routine state change; nothing actionable.\n\n[SILENT]"
+        )
+        assert result.success is True
+        mock_target.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_silent_with_surrounding_whitespace_suppressed(self):
+        adapter, chat_id, mock_target = self._setup()
+        result = await adapter.send(chat_id, "  \n  [SILENT]\n  ")
+        assert result.success is True
+        mock_target.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_silent_response_still_delivers(self):
+        """A normal response must reach the cross-platform target."""
+        adapter, chat_id, mock_target = self._setup()
+        result = await adapter.send(chat_id, "Water leak detected in kitchen.")
+        assert result.success is True
+        mock_target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_silent_suppressed_even_with_deliver_log(self):
+        """Suppression runs before the deliver_type branch — log routes
+        also stay quiet so test webhooks do not litter the gateway log."""
+        adapter, chat_id, _ = self._setup(deliver_type="log")
+        with patch("gateway.platforms.webhook.logger") as mock_logger:
+            result = await adapter.send(chat_id, "[SILENT]")
+        assert result.success is True
+        # The "Suppressed" log line fires, the "Response for ..." one does not.
+        suppressed_logged = any(
+            "Suppressed" in str(c.args[0])
+            for c in mock_logger.info.call_args_list
+        )
+        assert suppressed_logged is True
+


### PR DESCRIPTION
## What

Suppress webhook responses that carry the `[SILENT]` sentinel before any cross-platform delivery, mirroring the existing cron behaviour.

## Why

Webhook subscriptions used for monitoring/triage (Home Assistant alert filters, GitHub event triage, etc.) follow the same "stay quiet unless noteworthy" convention as cron watchdogs. The cron scheduler already suppresses delivery when `SILENT_MARKER` is present anywhere in the agent's response (`cron/scheduler.py:1934`).

The webhook adapter had no equivalent suppression, so a triage prompt that returned `[SILENT]` would forward the literal sentinel to Telegram / Discord / Slack as a real message. Concretely I hit this configuring a Home Assistant alert-triage webhook: routine state-change events that the agent correctly classified `[SILENT]` were being delivered to my Telegram chat as the literal text `[SILENT]` instead of being dropped.

## How

`gateway/platforms/webhook.py` — at the top of `WebhookAdapter.send()`, check `SILENT_MARKER in content.strip().upper()` before dispatching to any delivery branch (log, github_comment, cross-platform). `SILENT_MARKER` is imported from `cron.scheduler` so the two stay in lockstep — there is already precedent for gateway -> cron imports (`gateway/run.py`, `gateway/platforms/api_server.py`).

## Tests

New `TestSilentSentinelSuppression` class in `tests/gateway/test_webhook_adapter.py` covering:

- bare `[SILENT]`
- `[SILENT]` after an explanation (matches cron's regression case from PR #5444)
- `[SILENT]` with surrounding whitespace / newlines
- non-`[SILENT]` responses still deliver via `gateway_runner`
- log-delivery routes also stay quiet (suppression runs first)

Local run on my fork:

```
$ pytest tests/gateway/test_webhook_adapter.py::TestSilentSentinelSuppression -x -q
.....                                                                    [100%]
5 passed in 0.46s

$ pytest tests/gateway/test_webhook_adapter.py -x -q
......................................................................   [100%]
70 passed in 0.76s
```

All 70 existing webhook adapter tests continue to pass.
