### PR TITLE
fix(gateway): prevent cron fd leaks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -119,6 +119,8 @@ _GATEWAY_AUTH_ERROR_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_NOFILE_SOFT_LIMIT = 4096
+
 _GATEWAY_RATE_LIMIT_RE = re.compile(
     r"(rate\s+limit|rate-limited|\b429\b|quota|usage\s+limit)",
     re.IGNORECASE,
@@ -17989,20 +17991,66 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     """
     from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.status import write_runtime_status
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
     CHANNEL_DIR_EVERY = 5    # ticks — every 5 minutes
     PASTE_SWEEP_EVERY = 60   # ticks — once per hour
     CURATOR_EVERY = 60       # ticks — poll hourly (inner gate handles the real cadence)
+    CRON_FAILURE_LOG_EVERY = 300.0
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
+    cron_failure_count = 0
+    last_cron_failure_log_at = 0.0
+
+    def _record_cron_status(**fields) -> None:
+        try:
+            write_runtime_status(cron=fields)
+        except Exception as status_exc:
+            logger.debug("Cron runtime status write failed: %s", status_exc)
+
     while not stop_event.is_set():
         try:
             cron_tick(verbose=False, adapters=adapters, loop=loop)
         except Exception as e:
-            logger.debug("Cron tick error: %s", e)
+            cron_failure_count += 1
+            now_monotonic = time.monotonic()
+            should_log = (
+                cron_failure_count == 1
+                or now_monotonic - last_cron_failure_log_at >= CRON_FAILURE_LOG_EVERY
+            )
+            if should_log:
+                logger.warning(
+                    "Cron tick failed (%d consecutive failure%s): %s",
+                    cron_failure_count,
+                    "" if cron_failure_count == 1 else "s",
+                    e,
+                    exc_info=True,
+                )
+                last_cron_failure_log_at = now_monotonic
+            _record_cron_status(
+                state="failing",
+                consecutive_failures=cron_failure_count,
+                last_error=f"{type(e).__name__}: {e}",
+                last_error_at=datetime.now().astimezone().isoformat(),
+            )
+        else:
+            if cron_failure_count:
+                logger.info(
+                    "Cron tick recovered after %d consecutive failure%s",
+                    cron_failure_count,
+                    "" if cron_failure_count == 1 else "s",
+                )
+            cron_failure_count = 0
+            _record_cron_status(
+                state="healthy",
+                consecutive_failures=0,
+                last_success_at=datetime.now().astimezone().isoformat(),
+                last_error=None,
+                last_error_at=None,
+            )
 
         tick_count += 1
 
@@ -18068,6 +18116,40 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker stopped")
 
 
+def _raise_gateway_nofile_limit(target: int = _GATEWAY_NOFILE_SOFT_LIMIT) -> None:
+    """Raise the process fd soft limit when the platform allows it."""
+    if os.name == "nt":
+        return
+    try:
+        import resource
+    except Exception:
+        return
+    try:
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    except (OSError, ValueError):
+        return
+    if soft < 0 or hard == 0:
+        return
+    desired = max(soft, target)
+    if hard > 0:
+        desired = min(desired, hard)
+    if desired <= soft:
+        logger.debug("Gateway fd limit: soft=%s hard=%s", soft, hard)
+        return
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (desired, hard))
+    except (OSError, ValueError) as exc:
+        logger.debug(
+            "Could not raise gateway fd limit from %s to %s (hard=%s): %s",
+            soft,
+            desired,
+            hard,
+            exc,
+        )
+        return
+    logger.info("Gateway fd limit raised: soft=%s->%s hard=%s", soft, desired, hard)
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -18082,6 +18164,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                  Useful for systemd services to avoid restart-loop deadlocks
                  when the previous process hasn't fully exited yet.
     """
+    _raise_gateway_nofile_limit()
+
     # ── Duplicate-instance guard ──────────────────────────────────────
     # Prevent two gateways from running under the same HERMES_HOME.
     # The PID file is scoped to HERMES_HOME, so future multi-profile

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -507,6 +507,7 @@ def write_runtime_status(
     exit_reason: Any = _UNSET,
     restart_requested: Any = _UNSET,
     active_agents: Any = _UNSET,
+    cron: Any = _UNSET,
     platform: Any = _UNSET,
     platform_state: Any = _UNSET,
     error_code: Any = _UNSET,
@@ -531,6 +532,17 @@ def write_runtime_status(
         payload["restart_requested"] = bool(restart_requested)
     if active_agents is not _UNSET:
         payload["active_agents"] = max(0, int(active_agents))
+    if cron is not _UNSET:
+        if cron is None:
+            payload.pop("cron", None)
+        else:
+            cron_payload = payload.get("cron", {})
+            if not isinstance(cron_payload, dict):
+                cron_payload = {}
+            if isinstance(cron, dict):
+                cron_payload.update(cron)
+            cron_payload["updated_at"] = _utc_now_iso()
+            payload["cron"] = cron_payload
 
     if platform is not _UNSET:
         platform_payload = payload["platforms"].get(platform, {})

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -16,6 +16,16 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from hermes_cli.colors import Colors, color
 
 
+def _cron_runtime_state() -> dict:
+    try:
+        from gateway.status import read_runtime_status
+    except Exception:
+        return {}
+    state = read_runtime_status() or {}
+    cron = state.get("cron", {}) if isinstance(state, dict) else {}
+    return cron if isinstance(cron, dict) else {}
+
+
 def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None) -> Optional[List[str]]:
     if skills is None:
         if single_skill is None:
@@ -140,9 +150,19 @@ def cron_status():
     print()
 
     pids = find_gateway_pids()
+    cron_state = _cron_runtime_state()
     if pids:
-        print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+        if cron_state.get("state") == "failing":
+            print(color("⚠ Gateway is running but the cron ticker is failing", Colors.YELLOW))
+        else:
+            print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
         print(f"  PID: {', '.join(map(str, pids))}")
+        if cron_state.get("state") == "failing":
+            failures = int(cron_state.get("consecutive_failures") or 0)
+            suffix = "" if failures == 1 else "s"
+            error = cron_state.get("last_error") or "unknown error"
+            print(color(f"  Cron tick failures: {failures} consecutive failure{suffix}", Colors.YELLOW))
+            print(color(f"  Last error: {error}", Colors.YELLOW))
     else:
         print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
         print()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -41,6 +41,8 @@ from hermes_cli.colors import Colors, color
 
 logger = logging.getLogger(__name__)
 
+_GATEWAY_NOFILE_SOFT_LIMIT = 4096
+
 # =============================================================================
 # Process Management (for manual gateway runs)
 # =============================================================================
@@ -2878,6 +2880,12 @@ def generate_launchd_plist() -> str:
         <key>SuccessfulExit</key>
         <false/>
     </dict>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>{_GATEWAY_NOFILE_SOFT_LIMIT}</integer>
+    </dict>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
@@ -3837,11 +3845,18 @@ def _runtime_health_lines() -> list[str]:
     active_agents = state.get("active_agents")
     restart_requested = state.get("restart_requested")
     platforms = state.get("platforms", {}) or {}
+    cron = state.get("cron", {}) or {}
 
     for platform, pdata in platforms.items():
         if pdata.get("state") == "fatal":
             message = pdata.get("error_message") or "unknown error"
             lines.append(f"⚠ {platform}: {message}")
+
+    if cron.get("state") == "failing":
+        failures = int(cron.get("consecutive_failures") or 0)
+        suffix = "" if failures == 1 else "s"
+        message = cron.get("last_error") or "unknown error"
+        lines.append(f"⚠ Cron ticker failing ({failures} consecutive failure{suffix}): {message}")
 
     if gateway_state == "startup_failed" and exit_reason:
         lines.append(f"⚠ Last startup issue: {exit_reason}")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -956,6 +956,16 @@ _INIT_LOCK = threading.RLock()
 _SQLITE_HEADER = b"SQLite format 3\x00"
 
 
+class KanbanConnection(sqlite3.Connection):
+    """SQLite connection whose context manager also closes the handle."""
+
+    def __exit__(self, exc_type, exc, tb):
+        try:
+            return super().__exit__(exc_type, exc, tb)
+        finally:
+            self.close()
+
+
 def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
     """Return True for a TLS record header at ``data[offset:]``."""
     if len(data) < offset + 5:
@@ -1141,6 +1151,9 @@ def connect(
 
     WAL mode is enabled on every connection; it's a no-op after the first
     time but keeps the code robust if the DB file is ever re-created.
+    The returned connection can be used as a context manager; unlike the
+    stdlib sqlite3 default, ``with connect() as conn:`` closes the handle
+    after committing or rolling back.
 
     The first connection to a given path auto-runs :func:`init_db` so
     fresh installs and test harnesses that construct `connect()`
@@ -1168,7 +1181,12 @@ def connect(
     # via _INITIALIZED_PATHS so it only runs once per process per path.
     _guard_existing_db_is_healthy(path)
     resolved = str(path.resolve())
-    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
+    conn = sqlite3.connect(
+        str(path),
+        isolation_level=None,
+        timeout=30,
+        factory=KanbanConnection,
+    )
     try:
         conn.row_factory = sqlite3.Row
         with _INIT_LOCK:

--- a/tests/gateway/test_cron_ticker_health.py
+++ b/tests/gateway/test_cron_ticker_health.py
@@ -1,0 +1,33 @@
+import logging
+import threading
+
+
+def test_cron_ticker_records_failure_and_recovery(monkeypatch, caplog):
+    from gateway.run import _start_cron_ticker
+
+    stop_event = threading.Event()
+    statuses = []
+    calls = {"count": 0}
+
+    def fake_tick(*, verbose, adapters, loop):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise OSError("too many open files")
+        stop_event.set()
+
+    monkeypatch.setattr("cron.scheduler.tick", fake_tick)
+    monkeypatch.setattr(
+        "gateway.status.write_runtime_status",
+        lambda **kwargs: statuses.append(kwargs),
+    )
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        _start_cron_ticker(stop_event, interval=0)
+
+    assert statuses[0]["cron"]["state"] == "failing"
+    assert statuses[0]["cron"]["consecutive_failures"] == 1
+    assert "OSError: too many open files" == statuses[0]["cron"]["last_error"]
+    assert statuses[1]["cron"]["state"] == "healthy"
+    assert statuses[1]["cron"]["consecutive_failures"] == 0
+    assert "Cron tick failed (1 consecutive failure)" in caplog.text
+    assert "Cron tick recovered after 1 consecutive failure" in caplog.text

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
-from hermes_cli.cron import cron_command
+from hermes_cli.cron import cron_command, cron_status
 
 
 @pytest.fixture()
@@ -17,6 +17,24 @@ def tmp_cron_dir(tmp_path, monkeypatch):
 
 
 class TestCronCommandLifecycle:
+    def test_status_surfaces_cron_ticker_failure(self, tmp_cron_dir, monkeypatch, capsys):
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1234])
+        monkeypatch.setattr(
+            "hermes_cli.cron._cron_runtime_state",
+            lambda: {
+                "state": "failing",
+                "consecutive_failures": 2,
+                "last_error": "OSError: too many open files",
+            },
+        )
+
+        cron_status()
+
+        out = capsys.readouterr().out
+        assert "Gateway is running but the cron ticker is failing" in out
+        assert "Cron tick failures: 2 consecutive failures" in out
+        assert "OSError: too many open files" in out
+
     def test_pause_resume_run(self, tmp_cron_dir, capsys):
         job = create_job(prompt="Check server status", schedule="every 1h")
 

--- a/tests/hermes_cli/test_gateway_runtime_health.py
+++ b/tests/hermes_cli/test_gateway_runtime_health.py
@@ -20,3 +20,21 @@ def test_runtime_health_lines_include_fatal_platform_and_startup_reason(monkeypa
 
     assert "⚠ telegram: another poller is active" in lines
     assert "⚠ Last startup issue: telegram conflict" in lines
+
+
+def test_runtime_health_lines_include_cron_failure(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.status.read_runtime_status",
+        lambda: {
+            "gateway_state": "running",
+            "cron": {
+                "state": "failing",
+                "consecutive_failures": 3,
+                "last_error": "OSError: too many open files",
+            },
+        },
+    )
+
+    lines = _runtime_health_lines()
+
+    assert "⚠ Cron ticker failing (3 consecutive failures): OSError: too many open files" in lines

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1630,6 +1630,9 @@ class TestProfileArg:
         plist = gateway_cli.generate_launchd_plist()
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>NumberOfFiles</key>" in plist
+        assert "<integer>4096</integer>" in plist
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -48,6 +48,14 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
+def test_connect_context_manager_closes_connection(kanban_home):
+    with kb.connect() as conn:
+        conn.execute("SELECT 1").fetchone()
+
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        conn.execute("SELECT 1").fetchone()
+
+
 def test_connect_rejects_tls_record_in_sqlite_header(tmp_path, monkeypatch):
     """Kanban should classify TLS-looking page-0 clobbers before WAL setup."""
     home = tmp_path / ".hermes"
@@ -2113,13 +2121,15 @@ def test_connect_falls_back_to_delete_on_locking_protocol(kanban_home, caplog):
 
     real_connect = _sqlite3.connect
 
-    class _WalBlockingConnection(_sqlite3.Connection):
-        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
-            if "journal_mode=wal" in sql.lower().replace(" ", ""):
-                raise _sqlite3.OperationalError("locking protocol")
-            return super().execute(sql, *args, **kwargs)
-
     def wal_blocking_connect(*args, **kwargs):
+        base_factory = kwargs.pop("factory", _sqlite3.Connection)
+
+        class _WalBlockingConnection(base_factory):
+            def execute(self, sql, *execute_args, **execute_kwargs):  # type: ignore[override]
+                if "journal_mode=wal" in sql.lower().replace(" ", ""):
+                    raise _sqlite3.OperationalError("locking protocol")
+                return super().execute(sql, *execute_args, **execute_kwargs)
+
         return real_connect(
             *args, factory=_WalBlockingConnection, **kwargs
         )
@@ -3338,4 +3348,3 @@ def test_maybe_emit_scratch_tip_skips_non_scratch_workspaces(kanban_home, caplog
                 "SELECT kind FROM task_events WHERE task_id = ?", (tid,),
             ).fetchall()
             assert "tip_scratch_workspace" not in [e["kind"] for e in events]
-

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json as jsonlib
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -74,6 +75,26 @@ def _patch_list_profiles(names: list[str]):
         patch("hermes_cli.profiles.profile_exists", side_effect=lambda x: x in names),
         patch("hermes_cli.profiles.get_active_profile_name", return_value=names[0] if names else "default"),
     ]
+
+
+def _fd_count() -> int:
+    if os.name == "nt":
+        pytest.skip("fd accounting is POSIX-only")
+    fd_dir = Path("/proc/self/fd")
+    if not fd_dir.is_dir():
+        fd_dir = Path("/dev/fd")
+    if not fd_dir.is_dir():
+        pytest.skip("fd directory not available")
+    return len(list(fd_dir.iterdir()))
+
+
+def test_list_triage_ids_does_not_leak_connections(kanban_home):
+    before = _fd_count()
+    for _ in range(5):
+        assert decomp.list_triage_ids() == []
+    after = _fd_count()
+
+    assert after <= before + 1
 
 
 def test_decompose_with_fanout_creates_children(kanban_home):


### PR DESCRIPTION
The gateway cron ticker could silently stop running jobs after the process exhausted file descriptors. The leak came from kanban auto-decompose paths using `with kb.connect()`; stdlib sqlite commits or rolls back there, but does not close the connection.

This patch makes kanban context-managed connections close, records cron ticker failures in runtime status, surfaces them in gateway/cron status, and raises the gateway fd soft limit as defense in depth.

Verification:
- `scripts/run_tests.sh` focused suite: 321 passed in the main checkout
- Clean `upstream/main` worktree: 6 changed assertions passed with `uv run --extra dev pytest`
