### PR TITLE
feat(plugins): add on_status_bar_render hook for plugin-contributed status bar fragments

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3766,6 +3766,16 @@ class HermesCLI:
                 if bg_proc_count:
                     parts.append(f"⚙ {bg_proc_count}")
                 parts.append(duration_label)
+                # Let plugins contribute extra fragments (e.g. quota status)
+                try:
+                    from hermes_cli.plugins import invoke_hook as _invoke_hook
+                    extra_results = _invoke_hook("on_status_bar_render", snapshot=snapshot)
+                    if extra_results and isinstance(extra_results, list):
+                        extra = " · ".join(str(x) for x in extra_results if x)
+                        if extra:
+                            parts.append(extra)
+                except Exception:
+                    pass
                 if yolo_active:
                     parts.append("⚠ YOLO")
                 return self._trim_status_bar_text(" · ".join(parts), width)
@@ -3788,6 +3798,16 @@ class HermesCLI:
             if bg_proc_count:
                 parts.append(f"⚙ {bg_proc_count}")
             parts.append(duration_label)
+            # Let plugins contribute extra fragments (e.g. quota status)
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                extra_results = _invoke_hook("on_status_bar_render", snapshot=snapshot)
+                if extra_results and isinstance(extra_results, list):
+                    extra = " │ ".join(str(x) for x in extra_results if x)
+                    if extra:
+                        parts.insert(-1, extra)  # before duration
+            except Exception:
+                pass
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
                 parts.append(prompt_elapsed)

--- a/cli.py
+++ b/cli.py
@@ -3864,6 +3864,17 @@ class HermesCLI:
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
+                    # Let plugins contribute extra fragments (e.g. quota status)
+                    try:
+                        from hermes_cli.plugins import invoke_hook as _invoke_hook
+                        extra_results = _invoke_hook("on_status_bar_render", snapshot=snapshot)
+                        if extra_results and isinstance(extra_results, list):
+                            extra_str = " · ".join(str(x) for x in extra_results if x)
+                            if extra_str:
+                                frags.append(("class:status-bar-dim", " · "))
+                                frags.append(("class:status-bar", extra_str))
+                    except Exception:
+                        pass
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
@@ -3903,6 +3914,17 @@ class HermesCLI:
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
+                    # Let plugins contribute extra fragments (e.g. quota status)
+                    try:
+                        from hermes_cli.plugins import invoke_hook as _invoke_hook
+                        extra_results = _invoke_hook("on_status_bar_render", snapshot=snapshot)
+                        if extra_results and isinstance(extra_results, list):
+                            extra_str = " │ ".join(str(x) for x in extra_results if x)
+                            if extra_str:
+                                frags.append(("class:status-bar-dim", " │ "))
+                                frags.append(("class:status-bar", extra_str))
+                    except Exception:
+                        pass
                     frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -142,6 +142,7 @@ VALID_HOOKS: Set[str] = {
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",
+    "on_status_bar_render",
     "subagent_stop",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent


### PR DESCRIPTION
## Summary

Adds an `on_status_bar_render` plugin hook that lets plugins contribute extra text fragments to the CLI status bar, without requiring patches to `cli.py`.

Closes #8642.

## Changes

### `hermes_cli/plugins.py`
- Add `"on_status_bar_render"` to `VALID_HOOKS`

### `cli.py`
- Invoke `on_status_bar_render` hook in both code paths of `_build_status_bar_text()`:
  - **Medium width** (`if width < 76`): separator `" · "`, `parts.append()`
  - **Full width**: separator `" │ "`, `parts.insert(-1, extra)` before duration

Each callback receives a `snapshot` dict and may return a string to append, or `None` to contribute nothing. The hook is wrapped in try/except so a misbehaving plugin cannot break the status bar.

## Snapshot dict

Plugins receive:
```python
{
    "model_short": str,
    "model_full": str,
    "context_percent": int,
    "context_tokens": int,
    "context_length": int,
    "duration": str,
    "session_id": str,
    "session_title": str,
    "active_background_tasks": int,
    "active_background_processes": int,
    "compressions": int,
    "prompt_elapsed": float or None,
}
```

## Use cases

With this hook, plugins can cleanly add:
- Quota/rate-limit status (Claude, Codex)
- Session title
- Active vision model indicator
- Cron job count
- Git dirty indicator
- Custom cost/usage tracking

## Backwards compatibility

No breaking changes. Plugins that don't register this hook see no difference. The hook is purely additive.

## Tested

- Plugin loads and hook is called on every status bar redraw
- Both width paths correctly display plugin output
- Hook failure does not break the status bar
- Hook works in idempotent re-application (survives `hermes update`)