### PR TITLE
fix: keep Codex OAuth strict and harden local integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __pycache__/web_tools.cpython-310.pyc
 logs/
 data/
 .pytest_cache/
+.memsearch/
 test_durations.json
 .pytest-cache/
 tmp/

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1349,20 +1349,13 @@ def _resolve_xai_oauth_for_aux() -> Optional[Tuple[str, str]]:
 
 
 def _read_codex_access_token() -> Optional[str]:
-    """Read a valid, non-expired Codex OAuth access token from Hermes auth store.
+    """Read a valid Codex OAuth access token from Hermes provider auth state.
 
-    If a credential pool exists but currently has no selectable runtime entry
-    (for example all pool slots are marked exhausted), fall back to the
-    profile's auth.json token instead of hard-failing. This keeps explicit
-    fallback-to-Codex working when the pool state is stale but the stored OAuth
-    token is still valid.
+    Codex OAuth is intentionally strict: auxiliary Codex clients must use the
+    same configured Hermes auth-store state as the main runtime resolver. Do
+    not satisfy this path from credential-pool entries, Codex CLI scans, proxy
+    helpers, or any silent recovery source.
     """
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        token = _pool_runtime_api_key(entry)
-        if token:
-            return token
-
     try:
         from hermes_cli.auth import _read_codex_tokens
         data = _read_codex_tokens()
@@ -1888,21 +1881,10 @@ def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
             "pass model explicitly (auxiliary.<task>.model in config.yaml)."
         )
         return None, None
-    pool_present, entry = _select_pool_entry("openai-codex")
-    if pool_present:
-        codex_token = _pool_runtime_api_key(entry)
-        if codex_token:
-            base_url = _pool_runtime_base_url(entry, _CODEX_AUX_BASE_URL) or _CODEX_AUX_BASE_URL
-        else:
-            codex_token = _read_codex_access_token()
-            if not codex_token:
-                return None, None
-            base_url = _CODEX_AUX_BASE_URL
-    else:
-        codex_token = _read_codex_access_token()
-        if not codex_token:
-            return None, None
-        base_url = _CODEX_AUX_BASE_URL
+    codex_token = _read_codex_access_token()
+    if not codex_token:
+        return None, None
+    base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", model)
     real_client = OpenAI(
         api_key=codex_token,
@@ -2465,6 +2447,8 @@ def _pool_cache_hint(
         normalized = _normalize_aux_provider(runtime.get("provider") or _read_main_provider())
     if normalized in {"", "auto", "custom"}:
         return ""
+    if normalized == "openai-codex":
+        return ""
     entry = _peek_pool_entry(normalized)
     if entry is None:
         return ""
@@ -2489,11 +2473,11 @@ def _recoverable_pool_provider(
 ) -> Optional[str]:
     """Infer which provider pool can recover the current auxiliary client."""
     normalized = _normalize_aux_provider(resolved_provider)
+    if normalized == "openai-codex":
+        return None
     if normalized not in {"", "auto", "custom"}:
         return normalized
     base = str(getattr(client, "base_url", "") or "")
-    if base_url_host_matches(base, "chatgpt.com"):
-        return "openai-codex"
     if base_url_host_matches(base, "openrouter.ai"):
         return "openrouter"
     if base_url_host_matches(base, "inference-api.nousresearch.com"):
@@ -4373,8 +4357,9 @@ def _get_cached_client(
     # after key #1 is marked exhausted the retry would still get key #1 from
     # the env var and fail again, causing the retry2_err handler to mark key #2.
     effective_api_key = api_key
-    if not effective_api_key:
-        _pe = _peek_pool_entry(_normalize_aux_provider(provider))
+    normalized_provider = _normalize_aux_provider(provider)
+    if not effective_api_key and normalized_provider != "openai-codex":
+        _pe = _peek_pool_entry(normalized_provider)
         if _pe is not None:
             _pk = _pool_runtime_api_key(_pe)
             if _pk:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -246,6 +246,20 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     if delay_match:
         value = float(delay_match.group(1))
         return value / 1000.0 if delay_match.group(2).lower() == "ms" else value
+    structured_delay_match = re.search(
+        r"['\"](?:resets_in_seconds|reset_in_seconds|retry_after)['\"]\s*:\s*['\"]?(\d+(?:\.\d+)?)",
+        message,
+        re.IGNORECASE,
+    )
+    if structured_delay_match:
+        return float(structured_delay_match.group(1))
+    resets_in_match = re.search(
+        r"resets?\s+in\s+(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)?",
+        message,
+        re.IGNORECASE,
+    )
+    if resets_in_match:
+        return float(resets_in_match.group(1))
     sec_match = re.search(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", message, re.IGNORECASE)
     if sec_match:
         return float(sec_match.group(1))
@@ -260,6 +274,19 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     if min_only_match:
         return int(min_only_match.group(1)) * 60
     return None
+
+
+def _extract_reset_at_from_message(message: str) -> Optional[float]:
+    if not message:
+        return None
+    reset_match = re.search(
+        r"['\"](?:resets_at|reset_at|retry_until)['\"]\s*:\s*['\"]?(\d+(?:\.\d+)?)",
+        message,
+        re.IGNORECASE,
+    )
+    if not reset_match:
+        return None
+    return _parse_absolute_timestamp(reset_match.group(1))
 
 
 def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -279,9 +306,11 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     )
     parsed_reset_at = _parse_absolute_timestamp(reset_at)
     if parsed_reset_at is None and isinstance(message, str):
-        retry_delay_seconds = _extract_retry_delay_seconds(message)
-        if retry_delay_seconds is not None:
-            parsed_reset_at = time.time() + retry_delay_seconds
+        parsed_reset_at = _extract_reset_at_from_message(message)
+        if parsed_reset_at is None:
+            retry_delay_seconds = _extract_retry_delay_seconds(message)
+            if retry_delay_seconds is not None:
+                parsed_reset_at = time.time() + retry_delay_seconds
     if parsed_reset_at is not None:
         normalized["reset_at"] = parsed_reset_at
     return normalized

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3184,15 +3184,15 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
+
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
     Raises AuthError if no Codex tokens are stored.
     """
     if _lock:
         with _auth_store_lock():
