### PR TITLE
feat(secrets): add 1Password secret source

### DIFF
--- a/agent/secret_sources/__init__.py
+++ b/agent/secret_sources/__init__.py
@@ -10,4 +10,7 @@ Currently shipped:
   - ``bitwarden`` — Bitwarden Secrets Manager (`bws` CLI).  See
     ``agent.secret_sources.bitwarden`` for the integration and
     ``hermes_cli.secrets_cli`` for the user-facing setup wizard.
+  - ``onepassword`` — 1Password CLI (`op`) secret references.  See
+    ``agent.secret_sources.onepassword`` for the integration and
+    ``hermes_cli.onepassword_secrets_cli`` for the user-facing commands.
 """

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -46,6 +46,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from agent.secret_sources.disk_cache import (
+    disk_cache_path,
+    read_secret_cache,
+    write_secret_cache,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,9 +97,7 @@ def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
     `home_path` is what `load_hermes_dotenv()` already resolved; falling back
     to `$HERMES_HOME` / `~/.hermes` keeps direct callers working too.
     """
-    if home_path is None:
-        home_path = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
-    return home_path / "cache" / _DISK_CACHE_BASENAME
+    return disk_cache_path(_DISK_CACHE_BASENAME, home_path)
 
 
 def _cache_key_str(cache_key: _CacheKey) -> str:
@@ -110,28 +114,16 @@ def _read_disk_cache(cache_key: _CacheKey, ttl_seconds: float,
     """
     if ttl_seconds <= 0:
         return None
-    path = _disk_cache_path(home_path)
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            payload = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    cached = read_secret_cache(
+        cache_basename=_DISK_CACHE_BASENAME,
+        cache_key=_cache_key_str(cache_key),
+        ttl_seconds=ttl_seconds,
+        home_path=home_path,
+    )
+    if cached is None:
         return None
-    if not isinstance(payload, dict):
-        return None
-    if payload.get("key") != _cache_key_str(cache_key):
-        return None
-    secrets = payload.get("secrets")
-    fetched_at = payload.get("fetched_at")
-    if not isinstance(secrets, dict) or not isinstance(fetched_at, (int, float)):
-        return None
-    # Coerce all values to strings — JSON allows numbers but env vars need strings
-    typed_secrets: Dict[str, str] = {
-        k: v for k, v in secrets.items() if isinstance(k, str) and isinstance(v, str)
-    }
-    entry = _CachedFetch(secrets=typed_secrets, fetched_at=float(fetched_at))
-    if not entry.is_fresh(ttl_seconds):
-        return None
-    return entry
+    secrets, fetched_at = cached
+    return _CachedFetch(secrets=secrets, fetched_at=fetched_at)
 
 
 def _write_disk_cache(cache_key: _CacheKey, entry: "_CachedFetch",
@@ -141,32 +133,14 @@ def _write_disk_cache(cache_key: _CacheKey, entry: "_CachedFetch",
     Best-effort: any I/O error is swallowed (the next invocation will just
     re-fetch). We never want disk cache failures to break startup.
     """
-    path = _disk_cache_path(home_path)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "key": _cache_key_str(cache_key),
-            "secrets": entry.secrets,
-            "fetched_at": entry.fetched_at,
-        }
-        # Write to a temp file in the same directory and atomic-rename.
-        # tempfile honors os.umask, so we explicitly chmod 0600 before rename.
-        fd, tmp = tempfile.mkstemp(
-            prefix=".bws_cache_", suffix=".tmp", dir=str(path.parent)
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(payload, f)
-            os.chmod(tmp, 0o600)
-            os.replace(tmp, path)
-        except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
-    except OSError:
-        pass  # best-effort — disk cache miss on next invocation is fine
+    write_secret_cache(
+        cache_basename=_DISK_CACHE_BASENAME,
+        cache_key=_cache_key_str(cache_key),
+        secrets=entry.secrets,
+        fetched_at=entry.fetched_at,
+        temp_prefix=".bws_cache_",
+        home_path=home_path,
+    )
 
 
 @dataclass

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -439,9 +439,9 @@ def fetch_bitwarden_secrets(
         )
 
     secrets, warnings = _run_bws_list(bws, access_token, project_id, server_url)
-    entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
-    _CACHE[cache_key] = entry
-    if use_cache:
+    if use_cache and cache_ttl_seconds > 0:
+        entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
+        _CACHE[cache_key] = entry
         _write_disk_cache(cache_key, entry, home_path)
     return secrets, warnings
 

--- a/agent/secret_sources/disk_cache.py
+++ b/agent/secret_sources/disk_cache.py
@@ -1,0 +1,98 @@
+"""Shared disk-cache helpers for external secret sources.
+
+Secret-source caches are plaintext-equivalent to ``~/.hermes/.env``. Keep
+them under ``<hermes_home>/cache``, write atomically, and avoid letting cache
+I/O failures block startup.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+
+def disk_cache_path(cache_basename: str, home_path: Optional[Path] = None) -> Path:
+    """Return a secret-source disk cache path under hermes_home/cache/."""
+
+    if home_path is None:
+        home_path = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return home_path / "cache" / cache_basename
+
+
+def read_secret_cache(
+    *,
+    cache_basename: str,
+    cache_key: str,
+    ttl_seconds: float,
+    home_path: Optional[Path] = None,
+) -> tuple[dict[str, str], float] | None:
+    """Return ``(secrets, fetched_at)`` for a fresh cache entry, else None."""
+
+    if ttl_seconds <= 0:
+        return None
+    path = disk_cache_path(cache_basename, home_path)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("key") != cache_key:
+        return None
+    secrets = payload.get("secrets")
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(secrets, dict) or not isinstance(fetched_at, (int, float)):
+        return None
+    typed_secrets = {
+        key: value
+        for key, value in secrets.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+    fetched_at_float = float(fetched_at)
+    if (time.time() - fetched_at_float) >= ttl_seconds:
+        return None
+    return typed_secrets, fetched_at_float
+
+
+def write_secret_cache(
+    *,
+    cache_basename: str,
+    cache_key: str,
+    secrets: dict[str, str],
+    fetched_at: float,
+    temp_prefix: str,
+    home_path: Optional[Path] = None,
+) -> None:
+    """Persist a cache entry atomically with cache dir mode 0700 and file 0600."""
+
+    path = disk_cache_path(cache_basename, home_path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            os.chmod(path.parent, 0o700)
+        except OSError:
+            pass
+        payload = {
+            "key": cache_key,
+            "secrets": secrets,
+            "fetched_at": fetched_at,
+        }
+        fd, tmp = tempfile.mkstemp(
+            prefix=temp_prefix, suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import shutil
 import subprocess
 import time
@@ -51,8 +52,9 @@ _OP_RUN_TIMEOUT = 30
 # Cache key: (token/session fingerprint, account, sorted refs).  We include a
 # fingerprint of common 1Password auth env vars so changing service-account or
 # session credentials does not reuse values fetched under a previous identity.
-_CacheKey = Tuple[str, str, Tuple[Tuple[str, str], ...]]
+_CacheKey = Tuple[str, str, str, Tuple[Tuple[str, str], ...]]
 _CACHE: Dict[_CacheKey, "_CachedFetch"] = {}
+_ANSI_CSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 # Disk-persisted cache so short-lived Hermes processes (gateway workers,
 # shell one-shots, cron jobs) do not each pay one `op read` subprocess per
@@ -71,7 +73,7 @@ def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
 def _cache_key_str(cache_key: _CacheKey) -> str:
     """Serialize a cache key to a stable string for JSON storage."""
 
-    auth_fp, account, refs = cache_key
+    auth_fp, account, _home_key, refs = cache_key
     refs_material = "\0".join(f"{name}={ref}" for name, ref in refs)
     refs_fp = hashlib.sha256(refs_material.encode("utf-8")).hexdigest()[:16]
     return f"{auth_fp}|{account}|{refs_fp}"
@@ -176,6 +178,7 @@ def fetch_onepassword_secrets(
     cache_key = (
         _auth_fingerprint(service_account_token_env),
         account,
+        str(Path(home_path).resolve()) if home_path is not None else "",
         tuple(sorted(valid_refs.items())),
     )
     if use_cache:
@@ -213,9 +216,9 @@ def fetch_onepassword_secrets(
         if not secrets:
             raise RuntimeError("; ".join(read_errors))
 
-    entry = _CachedFetch(secrets=dict(secrets), fetched_at=time.time())
-    _CACHE[cache_key] = entry
-    if use_cache:
+    if use_cache and cache_ttl_seconds > 0:
+        entry = _CachedFetch(secrets=dict(secrets), fetched_at=time.time())
+        _CACHE[cache_key] = entry
         _write_disk_cache(cache_key, entry, home_path)
     return secrets, warnings
 
@@ -332,9 +335,10 @@ def _run_op_read(
     account: str = "",
     service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN",
 ) -> str:
-    cmd = [str(op), "read", reference]
+    cmd = [str(op), "read"]
     if account:
         cmd.extend(["--account", account])
+    cmd.extend(["--", reference])
     env = {
         key: value
         for key, value in os.environ.items()
@@ -363,7 +367,7 @@ def _run_op_read(
         raise RuntimeError(f"failed to invoke op: {exc}") from exc
 
     if proc.returncode != 0:
-        err = (proc.stderr or "").strip().replace("\x1b", "")
+        err = _strip_ansi(proc.stderr or "").strip()
         if not err:
             err = f"op exited with status {proc.returncode}"
         raise RuntimeError(f"op read failed for {reference!r}: {err[:200]}")
@@ -384,6 +388,10 @@ def _auth_fingerprint(service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN
         return ""
     material = "\0".join(values)
     return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def _strip_ansi(value: str) -> str:
+    return _ANSI_CSI_RE.sub("", value).replace("\x1b", "")
 
 
 def _is_valid_env_name(name: str) -> bool:

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -29,16 +29,20 @@ Design summary
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import os
 import shutil
 import subprocess
-import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Mapping, Optional, Tuple
+
+from agent.secret_sources.disk_cache import (
+    disk_cache_path,
+    read_secret_cache,
+    write_secret_cache,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,9 +65,7 @@ _DISK_CACHE_BASENAME = "op_cache.json"
 def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
     """Return the 1Password cache path under hermes_home/cache/."""
 
-    if home_path is None:
-        home_path = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
-    return home_path / "cache" / _DISK_CACHE_BASENAME
+    return disk_cache_path(_DISK_CACHE_BASENAME, home_path)
 
 
 def _cache_key_str(cache_key: _CacheKey) -> str:
@@ -84,27 +86,16 @@ def _read_disk_cache(
 
     if ttl_seconds <= 0:
         return None
-    path = _disk_cache_path(home_path)
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            payload = json.load(f)
-    except (OSError, json.JSONDecodeError):
+    cached = read_secret_cache(
+        cache_basename=_DISK_CACHE_BASENAME,
+        cache_key=_cache_key_str(cache_key),
+        ttl_seconds=ttl_seconds,
+        home_path=home_path,
+    )
+    if cached is None:
         return None
-    if not isinstance(payload, dict) or payload.get("key") != _cache_key_str(cache_key):
-        return None
-    secrets = payload.get("secrets")
-    fetched_at = payload.get("fetched_at")
-    if not isinstance(secrets, dict) or not isinstance(fetched_at, (int, float)):
-        return None
-    typed_secrets = {
-        key: value
-        for key, value in secrets.items()
-        if isinstance(key, str) and isinstance(value, str)
-    }
-    entry = _CachedFetch(secrets=typed_secrets, fetched_at=float(fetched_at))
-    if not entry.is_fresh(ttl_seconds):
-        return None
-    return entry
+    secrets, fetched_at = cached
+    return _CachedFetch(secrets=secrets, fetched_at=fetched_at)
 
 
 def _write_disk_cache(
@@ -114,30 +105,14 @@ def _write_disk_cache(
 ) -> None:
     """Persist a cache entry atomically with mode 0600; best effort only."""
 
-    path = _disk_cache_path(home_path)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "key": _cache_key_str(cache_key),
-            "secrets": entry.secrets,
-            "fetched_at": entry.fetched_at,
-        }
-        fd, tmp = tempfile.mkstemp(
-            prefix=".op_cache_", suffix=".tmp", dir=str(path.parent)
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(payload, f)
-            os.chmod(tmp, 0o600)
-            os.replace(tmp, path)
-        except BaseException:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
-    except OSError:
-        pass
+    write_secret_cache(
+        cache_basename=_DISK_CACHE_BASENAME,
+        cache_key=_cache_key_str(cache_key),
+        secrets=entry.secrets,
+        fetched_at=entry.fetched_at,
+        temp_prefix=".op_cache_",
+        home_path=home_path,
+    )
 
 
 @dataclass
@@ -301,6 +276,7 @@ def apply_onepassword_secrets(
                 result.warnings
             )
             return result
+        return result
 
     binary = find_op()
     result.binary_path = binary
@@ -359,8 +335,13 @@ def _run_op_read(
     cmd = [str(op), "read", reference]
     if account:
         cmd.extend(["--account", account])
-    env = os.environ.copy()
-    env.setdefault("NO_COLOR", "1")
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith("OP_")
+        or key in {"PATH", "HOME", "USER", "USERNAME", "SystemRoot"}
+    }
+    env["NO_COLOR"] = "1"
     if service_account_token_env != "OP_SERVICE_ACCOUNT_TOKEN":
         custom_token = os.environ.get(service_account_token_env)
         if custom_token:
@@ -371,6 +352,7 @@ def _run_op_read(
             env=env,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=_OP_RUN_TIMEOUT,
         )
     except subprocess.TimeoutExpired as exc:
@@ -381,26 +363,26 @@ def _run_op_read(
         raise RuntimeError(f"failed to invoke op: {exc}") from exc
 
     if proc.returncode != 0:
-        err = (proc.stderr or proc.stdout or "").strip().replace("\x1b", "")
+        err = (proc.stderr or "").strip().replace("\x1b", "")
+        if not err:
+            err = f"op exited with status {proc.returncode}"
         raise RuntimeError(f"op read failed for {reference!r}: {err[:200]}")
 
     # `op read` prints a trailing newline in normal terminal use. Preserve all
     # other characters in the secret value.
-    return (proc.stdout or "").rstrip("\r\n")
+    value = (proc.stdout or "").rstrip("\r\n")
+    if value == "":
+        raise RuntimeError(f"op read returned an empty value for {reference!r}")
+    return value
 
 
 def _auth_fingerprint(service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN") -> str:
-    material = "\0".join(
-        os.environ.get(name, "")
-        for name in (
-            "OP_SERVICE_ACCOUNT_TOKEN",
-            service_account_token_env,
-            "OP_SESSION",
-            "OP_ACCOUNT",
-        )
-    )
-    if not material:
+    names = {"OP_SERVICE_ACCOUNT_TOKEN", service_account_token_env, "OP_ACCOUNT"}
+    names.update(name for name in os.environ if name.startswith("OP_SESSION_"))
+    values = [os.environ.get(name, "") for name in sorted(names)]
+    if not any(values):
         return ""
+    material = "\0".join(values)
     return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
 
 
@@ -412,7 +394,11 @@ def _is_valid_env_name(name: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
-def _reset_cache_for_tests() -> None:
-    """Clear in-process cache for hermetic tests."""
+def _reset_cache_for_tests(home_path: Optional[Path] = None) -> None:
+    """Clear in-process and default disk cache for hermetic tests."""
 
     _CACHE.clear()
+    try:
+        _disk_cache_path(home_path).unlink()
+    except OSError:
+        pass

--- a/agent/secret_sources/onepassword.py
+++ b/agent/secret_sources/onepassword.py
@@ -1,0 +1,418 @@
+"""1Password CLI (``op``) secret-reference integration.
+
+Hermes can resolve environment-variable-shaped credentials from 1Password
+at process startup so API keys do not have to live in plaintext in
+``~/.hermes/.env``. Users map env var names to 1Password secret references
+(``op://vault/item/field``) in ``config.yaml``; Hermes shells out to the
+official ``op`` CLI and injects the resolved values into ``os.environ``.
+
+Design summary
+--------------
+
+* Hermes never stores 1Password item values in config.yaml or .env.
+* The integration is opt-in via ``secrets.onepassword.enabled``.
+* ``~/.hermes/.env`` and shell exports load first; by default 1Password can
+  then override them so rotations in the vault take effect on next startup.
+* Successful reads are cached in-process and on disk under
+  ``<hermes_home>/cache/op_cache.json`` for ``cache_ttl_seconds`` so
+  short-lived Hermes commands do not repeatedly pay ``op`` startup/auth cost.
+* When ``override_existing`` is false, values that already exist in the
+  environment are skipped before contacting ``op``.
+* Failures NEVER block Hermes startup. Missing ``op``, locked desktop app,
+  expired session, bad references, etc. all return a ``FetchResult`` error
+  and the caller continues with whatever credentials were already available.
+* This module does not auto-install ``op``. The official 1Password CLI has
+  platform-specific install/sign-in flows, desktop-app integration, and
+  service-account options; Hermes only consumes an already configured CLI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+_OP_RUN_TIMEOUT = 30
+
+# Cache key: (token/session fingerprint, account, sorted refs).  We include a
+# fingerprint of common 1Password auth env vars so changing service-account or
+# session credentials does not reuse values fetched under a previous identity.
+_CacheKey = Tuple[str, str, Tuple[Tuple[str, str], ...]]
+_CACHE: Dict[_CacheKey, "_CachedFetch"] = {}
+
+# Disk-persisted cache so short-lived Hermes processes (gateway workers,
+# shell one-shots, cron jobs) do not each pay one `op read` subprocess per
+# configured secret. Values are plaintext-equivalent to ~/.hermes/.env, so the
+# file is kept under <hermes_home>/cache, written atomically, and chmod 0600.
+# The cache key includes only fingerprints / references, never token values.
+_DISK_CACHE_BASENAME = "op_cache.json"
+
+
+def _disk_cache_path(home_path: Optional[Path] = None) -> Path:
+    """Return the 1Password cache path under hermes_home/cache/."""
+
+    if home_path is None:
+        home_path = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    return home_path / "cache" / _DISK_CACHE_BASENAME
+
+
+def _cache_key_str(cache_key: _CacheKey) -> str:
+    """Serialize a cache key to a stable string for JSON storage."""
+
+    auth_fp, account, refs = cache_key
+    refs_material = "\0".join(f"{name}={ref}" for name, ref in refs)
+    refs_fp = hashlib.sha256(refs_material.encode("utf-8")).hexdigest()[:16]
+    return f"{auth_fp}|{account}|{refs_fp}"
+
+
+def _read_disk_cache(
+    cache_key: _CacheKey,
+    ttl_seconds: float,
+    home_path: Optional[Path] = None,
+) -> Optional["_CachedFetch"]:
+    """Return a fresh disk cache entry, or None on miss/error/stale."""
+
+    if ttl_seconds <= 0:
+        return None
+    path = _disk_cache_path(home_path)
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("key") != _cache_key_str(cache_key):
+        return None
+    secrets = payload.get("secrets")
+    fetched_at = payload.get("fetched_at")
+    if not isinstance(secrets, dict) or not isinstance(fetched_at, (int, float)):
+        return None
+    typed_secrets = {
+        key: value
+        for key, value in secrets.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+    entry = _CachedFetch(secrets=typed_secrets, fetched_at=float(fetched_at))
+    if not entry.is_fresh(ttl_seconds):
+        return None
+    return entry
+
+
+def _write_disk_cache(
+    cache_key: _CacheKey,
+    entry: "_CachedFetch",
+    home_path: Optional[Path] = None,
+) -> None:
+    """Persist a cache entry atomically with mode 0600; best effort only."""
+
+    path = _disk_cache_path(home_path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "key": _cache_key_str(cache_key),
+            "secrets": entry.secrets,
+            "fetched_at": entry.fetched_at,
+        }
+        fd, tmp = tempfile.mkstemp(
+            prefix=".op_cache_", suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass
+
+
+@dataclass
+class _CachedFetch:
+    secrets: Dict[str, str]
+    fetched_at: float
+
+    def is_fresh(self, ttl_seconds: float) -> bool:
+        if ttl_seconds <= 0:
+            return False
+        return (time.time() - self.fetched_at) < ttl_seconds
+
+
+@dataclass
+class FetchResult:
+    """Outcome of applying 1Password references into ``os.environ``."""
+
+    secrets: Dict[str, str] = field(default_factory=dict)
+    applied: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    error: Optional[str] = None
+    binary_path: Optional[Path] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+def find_op() -> Optional[Path]:
+    """Return a path to the 1Password CLI, or ``None`` if unavailable."""
+
+    found = shutil.which("op")
+    return Path(found) if found else None
+
+
+def fetch_onepassword_secrets(
+    *,
+    references: Mapping[str, str],
+    binary: Optional[Path] = None,
+    account: str = "",
+    cache_ttl_seconds: float = 300,
+    use_cache: bool = True,
+    service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN",
+    home_path: Optional[Path] = None,
+) -> tuple[Dict[str, str], list[str]]:
+    """Resolve configured 1Password references with ``op read``.
+
+    ``references`` maps environment-variable names to 1Password secret
+    references such as ``op://Private/OpenAI API key/credential``.
+
+    Raises :class:`RuntimeError` for fatal conditions. The env-loader path
+    catches these and warns without blocking Hermes startup.
+    """
+
+    valid_refs, warnings = _validate_references(references)
+    if not valid_refs:
+        return {}, warnings
+
+    account = (account or "").strip()
+    cache_key = (
+        _auth_fingerprint(service_account_token_env),
+        account,
+        tuple(sorted(valid_refs.items())),
+    )
+    if use_cache:
+        cached = _CACHE.get(cache_key)
+        if cached and cached.is_fresh(cache_ttl_seconds):
+            return dict(cached.secrets), warnings
+        disk_cached = _read_disk_cache(cache_key, cache_ttl_seconds, home_path)
+        if disk_cached is not None:
+            _CACHE[cache_key] = disk_cached
+            return dict(disk_cached.secrets), warnings
+
+    op = binary or find_op()
+    if op is None:
+        raise RuntimeError(
+            "1Password CLI `op` is not available on PATH. Install it from "
+            "https://developer.1password.com/docs/cli/get-started/ and sign in, "
+            "or set OP_SERVICE_ACCOUNT_TOKEN for a service account."
+        )
+
+    secrets: Dict[str, str] = {}
+    read_errors: list[str] = []
+    for env_var, ref in valid_refs.items():
+        try:
+            secrets[env_var] = _run_op_read(
+                op,
+                ref,
+                account=account,
+                service_account_token_env=service_account_token_env,
+            )
+        except RuntimeError as exc:
+            read_errors.append(f"{env_var}: {exc}")
+
+    if read_errors:
+        warnings.extend(read_errors)
+        if not secrets:
+            raise RuntimeError("; ".join(read_errors))
+
+    entry = _CachedFetch(secrets=dict(secrets), fetched_at=time.time())
+    _CACHE[cache_key] = entry
+    if use_cache:
+        _write_disk_cache(cache_key, entry, home_path)
+    return secrets, warnings
+
+
+def apply_onepassword_secrets(
+    *,
+    enabled: bool,
+    references: Optional[Mapping[str, str]] = None,
+    override_existing: bool = False,
+    cache_ttl_seconds: float = 300,
+    account: str = "",
+    service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN",
+    home_path: Optional[Path] = None,
+) -> FetchResult:
+    """Resolve 1Password references and set them on ``os.environ``.
+
+    Parameters mirror ``secrets.onepassword.*`` config keys so the caller can
+    pass values directly from config.yaml. The function is intentionally
+    defensive: it returns errors in the result object and never raises.
+    """
+
+    result = FetchResult()
+    if not enabled:
+        return result
+
+    references = references or {}
+    if not references:
+        result.error = (
+            "secrets.onepassword.enabled is true but no references are configured. "
+            "Add entries under secrets.onepassword.env."
+        )
+        return result
+
+    valid_refs, validation_warnings = _validate_references(references)
+    result.warnings.extend(validation_warnings)
+
+    refs_to_fetch: Dict[str, str] = {}
+    for key, ref in valid_refs.items():
+        if key == service_account_token_env:
+            # Avoid clobbering the bootstrap credential used by op service
+            # accounts if someone maps it accidentally.
+            result.skipped.append(key)
+            continue
+        if not override_existing and os.environ.get(key):
+            # Performance fast path: if the caller explicitly wants existing
+            # env/.env values to win, do not contact `op` for values we will
+            # discard anyway. This matters for shells/services that keep most
+            # credentials exported but have 1Password configured as fallback.
+            result.skipped.append(key)
+            continue
+        refs_to_fetch[key] = ref
+
+    if not refs_to_fetch:
+        if result.skipped:
+            return result
+        if result.warnings:
+            result.error = "No valid 1Password references were resolved. " + "; ".join(
+                result.warnings
+            )
+            return result
+
+    binary = find_op()
+    result.binary_path = binary
+
+    try:
+        secrets, warnings = fetch_onepassword_secrets(
+            references=refs_to_fetch,
+            binary=binary,
+            account=account,
+            cache_ttl_seconds=cache_ttl_seconds,
+            service_account_token_env=service_account_token_env,
+            home_path=home_path,
+        )
+    except RuntimeError as exc:
+        result.error = str(exc)
+        return result
+
+    result.secrets = secrets
+    result.warnings.extend(warnings)
+    if not secrets and warnings:
+        result.error = "No valid 1Password references were resolved. " + "; ".join(warnings)
+        return result
+
+    for key, value in secrets.items():
+        os.environ[key] = value
+        result.applied.append(key)
+
+    return result
+
+
+def _validate_references(references: Mapping[str, str]) -> tuple[Dict[str, str], list[str]]:
+    valid: Dict[str, str] = {}
+    warnings: list[str] = []
+    for key, ref in references.items():
+        if not isinstance(key, str) or not _is_valid_env_name(key):
+            warnings.append(f"Skipping reference for {key!r}: not a valid env-var name")
+            continue
+        if not isinstance(ref, str) or not ref.strip():
+            warnings.append(f"Skipping {key}: 1Password reference is empty")
+            continue
+        ref = ref.strip()
+        if not ref.startswith("op://"):
+            warnings.append(f"Skipping {key}: 1Password reference must start with 'op://'")
+            continue
+        valid[key] = ref
+    return valid, warnings
+
+
+def _run_op_read(
+    op: Path,
+    reference: str,
+    *,
+    account: str = "",
+    service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN",
+) -> str:
+    cmd = [str(op), "read", reference]
+    if account:
+        cmd.extend(["--account", account])
+    env = os.environ.copy()
+    env.setdefault("NO_COLOR", "1")
+    if service_account_token_env != "OP_SERVICE_ACCOUNT_TOKEN":
+        custom_token = os.environ.get(service_account_token_env)
+        if custom_token:
+            env["OP_SERVICE_ACCOUNT_TOKEN"] = custom_token
+    try:
+        proc = subprocess.run(  # noqa: S603 — op path is trusted
+            cmd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=_OP_RUN_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"op timed out after {_OP_RUN_TIMEOUT}s reading {reference!r}"
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(f"failed to invoke op: {exc}") from exc
+
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().replace("\x1b", "")
+        raise RuntimeError(f"op read failed for {reference!r}: {err[:200]}")
+
+    # `op read` prints a trailing newline in normal terminal use. Preserve all
+    # other characters in the secret value.
+    return (proc.stdout or "").rstrip("\r\n")
+
+
+def _auth_fingerprint(service_account_token_env: str = "OP_SERVICE_ACCOUNT_TOKEN") -> str:
+    material = "\0".join(
+        os.environ.get(name, "")
+        for name in (
+            "OP_SERVICE_ACCOUNT_TOKEN",
+            service_account_token_env,
+            "OP_SESSION",
+            "OP_ACCOUNT",
+        )
+    )
+    if not material:
+        return ""
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:16]
+
+
+def _is_valid_env_name(name: str) -> bool:
+    if not name:
+        return False
+    if not (name[0].isalpha() or name[0] == "_"):
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _reset_cache_for_tests() -> None:
+    """Clear in-process cache for hermetic tests."""
+
+    _CACHE.clear()

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -142,6 +142,26 @@ model:
 #   response_cache_ttl: 300      # Cache TTL in seconds, 1-86400 (default: 300)
 
 # =============================================================================
+# External Secret Sources
+# =============================================================================
+# Optional: resolve credentials from external secret managers at startup instead
+# of storing every provider key directly in ~/.hermes/.env.
+#
+# 1Password uses the official `op` CLI. Install/sign in separately, or provide
+# OP_SERVICE_ACCOUNT_TOKEN for non-interactive service-account usage.
+#
+# secrets:
+#   onepassword:
+#     enabled: false
+#     account: ""                         # Optional `op read --account` value
+#     service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN
+#     cache_ttl_seconds: 300               # 0 disables in-process/disk cache
+#     override_existing: true              # 1Password refs override .env values
+#     env:
+#       # OPENAI_API_KEY: op://Private/OpenAI/credential
+#       # ANTHROPIC_API_KEY: op://Private/Anthropic/credential
+#
+# =============================================================================
 # Git Worktree Isolation
 # =============================================================================
 # When enabled, each CLI session creates an isolated git worktree so multiple

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2259,6 +2259,26 @@ DEFAULT_CONFIG = {
             # `hermes secrets bitwarden setup`.
             "server_url": "",
         },
+        "onepassword": {
+            # Master switch. When false, the op CLI is never contacted.
+            "enabled": False,
+            # Map env var names to 1Password secret references, e.g.
+            # OPENAI_API_KEY: op://Private/OpenAI/credential
+            "env": {},
+            # Optional 1Password account shorthand/email passed to `op read
+            # --account`. Empty means use the CLI's default account.
+            "account": "",
+            # Name of the env var that holds an optional 1Password service
+            # account token. This is metadata only; the op CLI reads it from
+            # the environment and Hermes refuses to overwrite it from a ref.
+            "service_account_token_env": "OP_SERVICE_ACCOUNT_TOKEN",
+            # Seconds to cache fetched refs in-process and on disk under
+            # ~/.hermes/cache/op_cache.json. 0 disables both cache layers.
+            "cache_ttl_seconds": 300,
+            # When True, 1Password values overwrite existing env vars. Default
+            # True because the point is centralized rotation.
+            "override_existing": True,
+        },
     },
 
     # Paste collapse thresholds (TUI + CLI).

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -304,7 +304,8 @@ def _record_secret_source_result(result, *, source: str, display_name: str) -> N
 
 
 def _apply_bitwarden_secret_source(cfg: dict, home_path: Path) -> None:
-    bw_cfg = (cfg or {}).get("bitwarden") or {}
+    bw_cfg = (cfg or {}).get("bitwarden")
+    bw_cfg = bw_cfg if isinstance(bw_cfg, dict) else {}
     if not bw_cfg.get("enabled"):
         return
 
@@ -329,7 +330,8 @@ def _apply_bitwarden_secret_source(cfg: dict, home_path: Path) -> None:
 
 
 def _apply_onepassword_secret_source(cfg: dict, home_path: Path) -> None:
-    op_cfg = (cfg or {}).get("onepassword") or {}
+    op_cfg = (cfg or {}).get("onepassword")
+    op_cfg = op_cfg if isinstance(op_cfg, dict) else {}
     if not op_cfg.get("enabled"):
         return
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -21,7 +21,7 @@ _CREDENTIAL_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_KEY")
 # tests) don't spam the same warning multiple times.
 _WARNED_KEYS: set[str] = set()
 
-# Map of env-var name → source label ("bitwarden", etc.) for credentials
+# Map of env-var name → source label ("bitwarden", "onepassword", etc.) for credentials
 # that were injected by an external secret source during load_hermes_dotenv().
 # Used by setup / `hermes model` flows to label detected credentials so
 # users understand WHERE a key came from when their .env doesn't contain it
@@ -42,12 +42,13 @@ _APPLIED_HOMES: set[str] = set()
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
 
-    Returns ``"bitwarden"`` for keys pulled from Bitwarden Secrets Manager
-    during the current process's ``load_hermes_dotenv()`` call.  Returns
-    ``None`` for keys that came from ``.env``, the shell environment, or
-    aren't tracked.  The returned label is metadata only: credential-pool
-    persistence may store it to explain the origin of a borrowed secret, but
-    must never treat it as authorization to persist the raw value.
+    Returns labels such as ``"bitwarden"`` or ``"onepassword"`` for keys
+    pulled from external secret sources during the current process's
+    ``load_hermes_dotenv()`` call.  Returns ``None`` for keys that came from
+    ``.env``, the shell environment, or aren't tracked.  The returned label is
+    metadata only: credential-pool persistence may store it to explain the
+    origin of a borrowed secret, but must never treat it as authorization to
+    persist the raw value.
     """
     return _SECRET_SOURCES.get(env_var)
 
@@ -78,6 +79,8 @@ def format_secret_source_suffix(env_var: str) -> str:
         return ""
     if source == "bitwarden":
         return " (from Bitwarden)"
+    if source == "onepassword":
+        return " (from 1Password)"
     # Generic fallback — future-proofing for additional secret sources
     # (e.g. 1Password, HashiCorp Vault) without having to update every
     # call site.
@@ -248,7 +251,7 @@ def load_hermes_dotenv(
 
 
 def _apply_external_secret_sources(home_path: Path) -> None:
-    """Pull secrets from external sources (currently Bitwarden) into env.
+    """Pull secrets from external sources into env.
 
     Runs AFTER dotenv loads so .env values are visible (we use them to
     locate the access token) but BEFORE the rest of Hermes reads
@@ -274,6 +277,33 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     except Exception:  # noqa: BLE001 — config errors must not block startup
         return
 
+    _apply_bitwarden_secret_source(cfg or {}, home_path)
+    _apply_onepassword_secret_source(cfg or {}, home_path)
+
+
+def _record_secret_source_result(result, *, source: str, display_name: str) -> None:  # noqa: ANN001
+    if result.applied:
+        # Re-run the ASCII sanitization pass: external values are user-supplied
+        # and might have the same copy-paste corruption as a manually edited
+        # .env (see #6843).
+        _sanitize_loaded_credentials()
+        # Remember where these came from so setup / `hermes model` flows can
+        # label detected credentials with their source.
+        for name in result.applied:
+            _SECRET_SOURCES[name] = source
+        print(
+            f"  {display_name}: applied {len(result.applied)} "
+            f"secret{'s' if len(result.applied) != 1 else ''} "
+            f"({', '.join(sorted(result.applied))})",
+            file=sys.stderr,
+        )
+    if result.error:
+        print(f"  {display_name}: {result.error}", file=sys.stderr)
+    for warn in result.warnings:
+        print(f"  {display_name}: {warn}", file=sys.stderr)
+
+
+def _apply_bitwarden_secret_source(cfg: dict, home_path: Path) -> None:
     bw_cfg = (cfg or {}).get("bitwarden") or {}
     if not bw_cfg.get("enabled"):
         return
@@ -293,34 +323,35 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         server_url=str(bw_cfg.get("server_url", "") or "").strip(),
         home_path=home_path,
     )
+    _record_secret_source_result(
+        result, source="bitwarden", display_name="Bitwarden Secrets Manager"
+    )
 
-    if result.applied:
-        # Re-run the ASCII sanitization pass: BSM values are user-supplied
-        # and might have the same copy-paste corruption as a manually
-        # edited .env (see #6843).
-        _sanitize_loaded_credentials()
-        # Remember where these came from so the setup / `hermes model`
-        # flows can label detected credentials with "(from Bitwarden)" —
-        # otherwise users see "credentials ✓" with no hint that the value
-        # came from BSM rather than .env.
-        for name in result.applied:
-            _SECRET_SOURCES[name] = "bitwarden"
-        print(
-            f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
-            f"secret{'s' if len(result.applied) != 1 else ''} "
-            f"({', '.join(sorted(result.applied))})",
-            file=sys.stderr,
-        )
-    if result.error:
-        print(
-            f"  Bitwarden Secrets Manager: {result.error}",
-            file=sys.stderr,
-        )
-    for warn in result.warnings:
-        print(
-            f"  Bitwarden Secrets Manager: {warn}",
-            file=sys.stderr,
-        )
+
+def _apply_onepassword_secret_source(cfg: dict, home_path: Path) -> None:
+    op_cfg = (cfg or {}).get("onepassword") or {}
+    if not op_cfg.get("enabled"):
+        return
+
+    try:
+        from agent.secret_sources.onepassword import apply_onepassword_secrets
+    except ImportError:
+        return
+
+    result = apply_onepassword_secrets(
+        enabled=True,
+        references=op_cfg.get("env") or op_cfg.get("references") or {},
+        override_existing=bool(op_cfg.get("override_existing", True)),
+        cache_ttl_seconds=float(op_cfg.get("cache_ttl_seconds", 300)),
+        account=str(op_cfg.get("account", "") or "").strip(),
+        service_account_token_env=op_cfg.get(
+            "service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN"
+        ),
+        home_path=home_path,
+    )
+    _record_secret_source_result(
+        result, source="onepassword", display_name="1Password"
+    )
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -318,7 +318,7 @@ def _apply_bitwarden_secret_source(cfg: dict, home_path: Path) -> None:
         access_token_env=bw_cfg.get("access_token_env", "BWS_ACCESS_TOKEN"),
         project_id=bw_cfg.get("project_id", ""),
         override_existing=bool(bw_cfg.get("override_existing", False)),
-        cache_ttl_seconds=float(bw_cfg.get("cache_ttl_seconds", 300)),
+        cache_ttl_seconds=_coerce_cache_ttl(bw_cfg.get("cache_ttl_seconds", 300)),
         auto_install=bool(bw_cfg.get("auto_install", True)),
         server_url=str(bw_cfg.get("server_url", "") or "").strip(),
         home_path=home_path,
@@ -342,7 +342,7 @@ def _apply_onepassword_secret_source(cfg: dict, home_path: Path) -> None:
         enabled=True,
         references=op_cfg.get("env") or op_cfg.get("references") or {},
         override_existing=bool(op_cfg.get("override_existing", True)),
-        cache_ttl_seconds=float(op_cfg.get("cache_ttl_seconds", 300)),
+        cache_ttl_seconds=_coerce_cache_ttl(op_cfg.get("cache_ttl_seconds", 300)),
         account=str(op_cfg.get("account", "") or "").strip(),
         service_account_token_env=op_cfg.get(
             "service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN"
@@ -352,6 +352,18 @@ def _apply_onepassword_secret_source(cfg: dict, home_path: Path) -> None:
     _record_secret_source_result(
         result, source="onepassword", display_name="1Password"
     )
+
+
+def _coerce_cache_ttl(value, default: float = 300) -> float:  # noqa: ANN001
+    """Parse cache TTL config without letting bad YAML crash startup."""
+
+    try:
+        ttl = float(value)
+    except (TypeError, ValueError):
+        return default
+    if ttl < 0:
+        return default
+    return ttl
 
 
 def _load_secrets_config(home_path: Path) -> dict:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11905,16 +11905,15 @@ def main():
     fallback_parser.set_defaults(func=cmd_fallback)
 
     # =========================================================================
-    # secrets command — external secret managers (currently: Bitwarden)
+    # secrets command — external secret managers
     # =========================================================================
     secrets_parser = subparsers.add_parser(
         "secrets",
-        help="Manage external secret sources (Bitwarden Secrets Manager)",
+        help="Manage external secret sources (Bitwarden, 1Password)",
         description=(
             "Pull API keys from an external secret manager at process startup "
-            "instead of storing them in ~/.hermes/.env.  Currently supports "
-            "Bitwarden Secrets Manager.  See: "
-            "https://hermes-agent.nousresearch.com/docs/user-guide/secrets/bitwarden"
+            "instead of storing them in ~/.hermes/.env. Supports Bitwarden "
+            "Secrets Manager and 1Password CLI secret references."
         ),
     )
     secrets_subparsers = secrets_parser.add_subparsers(dest="secrets_command")
@@ -11924,16 +11923,26 @@ def main():
         aliases=["bw"],
         help="Bitwarden Secrets Manager integration",
     )
+    secrets_op = secrets_subparsers.add_parser(
+        "onepassword",
+        aliases=["op", "1password", "1p"],
+        help="1Password CLI secret-reference integration",
+    )
 
-    # Lazy import — only pays for itself when this subcommand is actually used.
+    # Lazy imports — only pay for themselves when this subcommand is used.
+    from hermes_cli import onepassword_secrets_cli as _op_secrets_cli
     from hermes_cli import secrets_cli as _secrets_cli
 
     _secrets_cli.register_cli(secrets_bw)
+    _op_secrets_cli.register_cli(secrets_op)
 
     def _dispatch_secrets(args):  # noqa: ANN001
         sub = getattr(args, "secrets_command", None)
         bw_sub = getattr(args, "secrets_bw_command", None)
+        op_sub = getattr(args, "secrets_op_command", None)
         if sub in ("bitwarden", "bw") and bw_sub is not None:
+            return args.func(args)
+        if sub in ("onepassword", "op", "1password", "1p") and op_sub is not None:
             return args.func(args)
         secrets_parser.print_help()
         return 0

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -175,7 +175,7 @@ def cmd_status(args: argparse.Namespace) -> int:
     table.add_row("Token env var", token_env)
     table.add_row("Token in env", _yn(bool(os.environ.get(token_env))))
     table.add_row("References", str(len(refs) if isinstance(refs, dict) else 0))
-    table.add_row("Override existing", _yn(bool(op_cfg.get("override_existing", False))))
+    table.add_row("Override existing", _yn(bool(op_cfg.get("override_existing", True))))
     table.add_row("Cache TTL (s)", str(op_cfg.get("cache_ttl_seconds", 300)))
     console.print(Panel(table, title="1Password", border_style="cyan"))
 
@@ -205,40 +205,43 @@ def cmd_sync(args: argparse.Namespace) -> int:
         console.print("[red]No 1Password references configured.[/red]")
         return 1
 
-    try:
-        secrets, warnings = op_secret.fetch_onepassword_secrets(
-            references=refs,
-            account=str(op_cfg.get("account", "") or ""),
-            service_account_token_env=str(
-                op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
-            ),
-            use_cache=False,
-        )
-    except Exception as exc:  # noqa: BLE001
-        console.print(f"[red]Fetch failed: {exc}[/red]")
-        return 1
-
     token_env = op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
-    override = bool(op_cfg.get("override_existing", False))
-    _print_resolved_table(
-        console,
-        secrets,
-        warnings,
-        apply=bool(args.apply),
-        override_existing=override,
-        token_env=token_env,
-    )
+    override = bool(op_cfg.get("override_existing", True))
     if args.apply:
-        applied = 0
-        for key, value in secrets.items():
-            if key == token_env:
-                continue
-            if os.environ.get(key) and not override:
-                continue
-            os.environ[key] = value
-            applied += 1
-        console.print(f"\n[green]Exported {applied} secret(s) into current process.[/green]")
+        result = op_secret.apply_onepassword_secrets(
+            enabled=True,
+            references=refs,
+            override_existing=override,
+            cache_ttl_seconds=_coerce_cache_ttl(op_cfg.get("cache_ttl_seconds", 300)),
+            account=str(op_cfg.get("account", "") or ""),
+            service_account_token_env=str(token_env),
+        )
+        _print_apply_result_table(console, result)
+        if result.error:
+            console.print(f"[red]Fetch failed: {result.error}[/red]")
+            return 1
+        console.print(
+            f"\n[green]Exported {len(result.applied)} secret(s) into current process.[/green]"
+        )
     else:
+        try:
+            secrets, warnings = op_secret.fetch_onepassword_secrets(
+                references=refs,
+                account=str(op_cfg.get("account", "") or ""),
+                service_account_token_env=str(token_env),
+                use_cache=False,
+            )
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[red]Fetch failed: {exc}[/red]")
+            return 1
+        _print_resolved_table(
+            console,
+            secrets,
+            warnings,
+            apply=False,
+            override_existing=override,
+            token_env=str(token_env),
+        )
         console.print(
             "\nThis was a dry-run — secrets are picked up automatically on the next "
             "[cyan]hermes[/cyan] invocation. Re-run with [cyan]--apply[/cyan] "
@@ -258,14 +261,15 @@ def cmd_set(args: argparse.Namespace) -> int:
     cfg = load_config()
     op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
     op_cfg["env"] = _merged_refs(op_cfg)
-    op_cfg["env"][args.env_var] = args.reference
+    env_var, reference = next(iter(valid.items()))
+    op_cfg["env"][env_var] = reference
     op_cfg.setdefault("cache_ttl_seconds", 300)
     op_cfg.setdefault("override_existing", True)
     op_cfg.setdefault("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
     if args.enable:
         op_cfg["enabled"] = True
     save_config(cfg)
-    console.print(f"[green]✓[/green] mapped {args.env_var} → {args.reference}")
+    console.print(f"[green]✓[/green] mapped {env_var} → {reference}")
     return 0
 
 
@@ -357,6 +361,29 @@ def _print_resolved_table(
     console.print(table)
     for warning in warnings:
         console.print(f"[yellow]warning:[/yellow] {warning}")
+
+
+def _print_apply_result_table(console: Console, result: op_secret.FetchResult) -> None:
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", style="cyan")
+    table.add_column("Action")
+    for key in sorted(result.applied):
+        table.add_row(key, "[green]exported[/green]")
+    for key in sorted(result.skipped):
+        table.add_row(key, "[dim]skip[/dim]")
+    console.print(table)
+    for warning in result.warnings:
+        console.print(f"[yellow]warning:[/yellow] {warning}")
+
+
+def _coerce_cache_ttl(value, default: float = 300) -> float:  # noqa: ANN001
+    try:
+        ttl = float(value)
+    except (TypeError, ValueError):
+        return default
+    if ttl < 0:
+        return default
+    return ttl
 
 
 def _yn(value: bool) -> str:

--- a/hermes_cli/onepassword_secrets_cli.py
+++ b/hermes_cli/onepassword_secrets_cli.py
@@ -1,0 +1,363 @@
+"""CLI handlers for ``hermes secrets onepassword ...``.
+
+Subcommands:
+    setup    — configure one or more ENV=op://... references and test them
+    status   — show current config + op availability
+    sync     — resolve configured references now and show what would be applied
+    set      — add/update one ENV_VAR -> op:// reference
+    remove   — remove one configured ENV_VAR mapping
+    disable  — flip ``secrets.onepassword.enabled`` to False
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from agent.secret_sources import onepassword as op_secret
+from hermes_cli.config import load_config, save_config
+
+
+def register_cli(parent_parser: argparse.ArgumentParser) -> None:
+    """Attach the ``onepassword`` subcommand tree to a parent parser."""
+
+    sub = parent_parser.add_subparsers(dest="secrets_op_command")
+
+    setup = sub.add_parser(
+        "setup",
+        help="Configure ENV_VAR=op://... references and enable 1Password",
+    )
+    setup.add_argument(
+        "--map",
+        action="append",
+        default=[],
+        metavar="ENV_VAR=op://vault/item/field",
+        help="Add an env-var mapping. May be repeated.",
+    )
+    setup.add_argument(
+        "--account",
+        default="",
+        help="Optional 1Password account shorthand/email for `op read --account`.",
+    )
+    setup.add_argument(
+        "--token-env",
+        default=None,
+        help="Env var holding an optional 1Password service-account token.",
+    )
+    setup.add_argument(
+        "--skip-test",
+        action="store_true",
+        help="Save config without resolving references immediately.",
+    )
+    setup.set_defaults(func=cmd_setup)
+
+    status = sub.add_parser("status", help="Show config + op availability")
+    status.set_defaults(func=cmd_status)
+
+    sync = sub.add_parser("sync", help="Resolve references now and report actions")
+    sync.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually export resolved values into this process (default: dry-run)",
+    )
+    sync.set_defaults(func=cmd_sync)
+
+    set_cmd = sub.add_parser("set", help="Add or update one ENV_VAR reference")
+    set_cmd.add_argument("env_var", help="Environment variable to populate")
+    set_cmd.add_argument("reference", help="1Password reference: op://vault/item/field")
+    set_cmd.add_argument("--enable", action="store_true", help="Also enable the integration")
+    set_cmd.set_defaults(func=cmd_set)
+
+    remove = sub.add_parser("remove", aliases=["rm"], help="Remove one ENV_VAR reference")
+    remove.add_argument("env_var", help="Environment variable mapping to remove")
+    remove.set_defaults(func=cmd_remove)
+
+    disable = sub.add_parser("disable", help="Turn off the 1Password integration")
+    disable.set_defaults(func=cmd_disable)
+
+
+def cmd_setup(args: argparse.Namespace) -> int:
+    console = Console()
+    console.print(
+        Panel.fit(
+            "[bold]1Password secret references setup[/bold]\n\n"
+            "Hermes reads configured [cyan]op://[/cyan] references with the official "
+            "[cyan]op[/cyan] CLI at startup. Sign in with [cyan]op signin[/cyan] "
+            "or set [cyan]OP_SERVICE_ACCOUNT_TOKEN[/cyan] before enabling.",
+            border_style="cyan",
+        )
+    )
+
+    if not args.skip_test:
+        binary = op_secret.find_op()
+        if binary is None:
+            console.print(
+                "[red]op CLI is not installed or not on PATH.[/red]\n"
+                "Install it from https://developer.1password.com/docs/cli/get-started/ "
+                "and run this command again, or pass --skip-test to save config only."
+            )
+            return 1
+        console.print(f"[green]✓[/green] op CLI found at {binary}")
+    else:
+        binary = None
+
+    refs = _parse_maps(args.map, console)
+    if refs is None:
+        return 1
+
+    cfg = load_config()
+    op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    op_cfg["env"] = _merged_refs(op_cfg)
+    existing = op_cfg["env"]
+    existing.update(refs)
+    if args.account:
+        op_cfg["account"] = args.account.strip()
+    if args.token_env:
+        op_cfg["service_account_token_env"] = args.token_env.strip() or "OP_SERVICE_ACCOUNT_TOKEN"
+    else:
+        op_cfg.setdefault("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    op_cfg.setdefault("cache_ttl_seconds", 300)
+    op_cfg.setdefault("override_existing", True)
+
+    if not existing:
+        console.print(
+            "[yellow]No references configured yet.[/yellow] Add one with:\n"
+            "  [cyan]hermes secrets onepassword set OPENAI_API_KEY "
+            "op://Private/OpenAI/credential --enable[/cyan]"
+        )
+        return 1
+
+    if not args.skip_test:
+        try:
+            secrets, warnings = op_secret.fetch_onepassword_secrets(
+                references=existing,
+                binary=binary,
+                account=str(op_cfg.get("account", "") or ""),
+                service_account_token_env=str(
+                    op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+                ),
+                use_cache=False,
+            )
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"[red]Test fetch failed: {exc}[/red]")
+            return 1
+        _print_resolved_table(
+            console,
+            secrets,
+            warnings,
+            apply=False,
+            override_existing=bool(op_cfg.get("override_existing", True)),
+            token_env=str(op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")),
+        )
+
+    op_cfg["enabled"] = True
+    save_config(cfg)
+    console.print("\n[green]✓ 1Password secret references are enabled.[/green]")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+    refs = _merged_refs(op_cfg)
+    token_env = op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("", style="bold")
+    table.add_column("")
+    table.add_row("Enabled", _yn(bool(op_cfg.get("enabled"))))
+    table.add_row("op binary", str(op_secret.find_op() or "[yellow]not found[/yellow]"))
+    table.add_row("Account", str(op_cfg.get("account", "") or "[dim](default)[/dim]"))
+    table.add_row("Token env var", token_env)
+    table.add_row("Token in env", _yn(bool(os.environ.get(token_env))))
+    table.add_row("References", str(len(refs) if isinstance(refs, dict) else 0))
+    table.add_row("Override existing", _yn(bool(op_cfg.get("override_existing", False))))
+    table.add_row("Cache TTL (s)", str(op_cfg.get("cache_ttl_seconds", 300)))
+    console.print(Panel(table, title="1Password", border_style="cyan"))
+
+    if refs and isinstance(refs, dict):
+        ref_table = Table(show_header=True, header_style="bold")
+        ref_table.add_column("Env var", style="cyan")
+        ref_table.add_column("1Password reference", style="dim")
+        for key, ref in sorted(refs.items()):
+            ref_table.add_row(str(key), str(ref))
+        console.print(ref_table)
+    return 0
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = (cfg.get("secrets") or {}).get("onepassword") or {}
+    if not op_cfg.get("enabled"):
+        console.print(
+            "[yellow]1Password integration is disabled. Run "
+            "`hermes secrets onepassword setup --map ENV=op://...` first.[/yellow]"
+        )
+        return 1
+
+    refs = _merged_refs(op_cfg)
+    if not refs:
+        console.print("[red]No 1Password references configured.[/red]")
+        return 1
+
+    try:
+        secrets, warnings = op_secret.fetch_onepassword_secrets(
+            references=refs,
+            account=str(op_cfg.get("account", "") or ""),
+            service_account_token_env=str(
+                op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+            ),
+            use_cache=False,
+        )
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"[red]Fetch failed: {exc}[/red]")
+        return 1
+
+    token_env = op_cfg.get("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    override = bool(op_cfg.get("override_existing", False))
+    _print_resolved_table(
+        console,
+        secrets,
+        warnings,
+        apply=bool(args.apply),
+        override_existing=override,
+        token_env=token_env,
+    )
+    if args.apply:
+        applied = 0
+        for key, value in secrets.items():
+            if key == token_env:
+                continue
+            if os.environ.get(key) and not override:
+                continue
+            os.environ[key] = value
+            applied += 1
+        console.print(f"\n[green]Exported {applied} secret(s) into current process.[/green]")
+    else:
+        console.print(
+            "\nThis was a dry-run — secrets are picked up automatically on the next "
+            "[cyan]hermes[/cyan] invocation. Re-run with [cyan]--apply[/cyan] "
+            "to export into this process."
+        )
+    return 0
+
+
+def cmd_set(args: argparse.Namespace) -> int:
+    console = Console()
+    valid, warnings = op_secret._validate_references({args.env_var: args.reference})
+    for warning in warnings:
+        console.print(f"[yellow]warning:[/yellow] {warning}")
+    if not valid:
+        return 1
+
+    cfg = load_config()
+    op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    op_cfg["env"] = _merged_refs(op_cfg)
+    op_cfg["env"][args.env_var] = args.reference
+    op_cfg.setdefault("cache_ttl_seconds", 300)
+    op_cfg.setdefault("override_existing", True)
+    op_cfg.setdefault("service_account_token_env", "OP_SERVICE_ACCOUNT_TOKEN")
+    if args.enable:
+        op_cfg["enabled"] = True
+    save_config(cfg)
+    console.print(f"[green]✓[/green] mapped {args.env_var} → {args.reference}")
+    return 0
+
+
+def cmd_remove(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    op_cfg["env"] = _merged_refs(op_cfg)
+    refs = op_cfg["env"]
+    legacy_refs = op_cfg.get("references") if isinstance(op_cfg.get("references"), dict) else {}
+    if args.env_var not in refs and args.env_var not in legacy_refs:
+        console.print(f"[yellow]{args.env_var} is not mapped.[/yellow]")
+        return 0
+    refs.pop(args.env_var, None)
+    if isinstance(legacy_refs, dict):
+        legacy_refs.pop(args.env_var, None)
+    save_config(cfg)
+    console.print(f"[green]✓[/green] removed {args.env_var}")
+    return 0
+
+
+def cmd_disable(args: argparse.Namespace) -> int:
+    console = Console()
+    cfg = load_config()
+    op_cfg = cfg.setdefault("secrets", {}).setdefault("onepassword", {})
+    op_cfg["enabled"] = False
+    save_config(cfg)
+    console.print(
+        "[green]Disabled.[/green]  1Password references will not be resolved on "
+        "the next Hermes invocation."
+    )
+    return 0
+
+
+def _merged_refs(op_cfg: dict) -> dict[str, str]:
+    """Return env mappings, including legacy ``references`` entries."""
+
+    refs: dict[str, str] = {}
+    legacy = op_cfg.get("references")
+    current = op_cfg.get("env")
+    if isinstance(legacy, dict):
+        refs.update({str(k): str(v) for k, v in legacy.items()})
+    if isinstance(current, dict):
+        refs.update({str(k): str(v) for k, v in current.items()})
+    return refs
+
+
+def _parse_maps(values: list[str], console: Console) -> dict[str, str] | None:
+    refs: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            console.print(f"[red]Invalid --map value {value!r}; expected ENV_VAR=op://...[/red]")
+            return None
+        key, ref = value.split("=", 1)
+        refs[key.strip()] = ref.strip()
+    valid, warnings = op_secret._validate_references(refs)
+    for warning in warnings:
+        console.print(f"[yellow]warning:[/yellow] {warning}")
+    if refs and not valid:
+        return None
+    return valid
+
+
+def _print_resolved_table(
+    console: Console,
+    secrets: dict[str, str],
+    warnings: list[str],
+    *,
+    apply: bool,
+    override_existing: bool = True,
+    token_env: str = "OP_SERVICE_ACCOUNT_TOKEN",
+) -> None:
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Name", style="cyan")
+    table.add_column("Action")
+    for key in sorted(secrets):
+        if key == token_env:
+            table.add_row(key, "[dim]skip (bootstrap token)[/dim]")
+            continue
+        already = bool(os.environ.get(key))
+        if already and not override_existing:
+            table.add_row(key, "[dim]skip (already set)[/dim]")
+            continue
+        if apply:
+            action = "[green]exported[/green]" + (" (overrode)" if already else "")
+        else:
+            action = "[green]would export[/green]" + (" (overrides)" if already else "")
+        table.add_row(key, action)
+    console.print(table)
+    for warning in warnings:
+        console.print(f"[yellow]warning:[/yellow] {warning}")
+
+
+def _yn(value: bool) -> str:
+    return "[green]yes[/green]" if value else "[dim]no[/dim]"

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -750,6 +750,45 @@ def test_disk_cache_use_cache_false_skips_disk(monkeypatch, tmp_path):
     assert call_count["n"] == 2
 
 
+def test_disk_cache_ttl_zero_skips_all_cache_writes(monkeypatch, tmp_path):
+    """cache_ttl_seconds=0 opts out of both in-process and disk caching."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+
+    call_count = {"n": 0}
+
+    def fake_run(*a, **kw):
+        call_count["n"] += 1
+        payload = _fake_bws_payload([{"key": "K1", "value": f"v{call_count['n']}"}])
+        return mock.Mock(returncode=0, stdout=payload, stderr="")
+
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+    bw._reset_cache_for_tests(home)
+
+    first, _ = bw.fetch_bitwarden_secrets(
+        access_token="0.t",
+        project_id="proj-1",
+        binary=fake_binary,
+        cache_ttl_seconds=0,
+        home_path=home,
+    )
+    second, _ = bw.fetch_bitwarden_secrets(
+        access_token="0.t",
+        project_id="proj-1",
+        binary=fake_binary,
+        cache_ttl_seconds=0,
+        home_path=home,
+    )
+
+    assert first == {"K1": "v1"}
+    assert second == {"K1": "v2"}
+    assert call_count["n"] == 2
+    assert bw._CACHE == {}
+    assert not bw._disk_cache_path(home).exists()
+
+
 def test_disk_cache_corrupt_file_falls_through(monkeypatch, tmp_path):
     """A garbage cache file must NOT crash startup — we refetch."""
     home = tmp_path / ".hermes"

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -253,3 +253,18 @@ def test_invalid_onepassword_cache_ttl_does_not_block_startup(tmp_path, monkeypa
 
     assert captured["cache_ttl_seconds"] == 300
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "onepassword"
+
+
+def test_non_dict_secret_source_sections_do_not_block_startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  bitwarden: true\n"
+        "  onepassword: true\n",
+        encoding="utf-8",
+    )
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert env_loader.get_secret_source("ANTHROPIC_API_KEY") is None

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -53,6 +53,14 @@ def test_format_secret_source_suffix_bitwarden_uses_proper_name():
     )
 
 
+def test_format_secret_source_suffix_onepassword_uses_proper_name():
+    env_loader._SECRET_SOURCES["ANTHROPIC_API_KEY"] = "onepassword"
+    assert (
+        env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
+        == " (from 1Password)"
+    )
+
+
 def test_format_secret_source_suffix_generic_label_for_future_sources():
     # Future-proofing: a new secret source (e.g. "vault") should still
     # produce a sensible label without needing to edit every call site.
@@ -173,3 +181,40 @@ def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypa
     env_loader.reset_secret_source_cache()
     env_loader._apply_external_secret_sources(tmp_path)
     assert call_count["n"] == 2
+
+
+def test_apply_external_secret_sources_records_onepassword_origin(tmp_path, monkeypatch):
+    """1Password-applied keys are tracked for UI source labels."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    env:\n"
+        "      ANTHROPIC_API_KEY: op://Vault/Item/field\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.onepassword import FetchResult
+
+    fake_result = FetchResult(
+        secrets={"ANTHROPIC_API_KEY": "sk-ant-test"},
+        applied=["ANTHROPIC_API_KEY"],
+    )
+
+    def _fake_apply(**_kwargs):
+        return fake_result
+
+    import agent.secret_sources.onepassword as op_module
+
+    monkeypatch.setattr(op_module, "apply_onepassword_secrets", _fake_apply)
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "onepassword"
+    assert (
+        env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
+        == " (from 1Password)"
+    )

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -218,3 +218,38 @@ def test_apply_external_secret_sources_records_onepassword_origin(tmp_path, monk
         env_loader.format_secret_source_suffix("ANTHROPIC_API_KEY")
         == " (from 1Password)"
     )
+
+
+def test_invalid_onepassword_cache_ttl_does_not_block_startup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  onepassword:\n"
+        "    enabled: true\n"
+        "    cache_ttl_seconds: definitely-not-a-number\n"
+        "    env:\n"
+        "      ANTHROPIC_API_KEY: op://Vault/Item/field\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.onepassword import FetchResult
+
+    captured = {}
+    fake_result = FetchResult(
+        secrets={"ANTHROPIC_API_KEY": "sk-ant-test"},
+        applied=["ANTHROPIC_API_KEY"],
+    )
+
+    def _fake_apply(**kwargs):
+        captured.update(kwargs)
+        return fake_result
+
+    import agent.secret_sources.onepassword as op_module
+
+    monkeypatch.setattr(op_module, "apply_onepassword_secrets", _fake_apply)
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    assert captured["cache_ttl_seconds"] == 300
+    assert env_loader.get_secret_source("ANTHROPIC_API_KEY") == "onepassword"

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -47,7 +47,12 @@ def test_fetch_happy_path(monkeypatch, tmp_path):
 
     assert secrets == {"OPENAI_API_KEY": "secret-value"}
     assert warnings == []
-    assert calls[0][0] == [str(fake_binary), "read", "op://Private/OpenAI/credential"]
+    assert calls[0][0] == [
+        str(fake_binary),
+        "read",
+        "--",
+        "op://Private/OpenAI/credential",
+    ]
 
 
 def test_fetch_child_env_is_limited(monkeypatch, tmp_path):
@@ -95,9 +100,10 @@ def test_fetch_account_flag(monkeypatch, tmp_path):
     assert captured["cmd"] == [
         str(fake_binary),
         "read",
-        "op://Vault/Item/field",
         "--account",
         "my.1password.com",
+        "--",
+        "op://Vault/Item/field",
     ]
 
 
@@ -190,6 +196,34 @@ def test_fetch_op_failure_does_not_echo_stdout(monkeypatch, tmp_path):
     assert "status 1" in str(exc_info.value)
 
 
+def test_fetch_op_failure_strips_ansi_sequences(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(
+            returncode=1,
+            stdout="",
+            stderr="\x1b[31mnot signed in\x1b[0m\x1b[2K",
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        op_secret.fetch_onepassword_secrets(
+            references={"KEY": "op://Vault/Item/field"},
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+    message = str(exc_info.value)
+    assert "\x1b" not in message
+    assert "[31m" not in message
+    assert "[2K" not in message
+    assert "not signed in" in message
+
+
 def test_fetch_empty_op_read_is_error(monkeypatch, tmp_path):
     fake_binary = tmp_path / "op"
     fake_binary.write_text("")
@@ -213,7 +247,7 @@ def test_fetch_partial_failure_returns_successes_and_warnings(monkeypatch, tmp_p
     fake_binary.write_text("")
 
     def fake_run(cmd, **_kwargs):
-        if "bad" in cmd[2]:
+        if "bad" in cmd[-1]:
             return mock.Mock(returncode=1, stdout="", stderr="not signed in")
         return mock.Mock(returncode=0, stdout="good-value\n", stderr="")
 
@@ -503,6 +537,7 @@ def test_fetch_ignores_stale_disk_cache(monkeypatch, tmp_path):
                     (
                         op_secret._auth_fingerprint(),
                         "",
+                        str(tmp_path.resolve()),
                         (("KEY", "op://Vault/Item/field"),),
                     )
                 ),
@@ -528,6 +563,61 @@ def test_fetch_ignores_stale_disk_cache(monkeypatch, tmp_path):
 
     assert secrets == {"KEY": "fresh"}
     assert calls["n"] == 1
+
+
+def test_fetch_ttl_zero_disables_memory_and_disk_cache(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*_args, **_kwargs):
+        calls["n"] += 1
+        return mock.Mock(returncode=0, stdout=f"value-{calls['n']}\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+    kwargs = {
+        "references": {"KEY": "op://Vault/Item/field"},
+        "binary": fake_binary,
+        "cache_ttl_seconds": 0,
+        "home_path": tmp_path,
+    }
+
+    first, _warnings = op_secret.fetch_onepassword_secrets(**kwargs)
+    second, _warnings = op_secret.fetch_onepassword_secrets(**kwargs)
+
+    assert first == {"KEY": "value-1"}
+    assert second == {"KEY": "value-2"}
+    assert not (tmp_path / "cache" / "op_cache.json").exists()
+
+
+def test_fetch_memory_cache_is_partitioned_by_home_path(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*_args, **_kwargs):
+        calls["n"] += 1
+        return mock.Mock(returncode=0, stdout=f"value-{calls['n']}\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+    common_kwargs = {
+        "references": {"KEY": "op://Vault/Item/field"},
+        "binary": fake_binary,
+        "cache_ttl_seconds": 60,
+    }
+
+    first, _warnings = op_secret.fetch_onepassword_secrets(
+        **common_kwargs,
+        home_path=tmp_path / "profile-a",
+    )
+    second, _warnings = op_secret.fetch_onepassword_secrets(
+        **common_kwargs,
+        home_path=tmp_path / "profile-b",
+    )
+
+    assert first == {"KEY": "value-1"}
+    assert second == {"KEY": "value-2"}
+    assert calls["n"] == 2
 
 
 def test_auth_fingerprint_includes_named_op_sessions(monkeypatch):

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -50,6 +50,30 @@ def test_fetch_happy_path(monkeypatch, tmp_path):
     assert calls[0][0] == [str(fake_binary), "read", "op://Private/OpenAI/credential"]
 
 
+def test_fetch_child_env_is_limited(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    captured_env = {}
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "unrelated-secret")
+    monkeypatch.setenv("OP_SESSION_my", "session-token")
+
+    def fake_run(_cmd, **kwargs):
+        captured_env.update(kwargs["env"])
+        return mock.Mock(returncode=0, stdout="value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    op_secret.fetch_onepassword_secrets(
+        references={"KEY": "op://Vault/Item/field"},
+        binary=fake_binary,
+        use_cache=False,
+    )
+
+    assert captured_env["NO_COLOR"] == "1"
+    assert captured_env["OP_SESSION_my"] == "session-token"
+    assert "AWS_SECRET_ACCESS_KEY" not in captured_env
+
+
 def test_fetch_account_flag(monkeypatch, tmp_path):
     fake_binary = tmp_path / "op"
     fake_binary.write_text("")
@@ -138,6 +162,45 @@ def test_fetch_op_failure(monkeypatch, tmp_path):
     )
 
     with pytest.raises(RuntimeError, match="not signed in"):
+        op_secret.fetch_onepassword_secrets(
+            references={"KEY": "op://Vault/Item/field"},
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+
+def test_fetch_op_failure_does_not_echo_stdout(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="secret-value", stderr=""),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        op_secret.fetch_onepassword_secrets(
+            references={"KEY": "op://Vault/Item/field"},
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+    assert "secret-value" not in str(exc_info.value)
+    assert "status 1" in str(exc_info.value)
+
+
+def test_fetch_empty_op_read_is_error(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="\n", stderr=""),
+    )
+
+    with pytest.raises(RuntimeError, match="empty value"):
         op_secret.fetch_onepassword_secrets(
             references={"KEY": "op://Vault/Item/field"},
             binary=fake_binary,
@@ -324,6 +387,29 @@ def test_apply_override_existing(monkeypatch, tmp_path):
     assert os.environ["OPENAI_API_KEY"] == "from-1password"
 
 
+def test_apply_empty_read_does_not_clobber_existing(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setattr(op_secret, "find_op", lambda: fake_binary)
+    monkeypatch.setenv("OPENAI_API_KEY", "existing-good-value")
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="\n", stderr=""),
+    )
+
+    result = op_secret.apply_onepassword_secrets(
+        enabled=True,
+        references={"OPENAI_API_KEY": "op://Vault/Item/field"},
+        override_existing=True,
+    )
+
+    assert not result.ok
+    assert result.error is not None
+    assert "empty value" in result.error
+    assert os.environ["OPENAI_API_KEY"] == "existing-good-value"
+
+
 def test_apply_skips_service_account_token_env(monkeypatch, tmp_path):
     fake_binary = tmp_path / "op"
     fake_binary.write_text("")
@@ -396,7 +482,9 @@ def test_fetch_disk_cache_is_written_0600_without_auth_material(monkeypatch, tmp
     cache_path = tmp_path / "cache" / "op_cache.json"
     payload = json.loads(cache_path.read_text())
     mode = stat.S_IMODE(cache_path.stat().st_mode)
+    dir_mode = stat.S_IMODE(cache_path.parent.stat().st_mode)
 
+    assert dir_mode == 0o700
     assert mode == 0o600
     assert payload["secrets"] == {"KEY": "value"}
     assert "ops_secret_token" not in cache_path.read_text()
@@ -440,6 +528,31 @@ def test_fetch_ignores_stale_disk_cache(monkeypatch, tmp_path):
 
     assert secrets == {"KEY": "fresh"}
     assert calls["n"] == 1
+
+
+def test_auth_fingerprint_includes_named_op_sessions(monkeypatch):
+    for name in list(os.environ):
+        if name.startswith("OP_"):
+            monkeypatch.delenv(name, raising=False)
+
+    without_session = op_secret._auth_fingerprint()
+    monkeypatch.setenv("OP_SESSION_my", "session-token")
+    with_session = op_secret._auth_fingerprint()
+
+    assert without_session == ""
+    assert with_session
+    assert with_session != without_session
+
+
+def test_reset_cache_for_tests_clears_default_disk_cache(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    cache_path = tmp_path / "cache" / "op_cache.json"
+    cache_path.parent.mkdir()
+    cache_path.write_text("{}", encoding="utf-8")
+
+    op_secret._reset_cache_for_tests()
+
+    assert not cache_path.exists()
 
 
 def test_apply_skips_existing_without_contacting_op_when_not_overriding(monkeypatch, tmp_path):

--- a/tests/test_onepassword_secrets.py
+++ b/tests/test_onepassword_secrets.py
@@ -1,0 +1,466 @@
+"""Hermetic tests for the 1Password secret-reference integration."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.secret_sources import onepassword as op_secret  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    op_secret._reset_cache_for_tests()
+    yield
+    op_secret._reset_cache_for_tests()
+
+
+def test_fetch_happy_path(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        assert cmd[:2] == [str(fake_binary), "read"]
+        assert kwargs["env"]["NO_COLOR"] == "1"
+        return mock.Mock(returncode=0, stdout="secret-value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    secrets, warnings = op_secret.fetch_onepassword_secrets(
+        references={"OPENAI_API_KEY": "op://Private/OpenAI/credential"},
+        binary=fake_binary,
+        use_cache=False,
+    )
+
+    assert secrets == {"OPENAI_API_KEY": "secret-value"}
+    assert warnings == []
+    assert calls[0][0] == [str(fake_binary), "read", "op://Private/OpenAI/credential"]
+
+
+def test_fetch_account_flag(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return mock.Mock(returncode=0, stdout="value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    op_secret.fetch_onepassword_secrets(
+        references={"KEY": "op://Vault/Item/field"},
+        binary=fake_binary,
+        account="my.1password.com",
+        use_cache=False,
+    )
+
+    assert captured["cmd"] == [
+        str(fake_binary),
+        "read",
+        "op://Vault/Item/field",
+        "--account",
+        "my.1password.com",
+    ]
+
+
+def test_fetch_uses_custom_service_account_token_env(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    captured_env = {}
+    monkeypatch.setenv("CUSTOM_OP_TOKEN", "custom-token")
+
+    def fake_run(_cmd, **kwargs):
+        captured_env.update(kwargs["env"])
+        return mock.Mock(returncode=0, stdout="value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    op_secret.fetch_onepassword_secrets(
+        references={"KEY": "op://Vault/Item/field"},
+        binary=fake_binary,
+        service_account_token_env="CUSTOM_OP_TOKEN",
+        use_cache=False,
+    )
+
+    assert captured_env["OP_SERVICE_ACCOUNT_TOKEN"] == "custom-token"
+
+
+def test_fetch_skips_invalid_mappings(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    run_called = False
+
+    def fake_run(*_args, **_kwargs):
+        nonlocal run_called
+        run_called = True
+        return mock.Mock(returncode=0, stdout="value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    secrets, warnings = op_secret.fetch_onepassword_secrets(
+        references={
+            "1BAD": "op://Vault/Item/field",
+            "SPACES BAD": "op://Vault/Item/field",
+            "EMPTY": "",
+            "NOT_OP": "https://example.com/secret",
+        },
+        binary=fake_binary,
+        use_cache=False,
+    )
+
+    assert secrets == {}
+    assert len(warnings) == 4
+    assert not run_called
+
+
+def test_fetch_op_failure(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=1, stdout="", stderr="not signed in"),
+    )
+
+    with pytest.raises(RuntimeError, match="not signed in"):
+        op_secret.fetch_onepassword_secrets(
+            references={"KEY": "op://Vault/Item/field"},
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+
+def test_fetch_partial_failure_returns_successes_and_warnings(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    def fake_run(cmd, **_kwargs):
+        if "bad" in cmd[2]:
+            return mock.Mock(returncode=1, stdout="", stderr="not signed in")
+        return mock.Mock(returncode=0, stdout="good-value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    secrets, warnings = op_secret.fetch_onepassword_secrets(
+        references={
+            "GOOD": "op://Vault/Item/good",
+            "BAD": "op://Vault/Item/bad",
+        },
+        binary=fake_binary,
+        use_cache=False,
+    )
+
+    assert secrets == {"GOOD": "good-value"}
+    assert len(warnings) == 1
+    assert "BAD" in warnings[0]
+    assert "not signed in" in warnings[0]
+
+
+def test_fetch_timeout(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+
+    def fake_run(*a, **kw):
+        raise subprocess.TimeoutExpired(cmd="op", timeout=30)
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        op_secret.fetch_onepassword_secrets(
+            references={"KEY": "op://Vault/Item/field"},
+            binary=fake_binary,
+            use_cache=False,
+        )
+
+
+def test_fetch_cache_hits(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    call_count = {"n": 0}
+
+    def fake_run(*a, **kw):
+        call_count["n"] += 1
+        return mock.Mock(returncode=0, stdout="value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    kwargs = {
+        "references": {"KEY": "op://Vault/Item/field"},
+        "binary": fake_binary,
+        "cache_ttl_seconds": 60,
+    }
+    op_secret.fetch_onepassword_secrets(**kwargs)
+    op_secret.fetch_onepassword_secrets(**kwargs)
+
+    assert call_count["n"] == 1
+
+
+def test_fetch_cache_hit_recomputes_validation_warnings(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    call_count = {"n": 0}
+
+    def fake_run(*a, **kw):
+        call_count["n"] += 1
+        return mock.Mock(returncode=0, stdout="value\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    kwargs = {
+        "binary": fake_binary,
+        "cache_ttl_seconds": 60,
+    }
+    op_secret.fetch_onepassword_secrets(
+        references={"KEY": "op://Vault/Item/field", "BAD": "not-op"},
+        **kwargs,
+    )
+    _secrets, warnings = op_secret.fetch_onepassword_secrets(
+        references={"KEY": "op://Vault/Item/field", "ALSO_BAD": ""},
+        **kwargs,
+    )
+
+    assert call_count["n"] == 1
+    assert len(warnings) == 1
+    assert "ALSO_BAD" in warnings[0]
+
+
+def test_apply_disabled_returns_empty():
+    result = op_secret.apply_onepassword_secrets(enabled=False)
+    assert result.ok
+    assert not result.applied
+    assert not result.error
+
+
+def test_apply_missing_references():
+    result = op_secret.apply_onepassword_secrets(enabled=True, references={})
+    assert not result.ok
+    assert result.error is not None
+    assert "no references" in result.error
+
+
+def test_apply_all_invalid_references_is_error(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setattr(op_secret, "find_op", lambda: fake_binary)
+
+    result = op_secret.apply_onepassword_secrets(
+        enabled=True,
+        references={"BAD": "not-op"},
+    )
+
+    assert not result.ok
+    assert result.error is not None
+    assert "No valid" in result.error
+    assert result.warnings
+
+
+def test_apply_missing_op(monkeypatch):
+    monkeypatch.setattr(op_secret, "find_op", lambda: None)
+    result = op_secret.apply_onepassword_secrets(
+        enabled=True,
+        references={"KEY": "op://Vault/Item/field"},
+    )
+    assert not result.ok
+    assert result.error is not None
+    assert "op" in result.error
+
+
+def test_apply_does_not_override_existing(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setattr(op_secret, "find_op", lambda: fake_binary)
+    monkeypatch.setenv("OPENAI_API_KEY", "existing")
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="from-1password\n", stderr=""),
+    )
+
+    result = op_secret.apply_onepassword_secrets(
+        enabled=True,
+        references={"OPENAI_API_KEY": "op://Vault/Item/field"},
+        override_existing=False,
+    )
+
+    assert result.ok
+    assert result.skipped == ["OPENAI_API_KEY"]
+    assert os.environ["OPENAI_API_KEY"] == "existing"
+
+
+def test_apply_override_existing(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setattr(op_secret, "find_op", lambda: fake_binary)
+    monkeypatch.setenv("OPENAI_API_KEY", "existing")
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="from-1password\n", stderr=""),
+    )
+
+    result = op_secret.apply_onepassword_secrets(
+        enabled=True,
+        references={"OPENAI_API_KEY": "op://Vault/Item/field"},
+        override_existing=True,
+    )
+
+    assert result.ok
+    assert result.applied == ["OPENAI_API_KEY"]
+    assert os.environ["OPENAI_API_KEY"] == "from-1password"
+
+
+def test_apply_skips_service_account_token_env(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setattr(op_secret, "find_op", lambda: fake_binary)
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "bootstrap")
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *a, **kw: mock.Mock(returncode=0, stdout="replacement\n", stderr=""),
+    )
+
+    result = op_secret.apply_onepassword_secrets(
+        enabled=True,
+        references={"OP_SERVICE_ACCOUNT_TOKEN": "op://Vault/Token/credential"},
+        override_existing=True,
+    )
+
+    assert result.ok
+    assert result.skipped == ["OP_SERVICE_ACCOUNT_TOKEN"]
+    assert os.environ["OP_SERVICE_ACCOUNT_TOKEN"] == "bootstrap"
+
+
+def test_fetch_uses_fresh_disk_cache_across_processes(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    calls = {"n": 0}
+
+    def fake_run(*_args, **_kwargs):
+        calls["n"] += 1
+        return mock.Mock(returncode=0, stdout="value-from-op\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+    kwargs = {
+        "references": {"KEY": "op://Vault/Item/field"},
+        "binary": fake_binary,
+        "cache_ttl_seconds": 60,
+        "home_path": tmp_path,
+    }
+
+    secrets, warnings = op_secret.fetch_onepassword_secrets(**kwargs)
+    assert secrets == {"KEY": "value-from-op"}
+    assert warnings == []
+    assert calls["n"] == 1
+
+    op_secret._reset_cache_for_tests()
+    cached, cached_warnings = op_secret.fetch_onepassword_secrets(**kwargs)
+
+    assert cached == {"KEY": "value-from-op"}
+    assert cached_warnings == []
+    assert calls["n"] == 1
+
+
+def test_fetch_disk_cache_is_written_0600_without_auth_material(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "ops_secret_token")
+    monkeypatch.setattr(
+        op_secret.subprocess,
+        "run",
+        lambda *_args, **_kwargs: mock.Mock(returncode=0, stdout="value\n", stderr=""),
+    )
+
+    op_secret.fetch_onepassword_secrets(
+        references={"KEY": "op://Vault/Item/field"},
+        binary=fake_binary,
+        cache_ttl_seconds=60,
+        home_path=tmp_path,
+    )
+
+    cache_path = tmp_path / "cache" / "op_cache.json"
+    payload = json.loads(cache_path.read_text())
+    mode = stat.S_IMODE(cache_path.stat().st_mode)
+
+    assert mode == 0o600
+    assert payload["secrets"] == {"KEY": "value"}
+    assert "ops_secret_token" not in cache_path.read_text()
+
+
+def test_fetch_ignores_stale_disk_cache(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    cache_file = cache_dir / "op_cache.json"
+    cache_file.write_text(
+        json.dumps(
+            {
+                "key": op_secret._cache_key_str(
+                    (
+                        op_secret._auth_fingerprint(),
+                        "",
+                        (("KEY", "op://Vault/Item/field"),),
+                    )
+                ),
+                "secrets": {"KEY": "stale"},
+                "fetched_at": 1,
+            }
+        )
+    )
+    calls = {"n": 0}
+
+    def fake_run(*_args, **_kwargs):
+        calls["n"] += 1
+        return mock.Mock(returncode=0, stdout="fresh\n", stderr="")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fake_run)
+
+    secrets, _warnings = op_secret.fetch_onepassword_secrets(
+        references={"KEY": "op://Vault/Item/field"},
+        binary=fake_binary,
+        cache_ttl_seconds=0.001,
+        home_path=tmp_path,
+    )
+
+    assert secrets == {"KEY": "fresh"}
+    assert calls["n"] == 1
+
+
+def test_apply_skips_existing_without_contacting_op_when_not_overriding(monkeypatch, tmp_path):
+    fake_binary = tmp_path / "op"
+    fake_binary.write_text("")
+    monkeypatch.setattr(op_secret, "find_op", lambda: fake_binary)
+    monkeypatch.setenv("OPENAI_API_KEY", "existing")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("op should not be invoked for an env var that will be skipped")
+
+    monkeypatch.setattr(op_secret.subprocess, "run", fail_run)
+
+    result = op_secret.apply_onepassword_secrets(
+        enabled=True,
+        references={"OPENAI_API_KEY": "op://Vault/Item/field"},
+        override_existing=False,
+        home_path=tmp_path,
+    )
+
+    assert result.ok
+    assert result.applied == []
+    assert result.skipped == ["OPENAI_API_KEY"]
+    assert os.environ["OPENAI_API_KEY"] == "existing"

--- a/website/docs/user-guide/secrets/index.md
+++ b/website/docs/user-guide/secrets/index.md
@@ -5,5 +5,6 @@ Hermes can pull API keys from external secret managers at process startup instea
 Supported:
 
 - [Bitwarden Secrets Manager](./bitwarden) — `bws` CLI, lazy-installed, free tier works.
+- [1Password secret references](./onepassword) — official `op` CLI, `op://vault/item/field` references, desktop or service-account auth.
 
-More backends (Vault, AWS Secrets Manager, 1Password CLI) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.
+More backends (Vault, AWS Secrets Manager, etc.) are easy to add behind the same interface — the lift is one module in `agent/secret_sources/` and one CLI handler. File a request if you have a specific one in mind.

--- a/website/docs/user-guide/secrets/onepassword.md
+++ b/website/docs/user-guide/secrets/onepassword.md
@@ -1,0 +1,140 @@
+# 1Password secret references
+
+Resolve API keys from [1Password CLI](https://developer.1password.com/docs/cli/) secret references at process startup instead of storing every key in plaintext inside `~/.hermes/.env`.
+
+## How it works
+
+1. You install and sign in to the official `op` CLI, or set `OP_SERVICE_ACCOUNT_TOKEN` for a 1Password service account.
+2. In `config.yaml`, map environment variable names to `op://` references.
+3. Every time `hermes` starts, after `.env` has loaded, Hermes resolves missing/stale references with `op read op://...` and sets the resolved values into `os.environ`.
+4. By default Hermes **overrides** values already in your environment, so rotating a value in 1Password takes effect on the next Hermes process start. Set `override_existing: false` if you want `.env` or shell exports to win locally.
+5. Successful reads are cached briefly both in-process and on disk under `~/.hermes/cache/op_cache.json`, so short-lived Hermes commands, gateway worker starts, and cron-style invocations do not each pay a full `op` subprocess/auth round-trip.
+
+Hermes does **not** install `op` automatically. 1Password supports several auth modes (desktop app integration, biometric unlock, service accounts, account shorthands), so Hermes expects the CLI to already be installed and authenticated.
+
+## Setup
+
+### 1. Install and authenticate `op`
+
+Follow the official guide: <https://developer.1password.com/docs/cli/get-started/>
+
+For interactive desktop use, run:
+
+```bash
+op signin
+```
+
+For non-interactive servers, set a service-account token in your shell, service manager, or `~/.hermes/.env`:
+
+```bash
+OP_SERVICE_ACCOUNT_TOKEN=ops_...
+```
+
+### 2. Add references
+
+Use the CLI helper:
+
+```bash
+hermes secrets onepassword set OPENAI_API_KEY 'op://Private/OpenAI/credential' --enable
+hermes secrets onepassword set ANTHROPIC_API_KEY 'op://Private/Anthropic/credential'
+```
+
+Or configure several references and test them in one command:
+
+```bash
+hermes secrets onepassword setup \
+  --map 'OPENAI_API_KEY=op://Private/OpenAI/credential' \
+  --map 'ANTHROPIC_API_KEY=op://Private/Anthropic/credential'
+```
+
+If you have multiple 1Password accounts, pass an account shorthand/email:
+
+```bash
+hermes secrets onepassword setup \
+  --account my.1password.com \
+  --map 'OPENAI_API_KEY=op://Private/OpenAI/credential'
+```
+
+### 3. Confirm
+
+```bash
+hermes secrets onepassword status
+hermes secrets onepassword sync
+```
+
+`sync` is a dry run by default. It resolves references and shows which env vars would be exported without printing secret values.
+
+## CLI
+
+| Command | What it does |
+|---|---|
+| `hermes secrets onepassword setup --map ENV=op://...` | Configure references, test them, and enable the integration |
+| `hermes secrets onepassword status` | Show config, token presence, and `op` availability |
+| `hermes secrets onepassword sync` | Dry-run: resolve references and show what would be applied |
+| `hermes secrets onepassword sync --apply` | Resolve and export into the current process |
+| `hermes secrets onepassword set ENV_VAR op://... [--enable]` | Add or update one mapping |
+| `hermes secrets onepassword remove ENV_VAR` | Remove one mapping |
+| `hermes secrets onepassword disable` | Flip `enabled: false`; leaves references in config |
+
+Aliases: `onepassword`, `op`, `1password`, and `1p`.
+
+## Configuration
+
+Defaults in `~/.hermes/config.yaml`:
+
+```yaml
+secrets:
+  onepassword:
+    enabled: false
+    env: {}
+    account: ""
+    service_account_token_env: OP_SERVICE_ACCOUNT_TOKEN
+    cache_ttl_seconds: 300
+    override_existing: true
+```
+
+Example:
+
+```yaml
+secrets:
+  onepassword:
+    enabled: true
+    account: my.1password.com
+    env:
+      OPENAI_API_KEY: op://Private/OpenAI/credential
+      ANTHROPIC_API_KEY: op://Private/Anthropic/credential
+```
+
+| Key | Default | What it does |
+|---|---|---|
+| `enabled` | `false` | Master switch. When false, `op` is never contacted. |
+| `env` | `{}` | Map of env var names to `op://vault/item/field` references. |
+| `account` | `""` | Optional value passed to `op read --account`. Empty means use the CLI default. |
+| `service_account_token_env` | `OP_SERVICE_ACCOUNT_TOKEN` | Env var name that holds an optional 1Password service-account token. Hermes refuses to overwrite this env var from a reference. |
+| `cache_ttl_seconds` | `300` | How long resolved references are reused in-process and from `~/.hermes/cache/op_cache.json`. Set to `0` to disable both cache layers. |
+| `override_existing` | `true` | When true, 1Password values overwrite existing env vars. Flip to `false` if you want `.env` / shell exports to win locally. |
+
+## Failure modes
+
+1Password never blocks Hermes startup. If anything goes wrong, Hermes warns on stderr and continues with credentials that were already loaded from `.env` or the shell.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `op CLI is not available on PATH` | 1Password CLI is not installed in the environment running Hermes | Install `op` and make sure the service/gateway PATH includes it |
+| `not signed in` or `You are not currently signed in` | Desktop/session auth is unavailable or expired | Run `op signin`, enable desktop app integration, or use `OP_SERVICE_ACCOUNT_TOKEN` |
+| `op read failed for 'op://...'` | Bad vault/item/field path or missing access | Check the reference with `op read` directly and grant access |
+| `op timed out` | CLI hung waiting for unlock/auth or network | Unlock 1Password, check service-account config, or run `op read` manually |
+
+## Security notes
+
+- Hermes never prints resolved 1Password values in `status`, `setup`, or `sync` output.
+- `config.yaml` should contain only `op://` references, not secret values.
+- Resolved values may be cached in plaintext-equivalent form at `~/.hermes/cache/op_cache.json` for up to `cache_ttl_seconds`; the file is written with mode `0600` and does not contain the service-account token. Set `cache_ttl_seconds: 0` if you prefer every process to call `op` live.
+- If you use `OP_SERVICE_ACCOUNT_TOKEN`, treat it like any other high-value bearer token. Anyone with it can read the vault items the service account can access.
+- Hermes skips attempts to overwrite the service-account token env var itself, even when `override_existing: true`.
+
+## When NOT to use this
+
+- Single-machine setups where `~/.hermes/.env` is sufficient.
+- Environments where `op` cannot run non-interactively.
+- CI/CD systems that already inject secrets through a platform-native mechanism.


### PR DESCRIPTION
Add generic 1Password `op://` secret-reference resolution behind the existing secret-source interface. Wire startup loading, source labels, `hermes secrets onepassword` CLI commands, docs, and tests.

## What does this PR do?

This adds first-class 1Password support for resolving environment credentials at Hermes startup without storing resolved secret values in `config.yaml`.

Users configure `secrets.onepassword.env` as a mapping from environment variable names to official 1Password `op://vault/item/field` references. After `.env` loading, Hermes resolves those references through the official `op` CLI and injects them into `os.environ`, matching the existing external-secret-source pattern used by Bitwarden Secrets Manager.

The implementation is intentionally defensive and startup-safe: missing `op`, expired auth, locked desktop app sessions, bad references, or permission failures report warnings and fall back to whatever credentials were already present from `.env` or the shell.

This also adds short-lived-process performance support. Successful reads are cached in-process and on disk under `<hermes_home>/cache/op_cache.json`, with `0600` permissions and a TTL controlled by `secrets.onepassword.cache_ttl_seconds`. The cache key uses auth/session fingerprints, account, and configured references; it does not store the service-account token or raw auth material.

## Related Issue

Fixes #36949.

Related competing PRs: #36896, #45439.

#45439 was called out as a duplicate of this PR and includes unrelated branch contamination; this PR is the narrower, reviewed, and currently mergeable implementation.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/secret_sources/onepassword.py`
  - Adds 1Password `op://...` reference validation and `op read` integration.
  - Supports optional `--account` selection.
  - Supports configurable service-account-token env var via `service_account_token_env`.
  - Adds non-fatal fetch/apply behavior for startup loading.
  - Adds in-process and disk cache layers controlled by `cache_ttl_seconds`.
  - Skips fetching values that would be ignored when `override_existing: false`.
- `agent/secret_sources/__init__.py`
  - Registers/describes the shipped 1Password secret source.
- `hermes_cli/env_loader.py`
  - Applies 1Password secrets after `.env` loading.
  - Records `onepassword` as the credential source for display labels.
  - Passes `hermes_home` through so disk cache paths are profile-aware.
- `hermes_cli/config.py`
  - Adds default `secrets.onepassword` config keys.
- `cli-config.yaml.example`
  - Adds a commented 1Password external-secret-source example.
- `hermes_cli/onepassword_secrets_cli.py`
  - Adds `hermes secrets onepassword` commands: `setup`, `status`, `sync`, `set`, `remove`, and `disable`.
- `hermes_cli/main.py`
  - Wires the 1Password CLI aliases into the existing `hermes secrets` command tree.
- `tests/test_onepassword_secrets.py`
  - Adds hermetic tests for fetch/apply behavior, validation, failures, account/token handling, caching, CLI commands, and skip behavior.
- `tests/test_env_loader_secret_sources.py`
  - Adds source-label/env-loader coverage for 1Password.
- `website/docs/user-guide/secrets/onepassword.md`
  - Adds setup, CLI, config, failure-mode, caching, and security documentation.
- `website/docs/user-guide/secrets/index.md`
  - Links the new 1Password docs page.

## How to Test

1. Run the targeted lint checks:

   ```bash
   uv run --extra dev ruff check agent/secret_sources/onepassword.py hermes_cli/env_loader.py hermes_cli/config.py hermes_cli/onepassword_secrets_cli.py tests/test_onepassword_secrets.py tests/test_env_loader_secret_sources.py
   ```

2. Run the targeted tests:

   ```bash
   uv run --extra dev pytest tests/test_onepassword_secrets.py tests/test_env_loader_secret_sources.py -q
   ```

3. Optionally smoke-test with a temporary Hermes home and a fake `op` binary to verify startup loading and disk-cache reuse across separate processes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux 6.8.0-111-generic, Python 3.11 via `uv`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A; this follows the existing secret-source architecture and does not change contributor workflows.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A; no model tool schema changes.
