### PR TITLE
fix(tui): contain libopentui.so /tmp file-handle leak (#32283)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1489,6 +1489,17 @@ def _launch_tui(
     env.setdefault("HERMES_CWD", os.getcwd())
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
 
+    # Contain the bundled-TUI libopentui.so /tmp leak (#32283): redirect
+    # the child's TMPDIR to a profile-scoped path under HERMES_HOME and
+    # sweep stale .<hex>-<digits>.so leak files from /tmp on every launch.
+    try:
+        from hermes_cli.tui_tmpdir import prepare_tui_tmpdir
+        from hermes_constants import get_hermes_home
+
+        prepare_tui_tmpdir(env, get_hermes_home())
+    except Exception:
+        pass
+
     wt_info = None
     if worktree:
         try:

--- a/hermes_cli/tui_tmpdir.py
+++ b/hermes_cli/tui_tmpdir.py
@@ -1,0 +1,97 @@
+"""Contain the bundled-TUI ``libopentui.so`` ``/tmp`` leak (issue #32283).
+
+The Ink TUI's bundled native helper extracts a ~4.5 MB ``libopentui.so``
+to ``os.tmpdir()`` on every render cycle and never reaps prior copies.
+On Linux installs where ``/tmp`` lives on the root partition (the
+common case), this fills the root disk in ~3 days — ~360-600 new
+``.so`` copies per hour, ~38 GB/day — and the agent then errors out
+with "no disk space" on every operation.
+
+Until the bundled extractor is patched to cache the file at a stable
+path, the Python launcher contains the leak at the *spawner* layer:
+
+1. Point ``TMPDIR`` at a profile-scoped directory under ``HERMES_HOME``
+   so the leak can never exhaust the root partition (the scoped dir is
+   on whichever filesystem the user already accepted for Hermes state).
+2. Sweep stale leak files (``.<hex>-<digits>.so``) from both ``/tmp``
+   and the scoped directory before spawning the TUI, so a long-running
+   user doesn't carry yesterday's leak forward.
+
+The sweep is *only* against the leak-specific filename pattern — it
+never touches well-formed shared objects, lockfiles, or anything else
+that legitimately lives in ``/tmp``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Iterable
+
+# Leak filenames look like ``/tmp/.f9f3dfe75bcf4fff-00000000.so`` —
+# a leading dot, lowercase-hex digest (16 chars in the wild but other
+# extractor builds use 8–32), a dash, a decimal counter, ``.so``.
+# This is deliberately tight so we never sweep an unrelated ``.so``.
+_LEAK_RE = re.compile(r"^\.[0-9a-f]{8,32}-\d{1,12}\.so$")
+
+
+def is_leak_filename(name: str) -> bool:
+    """True for ``.<hex>-<digits>.so`` filenames produced by the leak."""
+    return bool(_LEAK_RE.match(name))
+
+
+def sweep_libopentui_leaks(roots: Iterable[Path]) -> int:
+    """Unlink stale leak files in each root; return the number removed.
+
+    Missing roots, non-directory roots, and per-file ``unlink`` errors
+    are swallowed — sweeping is best-effort and must never block the
+    TUI from launching.
+    """
+    freed = 0
+    for root in roots:
+        try:
+            entries = list(root.iterdir())
+        except (FileNotFoundError, NotADirectoryError, PermissionError, OSError):
+            continue
+        for entry in entries:
+            if not is_leak_filename(entry.name):
+                continue
+            try:
+                entry.unlink()
+            except OSError:
+                continue
+            freed += 1
+    return freed
+
+
+def prepare_tui_tmpdir(env: dict, hermes_home: Path) -> Path:
+    """Point ``TMPDIR`` at a profile-scoped path and sweep prior leaks.
+
+    If the caller already set ``TMPDIR`` in ``env`` we honour it (the
+    user/operator may have a deliberate redirect, e.g. tmpfs mount) and
+    only sweep that location plus ``/tmp``.
+
+    Returns the scoped tmpdir path.
+    """
+    existing = (env.get("TMPDIR") or "").strip()
+    if existing:
+        scoped = Path(existing)
+    else:
+        scoped = hermes_home / "run" / "tui-tmp"
+        env["TMPDIR"] = str(scoped)
+
+    try:
+        scoped.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+
+    roots = [scoped]
+    # ``/tmp`` only exists on POSIX-like systems; the bug is Linux-only
+    # in practice (Windows has no ``/tmp`` and macOS ``$TMPDIR`` already
+    # points at a per-user dir under ``/var/folders``).
+    if os.name == "posix":
+        roots.append(Path("/tmp"))
+
+    sweep_libopentui_leaks(roots)
+    return scoped

--- a/tests/hermes_cli/test_tui_tmpdir.py
+++ b/tests/hermes_cli/test_tui_tmpdir.py
@@ -1,0 +1,137 @@
+"""Regression coverage for the ``libopentui.so`` /tmp leak fix (#32283).
+
+The TUI launcher now redirects ``TMPDIR`` to a profile-scoped path under
+``HERMES_HOME`` and sweeps the leak-specific ``.<hex>-<digits>.so``
+files before spawning the Ink child.  These tests pin both behaviours
+so a future refactor cannot silently re-enable the leak.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.tui_tmpdir import (
+    is_leak_filename,
+    prepare_tui_tmpdir,
+    sweep_libopentui_leaks,
+)
+
+
+class TestIsLeakFilename:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            ".f9f3dfe75bcf4fff-00000000.so",  # canonical shape from the bug report
+            ".deadbeef-1.so",
+            ".aabbccddeeff0011-12345.so",
+            ".0123456789abcdef0123456789abcdef-9.so",  # max-length hex digest
+        ],
+    )
+    def test_matches_leak_shapes(self, name):
+        assert is_leak_filename(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "libopentui.so",                       # legit shared object
+            "f9f3dfe75bcf4fff-00000000.so",        # missing leading dot
+            ".f9f3dfe75bcf4fff-00000000.txt",      # wrong extension
+            ".F9F3DFE7-0.so",                      # uppercase hex (extractor uses lowercase)
+            ".abcd-0.dylib",                       # not .so
+            ".abc-12345678901234.so",              # counter too long (>12 digits)
+            ".abc-.so",                            # missing counter
+            ".-1.so",                              # missing hex
+            ".session-active.json",                # unrelated tempfile shape
+        ],
+    )
+    def test_does_not_match_unrelated_files(self, name):
+        assert not is_leak_filename(name)
+
+
+class TestSweep:
+    def test_removes_only_leak_files(self, tmp_path):
+        leaks = [tmp_path / f".deadbeef-{i}.so" for i in range(3)]
+        keep = [
+            tmp_path / "libopentui.so",
+            tmp_path / ".session-active.json",
+            tmp_path / ".abc-1.dylib",
+        ]
+        for p in leaks + keep:
+            p.write_bytes(b"x")
+
+        freed = sweep_libopentui_leaks([tmp_path])
+
+        assert freed == 3
+        assert not any(p.exists() for p in leaks)
+        assert all(p.exists() for p in keep)
+
+    def test_missing_root_is_silent(self, tmp_path):
+        ghost = tmp_path / "does-not-exist"
+        assert sweep_libopentui_leaks([ghost]) == 0
+
+    def test_skips_files_passed_as_roots(self, tmp_path):
+        f = tmp_path / "regular-file"
+        f.write_bytes(b"x")
+        assert sweep_libopentui_leaks([f]) == 0
+        assert f.exists()
+
+    def test_sweeps_across_multiple_roots(self, tmp_path):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        (a / ".aaaaaaaa-1.so").write_bytes(b"x")
+        (b / ".bbbbbbbb-2.so").write_bytes(b"x")
+        assert sweep_libopentui_leaks([a, b]) == 2
+
+    def test_unlink_errors_are_swallowed(self, tmp_path, monkeypatch):
+        leak = tmp_path / ".deadbeef-1.so"
+        leak.write_bytes(b"x")
+        from pathlib import Path as _P
+
+        def boom(self):
+            raise PermissionError("read-only fs")
+
+        monkeypatch.setattr(_P, "unlink", boom)
+        # Should not raise, and should count zero (unlink failed for the
+        # only file present).
+        assert sweep_libopentui_leaks([tmp_path]) == 0
+
+
+class TestPrepareTuiTmpdir:
+    def test_sets_tmpdir_under_hermes_home_when_unset(self, tmp_path):
+        env: dict = {}
+        scoped = prepare_tui_tmpdir(env, tmp_path)
+
+        assert scoped == tmp_path / "run" / "tui-tmp"
+        assert env["TMPDIR"] == str(scoped)
+        assert scoped.is_dir()
+
+    def test_honours_existing_tmpdir(self, tmp_path):
+        custom = tmp_path / "custom-tmp"
+        env = {"TMPDIR": str(custom)}
+
+        scoped = prepare_tui_tmpdir(env, tmp_path / "irrelevant")
+
+        assert scoped == custom
+        assert env["TMPDIR"] == str(custom)
+        assert custom.is_dir()
+
+    def test_sweeps_scoped_dir_before_returning(self, tmp_path):
+        custom = tmp_path / "custom-tmp"
+        custom.mkdir()
+        leak = custom / ".cafef00d-7.so"
+        keep = custom / "libopentui.so"
+        leak.write_bytes(b"x")
+        keep.write_bytes(b"x")
+
+        prepare_tui_tmpdir({"TMPDIR": str(custom)}, tmp_path)
+
+        assert not leak.exists()
+        assert keep.exists()
+
+    def test_empty_tmpdir_is_treated_as_unset(self, tmp_path):
+        env = {"TMPDIR": "   "}
+        scoped = prepare_tui_tmpdir(env, tmp_path)
+        assert scoped == tmp_path / "run" / "tui-tmp"
+        assert env["TMPDIR"] == str(scoped)


