### PR TITLE
fix(security): apply 0600 permissions on memory plugin config files containing API keys

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -626,6 +626,10 @@ class HindsightMemoryProvider(MemoryProvider):
                 pass
         existing.update(values)
         config_path.write_text(json.dumps(existing, indent=2))
+        try:
+            os.chmod(config_path, 0o600)
+        except OSError:
+            pass
 
     def post_setup(self, hermes_home: str, config: dict) -> None:
         """Custom setup wizard — installs only the deps needed for the selected mode."""

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -249,6 +249,7 @@ class HonchoMemoryProvider(MemoryProvider):
     def save_config(self, values, hermes_home):
         """Write config to $HERMES_HOME/honcho.json (Honcho SDK native format)."""
         import json
+        import os
         from pathlib import Path
         config_path = Path(hermes_home) / "honcho.json"
         existing = {}
@@ -259,6 +260,10 @@ class HonchoMemoryProvider(MemoryProvider):
                 pass
         existing.update(values)
         config_path.write_text(json.dumps(existing, indent=2))
+        try:
+            os.chmod(config_path, 0o600)
+        except OSError:
+            pass
 
     def get_config_schema(self):
         return [

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -156,6 +156,10 @@ class Mem0MemoryProvider(MemoryProvider):
                 pass
         existing.update(values)
         config_path.write_text(json.dumps(existing, indent=2))
+        try:
+            os.chmod(config_path, 0o600)
+        except OSError:
+            pass
 
     def get_config_schema(self):
         return [

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -153,6 +153,10 @@ def _save_supermemory_config(values: dict, hermes_home: str) -> None:
             existing = {}
     existing.update(values)
     config_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    try:
+        os.chmod(config_path, 0o600)
+    except OSError:
+        pass
 
 
 def _detect_category(text: str) -> str:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,7 +6,9 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import os
 import re
+import stat
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -1548,4 +1550,15 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+def test_save_config_sets_owner_only_permissions(tmp_path):
+    """hindsight/config.json must be written with 0o600 so API key is not world-readable."""
+    provider = HindsightMemoryProvider()
+    provider.save_config({"api_key": "hd-test-key"}, str(tmp_path))
+    config_file = tmp_path / "hindsight" / "config.json"
+    assert config_file.exists()
+    mode = stat.S_IMODE(config_file.stat().st_mode)
+    assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
 

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -4,6 +4,9 @@ Salvaged from PRs #5301 (qaqcvc) and #5117 (vvvanguards).
 """
 
 import json
+import os
+import stat
+
 import pytest
 
 from plugins.memory.mem0 import Mem0MemoryProvider
@@ -201,6 +204,17 @@ class TestMem0ResponseUnwrapping:
 # ---------------------------------------------------------------------------
 # Default preservation
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+def test_save_config_sets_owner_only_permissions(tmp_path):
+    """mem0.json must be written with 0o600 so API key is not world-readable."""
+    provider = Mem0MemoryProvider()
+    provider.save_config({"api_key": "m0-test-key"}, str(tmp_path))
+    config_file = tmp_path / "mem0.json"
+    assert config_file.exists()
+    mode = stat.S_IMODE(config_file.stat().st_mode)
+    assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
 
 
 class TestMem0Defaults:

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -1,4 +1,6 @@
 import json
+import os
+import stat
 import threading
 
 import pytest
@@ -409,3 +411,13 @@ def test_get_config_schema_minimal():
     assert len(schema) == 1
     assert schema[0]["key"] == "api_key"
     assert schema[0]["secret"] is True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+def test_save_config_sets_owner_only_permissions(tmp_path):
+    """supermemory.json must be written with 0o600 so API key is not world-readable."""
+    _save_supermemory_config({"api_key": "sm-test-key"}, str(tmp_path))
+    config_file = tmp_path / "supermemory.json"
+    assert config_file.exists()
+    mode = stat.S_IMODE(config_file.stat().st_mode)
+    assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"

--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -2,12 +2,14 @@
 
 import json
 import os
+import stat
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho import HonchoMemoryProvider
 
 
 class TestHonchoClientConfigAutoEnable:
@@ -103,3 +105,14 @@ class TestHonchoClientConfigAutoEnable:
 
         assert cfg.api_key == "fallback-key"
         assert cfg.enabled is True  # from_env() sets enabled=True
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+def test_save_config_sets_owner_only_permissions(tmp_path):
+    """honcho.json must be written with 0o600 so API key is not world-readable."""
+    provider = HonchoMemoryProvider()
+    provider.save_config({"api_key": "hc-test-key"}, str(tmp_path))
+    config_file = tmp_path / "honcho.json"
+    assert config_file.exists()
+    mode = stat.S_IMODE(config_file.stat().st_mode)
+    assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"


### PR DESCRIPTION
## Summary

Four memory plugin `save_config()` methods write JSON config files via
`write_text()`, which obeys the process umask (typically `0o022`), leaving
them world-readable (`0o644`) on shared hosts:

| File | Secret stored |
|------|--------------|
| `~/.hermes/honcho.json` | Honcho API key (`"secret": True`) |
| `~/.hermes/mem0.json` | Mem0 Platform API key (`"secret": True`, required) |
| `~/.hermes/hindsight/config.json` | Hindsight Cloud API key (`"secret": True`) |
| `~/.hermes/supermemory.json` | Supermemory API key (`"secret": True`, required) |

A local user on a multi-user host could read these files and recover live API keys.

### Root cause

```python
# all four plugins — same pattern
config_path.write_text(json.dumps(existing, indent=2))
# ↑ obeys umask → 0o644 by default; no chmod follows
```

### Fix

Add `os.chmod(config_path, 0o600)` immediately after `write_text()` at
each of the four `save_config()` sites. `honcho/__init__.py` also adds a
local `import os` inside the method because that module has no top-level
`os` import.

Matches the pattern from the recent security cluster:
- `79fc92e9c` — `.env` creation sites
- `3bace071b` — `webhook_subscriptions.json`, `response_store.db`
- `782681f90` — Google Chat OAuth credentials

## Test plan

- [ ] One `test_save_config_sets_owner_only_permissions` regression test added per plugin, asserting the resulting file mode is `0o600` under a permissive umask (skipped on Windows where POSIX mode bits are not enforced)
- [ ] 414 / 414 tests passed across all five affected test suites
- [ ] `ruff check` clean on all changed files