-            auth_store = _load_auth_store()
-    else:
-        auth_store = _load_auth_store()
+            return _read_codex_tokens(_lock=False)
+
+    auth_store = _load_auth_store()
     state = _load_provider_state(auth_store, "openai-codex")
     if not state:
         raise AuthError(
@@ -5600,36 +5600,12 @@ def _compute_nous_auth_status() -> Dict[str, Any]:
 
 
 def get_codex_auth_status() -> Dict[str, Any]:
-    """Status snapshot for Codex auth.
-    
-    Checks the credential pool first (where `hermes auth` stores credentials),
-    then falls back to the legacy provider state.
-    """
-    # Check credential pool first — this is where `hermes auth` and
-    # `hermes model` store device_code tokens.
-    try:
-        from agent.credential_pool import load_pool
-        pool = load_pool("openai-codex")
-        if pool and pool.has_credentials():
-            entry = pool.select()
-            if entry is not None:
-                api_key = (
-                    getattr(entry, "runtime_api_key", None)
-                    or getattr(entry, "access_token", "")
-                )
-                if api_key and not _codex_access_token_is_expiring(api_key, 0):
-                    return {
-                        "logged_in": True,
-                        "auth_store": str(_auth_file_path()),
-                        "last_refresh": getattr(entry, "last_refresh", None),
-                        "auth_mode": "chatgpt",
-                        "source": f"pool:{getattr(entry, 'label', 'unknown')}",
-                        "api_key": api_key,
-                    }
-    except Exception:
-        pass
+    """Status snapshot for the strict Codex runtime auth path.
 
-    # Fall back to legacy provider state
+    Keep this aligned with ``resolve_codex_runtime_credentials()``: pool-only
+    entries must not make Codex look logged in if the runtime resolver would
+    fail.  That avoids masking missing or invalid Hermes auth-store state.
+    """
     try:
         creds = resolve_codex_runtime_credentials()
         return {
@@ -5645,6 +5621,8 @@ def get_codex_auth_status() -> Dict[str, Any]:
             "logged_in": False,
             "auth_store": str(_auth_file_path()),
             "error": str(exc),
+            "error_code": getattr(exc, "code", None),
+            "relogin_required": bool(getattr(exc, "relogin_required", False)),
         }
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9272,18 +9272,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
             logger.debug("FHS PATH guard check failed: %s", e)
 
         # Refresh the cua-driver binary used by the Computer Use toolset.
-        # The upstream installer is gated on macOS and on the binary already
-        # being on PATH, so this is a no-op for users who don't have it.
+        # Use the same resolver as the runtime/status paths so gateway/venv
+        # launches that miss ~/.local/bin on PATH still refresh installed CUA.
         # Tying the refresh to ``hermes update`` gives users a predictable
         # cadence (matches when they pull new agent code) without adding
         # startup latency or a per-launch GitHub API call.
         try:
-            if sys.platform == "darwin" and shutil.which("cua-driver"):
-                from hermes_cli.tools_config import install_cua_driver
+            if sys.platform == "darwin":
+                from tools.computer_use.cua_backend import resolve_cua_driver_command
 
-                print()
-                print("→ Refreshing cua-driver (Computer Use)...")
-                install_cua_driver(upgrade=True)
+                if resolve_cua_driver_command():
+                    from hermes_cli.tools_config import install_cua_driver
+
+                    print()
+                    print("→ Refreshing cua-driver (Computer Use)...")
+                    install_cua_driver(upgrade=True)
         except Exception as e:
             logger.debug("cua-driver refresh failed: %s", e)
 
@@ -12904,14 +12907,15 @@ Examples:
         "--upgrade",
         action="store_true",
         help=(
-            "Re-run the upstream installer even if cua-driver is already on "
-            "PATH. The upstream install.sh always pulls the latest release, "
-            "so this performs an in-place upgrade."
+            "Re-run the upstream installer even if cua-driver already resolves "
+            "via PATH, HERMES_CUA_DRIVER_CMD, ~/.local/bin, or the app bundle. "
+            "The upstream install.sh always pulls the latest release, so this "
+            "performs an in-place upgrade."
         ),
     )
     computer_use_sub.add_parser(
         "status",
-        help="Print whether cua-driver is installed and on PATH",
+        help="Print whether cua-driver is installed/resolvable",
     )
 
     def cmd_computer_use(args):
@@ -12921,14 +12925,15 @@ Examples:
             install_cua_driver(upgrade=bool(getattr(args, "upgrade", False)))
             return
         if action == "status":
-            import shutil
             import subprocess
-            path = shutil.which("cua-driver")
+            from tools.computer_use.cua_backend import resolve_cua_driver_command
+
+            path = resolve_cua_driver_command()
             if path:
                 version = ""
                 try:
                     version = subprocess.run(
-                        ["cua-driver", "--version"],
+                        [path, "--version"],
                         capture_output=True, text=True, timeout=5,
                     ).stdout.strip()
                 except Exception:
@@ -12939,7 +12944,7 @@ Examples:
                     print(f"cua-driver: installed at {path}")
                 print("  Refresh to latest: hermes computer-use install --upgrade")
                 return
-            print("cua-driver: not installed")
+            print("cua-driver: not installed or not executable")
             print("  Run: hermes computer-use install")
             return
         # No subcommand → show help

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -488,6 +488,16 @@ def _cua_driver_cmd() -> str:
     return os.environ.get("HERMES_CUA_DRIVER_CMD", "").strip() or "cua-driver"
 
 
