### PR TITLE
fix: route Feishu media uploads through HTTP/1.1 to avoid urllib3-future stream reset

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1451,6 +1451,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
         self._app_lock_identity: Optional[str] = None
+        self._tenant_access_token: Optional[str] = None
+        self._tenant_access_token_expires_at: float = 0.0
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
         self._pending_text_batch_tasks = self._text_batch_state.tasks
@@ -2106,25 +2108,9 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"Image file not found: {image_path}")
 
         try:
-            import io as _io
-            with open(image_path, "rb") as f:
-                image_bytes = f.read()
-            # Wrap in BytesIO so lark SDK's MultipartEncoder can read .name and .tell()
-            image_file = _io.BytesIO(image_bytes)
-            image_file.name = os.path.basename(image_path)
-            body = self._build_image_upload_body(
-                image_type=_FEISHU_IMAGE_UPLOAD_TYPE,
-                image=image_file,
-            )
-            request = self._build_image_upload_request(body)
-            upload_response = await asyncio.to_thread(self._client.im.v1.image.create, request)
-            image_key = self._extract_response_field(upload_response, "image_key")
+            image_key = await asyncio.to_thread(self._upload_feishu_image_http1, image_path)
             if not image_key:
-                return self._response_error_result(
-                    upload_response,
-                    default_message="image upload failed",
-                    override_error="Feishu image upload missing image_key",
-                )
+                return SendResult(success=False, error="Feishu image upload missing image_key")
 
             if caption:
                 post_payload = self._build_media_post_payload(
@@ -4317,21 +4303,14 @@ class FeishuAdapter(BasePlatformAdapter):
             requested_message_type=outbound_message_type,
         )
         try:
-            with open(file_path, "rb") as file_obj:
-                body = self._build_file_upload_body(
-                    file_type=upload_file_type,
-                    file_name=display_name,
-                    file=file_obj,
-                )
-                request = self._build_file_upload_request(body)
-                upload_response = await asyncio.to_thread(self._client.im.v1.file.create, request)
-            file_key = self._extract_response_field(upload_response, "file_key")
+            file_key = await asyncio.to_thread(
+                self._upload_feishu_file_http1,
+                file_path,
+                file_type=upload_file_type,
+                file_name=display_name,
+            )
             if not file_key:
-                return self._response_error_result(
-                    upload_response,
-                    default_message="file upload failed",
-                    override_error="Feishu file upload missing file_key",
-                )
+                return SendResult(success=False, error="Feishu file upload missing file_key")
 
             if caption:
                 media_tag = {
@@ -4441,6 +4420,89 @@ class FeishuAdapter(BasePlatformAdapter):
             message_id=self._extract_response_field(response, "message_id"),
             raw_response=response,
         )
