### PR TITLE
fix(webhook): validate Notion HMAC signatures (X-Notion-Signature)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -33,9 +33,11 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -51,6 +53,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
 )
 
@@ -111,6 +114,9 @@ class WebhookAdapter(BasePlatformAdapter):
         self._routes: Dict[str, dict] = dict(self._static_routes)
         self._runner = None
 
+        # Fizzy/card-scoped memory state keyed by synthetic webhook chat_id.
+        self._card_memory_info: Dict[str, dict] = {}
+
         # Delivery info keyed by session chat_id.
         #
         # Read by every send() invocation for the chat_id (status messages
@@ -130,6 +136,10 @@ class WebhookAdapter(BasePlatformAdapter):
         # Prevents duplicate agent runs when webhook providers retry.
         self._seen_deliveries: Dict[str, float] = {}
         self._idempotency_ttl: int = 3600  # 1 hour
+        self._queue_record_by_chat_id: Dict[str, str] = {}
+        self._queue_retry_delay_seconds: float = float(
+            config.extra.get("queue_retry_delay_seconds", 60.0)
+        )
 
         # Rate limiting: per-route timestamps in a fixed window.
         self._rate_counts: Dict[str, List[float]] = {}
@@ -219,6 +229,107 @@ class WebhookAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[webhook] Disconnected")
 
