### PR TITLE
fix(bootstrap): rebind yaml.safe_load through libyaml CSafeLoader

### DIFF
--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -1,24 +1,35 @@
-"""Windows UTF-8 bootstrap for Hermes entry points.
+"""Runtime bootstrap for Hermes entry points.
+
+Imported at the very top of every Hermes entry point (``hermes``,
+``hermes-agent``, ``hermes-acp``, ``python -m gateway.run``,
+``batch_runner.py``, ``cli.py``) before any other imports that might
+do file I/O or print to stdout, or load YAML.
+
+This module currently applies two unrelated runtime fixes:
+
+1. Windows UTF-8 stdio bootstrap — see ``apply_windows_utf8_bootstrap``.
+2. PyYAML CSafeLoader shim — see ``apply_yaml_csafe_shim``.
+
+Both are idempotent and silent (no logging, no raise) so they're safe
+to call from any entry point on any platform.
+
+==============================================================================
+1. Windows UTF-8 bootstrap
+==============================================================================
 
 Python on Windows has two long-standing text-encoding footguns:
 
-1. ``sys.stdout`` / ``sys.stderr`` are bound to the console code page
+a. ``sys.stdout`` / ``sys.stderr`` are bound to the console code page
    (``cp1252`` on US-locale installs), so ``print("café")`` crashes with
    ``UnicodeEncodeError: 'charmap' codec can't encode character``.
 
-2. Child processes spawned via ``subprocess`` don't know to use UTF-8
+b. Child processes spawned via ``subprocess`` don't know to use UTF-8
    unless ``PYTHONUTF8`` and/or ``PYTHONIOENCODING`` are set in their
    environment — so any Python subprocess (the execute_code sandbox,
    delegation children, linter subprocesses, etc.) inherits the same
    cp1252 defaults and hits the same UnicodeEncodeError.
 
-This module fixes both on Windows *only* — POSIX is untouched.  It
-should be imported at the very top of every Hermes entry point
-(``hermes``, ``hermes-agent``, ``hermes-acp``, ``python -m gateway.run``,
-``batch_runner.py``, ``cron/scheduler.py``) before any other imports
-that might do file I/O or print to stdout.
-
-What this module does on Windows:
+What ``apply_windows_utf8_bootstrap`` does on Windows:
 
   - Sets ``os.environ["PYTHONUTF8"] = "1"`` (PEP 540 UTF-8 mode) so
     every child process we spawn uses UTF-8 for ``open()`` and stdio.
@@ -29,22 +40,50 @@ What this module does on Windows:
     process, using the ``reconfigure()`` API (Python 3.7+).  This fixes
     ``print("café")`` in the parent without a re-exec.
 
-What this module does NOT do:
+It does NOT re-exec Python with ``-X utf8``, so ``open()`` calls in the
+*current* process still default to locale encoding.  Those need an
+explicit ``encoding="utf-8"`` at the call site (lint rule ``PLW1514`` /
+``PYI058``).  Ruff is the right tool for that sweep.
 
-  - It does not re-exec Python with ``-X utf8``, so ``open()`` calls in
-    the *current* process still default to locale encoding.  Those need
-    an explicit ``encoding="utf-8"`` at the call site (lint rule
-    ``PLW1514`` / ``PYI058``).  Ruff is the right tool for that sweep.
+On POSIX it is a complete no-op — POSIX systems are already UTF-8 by
+default in 99% of cases, and we don't want to touch ``LANG``/``LC_*``
+behavior that users may have configured intentionally.  If someone
+hits a C/POSIX locale on Linux, they can export ``PYTHONUTF8=1``
+themselves — we won't override.
 
-What this module does on POSIX:
+==============================================================================
+2. PyYAML CSafeLoader shim
+==============================================================================
 