+
+    def _upload_feishu_image_http1(self, image_path: str) -> str:
+        """Upload an image through raw HTTP/1.1 to avoid SDK multipart HTTP/2 resets."""
+        filename = os.path.basename(image_path)
+        with open(image_path, "rb") as image_file:
+            data = {"image_type": _FEISHU_IMAGE_UPLOAD_TYPE}
+            mime_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            files = {"image": (filename, image_file, mime_type)}
+            payload = self._post_feishu_media_upload("/open-apis/im/v1/images", data=data, files=files)
+        image_key = payload.get("image_key")
+        if not image_key:
+            raise RuntimeError("Feishu image upload missing image_key")
+        return str(image_key)
+
+    def _upload_feishu_file_http1(self, file_path: str, *, file_type: str, file_name: str) -> str:
+        """Upload a file through raw HTTP/1.1 to avoid SDK multipart HTTP/2 resets."""
+        with open(file_path, "rb") as file_obj:
+            data = {"file_type": file_type, "file_name": file_name}
+            mime_type = mimetypes.guess_type(file_name)[0] or "application/octet-stream"
+            files = {"file": (file_name, file_obj, mime_type)}
+            payload = self._post_feishu_media_upload("/open-apis/im/v1/files", data=data, files=files)
+        file_key = payload.get("file_key")
+        if not file_key:
+            raise RuntimeError("Feishu file upload missing file_key")
+        return str(file_key)
+
+    def _post_feishu_media_upload(self, path: str, *, data: Dict[str, str], files: Dict[str, Any]) -> Dict[str, Any]:
+        import httpx
+
+        base_url = _onboard_open_base_url(self._domain_name)
+        try:
+            with httpx.Client(timeout=30.0, http2=False, trust_env=False) as client:
+                token = self._get_tenant_access_token(client)
+                response = client.post(
+                    f"{base_url}{path}",
+                    headers={"Authorization": f"Bearer {token}"},
+                    data=data,
+                    files=files,
+                )
+                response.raise_for_status()
+                payload = response.json()
+        except Exception as exc:
+            logger.error("[Feishu] Raw media upload failed for %s: %s", path, exc, exc_info=True)
+            raise
+
+        code = payload.get("code", 0)
+        if code != 0:
+            msg = payload.get("msg") or payload.get("message") or "media upload failed"
+            raise RuntimeError(f"[{code}] {msg}")
+        data_payload = payload.get("data") or {}
+        if not isinstance(data_payload, dict):
+            raise RuntimeError("Feishu media upload returned invalid data")
+        return data_payload
+
+    def _get_tenant_access_token(self, client: Any) -> str:
+        now = time.time()
+        if self._tenant_access_token and self._tenant_access_token_expires_at - 60 > now:
+            return self._tenant_access_token
+
+        base_url = _onboard_open_base_url(self._domain_name)
+        response = client.post(
+            f"{base_url}/open-apis/auth/v3/tenant_access_token/internal",
+            json={"app_id": self._app_id, "app_secret": self._app_secret},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        code = payload.get("code", 0)
+        if code != 0:
+            msg = payload.get("msg") or payload.get("message") or "tenant access token request failed"
+            raise RuntimeError(f"[{code}] {msg}")
+
+        token = payload.get("tenant_access_token")
+        if not token:
+            raise RuntimeError("Feishu tenant access token response missing tenant_access_token")
+
+        expires_in = payload.get("expire", 7200)
+        try:
+            expires_at = now + max(0, int(expires_in))
+        except (TypeError, ValueError):
+            expires_at = now + 7200
+        self._tenant_access_token = str(token)
+        self._tenant_access_token_expires_at = expires_at
+        return self._tenant_access_token
 
     # =========================================================================
     # Connection internals — websocket / webhook setup

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2126,13 +2126,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter = FeishuAdapter(PlatformConfig())
         captured = {}
 
-        class _FileAPI:
-            def create(self, request):
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(file_key="file_123"),
-                )
-
         class _MessageAPI:
             def reply(self, request):
                 captured["request"] = request
