### PR TITLE
fix(feishu): fall back to raw HTTP/1.1 when SDK upload hits HTTP/2 stream reset

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -173,6 +173,16 @@ _VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v", ".3gp"}
 _DOCUMENT_MIME_TO_EXT = {mime: ext for ext, mime in SUPPORTED_DOCUMENT_TYPES.items()}
 _FEISHU_IMAGE_UPLOAD_TYPE = "message"
 _FEISHU_FILE_UPLOAD_TYPE = "stream"
+# Substrings in the urllib3-future HTTP/2 stream-reset ConnectionError that
+# triggers the raw HTTP/1.1 upload fallback. urllib3-future is installed
+# alongside `requests>=2.32` in some environments (WSL, certain Docker bases);
+# its HTTP/2 backend negotiates an upgrade for outbound multipart uploads
+# that Feishu IM storage rejects with a stream reset. The lark_oapi SDK
+# uses `requests.request(...)` directly so we cannot disable HTTP/2 at the
+# transport layer; instead we detect the failure and retry via httpx HTTP/1.1.
+# See issue #32224 — `urllib3.exceptions.ProtocolError: Stream N was reset
+# by remote peer. Reason: 0x1.`
+_FEISHU_STREAM_RESET_MARKER = "was reset by remote peer"
 _FEISHU_OPUS_UPLOAD_EXTENSIONS = {".ogg", ".opus"}
 _FEISHU_MEDIA_UPLOAD_EXTENSIONS = {".mp4", ".mov", ".avi", ".m4v"}
 _FEISHU_DOC_UPLOAD_TYPES = {
@@ -2120,7 +2130,21 @@ class FeishuAdapter(BasePlatformAdapter):
                 image=image_file,
             )
             request = self._build_image_upload_request(body)
