### PR TITLE
fix: align midnight modern theme and add auxiliary controls

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -130,6 +130,32 @@ def auto_title_session(
         logger.debug("Failed to set auto-generated title: %s", e)
 
 
+def _title_generation_enabled() -> bool:
+    """Return whether automatic session-title generation is enabled.
+
+    Operators can disable the background title-generation LLM call with:
+    ``auxiliary.title_generation.enabled: false``.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        return True
+
+    aux = config.get("auxiliary", {}) if isinstance(config, dict) else {}
+    task_config = aux.get("title_generation", {}) if isinstance(aux, dict) else {}
+    if not isinstance(task_config, dict):
+        return True
+
+    raw = task_config.get("enabled", True)
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        return raw.strip().lower() not in {"0", "false", "no", "off", "disabled"}
+    return bool(raw)
+
+
 def maybe_auto_title(
     session_db,
     session_id: str,
@@ -143,9 +169,14 @@ def maybe_auto_title(
     """Fire-and-forget title generation after the first exchange.
 
     Only generates a title when:
+    - ``auxiliary.title_generation.enabled`` is not false
     - This appears to be the first user→assistant exchange
     - No title is already set
     """
+    if not _title_generation_enabled():
+        logger.debug("Auto-title generation disabled by config")
+        return
+
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1023,6 +1023,7 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
         "title_generation": {
+            "enabled": True,
             "provider": "auto",
             "model": "",
             "base_url": "",
@@ -1627,6 +1628,10 @@ DEFAULT_CONFIG = {
         # raise these to keep more early failure evidence.
         "worker_log_rotate_bytes": 2 * 1024 * 1024,
         "worker_log_backup_count": 1,
+        # Optional per-worker chat iteration cap. When unset, Kanban workers
+        # inherit agent.max_turns like normal chat sessions. Set this to give
+        # board tasks a different budget without changing CLI/gateway turns.
+        "worker_max_turns": None,
         # Profile that decomposes tasks in the Triage column. When unset,
         # falls back to the default profile (the one `hermes` launches with
         # no -p flag). Set this to a dedicated 'orchestrator' profile if you

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5397,6 +5397,15 @@ def _positive_int(value: Any, default: int, *, minimum: int = 1) -> int:
     return parsed if parsed >= minimum else default
 
 
+def _load_kanban_config() -> dict:
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config().get("kanban") or {}
+    except Exception:
+        return {}
+
+
 def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, int]:
     """Return ``(rotate_bytes, backup_count)`` for worker log rotation.
 
@@ -5405,12 +5414,7 @@ def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, 
     raise either value from ``config.yaml`` without changing dispatcher code.
     """
     if kanban_cfg is None:
-        try:
-            from hermes_cli.config import load_config
-
-            kanban_cfg = (load_config().get("kanban") or {})
-        except Exception:
-            kanban_cfg = {}
+        kanban_cfg = _load_kanban_config()
     max_bytes = _positive_int(
         (kanban_cfg or {}).get("worker_log_rotate_bytes"),
         DEFAULT_LOG_ROTATE_BYTES,
@@ -5422,6 +5426,20 @@ def worker_log_rotation_config(kanban_cfg: Optional[dict] = None) -> tuple[int, 
         minimum=0,
     )
     return max_bytes, backup_count
+
+
+def worker_max_turns_config(kanban_cfg: Optional[dict] = None) -> Optional[int]:
+    """Return the Kanban-only worker iteration cap, if configured."""
+    if kanban_cfg is None:
+        kanban_cfg = _load_kanban_config()
+    raw = (kanban_cfg or {}).get("worker_max_turns")
+    if raw in (None, ""):
+        return None
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 1 else None
 
 
 def _rotated_log_path(log_path: Path, generation: int) -> Path:
@@ -5778,10 +5796,11 @@ def _default_spawn(
                 cmd.extend(["--skills", sk])
     if task.model_override:
         cmd.extend(["-m", task.model_override])
-    cmd.extend([
-        "chat",
-        "-q", prompt,
-    ])
+    worker_max_turns = worker_max_turns_config()
+    if worker_max_turns is not None:
+        cmd.extend(["chat", "--max-turns", str(worker_max_turns), "-q", prompt])
+    else:
+        cmd.extend(["chat", "-q", prompt])
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3807,13 +3807,14 @@ def mount_spa(application: FastAPI):
 # Built-in dashboard themes — label + description only.  The actual color
 # definitions live in the frontend (web/src/themes/presets.ts).
 _BUILTIN_DASHBOARD_THEMES = [
-    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
-    {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
-    {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
-    {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
-    {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
-    {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
-    {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "default",           "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
+    {"name": "default-large",     "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
+    {"name": "midnight",          "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
+    {"name": "midnight-modern",   "label": "Midnight Modern",     "description": "Midnight colors with original sizing, Geist typography, and no background image"},
+    {"name": "ember",             "label": "Ember",               "description": "Warm crimson and bronze — forge vibes"},
+    {"name": "mono",              "label": "Mono",                "description": "Clean grayscale — minimal and focused"},
+    {"name": "cyberpunk",         "label": "Cyberpunk",           "description": "Neon green on black — matrix terminal"},
+    {"name": "rose",              "label": "Rosé",                "description": "Soft pink and warm ivory — easy on the eyes"},
 ]
 
 

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,7 @@ from agent.title_generator import (
     generate_title,
     auto_title_session,
     maybe_auto_title,
+    _title_generation_enabled,
 )
 
 
@@ -160,6 +161,30 @@ class TestAutoTitleSession:
             db.set_session_title.assert_not_called()
 
 
+class TestTitleGenerationEnabled:
+    """Tests for the auxiliary.title_generation.enabled toggle."""
+
+    def test_defaults_to_enabled_when_config_missing(self):
+        with patch("hermes_cli.config.load_config", return_value={}):
+            assert _title_generation_enabled() is True
+
+    @pytest.mark.parametrize("value", [False, "false", "off", "disabled", "0", "no"])
+    def test_false_values_disable_title_generation(self, value):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"title_generation": {"enabled": value}}},
+        ):
+            assert _title_generation_enabled() is False
+
+    @pytest.mark.parametrize("value", [True, "true", "on", "1", "yes"])
+    def test_true_values_enable_title_generation(self, value):
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"title_generation": {"enabled": value}}},
+        ):
+            assert _title_generation_enabled() is True
+
+
 class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
 
@@ -238,3 +263,18 @@ class TestMaybeAutoTitle:
 
     def test_skips_if_no_session_db(self):
         maybe_auto_title(None, "sess-1", "hello", "response", [])  # no db
+
+    def test_skips_when_title_generation_disabled(self):
+        db = MagicMock()
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        with patch("agent.title_generator._title_generation_enabled", return_value=False), patch(
+            "agent.title_generator.auto_title_session"
+        ) as mock_auto:
+            maybe_auto_title(db, "sess-1", "hello", "hi there", history)
+            import time
+            time.sleep(0.1)
+            mock_auto.assert_not_called()

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -115,6 +115,9 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
    all proportionally in Tailwind v4. */
 @theme inline {
   --spacing: calc(0.25rem * var(--theme-spacing-mul, 1));
+  --font-sans: var(--theme-font-sans);
+  --font-mono: var(--theme-font-mono);
+  --font-display: var(--theme-font-display);
 }
 
 #root {

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -78,6 +78,36 @@ export const midnightTheme: DashboardTheme = {
   },
 };
 
+/**
+ * Midnight's deep blue-violet palette with contemporary Geist typography while
+ * preserving the original Midnight sizing/spacing. The explicit `bg: "none"`
+ * suppresses the default filler artwork so this variant stays image-free.
+ */
+export const midnightModernTheme: DashboardTheme = {
+  name: "midnight-modern",
+  label: "Midnight Modern",
+  description: "Midnight colors with original sizing, Geist typography, and no background image",
+  palette: midnightTheme.palette,
+  typography: {
+    ...DEFAULT_TYPOGRAPHY,
+    fontSans: `"Geist", ${SYSTEM_SANS}`,
+    fontMono: `"Geist Mono", ${SYSTEM_MONO}`,
+    fontDisplay: `"Geist", ${SYSTEM_SANS}`,
+    fontUrl:
+      "https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap",
+    letterSpacing: "-0.01em",
+  },
+  layout: midnightTheme.layout,
+  assets: {
+    bg: "none",
+  },
+  customCSS: `
+#root .font-mondwest {
+  font-family: var(--theme-font-sans) !important;
+}
+`,
+};
+
 export const emberTheme: DashboardTheme = {
   name: "ember",
   label: "Ember",
@@ -208,6 +238,7 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
   "default-large": defaultLargeTheme,
   midnight: midnightTheme,
+  "midnight-modern": midnightModernTheme,
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -341,6 +341,7 @@ Built-in themes:
 | **Hermes Teal** (`default`) | Dark teal + cream, system fonts, comfortable spacing |
 | **Hermes Teal (Large)** (`default-large`) | Same as default with 18px text and roomier spacing |
 | **Midnight** (`midnight`) | Deep blue-violet, Inter + JetBrains Mono |
+| **Midnight Modern** (`midnight-modern`) | Midnight colors, original Midnight sizing/spacing, Geist + Geist Mono, no background image |
 | **Ember** (`ember`) | Warm crimson + bronze, Spectral serif + IBM Plex Mono |
 | **Mono** (`mono`) | Grayscale, IBM Plex, compact |
 | **Cyberpunk** (`cyberpunk`) | Neon green on black, Share Tech Mono |


### PR DESCRIPTION
## Summary
- Align the Midnight Modern dashboard theme across server defaults, web presets, CSS, and docs
- Add an auxiliary.title_generation.enabled config toggle to disable background session-title LLM calls
- Add a Kanban worker_max_turns config override for board-worker chat budgets
- Reuse shared Kanban config loading for worker runtime settings and preserve per-task model overrides

## Test Plan
- [x] python -m pytest -o addopts='' tests/agent/test_title_generator.py -q
- [x] python -m pytest -o addopts='' tests/hermes_cli/test_kanban_core_functionality.py -q