@@ -2144,7 +2137,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._client = SimpleNamespace(
             im=SimpleNamespace(
                 v1=SimpleNamespace(
-                    file=_FileAPI(),
                     message=_MessageAPI(),
                 )
             )
@@ -2153,12 +2145,15 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with tempfile.NamedTemporaryFile("wb", suffix=".pdf", delete=False) as tmp:
-            tmp.write(b"%PDF-1.4 test")
+        with tempfile.NamedTemporaryFile("wb", suffix=".txt", delete=False) as tmp:
+            tmp.write(b"hello")
             file_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch.object(adapter, "_upload_feishu_file_http1", return_value="file_123"),
+            ):
                 result = asyncio.run(
                     adapter.send_document(
                         chat_id="oc_chat",
@@ -2179,15 +2174,33 @@ class TestAdapterBehavior(unittest.TestCase):
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
-        captured = {}
+        captured = {"client_kwargs": [], "http_posts": []}
 
-        class _FileAPI:
-            def create(self, request):
-                captured["upload_request"] = request
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(file_key="file_123"),
-                )
+        class _HTTPResponse:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        class _HTTPClient:
+            def __init__(self, *args, **kwargs):
+                captured["client_kwargs"].append(kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+            def post(self, url, **kwargs):
+                captured["http_posts"].append((url, kwargs))
+                if url.endswith("/open-apis/auth/v3/tenant_access_token/internal"):
+                    return _HTTPResponse({"code": 0, "tenant_access_token": "tenant_token", "expire": 7200})
+                return _HTTPResponse({"code": 0, "data": {"file_key": "file_123"}})
 
         class _MessageAPI:
             def create(self, request):
@@ -2200,7 +2213,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._client = SimpleNamespace(
             im=SimpleNamespace(
                 v1=SimpleNamespace(
-                    file=_FileAPI(),
                     message=_MessageAPI(),
                 )
             )
@@ -2209,19 +2221,28 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with tempfile.NamedTemporaryFile("wb", suffix=".pdf", delete=False) as tmp:
-            tmp.write(b"%PDF-1.4 test")
+        with tempfile.NamedTemporaryFile("wb", suffix=".txt", delete=False) as tmp:
+            tmp.write(b"hello")
             file_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("httpx.Client", _HTTPClient),
+            ):
                 result = asyncio.run(adapter.send_document(chat_id="oc_chat", file_path=file_path))
         finally:
             os.unlink(file_path)
 
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_file_msg")
-        self.assertEqual(captured["upload_request"].request_body.file_type, "pdf")
+        self.assertEqual(captured["client_kwargs"][0]["http2"], False)
+        self.assertEqual(captured["client_kwargs"][0]["trust_env"], False)
+        upload_url, upload_kwargs = captured["http_posts"][1]
+        self.assertTrue(upload_url.endswith("/open-apis/im/v1/files"))
+        self.assertEqual(upload_kwargs["data"]["file_type"], "stream")
+        self.assertEqual(upload_kwargs["files"]["file"][0], os.path.basename(file_path))
+        self.assertEqual(upload_kwargs["headers"]["Authorization"], "Bearer tenant_token")
         self.assertEqual(
             captured["message_request"].request_body.content,
             '{"file_key": "file_123"}',
@@ -2235,13 +2256,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter = FeishuAdapter(PlatformConfig())
         captured = {}
 
-        class _FileAPI:
-            def create(self, request):
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(file_key="file_123"),
-                )
-
         class _MessageAPI:
             def create(self, request):
                 captured["message_request"] = request
@@ -2253,7 +2267,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._client = SimpleNamespace(
             im=SimpleNamespace(
                 v1=SimpleNamespace(
-                    file=_FileAPI(),
                     message=_MessageAPI(),
                 )
             )
@@ -2267,7 +2280,10 @@ class TestAdapterBehavior(unittest.TestCase):
             file_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch.object(adapter, "_upload_feishu_file_http1", return_value="file_123"),
+            ):
                 result = asyncio.run(
                     adapter.send_document(chat_id="oc_chat", file_path=file_path, caption="报告请看")
                 )
@@ -2286,15 +2302,33 @@ class TestAdapterBehavior(unittest.TestCase):
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
-        captured = {}
+        captured = {"client_kwargs": [], "http_posts": []}
 
-        class _ImageAPI:
-            def create(self, request):
-                captured["upload_request"] = request
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(image_key="img_123"),
-                )
+        class _HTTPResponse:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        class _HTTPClient:
+            def __init__(self, *args, **kwargs):
+                captured["client_kwargs"].append(kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+            def post(self, url, **kwargs):
+                captured["http_posts"].append((url, kwargs))
+                if url.endswith("/open-apis/auth/v3/tenant_access_token/internal"):
+                    return _HTTPResponse({"code": 0, "tenant_access_token": "tenant_token", "expire": 7200})
+                return _HTTPResponse({"code": 0, "data": {"image_key": "img_123"}})
 
         class _MessageAPI:
             def create(self, request):
@@ -2307,7 +2341,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._client = SimpleNamespace(
             im=SimpleNamespace(
                 v1=SimpleNamespace(
-                    image=_ImageAPI(),
                     message=_MessageAPI(),
                 )
             )
@@ -2321,18 +2354,145 @@ class TestAdapterBehavior(unittest.TestCase):
             image_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("httpx.Client", _HTTPClient),
+            ):
                 result = asyncio.run(adapter.send_image_file(chat_id="oc_chat", image_path=image_path))
         finally:
             os.unlink(image_path)
 
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_image_msg")
-        self.assertEqual(captured["upload_request"].request_body.image_type, "message")
+        self.assertEqual(captured["client_kwargs"][0]["http2"], False)
+        self.assertEqual(captured["client_kwargs"][0]["trust_env"], False)
+        upload_url, upload_kwargs = captured["http_posts"][1]
+        self.assertTrue(upload_url.endswith("/open-apis/im/v1/images"))
+        self.assertEqual(upload_kwargs["data"]["image_type"], "message")
+        self.assertEqual(upload_kwargs["files"]["image"][0], os.path.basename(image_path))
+        self.assertEqual(upload_kwargs["headers"]["Authorization"], "Bearer tenant_token")
         self.assertEqual(
             captured["message_request"].request_body.content,
             '{"image_key": "img_123"}',
         )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_image_file_propagates_raw_upload_api_error(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _HTTPResponse:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        class _HTTPClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+            def post(self, url, **kwargs):
+                if url.endswith("/open-apis/auth/v3/tenant_access_token/internal"):
+                    return _HTTPResponse({"code": 0, "tenant_access_token": "tenant_token", "expire": 7200})
+                return _HTTPResponse({"code": 999, "msg": "upload rejected"})
+
+        class _MessageAPI:
+            def create(self, request):
+                raise AssertionError("message send should not run after upload failure")
+
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI())))
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".png", delete=False) as tmp:
+            tmp.write(b"\x89PNG\r\n\x1a\n")
+            image_path = tmp.name
+
+        try:
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("httpx.Client", _HTTPClient),
+            ):
+                result = asyncio.run(adapter.send_image_file(chat_id="oc_chat", image_path=image_path))
+        finally:
+            os.unlink(image_path)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, "[999] upload rejected")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_raw_upload_helpers_reuse_cached_tenant_access_token(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"token_posts": 0, "upload_urls": []}
+
+        class _HTTPResponse:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        class _HTTPClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+            def post(self, url, **kwargs):
+                if url.endswith("/open-apis/auth/v3/tenant_access_token/internal"):
+                    captured["token_posts"] += 1
+                    return _HTTPResponse({"code": 0, "tenant_access_token": "tenant_token", "expire": 7200})
+                captured["upload_urls"].append(url)
+                if url.endswith("/open-apis/im/v1/images"):
+                    return _HTTPResponse({"code": 0, "data": {"image_key": "img_123"}})
+                return _HTTPResponse({"code": 0, "data": {"file_key": "file_123"}})
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".png", delete=False) as image_tmp:
+            image_tmp.write(b"\x89PNG\r\n\x1a\n")
+            image_path = image_tmp.name
+        with tempfile.NamedTemporaryFile("wb", suffix=".txt", delete=False) as file_tmp:
+            file_tmp.write(b"hello")
+            file_path = file_tmp.name
+
+        try:
+            with patch("httpx.Client", _HTTPClient):
+                image_key = adapter._upload_feishu_image_http1(image_path)
+                file_key = adapter._upload_feishu_file_http1(
+                    file_path,
+                    file_type="stream",
+                    file_name=os.path.basename(file_path),
+                )
+        finally:
+            os.unlink(image_path)
+            os.unlink(file_path)
+
+        self.assertEqual(image_key, "img_123")
+        self.assertEqual(file_key, "file_123")
+        self.assertEqual(captured["token_posts"], 1)
+        self.assertEqual(len(captured["upload_urls"]), 2)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_image_file_with_caption_uses_single_post_message(self):
@@ -2341,13 +2501,6 @@ class TestAdapterBehavior(unittest.TestCase):
 
         adapter = FeishuAdapter(PlatformConfig())
         captured = {}