-  - Nothing.  POSIX systems are already UTF-8 by default in 99% of cases,
-    and we don't want to touch ``LANG``/``LC_*`` behavior that users may
-    have configured intentionally.  If someone hits a C/POSIX locale on
-    Linux, they can export ``PYTHONUTF8=1`` themselves — we won't override.
+PyYAML 6.0.x's pure-Python ``safe_load`` parser corrupts CPython's
+internal object/refcount state under sustained load on at least some
+WSL2 / glibc / kernel combinations — observed as ``TypeError: 'X'
+object is not subscriptable`` mid-parse, ``AttributeError: 'dict'
+object has no attribute 'match'`` from compiled-regex caches getting
+overwritten, and segfaults inside ``Py_INCREF``/``Py_DECREF``.
 
-Idempotent: safe to call multiple times.  ``_bootstrap_once`` guards
-against double-reconfigure.
+The same crashes reproduce across:
+  - uv-managed cpython-3.11.14 / 3.11.15 (clang, python-build-standalone)
+  - Ubuntu 24.04 system python3.12.3 (gcc, apt)
+
+The libyaml-backed C parser (``yaml.CSafeLoader`` / ``yaml._yaml``)
+does NOT exhibit this — thousands of repeated parses are clean.
+PyYAML keeps ``safe_load`` and ``load(..., Loader=CSafeLoader)`` as
+separate code paths for legacy compatibility; users of plain
+``safe_load`` get the broken pure-Python implementation by default
+even when libyaml is installed.
+
+``apply_yaml_csafe_shim`` rebinds ``yaml.safe_load`` and
+``yaml.safe_load_all`` to use ``CSafeLoader`` whenever the libyaml C
+extension is available.  This makes every ``yaml.safe_load(...)`` in
+Hermes (and in any third-party dependency that ``import yaml`` after
+us) take the stable C path automatically — no call-site changes
+needed.
+
+If libyaml isn't available (rare — wheels ship it), the shim is a
+silent no-op and the original behavior is preserved.
+
+==============================================================================
 """
 
 from __future__ import annotations
@@ -54,6 +93,7 @@ import sys
 
 _IS_WINDOWS = sys.platform == "win32"
 _bootstrap_applied = False
+_yaml_shim_applied = False
 
 
 def apply_windows_utf8_bootstrap() -> bool:
@@ -122,8 +162,75 @@ def apply_windows_utf8_bootstrap() -> bool:
     return True
 
 
-# Apply on import — entry points just need ``import hermes_bootstrap``
-# (or ``from hermes_bootstrap import apply_windows_utf8_bootstrap``) at
-# the very top of their module, before importing anything else.  The
-# import side effect does the right thing.
+def apply_yaml_csafe_shim() -> bool:
+    """Rebind ``yaml.safe_load`` and ``yaml.safe_load_all`` to use the
+    libyaml-backed ``CSafeLoader`` when available.
+
+    PyYAML's pure-Python ``safe_load`` non-deterministically corrupts
+    CPython object state under sustained use on some WSL2 / glibc
+    combinations (segfaults inside ``Py_INCREF``, ``TypeError`` on
+    mid-parse parser-event objects, ``AttributeError`` on cached
+    compiled regexes that get clobbered).  The C-backed loader is
+    immune.  See the module docstring for the full rationale.
+
+    Returns True if the rebind was applied, False otherwise.  Reasons
+    for returning False:
+
+      - Already applied on a previous call (idempotent).
+      - PyYAML isn't importable in this venv.
+      - libyaml C extension isn't available (no ``CSafeLoader``).
+      - Something else already replaced ``yaml.safe_load`` with a
+        non-PyYAML implementation; we leave that alone.
+
+    This function is platform-agnostic — the underlying bug is in
+    PyYAML's parser code, not in any OS-specific layer, so the shim
+    runs on Linux, macOS, and Windows alike.  The performance side
+    effect is also positive: CSafeLoader is roughly 5-7× faster than
+    the pure-Python loader on typical config files.
+    """
+    global _yaml_shim_applied
+
+    if _yaml_shim_applied:
+        return False
+
+    try:
+        import yaml  # type: ignore[import-not-found]
+    except Exception:
+        return False
+
+    csafe = getattr(yaml, "CSafeLoader", None)
+    if csafe is None:
+        return False
+
+    current_safe_load = getattr(yaml, "safe_load", None)
+    if current_safe_load is None:
+        return False
+    if getattr(current_safe_load, "__module__", "") != "yaml":
+        return False
+
+    def safe_load(stream):  # type: ignore[no-redef]
+        return yaml.load(stream, Loader=csafe)
+
+    def safe_load_all(stream):  # type: ignore[no-redef]
+        return yaml.load_all(stream, Loader=csafe)
+
+    safe_load.__name__ = "safe_load"
+    safe_load.__qualname__ = "safe_load"
+    safe_load.__doc__ = (
+        "Parse a YAML document via the libyaml CSafeLoader.\n\n"
+        "Rebound by hermes_bootstrap.apply_yaml_csafe_shim to dodge "
+        "PyYAML pure-Python parser memory-corruption bugs."
+    )
+    safe_load_all.__name__ = "safe_load_all"
+    safe_load_all.__qualname__ = "safe_load_all"
+    safe_load_all.__doc__ = safe_load.__doc__
+
+    yaml.safe_load = safe_load
+    yaml.safe_load_all = safe_load_all
+
+    _yaml_shim_applied = True
+    return True
+
+
 apply_windows_utf8_bootstrap()
+apply_yaml_csafe_shim()

--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -173,14 +173,19 @@ def apply_yaml_csafe_shim() -> bool:
     compiled regexes that get clobbered).  The C-backed loader is
     immune.  See the module docstring for the full rationale.
 
-    Returns True if the rebind was applied, False otherwise.  Reasons
-    for returning False:
+    Returns True if at least one rebind was applied, False otherwise.
+    Reasons for returning False:
 
       - Already applied on a previous call (idempotent).
       - PyYAML isn't importable in this venv.
       - libyaml C extension isn't available (no ``CSafeLoader``).
-      - Something else already replaced ``yaml.safe_load`` with a
-        non-PyYAML implementation; we leave that alone.
+      - Something else already replaced both ``yaml.safe_load`` and
+        ``yaml.safe_load_all`` with non-PyYAML implementations; we
+        leave those alone.
+
+    The two functions are checked and rebound independently: if only
+    one of them was customized upstream of us, the customized one is
+    preserved and the other still gets the CSafeLoader rebind.
 
     This function is platform-agnostic — the underlying bug is in
     PyYAML's parser code, not in any OS-specific layer, so the shim
@@ -202,31 +207,30 @@ def apply_yaml_csafe_shim() -> bool:
     if csafe is None:
         return False
 
-    current_safe_load = getattr(yaml, "safe_load", None)
-    if current_safe_load is None:
+    def _make_rebound(name, load_fn):
+        def rebound(stream):
+            return load_fn(stream, Loader=csafe)
+
+        rebound.__name__ = name
+        rebound.__qualname__ = name
+        rebound.__doc__ = (
+            "Parse YAML via the libyaml CSafeLoader.\n\n"
+            "Rebound by hermes_bootstrap.apply_yaml_csafe_shim to dodge "
+            "PyYAML pure-Python parser memory-corruption bugs."
+        )
+        return rebound
+
+    rebound_any = False
+    for name, load_fn in (("safe_load", yaml.load), ("safe_load_all", yaml.load_all)):
+        current = getattr(yaml, name, None)
+        if current is None or getattr(current, "__module__", "") != "yaml":
+            # Missing, or already replaced by someone else — leave it alone.
+            continue
+        setattr(yaml, name, _make_rebound(name, load_fn))
+        rebound_any = True
+
+    if not rebound_any:
         return False
-    if getattr(current_safe_load, "__module__", "") != "yaml":
-        return False
-
-    def safe_load(stream):  # type: ignore[no-redef]
-        return yaml.load(stream, Loader=csafe)
-
-    def safe_load_all(stream):  # type: ignore[no-redef]
-        return yaml.load_all(stream, Loader=csafe)
-
-    safe_load.__name__ = "safe_load"
-    safe_load.__qualname__ = "safe_load"
-    safe_load.__doc__ = (
-        "Parse a YAML document via the libyaml CSafeLoader.\n\n"
-        "Rebound by hermes_bootstrap.apply_yaml_csafe_shim to dodge "
-        "PyYAML pure-Python parser memory-corruption bugs."
-    )
-    safe_load_all.__name__ = "safe_load_all"
-    safe_load_all.__qualname__ = "safe_load_all"
-    safe_load_all.__doc__ = safe_load.__doc__
-
-    yaml.safe_load = safe_load
-    yaml.safe_load_all = safe_load_all
 
     _yaml_shim_applied = True
     return True

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -356,29 +356,56 @@ class TestYamlCSafeShim:
         # First call already happened at import time.
         assert hb.apply_yaml_csafe_shim() is False
 
-    def test_shim_no_op_when_pyyaml_missing(self):
+    def test_shim_no_op_when_pyyaml_missing(self, monkeypatch):
         """If PyYAML isn't importable, the shim must silently no-op
         rather than raising — Hermes installs without YAML extras
         should still launch.
 