+def _resolved_cua_driver_cmd() -> Optional[str]:
+    """Return the shared runtime-resolved cua-driver command/path."""
+    try:
+        from tools.computer_use.cua_backend import resolve_cua_driver_command
+
+        return resolve_cua_driver_command()
+    except Exception:
+        return None
+
+
 def _pip_install(
     args: List[str],
     *,
@@ -634,8 +644,7 @@ def install_cua_driver(upgrade: bool = False) -> bool:
         _print_warning("    Computer Use (cua-driver) is macOS-only; skipping.")
         return False
 
-    driver_cmd = _cua_driver_cmd()
-    binary = shutil.which(driver_cmd)
+    binary = _resolved_cua_driver_cmd()
 
     # Not installed → fresh install path (only when caller asked for it).
     if not binary and not upgrade:
@@ -651,12 +660,12 @@ def install_cua_driver(upgrade: bool = False) -> bool:
     if binary and not upgrade:
         try:
             version = subprocess.run(
-                [driver_cmd, "--version"],
+                [binary, "--version"],
                 capture_output=True, text=True, timeout=5,
             ).stdout.strip()
-            _print_success(f"    {driver_cmd} already installed: {version or 'unknown version'}")
+            _print_success(f"    {binary} already installed: {version or 'unknown version'}")
         except Exception:
-            _print_success(f"    {driver_cmd} already installed.")
+            _print_success(f"    {binary} already installed.")
         _print_info("    Grant macOS permissions if not done yet:")
         _print_info("      System Settings > Privacy & Security > Accessibility")
         _print_info("      System Settings > Privacy & Security > Screen Recording")
@@ -674,7 +683,7 @@ def install_cua_driver(upgrade: bool = False) -> bool:
         # Show before/after version when we have a baseline. Best-effort.
         try:
             before = subprocess.run(
-                [driver_cmd, "--version"],
+                [binary, "--version"],
                 capture_output=True, text=True, timeout=5,
             ).stdout.strip()
         except Exception:
@@ -686,13 +695,13 @@ def install_cua_driver(upgrade: bool = False) -> bool:
     if ok and before:
         try:
             after = subprocess.run(
-                [driver_cmd, "--version"],
+                [binary, "--version"],
                 capture_output=True, text=True, timeout=5,
             ).stdout.strip()
             if after and after != before:
-                _print_success(f"    {driver_cmd} upgraded: {before} → {after}")
+                _print_success(f"    {binary} upgraded: {before} → {after}")
             elif after:
-                _print_info(f"    {driver_cmd} up to date: {after}")
+                _print_info(f"    {binary} up to date: {after}")
         except Exception:
             pass
     return ok
@@ -704,7 +713,6 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
     The script is idempotent: it always downloads the latest release, so
     re-running it on an already-installed system performs an upgrade.
     """
-    import shutil
     import subprocess
 
     install_cmd = (
@@ -716,12 +724,12 @@ def _run_cua_driver_installer(label: str = "Installing", verbose: bool = True) -
         _print_info(f"    {label} cua-driver (macOS background computer-use)...")
     else:
         _print_info(f"    {label} cua-driver...")
-    driver_cmd = _cua_driver_cmd()
     try:
         result = subprocess.run(install_cmd, shell=True, timeout=300)
-        if result.returncode == 0 and shutil.which(driver_cmd):
+        resolved = _resolved_cua_driver_cmd()
+        if result.returncode == 0 and resolved:
             if verbose:
-                _print_success(f"    {driver_cmd} installed.")
+                _print_success(f"    {resolved} installed.")
                 _print_info("    IMPORTANT — grant macOS permissions now:")
                 _print_info("      System Settings > Privacy & Security > Accessibility")
                 _print_info("      System Settings > Privacy & Security > Screen Recording")
@@ -1869,7 +1877,7 @@ _POST_SETUP_INSTALLED: dict = {
     # entry when (a) the post_setup is the ONLY install side-effect for
     # a no-key provider, and (b) an installed-state check is cheap and
     # doesn't trigger a heavy import.
-    "cua_driver": lambda: bool(shutil.which(_cua_driver_cmd())),
+    "cua_driver": lambda: bool(_resolved_cua_driver_cmd()),
 }
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2178,7 +2178,7 @@ def _codex_full_login_worker(session_id: str) -> None:
         from hermes_cli.auth import (
             CODEX_OAUTH_CLIENT_ID,
             CODEX_OAUTH_TOKEN_URL,
-            DEFAULT_CODEX_BASE_URL,
+            _save_codex_tokens,
         )
         issuer = "https://auth.openai.com"
 
@@ -2258,31 +2258,13 @@ def _codex_full_login_worker(session_id: str) -> None:
         if not access_token:
             raise RuntimeError("token exchange did not return access_token")
 
-        # Persist via credential pool — same shape as auth_commands.add_command
-        from agent.credential_pool import (
-            PooledCredential,
-            load_pool,
-            AUTH_TYPE_OAUTH,
-            SOURCE_MANUAL,
-        )
-        import uuid as _uuid
-        pool = load_pool("openai-codex")
-        base_url = (
-            os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
-            or DEFAULT_CODEX_BASE_URL
-        )
-        entry = PooledCredential(
-            provider="openai-codex",
-            id=_uuid.uuid4().hex[:6],
-            label="dashboard device_code",
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=f"{SOURCE_MANUAL}:dashboard_device_code",
-            access_token=access_token,
-            refresh_token=refresh_token,
-            base_url=base_url,
-        )
-        pool.add_entry(entry)
+        # Persist to the strict Codex provider auth state used by
+        # resolve_codex_runtime_credentials(). Dashboard login must not create
+        # a credential-pool-only Codex entry that runtime auth would ignore.
+        _save_codex_tokens({
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+        })
         with _oauth_sessions_lock:
             sess["status"] = "approved"
         _log.info("oauth/device: openai-codex login completed (session=%s)", session_id)

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1164,13 +1164,19 @@ class HonchoSessionManager:
         if not session:
             return None
         try:
-            peer_id = self._resolve_peer_id(session, peer)
-            if peer_id is None:
+            observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
+            if observer_peer_id is None:
                 logger.warning("Could not resolve peer '%s' for set_peer_card in session '%s'", peer, session_key)
                 return None
-            peer_obj = self._get_or_create_peer(peer_id)
-            result = peer_obj.set_card(card)
-            logger.info("Updated peer card for %s (%d facts)", peer_id, len(card))
+            peer_obj = self._get_or_create_peer(observer_peer_id)
+            result = peer_obj.set_card(card, target=target_peer_id)
+            target_label = target_peer_id or observer_peer_id
+            logger.info(
+                "Updated peer card for observer=%s target=%s (%d facts)",
+                observer_peer_id,
+                target_label,
+                len(card),
+            )
             return result
         except Exception as e:
             logger.error("Failed to set peer card: %s", e)

--- a/scripts/benchmark_browser_eval.py
+++ b/scripts/benchmark_browser_eval.py
@@ -9,6 +9,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import platform
+import socket
 import shutil
 import statistics
 import subprocess
@@ -18,9 +20,29 @@ import time
 import urllib.request
 import json
 
+try:
+    from hermes_cli.browser_connect import get_chrome_debug_candidates
+except Exception:
+    get_chrome_debug_candidates = None  # type: ignore[assignment]
+
+
+class BenchmarkUnavailable(RuntimeError):
+    """Raised when this host cannot expose or reach the live CDP endpoint."""
+
 
 def _find_chrome() -> str:
-    for c in ("google-chrome", "chromium", "chromium-browser"):
+    if get_chrome_debug_candidates is not None:
+        try:
+            candidates = get_chrome_debug_candidates(platform.system())
+        except Exception:
+            candidates = []
+    else:
+        candidates = []
+
+    for candidate in candidates:
+        if candidate:
+            return candidate
+    for c in ("google-chrome", "google-chrome-stable", "chromium", "chromium-browser"):
         p = shutil.which(c)
         if p:
             return p
@@ -28,7 +50,33 @@ def _find_chrome() -> str:
     sys.exit(1)
 
 
+def _free_port() -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+    except OSError:
+        return 9333
+
+
+def _loopback_bind_probe() -> tuple[bool, str]:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+        return True, ""
+    except OSError as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
 def _start_chrome(port: int):
+    ok, reason = _loopback_bind_probe()
+    if not ok:
+        raise BenchmarkUnavailable(
+            "Loopback TCP bind is unavailable, so Chrome cannot expose the "
+            f"CDP endpoint required by this live benchmark ({reason})."
+        )
+    if port == 0:
+        port = _free_port()
     profile = tempfile.mkdtemp(prefix="hermes-bench-eval-")
     proc = subprocess.Popen(
         [
@@ -52,21 +100,48 @@ def _start_chrome(port: int):
         except Exception:
             time.sleep(0.25)
     proc.terminate()
-    raise RuntimeError("Chrome didn't expose CDP")
+    try:
+        proc.wait(timeout=3)
+    except Exception:
+        proc.kill()
+    shutil.rmtree(profile, ignore_errors=True)
+    raise BenchmarkUnavailable("Chrome didn't expose CDP")
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--iterations", type=int, default=50)
     parser.add_argument("--port", type=int, default=9333)
+    parser.add_argument(
+        "--cdp-url",
+        help="Attach to an existing browser WebSocket debugger URL instead of starting Chrome.",
+    )
+    parser.add_argument(
+        "--allow-unavailable",
+        action="store_true",
+        help="Exit 0 with an unavailable notice when Chrome/CDP cannot run on this host.",
+    )
     args = parser.parse_args()
 
-    proc, profile, cdp_url = _start_chrome(args.port)
+    proc = None
+    profile = None
     try:
-        from tools.browser_supervisor import SUPERVISOR_REGISTRY
+        if args.cdp_url:
+            cdp_url = args.cdp_url
+        else:
+            proc, profile, cdp_url = _start_chrome(args.port)
+    except BenchmarkUnavailable as exc:
+        print(f"browser_eval benchmark unavailable: {exc}", file=sys.stderr)
+        if args.allow_unavailable:
+            return
+        sys.exit(3)
+
+    supervisor_registry = None
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY as supervisor_registry
 
         # Warm up: start the supervisor, navigate to a page.
-        supervisor = SUPERVISOR_REGISTRY.get_or_start(
+        supervisor = supervisor_registry.get_or_start(
             task_id="bench-eval", cdp_url=cdp_url
         )
         # Give it a moment to attach.
@@ -115,7 +190,8 @@ def main():
             )
 
         print()
-        print(f"browser_eval benchmark — {args.iterations} iterations of `1 + 1`")
+        port = cdp_url.split("/devtools/", 1)[0].rsplit(":", 1)[-1]
+        print(f"browser_eval benchmark — {args.iterations} iterations of `1 + 1` on CDP port {port}")
         print("-" * 90)
         print(fmt("supervisor WS (Runtime.evaluate)", ws_times))
         print(fmt("agent-browser subprocess (eval)", sub_times))
@@ -125,13 +201,16 @@ def main():
             print(f"Speedup: {speedup:.1f}x (mean)")
 
     finally:
-        SUPERVISOR_REGISTRY.stop_all()
-        proc.terminate()
-        try:
-            proc.wait(timeout=3)
-        except Exception:
-            proc.kill()
-        shutil.rmtree(profile, ignore_errors=True)
+        if supervisor_registry is not None:
+            supervisor_registry.stop_all()
+        if proc is not None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=3)
+            except Exception:
+                proc.kill()
+        if profile is not None:
+            shutil.rmtree(profile, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -110,13 +110,13 @@ class TestReadCodexAccessToken:
         result = _read_codex_access_token()
         assert result == "tok-123"
 
-    def test_pool_without_selected_entry_falls_back_to_auth_store(self, tmp_path, monkeypatch):
+    def test_codex_access_token_uses_auth_store_not_pool(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir(parents=True, exist_ok=True)
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-        valid_jwt = "eyJhbGciOiJSUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTl9.sig"
-        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)), \
+        valid_jwt = "eyJhbG...OTl9.sig"
+        with patch("agent.auxiliary_client._select_pool_entry", side_effect=AssertionError("pool must not be used")), \
              patch("hermes_cli.auth._read_codex_tokens", return_value={
                  "tokens": {"access_token": valid_jwt, "refresh_token": "refresh"}
              }):
@@ -129,8 +129,7 @@ class TestReadCodexAccessToken:
         hermes_home.mkdir(parents=True, exist_ok=True)
         (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
-            result = _read_codex_access_token()
+        result = _read_codex_access_token()
         assert result is None
 
     def test_empty_token_returns_none(self, tmp_path, monkeypatch):
@@ -187,8 +186,7 @@ class TestReadCodexAccessToken:
             },
         }))
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
-            result = _read_codex_access_token()
+        result = _read_codex_access_token()
         assert result is None, "Expired JWT should return None"
 
     def test_valid_jwt_returns_token(self, tmp_path, monkeypatch):
@@ -359,9 +357,9 @@ class TestAnthropicOAuthFlag:
 
 
 class TestBuildCodexClient:
-    def test_pool_without_selected_entry_falls_back_to_auth_store(self):
+    def test_uses_auth_store_token_without_pool(self):
         with (
-            patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),
+            patch("agent.auxiliary_client._select_pool_entry", side_effect=AssertionError("pool must not be used")),
             patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
         ):
@@ -383,51 +381,27 @@ class TestBuildCodexClient:
         assert client is None
         assert model is None
 
-    def test_cached_codex_client_rebuilds_when_pool_entry_changes(self):
+    def test_cached_codex_client_ignores_pool_entry_changes(self):
         import agent.auxiliary_client as aux
 
-        class _Entry:
-            def __init__(self, entry_id, token):
-                self.id = entry_id
-                self.runtime_api_key = token
-                self.runtime_base_url = "https://chatgpt.com/backend-api/codex"
-
-        class _Pool:
-            def __init__(self):
-                self.entry = _Entry("cred-a", "tok-a")
-
-            def has_credentials(self):
-                return True
-
-            def current(self):
-                return self.entry
-
-            def peek(self):
-                return self.entry
-
-            def select(self):
-                return self.entry
-
-        pool = _Pool()
         client_a = MagicMock(name="codex-client-a")
-        client_b = MagicMock(name="codex-client-b")
 
         with (
-            patch("agent.auxiliary_client.load_pool", return_value=pool),
-            patch("agent.auxiliary_client.OpenAI", side_effect=[client_a, client_b]) as mock_openai,
+            patch("agent.auxiliary_client._peek_pool_entry", side_effect=AssertionError("pool hint must not be used")),
+            patch("agent.auxiliary_client._read_codex_access_token", return_value="codex-auth-token"),
+            patch("agent.auxiliary_client.OpenAI", return_value=client_a) as mock_openai,
         ):
             aux.shutdown_cached_clients()
             try:
                 first_client, first_model = aux._get_cached_client("openai-codex", "gpt-5.4")
-                pool.entry = _Entry("cred-b", "tok-b")
                 second_client, second_model = aux._get_cached_client("openai-codex", "gpt-5.4")
             finally:
                 aux.shutdown_cached_clients()
 
-        assert first_client is not second_client
+        assert first_client is second_client
         assert first_model == "gpt-5.4"
         assert second_model == "gpt-5.4"
-        assert mock_openai.call_count == 2
+        assert mock_openai.call_count == 1
 
 
 class TestResolveProviderClientUniversalModelFallback:
@@ -803,22 +777,20 @@ class TestExplicitProviderRouting:
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 
-    def test_codex_pool_entry_takes_priority_over_auth_store(self):
-        class _Entry:
-            access_token = "pooled-codex-token"
-            base_url = "https://chatgpt.com/backend-api/codex"
-
+    def test_codex_auth_store_takes_priority_over_pool(self):
         class _Pool:
             def has_credentials(self):
                 return True
 
             def select(self):
-                return _Entry()
+                raise AssertionError("Codex pool must not be used")
 
         with (
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
-            patch("agent.auxiliary_client.OpenAI"),
-            patch("hermes_cli.auth._read_codex_tokens", side_effect=AssertionError("legacy codex store should not run")),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+            patch("hermes_cli.auth._read_codex_tokens", return_value={
+                "tokens": {"access_token": "auth-store-codex-token", "refresh_token": "refresh"},
+            }),
         ):
             from agent.auxiliary_client import _build_codex_client
 
@@ -828,6 +800,7 @@ class TestGetTextAuxiliaryClient:
 
         assert isinstance(client, CodexAuxiliaryClient)
         assert model == "gpt-5.4"
+        assert mock_openai.call_args.kwargs["api_key"] == "auth-store-codex-token"
 
     def test_returns_none_when_nothing_available(self, monkeypatch):
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -2110,17 +2083,13 @@ class TestAuxiliaryAuthRefreshRetry:
 
 
 class TestAuxiliaryPoolRotationRetry:
-    def test_call_llm_rotates_explicit_codex_pool_on_429(self):
+    def test_call_llm_does_not_rotate_explicit_codex_pool_on_429(self):
         rate_err = Exception("usage limit reached")
         rate_err.status_code = 429
 
         stale_client = MagicMock()
         stale_client.base_url = "https://chatgpt.com/backend-api/codex"
-        stale_client.chat.completions.create.side_effect = [rate_err, rate_err]
-
-        fresh_client = MagicMock()
-        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
-        fresh_client.chat.completions.create.return_value = _DummyResponse("rotated-sync")
+        stale_client.chat.completions.create.side_effect = rate_err
 
         class _Pool:
             def __init__(self):
@@ -2140,37 +2109,31 @@ class TestAuxiliaryPoolRotationRetry:
 
         with (
             patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.4", None, None, None)),
-            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.4"), (fresh_client, "gpt-5.4")]),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(stale_client, "gpt-5.4")),
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False),
             patch("agent.auxiliary_client.load_pool", return_value=pool),
             patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback,
         ):
-            resp = call_llm(
-                task="compression",
-                provider="openai-codex",
-                model="gpt-5.4",
-                messages=[{"role": "user", "content": "hi"}],
-            )
+            with pytest.raises(Exception, match="usage limit reached"):
+                call_llm(
+                    task="compression",
+                    provider="openai-codex",
+                    model="gpt-5.4",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
 
-        assert resp.choices[0].message.content == "rotated-sync"
-        assert stale_client.chat.completions.create.call_count == 2
-        assert fresh_client.chat.completions.create.call_count == 1
-        assert len(pool.rotate_calls) == 1
-        assert pool.rotate_calls[0]["status_code"] == 429
+        assert stale_client.chat.completions.create.call_count == 1
+        assert pool.rotate_calls == []
         mock_fallback.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_async_call_llm_rotates_explicit_codex_pool_on_429(self):
+    async def test_async_call_llm_does_not_rotate_explicit_codex_pool_on_429(self):
         rate_err = Exception("usage limit reached")
         rate_err.status_code = 429
 
         stale_client = MagicMock()
         stale_client.base_url = "https://chatgpt.com/backend-api/codex"
-        stale_client.chat.completions.create = AsyncMock(side_effect=[rate_err, rate_err])
-
-        fresh_client = MagicMock()
-        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
-        fresh_client.chat.completions.create = AsyncMock(return_value=_DummyResponse("rotated-async"))
+        stale_client.chat.completions.create = AsyncMock(side_effect=rate_err)
 
         class _Pool:
             def __init__(self):
@@ -2190,23 +2153,21 @@ class TestAuxiliaryPoolRotationRetry:
 
         with (
             patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.4", None, None, None)),
-            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.4"), (fresh_client, "gpt-5.4")]),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(stale_client, "gpt-5.4")),
             patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False),
             patch("agent.auxiliary_client.load_pool", return_value=pool),
             patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback,
         ):
-            resp = await async_call_llm(
-                task="compression",
-                provider="openai-codex",
-                model="gpt-5.4",
-                messages=[{"role": "user", "content": "hi"}],
-            )
+            with pytest.raises(Exception, match="usage limit reached"):
+                await async_call_llm(
+                    task="compression",
+                    provider="openai-codex",
+                    model="gpt-5.4",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
 
-        assert resp.choices[0].message.content == "rotated-async"
-        assert stale_client.chat.completions.create.await_count == 2
-        assert fresh_client.chat.completions.create.await_count == 1
-        assert len(pool.rotate_calls) == 1
-        assert pool.rotate_calls[0]["status_code"] == 429
+        assert stale_client.chat.completions.create.await_count == 1
+        assert pool.rotate_calls == []
         mock_fallback.assert_not_called()
 
 
@@ -2551,7 +2512,11 @@ class TestCodexAuxiliaryAdapterTimeout:
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        elapsed = time.monotonic() - started
+        # macOS/CI timer-thread scheduling can add ~150ms under load; the
+        # contract is that the adapter raises its own TimeoutError instead of
+        # waiting for the surrounding pytest timeout or hanging indefinitely.
+        assert elapsed < 0.35
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2145,6 +2145,42 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     assert available == []
 
 
+def test_mark_exhausted_preserves_codex_usage_limit_reset_at(tmp_path, monkeypatch):
+    """Codex usage-limit errors include reset metadata inside the error string.
+
+    Persisting it prevents Hermes from treating a multi-hour ChatGPT quota
+    window as a generic one-hour cooldown, and makes the pool recover only
+    after the provider's actual reset.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_auth_store("access-quota", "refresh-quota"))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+
+    reset_at = time.time() + 7200
+    message = (
+        "Error code: 429 - {'error': {'type': 'usage_limit_reached', "
+        "'message': 'The usage limit has been reached', 'plan_type': 'pro', "
+        f"'resets_at': {reset_at}, 'resets_in_seconds': 7200}}"
+    )
+
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={"reason": "usage_limit_reached", "message": message},
+    )
+
+    stored = pool._entries[0]
+    assert stored is not None
+    assert stored.last_status == "exhausted"
+    assert stored.last_error_code == 429
+    assert stored.last_error_reset_at == pytest.approx(reset_at)
+    assert pool._available_entries(clear_expired=True, refresh=False) == []
+
+
 # ---------------------------------------------------------------------------
 # xAI OAuth terminal error quarantine
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -50,7 +50,8 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
         import cli as _cli_mod
         _cli_mod = importlib.reload(_cli_mod)
         with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
