### PR TITLE
feat: add PostHog observability plugin

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -221,6 +221,21 @@ _EXTRA_ENV_KEYS = frozenset({
     "LANGFUSE_PUBLIC_KEY",
     "LANGFUSE_SECRET_KEY",
     "LANGFUSE_BASE_URL",
+    # PostHog observability plugin — optional tuning keys + standard SDK vars.
+    # Activation is via plugins.enabled (opt-in through `hermes plugins enable
+    # observability/posthog`); credentials gate the plugin at runtime.
+    "HERMES_POSTHOG_PROJECT_TOKEN",
+    "HERMES_POSTHOG_HOST",
+    "HERMES_POSTHOG_DISTINCT_ID",
+    "HERMES_POSTHOG_ENV",
+    "HERMES_POSTHOG_RELEASE",
+    "HERMES_POSTHOG_SAMPLE_RATE",
+    "HERMES_POSTHOG_MAX_CHARS",
+    "HERMES_POSTHOG_PRIVACY_MODE",
+    "HERMES_POSTHOG_SYNC_MODE",
+    "HERMES_POSTHOG_DEBUG",
+    "POSTHOG_PROJECT_API_KEY",
+    "POSTHOG_HOST",
 })
 import yaml
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -663,6 +663,14 @@ def cmd_enable(name: str) -> None:
 
     if name in enabled and name not in disabled:
         console.print(f"[dim]Plugin '{name}' is already enabled.[/dim]")
+        missing_deps = _missing_pip_dependencies(name)
+        if missing_deps:
+            console.print(
+                "[yellow]![/yellow] Missing optional Python package(s): "
+                f"[bold]{', '.join(missing_deps)}[/bold]. Install them into the "
+                "Hermes Python environment before restarting, e.g. "
+                f"[cyan]{sys.executable} -m pip install {' '.join(missing_deps)}[/cyan]"
+            )
         return
 
     enabled.add(name)
@@ -673,6 +681,14 @@ def cmd_enable(name: str) -> None:
         f"[green]✓[/green] Plugin [bold]{name}[/bold] enabled. "
         "Takes effect on next session."
     )
+    missing_deps = _missing_pip_dependencies(name)
+    if missing_deps:
+        console.print(
+            "[yellow]![/yellow] Missing optional Python package(s): "
+            f"[bold]{', '.join(missing_deps)}[/bold]. Install them into the "
+            "Hermes Python environment before restarting, e.g. "
+            f"[cyan]{sys.executable} -m pip install {' '.join(missing_deps)}[/cyan]"
+        )
 
 
 def cmd_disable(name: str) -> None:
@@ -725,6 +741,66 @@ def _plugin_exists(name: str) -> bool:
         ):
             return True
     return False
+
+
+def _plugin_manifest_for_name(name: str) -> dict:
+    """Return the manifest for a user-installed or bundled plugin key/name."""
+    user_dir = _plugins_dir()
+    if user_dir.is_dir():
+        try:
+            candidate = _sanitize_plugin_name(name, user_dir, allow_subdir=True)
+        except ValueError:
+            candidate = None
+        if candidate and candidate.is_dir():
+            manifest = _read_manifest(candidate)
+            if manifest:
+                return manifest
+        for child in user_dir.iterdir():
+            if child.is_dir():
+                manifest = _read_manifest(child)
+                if manifest.get("name") == name:
+                    return manifest
+
+    from hermes_cli.plugins import get_bundled_plugins_dir
+    repo_plugins = get_bundled_plugins_dir()
+    if repo_plugins.is_dir():
+        try:
+            candidate = _sanitize_plugin_name(name, repo_plugins, allow_subdir=True)
+        except ValueError:
+            candidate = None
+        if candidate and candidate.is_dir():
+            manifest = _read_manifest(candidate)
+            if manifest:
+                return manifest
+    return {}
+
+
+def _missing_pip_dependencies(name: str) -> list[str]:
+    """Return ``pip_dependencies`` declared by a plugin but missing locally."""
+    manifest = _plugin_manifest_for_name(name)
+    deps = manifest.get("pip_dependencies") or []
+    if not isinstance(deps, list):
+        return []
+
+    import importlib.util
+
+    missing: list[str] = []
+    for dep in deps:
+        if not isinstance(dep, str) or not dep.strip():
+            continue
+        package = dep.strip()
+        module_name = (
+            package.split("[", 1)[0]
+            .split("=", 1)[0]
+            .split("<", 1)[0]
+            .split(">", 1)[0]
+            .split("~", 1)[0]
+            .strip()
+            .replace("-", "_")
+        )
+        if module_name and importlib.util.find_spec(module_name) is None:
+            missing.append(package)
+    return missing
 
 
 def _discover_all_plugins() -> list:

--- a/plugins/observability/posthog/README.md
+++ b/plugins/observability/posthog/README.md
@@ -1,0 +1,77 @@
+# PostHog Observability Plugin
+
+This plugin ships bundled with Hermes but is **opt-in** — it only loads when
+you explicitly enable it.
+
+It emits PostHog AI Observability events:
+
+- `$ai_generation` for each LLM/API call
+- `$ai_span` for tool calls
+
+PostHog creates trace groupings from the shared `$ai_trace_id` on those events.
+
+## Enable
+
+```bash
+python -m pip install posthog
+hermes plugins enable observability/posthog
+```
+
+Install the SDK into the same Python environment that runs Hermes. For a git
+install this is usually the Hermes venv, so this also works from the Hermes repo
+checkout:
+
+```bash
+./venv/bin/python -m ensurepip --upgrade  # only needed if pip is absent
+./venv/bin/python -m pip install posthog
+```
+
+Or check the box in the interactive `hermes plugins` UI. `plugin.yaml` declares
+`pip_dependencies: [posthog]`, and `hermes plugins enable observability/posthog`
+will warn if that package is not importable from the current Hermes Python.
+
+## Required credentials
+
+Set these in `~/.hermes/.env`:
+
+```bash
+HERMES_POSTHOG_PROJECT_TOKEN=phc_...
+HERMES_POSTHOG_HOST=https://us.i.posthog.com   # or https://eu.i.posthog.com / self-hosted
+```
+
+Without the SDK or project token the hooks no-op silently — the plugin fails
+open. Placeholder-looking tokens log a one-time warning and are ignored.
+
+## Verify
+
+```bash
+hermes plugins list                 # observability/posthog should show "enabled"
+hermes chat -q "hello"              # then check PostHog AI Observability
+```
+
+Look for `$ai_generation` events under Activity, or in **AI Observability → Generations / Traces**.
+
+## Optional tuning
+
+```bash
+HERMES_POSTHOG_DISTINCT_ID=hermes-agent       # fallback distinct_id
+HERMES_POSTHOG_ENV=production                 # event property tag
+HERMES_POSTHOG_RELEASE=v1.0.0                 # event property tag
+HERMES_POSTHOG_SAMPLE_RATE=0.5                # sample 50% of events
+HERMES_POSTHOG_MAX_CHARS=12000                # max chars per field
+HERMES_POSTHOG_PRIVACY_MODE=true              # omit prompt/response content
+HERMES_POSTHOG_SYNC_MODE=true                 # use SDK sync mode when available
+HERMES_POSTHOG_DEBUG=true                     # verbose plugin logging
+```
+
+## Privacy
+
+Set `HERMES_POSTHOG_PRIVACY_MODE=true` to avoid sending `$ai_input` and
+`$ai_output_choices`. Tool arguments/results are still sent in compacted form;
+use sampling or disable the plugin if those may contain sensitive data.
+
+## Disable
+
+```bash
+hermes plugins disable observability/posthog
+```

