### PR TITLE
fix: let tester retests bypass PR respawn guard

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4062,6 +4062,11 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# PR URL comments are duplicate-PR evidence for implementation lanes, but
+# QA/retest lanes routinely quote PR URLs as verification context and must
+# remain dispatchable.
+_RESPAWN_GUARD_PR_BYPASS_ASSIGNEES = {"tester", "qa"}
+
 
 @dataclass
 class DispatchResult:
@@ -4985,8 +4990,10 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) on an implementation lane.
+        A prior worker already opened a PR; re-spawning risks a duplicate
+        PR on the same task. QA/tester retest lanes bypass this check
+        because they quote PR URLs as verification context.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -4994,7 +5001,7 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT assignee, last_failure_error FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -5016,7 +5023,11 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ).fetchone():
         return "recent_success"
 
-    # 3. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # 3. GitHub PR URL in a recent comment — prior implementation worker already opened a PR.
+    assignee = (row["assignee"] or "").casefold()
+    if assignee in _RESPAWN_GUARD_PR_BYPASS_ASSIGNEES:
+        return None
+
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1252,15 +1252,27 @@ def test_respawn_guard_stale_success_not_guarded(kanban_home):
 
 
 def test_respawn_guard_active_pr_in_comment(kanban_home):
-    """A GitHub PR URL in a recent comment triggers active_pr."""
+    """A GitHub PR URL in a recent comment triggers active_pr for coding lanes."""
     with kb.connect() as conn:
-        t = kb.create_task(conn, title="has-pr", assignee="alice")
+        t = kb.create_task(conn, title="has-pr", assignee="coder")
         kb.add_comment(
             conn, t, "worker",
             "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "active_pr"
+
+
+def test_respawn_guard_active_pr_allows_tester_retest(kanban_home):
+    """Tester/QA retest cards often quote PR URLs but must remain spawnable."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="qa-retest", assignee="tester")
+        kb.add_comment(
+            conn, t, "worker",
+            "Retest requested after https://github.com/nuch1011/pigasus-homepage/pull/165",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
 
 
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
@@ -1352,14 +1364,14 @@ def test_dispatch_respawn_guard_skips_recent_success(
 def test_dispatch_respawn_guard_skips_active_pr(
     kanban_home, all_assignees_spawnable
 ):
-    """dispatch_once skips (but does not block) a task with an active PR comment."""
+    """dispatch_once skips (but does not block) coding tasks with an active PR comment."""
     spawned_ids = []
 
     def fake_spawn(task, workspace):
         spawned_ids.append(task.id)
 
     with kb.connect() as conn:
-        t = kb.create_task(conn, title="has-pr", assignee="alice")
+        t = kb.create_task(conn, title="has-pr", assignee="coder")
         kb.add_comment(
             conn, t, "worker",
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
@@ -1371,6 +1383,28 @@ def test_dispatch_respawn_guard_skips_active_pr(
     assert t not in res.auto_blocked
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_respawn_guard_allows_tester_active_pr_retest(
+    kanban_home, all_assignees_spawnable
+):
+    """dispatch_once spawns tester retest cards even if comments quote a PR URL."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="qa-retest", assignee="tester")
+        kb.add_comment(
+            conn, t, "worker",
+            "Ready for retest after https://github.com/nuch1011/pigasus-homepage/pull/165",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert (t, "active_pr") not in res.respawn_guarded
+    assert t in spawned_ids
+    assert t not in res.auto_blocked
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(


### PR DESCRIPTION
## Summary
- keep active_pr respawn guard for implementation lanes with PR URLs
- bypass that PR-link guard for tester/qa retest assignees so QA cards quoting PRs remain dispatchable
- add regression tests for check_respawn_guard and dispatch_once

## Test plan
- python -m pytest tests/hermes_cli/test_kanban_db.py -k 'respawn_guard' -q -o 'addopts='
- python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='
- git diff --check

Kanban: t_a98fd756