### PR TITLE
fix(anthropic): explicit ANTHROPIC_API_KEY beats autodiscovered OAuth

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1472,12 +1472,22 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
     if provider != "anthropic":
         return False
 
+    # Explicit user-configured credentials (env vars in ~/.hermes/.env) win
+    # over autodiscovered OAuth tokens from other tools' credential files.
+    # If a user has set ANTHROPIC_API_KEY they want the API-key path —
+    # x-api-key auth, no Claude Code identity injection, no mcp_ tool prefix.
+    # Autodiscovered Claude Code / Hermes PKCE tokens are kept as fallback so
+    # users without explicit env config still get a working anthropic session.
+    #
+    # env:ANTHROPIC_TOKEN remains ahead of env:ANTHROPIC_API_KEY because
+    # ANTHROPIC_TOKEN is the OAuth-specific env var — setting it explicitly
+    # is the user opting into the OAuth/subscription path.
     source_rank = {
         "env:ANTHROPIC_TOKEN": 0,
         "env:CLAUDE_CODE_OAUTH_TOKEN": 1,
-        "hermes_pkce": 2,
-        "claude_code": 3,
-        "env:ANTHROPIC_API_KEY": 4,
+        "env:ANTHROPIC_API_KEY": 2,
+        "hermes_pkce": 3,
+        "claude_code": 4,
     }
     manual_entries = sorted(
         (entry for entry in entries if _is_manual_source(entry.source)),

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1182,6 +1182,49 @@ def test_load_pool_prefers_anthropic_env_token_over_file_backed_oauth(tmp_path, 
     assert entry.access_token == "env-override-token"
 
 
+def test_load_pool_prefers_explicit_api_key_over_autodiscovered_oauth(tmp_path, monkeypatch):
+    """Regression: explicit ANTHROPIC_API_KEY must beat autodiscovered OAuth.
+
+    If a user has set ANTHROPIC_API_KEY in ~/.hermes/.env, that's explicit
+    consent to use the API-key path (x-api-key auth, no Claude Code identity
+    injection, no mcp_ tool-name prefix).  Autodiscovered Claude Code /
+    Hermes PKCE tokens from other tools' credential files must NOT silently
+    pre-empt that explicit configuration.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-explicit-user-key")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda pid: True)
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "autodiscovered-pkce-token",
+            "refreshToken": "pkce-refresh",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: {
+            "accessToken": "sk-ant-oat01-autodiscovered-claude-code",
+            "refreshToken": "cc-refresh",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.source == "env:ANTHROPIC_API_KEY"
+    assert entry.access_token == "sk-ant-api03-explicit-user-key"
+
+
 def test_least_used_strategy_selects_lowest_count(tmp_path, monkeypatch):
     """least_used strategy should select the credential with the lowest request_count."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
## Summary
If you set `ANTHROPIC_API_KEY` in `~/.hermes/.env`, you now actually get the API-key path — no Claude Code system prompt, no `mcp_` tool rename, no claude-cli user-agent.

## Root cause
`_normalize_pool_priorities()` in `agent/credential_pool.py` ranked credential sources for the anthropic pool. `env:ANTHROPIC_API_KEY` was at rank **4** — dead last, behind autodiscovered `hermes_pkce` and `claude_code` OAuth tokens from `~/.claude/.credentials.json`. Any user who'd ever run the Claude Code CLI (or done Hermes OAuth) had a credentials file on disk; that autodiscovered OAuth pre-empted their explicit API-key env var. Pool selects the OAuth entry → `_is_anthropic_oauth=True` → Claude Code masquerade fires.

## Fix
Reorder `source_rank`: explicit env vars first, autodiscovery as fallback.

| Before | After |
|---|---|
| 0 `env:ANTHROPIC_TOKEN` | 0 `env:ANTHROPIC_TOKEN` |
| 1 `env:CLAUDE_CODE_OAUTH_TOKEN` | 1 `env:CLAUDE_CODE_OAUTH_TOKEN` |
| 2 `hermes_pkce` | 2 **`env:ANTHROPIC_API_KEY`** |
| 3 `claude_code` | 3 `hermes_pkce` |
| 4 `env:ANTHROPIC_API_KEY` | 4 `claude_code` |

`ANTHROPIC_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` stay ahead of the API key — those are OAuth-specific env vars; setting one is explicit opt-in to OAuth. Manual entries (`hermes auth add`) still beat seeded entries unchanged.

## Validation
- `tests/agent/test_credential_pool.py`: 68 passed (67 existing + 1 new regression test).
- Existing `test_load_pool_prefers_anthropic_env_token_over_file_backed_oauth` still passes — `ANTHROPIC_TOKEN` still wins when set.
- New `test_load_pool_prefers_explicit_api_key_over_autodiscovered_oauth`: with `ANTHROPIC_API_KEY` set AND `~/.claude/.credentials.json` present, pool now selects the API key.
- E2E with real auth.json + autodiscovered `claude_code` creds: API key entry now picked (`source=env:ANTHROPIC_API_KEY`, `auth_type=api_key`, `_is_oauth_token()=False`).