### PR TITLE
fix: scope cron skill index to bound skills

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -897,6 +897,15 @@ def _write_skills_snapshot(
         logger.debug("Could not write skills prompt snapshot: %s", e)
 
 
+def _normalize_related_skill_names(raw: object) -> list[str]:
+    """Normalize related/linked skill metadata from skill frontmatter."""
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+    return [str(name).strip() for name in raw if str(name).strip()]
+
+
 def _build_snapshot_entry(
     skill_file: Path,
     skills_dir: Path,
@@ -917,6 +926,14 @@ def _build_snapshot_entry(
     if isinstance(platforms, str):
         platforms = [platforms]
 
+    hermes_metadata = frontmatter.get("metadata", {})
+    if isinstance(hermes_metadata, dict):
+        hermes_metadata = hermes_metadata.get("hermes", {})
+    else:
+        hermes_metadata = {}
+    if not isinstance(hermes_metadata, dict):
+        hermes_metadata = {}
+
     return {
         "skill_name": skill_name,
         "category": category,
@@ -924,6 +941,7 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "related_skills": _normalize_related_skill_names(hermes_metadata.get("related_skills")),
     }
 
 
@@ -981,9 +999,63 @@ def _skill_should_show(
     return True
 
 
+def _normalize_skill_index_scope(skill_names: "list[str] | tuple[str, ...] | set[str] | None") -> set[str] | None:
+    """Normalize an optional skill-index allowlist.
+
+    ``None`` means unscoped/full index. An empty collection means scoped to no
+    skills, which intentionally produces no advertised skill index.
+    """
+    if skill_names is None:
+        return None
+    return {str(name).strip() for name in skill_names if str(name).strip()}
+
+
+def _skill_in_index_scope(
+    frontmatter_name: str,
+    skill_name: str,
+    scoped_skill_names: "set[str] | None",
+) -> bool:
+    """Return True when a skill should appear under the optional scope."""
+    if scoped_skill_names is None:
+        return True
+    return frontmatter_name in scoped_skill_names or skill_name in scoped_skill_names
+
+
+def _expand_skill_index_scope(
+    skill_entries: list[dict],
+    scoped_skill_names: "set[str] | None",
+) -> set[str] | None:
+    """Include skills referenced by explicitly scoped skills.
+
+    Skill metadata commonly uses ``metadata.hermes.related_skills`` for linked
+    procedures.  Cron-bound skills should be able to advertise those linked
+    helpers without exposing the entire global profile index.
+    """
+    if scoped_skill_names is None:
+        return None
+    expanded = set(scoped_skill_names)
+    changed = True
+    while changed:
+        changed = False
+        for entry in skill_entries:
+            if not _skill_in_index_scope(
+                str(entry.get("frontmatter_name", "")),
+                str(entry.get("skill_name", "")),
+                expanded,
+            ):
+                continue
+            for related in entry.get("related_skills") or []:
+                related_name = str(related).strip()
+                if related_name and related_name not in expanded:
+                    expanded.add(related_name)
+                    changed = True
+    return expanded
+
+
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    scoped_skill_names: "list[str] | tuple[str, ...] | set[str] | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -998,7 +1070,13 @@ def build_skills_system_prompt(
     scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
     are read-only — they appear in the index but new skills are always created
     in the local dir.  Local skills take precedence when names collide.
+
+    ``scoped_skill_names`` restricts the advertised index to a fixed set of
+    skill names.  This is used by cron jobs with explicit bound skills so their
+    system prompt does not pre-advertise unrelated skills from the global
+    profile while the bound skill content is already injected in the user turn.
     """
+    scoped_skill_names = _normalize_skill_index_scope(scoped_skill_names)
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
 
@@ -1022,6 +1100,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        None if scoped_skill_names is None else tuple(sorted(scoped_skill_names)),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1037,14 +1116,16 @@ def build_skills_system_prompt(
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
-        for entry in snapshot.get("skills", []):
-            if not isinstance(entry, dict):
-                continue
+        snapshot_entries = [entry for entry in snapshot.get("skills", []) if isinstance(entry, dict)]
+        scoped_skill_names = _expand_skill_index_scope(snapshot_entries, scoped_skill_names)
+        for entry in snapshot_entries:
             skill_name = entry.get("skill_name") or ""
             category = entry.get("category") or "general"
             frontmatter_name = entry.get("frontmatter_name") or skill_name
             platforms = entry.get("platforms") or []
             if not skill_matches_platform({"platforms": platforms}):
+                continue
+            if not _skill_in_index_scope(frontmatter_name, skill_name, scoped_skill_names):
                 continue
             if frontmatter_name in disabled or skill_name in disabled:
                 continue
@@ -1064,13 +1145,20 @@ def build_skills_system_prompt(
     else:
         # Cold path: full filesystem scan + write snapshot for next time
         skill_entries: list[dict] = []
+        parsed_skill_entries: list[tuple[dict, bool, dict]] = []
         for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
             is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
             entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
             skill_entries.append(entry)
+            parsed_skill_entries.append((entry, is_compatible, frontmatter))
+
+        scoped_skill_names = _expand_skill_index_scope(skill_entries, scoped_skill_names)
+        for entry, is_compatible, frontmatter in parsed_skill_entries:
             if not is_compatible:
                 continue
             skill_name = entry["skill_name"]
+            if not _skill_in_index_scope(entry["frontmatter_name"], skill_name, scoped_skill_names):
+                continue
             if entry["frontmatter_name"] in disabled or skill_name in disabled:
                 continue
             if not _skill_should_show(
@@ -1116,15 +1204,27 @@ def build_skills_system_prompt(
     for ext_dir in external_dirs:
         if not ext_dir.exists():
             continue
+        parsed_external_entries: list[tuple[dict, bool, dict]] = []
         for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):
             try:
                 is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
+                entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
+                parsed_external_entries.append((entry, is_compatible, frontmatter))
+            except Exception as e:
+                logger.debug("Error reading external skill %s: %s", skill_file, e)
+        scoped_skill_names = _expand_skill_index_scope(
+            [entry for entry, _is_compatible, _frontmatter in parsed_external_entries],
+            scoped_skill_names,
+        )
+        for entry, is_compatible, frontmatter in parsed_external_entries:
+            try:
                 if not is_compatible:
                     continue
-                entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
                 skill_name = entry["skill_name"]
                 frontmatter_name = entry["frontmatter_name"]
                 if frontmatter_name in seen_skill_names:
+                    continue
+                if not _skill_in_index_scope(frontmatter_name, skill_name, scoped_skill_names):
                     continue
                 if frontmatter_name in disabled or skill_name in disabled:
                     continue
@@ -1139,7 +1239,7 @@ def build_skills_system_prompt(
                     (frontmatter_name, entry["description"])
                 )
             except Exception as e:
-                logger.debug("Error reading external skill %s: %s", skill_file, e)
+                logger.debug("Error reading external skill metadata %s: %s", entry, e)
 
         # External category descriptions
         for desc_file in iter_skill_index_files(ext_dir, "DESCRIPTION.md"):

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -829,7 +829,7 @@ CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -178,6 +178,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,
+            scoped_skill_names=getattr(agent, "_skill_index_scope", None),
         )
     else:
         skills_prompt = ""

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1001,6 +1001,17 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _cron_skill_index_scope(job: dict) -> list[str]:
+    """Return explicit cron-bound skills for scoping the system skill index."""
+    skills = job.get("skills")
+    if skills is None:
+        legacy_skill = job.get("skill")
+        skills = [legacy_skill] if legacy_skill else []
+    elif isinstance(skills, str):
+        skills = [skills]
+    return [str(name).strip() for name in skills if str(name).strip()]
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -1640,6 +1651,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             session_id=_cron_session_id,
             session_db=_session_db,
         )
+        _cron_skill_scope = _cron_skill_index_scope(job)
+        if _cron_skill_scope:
+            setattr(agent, "_skill_index_scope", _cron_skill_scope)
         
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -266,6 +266,86 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_scoped_skill_index_hides_unbound_skills(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name, desc in [
+            ("crawler-news", "Crawl configured source URLs"),
+            ("freshrss-triage", "Read FreshRSS feeds"),
+        ]:
+            skill_dir = tmp_path / "skills" / "cron" / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+        result = build_skills_system_prompt(scoped_skill_names=["crawler-news"])
+
+        assert "crawler-news" in result
+        assert "Crawl configured source URLs" in result
+        assert "freshrss-triage" not in result
+        assert "Read FreshRSS feeds" not in result
+
+    def test_scoped_skill_index_matches_directory_name(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "cron" / "ai-news-zh"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: localized-news\ndescription: Crawl configured source URLs\n---\n"
+        )
+
+        result = build_skills_system_prompt(scoped_skill_names=["ai-news-zh"])
+
+        assert "localized-news" in result
+        assert "Crawl configured source URLs" in result
+
+    def test_scoped_skill_index_includes_related_skills(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        primary = tmp_path / "skills" / "cron" / "crawler-news"
+        primary.mkdir(parents=True)
+        (primary / "SKILL.md").write_text(
+            "---\n"
+            "name: crawler-news\n"
+            "description: Crawl configured source URLs\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    related_skills: [shared-news-rules]\n"
+            "---\n"
+        )
+        related = tmp_path / "skills" / "cron" / "shared-news-rules"
+        related.mkdir(parents=True)
+        (related / "SKILL.md").write_text(
+            "---\nname: shared-news-rules\ndescription: Normalize news output\n---\n"
+        )
+        unrelated = tmp_path / "skills" / "cron" / "freshrss-triage"
+        unrelated.mkdir(parents=True)
+        (unrelated / "SKILL.md").write_text(
+            "---\nname: freshrss-triage\ndescription: Read FreshRSS feeds\n---\n"
+        )
+
+        result = build_skills_system_prompt(scoped_skill_names=["crawler-news"])
+
+        assert "crawler-news" in result
+        assert "shared-news-rules" in result
+        assert "Normalize news output" in result
+        assert "freshrss-triage" not in result
+
+    def test_unscoped_skill_index_uses_distinct_cache_entry(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ["first-skill", "second-skill"]:
+            skill_dir = tmp_path / "skills" / "tools" / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name}\n---\n"
+            )
+
+        scoped = build_skills_system_prompt(scoped_skill_names=["first-skill"])
+        unscoped = build_skills_system_prompt()
+
+        assert "first-skill" in scoped
+        assert "second-skill" not in scoped
+        assert "first-skill" in unscoped
+        assert "second-skill" in unscoped
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -328,6 +329,62 @@ class TestBuildSkillsSystemPrompt:
         assert "shared-news-rules" in result
         assert "Normalize news output" in result
         assert "freshrss-triage" not in result
+
+    def test_scoped_related_skills_ignore_legacy_snapshot(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        primary = tmp_path / "skills" / "cron" / "crawler-news"
+        primary.mkdir(parents=True)
+        (primary / "SKILL.md").write_text(
+            "---\n"
+            "name: crawler-news\n"
+            "description: Crawl configured source URLs\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    related_skills: [shared-news-rules]\n"
+            "---\n"
+        )
+        related = tmp_path / "skills" / "cron" / "shared-news-rules"
+        related.mkdir(parents=True)
+        (related / "SKILL.md").write_text(
+            "---\nname: shared-news-rules\ndescription: Normalize news output\n---\n"
+        )
+
+        from agent.prompt_builder import _build_skills_manifest
+
+        (tmp_path / ".skills_prompt_snapshot.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "manifest": _build_skills_manifest(tmp_path / "skills"),
+                    "skills": [
+                        {
+                            "skill_name": "crawler-news",
+                            "category": "cron",
+                            "frontmatter_name": "crawler-news",
+                            "description": "Crawl configured source URLs",
+                            "platforms": [],
+                            "conditions": {},
+                        },
+                        {
+                            "skill_name": "shared-news-rules",
+                            "category": "cron",
+                            "frontmatter_name": "shared-news-rules",
+                            "description": "Normalize news output",
+                            "platforms": [],
+                            "conditions": {},
+                        },
+                    ],
+                    "category_descriptions": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = build_skills_system_prompt(scoped_skill_names=["crawler-news"])
+
+        assert "crawler-news" in result
+        assert "shared-news-rules" in result
+        assert "Normalize news output" in result
 
     def test_unscoped_skill_index_uses_distinct_cache_entry(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/cron/test_cron_skill_index_scope.py
+++ b/tests/cron/test_cron_skill_index_scope.py
@@ -1,0 +1,25 @@
+"""Tests for cron-scoped skill index plumbing."""
+
+from cron.scheduler import _cron_skill_index_scope
+
+
+def test_cron_skill_index_scope_prefers_skills_list():
+    job = {"skill": "legacy-skill", "skills": ["first", " second ", ""]}
+
+    assert _cron_skill_index_scope(job) == ["first", "second"]
+
+
+def test_cron_skill_index_scope_accepts_legacy_skill():
+    job = {"skill": " legacy-skill "}
+
+    assert _cron_skill_index_scope(job) == ["legacy-skill"]
+
+
+def test_cron_skill_index_scope_accepts_string_skills_value():
+    job = {"skills": "single-skill"}
+
+    assert _cron_skill_index_scope(job) == ["single-skill"]
+
+
+def test_cron_skill_index_scope_empty_without_bound_skills():
+    assert _cron_skill_index_scope({}) == []


### PR DESCRIPTION
## Summary
- Scopes cron agents' system-prompt skill index to the skills explicitly bound on the job.
- Preserves legacy `skill` support and includes `metadata.hermes.related_skills` helpers in the scoped index.
- Keeps the skills toolset available for explicit `skill_view` / dynamic lookup while avoiding unrelated pre-advertised skills.

## Why
Cron jobs that bind a single skill currently still see the global skill index, so unrelated installed skills can look like attractive alternatives to the model. This fixes that prompt-surface leak without disabling the skills toolset for cron.

## Changes
- Add an optional `scoped_skill_names` allowlist to `build_skills_system_prompt` and include it in the prompt cache key.
- Thread cron job `skills` / legacy `skill` into the agent as `_skill_index_scope` before the system prompt is built.
- Store and expand `metadata.hermes.related_skills` entries so linked helper skills remain advertised.
- Add focused prompt-builder and cron scope tests.

## Validation
- `python -m pytest tests/agent/test_prompt_builder.py tests/cron/test_cron_skill_index_scope.py tests/run_agent/test_run_agent.py::TestBuildSystemPrompt -o 'addopts=' -q`
- `git diff --check`

## Scope
Focused cron/system-prompt change only. Does not change skill loading via `skill_view`; unadvertised skills remain available when explicitly requested by name.

Closes #32235
Refs #32236
