### PR TITLE
feat(dashboard): add agent situation board

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -21,6 +21,7 @@ import sys
 import threading
 import time
 import urllib.parse
+from datetime import datetime
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -770,6 +771,494 @@ async def get_action_status(name: str, lines: int = 200):
         "pid": pid,
         "lines": tail,
     }
+
+
+_AGENT_STATUSES = ("working", "idle", "needs_input", "blocked", "failed", "done", "scheduled")
+_AGENT_ATTENTION_ORDER = {
+    "failed": 0,
+    "blocked": 1,
+    "needs_input": 2,
+    "working": 3,
+    "scheduled": 4,
+    "done": 5,
+    "idle": 6,
+}
+_NEEDS_INPUT_MARKERS = (
+    "?",
+    "approve",
+    "approval",
+    "proceed",
+    "confirm",
+    "clarify",
+    "승인",
+    "확인",
+    "진행할까요",
+    "필요합니다",
+)
+_BLOCKED_MARKERS = (
+    "blocked",
+    "failed",
+    "failure",
+    "error",
+    "traceback",
+    "exception",
+    "auth failed",
+    "token expired",
+    "permission denied",
+    "막힘",
+    "실패",
+    "오류",
+    "에러",
+)
+
+
+def _agent_identity_from_session(session: Dict[str, Any]) -> Tuple[str, str, str]:
+    """Infer display identity from a session row without inventing state."""
+    haystack = " ".join(
+        str(session.get(k) or "") for k in ("source", "title", "preview", "model")
+    ).lower()
+    if "openclaw" in haystack or "댕댕" in haystack:
+        return "OpenClaw", "openclaw", "dog"
+    if "omx" in haystack:
+        return "OMX Worker", "omx_worker", "omx"
+    if "codex" in haystack:
+        return "Codex Worker", "codex_worker", "codex"
+
+    source = str(session.get("source") or "session").strip() or "session"
+    return f"Hermes {source.title()}", "hermes_session", "hermes"
+
+
+def _session_agent_status(session: Dict[str, Any], now: Optional[float] = None) -> str:
+    text = " ".join(str(session.get(k) or "") for k in ("title", "preview")).lower()
+    if any(marker in text for marker in _BLOCKED_MARKERS):
+        return "blocked"
+    if any(marker in text for marker in _NEEDS_INPUT_MARKERS):
+        return "needs_input"
+    if session.get("ended_at") is not None:
+        return "done"
+    if session.get("is_active"):
+        return "working"
+
+    now = time.time() if now is None else now
+    last_active = session.get("last_active") or session.get("started_at") or 0
+    try:
+        recent = (now - float(last_active)) < 300
+    except (TypeError, ValueError):
+        recent = False
+    return "working" if recent else "idle"
+
+
+def _agent_from_session(session: Dict[str, Any], now: Optional[float] = None) -> Dict[str, Any]:
+    """Convert a dashboard session row into an Agent Situation Board record."""
+    raw_id = str(session.get("id") or session.get("session_id") or "unknown")
+    name, kind, avatar = _agent_identity_from_session(session)
+    status = _session_agent_status(session, now=now)
+    source = str(session.get("source") or "session")
+    title = session.get("title") or "Untitled session"
+    preview = session.get("preview") or title
+    tool_calls = int(session.get("tool_call_count") or 0)
+    messages = int(session.get("message_count") or 0)
+    actions = ["peek", "open"]
+    if status in {"working", "idle", "needs_input", "blocked"}:
+        actions.append("reply")
+
+    return {
+        "id": f"session:{raw_id}",
+        "name": name,
+        "kind": kind,
+        "avatar": avatar,
+        "status": status,
+        "source": source,
+        "location": source,
+        "title": title,
+        "current_task": preview,
+        "progress": None,
+        "started_at": session.get("started_at"),
+        "last_signal_at": session.get("last_active") or session.get("started_at"),
+        "last_signal": f"{tool_calls} tool calls · {messages} messages",
+        "links": [{"label": "Sessions", "href": "/sessions"}],
+        "actions": actions,
+        "metadata": {
+            "model": session.get("model"),
+            "message_count": messages,
+            "tool_call_count": tool_calls,
+            "ended_at": session.get("ended_at"),
+        },
+    }
+
+
+def _coerce_agent_timestamp(value: Any) -> Optional[float]:
+    """Best-effort conversion of dashboard-adapter timestamps to epoch seconds."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            pass
+        try:
+            return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            return None
+    return None
+
+
+def _short_text(value: Any, fallback: str = "") -> str:
+    text = str(value or fallback or "").strip()
+    return text[:200]
+
+
+def _agent_from_cron_job(job: Dict[str, Any], now: Optional[float] = None) -> Dict[str, Any]:
+    """Convert a cron job record into an Agent Situation Board record."""
+    job_id = _short_text(job.get("id"), "unknown")
+    name = _short_text(job.get("name") or job.get("prompt") or job_id, "cron job")
+    enabled = bool(job.get("enabled", True))
+    state = _short_text(job.get("state"), "scheduled").lower()
+    error = job.get("last_error") or job.get("error") or job.get("delivery_error")
+    status = "failed" if error else ("scheduled" if enabled and state != "paused" else "idle")
+    if state in {"running", "working"}:
+        status = "working"
+    schedule_display = _short_text(job.get("schedule_display") or job.get("schedule"), "?")
+    next_run = job.get("next_run_at")
+    last_run = job.get("last_run_at")
+    last_signal_at = _coerce_agent_timestamp(last_run) or _coerce_agent_timestamp(next_run) or now
+    last_signal = f"next: {next_run or 'not scheduled'} · {schedule_display}"
+    if error:
+        last_signal = _short_text(error)
+
+    return {
+        "id": f"cron:{job_id}",
+        "name": f"Cron: {name}",
+        "kind": "cron_job",
+        "avatar": "clock",
+        "status": status,
+        "source": "cron",
+        "location": _short_text(job.get("deliver"), "scheduler"),
+        "title": name,
+        "current_task": _short_text(job.get("prompt") or job.get("script") or name),
+        "progress": None,
+        "started_at": _coerce_agent_timestamp(job.get("created_at")),
+        "last_signal_at": last_signal_at,
+        "last_signal": last_signal,
+        "links": [{"label": "Cron", "href": "/cron"}],
+        "actions": ["peek", "open"],
+        "metadata": {
+            "schedule": job.get("schedule"),
+            "schedule_display": schedule_display,
+            "next_run_at": next_run,
+            "last_run_at": last_run,
+            "state": state,
+            "enabled": enabled,
+            "profile": job.get("profile"),
+            "repeat": job.get("repeat"),
+        },
+    }
+
+
+def _kanban_status_to_agent_status(status: str) -> str:
+    return {
+        "running": "working",
+        "blocked": "blocked",
+        "review": "needs_input",
+        "done": "done",
+        "scheduled": "scheduled",
+        "ready": "scheduled",
+        "todo": "scheduled",
+        "triage": "needs_input",
+        "archived": "done",
+    }.get((status or "").lower(), "idle")
+
+
+def _agent_identity_from_text(text: str) -> Tuple[str, str]:
+    haystack = text.lower()
+    if "omx" in haystack:
+        return "omx", "omx"
+    if "codex" in haystack:
+        return "codex", "codex"
+    if "openclaw" in haystack or "댕댕" in haystack:
+        return "dog", "openclaw"
+    return "kanban", "kanban"
+
+
+def _task_field(task: Any, key: str, default: Any = None) -> Any:
+    if isinstance(task, dict):
+        return task.get(key, default)
+    return getattr(task, key, default)
+
+
+def _agent_from_kanban_task(task: Any, *, board: str = "default", now: Optional[float] = None) -> Dict[str, Any]:
+    """Convert a Kanban task/worker row into an Agent Situation Board record."""
+    task_id = _short_text(_task_field(task, "id"), "unknown")
+    title = _short_text(_task_field(task, "title"), "Untitled task")
+    assignee = _short_text(_task_field(task, "assignee"), "unassigned")
+    raw_status = _short_text(_task_field(task, "status"), "todo").lower()
+    agent_status = _kanban_status_to_agent_status(raw_status)
+    text = " ".join([assignee, title, _short_text(_task_field(task, "body"))])
+    avatar, _identity = _agent_identity_from_text(text)
+    priority = int(_task_field(task, "priority", 0) or 0)
+    pid = _task_field(task, "worker_pid")
+    failures = int(_task_field(task, "consecutive_failures", 0) or 0)
+    last_failure = _task_field(task, "last_failure_error")
+    last_signal_at = (
+        _coerce_agent_timestamp(_task_field(task, "last_heartbeat_at"))
+        or _coerce_agent_timestamp(_task_field(task, "started_at"))
+        or _coerce_agent_timestamp(_task_field(task, "created_at"))
+        or now
+    )
+    signal_bits = [raw_status, f"priority {priority}"]
+    if pid:
+        signal_bits.append(f"pid {pid}")
+    if failures:
+        signal_bits.append(f"failures {failures}")
+    if last_failure and agent_status in {"blocked", "failed"}:
+        signal_bits.append(_short_text(last_failure, "failure"))
+
+    return {
+        "id": f"kanban:{board}:{task_id}",
+        "name": f"Kanban: {assignee}",
+        "kind": "kanban_worker",
+        "avatar": avatar,
+        "status": agent_status,
+        "source": "kanban",
+        "location": f"board:{board}",
+        "title": title,
+        "current_task": title,
+        "progress": None,
+        "started_at": _coerce_agent_timestamp(_task_field(task, "started_at")) or _coerce_agent_timestamp(_task_field(task, "created_at")),
+        "last_signal_at": last_signal_at,
+        "last_signal": " · ".join(signal_bits),
+        "links": [{"label": "Kanban", "href": f"/kanban?board={urllib.parse.quote(board)}"}],
+        "actions": ["peek", "open"],
+        "metadata": {
+            "task_id": task_id,
+            "board": board,
+            "assignee": assignee,
+            "raw_status": raw_status,
+            "priority": priority,
+            "worker_pid": pid,
+            "consecutive_failures": failures,
+            "last_failure_error": last_failure,
+            "workspace_kind": _task_field(task, "workspace_kind"),
+            "workspace_path": _task_field(task, "workspace_path"),
+        },
+    }
+
+
+def _agent_from_background_process(proc: Dict[str, Any], now: Optional[float] = None) -> Dict[str, Any]:
+    """Convert a managed terminal background process into an Agent record."""
+    session_id = _short_text(proc.get("session_id") or proc.get("id"), "unknown")
+    command = _short_text(proc.get("command"), session_id)
+    raw_status = _short_text(proc.get("status"), "running").lower()
+    exit_code = proc.get("exit_code")
+    if raw_status == "running":
+        status = "working"
+    elif exit_code not in (None, 0, "0"):
+        status = "failed"
+    else:
+        status = "done"
+    started_at = _coerce_agent_timestamp(proc.get("started_at"))
+    uptime = proc.get("uptime_seconds")
+    pid = proc.get("pid")
+    signal_bits = [raw_status]
+    if pid:
+        signal_bits.append(f"pid {pid}")
+    if uptime is not None:
+        signal_bits.append(f"{uptime}s")
+    if raw_status != "running" and exit_code is not None:
+        signal_bits.append(f"exit {exit_code}")
+
+    return {
+        "id": f"process:{session_id}",
+        "name": f"Process: {session_id}",
+        "kind": "background_process",
+        "avatar": "terminal",
+        "status": status,
+        "source": "process",
+        "location": _short_text(proc.get("cwd"), "terminal"),
+        "title": command,
+        "current_task": command,
+        "progress": None,
+        "started_at": started_at,
+        "last_signal_at": now or started_at,
+        "last_signal": " · ".join(signal_bits),
+        "links": [{"label": "Processes", "href": "/agents"}],
+        "actions": ["peek", "open"],
+        "metadata": {
+            "session_id": session_id,
+            "pid": pid,
+            "cwd": proc.get("cwd"),
+            "exit_code": exit_code,
+            "output_preview": proc.get("output_preview"),
+        },
+    }
+
+
+def _normalise_agent_filter(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = value.strip().lower()
+    if not text or text == "all":
+        return None
+    return text
+
+
+def _build_agents_response(
+    sessions: List[Dict[str, Any]],
+    *,
+    extra_agents: Optional[List[Dict[str, Any]]] = None,
+    now: Optional[float] = None,
+    source_filter: Optional[str] = None,
+    status_filter: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the read-only Agent Situation Board payload."""
+    now = time.time() if now is None else now
+    agents = [_agent_from_session(session, now=now) for session in sessions]
+    agents.extend(extra_agents or [])
+
+    requested_source = _normalise_agent_filter(source_filter)
+    requested_status = _normalise_agent_filter(status_filter)
+    if requested_source:
+        agents = [agent for agent in agents if str(agent.get("source", "")).lower() == requested_source]
+    if requested_status:
+        agents = [agent for agent in agents if str(agent.get("status", "")).lower() == requested_status]
+
+    agents.sort(
+        key=lambda agent: (
+            _AGENT_ATTENTION_ORDER.get(agent["status"], 99),
+            -(float(agent.get("last_signal_at") or 0)),
+            agent["name"],
+        )
+    )
+
+    summary = {status: 0 for status in _AGENT_STATUSES}
+    for agent in agents:
+        summary[agent["status"]] = summary.get(agent["status"], 0) + 1
+
+    events = []
+    for agent in agents[:20]:
+        if not agent.get("last_signal_at"):
+            continue
+        level = "warning" if agent["status"] in {"blocked", "failed", "needs_input"} else "info"
+        events.append(
+            {
+                "ts": agent["last_signal_at"],
+                "agent_id": agent["id"],
+                "level": level,
+                "message": agent.get("last_signal") or agent.get("current_task") or agent["status"],
+            }
+        )
+
+    return {
+        "generated_at": now,
+        "summary": summary,
+        "agents": agents,
+        "events": events,
+        "filters": {"source": requested_source or "all", "status": requested_status or "all"},
+    }
+
+
+def _load_cron_agent_rows(limit: int, now: float) -> List[Dict[str, Any]]:
+    try:
+        from cron.jobs import list_jobs
+        jobs = list_jobs(include_disabled=True)
+    except Exception:
+        _log.exception("Failed to load cron jobs for Agent Situation Board")
+        return []
+    return [_agent_from_cron_job(job, now=now) for job in jobs[:limit]]
+
+
+def _load_kanban_agent_rows(limit: int, now: float) -> List[Dict[str, Any]]:
+    try:
+        from hermes_cli.kanban_db import connect, list_boards, list_tasks
+    except Exception:
+        _log.exception("Failed to import kanban helpers for Agent Situation Board")
+        return []
+
+    agents: List[Dict[str, Any]] = []
+    try:
+        boards = list_boards(include_archived=False)
+    except Exception:
+        _log.exception("Failed to list kanban boards for Agent Situation Board")
+        return []
+
+    for board_info in boards:
+        if len(agents) >= limit:
+            break
+        board = str(board_info.get("slug") or board_info.get("id") or "default")
+        conn = None
+        try:
+            conn = connect(board=board)
+            tasks = list_tasks(
+                conn,
+                include_archived=False,
+                limit=max(1, limit - len(agents)),
+                order_by="updated",
+            )
+        except ValueError:
+            try:
+                tasks = list_tasks(conn, include_archived=False, limit=max(1, limit - len(agents))) if conn else []
+            except Exception:
+                _log.exception("Failed to list kanban tasks for board %s", board)
+                tasks = []
+        except Exception:
+            _log.exception("Failed to list kanban tasks for board %s", board)
+            tasks = []
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+        agents.extend(_agent_from_kanban_task(task, board=board, now=now) for task in tasks)
+    return agents
+
+
+def _load_background_process_agent_rows(limit: int, now: float) -> List[Dict[str, Any]]:
+    try:
+        from tools.process_registry import process_registry
+        processes = process_registry.list_sessions()
+    except Exception:
+        _log.exception("Failed to load background processes for Agent Situation Board")
+        return []
+    return [_agent_from_background_process(proc, now=now) for proc in processes[:limit]]
+
+
+@app.get("/api/agents")
+async def get_agents(limit: int = 50, source: Optional[str] = None, status: Optional[str] = None):
+    """Read-only Agent Situation Board aggregator."""
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        try:
+            limit = max(1, min(limit, 200))
+            sessions = db.list_sessions_rich(limit=limit, offset=0)
+            now = time.time()
+            for session in sessions:
+                session["is_active"] = (
+                    session.get("ended_at") is None
+                    and (now - session.get("last_active", session.get("started_at", 0))) < 300
+                )
+            extra_agents: List[Dict[str, Any]] = []
+            extra_agents.extend(_load_cron_agent_rows(limit, now))
+            extra_agents.extend(_load_kanban_agent_rows(limit, now))
+            extra_agents.extend(_load_background_process_agent_rows(limit, now))
+            return _build_agents_response(
+                sessions,
+                extra_agents=extra_agents,
+                now=now,
+                source_filter=source,
+                status_filter=status,
+            )
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/agents failed")
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/sessions")

