### PR TITLE
fix(opencode-go): avoid sending both thinking and reasoning_effort for Kimi K2

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -41,17 +41,18 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape.
+            # WARNING: Moonshot rejects requests that include BOTH
+            # extra_body.thinking AND top-level reasoning_effort.
+            # We prefer reasoning_effort when an effort level is configured,
+            # otherwise fall back to the binary thinking toggle.
             if not isinstance(reasoning_config, dict):
                 # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
             if not enabled:
+                extra_body["thinking"] = {"type": "disabled"}
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()
@@ -59,6 +60,12 @@ class OpenCodeGoProfile(ProviderProfile):
                 top_level["reasoning_effort"] = "high"
             elif effort in {"low", "medium", "high"}:
                 top_level["reasoning_effort"] = effort
+
+            # Only send thinking toggle when NOT also sending reasoning_effort.
+            # Moonshot rejects requests with both parameters.
+            if not top_level.get("reasoning_effort"):
+                extra_body["thinking"] = {"type": "enabled"}
+
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):


### PR DESCRIPTION
## Summary

Fixes #32223

Moonshot's backend rejects requests containing both `extra_body.thinking` and `top-level reasoning_effort` simultaneously.

## Changes

Modified `OpenCodeGoProfile.build_api_kwargs_extras()` for Kimi K2 models:
- If `reasoning_effort` is configured (low/medium/high), send only that
- Otherwise, send only the binary `thinking` toggle

## Before

```python
extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
# ... then also set reasoning_effort if effort is configured
# Result: both parameters sent → HTTP 400
```

## After

```python
# Set reasoning_effort if effort is configured
if effort in {"low", "medium", "high"}:
    top_level["reasoning_effort"] = effort

# Only send thinking toggle when NOT sending reasoning_effort
if not top_level.get("reasoning_effort"):
    extra_body["thinking"] = {"type": "enabled"}
```

## Testing

- Manual testing with `/model kimi-k2.6` and `agent.reasoning_effort: medium` should now succeed
- Follows the same pattern suggested in the issue