### PR TITLE
fix: persist subagent cost to state DB after rollup

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2298,6 +2298,28 @@ def delegate_task(
         except Exception:
             logger.debug("Subagent cost rollup failed", exc_info=True)
 
+        # Persist the subagent cost delta to the state DB so
+        # hermes insights and the sessions.estimated_cost_usd
+        # column stay accurate.  update_token_counts() uses
+        # additive mode (COALESCE + delta), so this correctly
+        # accumulates on top of the parent's own API call costs
+        # that are already in the DB from conversation_loop.py.
+        # Port of Kilo-Org/kilocode#9448 + follow-up fix for
+        # NousResearch/hermes-agent#32220.
+        try:
+            _session_db = getattr(parent_agent, "_session_db", None)
+            if _session_db is not None:
+                _session_db.update_token_counts(
+                    parent_agent.session_id,
+                    estimated_cost_usd=float(_children_cost_total),
+                    cost_status="estimated",
+                    cost_source="subagent",
+                )
+        except Exception:
+            logger.debug(
+                "Subagent cost DB persistence failed", exc_info=True
+            )
+
     total_duration = round(time.monotonic() - overall_start, 2)
 
     return json.dumps(


### PR DESCRIPTION
## Summary

`delegate_task` rolls up subagent costs into the parent agent's in-memory `session_estimated_cost_usd`, but those costs were never flushed to the state DB. This meant the live cost footer was correct, but `hermes insights` and the `sessions.estimated_cost_usd` column permanently undercounted costs in proportion to subagent usage (observed gap: $12.20 vs $3.37 on a subagent-heavy day).

## Fix

After the in-memory rollup in `delegate_tool.py`, persist the subagent cost delta to the state DB via `update_token_counts()`. Since `update_token_counts()` uses additive mode (`COALESCE + delta`), this correctly accumulates on top of the parent's own API call costs already in the DB.

Nested orchestrator→worker→worker trees work naturally: each layer adds its children's costs, and when the orchestrator is rolled up by its parent, the cascading additive deltas produce the correct total.

## Files Changed

- `tools/delegate_tool.py`: Added `update_token_counts()` call after in-memory rollup (~20 lines)

## Verification

- [x] Python syntax check passed
- [x] Graceful degradation if `_session_db` is None (test fixtures, ACP sessions)
- [x] Additive DB semantics preserve nested delegation cost totals

Closes #32220