### PR TITLE
chore(models): drop retired grok-4-1-fast from metadata, tests, and provider docs (#29523)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -211,9 +211,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # matches "grok-4.20-0309-reasoning" / "-non-reasoning" / "-multi-agent-0309".
     "grok-build": 256000,       # grok-build-0.1
     "grok-code-fast": 256000,   # grok-code-fast-1
-    "grok-4-1-fast": 2000000,   # grok-4-1-fast-(non-)reasoning
     "grok-2-vision": 8192,      # grok-2-vision, -1212, -latest
-    "grok-4-fast": 2000000,     # grok-4-fast-(non-)reasoning
+    "grok-4-fast": 2000000,     # grok-4-fast-(non-)reasoning, also matches -reasoning
     "grok-4.20": 2000000,       # grok-4.20-0309-(non-)reasoning, -multi-agent-0309
     "grok-4.3": 1000000,        # grok-4.3, grok-4.3-latest — 1M context per docs.x.ai
     "grok-4": 256000,           # grok-4, grok-4-0709

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -240,6 +240,7 @@ AUTHOR_MAP = {
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",
     "harryykyle1@gmail.com": "hharry11",
     "wysie@users.noreply.github.com": "wysie",
+    "ronhi@buildabear1.localdomain": "RonHillDev",  # PR #29523 salvage (machine-local commit email)
     "jkausel@gmail.com": "jkausel-ai",
     "e.silacandmr@gmail.com": "Es1la",
     "51599529+stephen0110@users.noreply.github.com": "stephen0110",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -161,7 +161,6 @@ class TestDefaultContextLengths:
         # Values sourced from models.dev (2026-04).
         expected = {
             "grok-4.20": 2000000,
-            "grok-4-1-fast": 2000000,
             "grok-4-fast": 2000000,
             "grok-4": 256000,
             "grok-build": 256000,
@@ -190,8 +189,6 @@ class TestDefaultContextLengths:
                 ("grok-4.20-0309-reasoning", 2000000),
                 ("grok-4.20-0309-non-reasoning", 2000000),
                 ("grok-4.20-multi-agent-0309", 2000000),
-                ("grok-4-1-fast-reasoning", 2000000),
-                ("grok-4-1-fast-non-reasoning", 2000000),
                 ("grok-4-fast-reasoning", 2000000),
                 ("grok-4-fast-non-reasoning", 2000000),
                 ("grok-4", 256000),

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -264,7 +264,7 @@ When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoin
 
 ### xAI (Grok) — Responses API + Prompt Caching
 
-xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-1-fast-reasoning`.
+xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-fast-reasoning`.
 
 SuperGrok and X Premium+ subscribers can sign in with browser OAuth instead of using an API key — pick **xAI Grok OAuth (SuperGrok / Premium+)** in `hermes model`, or run `hermes auth add xai-oauth`. The same OAuth bearer token is automatically reused by direct-to-xAI tools (TTS, image gen, video gen, transcription). See the [xAI Grok OAuth guide](../guides/xai-grok-oauth.md) for the full flow — and if Hermes runs on a remote host, also see [OAuth over SSH / Remote Hosts](../guides/oauth-over-ssh.md) for the required `ssh -L` tunnel.
 


### PR DESCRIPTION
## Summary

Drops the retired `grok-4-1-fast` model from `agent/model_metadata.py`'s `DEFAULT_CONTEXT_LENGTHS`, the corresponding test assertions, and the xAI provider docs. Pure metadata + docs cleanup, no runtime behavior change for any non-retired model.

Salvages PR #29523 (@RonHillDev). Closes #29523's original issue scope (retired model still surfacing in user-facing lists, error messages, and docs).

## Changes

- **`agent/model_metadata.py`** — remove `"grok-4-1-fast": 2000000` from `DEFAULT_CONTEXT_LENGTHS`. The `grok-4-fast` entry already covers the live successor at the same 2M context.
- **`tests/agent/test_model_metadata.py`** — remove the `grok-4-1-fast` assertion from `test_grok_models_context_lengths` and the `grok-4-1-fast-reasoning` / `-non-reasoning` cases from `test_grok_substring_matching`.
- **`website/docs/integrations/providers.md`** — `/model grok-4-1-fast-reasoning` → `/model grok-4-fast-reasoning` in the xAI Grok section.
- **`scripts/release.py`** (follow-up) — AUTHOR_MAP entry for `ronhi@buildabear1.localdomain` → `RonHillDev` so the attribution check passes (the original commit was authored from a machine-local email, not a GitHub noreply).

## What's preserved

- The historical comment block at `agent/model_metadata.py:257-258` still references `grok-4-1-fast-(non-)reasoning` in the "REJECTS effort" list — that's documenting what was tested live on 2026-05-10, not asserting current capability. Untouched.
- `hermes_cli/models.py` `_XAI_STATIC_FALLBACK` is also untouched — #23291 already collapsed it to live models, re-adding entries here would regress the upstream sweep.

## Validation

```
scripts/run_tests.sh tests/agent/test_model_metadata.py
=== 102 tests passed, 0 failed in 1.3s ===
```

## Credit

@RonHillDev did the work. Salvage just adds the AUTHOR_MAP entry needed for CI.
