### PR TITLE
fix(url_safety): allow DNS failure when allow_private_urls=true

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -406,11 +406,31 @@ class TestAllowPrivateUrlsIntegration:
         ]):
             assert is_safe_url("http://169.254.42.99/anything") is False
 
-    def test_dns_failure_still_blocked_with_toggle(self, monkeypatch):
-        """DNS failures are still blocked even with toggle on."""
+    def test_dns_failure_allowed_when_toggle_on(self, monkeypatch):
+        """DNS failures pass when toggle is on (#32217).
+
+        Sandboxed environments such as NVIDIA OpenShell intentionally block
+        direct DNS (``socket.getaddrinfo``) while routing every HTTP request
+        through a proxy that does its own resolution. When the user has
+        explicitly opted out of SSRF protection, fail-closed on
+        ``gaierror`` would block every web tool call even though the proxy
+        could legitimately reach the host.
+        """
         monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("fail")):
-            assert is_safe_url("https://nonexistent.example.com") is False
+            assert is_safe_url("https://news.ycombinator.com") is True
+
+    def test_dns_failure_metadata_hostname_blocked_even_with_toggle(self, monkeypatch):
+        """metadata.google.internal stays blocked under DNS failure + toggle.
+
+        The always-blocked hostname check fires before DNS resolution, so
+        opening the gaierror exit when the toggle is on cannot be turned
+        into a metadata-endpoint bypass.
+        """
+        monkeypatch.setenv("HERMES_ALLOW_PRIVATE_URLS", "true")
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("fail")):
+            assert is_safe_url("http://metadata.google.internal/") is False
+            assert is_safe_url("http://metadata.goog/") is False
 
     def test_empty_url_still_blocked_with_toggle(self, monkeypatch):
         """Empty URLs are still blocked."""

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -304,8 +304,24 @@ def is_safe_url(url: str) -> bool:
         try:
             addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
         except socket.gaierror:
-            # DNS resolution failed — fail closed. If DNS can't resolve it,
-            # the HTTP client will also fail, so blocking loses nothing.
+            # DNS resolution failed. Default is fail-closed: if DNS can't
+            # resolve, the HTTP client typically can't reach the host either.
+            #
+            # Exception: when the user has explicitly opted out of SSRF
+            # protection (``security.allow_private_urls: true``), allow the
+            # request through. This unblocks sandboxed environments
+            # (NVIDIA OpenShell, corporate proxies, some VPNs) where direct
+            # DNS is intentionally disabled by network policy but ALL HTTP
+            # egress flows through a proxy that resolves names itself.
+            # Always-blocked hostnames (``metadata.google.internal``, etc.)
+            # were already caught above and still block here.
+            if allow_all_private:
+                logger.debug(
+                    "Allowing DNS-unresolvable hostname "
+                    "(security.allow_private_urls=true): %s",
+                    hostname,
+                )
+                return True
             logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
             return False
 


### PR DESCRIPTION
## What does this PR do?

`tools/url_safety.is_safe_url()` runs `socket.getaddrinfo()` pre-flight on every URL and fails closed when the lookup raises `gaierror`. That's the right default, but it makes proxy-only sandbox environments unusable — NVIDIA OpenShell, some corporate proxies, and a few VPNs intentionally block direct DNS and require all HTTP egress to flow through a proxy that resolves names itself. In those environments every `web_search` / `web_extract` / vision-URL call was blocked with `"Blocked: URL targets a private or internal network address"`, even with `security.allow_private_urls: true` (or `HERMES_ALLOW_PRIVATE_URLS=true`) explicitly set.

When the user has opted out of private-IP blocking, treat `gaierror` as non-blocking: the downstream HTTP client (typically through `HTTPS_PROXY`) will perform its own resolution. The fail-closed default for the no-toggle case is unchanged.

The always-blocked hostname check (`metadata.google.internal`, `metadata.goog`) runs above the DNS step and already returns False before this branch is reached, so the new branch cannot be turned into a metadata-endpoint bypass. A regression test pins that invariant.

## Related Issue

Fixes #32217

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/url_safety.py` — `is_safe_url()` `gaierror` branch now returns True when `allow_all_private` is set, with a debug log explaining the bypass. Default fail-closed path is preserved when the toggle is off.
- `tests/tools/test_url_safety.py` — replaces `test_dns_failure_still_blocked_with_toggle` (which asserted the old behavior) with `test_dns_failure_allowed_when_toggle_on`, and adds `test_dns_failure_metadata_hostname_blocked_even_with_toggle` to assert the always-blocked floor still fires when DNS fails and the toggle is on.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_url_safety.py -v` — 113 cases pass, including the two new ones.
2. Manual reproduction in a sandbox with no direct DNS but a working proxy:
   ```
   HERMES_ALLOW_PRIVATE_URLS=true hermes -z "Use web_extract on https://example.com"
   ```
   Before this PR: blocked with `"URL targets a private or internal network address"` because `getaddrinfo` failed first. After this PR: the request reaches Firecrawl/Tavily through the proxy and returns content.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline docstring on the new branch covers the rationale)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; the existing `security.allow_private_urls` is unchanged)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

> Audited siblings: `is_always_blocked_url()` in the same module already treats `gaierror` as non-always-blocked (returns False on the same line range) and does not need parallel widening — its semantics are "is this URL in the cloud-metadata sentinel set" which doesn't depend on whether the user has opted out. The pre-flight callers (`tools/web/*`, `tools/vision/*`, `gateway/platforms/*` media fetch, redirect re-validation hooks) all consume `is_safe_url()`'s True/False directly, so the fix propagates through without per-call-site changes. No widening needed.

## Screenshots / Logs

Stack trace from #32217 (before fix), included for review:

```text
"error": "Blocked: URL targets a private or internal network address"
```

Debug log line on the new branch (after fix, with `allow_private_urls=true`):

```text
DEBUG: Allowing DNS-unresolvable hostname (security.allow_private_urls=true): news.ycombinator.com
```