-        We simulate "yaml not installed" by replacing the cached
-        ``sys.modules['yaml']`` with a bare object that lacks both
-        ``safe_load`` and ``CSafeLoader``.  The shim's checks fall
-        through and it returns False without raising.
+        Setting ``sys.modules['yaml'] = None`` makes ``import yaml``
+        raise a real ImportError ("import of yaml halted"), so this
+        exercises the shim's except branch, not just a missing
+        attribute.
         """
         hb = _fresh_import()
         hb._yaml_shim_applied = False
 
-        import yaml as real_yaml
-
-        sys.modules["yaml"] = object()
-        try:
-            result = hb.apply_yaml_csafe_shim()
-        finally:
-            sys.modules["yaml"] = real_yaml
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        result = hb.apply_yaml_csafe_shim()
 
         assert result is False
         assert hb._yaml_shim_applied is False
+
+    def test_shim_preserves_independently_customized_function(self, monkeypatch):
+        """safe_load and safe_load_all are guarded independently: if
+        someone customized only safe_load_all before the shim runs,
+        that customization survives while safe_load still gets the
+        CSafeLoader rebind."""
+        hb = _fresh_import()
+
+        import yaml
+
+        if not hasattr(yaml, "CSafeLoader"):
+            pytest.skip("libyaml C extension not installed; shim is a no-op")
+
+        def pristine_safe_load(stream):
+            raise NotImplementedError
+
+        pristine_safe_load.__module__ = "yaml"
+
+        def custom_safe_load_all(stream):
+            raise NotImplementedError
+
+        monkeypatch.setattr(yaml, "safe_load", pristine_safe_load)
+        monkeypatch.setattr(yaml, "safe_load_all", custom_safe_load_all)
+        hb._yaml_shim_applied = False
+
+        assert hb.apply_yaml_csafe_shim() is True
+        assert yaml.safe_load.__module__ == "hermes_bootstrap", (
+            "the un-customized safe_load should still get rebound"
+        )
+        assert yaml.safe_load_all is custom_safe_load_all, (
+            "a separately customized safe_load_all must not be clobbered"
+        )
 
     def test_shim_no_op_when_libyaml_missing(self, monkeypatch):
         """If PyYAML is installed but the C extension isn't (no

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -312,3 +312,94 @@ class TestEntryPointsImportBootstrap:
             f"configured before anything else initializes.  Move the "
             f"'import hermes_bootstrap' line to be the first import."
         )