--- a/tests/hermes_cli/test_agent_situation_board.py
+++ b/tests/hermes_cli/test_agent_situation_board.py
@@ -1,0 +1,257 @@
+"""Tests for the dashboard Agent Situation Board aggregator."""
+
+from __future__ import annotations
+
+
+def test_agent_from_active_discord_session_surfaces_working_status():
+    from hermes_cli.web_server import _agent_from_session
+
+    agent = _agent_from_session(
+        {
+            "id": "20260523_discord",
+            "source": "discord",
+            "title": "에이전트 상황판 만들기",
+            "preview": "좋아 시작해",
+            "started_at": 1000.0,
+            "last_active": 1290.0,
+            "ended_at": None,
+            "model": "gpt-5.5",
+            "is_active": True,
+            "tool_call_count": 3,
+            "message_count": 12,
+        },
+        now=1300.0,
+    )
+
+    assert agent["id"] == "session:20260523_discord"
+    assert agent["name"] == "Hermes Discord"
+    assert agent["kind"] == "hermes_session"
+    assert agent["status"] == "working"
+    assert agent["avatar"] == "hermes"
+    assert agent["source"] == "discord"
+    assert agent["title"] == "에이전트 상황판 만들기"
+    assert agent["current_task"] == "좋아 시작해"
+    assert agent["last_signal"] == "3 tool calls · 12 messages"
+    assert agent["actions"] == ["peek", "open", "reply"]
+    assert agent["links"] == [{"label": "Sessions", "href": "/sessions"}]
+
+
+def test_agent_from_session_detects_needs_input_and_codex_identity():
+    from hermes_cli.web_server import _agent_from_session
+
+    agent = _agent_from_session(
+        {
+            "id": "codex_waiting",
+            "source": "cli",
+            "title": "Codex worker asks for approval",
+            "preview": "Proceed? 승인 필요합니다",
+            "started_at": 1000.0,
+            "last_active": 1100.0,
+            "ended_at": None,
+            "is_active": False,
+            "tool_call_count": 0,
+            "message_count": 4,
+        },
+        now=1400.0,
+    )
+
+    assert agent["name"] == "Codex Worker"
+    assert agent["kind"] == "codex_worker"
+    assert agent["avatar"] == "codex"
+    assert agent["status"] == "needs_input"
+    assert "reply" in agent["actions"]
+
+
+def test_agent_response_summary_counts_statuses_and_orders_attention_first():
+    from hermes_cli.web_server import _build_agents_response
+
+    response = _build_agents_response(
+        [
+            {
+                "id": "idle_session",
+                "source": "cli",
+                "title": "Idle task",
+                "preview": "waiting",
+                "started_at": 1000.0,
+                "last_active": 1000.0,
+                "ended_at": None,
+                "is_active": False,
+                "tool_call_count": 0,
+                "message_count": 1,
+            },
+            {
+                "id": "blocked_session",
+                "source": "discord",
+                "title": "Blocked task",
+                "preview": "Auth failed: token expired",
+                "started_at": 1000.0,
+                "last_active": 1290.0,
+                "ended_at": None,
+                "is_active": True,
+                "tool_call_count": 1,
+                "message_count": 6,
+            },
+        ],
+        now=1300.0,
+    )
+
+    assert response["summary"]["blocked"] == 1
+    assert response["summary"]["idle"] == 1
+    assert response["summary"]["working"] == 0
+    assert response["agents"][0]["status"] == "blocked"
+    assert response["events"][0]["level"] == "warning"
+
+
+def test_cron_job_agent_surfaces_scheduled_and_paused_state():
+    from hermes_cli.web_server import _agent_from_cron_job
+
+    scheduled = _agent_from_cron_job(
+        {
+            "id": "job_daily",
+            "name": "Daily digest",
+            "prompt": "Summarize overnight agent activity",
+            "schedule_display": "0 9 * * *",
+            "next_run_at": "2026-05-23T09:00:00+00:00",
+            "last_run_at": "2026-05-22T09:00:00+00:00",
+            "state": "scheduled",
+            "enabled": True,
+        },
+        now=1000.0,
+    )
+
+    assert scheduled["id"] == "cron:job_daily"
+    assert scheduled["name"] == "Cron: Daily digest"
+    assert scheduled["kind"] == "cron_job"
+    assert scheduled["status"] == "scheduled"
+    assert scheduled["last_signal"] == "next: 2026-05-23T09:00:00+00:00 · 0 9 * * *"
+    assert scheduled["links"] == [{"label": "Cron", "href": "/cron"}]
+
+    paused = _agent_from_cron_job({"id": "job_paused", "name": "Paused", "enabled": False, "state": "paused"})
+    assert paused["status"] == "idle"
+
+
+def test_kanban_task_agent_maps_worker_status_and_failure_context():
+    from hermes_cli.web_server import _agent_from_kanban_task
+
+    running = _agent_from_kanban_task(
+        {
+            "id": "t_agentview",
+            "title": "Implement adapter",
+            "status": "running",
+            "assignee": "codex",
+            "priority": 7,
+            "created_at": 900,
+            "started_at": 950,
+            "last_heartbeat_at": 990,
+            "worker_pid": 4242,
+            "consecutive_failures": 0,
+        },
+        board="default",
+    )
+
+    assert running["id"] == "kanban:default:t_agentview"
+    assert running["name"] == "Kanban: codex"
+    assert running["kind"] == "kanban_worker"
+    assert running["status"] == "working"
+    assert running["last_signal"] == "running · priority 7 · pid 4242"
+    assert running["links"] == [{"label": "Kanban", "href": "/kanban?board=default"}]
+
+    blocked = _agent_from_kanban_task(
+        {
+            "id": "t_blocked",
+            "title": "Need auth",
+            "status": "blocked",
+            "assignee": "omx",
+            "created_at": 900,
+            "last_failure_error": "token expired",
+            "consecutive_failures": 2,
+        }
+    )
+    assert blocked["status"] == "blocked"
+    assert blocked["avatar"] == "omx"
+    assert blocked["metadata"]["consecutive_failures"] == 2
+
+
+def test_background_process_agent_maps_running_and_failed_processes():
+    from hermes_cli.web_server import _agent_from_background_process
+
+    running = _agent_from_background_process(
+        {
+            "session_id": "proc_123",
+            "command": "npm run dev",
+            "cwd": "/repo/web",
+            "pid": 1234,
+            "started_at": "2026-05-23T10:00:00",
+            "uptime_seconds": 42,
+            "status": "running",
+            "output_preview": "ready on 5173",
+        },
+        now=2000.0,
+    )
+
+    assert running["id"] == "process:proc_123"
+    assert running["name"] == "Process: proc_123"
+    assert running["kind"] == "background_process"
+    assert running["status"] == "working"
+    assert running["last_signal"] == "running · pid 1234 · 42s"
+    assert running["links"] == [{"label": "Processes", "href": "/agents"}]
+
+    failed = _agent_from_background_process({"session_id": "proc_bad", "command": "pytest", "status": "exited", "exit_code": 1})
+    assert failed["status"] == "failed"
+
+
+def test_agent_response_can_filter_by_source_and_status():
+    from hermes_cli.web_server import _build_agents_response
+
+    response = _build_agents_response(
+        [
+            {
+                "id": "discord_active",
+                "source": "discord",
+                "title": "Active work",
+                "preview": "still working",
+                "started_at": 1000.0,
+                "last_active": 1290.0,
+                "ended_at": None,
+                "is_active": True,
+            },
+            {
+                "id": "cli_idle",
+                "source": "cli",
+                "title": "Idle work",
+                "preview": "waiting",
+                "started_at": 1000.0,
+                "last_active": 1000.0,
+                "ended_at": None,
+                "is_active": False,
+            },
+        ],
+        extra_agents=[
+            {
+                "id": "cron:nightly",
+                "name": "Cron: Nightly",
+                "kind": "cron_job",
+                "avatar": "clock",
+                "status": "scheduled",
+                "source": "cron",
+                "location": "scheduler",
+                "title": "Nightly",
+                "current_task": "Nightly",
+                "progress": None,
+                "started_at": None,
+                "last_signal_at": 1200.0,
+                "last_signal": "next: soon",
+                "links": [{"label": "Cron", "href": "/cron"}],
+                "actions": ["peek", "open"],
+                "metadata": {},
+            }
+        ],
+        now=1300.0,
+        source_filter="cron",
+        status_filter="scheduled",
+    )
+
+    assert [agent["id"] for agent in response["agents"]] == ["cron:nightly"]
+    assert response["summary"]["scheduled"] == 1
+    assert response["summary"]["working"] == 0
+    assert response["filters"] == {"source": "cron", "status": "scheduled"}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,7 @@ import ConfigPage from "@/pages/ConfigPage";
 import DocsPage from "@/pages/DocsPage";
 import EnvPage from "@/pages/EnvPage";
 import SessionsPage from "@/pages/SessionsPage";
