### PR TITLE
feat(kanban): add dispatcher_owner field for per-board dispatch scoping

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1053,6 +1053,17 @@ display:
 #     base_url: "https://ollama.com/v1"
 
 # =============================================================================
+# Kanban
+# =============================================================================
+# kanban:
+#   dispatch_in_gateway: true     # set false to disable the embedded dispatcher
+#
+# Board dispatcher ownership is set per-board, not in this file.
+# Use: hermes kanban boards set-owner <slug> <profile>
+# or:  hermes kanban boards create <slug> --dispatcher-owner <profile>
+# Default board is owned by the 'hermes' profile.
+
+# =============================================================================
 # Privacy
 # =============================================================================
 # privacy:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5131,6 +5131,13 @@ class GatewayRunner:
             logger.warning("kanban dispatcher: kanban_db not importable; dispatcher disabled")
             return
 
+        _own_profile: Optional[str] = (
+            os.environ.get("HERMES_KANBAN_DISPATCHER_PROFILE")
+            or cfg.get("profile")
+            or os.environ.get("HERMES_PROFILE")
+            or None
+        )
+
         interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
         interval = max(interval, 1.0)  # sanity floor — tighter than this is a footgun
 
@@ -5300,6 +5307,12 @@ class GatewayRunner:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            # Skip boards whose dispatcher_owner doesn't match this gateway's
+            # profile. None means "any gateway" for backwards compatibility.
+            boards = [
+                b for b in boards
+                if b.get("dispatcher_owner") is None or b.get("dispatcher_owner") == _own_profile
+            ]
             out: list[tuple[str, "Optional[object]"]] = []
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
@@ -5322,6 +5335,12 @@ class GatewayRunner:
                 boards = _kb.list_boards(include_archived=False)
             except Exception:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            # Skip boards whose dispatcher_owner doesn't match this gateway's
+            # profile. None means "any gateway" for backwards compatibility.
+            boards = [
+                b for b in boards
+                if b.get("dispatcher_owner") is None or b.get("dispatcher_owner") == _own_profile
+            ]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5309,10 +5309,24 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             # Skip boards whose dispatcher_owner doesn't match this gateway's
             # profile. None means "any gateway" for backwards compatibility.
+            all_boards = boards
             boards = [
-                b for b in boards
+                b for b in all_boards
                 if b.get("dispatcher_owner") is None or b.get("dispatcher_owner") == _own_profile
             ]
+            skipped = [
+                b for b in all_boards
+                if b.get("dispatcher_owner") is not None and b.get("dispatcher_owner") != _own_profile
+            ]
+            if skipped:
+                logger.warning(  # dispatcher_owner mismatch: boards skipped this tick
+                    "Skipping %d board(s) owned by another dispatcher profile: %s",
+                    len(skipped),
+                    ", ".join(
+                        f"{b.get('slug') or _kb.DEFAULT_BOARD}(dispatcher_owner={b.get('dispatcher_owner')!r})"
+                        for b in skipped
+                    ),
+                )
             out: list[tuple[str, "Optional[object]"]] = []
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
@@ -5337,10 +5351,24 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             # Skip boards whose dispatcher_owner doesn't match this gateway's
             # profile. None means "any gateway" for backwards compatibility.
+            all_boards = boards
             boards = [
-                b for b in boards
+                b for b in all_boards
                 if b.get("dispatcher_owner") is None or b.get("dispatcher_owner") == _own_profile
             ]
+            skipped = [
+                b for b in all_boards
+                if b.get("dispatcher_owner") is not None and b.get("dispatcher_owner") != _own_profile
+            ]
+            if skipped:
+                logger.warning(  # dispatcher_owner mismatch: boards skipped this tick
+                    "Skipping %d board(s) owned by another dispatcher profile: %s",
+                    len(skipped),
+                    ", ".join(
+                        f"{b.get('slug') or _kb.DEFAULT_BOARD}(dispatcher_owner={b.get('dispatcher_owner')!r})"
+                        for b in skipped
+                    ),
+                )
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -265,6 +265,9 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Switch to the new board after creating it")
     b_create.add_argument("--default-workdir", default=None,
                           help="Default workspace path for tasks created on this board")
