### PR TITLE
fix(security): extend /proc read block to smaps, smaps_rollup, numa_maps, mem

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -94,7 +94,7 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertFalse(_is_blocked_device_path("/proc/self/fd/3"))
 
     def test_proc_sensitive_pseudo_files_blocked(self):
-        """environ/cmdline/maps under /proc/<pid> must be blocked (issue #4427)."""
+        """environ/cmdline/maps (and maps variants) under /proc/<pid> must be blocked (issue #4427)."""
         for path in (
             "/proc/self/environ",
             "/proc/12345/environ",
@@ -102,6 +102,14 @@ class TestDevicePathBlocking(unittest.TestCase):
             "/proc/99/cmdline",
             "/proc/self/maps",
             "/proc/1/maps",
+            "/proc/self/smaps",
+            "/proc/12345/smaps",
+            "/proc/self/smaps_rollup",
+            "/proc/99/smaps_rollup",
+            "/proc/self/numa_maps",
+            "/proc/1/numa_maps",
+            "/proc/self/mem",
+            "/proc/12345/mem",
         ):
             self.assertTrue(_is_blocked_device(path), f"{path} should be blocked")
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -137,10 +137,13 @@ def _is_blocked_device_path(path: str) -> bool:
         ("/fd/0", "/fd/1", "/fd/2")
     ):
         return True
-    # /proc/*/environ, /proc/*/cmdline, /proc/*/maps can leak secrets,
-    # command-line args, and memory layout from the host process (issue #4427)
+    # /proc/*/environ, /proc/*/cmdline, /proc/*/maps (and the maps variants
+    # smaps, smaps_rollup, numa_maps) can leak secrets, command-line args, and
+    # memory layout (ASLR bypass) from the host process (issue #4427).
+    # /proc/*/mem exposes raw process memory; block it as defense-in-depth even
+    # though it requires address knowledge to exploit usefully.
     if normalized.startswith("/proc/") and normalized.endswith(
-        ("/environ", "/cmdline", "/maps")
+        ("/environ", "/cmdline", "/maps", "/smaps", "/smaps_rollup", "/numa_maps", "/mem")
     ):
         return True
     return False


### PR DESCRIPTION
## Summary

PR #4609 blocked `read_file` access to `/proc/*/maps` to prevent ASLR
layout leakage, but the `endswith("/maps")` check does not catch three
closely-related paths that expose the same information:

| Path | What it leaks | Blocked before this PR? |
|------|--------------|------------------------|
| `/proc/*/smaps` | Full memory map with addresses (superset of `maps`) | ❌ |
| `/proc/*/smaps_rollup` | Aggregated memory layout with addresses | ❌ |
| `/proc/*/numa_maps` | Memory map with NUMA annotations | ❌ |
| `/proc/*/mem` | Raw process memory (defence-in-depth) | ❌ |

### Root cause

```python
# tools/file_tools.py  _is_blocked_device_path()
if normalized.startswith("/proc/") and normalized.endswith(
    ("/environ", "/cmdline", "/maps")   # "/smaps" ends in "smaps", not "/maps"
):
```

`"/proc/self/smaps".endswith("/maps")` → `False`.  An agent could call
`read_file("/proc/self/smaps")` and recover all virtual-address ranges
that the `maps` block was intended to prevent.

### Fix

Extend the `endswith` tuple to cover all four variants.  No behaviour
change for the already-blocked paths; `cpuinfo`, `meminfo`, `uptime`,
`version` remain accessible.

## Test plan

- [ ] `test_proc_sensitive_pseudo_files_blocked` extended with 8 new
  assertions covering `smaps`, `smaps_rollup`, `numa_maps`, and `mem`
  for both `/proc/self/` and `/proc/<pid>/` forms
- [ ] `test_proc_legitimate_files_not_blocked` unchanged — top-level
  `/proc` files stay accessible
- [ ] 39/39 tests passed (`tests/tools/test_file_read_guards.py`)
- [ ] `ruff check` clean

Partially addresses #4427.