+import AgentsPage from "@/pages/AgentsPage";
 import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
@@ -108,6 +109,7 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/agents": AgentsPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -134,6 +136,11 @@ const BUILTIN_NAV_REST: NavItem[] = [
     labelKey: "sessions",
     label: "Sessions",
     icon: MessageSquare,
+  },
+  {
+    path: "/agents",
+    label: "Agents",
+    icon: Activity,
   },
   {
     path: "/analytics",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -63,6 +63,13 @@ async function getSessionToken(): Promise<string> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getAgents: (params: { limit?: number; source?: string; status?: string } = {}) => {
+    const qs = new URLSearchParams();
+    qs.set("limit", String(params.limit ?? 50));
+    if (params.source && params.source !== "all") qs.set("source", params.source);
+    if (params.status && params.status !== "all") qs.set("status", params.status);
+    return fetchJSON<AgentsResponse>(`/api/agents?${qs.toString()}`);
+  },
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
@@ -380,6 +387,68 @@ export interface StatusResponse {
   latest_config_version: number;
   release_date: string;
   version: string;
+}
+
+export type AgentStatus =
+  | "working"
+  | "idle"
+  | "needs_input"
+  | "blocked"
+  | "failed"
+  | "done"
+  | "scheduled";
+
+export type AgentKind =
+  | "openclaw"
+  | "hermes_session"
+  | "codex_worker"
+  | "omx_worker"
+  | "cron_job"
+  | "kanban_worker"
+  | "background_process";
+
+export type AgentAction =
+  | "peek"
+  | "open"
+  | "reply"
+  | "wake"
+  | "dispatch"
+  | "pause"
+  | "resume"
+  | "stop";
+
+export interface AgentSummary {
+  id: string;
+  name: string;
+  kind: AgentKind;
+  avatar: "dog" | "hermes" | "codex" | "omx" | "bot" | "clock" | "kanban" | "terminal";
+  status: AgentStatus;
+  source: string;
+  location?: string | null;
+  title?: string | null;
+  current_task?: string | null;
+  progress?: number | null;
+  started_at?: number | string | null;
+  last_signal_at?: number | string | null;
+  last_signal?: string | null;
+  links: Array<{ label: string; href: string }>;
+  actions: AgentAction[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface AgentEvent {
+  ts: number | string;
+  agent_id: string;
+  level: "info" | "warning" | "error";
+  message: string;
+}
+
+export interface AgentsResponse {
+  generated_at: number | string;
+  summary: Record<AgentStatus, number>;
+  agents: AgentSummary[];
+  events: AgentEvent[];
+  filters?: { source: string; status: string };
 }
 
 export interface SessionInfo {

--- a/web/src/pages/AgentsPage.tsx
+++ b/web/src/pages/AgentsPage.tsx
@@ -1,0 +1,427 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  Bot,
+  CheckCircle2,
+  Clock,
+  Eye,
+  MessageSquare,
+  Pause,
+  Play,
+  RefreshCw,
+  ShieldAlert,
+  Sparkles,
+  Terminal,
+  Zap,
+} from "lucide-react";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { api } from "@/lib/api";
+import type { AgentAction, AgentsResponse, AgentStatus, AgentSummary } from "@/lib/api";
+import { cn, timeAgo } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Typography } from "@/components/NouiTypography";
+import { PluginSlot } from "@/plugins";
+
+const STATUS_LABELS: Record<AgentStatus, string> = {
+  working: "Working",
+  needs_input: "Needs input",
+  blocked: "Blocked",
+  failed: "Failed",
+  idle: "Idle",
+  done: "Done",
+  scheduled: "Scheduled",
+};
+
+const STATUS_STYLES: Record<AgentStatus, string> = {
+  working: "border-success/30 bg-success/10 text-success",
+  needs_input: "border-warning/40 bg-warning/10 text-warning",
+  blocked: "border-destructive/50 bg-destructive/10 text-destructive",
+  failed: "border-destructive/60 bg-destructive/15 text-destructive",
+  idle: "border-muted-foreground/20 bg-muted/20 text-muted-foreground",
+  done: "border-primary/30 bg-primary/10 text-primary",
+  scheduled: "border-[oklch(0.7_0.14_300)]/40 bg-[oklch(0.7_0.14_300)]/10 text-[oklch(0.78_0.12_300)]",
+};
+
+const STATUS_ICONS: Record<AgentStatus, typeof Activity> = {
+  working: Activity,
+  needs_input: MessageSquare,
+  blocked: ShieldAlert,
+  failed: AlertTriangle,
+  idle: Clock,
+  done: CheckCircle2,
+  scheduled: Clock,
+};
+
+const ACTION_ICONS: Record<AgentAction, typeof Eye> = {
+  peek: Eye,
+  open: Terminal,
+  reply: MessageSquare,
+  wake: Zap,
+  dispatch: Sparkles,
+  pause: Pause,
+  resume: Play,
+  stop: AlertTriangle,
+};
+
+const STATUS_ORDER: AgentStatus[] = [
+  "working",
+  "needs_input",
+  "blocked",
+  "idle",
+  "done",
+  "scheduled",
+  "failed",
+];
+
+const SOURCE_FILTERS = [
+  { value: "all", label: "All" },
+  { value: "discord", label: "Discord" },
+  { value: "cli", label: "CLI" },
+  { value: "cron", label: "Cron" },
+  { value: "kanban", label: "Kanban" },
+  { value: "process", label: "Processes" },
+  { value: "webhook", label: "Webhooks" },
+];
+
+const STATUS_FILTERS: Array<{ value: "all" | AgentStatus; label: string }> = [
+  { value: "all", label: "All" },
+  ...STATUS_ORDER.map((status) => ({ value: status, label: STATUS_LABELS[status] })),
+];
+
+function formatSignalTime(value: AgentSummary["last_signal_at"]): string {
+  if (typeof value === "number") return timeAgo(value);
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return timeAgo(parsed / 1000);
+  }
+  return "unknown";
+}
+
+function statusPill(status: AgentStatus) {
+  const Icon = STATUS_ICONS[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 border px-2 py-1 text-[10px] font-bold uppercase tracking-[0.12em]",
+        STATUS_STYLES[status],
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      {STATUS_LABELS[status]}
+    </span>
+  );
+}
+
+function avatarGlyph(agent: AgentSummary): string {
+  if (agent.avatar === "dog") return "🐶";
+  if (agent.avatar === "codex") return "⌘";
+  if (agent.avatar === "omx") return "◇";
+  if (agent.avatar === "hermes") return "✦";
+  if (agent.avatar === "clock") return "⏱";
+  if (agent.avatar === "kanban") return "▦";
+  if (agent.avatar === "terminal") return "▸";
+  return "🤖";
+}
+
+function SummaryCard({ status, count }: { status: AgentStatus; count: number }) {
+  const Icon = STATUS_ICONS[status];
+  return (
+    <Card className={cn("min-w-[10rem]", STATUS_STYLES[status])}>
+      <CardContent className="flex items-center justify-between gap-3 p-3">
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.14em] opacity-80">
+            {STATUS_LABELS[status]}
+          </p>
+          <p className="mt-1 text-3xl font-bold leading-none">{count}</p>
+        </div>
+        <Icon className="h-5 w-5 opacity-80" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function AgentCard({ agent, selected, onSelect }: { agent: AgentSummary; selected: boolean; onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "w-full border bg-card/70 p-3 text-left transition hover:border-primary/50 hover:bg-card",
+        selected ? "border-primary/70 ring-1 ring-primary/30" : "border-border",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center border border-current/20 bg-background-base text-xl">
+          {avatarGlyph(agent)}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-expanded text-sm font-bold uppercase tracking-[0.08em] text-midground">
+              {agent.name}
+            </span>
+            {statusPill(agent.status)}
+          </div>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {agent.title || agent.current_task || "No task title"}
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+            <span>{agent.kind}</span>
+            <span>·</span>
+            <span>{agent.source}</span>
+            <span>·</span>
+            <span>{formatSignalTime(agent.last_signal_at)}</span>
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function FilterChip({ active, children, onClick }: { active: boolean; children: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "border px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] transition",
+        active
+          ? "border-primary/70 bg-primary/15 text-primary"
+          : "border-border bg-background-base/50 text-muted-foreground hover:border-primary/40 hover:text-midground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function DetailDrawer({ agent }: { agent: AgentSummary | null }) {
+  if (!agent) {
+    return (
+      <Card className="h-full">
+        <CardContent className="flex min-h-72 flex-col items-center justify-center gap-3 text-center text-muted-foreground">
+          <Bot className="h-10 w-10" />
+          <p className="text-xs uppercase tracking-[0.14em]">Select an agent to inspect</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle>{agent.name}</CardTitle>
+          {statusPill(agent.status)}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-14 w-14 items-center justify-center border border-current/20 bg-background-base text-3xl">
+            {avatarGlyph(agent)}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-bold text-midground">{agent.title}</p>
+            <p className="mt-1 text-xs text-muted-foreground">{agent.kind} · {agent.source}</p>
+          </div>
+        </div>
+
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">Current task</p>
+          <p className="mt-1 text-sm text-midground/90">{agent.current_task || "No current task signal"}</p>
+        </div>
+
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">Last signal</p>
+          <p className="mt-1 text-sm text-midground/90">{agent.last_signal || "No signal yet"}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{formatSignalTime(agent.last_signal_at)}</p>
+        </div>
+
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">Next actions</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {agent.actions.map((action) => {
+              const Icon = ACTION_ICONS[action];
+              const enabled = action === "peek" || action === "open";
+              return (
+                <Button key={action} size="sm" ghost={!enabled} disabled={!enabled} title={enabled ? action : "Coming after safe action endpoints"}>
+                  <Icon className="h-3 w-3" />
+                  {action}
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">Links</p>
+          <div className="mt-2 space-y-1">
+            {agent.links.map((link) => (
+              <a key={`${link.label}:${link.href}`} href={link.href} className="block truncate text-xs text-primary hover:underline">
+                {link.label}: {link.href}
+              </a>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function AgentsPage() {
+  const [data, setData] = useState<AgentsResponse | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [sourceFilter, setSourceFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState<"all" | AgentStatus>("all");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadAgents = useCallback(() => {
+    setLoading(true);
+    api
+      .getAgents({ limit: 100, source: sourceFilter, status: statusFilter })
+      .then((response) => {
+        setData(response);
+        setSelectedId((current) => {
+          if (current && response.agents.some((agent) => agent.id === current)) return current;
+          return response.agents[0]?.id ?? null;
+        });
+        setError(null);
+      })
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, [sourceFilter, statusFilter]);
+
+  useEffect(() => {
+    loadAgents();
+    const timer = window.setInterval(loadAgents, 15_000);
+    return () => window.clearInterval(timer);
+  }, [loadAgents]);
+
+  const selectedAgent = useMemo(
+    () => data?.agents.find((agent) => agent.id === selectedId) ?? data?.agents[0] ?? null,
+    [data?.agents, selectedId],
+  );
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Spinner className="text-2xl text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PluginSlot name="agents:top" />
+
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <Typography as="h1" expanded className="text-2xl font-bold uppercase tracking-[0.08em] text-midground">
+            Agent Situation Board
+          </Typography>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+            댕댕이 · 멍멍이 · Codex/OMX workers를 한눈에 보는 관제판입니다. 지금은 read-only 신호를 모으고, 위험한 조작은 안전 endpoint가 생길 때까지 비활성화합니다.
+          </p>
+        </div>
+        <Button size="sm" onClick={loadAgents} disabled={loading}>
+          <RefreshCw className={cn("h-3 w-3", loading && "animate-spin")} />
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <Card className="border-destructive/40 bg-destructive/10 text-destructive">
+          <CardContent className="p-3 text-sm">Failed to load agents: {error}</CardContent>
+        </Card>
+      )}
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 xl:grid-cols-7">
+        {STATUS_ORDER.map((status) => (
+          <SummaryCard key={status} status={status} count={data?.summary[status] ?? 0} />
+        ))}
+      </div>
+
+      <Card>
+        <CardContent className="space-y-3 p-3">
+          <div>
+            <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">Signal source</p>
+            <div className="flex flex-wrap gap-2">
+              {SOURCE_FILTERS.map((filter) => (
+                <FilterChip
+                  key={filter.value}
+                  active={sourceFilter === filter.value}
+                  onClick={() => setSourceFilter(filter.value)}
+                >
+                  {filter.label}
+                </FilterChip>
+              ))}
+            </div>
+          </div>
+          <div>
+            <p className="mb-2 text-[10px] font-bold uppercase tracking-[0.14em] text-muted-foreground">Status</p>
+            <div className="flex flex-wrap gap-2">
+              {STATUS_FILTERS.map((filter) => (
+                <FilterChip
+                  key={filter.value}
+                  active={statusFilter === filter.value}
+                  onClick={() => setStatusFilter(filter.value)}
+                >
+                  {filter.label}
+                </FilterChip>
+              ))}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid min-h-0 gap-4 xl:grid-cols-[minmax(0,1fr)_24rem]">
+        <div className="space-y-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>Roster</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {data?.agents.length ? (
+                data.agents.map((agent) => (
+                  <AgentCard
+                    key={agent.id}
+                    agent={agent}
+                    selected={selectedAgent?.id === agent.id}
+                    onSelect={() => setSelectedId(agent.id)}
+                  />
+                ))
+              ) : (
+                <div className="border border-dashed border-border p-8 text-center text-sm text-muted-foreground">
+                  No agent signals yet. Recent Hermes sessions will appear here first.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Event stream</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {data?.events.length ? (
+                data.events.slice(0, 8).map((event) => (
+                  <div key={`${event.agent_id}:${event.ts}`} className="flex items-center gap-3 border border-border bg-background-base/50 px-3 py-2 text-xs">
+                    <span className={cn("h-2 w-2 rounded-full", event.level === "warning" ? "bg-warning" : event.level === "error" ? "bg-destructive" : "bg-primary")} />
+                    <span className="truncate text-muted-foreground">{event.agent_id}</span>
+                    <span className="min-w-0 flex-1 truncate text-midground">{event.message}</span>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground">No events yet.</p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <DetailDrawer agent={selectedAgent} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add read-only /api/agents aggregator for Hermes sessions, cron jobs, kanban tasks, and background processes
- Add dashboard Agents page with status/source filters, summary cards, event timeline, and detail drawer
- Add tests covering status mapping, filtering, ordering, and adapter rows

## Test Plan
- pytest -q tests/hermes_cli/test_agent_situation_board.py tests/gateway/test_go_command.py tests/test_cli_go_command.py
- npm --prefix web run build

Note: direct push to NousResearch/hermes-agent was denied for SoSyn2ne, so this PR is opened from the fork branch.