### PR TITLE
fix: scope cron skill index to bound skills when job specifies skills list

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,7 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+import contextvars
 import json
 import logging
 import os
@@ -27,6 +28,10 @@ from agent.skill_utils import (
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
+
+_SCOPED_SKILL_INDEX_NAMES: contextvars.ContextVar[tuple[str, ...] | None] = (
+    contextvars.ContextVar("hermes_scoped_skill_index_names", default=None)
+)
 
 # ---------------------------------------------------------------------------
 # Context file scanning — detect prompt injection / promptware in AGENTS.md,
@@ -924,12 +929,84 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "related_skills": sorted(_extract_related_skill_names(frontmatter)),
     }
 
 
 # =========================================================================
 # Skills index
 # =========================================================================
+
+def _normalize_skill_name_values(values) -> set[str]:
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, (list, tuple, set, frozenset)):
+        return set()
+
+    names: set[str] = set()
+    for value in values:
+        if value is None:
+            continue
+        for part in str(value).split(","):
+            name = part.strip().strip("'\"")
+            if name:
+                names.add(name)
+    return names
+
+
+def _extract_related_skill_names(frontmatter: dict) -> set[str]:
+    names = _normalize_skill_name_values(frontmatter.get("related_skills"))
+    metadata = frontmatter.get("metadata")
+    if isinstance(metadata, dict):
+        hermes = metadata.get("hermes")
+        if isinstance(hermes, dict):
+            names.update(_normalize_skill_name_values(hermes.get("related_skills")))
+    return names
+
+
+def set_scoped_skill_index_names(skill_names) -> contextvars.Token:
+    """Scope the pre-rendered skill index for the current context."""
+    names = tuple(sorted(_normalize_skill_name_values(skill_names)))
+    return _SCOPED_SKILL_INDEX_NAMES.set(names or None)
+
+
+def reset_scoped_skill_index_names(token: contextvars.Token) -> None:
+    _SCOPED_SKILL_INDEX_NAMES.reset(token)
+
+
+def _entry_skill_names(entry: dict) -> set[str]:
+    return {
+        str(name).strip()
+        for name in (entry.get("frontmatter_name"), entry.get("skill_name"))
+        if str(name).strip()
+    }
+
+
+def _expand_scoped_skill_names(
+    scoped_skill_names: set[str],
+    skill_entries: list[dict],
+) -> set[str]:
+    """Include scoped skills plus their transitive related_skills references."""
+    entries_by_name: dict[str, dict] = {}
+    for entry in skill_entries:
+        for name in _entry_skill_names(entry):
+            entries_by_name.setdefault(name, entry)
+
+    expanded = set(scoped_skill_names)
+    pending = list(scoped_skill_names)
+    while pending:
+        current = pending.pop()
+        entry = entries_by_name.get(current)
+        if not entry:
+            continue
+        for related in _normalize_skill_name_values(entry.get("related_skills")):
+            if related not in expanded:
+                expanded.add(related)
+                pending.append(related)
+    return expanded
+
 
 def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     """Read a SKILL.md once and return platform compatibility, frontmatter, and description.
@@ -984,6 +1061,7 @@ def _skill_should_show(
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    bound_skill_names=None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1005,6 +1083,12 @@ def build_skills_system_prompt(
     if not skills_dir.exists() and not external_dirs:
         return ""
 
+    if bound_skill_names is None:
+        scoped_skill_names = set(_SCOPED_SKILL_INDEX_NAMES.get() or ())
+    else:
+        scoped_skill_names = _normalize_skill_name_values(bound_skill_names)
+    scoped_skill_names = scoped_skill_names or None
+
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
@@ -1022,6 +1106,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        tuple(sorted(scoped_skill_names or set())),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1030,10 +1115,21 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    # Scoped cron prompts need fresh frontmatter so related_skills expansion
+    # works even when an older snapshot predates that metadata field.
+    snapshot = None if scoped_skill_names else _load_skills_snapshot(skills_dir)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
+    visible_skill_entries: list[dict] = []
+
+    def add_visible_skill(entry: dict) -> None:
+        if scoped_skill_names:
+            visible_skill_entries.append(entry)
+        else:
+            skills_by_category.setdefault(entry["category"], []).append(
+                (entry["frontmatter_name"], entry["description"])
+            )
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
@@ -1054,9 +1150,11 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(category, []).append(
-                (frontmatter_name, entry.get("description", ""))
-            )
+            entry = dict(entry)
+            entry["category"] = category
+            entry["frontmatter_name"] = frontmatter_name
+            entry["description"] = entry.get("description", "")
+            add_visible_skill(entry)
         category_descriptions = {
             str(k): str(v)
             for k, v in (snapshot.get("category_descriptions") or {}).items()
@@ -1079,9 +1177,7 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
-            )
+            add_visible_skill(entry)
 
         # Read category-level DESCRIPTION.md files
         for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
@@ -1109,9 +1205,13 @@ def build_skills_system_prompt(
     # and typically small).  Local skills already in skills_by_category take
     # precedence: we track seen names and skip duplicates from external dirs.
     seen_skill_names: set[str] = set()
-    for cat_skills in skills_by_category.values():
-        for name, _desc in cat_skills:
-            seen_skill_names.add(name)
+    if scoped_skill_names:
+        for entry in visible_skill_entries:
+            seen_skill_names.update(_entry_skill_names(entry))
+    else:
+        for cat_skills in skills_by_category.values():
+            for name, _desc in cat_skills:
+                seen_skill_names.add(name)
 
     for ext_dir in external_dirs:
         if not ext_dir.exists():
@@ -1135,9 +1235,7 @@ def build_skills_system_prompt(
                 ):
                     continue
                 seen_skill_names.add(frontmatter_name)
-                skills_by_category.setdefault(entry["category"], []).append(
-                    (frontmatter_name, entry["description"])
-                )
+                add_visible_skill(entry)
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)
 
@@ -1154,6 +1252,17 @@ def build_skills_system_prompt(
                 category_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
+
+    if scoped_skill_names:
+        expanded_names = _expand_scoped_skill_names(
+            scoped_skill_names,
+            visible_skill_entries,
+        )
+        for entry in visible_skill_entries:
+            if _entry_skill_names(entry) & expanded_names:
+                skills_by_category.setdefault(entry["category"], []).append(
+                    (entry["frontmatter_name"], entry["description"])
+                )
 
     if not skills_by_category:
         result = ""

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1001,6 +1001,17 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _job_skill_names(job: dict) -> list[str]:
+    skills = job.get("skills")
+    if skills is None:
+        legacy = job.get("skill")
+        skills = [legacy] if legacy else []
+    elif isinstance(skills, str):
+        skills = [skills]
+
+    return [str(name).strip() for name in skills if str(name).strip()]
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -1013,7 +1024,6 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             (if any) runs inline as before.
     """
     prompt = str(job.get("prompt") or "")
