### PR TITLE
fix: include Slack thread images in mention context

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -70,6 +70,9 @@ class _ThreadContextCache:
     fetched_at: float = field(default_factory=time.monotonic)
     message_count: int = 0
     parent_text: str = ""  # Raw text of the thread parent (for reply_to_text injection)
+    media_urls: List[str] = field(default_factory=list)
+    media_types: List[str] = field(default_factory=list)
+    attachment_notices: List[str] = field(default_factory=list)
 
 
 def check_slack_requirements() -> bool:
@@ -2008,6 +2011,10 @@ class SlackAdapter(BasePlatformAdapter):
                     for t in to_remove:
                         self._mentioned_threads.discard(t)
 
+        media_urls = []
+        media_types = []
+        attachment_notices: List[str] = []
+
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
         if is_thread_reply and not self._has_active_session_for_thread(
@@ -2023,6 +2030,12 @@ class SlackAdapter(BasePlatformAdapter):
             )
             if thread_context:
                 text = thread_context + text
+            cache_key = f"{channel_id}:{event_thread_ts}:{team_id}"
+            cached_context = self._thread_context_cache.get(cache_key)
+            if cached_context:
+                media_urls.extend(cached_context.media_urls)
+                media_types.extend(cached_context.media_types)
+                attachment_notices.extend(cached_context.attachment_notices)
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -2030,9 +2043,6 @@ class SlackAdapter(BasePlatformAdapter):
             msg_type = MessageType.COMMAND
 
         # Handle file attachments
-        media_urls = []
-        media_types = []
-        attachment_notices: List[str] = []
         files = event.get("files", [])
         for f in files:
             # Slack Connect channels return stub file objects with
@@ -2576,6 +2586,71 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Thread context fetching -----
 
+    async def _cache_image_files_from_slack_message(
+        self,
+        *,
+        files: List[Dict[str, Any]],
+        channel_id: str,
+        team_id: str = "",
+    ) -> Tuple[List[str], List[str], List[str]]:
+        """Download image attachments from a Slack message into Hermes' media cache."""
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        attachment_notices: List[str] = []
+
+        for file_obj in files or []:
+            f = file_obj
+            if f.get("file_access") == "check_file_info":
+                file_id = f.get("id")
+                if not file_id:
+                    continue
+                try:
+                    info_resp = await self._get_client(channel_id).files_info(file=file_id)
+                    if info_resp.get("ok"):
+                        f = info_resp["file"]
+                    else:
+                        detail = self._describe_slack_api_error(info_resp, file_obj=f)
+                        if detail:
+                            attachment_notices.append(detail)
+                            logger.warning("[Slack] %s", detail)
+                        else:
+                            logger.warning(
+                                "[Slack] files.info failed for %s: %s",
+                                file_id, info_resp.get("error"),
+                            )
+                        continue
+                except Exception as e:
+                    response = getattr(e, "response", None)
+                    detail = self._describe_slack_api_error(response, file_obj=f)
+                    if detail:
+                        attachment_notices.append(detail)
+                        logger.warning("[Slack] %s", detail)
+                    else:
+                        logger.warning("[Slack] files.info error for %s: %s", file_id, e, exc_info=True)
+                    continue
+
+            mimetype = f.get("mimetype", "unknown")
+            url = f.get("url_private_download") or f.get("url_private", "")
+            if not mimetype.startswith("image/") or not url:
+                continue
+
+            try:
+                ext = "." + mimetype.split("/")[-1].split(";")[0]
+                if ext not in {".jpg", ".jpeg", ".png", ".gif", ".webp"}:
+                    ext = ".jpg"
+                cached = await self._download_slack_file(url, ext, team_id=team_id)
+                media_urls.append(cached)
+                media_types.append(mimetype)
+            except Exception as e:  # pragma: no cover - defensive logging
+                detail = self._describe_slack_download_failure(e, file_obj=f)
+                if detail:
+                    attachment_notices.append(detail)
+                    logger.warning("[Slack] %s", detail)
+                else:
+                    logger.warning("[Slack] Failed to cache image from %s: %s", url, e, exc_info=True)
+
+        return media_urls, media_types, attachment_notices
+
     async def _fetch_thread_context(
         self, channel_id: str, thread_ts: str, current_ts: str,
         team_id: str = "", limit: int = 30,
@@ -2643,6 +2718,9 @@ class SlackAdapter(BasePlatformAdapter):
             bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
             context_parts = []
             parent_text = ""
+            thread_media_urls: List[str] = []
+            thread_media_types: List[str] = []
+            thread_attachment_notices: List[str] = []
             for msg in messages:
                 msg_ts = msg.get("ts", "")
                 # Exclude the current triggering message — it will be delivered
@@ -2676,8 +2754,6 @@ class SlackAdapter(BasePlatformAdapter):
                     continue
 
                 msg_text = msg.get("text", "").strip()
-                if not msg_text:
-                    continue
 
                 # Strip bot mentions from context messages
                 if bot_uid:
@@ -2689,6 +2765,25 @@ class SlackAdapter(BasePlatformAdapter):
                 if is_bot and not display_user:
                     display_user = msg.get("username") or "bot"
                 name = await self._resolve_user_name(display_user, chat_id=channel_id)
+                msg_media_urls, msg_media_types, msg_attachment_notices = await self._cache_image_files_from_slack_message(
+                    files=msg.get("files", []),
+                    channel_id=channel_id,
+                    team_id=msg.get("team") or team_id,
+                )
+                if msg_media_urls:
+                    thread_media_urls.extend(msg_media_urls)
+                    thread_media_types.extend(msg_media_types)
+                    attachment_label = "image" if len(msg_media_urls) == 1 else f"{len(msg_media_urls)} images"
+                    if msg_text:
+                        msg_text = f"{msg_text} [attached {attachment_label}]"
+                    else:
+                        msg_text = f"[attached {attachment_label}]"
+                if msg_attachment_notices:
+                    thread_attachment_notices.extend(msg_attachment_notices)
+
+                if not msg_text:
+                    continue
+
                 context_parts.append(f"{prefix}{name}: {msg_text}")
                 if is_parent:
                     parent_text = msg_text
@@ -2706,6 +2801,9 @@ class SlackAdapter(BasePlatformAdapter):
                 fetched_at=now,
                 message_count=len(context_parts),
                 parent_text=parent_text,
+                media_urls=thread_media_urls,
+                media_types=thread_media_types,
+                attachment_notices=thread_attachment_notices,
             )
             return content
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -92,6 +92,57 @@ def _redirect_cache(tmp_path, monkeypatch):
     )
 
 
