### PR TITLE
fix(copilot): derive runtime api_mode from active target model

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4622,6 +4622,7 @@ class HermesCLI:
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
                 explicit_base_url=self._explicit_base_url,
+                target_model=self.model,
             )
         except Exception as exc:
             _primary_exc = exc

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1061,7 +1061,7 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
-def _resolve_runtime_agent_kwargs() -> dict:
+def _resolve_runtime_agent_kwargs(target_model: str | None = None) -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
     Provider is read from ``config.yaml`` ``model.provider`` (the single
@@ -1069,6 +1069,13 @@ def _resolve_runtime_agent_kwargs() -> dict:
     var lookups internally for legacy compatibility, but the gateway does
     not consult environment variables for behavioral config — config.yaml
     is authoritative.
+
+    target_model: Optional active model name. When passed, providers that
+    derive ``api_mode`` per-model (Copilot, OpenCode Zen/Go) compute it
+    from this model instead of the stale ``model.default`` in config.
+    Without this, mid-session ``/model`` switches caused resolver and
+    normalizer to disagree, flapping the agent route signature and
+    forcing a full agent rebuild on every turn.
 
     If the primary provider fails with an authentication error, attempt to
     resolve credentials using the fallback provider chain from config.yaml
@@ -1081,7 +1088,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     from hermes_cli.auth import AuthError
 
     try:
-        runtime = resolve_runtime_provider()
+        runtime = resolve_runtime_provider(target_model=target_model)
     except AuthError as auth_exc:
         # Primary provider auth failed (expired token, revoked key, etc.).
         # Try the fallback provider chain before raising.
@@ -2389,7 +2396,7 @@ class GatewayRunner:
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_kwargs = _resolve_runtime_agent_kwargs(target_model=model)
         runtime_model = runtime_kwargs.pop("model", None)
         if runtime_model:
             logger.info(
@@ -8025,7 +8032,7 @@ class GatewayRunner:
                 from agent.model_metadata import get_model_context_length
 
                 _msg_cwd = os.environ.get("TERMINAL_CWD", os.path.expanduser("~"))
-                _msg_runtime = _resolve_runtime_agent_kwargs()
+                _msg_runtime = _resolve_runtime_agent_kwargs(target_model=self._model)
                 _msg_config_ctx = None
                 try:
                     _msg_cfg = _load_gateway_config()
@@ -9225,7 +9232,7 @@ class GatewayRunner:
 
         # Resolve runtime credentials for probing
         try:
-            runtime = _resolve_runtime_agent_kwargs()
+            runtime = _resolve_runtime_agent_kwargs(target_model=model)
             provider = provider or runtime.get("provider")
             base_url = base_url or runtime.get("base_url")
             api_key = runtime.get("api_key")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -219,22 +219,37 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+    model_name = str(target_model or model_cfg.get("default") or "").strip()
+    if not model_name:
+        return configured_mode or "chat_completions"
+    if target_model is None and configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
-    if not model_name:
-        return "chat_completions"
-
+    # Copilot exposes different model families through different API surfaces.
+    # When the caller knows the active/target model (CLI /model switch,
+    # subagents, cron, etc.), derive api_mode from that model instead of a
+    # stale persisted config default/api_mode. If inference fails, fall back to
+    # a matching-provider explicit config before the chat-completions default.
     try:
         from hermes_cli.models import copilot_model_api_mode
 
-        return copilot_model_api_mode(model_name, api_key=api_key)
+        inferred = copilot_model_api_mode(model_name, api_key=api_key)
+        if inferred:
+            return inferred
     except Exception:
-        return "chat_completions"
+        if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+            return configured_mode
+
+    if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+        return configured_mode
+    return "chat_completions"
 
 
 _VALID_API_MODES = {
@@ -340,7 +355,11 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=effective_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1058,6 +1077,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1171,7 +1191,7 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+            api_mode = _copilot_runtime_api_mode(model_cfg, api_key, target_model=target_model)
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
@@ -1272,6 +1292,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -1613,7 +1634,11 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(
+                model_cfg,
+                creds.get("api_key", ""),
+                target_model=target_model,
+            )
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2701,3 +2701,109 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+def test_copilot_api_mode_recomputes_from_target_model_even_with_matching_config(monkeypatch):
+    """A Copilot /model switch must not let stale persisted api_mode win.
+
+    Repro shape: config/default is GPT-5.x with codex_responses, active target
+    is Claude via Copilot. The active target model must drive endpoint mode.
+    """
+    model_cfg = {
+        "provider": "copilot",
+        "api_mode": "codex_responses",
+        "default": "gpt-5.5",
+    }
+
+    def fake_copilot_model_api_mode(model_name, api_key=None):
+        return "chat_completions" if "claude" in model_name else "codex_responses"
+
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", fake_copilot_model_api_mode)
+
+    assert (
+        rp._copilot_runtime_api_mode(
+            model_cfg,
+            api_key="gho_fake",
+            target_model="claude-opus-4.7-1m-internal",
+        )
+        == "chat_completions"
+    )
+
+
+def test_resolve_runtime_provider_threads_target_model_to_copilot_explicit_path(monkeypatch):
+    """The non-pool Copilot resolver path must also use target_model."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "copilot",
+            "api_mode": "codex_responses",
+            "default": "gpt-5.5",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "api_key": "gho_fake",
+            "base_url": "https://api.githubcopilot.com",
+            "source": "env:COPILOT_GITHUB_TOKEN",
+        },
+    )
+
+    def fake_copilot_model_api_mode(model_name, api_key=None):
+        return "chat_completions" if "claude" in model_name else "codex_responses"
+
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", fake_copilot_model_api_mode)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        target_model="claude-opus-4.7-1m-internal",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "chat_completions"
+
+
+def test_resolve_runtime_provider_threads_target_model_to_copilot_pool_path(monkeypatch):
+    """The credential-pool Copilot resolver path must use target_model too."""
+    class _Entry:
+        runtime_api_key = "gho_fake"
+        access_token = "gho_fake"
+        source = "env:COPILOT_GITHUB_TOKEN"
+        base_url = "https://api.githubcopilot.com"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "copilot",
+            "api_mode": "codex_responses",
+            "default": "gpt-5.5",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    # Force pool path instead of the explicit api-key provider path.
+    monkeypatch.setattr(rp, "_resolve_explicit_runtime", lambda **kwargs: None)
+
+    def fake_copilot_model_api_mode(model_name, api_key=None):
+        return "chat_completions" if "claude" in model_name else "codex_responses"
+
+    monkeypatch.setattr("hermes_cli.models.copilot_model_api_mode", fake_copilot_model_api_mode)
+
+    resolved = rp.resolve_runtime_provider(
+        requested="copilot",
+        target_model="claude-opus-4.7-1m-internal",
+    )
+
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "chat_completions"


### PR DESCRIPTION
## Summary

When a user switches models mid-session via `/model` (e.g. config default is `gpt-5.5` but the active model is `claude-opus-4.7-1m-internal` via Copilot), `_copilot_runtime_api_mode()` was deriving `api_mode` from `model_cfg["default"]` or a stale persisted `model.api_mode` rather than the currently active model.

This caused the resolver and the normalizer to disagree on `api_mode` on every turn, which in turn triggered constant OpenAI client rebuilds (a fresh `agent_init` log line on every conversation turn) and, for some model/endpoint pairs, outright HTTP failures because Copilot serves different model families through different API surfaces:

- GPT‑5.x non‑mini / `-codex` → `codex_responses`
- GPT‑5‑mini / 4.1 / 4o / Gemini → `chat_completions`
- Claude → `chat_completions` (or `anthropic_messages` depending on catalog)

## Fix

Thread the resolved `target_model` through `_resolve_explicit_runtime`, `_resolve_runtime_from_pool_entry`, and the legacy creds path into `_copilot_runtime_api_mode`, and have that helper prefer `copilot_model_api_mode(active_model)` inference over a stale configured `api_mode`. The configured `api_mode` is still honored when no `target_model` is supplied, so non-switching callers keep their existing behavior.

## Why

The same architectural smell — "runtime routing derives `api_mode` from stale config / default / main model instead of the actual target / active model" — shows up in several open PRs covering different surfaces (CLI switch, gateway switch, delegation, subagents, cron). This PR fixes the CLI/runtime path specifically and is intentionally scoped to one helper + its callers so it can land independently of the broader Copilot routing cleanups.

## Verification

Locally, after restarting the gateway with this patch loaded:

- A fresh session logs exactly one `agent_init` at session startup and **zero** on subsequent turns.
- Pre-patch, the same flow was logging a new `OpenAI client created (agent_init, shared=True) provider=copilot ...` line on every conversation turn.

## Tests

Two new unit tests added to `tests/hermes_cli/test_runtime_provider_resolution.py`:

- `test_copilot_api_mode_recomputes_from_target_model_even_with_matching_config` — proves that even when the configured `api_mode` matches the configured provider, an explicit `target_model` of a different family (Claude vs. GPT‑5.x) overrides it.
- `test_resolve_runtime_provider_threads_target_model_to_copilot_explicit_path` — proves the non-pool / explicit Copilot resolver path also threads `target_model` through.

Both pass:

```
tests/hermes_cli/test_runtime_provider_resolution.py ..    [100%]
2 passed, 129 deselected in 0.50s
```

## Related

Open PRs working the same area / same bug class:

- #27267 — closest match (same helper, same fix shape)
- #17622 — broader Copilot api_mode + token precedence cleanup
- #24251 — subagent variant
- #9033 — cron variant
- #6647 — delegation variant

Happy to rebase on or close in favor of #27267 if the maintainers prefer that landing path.
