### PR TITLE
fix: remove Discord mention redaction from secret scrubber

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -152,7 +152,7 @@ _JWT_RE = re.compile(
 
 # Discord user/role mentions: <@123456789012345678> or <@!123456789012345678>
 # Snowflake IDs are 17-20 digit integers that resolve to specific Discord accounts.
-_DISCORD_MENTION_RE = re.compile(r"<@!?(\d{17,20})>")
+
 
 # E.164 phone numbers: +<country><number>, 7-15 digits
 # Negative lookahead prevents matching hex strings or identifiers
@@ -424,9 +424,7 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     if "&" in text and "=" in text:
         text = _redact_form_body(text)
 
-    # Discord user/role mentions (<@snowflake_id>)
-    if "<@" in text:
-        text = _DISCORD_MENTION_RE.sub(lambda m: f"<@{'!' if '!' in m.group(0) else ''}***>", text)
+    
 
     # E.164 phone numbers (Signal, WhatsApp)
     if "+" in text:


### PR DESCRIPTION
## Summary

The secret redactor in `agent/redact.py` treats Discord mention snowflake IDs (`<@123456789012345678>`) as sensitive data and replaces the numeric ID with `***`, which breaks downstream message formatting when agents generate outgoing Discord messages.

## Why

Discord snowflake IDs are **not secrets** — they're public identifiers that Discord's own API makes visible to any user. Redacting them prevents Hermes agents from pinging users, roles, or bots in generated messages, which is a critical feature for Discord-integrated agents.

This is analogous to treating `@username` in email addresses as a secret — the format (`<@...>`) looks like it might be sensitive, but the content it wraps is intentionally public.

<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/7241e9fe-6d35-49c8-8c3b-97e58b6c7f81" />

## Changes

`agent/redact.py`:
- Remove `_DISCORD_MENTION_RE` regex pattern matching `<@!?(\d{17,20})>`
- Remove the `if "<@" in text` gate and `_DISCORD_MENTION_RE.sub()` call in `redact_sensitive_text()`

## Testing

All other redaction patterns remain intact:
- API keys (sk-, ghp_, pplx-, etc.) → still redacted
- Authorization headers → still redacted
- JWT tokens → still redacted
- DB connection strings → still redacted
- Private keys → still redacted
- Environment variable assignments → still redacted
- Phone numbers → still redacted
- URL secrets → still redacted

Discord mentions like `<@123456789012345678>` now pass through unchanged.

## Impact

None — this only affects the overly-aggressive redaction of Discord mention syntax, which isn't a security boundary. All real secret patterns remain fully covered.