### PR TITLE
fix(disk-cleanup): restrict cron-output classification to output subtree

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -481,7 +481,12 @@ def guess_category(path: Path) -> Optional[str]:
         }:
             return None
         if top == "cron" or top == "cronjobs":
-            return "cron-output"
+            # Only the per-run artefact subtree is disposable. Top-level
+            # files like jobs.json (the durable scheduler registry) and
+            # .tick.lock must never be auto-tracked for cleanup.
+            if len(rel.parts) >= 2 and rel.parts[1] == "output":
+                return "cron-output"
+            return None
         if top == "cache":
             return "temp"
     except ValueError:

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -127,13 +127,41 @@ class TestGuessCategory:
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
-    def test_cron_subtree_categorised(self, _isolate_env):
+    def test_cron_output_subtree_categorised(self, _isolate_env):
+        dg = _load_lib()
+        run_dir = _isolate_env / "cron" / "output" / "job-123"
+        run_dir.mkdir(parents=True)
+        p = run_dir / "run.md"
+        p.write_text("x")
+        assert dg.guess_category(p) == "cron-output"
+
+    def test_cron_jobs_registry_not_categorised(self, _isolate_env):
+        """Regression: ~/.hermes/cron/jobs.json is the durable scheduler
+        registry and must never be auto-tracked as cleanup candidate."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        p = cron_dir / "jobs.json"
+        p.write_text("[]")
+        assert dg.guess_category(p) is None
+
+    def test_cron_tick_lock_not_categorised(self, _isolate_env):
+        """Regression: the scheduler's tick lock is control-plane state."""
+        dg = _load_lib()
+        cron_dir = _isolate_env / "cron"
+        cron_dir.mkdir()
+        p = cron_dir / ".tick.lock"
+        p.write_text("")
+        assert dg.guess_category(p) is None
+
+    def test_cron_top_level_file_not_categorised(self, _isolate_env):
+        """Any other top-level cron/ file should also be left alone."""
         dg = _load_lib()
         cron_dir = _isolate_env / "cron"
         cron_dir.mkdir()
         p = cron_dir / "job_output.md"
         p.write_text("x")
-        assert dg.guess_category(p) == "cron-output"
+        assert dg.guess_category(p) is None
 
     def test_ordinary_file_returns_none(self, _isolate_env):
         dg = _load_lib()


### PR DESCRIPTION
## Summary

Fixes #32164.

`plugins/disk-cleanup/disk_cleanup.py::guess_category()` classified every
file under `~/.hermes/cron/` as `"cron-output"`. The plugin's automatic
cleanup pass later deletes tracked `cron-output` entries older than 14
days, which means the durable scheduler registry
(`~/.hermes/cron/jobs.json`) and the tick lock (`~/.hermes/cron/.tick.lock`)
were eligible for deletion. When `jobs.json` was removed the scheduler
reported `0` jobs.

Only the per-run artefact subtree `cron/output/{job_id}/*.md` is
disposable (see `cron/jobs.py:5`). This change limits the `cron-output`
category to that subtree and leaves top-level `cron/` control-plane files
untracked.

## Changes

- `plugins/disk-cleanup/disk_cleanup.py` — `guess_category()` now requires
  `rel.parts[1] == "output"` before returning `"cron-output"`; other
  top-level `cron/` paths return `None`.
- `tests/plugins/test_disk_cleanup_plugin.py` — replaced the broad
  `test_cron_subtree_categorised` with four explicit cases.

## Test plan

- [x] `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py` — 41 passed
- [x] New regression cases:
  - `cron/output/<job>/run.md` → `"cron-output"`
  - `cron/jobs.json` → `None`
  - `cron/.tick.lock` → `None`
  - `cron/<any-other-top-level>` → `None`