### PR TITLE
fix(gateway): deliver script and config MEDIA attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -835,6 +835,7 @@ MEDIA_DELIVERY_SAFE_ROOTS = (
     VIDEO_CACHE_DIR,
     DOCUMENT_CACHE_DIR,
     SCREENSHOT_CACHE_DIR,
+    _HERMES_HOME / "media_cache",
     _HERMES_HOME / "image_cache",
     _HERMES_HOME / "audio_cache",
     _HERMES_HOME / "video_cache",
@@ -2413,7 +2414,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|md|csv|tsv|json|xml|ya?ml|toml|ini|cfg|log|py|sh|ts|js|html?|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
@@ -2463,9 +2464,12 @@ class BasePlatformAdapter(ABC):
             # Audio (delivered as voice/audio where supported)
             '.mp3', '.wav', '.ogg', '.m4a', '.flac',
             # Documents (uploaded as file attachments)
-            '.pdf', '.docx', '.doc', '.odt', '.rtf', '.txt', '.md',
+            '.pdf', '.docx', '.doc', '.odt', '.rtf', '.txt', '.md', '.log',
+            # Code/scripts/configs (uploaded as file attachments)
+            '.py', '.sh', '.bash', '.zsh', '.js', '.ts', '.json', '.xml', '.yaml', '.yml',
+            '.toml', '.ini', '.cfg',
             # Spreadsheets / data
-            '.xlsx', '.xls', '.ods', '.csv', '.tsv', '.json', '.xml', '.yaml', '.yml',
+            '.xlsx', '.xls', '.ods', '.csv', '.tsv',
             # Presentations
             '.pptx', '.ppt', '.odp', '.key',
             # Archives

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -330,6 +330,14 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    @pytest.mark.parametrize("suffix", [".sh", ".py", ".md", ".yaml", ".toml", ".log"])
+    def test_media_tag_supports_code_script_and_config_documents(self, suffix):
+        content = f"Here is the file:\nMEDIA:/home/adam/.hermes/media_cache/report{suffix}"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [(f"/home/adam/.hermes/media_cache/report{suffix}", False)]
+        assert "MEDIA:" not in cleaned
+        assert "Here is the file" in cleaned
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the
@@ -381,6 +389,17 @@ class TestMediaDeliveryPathValidation:
         self._patch_roots(monkeypatch, root)
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(media_file)) == str(media_file.resolve())
+
+    def test_default_safe_roots_include_legacy_generic_media_cache(self):
+        """MEDIA:<path> guidance historically pointed agents at ~/.hermes/media_cache.
+
+        Keep that generic cache deliverable so generated scripts/documents don't
+        get stripped after extract_media finds them.
+        """
+        import gateway.platforms.base as base
+
+        roots = {root.name for root in base.MEDIA_DELIVERY_SAFE_ROOTS}
+        assert "media_cache" in roots
 
     def test_rejects_existing_file_outside_safe_root(self, tmp_path, monkeypatch):
         root = tmp_path / "media-cache"


### PR DESCRIPTION
## Summary
- teach gateway MEDIA tag extraction to recognise script/code/config/document extensions like `.sh`, `.py`, `.md`, `.yaml`, `.toml`, and `.log`
- add legacy `~/.hermes/media_cache` to the safe delivery roots so files agents already write there are uploaded instead of silently skipped
- add regression tests for both behaviours

## Test Plan
- `python -m pytest tests/gateway/test_platform_base.py -q -o 'addopts='`
- live smoke: `send_message` to Telegram home with `MEDIA:/home/adam/.hermes/media_cache/hermes-media-delivery-smoke.txt` returned success/message_id