-             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}), \
+             patch.dict("os.environ", clean_env, clear=False):
             return _cli_mod.HermesCLI(**kwargs)
 
 

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -75,6 +75,36 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
+def test_read_codex_tokens_ignores_credential_pool_entries(tmp_path, monkeypatch):
+    """Codex runtime auth is strict: no fallback to credential_pool entries."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [{
+                "id": "codex-pool-1",
+                "label": "openai-codex-oauth-1",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "pool-access",
+                "refresh_token": "pool-refresh",
+            }]
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        _read_codex_tokens()
+    assert exc.value.code == "codex_auth_missing"
+
+    status = get_codex_auth_status()
+    assert status["logged_in"] is False
+    assert status["error_code"] == "codex_auth_missing"
+
+
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -766,7 +766,8 @@ def test_computer_use_needs_configuration_when_cua_driver_post_setup_pending():
     Returning users enabling Computer Use through `hermes tools` must reach the
     cua-driver post-setup installer even though the provider has no API keys.
     """
-    with patch("shutil.which", return_value=None):
+    with patch("shutil.which", return_value=None), \
+         patch("tools.computer_use.cua_backend._is_executable_file", return_value=False):
         assert _toolset_needs_configuration_prompt("computer_use", {}) is True
 
 
@@ -813,7 +814,18 @@ def test_computer_use_post_setup_respects_custom_driver_command_when_installed()
         _run_post_setup("cua_driver")
 
     run.assert_called_once()
