### PR TITLE
fix(agent): log outer-loop exceptions at ERROR with traceback

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3945,8 +3945,14 @@ def run_conversation(
                 print(f"❌ {error_msg}")
             except (OSError, ValueError):
                 logger.error(error_msg)
-            
-            logger.debug("Outer loop error in API call #%d", api_call_count, exc_info=True)
+
+            # Emit the full traceback at ERROR level so it lands in both
+            # agent.log AND errors.log.  Previously this was logged at DEBUG,
+            # which meant intermittent outer-loop failures were unreproducible
+            # — users would see a one-line summary on screen with no way to
+            # recover the call site.  logger.exception() includes the
+            # traceback automatically and emits at ERROR.
+            logger.exception("Outer loop error in API call #%d", api_call_count)
             
             # If an assistant message with tool_calls was already appended,
             # the API expects a role="tool" result for every tool_call_id.


### PR DESCRIPTION
## Summary

Outer-loop exceptions in the agent conversation loop now log the full traceback at ERROR level instead of DEBUG, so they land in `errors.log` and become diagnosable.

## What was wrong

The `except Exception` guard in `run_conversation()` catches anything raised inside the agent loop (streaming, tool dispatch, message construction, post-turn hooks, etc.). It prints a one-line summary to the screen and logged the traceback at DEBUG — which doesn't reach `errors.log` (WARNING+). Users hitting intermittent failures saw `❌ Error during OpenAI-compatible API call #N: <message>` with no way to recover the call site afterward.

## How this surfaced

While salvaging issue #492, a `terminal` tool call raised `RuntimeError: Could not determine home directory.` mid-loop (from a `Path("~/...").expanduser()` somewhere in the dispatch path, exact site unknown). The CLI showed the one-liner. The next tool call worked fine. Investigation today found:
- `errors.log` was empty for that session — the `logger.debug(..., exc_info=True)` swallowed the traceback
- The exception text matches CPython's `pathlib._make_child_relpath` raise when `os.path.expanduser("~")` can't resolve, but without a stack trace there are 50+ candidate call sites
- We can't fix this class of bug without first capturing the trace

## Change

`logger.debug("Outer loop error in API call #%d", api_call_count, exc_info=True)` → `logger.exception("Outer loop error in API call #%d", api_call_count)`

`logger.exception()` emits at ERROR with the traceback automatically. Control flow is unchanged; this is pure observability.

## Validation

- Targeted import sanity check passes (`python -c "import agent.conversation_loop"`)
- Linter clean

## Follow-up

When this fix is in main and someone hits the `Could not determine home directory` recurrence (or any other intermittent outer-loop failure), `errors.log` will now have the full stack trace and we can fix the root cause directly.

## Infographic

![chalkboard infographic showing before/after of outer-loop exception logging](https://v3b.fal.media/files/b/0a9badd9/CEJHX1GvradDXNo-PKwcy_UgLQ4QEZ.png)