+
+
+class TestYamlCSafeShim:
+    """Bootstrap rebinds yaml.safe_load to use the libyaml CSafeLoader
+    on import.  PyYAML's pure-Python parser non-deterministically
+    corrupts CPython object/refcount state under sustained load on
+    some WSL2 / glibc combinations; the C-backed parser is immune.
+    See module docstring for full rationale."""
+
+    def test_safe_load_uses_csafe_loader_after_bootstrap(self):
+        """After hermes_bootstrap import, yaml.safe_load must route
+        through the libyaml C parser.  We check the rebound function's
+        identifying attributes — it lives in hermes_bootstrap.py and
+        invokes yaml.load with Loader=CSafeLoader."""
+        _fresh_import()
+        import yaml
+
+        if not hasattr(yaml, "CSafeLoader"):
+            pytest.skip("libyaml C extension not installed; shim is a no-op")
+
+        # The rebound function is defined inside hermes_bootstrap.py.
+        assert yaml.safe_load.__module__ == "hermes_bootstrap", (
+            f"yaml.safe_load.__module__ is {yaml.safe_load.__module__!r}; "
+            f"expected 'hermes_bootstrap' (shim should have rebound it)"
+        )
+        assert yaml.safe_load_all.__module__ == "hermes_bootstrap"
+
+    def test_safe_load_round_trips_basic_yaml(self):
+        """Sanity: the rebound safe_load actually parses YAML correctly
+        (it's not just a dummy stub)."""
+        _fresh_import()
+        import yaml
+
+        text = "a: 1\nb:\n  - x\n  - y\nc: hello\n"
+        result = yaml.safe_load(text)
+        assert result == {"a": 1, "b": ["x", "y"], "c": "hello"}
+
+    def test_yaml_shim_is_idempotent(self):
+        """Calling apply_yaml_csafe_shim twice must be a no-op the
+        second time (returns False)."""
+        hb = _fresh_import()
+        # First call already happened at import time.
+        assert hb.apply_yaml_csafe_shim() is False
+
+    def test_shim_no_op_when_pyyaml_missing(self):
+        """If PyYAML isn't importable, the shim must silently no-op
+        rather than raising — Hermes installs without YAML extras
+        should still launch.
+
+        We simulate "yaml not installed" by replacing the cached
+        ``sys.modules['yaml']`` with a bare object that lacks both
+        ``safe_load`` and ``CSafeLoader``.  The shim's checks fall
+        through and it returns False without raising.
+        """
+        hb = _fresh_import()
+        hb._yaml_shim_applied = False
+
+        import yaml as real_yaml
+
+        sys.modules["yaml"] = object()
+        try:
+            result = hb.apply_yaml_csafe_shim()
+        finally:
+            sys.modules["yaml"] = real_yaml
+
+        assert result is False
+        assert hb._yaml_shim_applied is False
+
+    def test_shim_no_op_when_libyaml_missing(self, monkeypatch):
+        """If PyYAML is installed but the C extension isn't (no
+        ``yaml.CSafeLoader``), the shim must silently no-op rather
+        than rebinding to something that doesn't exist."""
+        hb = _fresh_import()
+        hb._yaml_shim_applied = False
+
+        import yaml
+
+        # Stand up a fake yaml module that pretends libyaml isn't there.
+        class _FakeYaml:
+            __name__ = "yaml"
+            safe_load = yaml.safe_load
+            # No CSafeLoader attribute.
+
+        monkeypatch.setitem(sys.modules, "yaml", _FakeYaml())
+        try:
+            result = hb.apply_yaml_csafe_shim()
+        finally:
+            sys.modules["yaml"] = yaml
+
+        assert result is False
+        assert hb._yaml_shim_applied is False


