### PR TITLE
fix(vision): don't retry non-retryable 4xx image downloads

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -293,6 +293,61 @@ class TestErrorLoggingExcInfo:
             assert error_records[0].exc_info is not None
 
     @pytest.mark.asyncio
+    async def test_download_does_not_retry_on_4xx(self, tmp_path):
+        """A 4xx client error (e.g. 404) is not transient and must not be retried."""
+        import httpx
+
+        from tools.vision_tools import _download_image
+
+        request = httpx.Request("GET", "https://example.com/missing.jpg")
+        response = httpx.Response(404, request=request)
+
+        with patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=response)
+            mock_client_cls.return_value = mock_client
+
+            dest = tmp_path / "image.jpg"
+            with pytest.raises(httpx.HTTPStatusError):
+                await _download_image(
+                    "https://example.com/missing.jpg", dest, max_retries=3
+                )
+
+            # Exactly one GET despite max_retries=3 — no pointless retries on 404.
+            assert mock_client.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_download_retries_on_429(self, tmp_path):
+        """429 (Too Many Requests) is the one 4xx that should still be retried."""
+        import httpx
+
+        from tools.vision_tools import _download_image
+
+        request = httpx.Request("GET", "https://example.com/busy.jpg")
+        response = httpx.Response(429, request=request)
+
+        with (
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+            patch("asyncio.sleep", new_callable=AsyncMock),  # skip real backoff
+        ):
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=response)
+            mock_client_cls.return_value = mock_client
+
+            dest = tmp_path / "image.jpg"
+            with pytest.raises(httpx.HTTPStatusError):
+                await _download_image(
+                    "https://example.com/busy.jpg", dest, max_retries=3
+                )
+
+            # All attempts used — 429 is retried, unlike other 4xx.
+            assert mock_client.get.call_count == 3
+
+    @pytest.mark.asyncio
     async def test_analysis_error_logs_exc_info(self, caplog):
         """When vision_analyze_tool encounters an error, it should log with exc_info."""
         with (

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -210,6 +210,19 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
             return destination
         except Exception as e:
             last_error = e
+            # Fail fast on non-retryable HTTP client errors. A 4xx (e.g. 404 Not
+            # Found, 403 Forbidden) means the same request will keep failing, so
+            # retrying the identical URL only wastes time and floods the logs.
+            # 429 (Too Many Requests) is the one 4xx worth retrying with backoff.
+            if isinstance(e, httpx.HTTPStatusError):
+                status = e.response.status_code
+                if 400 <= status < 500 and status != 429:
+                    logger.error(
+                        "Image download failed (HTTP %s, not retrying): %s",
+                        status,
+                        image_url,
+                    )
+                    raise
             if attempt < max_retries - 1:
                 wait_time = 2 ** (attempt + 1)  # 2s, 4s, 8s
                 logger.warning("Image download failed (attempt %s/%s): %s", attempt + 1, max_retries, str(e)[:50])


### PR DESCRIPTION
## What does this PR do?

`_download_image()` in `tools/vision_tools.py` caught `httpx.HTTPStatusError` in a broad
`except Exception` and retried the **identical URL** up to 3× with 2s/4s exponential backoff.
For a fixed URL a 4xx (`404`/`403`) is deterministic, so those retries can never succeed —
they only add ~6s of latency and emit duplicate ERROR tracebacks before failing with the same
error.

This makes the retry loop fail fast on non-retryable 4xx, while preserving retries for the one
4xx that *is* worth retrying — `429 Too Many Requests` — as well as 5xx and network/timeout
errors.

## Related Issue

Fixes #32296

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/vision_tools.py` — in the `_download_image()` retry loop, re-raise immediately when the
  caught exception is an `httpx.HTTPStatusError` with a 4xx status other than 429.
- `tests/tools/test_vision_tools.py` — added `test_download_does_not_retry_on_4xx` (404 → exactly
  one GET despite `max_retries=3`) and `test_download_retries_on_429` (429 → all 3 attempts used).

## How to Test

1. `pytest tests/tools/test_vision_tools.py -k download -q`
2. The two new tests assert: 404 issues a single GET (no retry); 429 still retries `max_retries`
   times.
3. Full file: `pytest tests/tools/test_vision_tools.py -q` → 66 passed, 6 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(vision): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the vision test file and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux 6.17)

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing/config/tool-schema changes; behavior change is internal retry policy)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] Tool descriptions/schemas — N/A (no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)