### PR DESCRIPTION
## What does this PR do?

Contains the bundled-TUI ``libopentui.so`` ``/tmp`` file-handle leak reported in [#32283](https://github.com/NousResearch/hermes-agent/issues/32283) at the spawner layer, until the underlying extractor is patched to cache the file at a stable path.

The Ink TUI's transitive native helper re-extracts ``libopentui.so`` (~4.5 MB) to ``os.tmpdir()`` on every render cycle and never reaps prior copies. On Linux installs where ``/tmp`` lives on the root partition (the default Ubuntu layout) this fills the root disk in ~3 days — ~360-600 new ``.<hex>-<digits>.so`` files per hour, ~38 GB/day — and Hermes then errors out with "no disk space" on every operation. The reporter's cron-based sweep is a band-aid because the leak keeps happening.

The fix is a small spawner-side guard that runs before every TUI spawn:

- **Confine** — point the child's ``TMPDIR`` at ``HERMES_HOME / "run" / "tui-tmp"`` so the leak lands on whichever filesystem the user already accepted for Hermes state, not the root partition.
- **Reap** — sweep stale ``.<hex>-<digits>.so`` files from both ``/tmp`` (cleans up the user's pre-existing leak) and the scoped dir before spawning.

The sweep regex is deliberately tight (keyed on the exact shape from the bug report — leading dot, 8-32 lowercase hex chars, dash, ≤12-digit counter, ``.so``) so legitimate files in ``/tmp`` are never touched.

## Related Issue

[#32283](https://github.com/NousResearch/hermes-agent/issues/32283) — libopentui.so file handle leak fills /tmp with thousands of identical .so copies, exhausting root disk.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- ``hermes_cli/tui_tmpdir.py`` (new, +97 lines) — three helpers:
  - ``is_leak_filename(name)`` / ``_LEAK_RE`` — tight regex (``^\.[0-9a-f]{8,32}-\d{1,12}\.so$``) keyed on the leak's exact filename shape; rejects real ``.so`` files, ``.dylib``, uppercase hex, missing dot, etc.
  - ``sweep_libopentui_leaks(roots)`` — best-effort ``unlink`` across each root; swallows ``FileNotFoundError`` / ``PermissionError`` / ``OSError`` so a sweep failure can never block the TUI from launching. Returns the count freed for observability.
  - ``prepare_tui_tmpdir(env, hermes_home)`` — sets ``TMPDIR`` to a profile-scoped path when unset, honours an existing ``TMPDIR``, sweeps both the scoped dir and (on POSIX) ``/tmp`` before returning.
- ``hermes_cli/main.py`` (+11 lines) — wire ``prepare_tui_tmpdir`` into ``_launch_tui`` right after ``NODE_ENV`` is set and before profile/model/toolset env vars are layered on. Wrapped in a broad ``try/except`` because the TUI launcher is the user's only recovery surface (``hermes update``, ``hermes doctor`` all live inside it) and the guard must NEVER prevent the TUI from spawning.
- ``tests/hermes_cli/test_tui_tmpdir.py`` (new, +137 lines, 22 cases across 3 classes):
  - ``TestIsLeakFilename`` — 13 cases: 4 positives, 9 parametrised negatives (real ``libopentui.so``, missing dot, wrong extension, uppercase hex, ``.dylib``, overlong counter, unrelated dotted tempfile).
  - ``TestSweep`` — 5 cases: mixed dir (only leak files removed), silent-on-missing-root, file-as-root no-op, multi-root summation, ``OSError``-swallowing invariant via ``monkeypatch`` on ``Path.unlink``.
  - ``TestPrepareTuiTmpdir`` — 4 cases: default scoped path, honour existing ``TMPDIR``, scoped-dir sweep before return, whitespace-only ``TMPDIR`` treated as unset.

The TUI bundle / Ink JS source is untouched — this PR only changes how the Python launcher prepares the child's environment.

## How to Test

1. Check out this branch and ensure ``.venv`` is set up: ``python3 -m venv .venv && source .venv/bin/activate && pip install -e \".[all,dev]\"``
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_tui_tmpdir.py
   ```
   Expected: 22 passed.
3. Run the related TUI launcher tests to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_tui_tmpdir.py tests/hermes_cli/test_tui_bundled.py tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_tui_npm_install.py
   ```
   Expected: 80 passed.
4. (Linux only) End-to-end manual repro:
   ```
   # Before:
   find /tmp -maxdepth 1 -name '.*.so' | wc -l   # accumulates while TUI runs
   # After (this PR):
   hermes --tui                                  # spawn the TUI
   ls -la \"$HERMES_HOME/run/tui-tmp\"             # any leaks land here, not /tmp
   find /tmp -maxdepth 1 -name '.*.so' | wc -l   # 0 after first spawn (sweep ran)
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (``fix(tui): …`` × 2, ``test(tui): …`` × 1)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run ``scripts/run_tests.sh tests/hermes_cli/test_tui_tmpdir.py`` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, ``docs/``, docstrings) — N/A (internal launcher helper; behavior is documented in the module docstring)
- [x] I've updated ``cli-config.yaml.example`` if I added/changed config keys — N/A (no new config keys; ``TMPDIR`` is a standard env var)
- [x] I've updated ``CONTRIBUTING.md`` or ``AGENTS.md`` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — ``/tmp`` sweep is POSIX-only (gated on ``os.name == 'posix'``); the ``TMPDIR`` redirect is portable; tests are hermetic (``tmp_path`` + ``monkeypatch``).
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
\$ scripts/run_tests.sh tests/hermes_cli/test_tui_tmpdir.py
Discovered 1 test files (22 tests) under ['tests/hermes_cli/test_tui_tmpdir.py']; running with -j 24
[100.0% |    22/22 | ✓22 | ✗ 0] ✓ tests/hermes_cli/test_tui_tmpdir.py (22✓, 0.4s)
=== Summary: 1 files, 22 tests passed, 0 failed (100% complete) in 0.4s (24 workers) ===

\$ scripts/run_tests.sh tests/hermes_cli/test_tui_tmpdir.py tests/hermes_cli/test_tui_bundled.py tests/hermes_cli/test_tui_resume_flow.py tests/hermes_cli/test_tui_npm_install.py
Discovered 4 test files (80 tests) under [...]
[100.0% |    80/80 | ✓80 | ✗ 0] ✓ ...
=== Summary: 4 files, 80 tests passed, 0 failed (100% complete) in 1.6s ===
```