--- a/plugins/observability/posthog/__init__.py
+++ b/plugins/observability/posthog/__init__.py
@@ -1,0 +1,675 @@
+"""posthog — Hermes plugin for PostHog AI observability.
+
+Captures Hermes LLM calls as PostHog ``$ai_generation`` events and tool calls
+as ``$ai_span`` events. Activation is handled by the Hermes plugin system — the
+plugin only loads when listed in ``plugins.enabled``. At runtime it also
+requires the optional ``posthog`` SDK and a PostHog project token; if either is
+missing, hooks are inert.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import re
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    from posthog import Posthog
+except Exception:  # pragma: no cover - optional dependency
+    Posthog = None
+
+
+@dataclass
+class GenerationState:
+    span_id: str
+    started_at: float
+    input_messages: list[dict[str, Any]] = field(default_factory=list)
+    model: str = ""
+    provider: str = ""
+    api_mode: str = ""
+    base_url: str = ""
+    platform: str = ""
+
+
+@dataclass
+class ToolState:
+    span_id: str
+    parent_id: str
+    started_at: float
+    tool_name: str
+    args: Any = None
+
+
+@dataclass
+class TraceState:
+    trace_id: str
+    session_id: str = ""
+    task_id: str = ""
+    started_at: float = field(default_factory=time.time)
+    generations: Dict[str, GenerationState] = field(default_factory=dict)
+    tools: Dict[str, ToolState] = field(default_factory=dict)
+    pending_tools_by_name: Dict[str, list[ToolState]] = field(default_factory=dict)
+    current_generation_id: str = ""
+    last_updated_at: float = field(default_factory=time.time)
+
+
+_STATE_LOCK = threading.Lock()
+_TRACE_STATE: Dict[str, TraceState] = {}
+_POSTHOG_CLIENT = None
+_INIT_FAILED = object()
+_READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
+_READ_FILE_HEAD_LINES = 25
+_READ_FILE_TAIL_LINES = 15
+_DEFAULT_MAX_CHARS = 12000
+_MAX_TRACE_STATES = 512
+_TRACE_STATE_TTL_SECONDS = 60 * 60
+_VALID_TOKEN_PREFIXES = ("phc_",)
+_PLACEHOLDER_VALUES = {
+    "placeholder",
+    "test-key",
+    "your-posthog-token",
+    "your-posthog-key",
+    "your-key",
+    "change-me",
+    "replace_me",
+    "xxx",
+    "dummy-key-here",
+    "<your-key>",
+    "<ph_project_token>",
+}
+_ALLOWED_ID_RE = re.compile(r"[^A-Za-z0-9\-_~.@()!':|]")
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _env_bool(*names: str) -> bool:
+    for name in names:
+        value = _env(name).lower()
+        if value:
+            return value in {"1", "true", "yes", "on"}
+    return False
+
+
+def _debug_enabled() -> bool:
+    return _env_bool("HERMES_POSTHOG_DEBUG")
+
+
+def _debug(message: str) -> None:
+    if _debug_enabled():
+        logger.info("PostHog observability: %s", message)
+
+
+def _redact_key_preview(value: str) -> str:
+    if not value:
+        return "<empty>"
+    if len(value) <= 20:
+        return repr(value)
+    return repr(value[:6] + "...")
+
+
+def _validate_project_token(value: str) -> Optional[str]:
+    if not value:
+        return None
+    if value.lower() in _PLACEHOLDER_VALUES:
+        return f"HERMES_POSTHOG_PROJECT_TOKEN={_redact_key_preview(value)} looks like a placeholder"
+    if value.startswith(_VALID_TOKEN_PREFIXES):
+        return None
+    # PostHog project tokens are normally phc_...; fail closed for common junk,
+    # but allow uncommon/self-hosted token formats that are long enough to be real.
+    if len(value) < 16 or any(marker in value.lower() for marker in ("your", "placeholder", "dummy")):
+        return (
+            f"HERMES_POSTHOG_PROJECT_TOKEN={_redact_key_preview(value)} "
+            "does not look like a PostHog project token (expected phc_...)"
+        )
+    return None
+
+
+def _get_posthog():
+    """Return a cached PostHog client, or ``None`` if unavailable."""
+    global _POSTHOG_CLIENT
+    if _POSTHOG_CLIENT is _INIT_FAILED:
+        return None
+    if _POSTHOG_CLIENT is not None:
+        return _POSTHOG_CLIENT
+    if Posthog is None:
+        _POSTHOG_CLIENT = _INIT_FAILED
+        return None
+
+    token = _env("HERMES_POSTHOG_PROJECT_TOKEN") or _env("POSTHOG_PROJECT_API_KEY")
+    if not token:
+        _POSTHOG_CLIENT = _INIT_FAILED
+        return None
+
+    token_issue = _validate_project_token(token)
+    if token_issue:
+        logger.warning(
+            "PostHog plugin: project token looks invalid, events will NOT be emitted (%s). "
+            "Set a real project token (phc_...) in HERMES_POSTHOG_PROJECT_TOKEN or unset it.",
+            token_issue,
+        )
+        _POSTHOG_CLIENT = _INIT_FAILED
+        return None
+
+    host = _env("HERMES_POSTHOG_HOST") or _env("POSTHOG_HOST") or "https://us.i.posthog.com"
+    kwargs: Dict[str, Any] = {"host": host}
+    # Keep sync mode conservative: the SDK option name has existed across recent
+    # versions and makes short-lived Hermes runs more reliable when enabled.
+    if _env_bool("HERMES_POSTHOG_SYNC_MODE"):
+        kwargs["sync_mode"] = True
+    if _env_bool("HERMES_POSTHOG_PRIVACY_MODE"):
+        kwargs["privacy_mode"] = True
+
+    try:
+        _POSTHOG_CLIENT = Posthog(token, **kwargs)
+    except Exception as exc:  # pragma: no cover - fail-open
+        logger.warning("Could not initialize PostHog client: %s", exc)
+        _POSTHOG_CLIENT = _INIT_FAILED
+        return None
+    return _POSTHOG_CLIENT
+
+
+def _trace_key(task_id: str, session_id: str) -> str:
+    if task_id:
+        return task_id
+    if session_id:
+        return f"session:{session_id}"
+    return f"thread:{threading.get_ident()}"
+
+
+def _safe_id(value: str) -> str:
+    value = str(value or "")
+    if not value:
+        return uuid.uuid4().hex
+    return _ALLOWED_ID_RE.sub("_", value)[:200]
+
+
+def _new_id(prefix: str = "") -> str:
+    value = uuid.uuid4().hex
+    return f"{prefix}{value}" if prefix else value
+
+
+def _distinct_id(*, session_id: str = "", task_id: str = "") -> str:
+    configured = _env("HERMES_POSTHOG_DISTINCT_ID")
+    if configured:
+        return configured
+    if session_id:
+        return f"session:{_safe_id(session_id)}"
+    if task_id:
+        return f"task:{_safe_id(task_id)}"
+    return "hermes-agent"
+
+
+def _should_sample() -> bool:
+    raw = _env("HERMES_POSTHOG_SAMPLE_RATE", "1.0") or "1.0"
+    try:
+        rate = float(raw)
+    except ValueError:
+        logger.warning("Invalid HERMES_POSTHOG_SAMPLE_RATE=%r", raw)
+        return True
+    if rate >= 1.0:
+        return True
+    if rate <= 0.0:
+        return False
+    return random.random() < rate
+
+
+def _truncate_text(value: str, max_chars: int) -> str:
+    if len(value) <= max_chars:
+        return value
+    return value[:max_chars] + f"... [truncated {len(value) - max_chars} chars]"
+
+
+def _maybe_parse_json_string(value: str) -> Any:
+    stripped = value.strip()
+    if len(stripped) < 2 or stripped[0] not in "{[" or stripped[-1] not in "}]":
+        if len(stripped) < 2 or stripped[0] not in "{[":
+            return value
+    try:
+        parsed, idx = json.JSONDecoder().raw_decode(stripped)
+    except Exception:
+        return value
+    if not isinstance(parsed, (dict, list)):
+        return value
+    trailing = stripped[idx:].strip()
+    if not trailing:
+        return parsed
+    if isinstance(parsed, dict):
+        merged = dict(parsed)
+        merged["_trailing_text"] = trailing
+        return merged
+    return {"data": parsed, "_trailing_text": trailing}
+
+
+def _looks_like_read_file_payload(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("content"), str)
+        and "total_lines" in value
+        and "file_size" in value
+        and "is_binary" in value
+        and "is_image" in value
+        and not value.get("error")
+    )
+
+
+def _parse_read_file_lines(content: str) -> list[dict[str, Any]]:
+    if not isinstance(content, str) or not content:
+        return []
+    lines = []
+    for raw_line in content.splitlines():
+        match = _READ_FILE_LINE_RE.match(raw_line)
+        if not match:
+            return []
+        lines.append({"line": int(match.group(1)), "text": match.group(2)})
+    return lines
+
+
+def _build_read_file_preview(lines: list[dict[str, Any]]) -> dict[str, Any]:
+    if len(lines) <= (_READ_FILE_HEAD_LINES + _READ_FILE_TAIL_LINES):
+        return {"lines": lines}
+    return {
+        "head": lines[:_READ_FILE_HEAD_LINES],
+        "tail": lines[-_READ_FILE_TAIL_LINES:],
+        "omitted_line_count": len(lines) - _READ_FILE_HEAD_LINES - _READ_FILE_TAIL_LINES,
+    }
+
+
+def _normalize_read_file_payload(value: dict[str, Any], *, args: Any = None) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    if isinstance(args, dict):
+        for key in ("path", "offset", "limit"):
+            if key in args:
+                normalized[key] = args[key]
+    lines = _parse_read_file_lines(value.get("content", ""))
+    if lines:
+        normalized["returned_lines"] = {"start": lines[0]["line"], "end": lines[-1]["line"], "count": len(lines)}
+        normalized["content_preview"] = _build_read_file_preview(lines)
+    elif value.get("content"):
+        normalized["content_preview"] = {"text": value.get("content", "")}
+    for key in ("total_lines", "file_size", "truncated", "is_binary", "is_image", "hint", "mime_type", "dimensions", "error"):
+        if key in value:
+            normalized[key] = value[key]
+    if isinstance(value.get("base64_content"), str) and value["base64_content"]:
+        normalized["base64_content"] = {"omitted": True, "length": len(value["base64_content"])}
+    return normalized
+
+
+def _normalize_payload(value: Any, *, tool_name: str = "", args: Any = None) -> Any:
+    if _looks_like_read_file_payload(value):
+        return _normalize_read_file_payload(value, args=args if tool_name == "read_file" else None)
+    return value
+
+
+def _max_chars() -> int:
+    raw = _env("HERMES_POSTHOG_MAX_CHARS", str(_DEFAULT_MAX_CHARS)) or str(_DEFAULT_MAX_CHARS)
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid HERMES_POSTHOG_MAX_CHARS=%r; using %s", raw, _DEFAULT_MAX_CHARS)
+        return _DEFAULT_MAX_CHARS
+    if value <= 0:
+        logger.warning("Invalid HERMES_POSTHOG_MAX_CHARS=%r; using %s", raw, _DEFAULT_MAX_CHARS)
+        return _DEFAULT_MAX_CHARS
+    return value
+
+
+def _safe_value(value: Any, *, max_chars: Optional[int] = None, depth: int = 0, parse_json_strings: bool = False) -> Any:
+    max_chars = max_chars if max_chars is not None else _max_chars()
+    if depth > 4:
+        return "<max-depth>"
+    if value is None or isinstance(value, (int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return {"type": "bytes", "len": len(value)}
+    if isinstance(value, str):
+        if parse_json_strings:
+            parsed = _maybe_parse_json_string(value)
+            if parsed is not value:
+                return _safe_value(parsed, max_chars=max_chars, depth=depth, parse_json_strings=True)
+        return _truncate_text(value, max_chars)
+    if isinstance(value, dict):
+        normalized = _normalize_payload(value)
+        if normalized is not value:
+            return _safe_value(normalized, max_chars=max_chars, depth=depth, parse_json_strings=parse_json_strings)
+        return {str(k): _safe_value(v, max_chars=max_chars, depth=depth + 1, parse_json_strings=parse_json_strings) for k, v in list(value.items())[:50]}
+    if isinstance(value, (list, tuple, set)):
+        return [_safe_value(v, max_chars=max_chars, depth=depth + 1, parse_json_strings=parse_json_strings) for v in list(value)[:50]]
+    if hasattr(value, "__dict__"):
+        return _safe_value(vars(value), max_chars=max_chars, depth=depth + 1, parse_json_strings=parse_json_strings)
+    return _truncate_text(repr(value), max_chars)
+
+
+def _coerce_request_messages(*, request_messages: Any = None, messages: Any = None, conversation_history: Any = None, user_message: Any = None) -> list[dict[str, Any]]:
+    for candidate in (request_messages, messages, conversation_history):
+        if isinstance(candidate, list):
+            return candidate
+    if user_message is None:
+        return []
+    return [{"role": "user", "content": user_message}]
+
+
+def _serialize_messages(messages: Any) -> list[dict[str, Any]]:
+    if not isinstance(messages, list):
+        return []
+    serialized = []
+    for message in messages[-12:]:
+        if not isinstance(message, dict):
+            continue
+        item = {"role": message.get("role"), "content": _safe_value(message.get("content"), parse_json_strings=(message.get("role") == "tool"))}
+        if message.get("tool_call_id"):
+            item["tool_call_id"] = message.get("tool_call_id")
+        if message.get("name"):
+            item["name"] = _safe_value(message.get("name"))
+        if message.get("tool_calls"):
+            item["tool_calls"] = _safe_value(message.get("tool_calls"), parse_json_strings=True)
+        serialized.append(item)
+    return serialized
+
+
+def _serialize_tool_calls(tool_calls: Any) -> list[dict[str, Any]]:
+    if not tool_calls:
+        return []
+    serialized = []
+    for tool_call in tool_calls:
+        fn = getattr(tool_call, "function", None)
+        name = getattr(fn, "name", None) if fn else None
+        arguments = getattr(fn, "arguments", None) if fn else None
+        serialized.append({
+            "id": getattr(tool_call, "id", None),
+            "type": getattr(tool_call, "type", None) or "function",
+            "name": name,
+            "arguments": _safe_value(arguments),
+            "function": {"name": name, "arguments": _safe_value(arguments)},
+        })
+    return serialized
+
+
+def _serialize_assistant_output(*, assistant_message: Any = None, assistant_response: Any = None, assistant_content_chars: int = 0, assistant_tool_call_count: int = 0) -> list[dict[str, Any]]:
+    if assistant_message is not None:
+        return [{
+            "role": "assistant",
+            "content": _safe_value(getattr(assistant_message, "content", None)),
+            "reasoning": _safe_value(getattr(assistant_message, "reasoning", None)),
+            "tool_calls": _serialize_tool_calls(getattr(assistant_message, "tool_calls", None)),
+        }]
+    if assistant_response is not None:
+        return [{"role": "assistant", "content": _safe_value(assistant_response)}]
+    return [{
+        "role": "assistant",
+        "content": f"[{assistant_content_chars} chars]" if assistant_content_chars else None,
+        "tool_calls": [{"id": f"tc_{i}"} for i in range(assistant_tool_call_count)] if assistant_tool_call_count else [],
+    }]
+
+
+def _tool_names_from_output(output_choices: list[dict[str, Any]]) -> list[str]:
+    names: list[str] = []
+    for choice in output_choices:
+        calls = choice.get("tool_calls") if isinstance(choice, dict) else None
+        if isinstance(calls, list):
+            for call in calls:
+                if isinstance(call, dict) and call.get("name"):
+                    names.append(str(call["name"]))
+    return names
+
+
+def _usage_tokens(usage: Any) -> dict[str, int]:
+    if not isinstance(usage, dict):
+        return {}
+    input_tokens = usage.get("input_tokens") or usage.get("prompt_tokens") or 0
+    output_tokens = usage.get("output_tokens") or usage.get("completion_tokens") or 0
+    details: dict[str, int] = {}
+    if input_tokens:
+        details["$ai_input_tokens"] = int(input_tokens)
+    if output_tokens:
+        details["$ai_output_tokens"] = int(output_tokens)
+    for src, dst in (
+        ("cache_read_tokens", "$ai_cache_read_input_tokens"),
+        ("cache_write_tokens", "$ai_cache_creation_input_tokens"),
+        ("reasoning_tokens", "$ai_reasoning_tokens"),
+    ):
+        if usage.get(src):
+            details[dst] = int(usage[src])
+    return details
+
+
+def _capture(event: str, *, distinct_id: str, properties: dict[str, Any]) -> None:
+    client = _get_posthog()
+    if client is None or not _should_sample():
+        return
+    try:
+        client.capture(distinct_id=distinct_id, event=event, properties=properties)
+        if hasattr(client, "flush"):
+            client.flush()
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"capture failed: {exc}")
+
+
+def _base_properties(state: TraceState) -> dict[str, Any]:
+    props: dict[str, Any] = {"$ai_trace_id": state.trace_id}
+    if state.session_id:
+        props["$ai_session_id"] = state.session_id
+    env = _env("HERMES_POSTHOG_ENV")
+    release = _env("HERMES_POSTHOG_RELEASE")
+    if env:
+        props["hermes.environment"] = env
+    if release:
+        props["hermes.release"] = release
+    if state.task_id:
+        props["hermes.task_id"] = state.task_id
+    return props
+
+
+def _prune_trace_states(now: Optional[float] = None) -> None:
+    """Bound in-memory trace bookkeeping for long-running gateway processes."""
+    if not _TRACE_STATE:
+        return
+    now = now or time.time()
+    stale_keys = [
+        key for key, state in _TRACE_STATE.items()
+        if now - state.last_updated_at > _TRACE_STATE_TTL_SECONDS
+    ]
+    for key in stale_keys:
+        _TRACE_STATE.pop(key, None)
+    if len(_TRACE_STATE) <= _MAX_TRACE_STATES:
+        return
+    overflow = len(_TRACE_STATE) - _MAX_TRACE_STATES
+    oldest = sorted(_TRACE_STATE.items(), key=lambda item: item[1].last_updated_at)[:overflow]
+    for key, _state in oldest:
+        _TRACE_STATE.pop(key, None)
+
+
+def _ensure_trace_state(task_key: str, *, task_id: str = "", session_id: str = "") -> TraceState:
+    now = time.time()
+    _prune_trace_states(now)
+    state = _TRACE_STATE.get(task_key)
+    if state is None:
+        seed = task_id or session_id or _new_id()
+        state = TraceState(trace_id=_safe_id(seed), session_id=session_id, task_id=task_id)
+        _TRACE_STATE[task_key] = state
+    state.last_updated_at = now
+    return state
+
+
+def on_pre_llm_call(*, task_id: str = "", session_id: str = "", messages: Any = None, **kwargs: Any) -> None:
+    # Legacy Hermes hook shape: only request-like when messages is a list.
+    if not isinstance(messages, list):
+        return
+    on_pre_llm_request(task_id=task_id, session_id=session_id, messages=messages, **kwargs)
+
+
+def on_pre_llm_request(
+    *,
+    task_id: str = "",
+    session_id: str = "",
+    platform: str = "",
+    model: str = "",
+    provider: str = "",
+    base_url: str = "",
+    api_mode: str = "",
+    api_call_count: int = 0,
+    request_messages: Any = None,
+    messages: Any = None,
+    conversation_history: Any = None,
+    user_message: Any = None,
+    **_: Any,
+) -> None:
+    if _get_posthog() is None:
+        return
+    input_messages = _serialize_messages(_coerce_request_messages(
+        request_messages=request_messages,
+        messages=messages,
+        conversation_history=conversation_history,
+        user_message=user_message,
+    ))
+    task_key = _trace_key(task_id, session_id)
+    req_key = str(api_call_count or 0)
+    with _STATE_LOCK:
+        state = _ensure_trace_state(task_key, task_id=task_id, session_id=session_id)
+        span_id = _new_id("gen_")
+        state.current_generation_id = span_id
+        state.generations[req_key] = GenerationState(
+            span_id=span_id,
+            started_at=time.time(),
+            input_messages=input_messages,
+            model=model,
+            provider=provider,
+            api_mode=api_mode,
+            base_url=base_url,
+            platform=platform,
+        )
+
+
+def on_post_llm_call(
+    *,
+    task_id: str = "",
+    session_id: str = "",
+    provider: str = "",
+    base_url: str = "",
+    api_mode: str = "",
+    model: str = "",
+    api_call_count: int = 0,
+    assistant_message: Any = None,
+    response: Any = None,
+    api_duration: float = 0.0,
+    finish_reason: str = "",
+    usage: Any = None,
+    assistant_content_chars: int = 0,
+    assistant_tool_call_count: int = 0,
+    assistant_response: Any = None,
+    **_: Any,
+) -> None:
+    if _get_posthog() is None:
+        return
+    task_key = _trace_key(task_id, session_id)
+    req_key = str(api_call_count or 0)
+    with _STATE_LOCK:
+        state = _TRACE_STATE.get(task_key)
+        generation = state.generations.pop(req_key, None) if state else None
+    if state is None or generation is None:
+        return
+
+    output_choices = _serialize_assistant_output(
+        assistant_message=assistant_message,
+        assistant_response=assistant_response,
+        assistant_content_chars=assistant_content_chars,
+        assistant_tool_call_count=assistant_tool_call_count,
+    )
+    tool_names = _tool_names_from_output(output_choices)
+    raw_usage = usage or getattr(response, "usage", None)
+    props = _base_properties(state)
+    props.update({
+        "$ai_span_id": generation.span_id,
+        "$ai_span_name": f"LLM call {api_call_count}",
+        "$ai_model": model or generation.model,
+        "$ai_provider": provider or generation.provider,
+        "$ai_latency": round(float(api_duration), 3) if api_duration else round(time.time() - generation.started_at, 3),
+        "$ai_tools_called": tool_names,
+        "$ai_tool_call_count": len(tool_names) or assistant_tool_call_count,
+        "hermes.api_mode": api_mode or generation.api_mode,
+        "hermes.platform": generation.platform,
+        "hermes.base_url": base_url or generation.base_url,
+    })
+    props.update(_usage_tokens(raw_usage))
+    if finish_reason:
+        props["hermes.finish_reason"] = finish_reason
+    if not _env_bool("HERMES_POSTHOG_PRIVACY_MODE"):
+        props["$ai_input"] = generation.input_messages
+        props["$ai_output_choices"] = output_choices
+
+    _capture("$ai_generation", distinct_id=_distinct_id(session_id=session_id, task_id=task_id), properties=props)
+
+
+def on_pre_tool_call(*, tool_name: str = "", args: Any = None, task_id: str = "", session_id: str = "", tool_call_id: str = "", **_: Any) -> None:
+    if _get_posthog() is None:
+        return
+    task_key = _trace_key(task_id, session_id)
+    with _STATE_LOCK:
+        state = _TRACE_STATE.get(task_key)
+        if state is None:
+            state = _ensure_trace_state(task_key, task_id=task_id, session_id=session_id)
+        tool = ToolState(
+            span_id=_new_id("tool_"),
+            parent_id=state.current_generation_id or state.trace_id,
+            started_at=time.time(),
+            tool_name=tool_name,
+            args=_safe_value(args, parse_json_strings=True),
+        )
+        if tool_call_id:
+            state.tools[tool_call_id] = tool
+        else:
+            state.pending_tools_by_name.setdefault(tool_name, []).append(tool)
+
+
+def on_post_tool_call(*, tool_name: str = "", args: Any = None, result: Any = None, task_id: str = "", session_id: str = "", tool_call_id: str = "", **_: Any) -> None:
+    if _get_posthog() is None:
+        return
+    task_key = _trace_key(task_id, session_id)
+    with _STATE_LOCK:
+        state = _TRACE_STATE.get(task_key)
+        if state is None:
+            return
+        tool = None
+        if tool_call_id:
+            tool = state.tools.pop(tool_call_id, None)
+        if tool is None:
+            queue = state.pending_tools_by_name.get(tool_name)
+            if queue:
+                tool = queue.pop(0)
+                if not queue:
+                    state.pending_tools_by_name.pop(tool_name, None)
+    if tool is None:
+        return
+
+    result_value = _maybe_parse_json_string(result) if isinstance(result, str) else result
+    result_value = _normalize_payload(result_value, tool_name=tool_name, args=args)
+    props = _base_properties(state)
+    props.update({
+        "$ai_span_id": tool.span_id,
+        "$ai_parent_id": tool.parent_id,
+        "$ai_span_name": f"Tool: {tool_name}",
+        "$ai_input_state": tool.args,
+        "$ai_output_state": _safe_value(result_value, parse_json_strings=True),
+        "$ai_latency": round(time.time() - tool.started_at, 3),
+        "hermes.tool_name": tool_name,
+        "hermes.tool_call_id": tool_call_id,
+    })
+    _capture("$ai_span", distinct_id=_distinct_id(session_id=session_id, task_id=task_id), properties=props)
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_api_request", on_pre_llm_request)
+    ctx.register_hook("post_api_request", on_post_llm_call)
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
+    ctx.register_hook("post_llm_call", on_post_llm_call)
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)

--- a/plugins/observability/posthog/plugin.yaml
+++ b/plugins/observability/posthog/plugin.yaml
@@ -1,0 +1,15 @@
+name: posthog
+version: "1.0.0"
+description: "Optional PostHog AI observability for Hermes — captures LLM generations and tool spans. Opt-in via `hermes plugins enable observability/posthog` (or check the box in `hermes plugins`)."
+author: NousResearch
+pip_dependencies:
+  - posthog
+requires_env:
+  - HERMES_POSTHOG_PROJECT_TOKEN
+hooks:
+  - pre_api_request
+  - post_api_request
+  - pre_llm_call
+  - post_llm_call
+  - pre_tool_call
+  - post_tool_call

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -14,6 +14,7 @@ import yaml
 from hermes_cli.plugins_cmd import (
     PluginOperationError,
     _copy_example_files,
+    _missing_pip_dependencies,
     _read_manifest,
     _repo_name_from_url,
     _resolve_git_executable,
@@ -249,6 +250,27 @@ class TestReadManifest:
         (tmp_path / "plugin.yaml").write_text("")
         result = _read_manifest(tmp_path)
         assert result == {}
+
+
+class TestPipDependencyWarnings:
+    def test_missing_pip_dependencies_checks_manifest_packages(self, tmp_path, monkeypatch):
+        import importlib.util
+        import hermes_cli.plugins_cmd as pc
+
+        home = tmp_path / ".hermes"
+        plugin_dir = home / "plugins" / "observability" / "posthog"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            yaml.dump({"name": "posthog", "pip_dependencies": ["posthog", "requests>=2"]})
+        )
+        monkeypatch.setattr(pc, "get_hermes_home", lambda: home)
+
+        def fake_find_spec(name):
+            return object() if name == "requests" else None
+
+        monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+        assert _missing_pip_dependencies("observability/posthog") == ["posthog"]
 
 
 # ── cmd_install tests ─────────────────────────────────────────────────────────

--- a/tests/plugins/test_posthog_plugin.py
+++ b/tests/plugins/test_posthog_plugin.py
@@ -1,0 +1,351 @@
+"""Tests for the bundled observability/posthog plugin."""
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "posthog"
+
+
+class _FakePosthog:
+    instances: list["_FakePosthog"] = []
+
+    def __init__(self, project_api_key, **kwargs):
+        self.project_api_key = project_api_key
+        self.kwargs = kwargs
+        self.events: list[dict] = []
+        self.flushed = 0
+        _FakePosthog.instances.append(self)
+
+    def capture(self, *args, **kwargs):
+        self.events.append({"args": args, "kwargs": kwargs})
+
+    def flush(self):
+        self.flushed += 1
+
+
+class _Ctx:
+    def __init__(self):
+        self.hooks = []
+
+    def register_hook(self, name, fn):
+        self.hooks.append((name, fn))
+
+
+def _fresh_plugin(monkeypatch=None):
+    mod_name = "plugins.observability.posthog"
+    sys.modules.pop(mod_name, None)
+    mod = importlib.import_module(mod_name)
+    if monkeypatch is not None:
+        _FakePosthog.instances.clear()
+        monkeypatch.setattr(mod, "Posthog", _FakePosthog, raising=False)
+    return mod
+
+
+def _clear_env(monkeypatch):
+    for key in (
+        "HERMES_POSTHOG_PROJECT_TOKEN",
+        "HERMES_POSTHOG_HOST",
+        "HERMES_POSTHOG_DISTINCT_ID",
+        "HERMES_POSTHOG_ENV",
+        "HERMES_POSTHOG_RELEASE",
+        "HERMES_POSTHOG_SAMPLE_RATE",
+        "HERMES_POSTHOG_MAX_CHARS",
+        "HERMES_POSTHOG_PRIVACY_MODE",
+        "HERMES_POSTHOG_SYNC_MODE",
+        "HERMES_POSTHOG_DEBUG",
+        "POSTHOG_PROJECT_API_KEY",
+        "POSTHOG_HOST",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestManifest:
+    def test_plugin_directory_exists(self):
+        assert PLUGIN_DIR.is_dir()
+        assert (PLUGIN_DIR / "plugin.yaml").exists()
+        assert (PLUGIN_DIR / "__init__.py").exists()
+        assert (PLUGIN_DIR / "README.md").exists()
+
+    def test_manifest_fields(self):
+        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+        assert data["name"] == "posthog"
+        assert data["version"]
+        assert "posthog" in data["pip_dependencies"]
+        assert set(data["hooks"]) == {
+            "pre_api_request", "post_api_request",
+            "pre_llm_call", "post_llm_call",
+            "pre_tool_call", "post_tool_call",
+        }
+        assert "HERMES_POSTHOG_PROJECT_TOKEN" in data["requires_env"]
+
+
+class TestDiscovery:
+    def test_plugin_is_discovered_as_standalone_opt_in(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        manager = plugins_mod.PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins.get("observability/posthog")
+        assert loaded is not None, "plugin not discovered"
+        assert loaded.enabled is False
+        assert "not enabled" in (loaded.error or "").lower()
+
+
+class TestRuntimeGate:
+    def test_get_posthog_returns_none_without_credentials(self, monkeypatch):
+        _clear_env(monkeypatch)
+        plugin = _fresh_plugin(monkeypatch)
+        assert plugin._get_posthog() is None
+
+    def test_get_posthog_caches_failure_no_env_rereads(self, monkeypatch):
+        _clear_env(monkeypatch)
+        plugin = _fresh_plugin(monkeypatch)
+        assert plugin._get_posthog() is None
+
+        import os
+        real_get = os.environ.get
+        called = {"n": 0}
+
+        def tracking_get(key, default=None):
+            if key.startswith(("HERMES_POSTHOG_", "POSTHOG_")):
+                called["n"] += 1
+            return real_get(key, default)
+
+        monkeypatch.setattr(os.environ, "get", tracking_get)
+        for _ in range(10):
+            assert plugin._get_posthog() is None
+        assert called["n"] == 0
+
+    def test_get_posthog_does_not_import_hermes_config(self, monkeypatch):
+        _clear_env(monkeypatch)
+        sys.modules.pop("hermes_cli.config", None)
+        plugin = _fresh_plugin(monkeypatch)
+        for _ in range(5):
+            plugin._get_posthog()
+        assert "hermes_cli.config" not in sys.modules
+
+    def test_valid_credentials_initialize_client(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_PROJECT_TOKEN", "phc_real_project_token")
+        monkeypatch.setenv("HERMES_POSTHOG_HOST", "https://eu.i.posthog.com")
+        plugin = _fresh_plugin(monkeypatch)
+
+        client = plugin._get_posthog()
+
+        assert isinstance(client, _FakePosthog)
+        assert client.project_api_key == "phc_real_project_token"
+        assert client.kwargs["host"] == "https://eu.i.posthog.com"
+
+    def test_invalid_max_chars_falls_back_instead_of_raising(self, monkeypatch, caplog):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_MAX_CHARS", "not-an-int")
+        plugin = _fresh_plugin(monkeypatch)
+
+        with caplog.at_level(logging.WARNING, logger="plugins.observability.posthog"):
+            assert plugin._safe_value("x" * 12005).endswith("[truncated 5 chars]")
+
+        assert "Invalid HERMES_POSTHOG_MAX_CHARS" in caplog.text
+
+    def test_trace_state_pruning_bounds_long_running_processes(self, monkeypatch):
+        _clear_env(monkeypatch)
+        plugin = _fresh_plugin(monkeypatch)
+        plugin._TRACE_STATE.clear()
+        now = 10_000.0
+        plugin._TRACE_STATE["fresh"] = plugin.TraceState(trace_id="fresh", last_updated_at=now)
+        plugin._TRACE_STATE["stale"] = plugin.TraceState(
+            trace_id="stale",
+            last_updated_at=now - plugin._TRACE_STATE_TTL_SECONDS - 1,
+        )
+
+        plugin._prune_trace_states(now)
+
+        assert "fresh" in plugin._TRACE_STATE
+        assert "stale" not in plugin._TRACE_STATE
+
+
+class TestPlaceholderDetection:
+    LOGGER_NAME = "plugins.observability.posthog"
+
+    @pytest.mark.parametrize("placeholder", ["placeholder", "test-key", "your-posthog-token", "change-me", "xxx"])
+    def test_common_placeholder_tokens_warn_and_skip(self, monkeypatch, caplog, placeholder):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_PROJECT_TOKEN", placeholder)
+        plugin = _fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert plugin._get_posthog() is None
+        assert "HERMES_POSTHOG_PROJECT_TOKEN" in caplog.text
+        assert _FakePosthog.instances == []
+
+    def test_valid_phc_token_does_not_warn(self, monkeypatch, caplog):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_PROJECT_TOKEN", "phc_real_project_token")
+        plugin = _fresh_plugin(monkeypatch)
+        with caplog.at_level(logging.WARNING, logger=self.LOGGER_NAME):
+            assert isinstance(plugin._get_posthog(), _FakePosthog)
+        assert "placeholder" not in caplog.text.lower()
+
+
+class TestHooks:
+    def test_hooks_noop_without_client(self, monkeypatch):
+        _clear_env(monkeypatch)
+        plugin = _fresh_plugin(monkeypatch)
+        plugin.on_pre_llm_call(task_id="t", session_id="s", messages=[{"role": "user", "content": "hi"}])
+        plugin.on_pre_llm_request(task_id="t", session_id="s", api_call_count=1, request_messages=[])
+        plugin.on_post_llm_call(task_id="t", session_id="s", api_call_count=1)
+        plugin.on_pre_tool_call(tool_name="read_file", args={}, task_id="t", session_id="s")
+        plugin.on_post_tool_call(tool_name="read_file", args={}, result="ok", task_id="t", session_id="s")
+
+    def test_registers_all_hooks(self, monkeypatch):
+        plugin = _fresh_plugin(monkeypatch)
+        ctx = _Ctx()
+        plugin.register(ctx)
+        assert [name for name, _fn in ctx.hooks] == [
+            "pre_api_request", "post_api_request",
+            "pre_llm_call", "post_llm_call",
+            "pre_tool_call", "post_tool_call",
+        ]
+
+    def test_generation_capture_emits_posthog_ai_generation_event(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_PROJECT_TOKEN", "phc_real_project_token")
+        monkeypatch.setenv("HERMES_POSTHOG_DISTINCT_ID", "agent-test")
+        plugin = _fresh_plugin(monkeypatch)
+
+        plugin.on_pre_llm_request(
+            task_id="task-1",
+            session_id="session-1",
+            platform="discord",
+            model="gpt-5-mini",
+            provider="openai",
+            api_mode="responses",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "hello"}],
+        )
+        plugin.on_post_llm_call(
+            task_id="task-1",
+            session_id="session-1",
+            provider="openai",
+            base_url="https://api.openai.com/v1",
+            api_mode="responses",
+            model="gpt-5-mini",
+            api_call_count=1,
+            assistant_response="hi there",
+            api_duration=1.234,
+            usage={"input_tokens": 3, "output_tokens": 4},
+        )
+
+        client = plugin._get_posthog()
+        event = client.events[-1]["kwargs"]
+        assert event["distinct_id"] == "agent-test"
+        assert event["event"] == "$ai_generation"
+        props = event["properties"]
+        assert props["$ai_trace_id"]
+        assert props["$ai_session_id"] == "session-1"
+        assert props["$ai_model"] == "gpt-5-mini"
+        assert props["$ai_provider"] == "openai"
+        assert props["$ai_input"] == [{"role": "user", "content": "hello"}]
+        assert props["$ai_output_choices"] == [{"role": "assistant", "content": "hi there"}]
+        assert props["$ai_input_tokens"] == 3
+        assert props["$ai_output_tokens"] == 4
+        assert props["$ai_latency"] == 1.234
+        assert client.flushed == 1
+
+    def test_privacy_mode_omits_generation_input_and_output(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_PROJECT_TOKEN", "phc_real_project_token")
+        monkeypatch.setenv("HERMES_POSTHOG_PRIVACY_MODE", "true")
+        plugin = _fresh_plugin(monkeypatch)
+
+        plugin.on_pre_llm_request(
+            task_id="task-privacy",
+            session_id="session-privacy",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "secret"}],
+        )
+        plugin.on_post_llm_call(
+            task_id="task-privacy",
+            session_id="session-privacy",
+            api_call_count=1,
+            assistant_response="secret answer",
+        )
+
+        props = plugin._get_posthog().events[-1]["kwargs"]["properties"]
+        assert "$ai_input" not in props
+        assert "$ai_output_choices" not in props
+
+    def test_tool_call_emits_posthog_ai_span_event(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_PROJECT_TOKEN", "phc_real_project_token")
+        plugin = _fresh_plugin(monkeypatch)
+
+        plugin.on_pre_llm_request(
+            task_id="task-tools",
+            session_id="session-tools",
+            api_call_count=1,
+            request_messages=[{"role": "user", "content": "read"}],
+        )
+        plugin.on_pre_tool_call(
+            task_id="task-tools",
+            session_id="session-tools",
+            tool_name="read_file",
+            tool_call_id="call-1",
+            args={"path": "/tmp/a"},
+        )
+        plugin.on_post_tool_call(
+            task_id="task-tools",
+            session_id="session-tools",
+            tool_name="read_file",
+            tool_call_id="call-1",
+            args={"path": "/tmp/a"},
+            result='{"content": "1|hello", "total_lines": 1, "file_size": 7, "is_binary": false, "is_image": false}',
+        )
+
+        event = plugin._get_posthog().events[-1]["kwargs"]
+        assert event["event"] == "$ai_span"
+        props = event["properties"]
+        assert props["$ai_trace_id"]
+        assert props["$ai_session_id"] == "session-tools"
+        assert props["$ai_span_name"] == "Tool: read_file"
+        assert props["hermes.tool_name"] == "read_file"
+        assert props["$ai_input_state"] == {"path": "/tmp/a"}
+        assert props["$ai_output_state"]["returned_lines"] == {"start": 1, "end": 1, "count": 1}
+
+    def test_serialize_tool_calls_extracts_tool_names_for_generation(self, monkeypatch):
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_POSTHOG_PROJECT_TOKEN", "phc_real_project_token")
+        plugin = _fresh_plugin(monkeypatch)
+
+        class _Fn:
+            name = "terminal"
+            arguments = '{"command":"date"}'
+
+        class _ToolCall:
+            id = "call-terminal"
+            type = "function"
+            function = _Fn()
+
+        class _Assistant:
+            content = None
+            reasoning = None
+            tool_calls = [_ToolCall()]
+
+        plugin.on_pre_llm_request(task_id="task-tc", session_id="session-tc", api_call_count=1, request_messages=[])
+        plugin.on_post_llm_call(task_id="task-tc", session_id="session-tc", api_call_count=1, assistant_message=_Assistant())
+
+        props = plugin._get_posthog().events[-1]["kwargs"]["properties"]
+        assert props["$ai_tools_called"] == ["terminal"]
+        assert props["$ai_tool_call_count"] == 1


### PR DESCRIPTION
## Summary
- Add a bundled, opt-in `observability/posthog` plugin for PostHog AI Observability events.
- Capture LLM calls as `$ai_generation` and tool calls as `$ai_span`, with shared trace/session IDs and compacted tool output previews.
- Add PostHog environment keys to Hermes config handling and warn during `hermes plugins enable` when declared plugin `pip_dependencies` are missing from the active Hermes Python environment.
- Document setup, required credentials, privacy/sampling options, and verification steps.

## Safety / privacy
- Plugin remains disabled until explicitly enabled via `hermes plugins enable observability/posthog` or the plugin UI.
- Runtime capture is gated on both the optional `posthog` SDK and a real PostHog project token; missing SDK/credentials fail open as no-ops.
- Placeholder-looking tokens are rejected with a warning.
- `HERMES_POSTHOG_PRIVACY_MODE=true` omits prompt/response payloads, and `HERMES_POSTHOG_MAX_CHARS` bounds serialized fields.
- In-memory trace bookkeeping is TTL/size bounded for long-running gateway processes.

## Test plan
- [x] `python -m pytest tests/plugins/test_posthog_plugin.py tests/hermes_cli/test_plugins_cmd.py -q` — 93 passed, 1 warning
- [x] `git diff --cached --check`
- [x] `hermes plugins list | grep -i posthog`
- [x] Independent staged-diff review found no blocking issues