-    assert run.call_args.args[0] == ["custom-cua", "--version"]
+    assert run.call_args.args[0] == ["/opt/bin/custom-cua", "--version"]
+
+
+def test_computer_use_configuration_check_uses_cua_resolver_fallback():
+    """The setup gate should share runtime fallback paths for app-bundle installs."""
+    bundle = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver"
+
+    with patch.dict("os.environ", {"HERMES_CUA_DRIVER_CMD": ""}), \
+         patch("shutil.which", return_value=None), \
+         patch("tools.computer_use.cua_backend._is_executable_file",
+               side_effect=lambda p: p == bundle):
+        assert _toolset_needs_configuration_prompt("computer_use", {}) is False
 
 
 def test_computer_use_post_setup_missing_override_does_not_accept_default_binary():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2084,6 +2084,8 @@ class TestPtyWebSocket:
 
         # Avoid exec'ing the actual TUI in tests: every test below installs
         # its own fake argv via ``ws._resolve_chat_argv``.
+        if not ws.PtyBridge.is_available():
+            pytest.skip("PTY bridge optional dependency is unavailable")
         self.ws_module = ws
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
         self.token = ws._SESSION_TOKEN

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -212,6 +212,33 @@ class TestPeerLookupHelpers:
         assert mgr.get_peer_card(session.key) == ["Name: Robert"]
         assistant_peer.get_card.assert_called_once_with(target=session.user_peer_id)
 