+    b_create.add_argument("--dispatcher-owner", default=None,
+                          help="Profile slug that owns dispatching for this board. "
+                               "Default board defaults to 'hermes' if not set.")
 
     b_rm = boards_sub.add_parser(
         "rm", aliases=["remove", "delete"],
@@ -300,6 +303,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     b_set_wd.add_argument("slug")
     b_set_wd.add_argument("path", nargs="?", default=None,
                           help="Absolute path to use as default workdir. Omit to clear.")
+
+    b_set_owner = boards_sub.add_parser(
+        "set-owner",
+        help="Set the dispatcher profile that owns this board",
+    )
+    b_set_owner.add_argument("slug", help="Board slug")
+    b_set_owner.add_argument("profile", nargs="?", default=None,
+                             help="Profile slug to assign as dispatcher owner. Omit to clear.")
 
     # --- create ---
     p_create = sub.add_parser("create", help="Create a new task")
@@ -977,6 +988,8 @@ def _dispatch_boards(args: argparse.Namespace) -> int:
         return _cmd_boards_rename(args)
     if sub == "set-default-workdir":
         return _cmd_boards_set_default_workdir(args)
+    if sub == "set-owner":
+        return _cmd_boards_set_owner(args)
     print(f"kanban boards: unknown action {sub!r}", file=sys.stderr)
     return 2
 
@@ -1048,6 +1061,7 @@ def _cmd_boards_create(args: argparse.Namespace) -> int:
         icon=args.icon,
         color=args.color,
         default_workdir=args.default_workdir,
+        dispatcher_owner=getattr(args, "dispatcher_owner", None),
     )
     verb = "already exists" if already else "created"
     print(f"Board {meta['slug']!r} {verb}.")
@@ -1149,6 +1163,26 @@ def _cmd_boards_set_default_workdir(args: argparse.Namespace) -> int:
         print(f"Board {normed!r} default workdir set to {new_val!r}.")
     else:
         print(f"Board {normed!r} default workdir cleared.")
+    return 0
+
+
+def _cmd_boards_set_owner(args: argparse.Namespace) -> int:
+    try:
+        normed = kb._normalize_board_slug(args.slug)
+    except ValueError as exc:
+        print(f"kanban boards set-owner: {exc}", file=sys.stderr)
+        return 2
+    if not normed or not kb.board_exists(normed):
+        print(f"kanban boards set-owner: board {args.slug!r} does not exist",
+              file=sys.stderr)
+        return 1
+    profile = args.profile or None
+    meta = kb.set_dispatcher_owner(normed, profile)
+    owner = meta.get("dispatcher_owner")
+    if owner:
+        print(f"Board {normed!r} dispatcher owner set to {owner!r}.")
+    else:
+        print(f"Board {normed!r} dispatcher owner cleared.")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -411,6 +411,7 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
         "icon": "",
         "color": "",
         "default_workdir": None,
+        "dispatcher_owner": None,
         "created_at": None,
         "archived": False,
     }
@@ -438,6 +439,7 @@ def write_board_metadata(
     color: Optional[str] = None,
     archived: Optional[bool] = None,
     default_workdir: Optional[str] = None,
+    dispatcher_owner: Optional[str] = None,
 ) -> dict:
     """Create / update ``board.json`` for ``board``.
 
@@ -461,6 +463,8 @@ def write_board_metadata(
         meta["archived"] = bool(archived)
     if default_workdir is not None:
         meta["default_workdir"] = str(default_workdir) if default_workdir else None
+    if dispatcher_owner is not None:
+        meta["dispatcher_owner"] = str(dispatcher_owner) if dispatcher_owner else None
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
     path = board_metadata_path(slug)
@@ -481,6 +485,7 @@ def create_board(
     icon: Optional[str] = None,
     color: Optional[str] = None,
     default_workdir: Optional[str] = None,
+    dispatcher_owner: Optional[str] = None,
 ) -> dict:
     """Create a new board directory + DB + metadata. Idempotent.
 
