### PR TITLE
fix: suppress stale process watch notifications

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -999,6 +999,53 @@ def test_drain_notifications_skips_consumed():
             process_registry.completion_queue.get_nowait()
 
 
+def test_drain_notifications_skips_consumed_watch_events():
+    """Consumed sessions must not replay stale watch notifications later."""
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    process_registry._completion_consumed.add("proc_consumed_watch")
+    process_registry.completion_queue.put({
+        "type": "watch_match",
+        "session_id": "proc_consumed_watch",
+        "command": "tail -f x",
+        "pattern": "Application startup complete",
+        "output": "Application startup complete",
+        "suppressed": 0,
+    })
+    process_registry.completion_queue.put({
+        "type": "watch_disabled",
+        "session_id": "proc_consumed_watch",
+        "message": "Watch disabled for proc_consumed_watch",
+    })
+
+    try:
+        results = process_registry.drain_notifications()
+        assert results == []
+    finally:
+        process_registry._completion_consumed.discard("proc_consumed_watch")
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
+def test_kill_process_marks_session_consumed(registry):
+    """Killing a watched process should suppress queued stale notifications."""
+    s = _make_session(sid="proc_kill_consumed")
+    s.detached = True
+    s.pid_scope = "host"
+    s.pid = 12345
+    registry._running[s.id] = s
+    registry._is_host_pid_alive = MagicMock(return_value=True)
+    registry._terminate_host_pid = MagicMock()
+
+    result = registry.kill_process(s.id)
+
+    assert result["status"] == "killed"
+    assert s.id in registry._completion_consumed
+
+
 def test_drain_notifications_empty_queue():
     from tools.process_registry import process_registry
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -887,7 +887,7 @@ class ProcessRegistry:
             except Exception:
                 break
             _evt_sid = evt.get("session_id", "")
-            if evt.get("type") == "completion" and self.is_completion_consumed(_evt_sid):
+            if _evt_sid and self.is_completion_consumed(_evt_sid):
                 continue
             text = format_process_notification(evt)
             if text:
@@ -1175,6 +1175,10 @@ class ProcessRegistry:
                 }
             session.exited = True
             session.exit_code = -15  # SIGTERM
+            # process.kill is an explicit user/agent action.  Do not later
+            # replay queued watch_match/watch_disabled/completion events for
+            # this session as fresh "IMPORTANT" notifications.
+            self._completion_consumed.add(session.id)
             self._move_to_finished(session)
             self._write_checkpoint()
             return {"status": "killed", "session_id": session.id}


### PR DESCRIPTION
## Summary
- Skip all queued notification types for consumed process sessions, not just completion events
- Mark killed process sessions as consumed before moving them to finished
- Add regression coverage for stale watch events and kill suppression

## Test Plan
- [x] uv run --extra dev --extra pty pytest -q tests/tools/test_process_registry.py -q