+    def test_set_peer_card_uses_same_observer_target_as_get_peer_card(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.set_card.return_value = ["Name: Robert"]
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        assert mgr.set_peer_card(session.key, ["Name: Robert"]) == ["Name: Robert"]
+        mgr._get_or_create_peer.assert_called_once_with(session.assistant_peer_id)
+        assistant_peer.set_card.assert_called_once_with(
+            ["Name: Robert"],
+            target=session.user_peer_id,
+        )
+
+    def test_set_peer_card_unified_mode_updates_user_self_card(self):
+        mgr, session = self._make_cached_manager()
+        mgr._ai_observe_others = False
+        user_peer = MagicMock()
+        user_peer.set_card.return_value = ["Name: Robert"]
+        mgr._get_or_create_peer = MagicMock(return_value=user_peer)
+
+        assert mgr.set_peer_card(session.key, ["Name: Robert"]) == ["Name: Robert"]
+        mgr._get_or_create_peer.assert_called_once_with(session.user_peer_id)
+        user_peer.set_card.assert_called_once_with(
+            ["Name: Robert"],
+            target=None,
+        )
+
     def test_search_context_uses_assistant_perspective_with_target(self):
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()

--- a/tests/test_benchmark_browser_eval.py
+++ b/tests/test_benchmark_browser_eval.py
@@ -1,0 +1,129 @@
+"""Tests for the browser eval benchmark helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import benchmark_browser_eval as bench
+
+
+def test_find_chrome_uses_shared_debug_candidates(monkeypatch, tmp_path):
+    chrome = tmp_path / "Chrome"
+    chrome.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(bench.platform, "system", lambda: "Darwin", raising=False)
+    monkeypatch.setattr(bench, "get_chrome_debug_candidates", lambda system: [str(chrome)], raising=False)
+
+    assert bench._find_chrome() == str(chrome)
+
+
+def test_free_port_returns_bindable_loopback_port(monkeypatch):
+    class FakeSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def bind(self, addr):
+            self.addr = addr
+
+        def getsockname(self):
+            return ("127.0.0.1", 49152)
+
+    monkeypatch.setattr(bench.socket, "socket", lambda *args, **kwargs: FakeSocket())
+    port = bench._free_port()
+
+    assert port == 49152
+
+
+def test_free_port_falls_back_when_loopback_bind_is_blocked(monkeypatch):
+    class BlockedSocket:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def bind(self, addr):
+            raise PermissionError("blocked")
+
+    monkeypatch.setattr(bench.socket, "socket", lambda *args, **kwargs: BlockedSocket())
+
+    port = bench._free_port()
+
+    assert port == 9333
+
+
+def test_start_chrome_cleans_profile_when_cdp_never_appears(monkeypatch, tmp_path):
+    profile = tmp_path / "profile"
+    removed: list[Path] = []
+
+    class FakeProc:
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    def fake_mkdtemp(prefix):
+        profile.mkdir()
+        return str(profile)
+
+    def fake_popen(*args, **kwargs):
+        return FakeProc()
+
+    def fake_urlopen(*args, **kwargs):
+        raise OSError("no cdp")
+
+    def fake_rmtree(path, ignore_errors=False):
+        removed.append(Path(path))
+
+    monkeypatch.setattr(bench, "_find_chrome", lambda: "/bin/chrome")
+    monkeypatch.setattr(bench, "_loopback_bind_probe", lambda: (True, ""))
+    monkeypatch.setattr(bench.tempfile, "mkdtemp", fake_mkdtemp)
+    monkeypatch.setattr(bench.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(bench.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(bench.time, "monotonic", iter([0, 16]).__next__)
+    monkeypatch.setattr(bench.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(bench.shutil, "rmtree", fake_rmtree)
+
+    with pytest.raises(bench.BenchmarkUnavailable, match="Chrome didn't expose CDP"):
+        bench._start_chrome(9333)
+
+    assert removed == [profile]
+
+
+def test_start_chrome_fails_fast_when_loopback_bind_is_blocked(monkeypatch):
+    popen_called = False
+
+    def fake_popen(*args, **kwargs):
+        nonlocal popen_called
+        popen_called = True
+
+    monkeypatch.setattr(bench, "_loopback_bind_probe", lambda: (False, "PermissionError: blocked"))
+    monkeypatch.setattr(bench.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(bench.BenchmarkUnavailable, match="Loopback TCP bind is unavailable"):
+        bench._start_chrome(9333)
+
+    assert popen_called is False
+
+
+def test_main_allow_unavailable_returns_zero(monkeypatch, capsys):
+    monkeypatch.setattr(bench.sys, "argv", ["benchmark_browser_eval.py", "--allow-unavailable"])
+    monkeypatch.setattr(
+        bench,
+        "_start_chrome",
+        lambda port: (_ for _ in ()).throw(bench.BenchmarkUnavailable("no cdp")),
+    )
+
+    bench.main()
+
+    captured = capsys.readouterr()
+    assert "benchmark unavailable: no cdp" in captured.err

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4079,6 +4079,7 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
             ),
+            patch("platform.system", return_value="Linux"),
         ):
             resp = server.handle_request(
                 {

--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import sys
@@ -63,6 +64,13 @@ class TestSchema:
         assert props["element"]["type"] == "integer"
         assert props["coordinate"]["type"] == "array"
 
+    def test_schema_supports_window_title_capture_scoping(self):
+        from tools.computer_use.schema import COMPUTER_USE_SCHEMA
+        props = COMPUTER_USE_SCHEMA["parameters"]["properties"]
+        assert "window_title" in props
+        assert props["window_title"]["type"] == "string"
+        assert "Hermes-side capture scope" in props["window_title"]["description"]
+
     def test_schema_lists_all_expected_actions(self):
         from tools.computer_use.schema import COMPUTER_USE_SCHEMA
         actions = set(COMPUTER_USE_SCHEMA["parameters"]["properties"]["action"]["enum"])
@@ -116,6 +124,84 @@ class TestRegistration:
             assert entry.check_fn() is False
 
 
+class TestCuaDriverResolution:
+    def _reload_backend(self):
+        import tools.computer_use.cua_backend as cua_backend
+        return importlib.reload(cua_backend)
+
+    def test_resolves_app_bundle_when_not_on_path(self):
+        bundle = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver"
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_CUA_DRIVER_CMD", None)
+            cua_backend = self._reload_backend()
+            with patch.object(cua_backend.shutil, "which", return_value=None), \
+                 patch.object(cua_backend, "_is_executable_file",
+                              side_effect=lambda p: p == bundle):
+                assert cua_backend.resolve_cua_driver_command() == bundle
+                assert cua_backend.cua_driver_binary_available() is True
+
+    def test_path_wins_before_installed_fallbacks(self):
+        path_binary = "/opt/homebrew/bin/cua-driver"
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_CUA_DRIVER_CMD", None)
+            cua_backend = self._reload_backend()
+            with patch.object(cua_backend.shutil, "which", return_value=path_binary), \
+                 patch.object(cua_backend, "_is_executable_file", return_value=True):
+                assert cua_backend.resolve_cua_driver_command() == path_binary
+
+    def test_local_bin_fallback_wins_before_app_bundle(self):
+        local = os.path.expanduser("~/.local/bin/cua-driver")
+        bundle = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver"
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_CUA_DRIVER_CMD", None)
+            cua_backend = self._reload_backend()
+            with patch.object(cua_backend.shutil, "which", return_value=None), \
+                 patch.object(cua_backend, "_is_executable_file",
+                              side_effect=lambda p: p in {local, bundle}):
+                assert cua_backend.resolve_cua_driver_command() == local
+
+    def test_env_override_invalid_does_not_fallback(self):
+        bundle = "/Applications/CuaDriver.app/Contents/MacOS/cua-driver"
+        with patch.dict(os.environ, {"HERMES_CUA_DRIVER_CMD": "/missing/cua-driver"}, clear=False):
+            cua_backend = self._reload_backend()
+            with patch.object(cua_backend.shutil, "which", return_value=None), \
+                 patch.object(cua_backend, "_is_executable_file",
+                              side_effect=lambda p: p == bundle):
+                assert cua_backend.resolve_cua_driver_command() is None
+                assert cua_backend.cua_driver_binary_available() is False
+
+    def test_env_override_valid_absolute_path_wins(self):
+        override = "/tmp/custom-cua-driver"
+        with patch.dict(os.environ, {"HERMES_CUA_DRIVER_CMD": override}, clear=False):
+            cua_backend = self._reload_backend()
+            with patch.object(cua_backend, "_is_executable_file",
+                              side_effect=lambda p: p == override):
+                assert cua_backend.resolve_cua_driver_command() == override
+
+    def test_parse_windows_preserves_titles_for_safe_scoping(self):
+        cua_backend = self._reload_backend()
+        text = '- Google Chrome (pid 123) "Hermes CUA Probe abc" [window_id: 456]'
+        windows = cua_backend._parse_windows_from_text(text)
+        assert windows == [{
+            "app_name": "Google Chrome",
+            "pid": 123,
+            "title": "Hermes CUA Probe abc",
+            "window_id": 456,
+            "off_screen": False,
+        }]
+
+    def test_parse_windows_tolerates_legacy_lines_without_title(self):
+        cua_backend = self._reload_backend()
+        text = '- TextEdit (pid 321) [off-screen] [window_id: 654]'
+        windows = cua_backend._parse_windows_from_text(text)
+        assert windows == [{
+            "app_name": "TextEdit",
+            "pid": 321,
+            "title": "",
+            "window_id": 654,
+            "off_screen": True,
+        }]
+
 # ---------------------------------------------------------------------------
 # Dispatch & action routing
 # ---------------------------------------------------------------------------
@@ -139,6 +225,20 @@ class TestDispatch:
         parsed = json.loads(out)
         assert "apps" in parsed
         assert parsed["count"] == 0
+
+    def test_capture_routes_window_title_to_backend(self, noop_backend):
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({
+            "action": "capture",
+            "mode": "ax",
+            "app": "Google Chrome",
+            "window_title": "Hermes CUA Probe",
+        })
+        parsed = json.loads(out)
+        assert parsed["window_title"] == "Hermes CUA Probe"
+        capture_kw = next(c[1] for c in noop_backend.calls if c[0] == "capture")
+        assert capture_kw["app"] == "Google Chrome"
+        assert capture_kw["window_title"] == "Hermes CUA Probe"
 
     def test_wait_clamps_long_waits(self, noop_backend):
         from tools.computer_use.tool import handle_computer_use

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -86,7 +86,12 @@ class ComputerUseBackend(ABC):
 
     # ── Capture ─────────────────────────────────────────────────────
     @abstractmethod
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult: ...
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+    ) -> CaptureResult: ...
 
     # ── Pointer actions ─────────────────────────────────────────────
     @abstractmethod

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -47,15 +47,51 @@ logger = logging.getLogger(__name__)
 
 PINNED_CUA_DRIVER_VERSION = os.environ.get("HERMES_CUA_DRIVER_VERSION", "0.5.0")
 
-_CUA_DRIVER_CMD = os.environ.get("HERMES_CUA_DRIVER_CMD", "cua-driver")
 _CUA_DRIVER_ARGS = ["mcp"]  # stdio MCP transport
 
 # Regex to parse list_windows text output lines:
 #   "- AppName (pid 12345) "Title" [window_id: 67890]"
 _WINDOW_LINE_RE = re.compile(
-    r'^-\s+(.+?)\s+\(pid\s+(\d+)\)\s+.*\[window_id:\s+(\d+)\]',
+    # Newer cua-driver text includes a quoted title; older builds emitted
+    # additional flags/free text before the window_id without a stable title.
+    r'^-\s+(.+?)\s+\(pid\s+(\d+)\)\s+(?:"([^"]*)"\s+)?(?:.*?\s+)?\[window_id:\s+(\d+)\]',
     re.MULTILINE,
 )
+
+# Fallback locations used by the upstream installer / CuaDriver.app on macOS.
+# `cua-driver` is not always on Hermes' PATH (notably gateway/venv launches),
+# while the app bundle path is the authoritative TCC-attributed binary.
+_FALLBACK_CUA_DRIVER_PATHS = (
+    os.path.expanduser("~/.local/bin/cua-driver"),
+    "/Applications/CuaDriver.app/Contents/MacOS/cua-driver",
+)
+
+
+def _is_executable_file(path: str) -> bool:
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def resolve_cua_driver_command() -> Optional[str]:
+    """Return the executable cua-driver command/path, or None if unavailable.
+
+    HERMES_CUA_DRIVER_CMD is an explicit override: if set but invalid, do not
+    silently fall back to another binary because that hides broken config.
+    """
+    override = os.environ.get("HERMES_CUA_DRIVER_CMD", "").strip()
+    if override:
+        if os.path.isabs(override):
+            return override if _is_executable_file(override) else None
+        resolved = shutil.which(override)
+        return resolved or None
+
+    resolved = shutil.which("cua-driver")
+    if resolved:
+        return resolved
+    for candidate in _FALLBACK_CUA_DRIVER_PATHS:
+        if _is_executable_file(candidate):
+            return candidate
+    return None
+
 
 # Regex to parse element lines from get_window_state AX tree markdown.
 #
@@ -86,8 +122,8 @@ def _is_arm_mac() -> bool:
 
 
 def cua_driver_binary_available() -> bool:
-    """True if `cua-driver` is on $PATH or HERMES_CUA_DRIVER_CMD resolves."""
-    return bool(shutil.which(_CUA_DRIVER_CMD))
+    """True if a usable `cua-driver` binary can be resolved."""
+    return resolve_cua_driver_command() is not None
 
 
 def cua_driver_install_hint() -> str:
@@ -108,7 +144,8 @@ def _parse_windows_from_text(text: str) -> List[Dict[str, Any]]:
         windows.append({
             "app_name": m.group(1).strip(),
             "pid": int(m.group(2)),
-            "window_id": int(m.group(3)),
+            "title": m.group(3) or "",
+            "window_id": int(m.group(4)),
             "off_screen": "[off-screen]" in m.group(0),
         })
     return windows
@@ -239,11 +276,12 @@ class _CuaDriverSession:
         from mcp import ClientSession, StdioServerParameters
         from mcp.client.stdio import stdio_client
 
-        if not cua_driver_binary_available():
+        command = resolve_cua_driver_command()
+        if not command:
             raise RuntimeError(cua_driver_install_hint())
 
         params = StdioServerParameters(
-            command=_CUA_DRIVER_CMD,
+            command=command,
             args=_CUA_DRIVER_ARGS,
             env={**os.environ},
         )
@@ -340,6 +378,7 @@ class CuaDriverBackend(ComputerUseBackend):
         self._active_pid: Optional[int] = None
         self._active_window_id: Optional[int] = None
         self._last_app: Optional[str] = None  # last app name targeted via capture/focus_app
+        self._last_window_title: Optional[str] = None
 
     # ── Lifecycle ──────────────────────────────────────────────────
     def start(self) -> None:
@@ -357,8 +396,13 @@ class CuaDriverBackend(ComputerUseBackend):
         return cua_driver_binary_available()
 
     # ── Capture ────────────────────────────────────────────────────
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        """Capture the frontmost on-screen window (optionally filtered by app name).
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+    ) -> CaptureResult:
+        """Capture the frontmost on-screen window, optionally filtered by app/title.
 
         Maps hermes `capture(mode, app)` → cua-driver `list_windows` +
         `get_window_state` (ax/som) or `screenshot` (vision).
@@ -415,21 +459,42 @@ class CuaDriverBackend(ComputerUseBackend):
                 )
             windows = filtered
 
+        # Filter by window title (case-insensitive substring) if requested.
+        # This is critical for browsers/editors where many windows share the
+        # same app name; never fall back to a different window on title miss.
+        if window_title:
+            title_lower = window_title.lower()
+            title_filtered = [
+                w for w in windows
+                if title_lower in str(w.get("title") or "").lower()
+            ]
+            if not title_filtered:
+                scope = f" app={app!r}" if app else ""
+                return CaptureResult(
+                    mode=mode, width=0, height=0, png_b64=None,
+                    elements=[], app="",
+                    window_title=f"<no on-screen window matched{scope} window_title={window_title!r}>",
+                    png_bytes_len=0,
+                )
+            windows = title_filtered
+
         # Pick first on-screen window (sorted by z_index / z-order above).
         target = next((w for w in windows if not w["off_screen"]), windows[0])
         self._active_pid = target["pid"]
         self._active_window_id = target["window_id"]
         app_name = target["app_name"]
-        # Record the resolved app name so capture_after= follow-ups can re-target
-        # the same app rather than falling back to the frontmost window.
+        # Record the resolved app/title so capture_after= follow-ups can re-target
+        # the same window rather than falling back to the frontmost window.
         if app or not self._last_app:
             self._last_app = app_name
+        if window_title or not self._last_window_title:
+            self._last_window_title = str(target.get("title") or window_title or "") or None
 
         # Step 2: capture.
         png_b64: Optional[str] = None
         elements: List[UIElement] = []
         width = height = 0
-        window_title = ""
+        resolved_window_title = str(target.get("title") or "")
 
         if mode == "vision":
             # screenshot tool: just the PNG, no AX walk.
@@ -460,7 +525,7 @@ class CuaDriverBackend(ComputerUseBackend):
             # Extract window title from the AX tree first AXWindow line.
             wt = re.search(r'AXWindow\s+"([^"]+)"', tree)
             if wt:
-                window_title = wt.group(1)
+                resolved_window_title = wt.group(1)
 
         png_bytes_len = 0
         if png_b64:
@@ -469,6 +534,9 @@ class CuaDriverBackend(ComputerUseBackend):
             except Exception:
                 png_bytes_len = len(png_b64) * 3 // 4
 
+        if resolved_window_title:
+            self._last_window_title = resolved_window_title
+
         return CaptureResult(
             mode=mode,
             width=width,
@@ -476,7 +544,7 @@ class CuaDriverBackend(ComputerUseBackend):
             png_b64=png_b64,
             elements=elements,
             app=app_name,
-            window_title=window_title,
+            window_title=resolved_window_title,
             png_bytes_len=png_bytes_len,
         )
 
@@ -683,6 +751,7 @@ class CuaDriverBackend(ComputerUseBackend):
             self._active_pid = target["pid"]
             self._active_window_id = target["window_id"]
             self._last_app = target["app_name"]  # preserve for capture_after= follow-ups
+            self._last_window_title = None
             return ActionResult(
                 ok=True, action="focus_app",
                 message=f"Targeted {target['app_name']} (pid {self._active_pid}, "

--- a/tools/computer_use/schema.py
+++ b/tools/computer_use/schema.py
@@ -75,6 +75,19 @@ COMPUTER_USE_SCHEMA: Dict[str, Any] = {
                     "frontmost app's window or the whole screen."
                 ),
             },
+            "window_title": {
+                "type": "string",
+                "description": (
+                    "Optional Hermes-side capture scope. First resolve an "
+                    "on-screen window whose title contains this string "
+                    "(case-insensitive), then call the structured cua-driver "
+                    "window primitives for that window. Use with app= when "
+                    "multiple browser/editor windows may be open; if no "
+                    "matching title is found, capture returns an explicit "
+                    "empty result instead of falling back to the frontmost "
+                    "or unrelated window."
+                ),
+            },
             "max_elements": {
                 "type": "integer",
                 "description": (

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -167,10 +167,15 @@ class _NoopBackend(ComputerUseBackend):  # pragma: no cover
     def stop(self) -> None: self._started = False
     def is_available(self) -> bool: return True
 
-    def capture(self, mode: str = "som", app: Optional[str] = None) -> CaptureResult:
-        self.calls.append(("capture", {"mode": mode, "app": app}))
+    def capture(
+        self,
+        mode: str = "som",
+        app: Optional[str] = None,
+        window_title: Optional[str] = None,
+    ) -> CaptureResult:
+        self.calls.append(("capture", {"mode": mode, "app": app, "window_title": window_title}))
         return CaptureResult(mode=mode, width=1024, height=768, png_b64=None,
-                             elements=[], app=app or "", window_title="")
+                             elements=[], app=app or "", window_title=window_title or "")
 
     def click(self, **kw) -> ActionResult:
         self.calls.append(("click", kw))
@@ -320,7 +325,10 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         mode = str(args.get("mode", "som"))
         if mode not in {"som", "vision", "ax"}:
             return json.dumps({"error": f"bad mode {mode!r}; use som|vision|ax"})
-        cap = backend.capture(mode=mode, app=args.get("app"))
+        capture_kwargs = {"mode": mode, "app": args.get("app")}
+        if args.get("window_title"):
+            capture_kwargs["window_title"] = args.get("window_title")
+        cap = backend.capture(**capture_kwargs)
         return _capture_response(cap, max_elements=_coerce_max_elements(args.get("max_elements")))
 
     if action == "wait":
@@ -685,7 +693,11 @@ def _maybe_follow_capture(
         # that capture_after=True re-captures the same app rather than the frontmost
         # window (which may have changed if the action caused a focus shift).
         last_app = getattr(backend, "_last_app", None)
-        cap = backend.capture(mode="som", app=last_app)
+        last_window_title = getattr(backend, "_last_window_title", None)
+        capture_kwargs = {"mode": "som", "app": last_app}
+        if last_window_title:
+            capture_kwargs["window_title"] = last_window_title
+        cap = backend.capture(**capture_kwargs)
     except Exception as e:
         logger.warning("follow-up capture failed: %s", e)
         return _text_response(res)

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -317,7 +317,7 @@ export function StatusRule({
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel)
 
   return (
-    <Box height={1}>
+    <Box backgroundColor={t.color.statusBg} height={1}>
       <Box flexShrink={1} width={leftWidth}>
         <Text color={t.color.border} wrap="truncate-end">
           {'─ '}


### PR DESCRIPTION
## Summary
- Keep Codex OAuth strict: auth store/configured credentials only, with no credential-pool, scan, proxy, sidecar, cache, or recovery fallback paths.
- Centralize and test CUA driver resolution/window scoping behavior.
- Fix Honcho peer-card observer/target handling.
- Harden browser benchmark CDP-unavailable behavior and TUI/web tests/local artifact ignores.

## Test Plan
- `./scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_tools_config.py tests/tools/test_computer_use.py tests/honcho_plugin/test_session.py tests/test_benchmark_browser_eval.py tests/test_tui_gateway_server.py tests/cli/test_cli_init.py`
  - 903 passed, 0 failed, 12 skipped/non-executed.
- `git diff --check`
- `git diff --check origin/main..HEAD`
- Secret scan artifacts from the GoalOps run reported PASS with `review_required_count=0`.

## Notes
- Full suite was not run locally.
- Branch was rebased on current `origin/main` before opening this PR.
