### PR TITLE
fix(cli): strip OSC 8 hyperlink sequences in ChatConsole output

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2610,6 +2610,12 @@ def _collect_query_images(query: str | None, image_arg: str | None = None) -> tu
     return message, deduped
 
 
+# Strip OSC escape sequences (e.g. OSC-8 hyperlinks) that prompt_toolkit's
+# ANSI parser can't handle — it strips \x1b but passes the payload through
+# as literal text, garbling the TUI output.
+_OSC_ESCAPE_RE = re.compile(r"\x1b\][\s\S]*?(?:\x07|\x1b\\)")
+
+
 class ChatConsole:
     """Rich Console adapter for prompt_toolkit's patch_stdout context.
 
@@ -2636,6 +2642,10 @@ class ChatConsole:
         self._inner.width = shutil.get_terminal_size((80, 24)).columns
         self._inner.print(*args, **kwargs)
         output = self._buffer.getvalue()
+        # Strip OSC escape sequences (e.g. OSC-8 hyperlinks) before
+        # routing through prompt_toolkit's ANSI parser, which only
+        # handles CSI/SGR and passes OSC payload through as literal text.
+        output = _OSC_ESCAPE_RE.sub("", output)
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 


### PR DESCRIPTION
## What

Fix garbled OSC 8 escape sequence payload leaking into the banner title after `/clear` in TUI mode.

## Why

When `/clear` is called, the banner is re-rendered through `ChatConsole`, which routes Rich-rendered ANSI through `_cprint()` → `print_formatted_text(ANSI(...))`. Rich's `[link=...]` markup generates OSC 8 hyperlink escape sequences (`\x1b]8;...\x1b\\`), but prompt_toolkit's `ANSI` parser only handles CSI/SGR sequences. It strips `\x1b` but passes the raw OSC payload through as literal text, producing garbled output like:

```
8;id=314014;https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.16Hermes Agent v0.14.0...
```

Normal startup is unaffected because it uses `self.console` directly (writes raw to stdout where OSC 8 works fine).

## How

Added `_OSC_ESCAPE_RE` — a regex that matches OSC escape sequences (`\x1b]...\x07` / `\x1b]...\x1b\\`) — and applies it in `ChatConsole.print()` to strip OSC sequences before routing through prompt_toolkit. CSI/SGR color sequences are preserved. Visible text between OSC sequences (the version label) is kept intact.

## Testing

- All 36 banner + ansi_strip tests pass
- Manually tested on macOS: `/clear` no longer shows garbled OSC payload in the banner title
- Regression: normal startup (`hermes`) banner renders identically — OSC hyperlinks still work there since that path uses `self.console` directly
- Cross-platform: change uses only `re` (stdlib), no OS-specific code

## Platforms tested

macOS (primary). Change is platform-agnostic.