### PR TITLE
fix: add feishu to want_opus for TTS OGG voice bubbles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11354,8 +11354,11 @@ class GatewayRunner:
         import uuid as _uuid
         audio_path = None
         actual_path = None
+        converted_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import (
+                text_to_speech_tool, _strip_markdown_for_tts, _convert_to_opus,
+            )
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
@@ -11408,9 +11411,17 @@ class GatewayRunner:
                     thread_meta["notify"] = True
                 else:
                     thread_meta = {"notify": True}
+
+                # Feishu requires OGG Opus for voice bubbles — convert if needed.
+                send_path = actual_path
+                if event.source.platform == "feishu" and not actual_path.lower().endswith((".ogg", ".opus")):
+                    converted_path = _convert_to_opus(actual_path)
+                    if converted_path:
+                        send_path = converted_path
+
                 send_kwargs: Dict[str, Any] = {
                     "chat_id": event.source.chat_id,
-                    "audio_path": actual_path,
+                    "audio_path": send_path,
                     "reply_to": reply_anchor,
                     "metadata": thread_meta,
                 }
@@ -11418,7 +11429,7 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:
-            for p in {audio_path, actual_path} - {None}:
+            for p in {audio_path, actual_path, converted_path} - {None}:
                 try:
                     os.unlink(p)
                 except OSError:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11354,11 +11354,8 @@ class GatewayRunner:
         import uuid as _uuid
         audio_path = None
         actual_path = None
-        converted_path = None
         try:
-            from tools.tts_tool import (
-                text_to_speech_tool, _strip_markdown_for_tts, _convert_to_opus,
-            )
+            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
@@ -11411,17 +11408,9 @@ class GatewayRunner:
                     thread_meta["notify"] = True
                 else:
                     thread_meta = {"notify": True}
-
-                # Feishu requires OGG Opus for voice bubbles — convert if needed.
-                send_path = actual_path
-                if event.source.platform == "feishu" and not actual_path.lower().endswith((".ogg", ".opus")):
-                    converted_path = _convert_to_opus(actual_path)
-                    if converted_path:
-                        send_path = converted_path
-
                 send_kwargs: Dict[str, Any] = {
                     "chat_id": event.source.chat_id,
-                    "audio_path": send_path,
+                    "audio_path": actual_path,
                     "reply_to": reply_anchor,
                     "metadata": thread_meta,
                 }
@@ -11429,7 +11418,7 @@ class GatewayRunner:
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
         finally:
-            for p in {audio_path, actual_path, converted_path} - {None}:
+            for p in {audio_path, actual_path} - {None}:
                 try:
                     os.unlink(p)
                 except OSError:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1864,7 +1864,7 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = (platform in {"telegram", "feishu"})
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## Summary
Add Feishu to `want_opus` in `text_to_speech` tool so that Feishu platform also outputs `.ogg` format for voice bubbles (same as Telegram).

## Change
```python
# tools/tts_tool.py line 1867
-want_opus = (platform == "telegram")
+want_opus = (platform in {"telegram", "feishu"})
```

## Why
- Feishu voice messages require Opus `.ogg` format
- Without this change, TTS outputs `.mp3` which Feishu renders as a file attachment, not a voice bubble
- With this change, `voice_compatible: true` is set, gateway routes to `send_voice()` → native voice bubble