-    skills = job.get("skills")
 
     # Run data-collection script if configured, inject output as context.
     script_path = job.get("script")
@@ -1103,13 +1113,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         "findings normally, or say [SILENT] and nothing more.]\n\n"
     )
     prompt = cron_hint + prompt
-    if skills is None:
-        legacy = job.get("skill")
-        skills = [legacy] if legacy else []
-    elif isinstance(skills, str):
-        skills = [skills]
-
-    skill_names = [str(name).strip() for name in skills if str(name).strip()]
+    skill_names = _job_skill_names(job)
     if not skill_names:
         return _scan_assembled_cron_prompt(prompt, job)
 
@@ -1381,6 +1385,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     logger.info("Prompt: %s", prompt[:100])
 
     agent = None
+    _scoped_skill_index_token = None
 
     # Mark this as a cron session so the approval system can apply cron_mode.
     # This env var is process-wide and persists for the lifetime of the
@@ -1451,6 +1456,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
     try:
+        _bound_skill_names = _job_skill_names(job)
+        if _bound_skill_names:
+            from agent.prompt_builder import set_scoped_skill_index_names
+            _scoped_skill_index_token = set_scoped_skill_index_names(_bound_skill_names)
+
         # Re-read .env and config.yaml fresh every run so provider/key
         # changes take effect without a gateway restart.
         from dotenv import load_dotenv
