### PR TITLE
fix(tts): prevent double [pause] in xAI auto speech tags (#29417)

### DIFF
--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -25,6 +25,53 @@ def test_apply_xai_auto_speech_tags_preserves_all_documented_xai_tags():
     assert _apply_xai_auto_speech_tags(text) == text
 
 
+def test_apply_xai_auto_speech_tags_multi_paragraph_emits_single_pause():
+    """Regression for #29417 — multi-paragraph input doubled the pause.
+
+    Pre-fix the paragraph substitution injected ``[pause]`` between
+    paragraphs, then the unconditional first-sentence substitution
+    added another one right after, producing ``[pause] [pause]`` in
+    the audio.  The fix re-checks the tag-detection guard after the
+    paragraph pass.
+
+    Requires a first sentence of 12+ chars to hit the
+    ``_XAI_FIRST_SENTENCE_RE`` length floor — the trivial
+    ``"Hello.\\n\\nWorld."`` case dodged the bug by accident.
+    """
+    text = "Welcome to the demo of our new product line.\n\nIt has many features."
+    result = _apply_xai_auto_speech_tags(text)
+
+    # Exactly one [pause] between the paragraphs, not two.
+    assert result.count("[pause]") == 1, (
+        f"expected single [pause], got {result.count('[pause]')} in {result!r}"
+    )
+    assert result == (
+        "Welcome to the demo of our new product line. [pause] It has many features."
+    )
+
+
+def test_apply_xai_auto_speech_tags_single_paragraph_still_gets_first_sentence_pause():
+    """Sanity guard — the fix only suppresses the first-sentence pass when
+    a paragraph pass already injected ``[pause]``.  Single-paragraph input
+    must still get its first-sentence pause.
+    """
+    text = "Welcome to the demo of our new product line. It has many features."
+    assert _apply_xai_auto_speech_tags(text) == (
+        "Welcome to the demo of our new product line. [pause] It has many features."
+    )
+
+
+def test_apply_xai_auto_speech_tags_single_newline_still_gets_first_sentence_pause():
+    """A single newline isn't a paragraph break — no ``[pause]`` injected by
+    the paragraph pass, so the first-sentence pause MUST still fire.
+    Guards against the fix being too greedy.
+    """
+    text = "Welcome to the demo of our new product line.\nIt has many features."
+    assert _apply_xai_auto_speech_tags(text) == (
+        "Welcome to the demo of our new product line. [pause] It has many features."
+    )
+
+
 def test_generate_xai_tts_sends_auto_speech_tags_when_enabled(tmp_path, monkeypatch):
     captured = {}
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1078,7 +1078,8 @@ def _apply_xai_auto_speech_tags(text: str) -> str:
 
     clean = re.sub(r"\n\s*\n+", " [pause] ", clean)
     clean = re.sub(r"\s*\n\s*", " ", clean)
-    clean = _XAI_FIRST_SENTENCE_RE.sub(r"\1 [pause] ", clean, count=1)
+    if not _XAI_SPEECH_TAG_RE.search(clean):
+        clean = _XAI_FIRST_SENTENCE_RE.sub(r"\1 [pause] ", clean, count=1)
     clean = re.sub(r"\s{2,}", " ", clean).strip()
     return clean
 


### PR DESCRIPTION
## Summary

Multi-paragraph xAI TTS input no longer produces a double `[pause]` in the audio.

Salvages PR #29417 (@EloquentBrush0x) + adds regression coverage.

## Root cause

`_apply_xai_auto_speech_tags` ran two pause-insertion passes unconditionally:

1. Paragraph breaks (`\n\n`) → `" [pause] "`
2. First-sentence boundary → `" [pause] "`

The tag-detection guard at the top of the function only checked the *original* input. After step 1 injected `[pause]`, step 2 fired again on the now-mutated text, producing `"...sentence. [pause] [pause] Next paragraph..."`.

## Fix

Re-check the tag guard after the paragraph pass. If `[pause]` was already injected, skip the first-sentence substitution.

```python
clean = re.sub(r"\n\s*\n+", " [pause] ", clean)
clean = re.sub(r"\s*\n\s*", " ", clean)
if not _XAI_SPEECH_TAG_RE.search(clean):   # ← new guard
    clean = _XAI_FIRST_SENTENCE_RE.sub(r"\1 [pause] ", clean, count=1)
```

## Repro caveat

The PR's quoted repro (`"Hello world.\n\nSecond paragraph."`) doesn't actually trip the bug — `_XAI_FIRST_SENTENCE_RE` has a 12-char length floor (`r"^(.{12,120}?[.!?…])\s+(?=\S)"`) and `"Hello world."` is exactly 12 chars total, so the regex can't satisfy the `[.!?…]` terminator after `.{12}`. The bug is real but needs a first sentence with at least one character beyond the terminator. Test added below uses `"Welcome to the demo of our new product line.\n\nIt has many features."` which DOES reproduce.

## Validation

3 new tests in `tests/tools/test_tts_xai_speech_tags.py`:

| Test | Guards against |
|---|---|
| `multi_paragraph_emits_single_pause` | The bug returning |
| `single_paragraph_still_gets_first_sentence_pause` | The fix being too aggressive (no `[pause]` from paragraph pass → first-sentence must still fire) |
| `single_newline_still_gets_first_sentence_pause` | Confusing `\n` with `\n\n` |

```
scripts/run_tests.sh tests/tools/test_tts_xai_speech_tags.py
=== 8 tests passed, 0 failed in 0.4s ===
```

## Credit

@EloquentBrush0x did the diagnosis and shipped the one-line fix. Follow-up is just the regression tests (their PR included a "test plan" checklist but no test code).