+@pytest.mark.asyncio
+async def test_thread_context_images_are_forwarded_to_message_event(adapter):
+    client = AsyncMock()
+    client.conversations_replies = AsyncMock(return_value={
+        "messages": [
+            {
+                "ts": "1000.0",
+                "user": "U1",
+                "text": "Here is the shelf photo",
+                "files": [
+                    {
+                        "id": "F1",
+                        "name": "shelf.jpg",
+                        "mimetype": "image/jpeg",
+                        "url_private_download": "https://files.slack.com/files-pri/T1-F1/shelf.jpg",
+                    }
+                ],
+            },
+            {
+                "ts": "1000.1",
+                "user": "U2",
+                "text": "<@U_BOT> can you check the photo above?",
+            },
+        ]
+    })
+    adapter._app.client = client
+    adapter._team_clients = {"T1": client}
+    adapter._team_bot_user_ids = {"T1": "U_BOT"}
+    adapter._channel_team = {"C1": "T1"}
+    adapter._user_name_cache = {"U1": "Alice", "U2": "Bob"}
+    adapter._download_slack_file = AsyncMock(return_value="/tmp/hermes-shelf.jpg")
+
+    await adapter._handle_slack_message({
+        "type": "app_mention",
+        "channel": "C1",
+        "channel_type": "channel",
+        "team": "T1",
+        "thread_ts": "1000.0",
+        "ts": "1000.1",
+        "user": "U2",
+        "text": "<@U_BOT> can you check the photo above?",
+    })
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.media_urls == ["/tmp/hermes-shelf.jpg"]
+    assert event.media_types == ["image/jpeg"]
+    assert event.message_type == MessageType.PHOTO
+    assert "Alice: Here is the shelf photo [attached image]" in event.text
+
+
 # ---------------------------------------------------------------------------
 # TestSlashCommandSessionIsolation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- cache image attachments from prior Slack thread messages when fetching first-turn thread context
- forward those cached images through the inbound MessageEvent so vision routing can see photos posted before the @mention
- add a regression test for @mentioning Hermes in a thread whose parent message includes an image

## Tests
- /usr/local/lib/hermes-agent/venv/bin/python -S with worktree path + venv site-packages, pytest -q -o addopts= tests/gateway/test_slack.py::test_thread_context_images_are_forwarded_to_message_event tests/gateway/test_slack_approval_buttons.py::TestSlackThreadContext