### PR DESCRIPTION
## What does this PR do?

Adds a small idempotent shim to `hermes_bootstrap.py` that rebinds `yaml.safe_load` and `yaml.safe_load_all` to use the libyaml-backed `CSafeLoader` whenever the C extension is available. PyYAML's pure-Python `safe_load` parser non-deterministically corrupts CPython's internal object/refcount state under sustained use on at least some WSL2 / glibc / kernel combinations — observed as `TypeError` / `AttributeError` mid-parse and segfaults inside `Py_INCREF`/`Py_DECREF`. The libyaml C parser is immune. PyYAML keeps `safe_load` and `load(..., Loader=CSafeLoader)` as separate code paths for legacy compatibility, so plain `safe_load` users get the broken pure-Python implementation even when libyaml is installed.

The shim is silent and idempotent: if PyYAML or libyaml is missing it's a no-op. Because every Hermes entry point already imports `hermes_bootstrap` first (enforced by `TestEntryPointsImportBootstrap`), no call-site changes are needed — every existing `yaml.safe_load(...)` in the codebase (and any third-party dep that `import yaml` after us) takes the stable C path automatically.

## Related Issue

No prior issue. Found and root-caused while debugging a Hermes installation on WSL2 (kernel `6.6.114.1-microsoft-standard-WSL2`, Ubuntu 24.04, system Python 3.12.3 + uv-managed Python 3.11.15). Happy to file one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_bootstrap.py`:
  - Added `apply_yaml_csafe_shim()` function with module-level call alongside the existing `apply_windows_utf8_bootstrap()`.
  - Updated module docstring to describe both runtime fixes.
  - Added `_yaml_shim_applied` global guard for idempotence.
- `tests/test_hermes_bootstrap.py`:
  - Added `TestYamlCSafeShim` class with five tests: rebind verification, basic round-trip parsing, idempotence, no-op when PyYAML missing, no-op when libyaml missing.

No call-site changes anywhere else — the shim works through `yaml.safe_load`'s module-level binding.

## How to Test

### Reproduce the underlying PyYAML bug (without this PR)

```bash
python -u -c "
import yaml, time
text = open('config.yaml').read()  # any non-trivial yaml file works
for i in range(50):
    yaml.load(text, Loader=yaml.SafeLoader)  # pure-Python loader
