### PR TITLE
fix(bluebubbles): stop double-delivering messages via updated-message webhook

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -92,6 +92,7 @@ _TAPBACK_REMOVED = {
 
 # Webhook event types that carry user messages
 _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
+_DESIRED_WEBHOOK_EVENTS = ["new-message"]
 
 # Log redaction patterns
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
@@ -363,18 +364,34 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         webhook_url = self._webhook_register_url
 
-        # Crash resilience — reuse an existing registration if present
+        # Crash resilience — reuse an existing registration only if it already
+        # has exactly the desired event set. Older Hermes builds registered
+        # ``updated-message`` too, which can double-deliver the same inbound
+        # message after BlueBubbles metadata/read-state changes.
         existing = await self._find_registered_webhooks(webhook_url)
         if existing:
-            logger.info(
-                "[bluebubbles] webhook already registered: %s",
-                self._webhook_register_url_for_log,
-            )
-            return True
+            stale = [wh for wh in existing if wh.get("events") != _DESIRED_WEBHOOK_EVENTS]
+            if not stale and len(existing) == 1:
+                logger.info(
+                    "[bluebubbles] webhook already registered: %s",
+                    self._webhook_register_url_for_log,
+                )
+                return True
+            # Stale cleanup must succeed before a replacement is created.
+            # ``_unregister_webhook`` swallows a failed DELETE and returns
+            # False; registering anyway would leave the stale registration
+            # live alongside the new one and keep double-delivering.
+            if not await self._unregister_webhook():
+                logger.warning(
+                    "[bluebubbles] could not remove stale webhook registration; "
+                    "skipping re-registration to avoid duplicate delivery: %s",
+                    self._webhook_register_url_for_log,
+                )
+                return False
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message"],
+            "events": list(_DESIRED_WEBHOOK_EVENTS),
         }
 
         try:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -362,18 +362,70 @@ class TestBlueBubblesWebhookRegistration:
     # -- _register_webhook --
 
     def test_register_fresh(self, monkeypatch):
-        """No existing webhook → POST creates one."""
+        """No existing webhook → POST creates a new-message-only registration."""
         import asyncio
         adapter = _make_adapter(monkeypatch)
         adapter.client = self._mock_client(
             get_response={"status": 200, "data": []},
             post_response={"status": 200, "data": {"id": 42}},
         )
+        captured_payload = None
+        orig_api_post = adapter._api_post
+
+        async def tracking_post(path, payload):
+            nonlocal captured_payload
+            captured_payload = payload
+            return await orig_api_post(path, payload)
+
+        adapter._api_post = tracking_post
         ok = asyncio.get_event_loop().run_until_complete(
             adapter._register_webhook()
         )
         assert ok is True
+        assert captured_payload is not None
+        assert captured_payload["events"] == ["new-message"]
 
