### PR TITLE
fix(skills): use atomic_json_write for LockFile and TapsManager

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -27,6 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
 from agent.skill_utils import is_excluded_skill_path
+from utils import atomic_json_write
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse, urlunparse
 
@@ -2836,8 +2837,7 @@ class HubLockFile:
             return {"version": 1, "installed": {}}
 
     def save(self, data: dict) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        atomic_json_write(self.path, data)
 
     def record_install(
         self,
@@ -2909,8 +2909,7 @@ class TapsManager:
             return []
 
     def save(self, taps: List[dict]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
+        atomic_json_write(self.path, {"taps": taps})
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""


### PR DESCRIPTION
**What does this PR do?**
`LockFile.save()` and `TapsManager.save()` write `lock.json` and `taps.json` using `write_text()`, which is non-atomic. If the process is killed or crashes mid-write (e.g. OOM, SIGKILL, power loss), the target file is left partially written and JSON-corrupt. On the next run `load()` falls back to an empty default — silently discarding all installed-skill records or all custom taps.

Switches both methods to `atomic_json_write` from `utils`, which writes to a temp file, fsyncs, then `os.replace`s — guaranteeing the old file survives intact if the write doesn't complete.

**Type of Change**
- [x] Bug fix

**Changes Made**
- `tools/skills_hub.py`: replace `write_text` with `atomic_json_write` in `LockFile.save()` and `TapsManager.save()`

**How to Test**
1. Add a skill tap: `hermes skills hub tap some/repo`
2. Kill -9 the process during the write
3. Confirm `taps.json` is not corrupted on next read
4. Same for `hermes skills install` → kill → re-run `hermes skills list`

**Checklist**
- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs to avoid duplicates
- [x] PR contains only changes related to this fix
- [x] Tested on: Ubuntu 24.04 (WSL2)
- [x] No documentation changes needed