-
-        class _ImageAPI:
-            def create(self, request):
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(image_key="img_123"),
-                )
 
         class _MessageAPI:
             def create(self, request):
@@ -2360,7 +2513,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._client = SimpleNamespace(
             im=SimpleNamespace(
                 v1=SimpleNamespace(
-                    image=_ImageAPI(),
                     message=_MessageAPI(),
                 )
             )
@@ -2374,7 +2526,10 @@ class TestAdapterBehavior(unittest.TestCase):
             image_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch.object(adapter, "_upload_feishu_image_http1", return_value="img_123"),
+            ):
                 result = asyncio.run(
                     adapter.send_image_file(chat_id="oc_chat", image_path=image_path, caption="截图说明")
                 )
@@ -2394,14 +2549,7 @@ class TestAdapterBehavior(unittest.TestCase):
 
         adapter = FeishuAdapter(PlatformConfig())
         captured = {}
-
-        class _FileAPI:
-            def create(self, request):
-                captured["upload_request"] = request
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(file_key="file_video_123"),
-                )
+        upload_file = Mock(return_value="file_video_123")
 
         class _MessageAPI:
             def create(self, request):
@@ -2414,7 +2562,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._client = SimpleNamespace(
             im=SimpleNamespace(
                 v1=SimpleNamespace(
-                    file=_FileAPI(),
                     message=_MessageAPI(),
                 )
             )
@@ -2428,13 +2575,17 @@ class TestAdapterBehavior(unittest.TestCase):
             video_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch.object(adapter, "_upload_feishu_file_http1", upload_file),
+            ):
                 result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
         finally:
             os.unlink(video_path)
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["upload_request"].request_body.file_type, "mp4")
+        upload_file.assert_called_once()
+        self.assertEqual(upload_file.call_args.kwargs["file_type"], "mp4")
         self.assertEqual(captured["message_request"].request_body.msg_type, "media")
         self.assertEqual(captured["message_request"].request_body.content, '{"file_key": "file_video_123"}')
 