+
+    def test_register_replaces_stale_event_registration(self, monkeypatch):
+        """Existing matching URL with updated-message is removed and recreated cleanly."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        url = adapter._webhook_register_url
+        deleted = []
+        captured_payload = None
+
+        adapter.client = self._mock_client(
+            get_response={"status": 200, "data": [
+                {"id": 7, "url": url, "events": ["new-message", "updated-message"]},
+            ]},
+            post_response={"status": 200, "data": {"id": 8}},
+        )
+
+        async def tracking_delete(*args, **kwargs):
+            deleted.append(args[0] if args else "")
+            class R:
+                status_code = 200
+                def raise_for_status(self):
+                    pass
+            return R()
+
+        orig_api_post = adapter._api_post
+
+        async def tracking_post(path, payload):
+            nonlocal captured_payload
+            captured_payload = payload
+            return await orig_api_post(path, payload)
+
+        adapter.client.delete = tracking_delete
+        adapter._api_post = tracking_post
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+        assert ok is True
+        assert len(deleted) == 1
+        assert "/api/v1/webhook/7" in deleted[0]
+        assert captured_payload is not None
+        assert captured_payload["events"] == ["new-message"]
 
     def test_register_reuses_existing(self, monkeypatch):
         """Crash resilience — existing registration is reused, no POST needed."""
@@ -438,3 +490,81 @@ class TestBlueBubblesWebhookRegistration:
         assert len(deleted_ids) == 2
 
 
+
+
+class TestBlueBubblesStaleRegistrationFailureHandling:
+    """A failed stale-registration DELETE must not be followed by a POST.
+
+    ``_unregister_webhook`` catches a failing DELETE and returns False. If
+    ``_register_webhook`` ignores that result it will create a second live
+    registration while the stale ``updated-message`` one survives, which is
+    exactly the double-delivery this PR removes.
+    """
+
+    @staticmethod
+    def _adapter(monkeypatch, registrations, delete_ok):
+        adapter = _make_adapter(monkeypatch)
+        posted = []
+
+        async def mock_get(*args, **kwargs):
+            class R:
+                status_code = 200
+                def raise_for_status(self):
+                    pass
+                def json(self):
+                    return {"status": 200, "data": registrations}
+            return R()
+
+        async def mock_post(*args, **kwargs):
+            posted.append((args, kwargs))
+            class R:
+                status_code = 200
+                def raise_for_status(self):
+                    pass
+                def json(self):
+                    return {"status": 200, "data": {"id": 99}}
+            return R()
+
+        async def mock_delete(*args, **kwargs):
+            class R:
+                status_code = 200 if delete_ok else 500
+                def raise_for_status(self_inner):
+                    if not delete_ok:
+                        raise Exception("delete failed")
+            return R()
+
+        adapter.client = type(
+            "MockClient", (),
+            {"get": mock_get, "post": mock_post, "delete": mock_delete},
+        )()
+        return adapter, posted
+
+    @pytest.mark.asyncio
+    async def test_failed_delete_performs_no_replacement_post(self, monkeypatch):
+        adapter, _ = self._adapter(monkeypatch, [], True)
+        url = adapter._webhook_register_url
+        adapter, posted = self._adapter(
+            monkeypatch,
+            [{"id": 1, "url": url, "events": ["new-message", "updated-message"]}],
+            delete_ok=False,
+        )
+
+        ok = await adapter._register_webhook()
+
+        assert ok is False, "failed stale cleanup must be reported"
+        assert not posted, "no replacement POST while the stale registration is live"
+
+    @pytest.mark.asyncio
+    async def test_successful_delete_registers_replacement(self, monkeypatch):
+        adapter, _ = self._adapter(monkeypatch, [], True)
+        url = adapter._webhook_register_url
+        adapter, posted = self._adapter(
+            monkeypatch,
+            [{"id": 1, "url": url, "events": ["new-message", "updated-message"]}],
+            delete_ok=True,
+        )
+
+        ok = await adapter._register_webhook()
+
+        assert ok is True
+        assert len(posted) == 1, "stale registration replaced with the desired one"


### PR DESCRIPTION
## Summary

The BlueBubbles gateway adapter was registering its webhook with `events=["new-message", "updated-message"]`. BlueBubbles fires `updated-message` whenever message metadata changes (read receipts, edit state, tapback updates), so any inbound message produced two webhook deliveries to Hermes:

1. one from `new-message` (the inbound message)
2. one (or more) from a subsequent `updated-message` for the same message

For text inbounds this could double-trigger gateway processing of the same message.

Additionally, on adapter startup the crash-resilience path *reused* any existing registration verbatim. Older Hermes builds had registered the `[new-message, updated-message]` event set, so the bug persisted across restarts even after a code fix — the stale registration was never replaced.

## Fix

1. Register only `["new-message"]` going forward.
2. On startup, treat an existing registration as reusable **only** if its event list exactly matches the desired set. Otherwise unregister it and re-create, so older `updated-message` registrations get cleaned up automatically the next time the gateway restarts.

A single-element `_DESIRED_WEBHOOK_EVENTS` constant keeps the registration payload and the equality check in lockstep.

## Tests

Three test changes/additions in `tests/gateway/test_bluebubbles.py::TestBlueBubblesWebhookRegistration`:

- `test_register_fresh` — now also asserts the POST payload `events == ["new-message"]`.
- `test_register_replaces_stale_event_registration` (new) — an existing `[new-message, updated-message]` registration is DELETEd and re-POSTed with `[new-message]`.
- `test_register_reuses_existing` — unchanged behavior for the matching-events case.

All three pass:

```
tests/gateway/test_bluebubbles.py ...   [100%]
3 passed, 48 deselected in 0.12s
```
