### PR TITLE
fix(security): use secure_parent_dir in google_chat _write_private_json

### DIFF
--- a/plugins/platforms/google_chat/oauth.py
+++ b/plugins/platforms/google_chat/oauth.py
@@ -75,7 +75,7 @@ logger = logging.getLogger("gateway.platforms.google_chat_user_oauth")
 # Use the project's HERMES_HOME helper so the token follows the user's
 # profile (e.g. tests can override via HERMES_HOME=/tmp/...).
 try:
-    from hermes_constants import display_hermes_home, get_hermes_home
+    from hermes_constants import display_hermes_home, get_hermes_home, secure_parent_dir
 except (ModuleNotFoundError, ImportError):
     # Fallback for environments where hermes_constants isn't importable
     # (mirrors the same fallback used by the google-workspace skill's
@@ -90,6 +90,15 @@ except (ModuleNotFoundError, ImportError):
             return "~/" + str(home.relative_to(Path.home()))
         except ValueError:
             return str(home)
+
+    def secure_parent_dir(path: Path) -> None:
+        parent = path.parent.resolve()
+        if parent == Path("/") or len(parent.parts) < 3:
+            return
+        try:
+            os.chmod(parent, 0o700)
+        except OSError:
+            pass
 
 from utils import atomic_replace
 
@@ -329,10 +338,7 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
 def _write_private_json(path: Path, data: Any) -> None:
     """Atomically write JSON with 0o600 permissions where supported."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(path.parent, 0o700)
-    except OSError:
-        pass
+    secure_parent_dir(path)
 
     tmp_path = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
     try:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -1689,6 +1689,52 @@ class TestUserOAuthHelper:
             },
         )
 
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
+    def test_write_private_json_skips_chmod_on_shallow_parent(self, tmp_path):
+        """secure_parent_dir() must not chmod / or depth-1 dirs.
+
+        Regression guard for the parity gap with 4ead464f9: _write_private_json
+        previously called os.chmod(path.parent, 0o700) directly, which would
+        brick the host if HERMES_HOME resolved to /.
+        """
+        from plugins.platforms.google_chat.oauth import _write_private_json
+
+        called_paths = []
+        original_chmod = os.chmod
+
+        def _spy_chmod(path, mode, **kw):
+            called_paths.append((str(path), mode))
+            return original_chmod(path, mode, **kw)
+
+        # Write to a normal nested path — chmod on parent is safe and expected.
+        target = tmp_path / "subdir" / "token.json"
+        with patch("os.chmod", side_effect=_spy_chmod):
+            _write_private_json(target, {"key": "val"})
+
+        # The parent (tmp_path/subdir) must have been chmod'd 0o700.
+        parent_str = str(target.parent.resolve())
+        assert any(p == parent_str and m == 0o700 for p, m in called_paths), (
+            f"Expected chmod 0o700 on {parent_str!r}; calls were {called_paths}"
+        )
+
+        # Now verify that a shallow path (depth < 3) is NOT chmod'd.
+        # We can't actually point at / in a test, so we verify secure_parent_dir
+        # logic directly using the imported (or fallback) implementation.
+        from plugins.platforms.google_chat.oauth import secure_parent_dir
+
+        shallow_calls = []
+
+        def _spy2(path, mode, **kw):
+            shallow_calls.append(str(path))
+
+        from pathlib import Path as _Path
+        with patch("os.chmod", side_effect=_spy2):
+            secure_parent_dir(_Path("/tmp"))  # depth-1 child of /
+
+        assert shallow_calls == [], (
+            f"secure_parent_dir must not chmod /tmp; got {shallow_calls}"
+        )
+
 
 class TestPerUserAttachmentRouting:
     """The bot must use the *requesting user's* OAuth token when sending


### PR DESCRIPTION
## Summary

- `4ead464f9` added `secure_parent_dir()` to guard `os.chmod(path.parent, 0o700)` against bricking the host when `HERMES_HOME` resolves to `/` or a depth-1 directory, and updated five call sites in `agent/google_oauth.py`, `hermes_cli/auth.py`, and `tools/mcp_oauth.py`.
- `plugins/platforms/google_chat/oauth.py` was introduced by `782681f90` **in the same security batch** and contains the same bare `os.chmod(path.parent, 0o700)` call inside `_write_private_json()` — it was not included in the `4ead464f9` fix.
- This PR closes the parity gap: replaces the bare call with `secure_parent_dir(path)`, and adds a fallback definition to the existing `try/except ImportError` block for environments where `hermes_constants` is not importable.

## Changes

- `plugins/platforms/google_chat/oauth.py`: import `secure_parent_dir` from `hermes_constants` (with inline fallback); replace `os.chmod(path.parent, 0o700)` in `_write_private_json()`.
- `tests/gateway/test_google_chat.py`: add `test_write_private_json_skips_chmod_on_shallow_parent` to `TestUserOAuthHelper` — verifies that `secure_parent_dir` is invoked for normal nested paths and skipped for shallow paths (depth < 3).

## Test plan

- [ ] `python -m pytest tests/gateway/test_google_chat.py::TestUserOAuthHelper -v` — all 13 tests pass
- [ ] Confirm new test `test_write_private_json_skips_chmod_on_shallow_parent` passes on macOS/Linux
- [ ] Confirm test is skipped on Windows (`os.name == "nt"`)