@@ -1811,6 +1821,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
+        if _scoped_skill_index_token is not None:
+            try:
+                from agent.prompt_builder import reset_scoped_skill_index_names
+                reset_scoped_skill_index_names(_scoped_skill_index_token)
+            except Exception as e:
+                logger.debug("Job '%s': failed to reset scoped skill index: %s", job_id, e)
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -266,6 +266,99 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_bound_skills_scope_index(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        bound_dir = tmp_path / "skills" / "feeds" / "freshrss-reader"
+        bound_dir.mkdir(parents=True)
+        (bound_dir / "SKILL.md").write_text(
+            "---\nname: freshrss-reader\ndescription: Read feed entries\n---\n"
+        )
+        other_dir = tmp_path / "skills" / "web" / "source-crawler"
+        other_dir.mkdir(parents=True)
+        (other_dir / "SKILL.md").write_text(
+            "---\nname: source-crawler\ndescription: Crawl source URLs\n---\n"
+        )
+
+        result = build_skills_system_prompt(bound_skill_names=["freshrss-reader"])
+
+        assert "freshrss-reader" in result
+        assert "Read feed entries" in result
+        assert "source-crawler" not in result
+        assert "Crawl source URLs" not in result
+
+    def test_empty_bound_skills_keep_full_index(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for category, name in [("feeds", "freshrss-reader"), ("web", "source-crawler")]:
+            skill_dir = tmp_path / "skills" / category / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} description\n---\n"
+            )
+
+        result = build_skills_system_prompt(bound_skill_names=[])
+
+        assert "freshrss-reader" in result
+        assert "source-crawler" in result
+
+    def test_bound_skill_includes_related_skills(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        primary = tmp_path / "skills" / "feeds" / "freshrss-reader"
+        primary.mkdir(parents=True)
+        (primary / "SKILL.md").write_text(
+            "---\n"
+            "name: freshrss-reader\n"
+            "description: Read feed entries\n"
+            "metadata:\n"
+            "  hermes:\n"
+            "    related_skills: [source-crawler]\n"
+            "---\n"
+        )
+        related = tmp_path / "skills" / "web" / "source-crawler"
+        related.mkdir(parents=True)
+        (related / "SKILL.md").write_text(
+            "---\nname: source-crawler\ndescription: Crawl source URLs\n---\n"
+        )
+        unrelated = tmp_path / "skills" / "mail" / "newsletter-reader"
+        unrelated.mkdir(parents=True)
+        (unrelated / "SKILL.md").write_text(
+            "---\nname: newsletter-reader\ndescription: Read newsletters\n---\n"
+        )
+
+        result = build_skills_system_prompt(bound_skill_names=["freshrss-reader"])
+
+        assert "freshrss-reader" in result
+        assert "source-crawler" in result
+        assert "newsletter-reader" not in result
+
+    def test_context_scoped_skills_do_not_leak_after_reset(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for category, name in [("feeds", "freshrss-reader"), ("web", "source-crawler")]:
+            skill_dir = tmp_path / "skills" / category / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} description\n---\n"
+            )
+
+        from agent.prompt_builder import (
+            reset_scoped_skill_index_names,
+            set_scoped_skill_index_names,
+        )
+
+        token = set_scoped_skill_index_names(["freshrss-reader"])
+        try:
+            scoped = build_skills_system_prompt()
+            explicit_empty = build_skills_system_prompt(bound_skill_names=[])
+        finally:
+            reset_scoped_skill_index_names(token)
+        unscoped = build_skills_system_prompt()
+
+        assert "freshrss-reader" in scoped
+        assert "source-crawler" not in scoped
+        assert "freshrss-reader" in explicit_empty
+        assert "source-crawler" in explicit_empty
+        assert "freshrss-reader" in unscoped
+        assert "source-crawler" in unscoped
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"
@@ -1192,6 +1285,4 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-
 


### PR DESCRIPTION
## Summary

When a cron job declares a `skills:` list, the skill index injected into the system prompt is now filtered to that set. Cron-fired runs no longer see the agent's full skill catalogue when only a subset is bound.

## Why this matters

Reported in #32235: cron jobs that bind a subset of skills still see every skill in the index, which leaks unrelated capabilities into the system prompt and inflates context for the bounded run. The fix scopes the index to the bound names so the system prompt matches the job's declared surface.

## Changes

- `agent/prompt_builder.py`: adds a ContextVar (`_SCOPED_SKILL_INDEX_NAMES`) that scopes `_build_snapshot_entry` and the skill-index assembly to the bound skill names; preserves the related-skills graph so dependencies still resolve
- `cron/scheduler.py`: threads the bound `skills:` list through to the scoped ContextVar before building the system prompt for a cron-fired run
- `tests/agent/test_prompt_builder.py`: covers scoped, unscoped, and fallback paths

## Testing

`pytest tests/agent/test_prompt_builder.py`

Fixes #32235

AI was used for assistance.