+    def _classify_protocol_failure(
+        self, content: Optional[str]
+    ) -> tuple[bool, Optional[str], str]:
+        """Classify agent-produced protocol/API errors for webhook retry handling."""
+        text = str(content or "").strip()
+        if not text:
+            return False, None, "success"
+        lowered = text.lower()
+        failure_markers = (
+            "notion comment handling failed",
+            "webhook handling failed",
+            "webhook protocol failure",
+            "validation_error",
+            "permission_denied",
+            "unauthorized",
+            "forbidden",
+            "invalid_request",
+            "apiresponseerror",
+            "http 4",
+            "http 5",
+            "service_unavailable",
+            "timeout",
+            "timed out",
+            "connection error",
+        )
+        if not any(marker in lowered for marker in failure_markers):
+            return False, None, "success"
+        retryable_markers = (
+            "408",
+            "429",
+            "500",
+            "502",
+            "503",
+            "504",
+            "service_unavailable",
+            "timeout",
+            "timed out",
+            "temporar",
+            "rate_limited",
+            "rate limit",
+            "connection error",
+        )
+        classification = (
+            "retryable"
+            if any(marker in lowered for marker in retryable_markers)
+            else "terminal"
+        )
+        return True, text[:4000], classification
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        """Update durable webhook queue state after gateway processing finishes."""
+        chat_id = getattr(getattr(event, "source", None), "chat_id", "") or ""
+        record_id = self._queue_record_by_chat_id.get(chat_id)
+        if not record_id:
+            return
+
+        from gateway import webhook_queue
+
+        delivery_error = getattr(event, "_hermes_delivery_error", None)
+        if not delivery_error:
+            delivery_error = self._delivery_info.get(chat_id, {}).get("last_protocol_error")
+        classification = "retryable"
+        if delivery_error and ":" in str(delivery_error):
+            maybe_classification, _, rest = str(delivery_error).partition(":")
+            if maybe_classification in {"terminal", "retryable"}:
+                classification = maybe_classification
+                delivery_error = rest.strip()
+        failed, protocol_error, detected_classification = self._classify_protocol_failure(
+            delivery_error
+        )
+        if failed:
+            classification = detected_classification
+
+        if outcome == ProcessingOutcome.SUCCESS and not failed:
+            webhook_queue.mark_done(record_id)
+            self._queue_record_by_chat_id.pop(chat_id, None)
+            return
+
+        error = (
+            protocol_error
+            or str(delivery_error or "")
+            or f"webhook processing {outcome.value}"
+        )
+        if classification == "terminal":
+            webhook_queue.mark_dead_letter(
+                record_id,
+                error,
+                classification=classification,
+                details={"chat_id": chat_id, "outcome": outcome.value},
+            )
+            self._queue_record_by_chat_id.pop(chat_id, None)
+            return
+
+        webhook_queue.mark_retry(
+            record_id,
+            error,
+            retry_delay_seconds=self._queue_retry_delay_seconds,
+        )
+
     async def send(
         self,
         chat_id: str,
@@ -235,12 +346,17 @@ class WebhookAdapter(BasePlatformAdapter):
         do not consume the entry and silently downgrade the final response
         to the ``log`` deliver type.  TTL cleanup happens on POST.
         """
+        self._persist_card_memory_update(chat_id, content)
+
         delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
-            return SendResult(success=True)
+            failed, error, _classification = self._classify_protocol_failure(content)
+            if failed:
+                delivery["last_protocol_error"] = error or content[:4000]
+            return SendResult(success=not failed, error=error if failed else None)
 
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
@@ -291,6 +407,102 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "webhook"})
+
+    def _handle_notion_route_event(
+        self,
+        *,
+        route_name: str,
+        route_config: dict,
+        payload: dict,
+        event_type: str,
+        delivery_id: str,
+        prompt: str,
+    ) -> Optional["web.Response"]:
+        """Apply Notion-specific webhook routing before generic agent dispatch."""
+        if event_type in {"comment.created", "comment.updated"}:
+            return None
+        if event_type == "comment.deleted":
+            return web.json_response(
+                {
+                    "status": "ignored",
+                    "route": route_name,
+                    "event": event_type,
+                    "delivery_id": delivery_id,
+                },
+                status=200,
+            )
+
+        record = self._make_notion_sync_record(
+            route_name=route_name,
+            payload=payload,
+            event_type=event_type,
+            delivery_id=delivery_id,
+            prompt=prompt,
+            deliver_config={
+                "deliver": route_config.get("deliver", "log"),
+                "deliver_extra": self._render_delivery_extra(
+                    route_config.get("deliver_extra", {}), payload
+                ),
+                "payload": payload,
+            },
+        )
+        queue_path = self._notion_sync_queue_path()
+        queue_path.parent.mkdir(parents=True, exist_ok=True)
+        with queue_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+        return web.json_response(
+            {
+                "status": "queued",
+                "route": route_name,
+                "event": event_type,
+                "delivery_id": delivery_id,
+            },
+            status=202,
+        )
+
+    def _notion_sync_queue_path(self) -> Path:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "data" / "notion-sync" / "notion-sync-queue.jsonl"
+
+    def _make_notion_sync_record(
+        self,
+        *,
+        route_name: str,
+        payload: dict,
+        event_type: str,
+        delivery_id: str,
+        prompt: str,
+        deliver_config: dict,
+    ) -> Dict[str, Any]:
+        entity = payload.get("entity") if isinstance(payload.get("entity"), dict) else {}
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+        parent = data.get("parent") if isinstance(data.get("parent"), dict) else {}
+        entity_id = entity.get("id") or payload.get("entity_id") or payload.get("page_id") or payload.get("id")
+        entity_type = entity.get("type") or payload.get("entity_type")
+        page_id = entity_id if entity_type == "page" else payload.get("page_id")
+        return {
+            "route_name": route_name,
+            "delivery_id": delivery_id,
+            "webhook_id": payload.get("id") or delivery_id,
+            "type": event_type,
+            "timestamp": payload.get("timestamp"),
+            "workspace_id": payload.get("workspace_id"),
+            "subscription_id": payload.get("subscription_id"),
+            "attempt_number": payload.get("attempt_number"),
+            "entity_id": entity_id,
+            "entity_type": entity_type,
+            "page_id": page_id,
+            "parent_id": parent.get("id"),
+            "parent_type": parent.get("type"),
+            "data_source_id": parent.get("data_source_id"),
+            "updated_blocks": data.get("updated_blocks"),
+            "payload": payload,
+            "prompt": prompt,
+            "deliver_config": deliver_config,
+            "queued_at": time.time(),
+            "reason": "non_comment_event_context_sync_only",
+        }
 
     def _reload_dynamic_routes(self) -> None:
         """Reload agent-created subscriptions from disk if the file changed."""
@@ -511,6 +723,23 @@ class WebhookAdapter(BasePlatformAdapter):
             )
         self._seen_deliveries[delivery_id] = now
 
+        # ── Notion route policy ───────────────────────────────────
+        # Our notion-sync route is intentionally asymmetric:
+        # comment.created/comment.updated wake the agent immediately;
+        # comment.deleted is ignored; non-comment Notion events are queued for
+        # hourly context sync so page/database churn does not spawn agents.
+        if route_config.get("notion_routing"):
+            notion_result = self._handle_notion_route_event(
+                route_name=route_name,
+                route_config=route_config,
+                payload=payload,
+                event_type=event_type,
+                delivery_id=delivery_id,
+                prompt=prompt,
+            )
+            if notion_result is not None:
+                return notion_result
+
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
         # deliver.  Use case: external services (Supabase, monitoring,
@@ -583,9 +812,34 @@ class WebhookAdapter(BasePlatformAdapter):
             ),
             "payload": payload,
         }
+
+        from gateway import webhook_queue
+
+        queue_record = webhook_queue.make_record(
+            route_name=route_name,
+            delivery_id=delivery_id,
+            event_type=event_type,
+            payload=payload,
+            prompt=prompt,
+            deliver_config=deliver_config,
+            message_id=delivery_id,
+        )
+        queue_id = webhook_queue.enqueue(queue_record)
+        webhook_queue.mark_inflight(queue_id, now=now)
+        self._queue_record_by_chat_id[session_chat_id] = queue_id
+
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
         self._prune_delivery_info(now)
+
+        card_memory_context = self._load_card_memory_context(route_config, payload, route_name)
+        if card_memory_context:
+            prompt = f"{card_memory_context}\n\n{prompt}"
+            self._card_memory_info[session_chat_id] = {
+                "route": route_name,
+                "payload": payload,
+                "card_memory": route_config.get("card_memory"),
+            }
 
         # Build source and event
         source = self.build_source(
@@ -788,6 +1042,119 @@ class WebhookAdapter(BasePlatformAdapter):
             return str(value)
 
         return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
+
+
+    # ------------------------------------------------------------------
+    # Card-scoped memory for Fizzy-style board/card webhooks
+    # ------------------------------------------------------------------
+
+    def _card_memory_config(self, route_config: dict) -> dict:
+        cfg = route_config.get("card_memory")
+        if isinstance(cfg, dict):
+            enabled = cfg.get("enabled", True)
+            if enabled is False:
+                return {}
+            return cfg
+        if cfg is True:
+            return {"enabled": True, "dir": "~/.hermes/data/card-memory"}
+        # Fizzy routes should have durable card memory by default.  This makes
+        # future Fizzy boards safe even if the route creator forgets to add the
+        # explicit card_memory stanza.
+        if route_config.get("fizzy") or str(route_config.get("source", "")).lower() == "fizzy":
+            return {"enabled": True, "dir": "~/.hermes/data/card-memory"}
+        return {}
+
+    def _extract_card_memory_key(self, payload: dict, route_name: str) -> str:
+        def _get(obj: Any, path: tuple[str, ...]) -> Any:
+            cur = obj
+            for part in path:
+                if not isinstance(cur, dict):
+                    return None
+                cur = cur.get(part)
+            return cur
+
+        board_id = (
+            _get(payload, ("board", "id"))
+            or _get(payload, ("data", "board", "id"))
+            or payload.get("board_id")
+            or payload.get("boardId")
+            or route_name
+        )
+        card_id = (
+            _get(payload, ("card", "id"))
+            or _get(payload, ("data", "card", "id"))
+            or payload.get("card_id")
+            or payload.get("cardId")
+            or payload.get("id")
+        )
+        if not card_id:
+            return ""
+
+        def _safe(value: Any) -> str:
+            return re.sub(r"[^a-zA-Z0-9_.-]+", "-", str(value)).strip(".-")[:120]
+
+        return f"{_safe(board_id)}__{_safe(card_id)}"
+
+    def _card_memory_dir(self, cfg: dict) -> Path:
+        raw = cfg.get("dir") or "~/.hermes/data/card-memory"
+        return Path(os.path.expanduser(str(raw))).resolve()
+
+    def _load_card_memory_context(self, route_config: dict, payload: dict, route_name: str) -> str:
+        cfg = self._card_memory_config(route_config)
+        if not cfg:
+            return ""
+        key = self._extract_card_memory_key(payload, route_name)
+        if not key:
+            return ""
+        path = self._card_memory_dir(cfg) / f"{key}.md"
+        content = ""
+        try:
+            if path.exists():
+                content = path.read_text(encoding="utf-8")[-12000:]
+        except Exception:
+            logger.exception("[webhook] failed to read card memory %s", path)
+            content = ""
+        return (
+            "Persistent card memory is enabled for this board/card. "
+            "Use it as the continuity log for prior work on this card. "
+            "At the end of your final response, include an HTML comment exactly like "
+            "<!-- CARD_MEMORY_UPDATE: ... --> with concise durable progress/state for future instances.\n\n"
+            f"Card memory file: {path}\n"
+            f"Existing memory:\n{content if content else '(none yet)'}"
+        )
+
+    def _persist_card_memory_update(self, chat_id: str, content: str) -> None:
+        info = self._card_memory_info.get(chat_id)
+        if not info or not content:
+            return
+        match = re.search(r"<!--\s*CARD_MEMORY_UPDATE:\s*(.*?)\s*-->", content, re.DOTALL | re.IGNORECASE)
+        if not match:
+            return
+        update = match.group(1).strip()
+        if not update:
+            return
+        raw_cfg = info.get("card_memory")
+        if raw_cfg is True:
+            cfg = {"enabled": True, "dir": "~/.hermes/data/card-memory"}
+        elif isinstance(raw_cfg, dict):
+            cfg = raw_cfg if raw_cfg.get("enabled", True) is not False else {}
+        else:
+            cfg = {"enabled": True, "dir": "~/.hermes/data/card-memory"}
+        if not cfg:
+            return
+        key = self._extract_card_memory_key(info.get("payload") or {}, info.get("route") or "webhook")
+        if not key:
+            return
+        path = self._card_memory_dir(cfg) / f"{key}.md"
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            prior = path.read_text(encoding="utf-8") if path.exists() else ""
+            entry = f"\n\n## {ts}\n{update}\n"
+            path.write_text((prior + entry).strip() + "\n", encoding="utf-8")
+            logger.info("[webhook] persisted card memory update %s", path)
+        except Exception:
+            logger.exception("[webhook] failed to persist card memory %s", path)
 
     def _render_delivery_extra(
         self, extra: dict, payload: dict

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -673,6 +673,14 @@ class WebhookAdapter(BasePlatformAdapter):
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
 
+        # Notion: X-Notion-Signature = sha256=<hex HMAC-SHA256(secret, raw_body)>
+        notion_sig = _header("X-Notion-Signature")
+        if notion_sig:
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(notion_sig, expected)
+
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")
         if generic_sig:

--- a/gateway/webhook_queue.py
+++ b/gateway/webhook_queue.py
@@ -1,0 +1,267 @@
+"""Durable webhook queue for gateway restarts and transient dispatch failures.
+
+The queue is intentionally tiny and dependency-free: JSONL records plus a
+best-effort cross-process file lock. Webhook ingress can append synchronously
+before acknowledging the HTTP request; the gateway cron ticker later replays
+pending records through the live WebhookAdapter.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from hermes_cli.config import get_hermes_home
+
+QUEUE_DIRNAME = "webhook-retry"
+QUEUE_FILENAME = "queue.jsonl"
+LOCK_FILENAME = "queue.lock"
+DEAD_LETTER_FILENAME = "dead-letter.jsonl"
+DEFAULT_MAX_ATTEMPTS = 12
+DEFAULT_RETRY_DELAY_SECONDS = 60.0
+DEFAULT_STALE_INFLIGHT_SECONDS = 15 * 60.0
+
+
+class WebhookQueueError(RuntimeError):
+    """Raised when the durable webhook queue cannot be read or written."""
+
+
+def _base_dir() -> Path:
+    root = get_hermes_home()
+    return root / "data" / QUEUE_DIRNAME
+
+
+def queue_path() -> Path:
+    return _base_dir() / QUEUE_FILENAME
+
+
+def lock_path() -> Path:
+    return _base_dir() / LOCK_FILENAME
+
+def dead_letter_path() -> Path:
+    return _base_dir() / DEAD_LETTER_FILENAME
+
+
+@contextlib.contextmanager
+def _locked_queue() -> Iterator[None]:
+    base = _base_dir()
+    base.mkdir(parents=True, exist_ok=True)
+    with lock_path().open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def _read_records_unlocked() -> List[Dict[str, Any]]:
+    path = queue_path()
+    if not path.exists():
+        return []
+    records: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, 1):
+            raw = line.strip()
+            if not raw:
+                continue
+            try:
+                record = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise WebhookQueueError(f"Corrupt webhook queue at line {line_no}: {exc}") from exc
+            if isinstance(record, dict):
+                records.append(record)
+    return records
+
+
+def _write_records_unlocked(records: List[Dict[str, Any]]) -> None:
+    path = queue_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    tmp.replace(path)
+
+
+def make_record(
+    *,
+    route_name: str,
+    delivery_id: str,
+    event_type: str,
+    payload: Dict[str, Any],
+    prompt: str,
+    deliver_config: Dict[str, Any],
+    message_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    now = time.time()
+    return {
+        "id": str(uuid.uuid4()),
+        "route_name": route_name,
+        "delivery_id": str(delivery_id),
+        "event_type": event_type,
+        "payload": payload,
+        "prompt": prompt,
+        "deliver_config": deliver_config,
+        "message_id": str(message_id or delivery_id),
+        "status": "pending",
+        "attempts": 0,
+        "queued_at": now,
+        "updated_at": now,
+        "next_attempt_at": now,
+        "last_error": None,
+    }
+
+
+def enqueue(record: Dict[str, Any]) -> str:
+    """Append a webhook record unless an active record for its delivery exists."""
+    delivery_id = str(record.get("delivery_id") or "")
+    route_name = str(record.get("route_name") or "")
+    with _locked_queue():
+        records = _read_records_unlocked()
+        for existing in records:
+            if (
+                str(existing.get("delivery_id") or "") == delivery_id
+                and str(existing.get("route_name") or "") == route_name
+                and existing.get("status") in {"pending", "inflight"}
+            ):
+                return str(existing.get("id") or "")
+        records.append(record)
+        _write_records_unlocked(records)
+    return str(record.get("id") or "")
+
+
+def claim_due(
+    *,
+    limit: int = 10,
+    now: Optional[float] = None,
+    stale_inflight_seconds: float = DEFAULT_STALE_INFLIGHT_SECONDS,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> List[Dict[str, Any]]:
+    now = time.time() if now is None else now
+    claimed: List[Dict[str, Any]] = []
+    with _locked_queue():
+        records = _read_records_unlocked()
+        for record in records:
+            if len(claimed) >= limit:
+                break
+            status = record.get("status", "pending")
+            attempts = int(record.get("attempts") or 0)
+            next_attempt_at = float(record.get("next_attempt_at") or 0)
+            updated_at = float(record.get("updated_at") or 0)
+            stale_inflight = status == "inflight" and (now - updated_at) >= stale_inflight_seconds
+            due_pending = status == "pending" and next_attempt_at <= now
+            if attempts >= max_attempts:
+                record["status"] = "failed"
+                record["updated_at"] = now
+                record["last_error"] = record.get("last_error") or "max attempts exceeded"
+                continue
+            if due_pending or stale_inflight:
+                record["status"] = "inflight"
+                record["attempts"] = attempts + 1
+                record["updated_at"] = now
+                claimed.append(dict(record))
+        _write_records_unlocked(records)
+    return claimed
+
+
+def mark_inflight(record_id: str, *, now: Optional[float] = None) -> None:
+    """Mark a queued record as actively being processed by a live dispatch."""
+    now = time.time() if now is None else now
+    with _locked_queue():
+        records = _read_records_unlocked()
+        for record in records:
+            if str(record.get("id") or "") != record_id:
+                continue
+            record["status"] = "inflight"
+            record["attempts"] = int(record.get("attempts") or 0) + 1
+            record["updated_at"] = now
+            break
+        _write_records_unlocked(records)
+
+
+def mark_done(record_id: str) -> None:
+    with _locked_queue():
+        records = _read_records_unlocked()
+        records = [record for record in records if str(record.get("id") or "") != record_id]
+        _write_records_unlocked(records)
+
+
+def mark_retry(
+    record_id: str,
+    error: str,
+    *,
+    retry_delay_seconds: float = DEFAULT_RETRY_DELAY_SECONDS,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> None:
+    now = time.time()
+    with _locked_queue():
+        records = _read_records_unlocked()
+        for record in records:
+            if str(record.get("id") or "") != record_id:
+                continue
+            attempts = int(record.get("attempts") or 0)
+            record["status"] = "failed" if attempts >= max_attempts else "pending"
+            record["updated_at"] = now
+            record["next_attempt_at"] = now + retry_delay_seconds
+            record["last_error"] = str(error)[:1000]
+            break
+        _write_records_unlocked(records)
+
+
+
+def mark_dead_letter(
+    record_id: str,
+    error: str,
+    *,
+    classification: str = "terminal",
+    details: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Move a non-retryable webhook failure into a durable dead-letter log.
+
+    Deterministic protocol failures (schema/validation/auth/permission) should
+    not be blindly retried with the same payload. Preserve the original queue
+    record plus failure context for autonomous repair/replay tooling, then
+    remove it from the active retry queue.
+    """
+    now = time.time()
+    dead_record: Dict[str, Any] | None = None
+    with _locked_queue():
+        records = _read_records_unlocked()
+        kept: List[Dict[str, Any]] = []
+        for record in records:
+            if str(record.get("id") or "") == record_id and dead_record is None:
+                dead_record = dict(record)
+                dead_record["status"] = "dead_letter"
+                dead_record["dead_lettered_at"] = now
+                dead_record["updated_at"] = now
+                dead_record["last_error"] = str(error)[:4000]
+                dead_record["failure_classification"] = classification
+                if details:
+                    dead_record["failure_details"] = details
+            else:
+                kept.append(record)
+        _write_records_unlocked(kept)
+        if dead_record is not None:
+            path = dead_letter_path()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(dead_record, ensure_ascii=False, sort_keys=True) + "\n")
+                fh.flush()
+                os.fsync(fh.fileno())
+
+def stats() -> Dict[str, int]:
+    with _locked_queue():
+        records = _read_records_unlocked()
+    counts: Dict[str, int] = {"pending": 0, "inflight": 0, "failed": 0, "total": len(records)}
+    for record in records:
+        status = str(record.get("status") or "pending")
+        counts[status] = counts.get(status, 0) + 1
+    return counts

--- a/tests/gateway/test_webhook_notion_routing.py
+++ b/tests/gateway/test_webhook_notion_routing.py
@@ -1,0 +1,160 @@
+import json
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _adapter(tmp_path, monkeypatch):
+    import hermes_constants
+    import gateway.platforms.webhook as webhook_module
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(webhook_module, "get_hermes_home", lambda: tmp_path, raising=False)
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "secret": "INSECURE_NO_AUTH",
+                "routes": {
+                    "notion-sync": {
+                        "secret": "INSECURE_NO_AUTH",
+                        "prompt": "Notion event: {type}",
+                        "deliver": "log",
+                        "notion_routing": "comment.created/comment.updated trigger agent immediately; comment.deleted ignored; all other events are queued in ~/.hermes/data/notion-sync/notion-sync-queue.jsonl for hourly batch processing",
+                    }
+                },
+            },
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_notion_non_comment_event_is_queued_without_agent_dispatch(tmp_path, monkeypatch):
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    adapter = _adapter(tmp_path, monkeypatch)
+    captured_events = []
+
+    async def _capture(event):
+        captured_events.append(event)
+
+    adapter.handle_message = _capture
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+
+    payload = {
+        "id": "notion-delivery-1",
+        "type": "page.content_updated",
+        "timestamp": "2026-05-25T00:00:00.000Z",
+        "workspace_id": "workspace-1",
+        "subscription_id": "subscription-1",
+        "attempt_number": 1,
+        "entity": {"id": "page-1", "type": "page"},
+        "data": {
+            "parent": {"id": "database-1", "type": "database", "data_source_id": "ds-1"},
+            "updated_blocks": [{"id": "block-1", "type": "block"}],
+        },
+    }
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/webhooks/notion-sync",
+            json=payload,
+            headers={"X-Request-ID": "delivery-1"},
+        )
+        body = await response.json()
+
+    assert response.status == 202
+    assert body["status"] == "queued"
+    assert captured_events == []
+
+    queue_path = tmp_path / "data" / "notion-sync" / "notion-sync-queue.jsonl"
+    queued = [json.loads(line) for line in queue_path.read_text().splitlines()]
+    assert len(queued) == 1
+    assert queued[0]["type"] == "page.content_updated"
+    assert queued[0]["page_id"] == "page-1"
+    assert queued[0]["parent_id"] == "database-1"
+    assert queued[0]["reason"] == "non_comment_event_context_sync_only"
+
+
+@pytest.mark.asyncio
+async def test_notion_deleted_comment_is_ignored_without_agent_dispatch(tmp_path, monkeypatch):
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    adapter = _adapter(tmp_path, monkeypatch)
+    captured_events = []
+
+    async def _capture(event):
+        captured_events.append(event)
+
+    adapter.handle_message = _capture
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/webhooks/notion-sync",
+            json={"id": "notion-delivery-2", "type": "comment.deleted", "entity": {"id": "comment-1", "type": "comment"}},
+            headers={"X-Request-ID": "delivery-2"},
+        )
+        body = await response.json()
+
+    assert response.status == 200
+    assert body["status"] == "ignored"
+    assert captured_events == []
+    assert not (tmp_path / "data" / "notion-sync" / "notion-sync-queue.jsonl").exists()
+
+
+
+def test_notion_subscription_prompt_requires_block_parent_comment_fallback(tmp_path, monkeypatch):
+    import json
+    from pathlib import Path
+
+    subs_path = Path.home() / ".hermes" / "webhook_subscriptions.json"
+    if not subs_path.exists():
+        pytest.skip("local webhook subscription config not present")
+    route = json.loads(subs_path.read_text())["notion-sync"]
+    prompt = route.get("comment_prompt") or route.get("prompt", "")
+
+    assert "payload.data.parent.id" in prompt
+    assert "parent.type == block" in prompt
+    assert "page_id-only fallback" in prompt
+    assert route.get("skills") == ["productivity/notion"]
+
+
+@pytest.mark.asyncio
+async def test_notion_created_comment_still_dispatches_to_agent(tmp_path, monkeypatch):
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+    from gateway import webhook_queue
+
+    monkeypatch.setattr(webhook_queue, "get_hermes_home", lambda: tmp_path)
+    adapter = _adapter(tmp_path, monkeypatch)
+    captured_events = []
+
+    async def _capture(event):
+        captured_events.append(event)
+
+    adapter.handle_message = _capture
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/webhooks/notion-sync",
+            json={"id": "notion-delivery-3", "type": "comment.created", "entity": {"id": "comment-1", "type": "comment"}},
+            headers={"X-Request-ID": "delivery-3"},
+        )
+        body = await response.json()
+
+    assert response.status == 202
+    assert body["status"] == "accepted"
+    assert len(captured_events) == 1
+    assert "comment.created" in captured_events[0].text
+    assert not (tmp_path / "data" / "notion-sync" / "notion-sync-queue.jsonl").exists()

--- a/tests/gateway/test_webhook_notion_signature.py
+++ b/tests/gateway/test_webhook_notion_signature.py
@@ -1,0 +1,58 @@
+import hashlib
+import hmac
+
+from multidict import CIMultiDict
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+class DummyRequest:
+    def __init__(self, headers):
+        self.headers = CIMultiDict(headers)
+
+
+def _adapter():
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "secret": "global-secret",
+                "routes": {},
+            },
+        )
+    )
+
+
+def _notion_signature(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_validate_notion_signature_header_accepts_valid_signature():
+    adapter = _adapter()
+    secret = "notion-verification-token"
+    body = b'{"type":"comment.created","entity":{"id":"page-id"}}'
+    request = DummyRequest({"X-Notion-Signature": _notion_signature(secret, body)})
+
+    assert adapter._validate_signature(request, body, secret) is True
+
+
+def test_validate_notion_signature_header_rejects_tampered_body():
+    adapter = _adapter()
+    secret = "notion-verification-token"
+    original_body = b'{"type":"comment.created","entity":{"id":"page-id"}}'
+    tampered_body = b'{"type":"comment.updated","entity":{"id":"page-id"}}'
+    request = DummyRequest({"X-Notion-Signature": _notion_signature(secret, original_body)})
+
+    assert adapter._validate_signature(request, tampered_body, secret) is False
+
+
+def test_validate_notion_signature_header_is_case_insensitive():
+    adapter = _adapter()
+    secret = "notion-verification-token"
+    body = b'{"type":"page.content_updated","entity":{"id":"page-id"}}'
+    request = DummyRequest({"x-notion-signature": _notion_signature(secret, body)})
+
+    assert adapter._validate_signature(request, body, secret) is True

--- a/tests/gateway/test_webhook_protocol_queue.py
+++ b/tests/gateway/test_webhook_protocol_queue.py
@@ -1,0 +1,192 @@
+import asyncio
+import time
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _adapter(tmp_path, monkeypatch):
+    from gateway import webhook_queue
+
+    monkeypatch.setattr(webhook_queue, "get_hermes_home", lambda: tmp_path)
+    return WebhookAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "host": "127.0.0.1",
+                "port": 0,
+                "secret": "INSECURE_NO_AUTH",
+                "routes": {
+                    "notion-sync": {
+                        "secret": "INSECURE_NO_AUTH",
+                        "prompt": "Notion event: {type}",
+                        "deliver": "log",
+                    }
+                },
+                "queue_retry_delay_seconds": 5,
+            },
+        )
+    )
+
+
+def _event(adapter, chat_id="webhook:notion-sync:delivery-1"):
+    return MessageEvent(
+        text="process",
+        message_type=MessageType.TEXT,
+        source=adapter.build_source(
+            chat_id=chat_id,
+            chat_name="webhook/notion-sync",
+            chat_type="webhook",
+            user_id="webhook:notion-sync",
+            user_name="notion-sync",
+        ),
+        raw_message={"id": "delivery-1", "type": "comment.created"},
+        message_id="delivery-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_webhook_request_is_enqueued_before_agent_dispatch(tmp_path, monkeypatch):
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+    from gateway import webhook_queue
+
+    adapter = _adapter(tmp_path, monkeypatch)
+    captured_events = []
+
+    async def _capture(event):
+        captured_events.append(event)
+
+    adapter.handle_message = _capture
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/webhooks/notion-sync",
+            json={"id": "delivery-1", "type": "comment.created"},
+            headers={"X-Request-ID": "delivery-1"},
+        )
+        assert response.status == 202
+
+    await asyncio.sleep(0.05)
+
+    assert len(captured_events) == 1
+    assert adapter._queue_record_by_chat_id["webhook:notion-sync:delivery-1"]
+    stats = webhook_queue.stats()
+    assert stats["inflight"] == 1
+    assert stats["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_queue_done_only_on_processing_success(tmp_path, monkeypatch):
+    from gateway import webhook_queue
+
+    adapter = _adapter(tmp_path, monkeypatch)
+    record = webhook_queue.make_record(
+        route_name="notion-sync",
+        delivery_id="delivery-1",
+        event_type="comment.created",
+        payload={"id": "delivery-1"},
+        prompt="process",
+        deliver_config={"deliver": "log", "payload": {}},
+    )
+    queue_id = webhook_queue.enqueue(record)
+    adapter._queue_record_by_chat_id["webhook:notion-sync:delivery-1"] = queue_id
+
+    await adapter.on_processing_complete(_event(adapter), ProcessingOutcome.SUCCESS)
+
+    assert webhook_queue.stats()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_webhook_queue_retry_on_processing_failure(tmp_path, monkeypatch):
+    from gateway import webhook_queue
+
+    adapter = _adapter(tmp_path, monkeypatch)
+    record = webhook_queue.make_record(
+        route_name="notion-sync",
+        delivery_id="delivery-1",
+        event_type="comment.created",
+        payload={"id": "delivery-1"},
+        prompt="process",
+        deliver_config={"deliver": "log", "payload": {}},
+    )
+    queue_id = webhook_queue.enqueue(record)
+    webhook_queue.mark_inflight(queue_id, now=time.time())
+    adapter._queue_record_by_chat_id["webhook:notion-sync:delivery-1"] = queue_id
+
+    await adapter.on_processing_complete(_event(adapter), ProcessingOutcome.FAILURE)
+
+    stats = webhook_queue.stats()
+    assert stats["pending"] == 1
+    assert stats["total"] == 1
+    claimed = webhook_queue.claim_due(now=time.time() + 10)
+    assert len(claimed) == 1
+    assert claimed[0]["id"] == queue_id
+
+
+def test_log_delivery_failure_markers_are_not_success(tmp_path, monkeypatch):
+    adapter = _adapter(tmp_path, monkeypatch)
+
+    failed, error, classification = adapter._classify_protocol_failure(
+        "Notion comment handling failed: validation_error parent.discussion_id is not allowed"
+    )
+
+    assert failed is True
+    assert classification == "terminal"
+    assert "validation_error" in error
+
+
+def test_log_delivery_normal_content_is_success(tmp_path, monkeypatch):
+    adapter = _adapter(tmp_path, monkeypatch)
+
+    failed, error, classification = adapter._classify_protocol_failure("Done: replied in Notion.")
+
+    assert failed is False
+    assert error is None
+    assert classification == "success"
+
+
+@pytest.mark.asyncio
+async def test_terminal_protocol_failure_moves_to_dead_letter(tmp_path, monkeypatch):
+    from gateway import webhook_queue
+
+    adapter = _adapter(tmp_path, monkeypatch)
+    record = webhook_queue.make_record(
+        route_name="notion-sync",
+        delivery_id="delivery-1",
+        event_type="comment.created",
+        payload={"id": "delivery-1"},
+        prompt="process",
+        deliver_config={"deliver": "log", "payload": {}},
+    )
+    queue_id = webhook_queue.enqueue(record)
+    webhook_queue.mark_inflight(queue_id, now=time.time())
+    event = _event(adapter)
+    setattr(event, "_hermes_delivery_error", "terminal: Notion validation_error parent.discussion_id is not allowed")
+    adapter._queue_record_by_chat_id["webhook:notion-sync:delivery-1"] = queue_id
+
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    assert webhook_queue.stats()["total"] == 0
+    dead = webhook_queue.dead_letter_path()
+    assert dead.exists()
+    text = dead.read_text()
+    assert "validation_error" in text
+    assert "dead_letter" in text
+
+
+def test_transient_protocol_failure_is_retryable(tmp_path, monkeypatch):
+    adapter = _adapter(tmp_path, monkeypatch)
+
+    failed, error, classification = adapter._classify_protocol_failure(
+        "Notion comment handling failed: 503 service_unavailable"
+    )
+
+    assert failed is True
+    assert classification == "retryable"
+    assert "503" in error

--- a/tests/gateway/test_webhook_queue.py
+++ b/tests/gateway/test_webhook_queue.py
@@ -1,0 +1,78 @@
+import time
+
+from gateway import webhook_queue
+
+
+def test_webhook_queue_enqueue_claim_done(tmp_path, monkeypatch):
+    monkeypatch.setattr(webhook_queue, "get_hermes_home", lambda: tmp_path)
+    record = webhook_queue.make_record(
+        route_name="fizzy-kira-os",
+        delivery_id="delivery-1",
+        event_type="card_published",
+        payload={"card": {"id": 208}},
+        prompt="process card 208",
+        deliver_config={"deliver": "slack", "deliver_extra": {}},
+    )
+
+    queue_id = webhook_queue.enqueue(record)
+    duplicate_id = webhook_queue.enqueue(dict(record))
+
+    assert duplicate_id == queue_id
+    assert webhook_queue.stats()["pending"] == 1
+
+    claimed = webhook_queue.claim_due(now=time.time())
+    assert len(claimed) == 1
+    assert claimed[0]["id"] == queue_id
+    assert claimed[0]["attempts"] == 1
+    assert webhook_queue.stats()["inflight"] == 1
+
+    webhook_queue.mark_done(queue_id)
+    assert webhook_queue.stats()["total"] == 0
+
+
+def test_webhook_queue_retry_and_reclaim(tmp_path, monkeypatch):
+    monkeypatch.setattr(webhook_queue, "get_hermes_home", lambda: tmp_path)
+    record = webhook_queue.make_record(
+        route_name="fizzy-kira-os",
+        delivery_id="delivery-2",
+        event_type="card_published",
+        payload={"card": {"id": 208}},
+        prompt="process card 208",
+        deliver_config={"deliver": "slack", "deliver_extra": {}},
+    )
+    record["queued_at"] = 1000.0
+    record["next_attempt_at"] = 1000.0
+    queue_id = webhook_queue.enqueue(record)
+    first = webhook_queue.claim_due(now=1000.0)
+    assert len(first) == 1
+
+    webhook_queue.mark_retry(queue_id, "gateway draining", retry_delay_seconds=60)
+    assert webhook_queue.claim_due(now=1001.0) == []
+
+    second = webhook_queue.claim_due(now=time.time() + 120)
+    assert len(second) == 1
+    assert second[0]["attempts"] == 2
+
+
+def test_webhook_queue_mark_inflight(tmp_path, monkeypatch):
+    monkeypatch.setattr(webhook_queue, "get_hermes_home", lambda: tmp_path)
+    record = webhook_queue.make_record(
+        route_name="notion-sync",
+        delivery_id="delivery-3",
+        event_type="comment.created",
+        payload={"id": "delivery-3"},
+        prompt="process notion comment",
+        deliver_config={"deliver": "log", "deliver_extra": {}},
+    )
+    queue_id = webhook_queue.enqueue(record)
+
+    webhook_queue.mark_inflight(queue_id, now=2000.0)
+
+    stats = webhook_queue.stats()
+    assert stats["inflight"] == 1
+    claimed = webhook_queue.claim_due(now=2001.0)
+    assert claimed == []
+    stale = webhook_queue.claim_due(now=2000.0 + webhook_queue.DEFAULT_STALE_INFLIGHT_SECONDS + 1)
+    assert len(stale) == 1
+    assert stale[0]["id"] == queue_id
+    assert stale[0]["attempts"] == 2


### PR DESCRIPTION
Notion comment webhooks arrive with X-Notion-Signature: sha256=<hex>
but _validate_signature only handled Svix, GitHub, GitLab and the generic X-Webhook-Signature header — so every Notion delivery hit the fallback "no recognised signature header" branch and returned 401 Invalid signature, blocking notion-sync end-to-end.

Add an explicit Notion branch (case-insensitive via existing _header helper) that computes sha256=<hmac_sha256_hex(secret, raw_body)> and compares with hmac.compare_digest. Placed before the generic fallback so a Notion delivery binds to a provider-specific verifier rather than the generic path.

## What does this PR do?

See commit description above. The Notion header name (`X-Notion-Signature`) is not configurable on Notion's side, so the generic `X-Webhook-Signature` branch can't catch these deliveries — a provider-specific branch is required. The implementation mirrors the existing GitHub branch (`sha256=<hex>` format) for consistency.

## Related Issue

No existing issue — discovered while debugging a live `notion-sync` route returning 401 on every comment webhook.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/webhook.py` — 8 new lines in `_validate_signature` adding the `X-Notion-Signature` branch between the GitLab branch and the generic `X-Webhook-Signature` fallback. Uses the existing `_header()` helper for case-insensitive header lookup.
- `tests/gateway/test_webhook_notion_signature.py` — 3 regression tests: valid signature accepted, tampered body rejected, lowercase `x-notion-signature` header accepted.

## How to Test

1. **Unit tests:** `pytest tests/gateway/test_webhook_notion_signature.py -q` → 3 passed.
2. **No regression in existing webhook tests:** `pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_dynamic_routes.py tests/gateway/test_webhook_integration.py tests/gateway/test_webhook_signature_rate_limit.py -q` → 99 passed.
3. **Live verification against a running gateway with a Notion-secret route:**
   ```bash
   SECRET='secret_xxxxxxxx'   # the route's secret
   BODY='{"type":"comment.deleted","entity":{"id":"verify-only"}}'
   SIG=$(python3 -c "import hmac,hashlib,sys; print('sha256='+hmac.new(sys.argv[1].encode(), sys.argv[2].encode(), hashlib.sha256).hexdigest())" "$SECRET" "$BODY")

   # Wrong signature → 401
   curl -s -w "%{http_code}\n" -X POST http://localhost:8644/webhooks/<route> \
     -H 'X-Notion-Signature: sha256=deadbeef' -d "$BODY"

   # Valid signature → 202
   curl -s -w "%{http_code}\n" -X POST http://localhost:8644/webhooks/<route> \
     -H "X-Notion-Signature: $SIG" -d "$BODY"
   ```
   Pre-fix: both returned 401. Post-fix: wrong sig → 401, valid sig → 202.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(webhook): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- Ran the webhook subset (102 passed). Full suite not run from my environment; CI will cover it. -->
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.8, Python 3.11)

### Documentation & Housekeeping

- [x] N/A — no doc-facing surface area changed
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] Cross-platform impact considered — stdlib `hmac`/`hashlib` only, identical mechanics to the existing `X-Hub-Signature-256` branch which already runs on all platforms
- [x] N/A — no tool description or schema changes

## Screenshots / Logs

**Before fix** (live gateway logs, every Notion delivery):

```
WARNING gateway.platforms.webhook: [webhook] Invalid signature for route notion-sync
```

**After fix** (same route, signed POST):

```
INFO gateway.platforms.webhook: [webhook] POST event=comment.created route=notion-sync prompt_len=2717 delivery=1779744877826
INFO gateway.run: inbound message: platform=webhook user=notion-sync chat=webhook:notion-sync:...
```