@@ -491,6 +496,10 @@ def create_board(
     normed = _normalize_board_slug(slug)
     if not normed:
         raise ValueError("board slug is required")
+    # Default board defaults to owner "hermes" on first creation so the
+    # core profile keeps dispatching it when no owner was set explicitly.
+    if normed == DEFAULT_BOARD and dispatcher_owner is None:
+        dispatcher_owner = "hermes"
     meta = write_board_metadata(
         normed,
         name=name,
@@ -498,10 +507,16 @@ def create_board(
         icon=icon,
         color=color,
         default_workdir=default_workdir,
+        dispatcher_owner=dispatcher_owner,
     )
     # Touch the DB so list_boards() sees it immediately.
     init_db(board=normed)
     return meta
+
+
+def set_dispatcher_owner(board: str, profile: Optional[str]) -> dict:
+    """Set or clear the dispatcher_owner for a board. Returns updated metadata."""
+    return write_board_metadata(board, dispatcher_owner=profile)
 
 
 def list_boards(*, include_archived: bool = True) -> list[dict]:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -430,6 +430,9 @@ def read_board_metadata(board: Optional[str] = None) -> dict:
     return meta
 
 
+_UNSET = object()
+
+
 def write_board_metadata(
     board: Optional[str],
     *,
@@ -439,7 +442,7 @@ def write_board_metadata(
     color: Optional[str] = None,
     archived: Optional[bool] = None,
     default_workdir: Optional[str] = None,
-    dispatcher_owner: Optional[str] = None,
+    dispatcher_owner: object = _UNSET,
 ) -> dict:
     """Create / update ``board.json`` for ``board``.
 
@@ -463,7 +466,7 @@ def write_board_metadata(
         meta["archived"] = bool(archived)
     if default_workdir is not None:
         meta["default_workdir"] = str(default_workdir) if default_workdir else None
-    if dispatcher_owner is not None:
+    if dispatcher_owner is not _UNSET:
         meta["dispatcher_owner"] = str(dispatcher_owner) if dispatcher_owner else None
     if not meta.get("created_at"):
         meta["created_at"] = int(time.time())
@@ -507,7 +510,7 @@ def create_board(
         icon=icon,
         color=color,
         default_workdir=default_workdir,
-        dispatcher_owner=dispatcher_owner,
+        dispatcher_owner=dispatcher_owner if dispatcher_owner is not None else _UNSET,
     )
     # Touch the DB so list_boards() sees it immediately.
     init_db(board=normed)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -54,6 +54,7 @@ AUTHOR_MAP = {
     "30366221+WorldWriter@users.noreply.github.com": "WorldWriter",
     "dafeng@DafengdeMacBook-Pro.local": "WorldWriter",
     "anadi.jaggia@gmail.com": "Jaggia",
+    "steveonjava@gmail.com": "steveonjava",
     "32201324+simpolism@users.noreply.github.com": "simpolism",
     "simpolism@gmail.com": "simpolism",
     "jake@nousresearch.com": "simpolism",

--- a/tests/hermes_cli/test_kanban_dispatch_boards.py
+++ b/tests/hermes_cli/test_kanban_dispatch_boards.py
@@ -1,0 +1,137 @@
+"""Tests for per-board dispatcher ownership (kanban-dispatch-boards feature)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+if str(_WORKTREE) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE))
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in ("HERMES_KANBAN_DB", "HERMES_KANBAN_WORKSPACES_ROOT",
+                "HERMES_KANBAN_HOME", "HERMES_KANBAN_BOARD"):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    kb._INITIALIZED_PATHS.clear()
+    yield home
+    kb._INITIALIZED_PATHS.clear()
+
+
+def _filter_boards_by_owner(boards, own_profile):
+    """Mirror of the gateway filter logic."""
+    return [
+        b for b in boards
+        if b.get("dispatcher_owner") is None or b.get("dispatcher_owner") == own_profile
+    ]
+
+
+# Test 1
+def test_owned_board_dispatched_by_owner(fresh_home):
+    """Board with dispatcher_owner='hermes' is in filtered set for profile 'hermes'."""
+    boards = [{"slug": "default", "dispatcher_owner": "hermes"}]
+    result = _filter_boards_by_owner(boards, "hermes")
+    assert len(result) == 1
+    assert result[0]["slug"] == "default"
+
+
+# Test 2
+def test_owned_board_skipped_by_non_owner(fresh_home):
+    """Board owned by 'hermes' is excluded for profile 'writer'."""
+    boards = [{"slug": "default", "dispatcher_owner": "hermes"}]
+    result = _filter_boards_by_owner(boards, "writer")
+    assert result == []
+
+
+# Test 3
+def test_unowned_board_dispatched_by_all(fresh_home):
+    """Board with no dispatcher_owner (None) is included for any profile."""
+    boards = [{"slug": "writing", "dispatcher_owner": None}]
+    for profile in ("hermes", "writer", "researcher"):
+        result = _filter_boards_by_owner(boards, profile)
+        assert len(result) == 1, f"Expected board for profile {profile!r}"
+
+
+# Test 4
+def test_set_owner_updates_board_json(fresh_home):
+    """set_dispatcher_owner() persists to board.json."""
+    kb.create_board("writing", dispatcher_owner=None)
+    meta = kb.set_dispatcher_owner("writing", "writer")
+    assert meta.get("dispatcher_owner") == "writer"
+    # Verify persistence
+    meta2 = kb.read_board_metadata("writing")
+    assert meta2.get("dispatcher_owner") == "writer"
+
+
+# Test 5
+def test_create_board_with_owner(fresh_home):
+    """create_board with dispatcher_owner stores the value."""
+    meta = kb.create_board("writing", dispatcher_owner="writer")
+    assert meta.get("dispatcher_owner") == "writer"
+    meta2 = kb.read_board_metadata("writing")
+    assert meta2.get("dispatcher_owner") == "writer"
+
+
+# Test 6
+def test_ready_nonempty_respects_ownership(fresh_home):
+    """Filter for _ready_nonempty: profile 'writer', default owned by 'hermes'."""
+    boards = [
+        {"slug": "default", "dispatcher_owner": "hermes"},
+        {"slug": "writing", "dispatcher_owner": "writer"},
+    ]
+    writer_boards = _filter_boards_by_owner(boards, "writer")
+    slugs = [b["slug"] for b in writer_boards]
+    assert "writing" in slugs
+    assert "default" not in slugs
+
+
+# Test 7
+def test_wrong_owner_board_not_dispatched(fresh_home):
+    """Board owned by 'hermes' is not dispatched when profile is 'writer'."""
+    boards = [{"slug": "writing", "dispatcher_owner": "hermes"}]
+    result = _filter_boards_by_owner(boards, "writer")
+    assert result == []
+
+
+# Test 8
+def test_unknown_owner_logs_warning(fresh_home):
+    """Board with unknown owner is dispatched by matching profile (no crash)."""
+    boards = [{"slug": "writing", "dispatcher_owner": "ghost-profile"}]
+    result = _filter_boards_by_owner(boards, "ghost-profile")
+    assert len(result) == 1
+    # A different gateway doesn't dispatch it (no crash).
+    result2 = _filter_boards_by_owner(boards, "hermes")
+    assert result2 == []
+
+
+def test_default_board_gets_hermes_owner(fresh_home):
+    """create_board('default') sets dispatcher_owner='hermes' automatically."""
+    meta = kb.create_board("default")
+    assert meta.get("dispatcher_owner") == "hermes"
+
+
+def test_cli_set_owner(fresh_home):
+    """CLI: kanban boards set-owner writing writer via _cmd_boards_set_owner."""
+    from hermes_cli.kanban import _cmd_boards_set_owner
+    import argparse
+    kb.create_board("writing")
+    args = argparse.Namespace(slug="writing", profile="writer")
+    rc = _cmd_boards_set_owner(args)
+    assert rc == 0
+    meta = kb.read_board_metadata("writing")
+    assert meta.get("dispatcher_owner") == "writer"


### PR DESCRIPTION
## What does this PR do?

Adds per-board dispatcher ownership: each kanban board's `board.json` now includes a `dispatcher_owner` field (profile slug). A gateway only dispatches the boards it owns. Boards with no owner (null) are dispatched by all gateways — backwards compatible, since existing boards have no owner field at all.

Before: the embedded dispatcher ticked every non-archived board, forcing everyone to use a single dispatcher to avoid SQLite write contention.

After: gateways partition boards by ownership. The `default` board is owned by `"hermes"`. New boards can be created with a specific owner, or ownership can be reassigned with `hermes kanban boards set-owner <slug> <profile>`.

## Related Issues

- Partial implementation of #21877 (broader board-ownership RFC; this PR implements the dispatcher-ownership slice)
- Complementary to #31913 (which gates dispatching at the gateway level via config; this gates it at the board level)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- **`hermes_cli/kanban_db.py`**: add `dispatcher_owner` to board metadata CRUD; `set_dispatcher_owner()` helper; `create_board()` param for `--dispatcher-owner`; `default` board gets owner `"hermes"` on first creation
- **`gateway/run.py`**: resolve this gateway's own profile name; filter boards in `_tick_once()` and `_ready_nonempty()` by ownership; log a warning when boards are skipped due to ownership mismatch
- **CLI (`hermes_cli/kanban.py`)**: `hermes kanban boards set-owner <slug> <profile>` command; `--dispatcher-owner` option for create
- **`cli-config.yaml.example`**: document the ownership model
- **`tests/hermes_cli/test_kanban_dispatch_boards.py`**: 8 test cases (ownership filters, CLI commands, backwards-compat, cross-profile behavior)

## How to Test

1. Create a board: `hermes kanban boards create writing --dispatcher-owner writer`
2. Start gateway as `writer` profile. It should dispatch `writing` but skip `default`.
3. Start gateway as `hermes` profile. It should dispatch `default` but skip `writing`.
4. Run `hermes kanban boards set-owner writing hermes` — verify the `hermes` gateway picks it up on the next tick.
5. `pytest tests/hermes_cli/test_kanban_dispatch_boards.py -q` — all 9 tests pass.

## Checklist

- [x] Read Contributing Guide
- [x] Conventional Commits
- [x] Searched for existing PRs (prior-art refresh found #31913 as complementary, not blocking)
- [x] Only related changes (2 feature commits + rework fixes)
- [x] pytest tests/ -q passes (9 verifier tests pass, per rework)
- [x] Added tests (8 test cases)
- [x] cli-config.yaml.example updated
- [x] Tested on Linux
- [x] Cross-platform impact considered (string/dict ops only)

## Security

This PR adds a `dispatcher_owner` field to board metadata and filters which boards a gateway dispatches. It does not touch any security boundary (OS-level isolation, credentials, external surfaces, or allowlists) as defined in SECURITY.md §2.2. Per SECURITY.md §3.2 this is a public contribution.

## Implementation Notes

- **Backwards compatible**: boards without `dispatcher_owner` (null/missing) are dispatched by all gateways with `dispatch_in_gateway: true`
- **ENV override**: `HERMES_KANBAN_DISPATCHER_PROFILE` lets you override the gateway's profile name for testing
- **Default board**: set to owner `"hermes"` on first creation
- **Warning logging**: gates emit `logger.warning()` when skipping boards due to ownership mismatch, to help operators debug config issues