@@ -2445,14 +2596,7 @@ class TestAdapterBehavior(unittest.TestCase):
 
         adapter = FeishuAdapter(PlatformConfig())
         captured = {}
-
-        class _FileAPI:
-            def create(self, request):
-                captured["upload_request"] = request
-                return SimpleNamespace(
-                    success=lambda: True,
-                    data=SimpleNamespace(file_key="file_audio_123"),
-                )
+        upload_file = Mock(return_value="file_audio_123")
 
         class _MessageAPI:
             def create(self, request):
@@ -2465,7 +2609,6 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._client = SimpleNamespace(
             im=SimpleNamespace(
                 v1=SimpleNamespace(
-                    file=_FileAPI(),
                     message=_MessageAPI(),
                 )
             )
@@ -2479,13 +2622,17 @@ class TestAdapterBehavior(unittest.TestCase):
             audio_path = tmp.name
 
         try:
-            with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch.object(adapter, "_upload_feishu_file_http1", upload_file),
+            ):
                 result = asyncio.run(adapter.send_voice(chat_id="oc_chat", audio_path=audio_path))
         finally:
             os.unlink(audio_path)
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["upload_request"].request_body.file_type, "opus")
+        upload_file.assert_called_once()
+        self.assertEqual(upload_file.call_args.kwargs["file_type"], "opus")
         self.assertEqual(captured["message_request"].request_body.msg_type, "audio")
         self.assertEqual(captured["message_request"].request_body.content, '{"file_key": "file_audio_123"}')
 


### PR DESCRIPTION
## Summary

Feishu image and file uploads now go through an explicit HTTP/1.1 multipart path so urllib3-future's HTTP/2 default no longer resets the upload stream mid-body. The tenant access token is cached between uploads.

## Why this matters

Reported in #32224: the lark SDK's `image.create` and `file.create` calls went through urllib3-future's HTTP/2 transport. The Feishu open-API server resets the multipart upload stream partway through the body, the SDK swallows the reset, and the caller sees `image_key` / `file_key` missing with no actionable error. Reproduces every time on the upgraded transport.

## Changes

- `gateway/platforms/feishu.py`:
  - adds `_upload_feishu_image_http1()` and `_upload_feishu_file_http1()`: explicit HTTP/1.1 multipart POSTs against the open-API endpoints
  - extracts `_post_feishu_media_upload()` as the shared low-level upload helper
  - adds `_get_tenant_access_token()` with a cached token + expiry so each upload doesn't re-acquire
  - replaces the lark SDK `image.create` / `file.create` calls in `_send_image_file` and the file path with the new helpers
  - surfaces an explicit `SendResult(success=False, error="...")` when the upload response is missing the key, instead of relying on the SDK response shape
- `tests/gateway/test_feishu.py`: covers HTTP/1.1 path, error propagation from raw upload, cached-token reuse across two uploads, single-post-message caption path

## Testing

`pytest tests/gateway/test_feishu.py`

Fixes #32224

AI was used for assistance.