print('done')
"
```

On affected systems this segfaults (exit 139) or raises `TypeError: 'ScalarEvent' object is not subscriptable` partway through. Crash rate roughly 60% over 10 runs in my environment. Reproduces across:

- uv-managed cpython-3.11.14 / 3.11.15 (clang, python-build-standalone)
- Ubuntu 24.04 system python3.12.3 (gcc, apt)
- WSL2 kernels `6.6.87.2-microsoft-standard-WSL2` and `6.6.114.1-microsoft-standard-WSL2` (six months apart)

The C parser path (`yaml.load(text, Loader=yaml.CSafeLoader)`) is rock solid on the same host — thousands of repeated parses are clean.

### Verify the fix

```bash
pytest tests/test_hermes_bootstrap.py -v
# 17 passed, 5 skipped (Windows-only tests)
```

Or, manually:

```bash
python -c "
import hermes_bootstrap, yaml
print('shim applied:', hermes_bootstrap._yaml_shim_applied)
print('safe_load source:', yaml.safe_load.__module__)
"
# shim applied: True
# safe_load source: hermes_bootstrap
```

### Performance side-effect

CSafeLoader is roughly 5-7× faster than the pure-Python loader on typical config files. On the 527-line `~/.hermes/config.yaml`:

- Before: ~9.7 ms / parse
- After:  ~1.3 ms / parse

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(bootstrap):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/test_hermes_bootstrap.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 on WSL2 (Windows 11), kernels 6.6.87.2 and 6.6.114.1, system Python 3.12.3 and uv-managed CPython 3.11.15

### Documentation & Housekeeping

- [x] I've updated the `hermes_bootstrap.py` module docstring to describe both runtime fixes — the new docstring section explains the bug, the reproduction, and what the shim does
- [x] No `cli-config.yaml.example` config keys added/changed — N/A
- [x] No architecture or workflow change — N/A
- [x] Cross-platform: shim is platform-agnostic (the underlying PyYAML bug is in parser code, not in any OS-specific layer); silent no-op when libyaml isn't available, so installs without YAML extras still launch
- [x] No tool descriptions/schemas changed — N/A

## Notes for Reviewers

- The shim only rebinds when the existing `yaml.safe_load`'s `__module__` is `"yaml"` — i.e. it explicitly avoids stomping on something that's already been replaced by another shim. If a future contributor or a downstream user needs to override this, they can do so freely after `hermes_bootstrap` import without losing their override on a subsequent call.
- Reasoned about the alternative of patching every `yaml.safe_load` call site directly (~15 in non-test code). That approach is more invasive, easy for new contributions to forget, and doesn't help third-party deps. The `hermes_bootstrap` rebind is small, single-source-of-truth, and works for everyone who imports `yaml` after us.
- I'm not certain how broadly this affects Hermes users — the WSL2/glibc combination might be unusually common but the failure mode is silent corruption that frequently looks like flaky CI rather than a clean crash, so reports may be sparse. Adopting the shim has zero downside on stable systems (faster parsing, identical behavior) and meaningfully improves stability on the affected ones.

Made with [Cursor](https://cursor.com)