### PR TITLE
fix(security): add missing credential paths to write denylist

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -56,6 +56,10 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".npmrc"),
             os.path.join(home, ".pypirc"),
             os.path.join(home, ".git-credentials"),
+            # HashiCorp Vault bootstrap token — analogous to ~/.netrc.
+            os.path.join(home, ".vault-token"),
+            # Rust / crates.io registry token — analogous to ~/.npmrc.
+            os.path.join(home, ".cargo", "credentials.toml"),
             "/etc/sudoers",
             "/etc/passwd",
             "/etc/shadow",
@@ -78,6 +82,10 @@ def build_write_denied_prefixes(home: str) -> list[str]:
             os.path.join(home, ".azure"),
             os.path.join(home, ".config", "gh"),
             os.path.join(home, ".config", "gcloud"),
+            # GitHub Hub CLI tokens — analogous to ~/.config/gh/.
+            os.path.join(home, ".config", "hub"),
+            # Terraform Cloud credentials — analogous to ~/.aws/.
+            os.path.join(home, ".terraform.d"),
         ]
     ]
 

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -78,6 +78,14 @@ class TestWriteDenyExactPaths:
         for name in [".npmrc", ".pypirc", ".pgpass"]:
             assert _is_write_denied(os.path.join(home, name)) is True, f"{name} should be denied"
 
+    def test_vault_token(self):
+        path = os.path.join(str(Path.home()), ".vault-token")
+        assert _is_write_denied(path) is True
+
+    def test_cargo_credentials(self):
+        path = os.path.join(str(Path.home()), ".cargo", "credentials.toml")
+        assert _is_write_denied(path) is True
+
 
 class TestWriteDenyPrefixes:
     def test_ssh_prefix(self):
@@ -94,6 +102,14 @@ class TestWriteDenyPrefixes:
 
     def test_kube_prefix(self):
         path = os.path.join(str(Path.home()), ".kube", "config")
+        assert _is_write_denied(path) is True
+
+    def test_config_hub_prefix(self):
+        path = os.path.join(str(Path.home()), ".config", "hub", "config")
+        assert _is_write_denied(path) is True
+
+    def test_terraform_d_prefix(self):
+        path = os.path.join(str(Path.home()), ".terraform.d", "credentials.tfrc.json")
         assert _is_write_denied(path) is True
 
     def test_sudoers_d_prefix(self):


### PR DESCRIPTION
## Problem

The write denylist in `agent/file_safety.py` already protects SSH keys, AWS, GPG, npm, PyPI, Docker, Azure, GitHub CLI (`~/.config/gh/`), `~/.git-credentials`, and `~/.config/gcloud/`. Four analogous credential stores were left unprotected:

| Missing path | Credential type | Analogous to |
|---|---|---|
| `~/.vault-token` | HashiCorp Vault bootstrap token | `~/.netrc` |
| `~/.cargo/credentials.toml` | crates.io registry API token | `~/.npmrc` / `~/.pypirc` |
| `~/.config/hub/` | GitHub Hub CLI OAuth tokens | `~/.config/gh/` |
| `~/.terraform.d/` | Terraform Cloud credentials | `~/.aws/` |

Under prompt injection, an agent could be instructed to overwrite any of these files to destroy or backdoor credentials (e.g. planting a malicious crates.io token or destroying a Vault bootstrap token).

## Fix

- Add `~/.vault-token` and `~/.cargo/credentials.toml` to `build_write_denied_paths()` (exact-file block)
- Add `~/.config/hub` and `~/.terraform.d` to `build_write_denied_prefixes()` (directory block)

## Testing

- [ ] `tests/tools/test_write_deny.py` — 4 new test methods, all pass (24/24 total)
- [ ] No false positives: existing `TestWriteAllowed` suite unchanged and green