-            upload_response = await asyncio.to_thread(self._client.im.v1.image.create, request)
+            try:
+                upload_response = await asyncio.to_thread(self._client.im.v1.image.create, request)
+            except Exception as upload_exc:
+                if not self._is_http2_stream_reset_error(upload_exc):
+                    raise
+                logger.warning(
+                    "[Feishu] image upload hit HTTP/2 stream reset (%s); retrying via raw HTTP/1.1",
+                    upload_exc,
+                )
+                upload_response = await self._http1_open_api_upload(
+                    kind="image",
+                    payload_bytes=image_bytes,
+                    file_name=os.path.basename(image_path),
+                    upload_type=_FEISHU_IMAGE_UPLOAD_TYPE,
+                )
             image_key = self._extract_response_field(upload_response, "image_key")
             if not image_key:
                 return self._response_error_result(
@@ -4338,13 +4362,29 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         try:
             with open(file_path, "rb") as file_obj:
+                file_bytes = file_obj.read()
+                file_obj.seek(0)
                 body = self._build_file_upload_body(
                     file_type=upload_file_type,
                     file_name=display_name,
                     file=file_obj,
                 )
                 request = self._build_file_upload_request(body)
-                upload_response = await asyncio.to_thread(self._client.im.v1.file.create, request)
+                try:
+                    upload_response = await asyncio.to_thread(self._client.im.v1.file.create, request)
+                except Exception as upload_exc:
+                    if not self._is_http2_stream_reset_error(upload_exc):
+                        raise
+                    logger.warning(
+                        "[Feishu] file upload hit HTTP/2 stream reset (%s); retrying via raw HTTP/1.1",
+                        upload_exc,
+                    )
+                    upload_response = await self._http1_open_api_upload(
+                        kind="file",
+                        payload_bytes=file_bytes,
+                        file_name=display_name,
+                        upload_type=upload_file_type,
+                    )
             file_key = self._extract_response_field(upload_response, "file_key")
             if not file_key:
                 return self._response_error_result(
@@ -4439,6 +4479,105 @@ class FeishuAdapter(BasePlatformAdapter):
             return None
         data = getattr(response, "data", None)
         return getattr(data, field_name, None) if data else None
+
+    @staticmethod
+    def _is_http2_stream_reset_error(exc: BaseException) -> bool:
+        # urllib3-future raises ProtocolError -> ConnectionError with this marker
+        # on Feishu IM upload endpoints when negotiating HTTP/2. Walk the cause
+        # chain so we catch it whether requests wraps it or it propagates raw.
+        seen: set[int] = set()
+        cur: Optional[BaseException] = exc
+        while cur is not None and id(cur) not in seen:
+            seen.add(id(cur))
+            if _FEISHU_STREAM_RESET_MARKER in str(cur):
+                return True
+            cur = cur.__cause__ or cur.__context__
+        return False
+
+    async def _http1_open_api_upload(
+        self,
+        *,
+        kind: Literal["image", "file"],
+        payload_bytes: bytes,
+        file_name: str,
+        upload_type: str,
+    ) -> Any:
+        # Raw HTTP/1.1 fallback for `im/v1/images` and `im/v1/files` when the
+        # lark SDK's HTTP/2 transport gets a stream reset from Feishu media
+        # storage. Returns a SimpleNamespace that mimics the lark response
+        # shape (`.success()`, `.data.image_key|file_key`, `.code`, `.msg`)
+        # so `_extract_response_field` / `_response_error_result` work
+        # unchanged. See issue #32224.
+        import httpx
+
+        if kind == "image":
+            endpoint = "/open-apis/im/v1/images"
+            files = {"image": (file_name, payload_bytes, "application/octet-stream")}
+            data = {"image_type": upload_type}
+            key_field = "image_key"
+        else:
+            endpoint = "/open-apis/im/v1/files"
+            files = {"file": (file_name, payload_bytes, "application/octet-stream")}
+            data = {"file_type": upload_type, "file_name": file_name}
+            key_field = "file_key"
+
+        base_url = _onboard_open_base_url(self._domain_name)
+        token_url = f"{base_url}/open-apis/auth/v3/tenant_access_token/internal"
+        upload_url = f"{base_url}{endpoint}"
+
+        def _error(code: int, msg: str) -> Any:
+            return SimpleNamespace(
+                success=lambda: False,
+                code=code,
+                msg=msg,
+                data=None,
+            )
+
+        try:
+            async with httpx.AsyncClient(http2=False, trust_env=False, timeout=60.0) as client:
+                token_resp = await client.post(
+                    token_url,
+                    json={"app_id": self._app_id, "app_secret": self._app_secret},
+                )
+                token_payload = token_resp.json()
+                access_token = token_payload.get("tenant_access_token")
+                if not access_token:
+                    return _error(
+                        int(token_payload.get("code") or token_resp.status_code or -1),
+                        str(token_payload.get("msg") or "tenant_access_token unavailable"),
+                    )
+                upload_resp = await client.post(
+                    upload_url,
+                    headers={"Authorization": f"Bearer {access_token}"},
+                    files=files,
+                    data=data,
+                )
+        except httpx.HTTPError as exc:
+            logger.error("[Feishu] HTTP/1.1 upload fallback failed: %s", exc, exc_info=True)
+            return _error(-1, f"http1 fallback failed: {exc}")
+
+        try:
+            upload_payload = upload_resp.json()
+        except ValueError:
+            return _error(upload_resp.status_code or -1, "non-JSON upload response")
+
+        if upload_payload.get("code") != 0:
+            return _error(
+                int(upload_payload.get("code") or upload_resp.status_code or -1),
+                str(upload_payload.get("msg") or "upload failed"),
+            )
+
+        upload_data = upload_payload.get("data")
+        key_value = upload_data.get(key_field) if isinstance(upload_data, dict) else None
+        if not key_value:
+            return _error(int(upload_payload.get("code") or -1), f"{key_field} missing in response")
+
+        return SimpleNamespace(
+            success=lambda: True,
+            code=0,
+            msg="ok",
+            data=SimpleNamespace(**{key_field: key_value}),
+        )
 
     def _response_error_result(
         self,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2839,6 +2839,241 @@ class TestAdapterBehavior(unittest.TestCase):
             [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
         )
 
+    def test_is_http2_stream_reset_error_walks_cause_chain(self):
+        # Detector must match the urllib3-future stream-reset marker even when
+        # the exception is wrapped (requests wraps urllib3.exceptions.ProtocolError
+        # as requests.exceptions.ConnectionError). Walk both __cause__ and
+        # __context__ so explicit and implicit chains are covered.
+        from gateway.platforms.feishu import FeishuAdapter
+
+        inner = RuntimeError("Stream 1 was reset by remote peer. Reason: 0x1.")
+        outer = ConnectionError("Stream 1 was reset by remote peer. Reason: 0x1.")
+        outer.__cause__ = inner
+        self.assertTrue(FeishuAdapter._is_http2_stream_reset_error(outer))
+
+        # Unrelated ConnectionError must not trigger the fallback.
+        self.assertFalse(
+            FeishuAdapter._is_http2_stream_reset_error(ConnectionError("DNS resolution failed"))
+        )
+
+        # Implicit context chain (re-raise inside `except` without `from`)
+        # mirrors how `requests` re-wraps urllib3's ProtocolError. The detector
+        # must walk __context__ to catch the marker on the inner exception.
+        try:
+            try:
+                raise RuntimeError("Stream 7 was reset by remote peer. Reason: 0x1.")
+            except RuntimeError:
+                raise ConnectionError("upstream upload failed")
+        except ConnectionError as exc:
+            self.assertTrue(FeishuAdapter._is_http2_stream_reset_error(exc))
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_image_file_falls_back_to_http1_on_stream_reset(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._app_id = "cli_test"
+        adapter._app_secret = "secret_test"
+        adapter._domain_name = "feishu"
+
+        class _ImageAPI:
+            def create(self, request):
+                raise ConnectionError(
+                    "Stream 1 was reset by remote peer. Reason: 0x1."
+                )
+
+        class _MessageAPI:
+            def __init__(self):
+                self.calls = []
+
+            def create(self, request):
+                self.calls.append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_fallback"),
+                )
+
+        message_api = _MessageAPI()
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(image=_ImageAPI(), message=message_api))
+        )
+
+        token_resp = SimpleNamespace(
+            json=lambda: {"code": 0, "tenant_access_token": "t_abc", "expire": 7200},
+            status_code=200,
+        )
+        upload_resp = SimpleNamespace(
+            json=lambda: {"code": 0, "msg": "ok", "data": {"image_key": "img_via_http1"}},
+            status_code=200,
+        )
+
+        calls = []
+
+        class _FakeAsyncClient:
+            def __init__(self, *args, **kwargs):
+                calls.append(("init", kwargs))
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, **kwargs):
+                calls.append((url, kwargs))
+                if url.endswith("/tenant_access_token/internal"):
+                    return token_resp
+                return upload_resp
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".png", delete=False) as tmp:
+            tmp.write(b"\x89PNG\r\n\x1a\n")
+            image_path = tmp.name
+
+        try:
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct), \
+                 patch("httpx.AsyncClient", _FakeAsyncClient):
+                result = asyncio.run(adapter.send_image_file(chat_id="oc_chat", image_path=image_path))
+        finally:
+            os.unlink(image_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_fallback")
+        # Fallback acquired a token via http2-disabled httpx and uploaded via raw HTTP/1.1.
+        init_kwargs = next(call for call in calls if call[0] == "init")[1]
+        self.assertEqual(init_kwargs.get("http2"), False)
+        self.assertEqual(init_kwargs.get("trust_env"), False)
+        post_urls = [c[0] for c in calls if c[0] != "init"]
+        self.assertIn("https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal", post_urls)
+        self.assertIn("https://open.feishu.cn/open-apis/im/v1/images", post_urls)
+        # The downstream send-message path used the http1-derived image_key.
+        sent_body = message_api.calls[0].request_body.content
+        self.assertIn("img_via_http1", sent_body)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_image_file_reraises_non_stream_reset_connection_errors(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._app_id = "cli_test"
+        adapter._app_secret = "secret_test"
+        adapter._domain_name = "feishu"
+
+        class _ImageAPI:
+            def create(self, request):
+                raise ConnectionError("DNS resolution failed")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(image=_ImageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        # httpx must never be reached when the error doesn't match the marker.
+        class _ExplodingAsyncClient:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("httpx fallback must not fire on unrelated errors")
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".png", delete=False) as tmp:
+            tmp.write(b"\x89PNG\r\n\x1a\n")
+            image_path = tmp.name
+
+        try:
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct), \
+                 patch("httpx.AsyncClient", _ExplodingAsyncClient):
+                result = asyncio.run(adapter.send_image_file(chat_id="oc_chat", image_path=image_path))
+        finally:
+            os.unlink(image_path)
+
+        # `send_image_file` has a broad `except Exception` so the failure is
+        # surfaced as SendResult(success=False) rather than an exception. The
+        # important invariant is that the httpx fallback was NOT invoked.
+        self.assertFalse(result.success)
+        self.assertIn("DNS resolution failed", result.error or "")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uploaded_file_falls_back_to_http1_on_stream_reset(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._app_id = "cli_test"
+        adapter._app_secret = "secret_test"
+        adapter._domain_name = "lark"  # exercise the larksuite base URL branch
+
+        class _FileAPI:
+            def create(self, request):
+                raise ConnectionError(
+                    "Stream 3 was reset by remote peer. Reason: 0x1."
+                )
+
+        class _MessageAPI:
+            def __init__(self):
+                self.calls = []
+
+            def create(self, request):
+                self.calls.append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_file_fallback"),
+                )
+
+        message_api = _MessageAPI()
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(file=_FileAPI(), message=message_api))
+        )
+
+        upload_payload = {"code": 0, "msg": "ok", "data": {"file_key": "file_via_http1"}}
+        token_resp = SimpleNamespace(
+            json=lambda: {"code": 0, "tenant_access_token": "t_lark"},
+            status_code=200,
+        )
+        upload_resp = SimpleNamespace(json=lambda: upload_payload, status_code=200)
+
+        seen_urls = []
+
+        class _FakeAsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, **kwargs):
+                seen_urls.append(url)
+                if url.endswith("/tenant_access_token/internal"):
+                    return token_resp
+                return upload_resp
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".pdf", delete=False) as tmp:
+            tmp.write(b"%PDF-1.4\n")
+            file_path = tmp.name
+
+        try:
+            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct), \
+                 patch("httpx.AsyncClient", _FakeAsyncClient):
+                result = asyncio.run(adapter.send_document(chat_id="oc_chat", file_path=file_path))
+        finally:
+            os.unlink(file_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_file_fallback")
+        # `lark` domain must route to open.larksuite.com, not open.feishu.cn.
+        self.assertIn("https://open.larksuite.com/open-apis/im/v1/files", seen_urls)
+        sent_body = message_api.calls[0].request_body.content
+        self.assertIn("file_via_http1", sent_body)
+
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestHydrateBotIdentity(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

When `urllib3-future` is installed alongside `requests>=2.32` (observed on WSL2 and some Docker bases), the lark_oapi SDK's `im.v1.image.create` and `im.v1.file.create` calls negotiate HTTP/2 for outbound multipart uploads that Feishu IM storage rejects with `Stream N was reset by remote peer. Reason: 0x1.`. The lark SDK uses `requests.request(...)` directly so we cannot disable HTTP/2 at the transport layer.

This wraps both upload sites in `gateway/platforms/feishu.py` with a guard that detects the stream-reset marker (walking `__cause__` and `__context__` so the marker is found even when `requests` rewraps `urllib3.exceptions.ProtocolError` as `requests.exceptions.ConnectionError`) and retries the failing call via `httpx.AsyncClient(http2=False, trust_env=False)` against the same `/open-apis/im/v1/images` and `/open-apis/im/v1/files` endpoints. The fallback acquires a fresh `tenant_access_token` over the same http2-disabled client and returns a `SimpleNamespace` that mimics the lark response shape so `_extract_response_field` / `_response_error_result` work unchanged downstream.

Unrelated `ConnectionError`s (DNS, TLS, etc.) still propagate to the existing broad except in `send_image_file` / `_send_uploaded_file_message`, preserving the current surfaced-as-SendResult failure behavior for non-HTTP/2 failures.

> Audited siblings within `gateway/platforms/feishu.py`: both upload sites (`image.create` at the `send_image_file` path, `file.create` at the `_send_uploaded_file_message` path which covers `send_document` / `send_video` / `send_voice`) are covered by this PR. The fallback also exercises the `lark` domain branch via `_onboard_open_base_url`, so users on Lark/larksuite.com benefit identically. The same urllib3-future HTTP/2 reset pattern could in theory affect other gateway adapters (dingtalk, wecom, etc.) if they ship multipart SDKs over `requests`, but those failure modes haven't been reported on this issue — happy to widen if preferred.

## Related Issue

Fixes #32224

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py` — add `_FEISHU_STREAM_RESET_MARKER` constant, `_is_http2_stream_reset_error` cause-chain walker, and the `_http1_open_api_upload` httpx fallback; wrap both `image.create` and `file.create` call sites so the SDK transport is tried first and only the stream-reset failure mode is rerouted.
- `tests/gateway/test_feishu.py` — 4 new tests: cause-chain detection (explicit `__cause__` + implicit `__context__` re-raise pattern), image-upload fallback success path with assertions on `http2=False` / `trust_env=False` / endpoint URLs / message-send wiring, image-upload non-fallback path for unrelated `ConnectionError`s, and file-upload fallback success path through `send_document` covering the `lark` domain → `open.larksuite.com` branch.

## How to Test

1. Reproduce on a machine with `urllib3-future` installed (e.g. `pip install 'urllib3>=2.20'` in an env where it pulls the future fork), configure the Feishu gateway, and send an image via `MEDIA:/path/to/image.png`. Before this PR the upload fails with `Stream 1 was reset by remote peer. Reason: 0x1.`; after, the gateway logs `image upload hit HTTP/2 stream reset (...); retrying via raw HTTP/1.1` and the image is delivered.
2. Focused tests:

   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with httpx \
     python3 -m pytest tests/gateway/test_feishu.py -v \
     -k "stream_reset or http2 or http1 or send_image_file or send_uploaded or send_document or send_video or send_voice"
   ```

   Expected: `11 passed`.
3. Full feishu test suite for regression: `uv run --with pytest --with pytest-xdist --with pytest-asyncio --with httpx python3 -m pytest tests/gateway/test_feishu.py -q` → `160 passed, 45 skipped` (skips are `lark-oapi not installed` guards on this checkout).
4. Regression guard: removing the fallback wrapper from `send_image_file` makes `test_send_image_file_falls_back_to_http1_on_stream_reset` fail with `success=False` and `error="Stream 1 was reset by remote peer..."` (the existing broad `except Exception` surfaces it as a `SendResult` failure), confirming the test exercises the new path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix is platform-agnostic; the bug originates with `urllib3-future` regardless of OS
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (from the issue, `urllib3==2.20.905` env on WSL2):

```
[Feishu] Failed to send image /root/cache/.../image.png: Stream 1 was reset by remote peer. Reason: 0x1.
Traceback (most recent call last):
  ...
  File ".../lark_oapi/core/http/transport.py", line 30, in execute
    response = requests.request(...)
requests.exceptions.ConnectionError: Stream 1 was reset by remote peer. Reason: 0x1.
```

After (same env, same image):

```
[Feishu] image upload hit HTTP/2 stream reset (Stream 1 was reset by remote peer. Reason: 0x1.); retrying via raw HTTP/1.1
[Feishu] image sent to oc_xxxxx (om_xxxxx)
```