### PR TITLE
fix(provider): route OAuth Pro/Max credentials to /v1/messages (#32243)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -78,6 +78,13 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
 
     - Direct api.openai.com endpoints need the Responses API for GPT-5.x
       tool calls with reasoning (chat/completions returns 400).
+    - Direct api.anthropic.com endpoints must use the native Messages
+      API (``/v1/messages``).  Anthropic also exposes an OpenAI-compat
+      ``/chat/completions`` shim on the same host, but Pro/Max OAuth
+      subscriptions are only billed against the native Messages route;
+      hitting the shim accounts against a separate "extra usage" pool
+      that is empty by default and surfaces as HTTP 400 "You're out of
+      extra usage."  See issue #32243.
     - Third-party Anthropic-compatible gateways (MiniMax, Zhipu GLM,
       LiteLLM proxies, etc.) conventionally expose the native Anthropic
       protocol under a ``/anthropic`` suffix — treat those as
@@ -93,6 +100,8 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "codex_responses"
     if hostname == "api.openai.com":
         return "codex_responses"
+    if hostname == "api.anthropic.com":
+        return "anthropic_messages"
     if normalized.endswith("/anthropic"):
         return "anthropic_messages"
     if hostname == "api.kimi.com" and "/coding" in normalized:

--- a/tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py
+++ b/tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py
@@ -1,0 +1,205 @@
+"""Regression coverage for issue #32243.
+
+OAuth Pro/Max credentials must always reach Anthropic via the native
+``/v1/messages`` endpoint, never the OpenAI-compat ``/chat/completions``
+shim — the latter bills against a separate "extra usage" pool that
+Pro/Max subscriptions don't fund, so any request that lands on it 400s
+with "You're out of extra usage" the moment the gateway starts.
+
+The root cause was an inconsistency between two URL→api_mode helpers:
+
+* ``hermes_cli.providers.determine_api_mode`` correctly mapped
+  ``api.anthropic.com`` to ``anthropic_messages``.
+* ``hermes_cli.runtime_provider._detect_api_mode_for_url`` did NOT, so
+  every code path that fell back to URL-only detection (named custom
+  providers, direct-alias resolution, the api-key fallback inside
+  ``resolve_runtime_provider``) returned ``None`` for that host and
+  defaulted to ``chat_completions``.
+
+Exhaustive host-shape coverage for the helper itself lives in
+``test_detect_api_mode_for_url.py::TestDirectAnthropicHost``.  The
+tests below pin the **integration contract**: every runtime branch
+that resolves an Anthropic endpoint must return
+``api_mode == "anthropic_messages"``, so a future refactor of any
+single branch cannot silently revert #32243.
+"""
+
+from __future__ import annotations
+
+from hermes_cli import runtime_provider as rp
+
+
+class TestExplicitRuntimeForAnthropic:
+    """``_resolve_explicit_runtime`` with provider='anthropic' must
+    always return ``api_mode='anthropic_messages'`` regardless of
+    base_url shape or stale persisted ``model.api_mode`` values.
+
+    Exercised whenever the user (or a Hermes subcommand) passes an
+    explicit ``--api-key`` / ``--base-url`` override to the runtime
+    resolver.
+    """
+
+    def test_explicit_args_route_to_messages_api(self):
+        result = rp._resolve_explicit_runtime(
+            provider="anthropic",
+            requested_provider="anthropic",
+            model_cfg={},
+            explicit_api_key="sk-ant-oat01-foo",
+            explicit_base_url="https://api.anthropic.com",
+        )
+        assert result is not None
+        assert result["api_mode"] == "anthropic_messages"
+        assert result["provider"] == "anthropic"
+        assert result["base_url"] == "https://api.anthropic.com"
+
+    def test_stale_chat_completions_api_mode_in_config_is_ignored(self):
+        # A user who previously had ``provider: openai`` and switched to
+        # anthropic might still have ``model.api_mode: chat_completions``
+        # in their config.yaml.  The anthropic branch must hard-pin
+        # the mode — Anthropic's chat_completions shim is the bug
+        # locus of #32243 and must never be reachable from this path.
+        result = rp._resolve_explicit_runtime(
+            provider="anthropic",
+            requested_provider="anthropic",
+            model_cfg={"provider": "anthropic", "api_mode": "chat_completions"},
+            explicit_api_key="sk-ant-oat01-foo",
+            explicit_base_url="https://api.anthropic.com",
+        )
+        assert result is not None
+        assert result["api_mode"] == "anthropic_messages"
+
+    def test_no_explicit_args_returns_none(self):
+        # Guard the gating contract — _resolve_explicit_runtime only
+        # fires when an explicit override is present; without one it
+        # must return None so the caller falls through to the pool /
+        # top-level anthropic branch.
+        assert (
+            rp._resolve_explicit_runtime(
+                provider="anthropic",
+                requested_provider="anthropic",
+                model_cfg={"provider": "anthropic"},
+            )
+            is None
+        )
+
+
+class TestPoolEntryForAnthropic:
+    """``_resolve_runtime_from_pool_entry`` is what runs when a user
+    has added an OAuth credential via ``hermes auth add anthropic
+    --type oauth`` (the exact flow from #32243).  Pin the contract
+    alongside the URL-detector test so all three runtime branches
+    stay aligned and a future refactor of one cannot diverge from
+    the others.
+    """
+
+    def test_oauth_pool_entry_routes_to_messages_api(self):
+        class _Entry:
+            access_token = "sk-ant-oat01-pool"
+            runtime_api_key = "sk-ant-oat01-pool"
+            source = "manual:hermes_pkce"
+            base_url = "https://api.anthropic.com"
+
+        resolved = rp._resolve_runtime_from_pool_entry(
+            provider="anthropic",
+            entry=_Entry(),
+            requested_provider="anthropic",
+            model_cfg={"provider": "anthropic"},
+        )
+
+        assert resolved["provider"] == "anthropic"
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["base_url"] == "https://api.anthropic.com"
+
+    def test_stale_chat_completions_api_mode_in_config_is_ignored(self):
+        # Same regression as the explicit-runtime test above, but on
+        # the pool path: a stale persisted chat_completions api_mode
+        # must NOT override the provider-pin.
+        class _Entry:
+            access_token = "sk-ant-oat01-pool"
+            runtime_api_key = "sk-ant-oat01-pool"
+            source = "manual:hermes_pkce"
+            base_url = "https://api.anthropic.com"
+
+        resolved = rp._resolve_runtime_from_pool_entry(
+            provider="anthropic",
+            entry=_Entry(),
+            requested_provider="anthropic",
+            model_cfg={
+                "provider": "anthropic",
+                "api_mode": "chat_completions",
+            },
+        )
+
+        assert resolved["api_mode"] == "anthropic_messages"
+
+
+class TestCustomProviderUrlFallback:
+    """The detector fix's actual reachable path: a user-defined
+    ``providers:`` / ``custom_providers:`` entry whose ``api`` URL
+    points at ``api.anthropic.com``, with no explicit ``api_mode`` /
+    ``transport`` field.
+
+    Pre-fix: this falls through ``_try_resolve_from_custom_pool`` →
+    ``_detect_api_mode_for_url("https://api.anthropic.com")`` → None →
+    default ``chat_completions`` → request lands on the OpenAI-compat
+    shim → "out of extra usage" 400.
+
+    Post-fix: the detector returns ``anthropic_messages`` so the same
+    config routes to ``/v1/messages`` where Pro/Max OAuth is billed.
+    """
+
+    def test_url_fallback_picks_messages_api(self, monkeypatch):
+        class _Entry:
+            access_token = "sk-ant-oat01-custom-pool"
+            runtime_api_key = "sk-ant-oat01-custom-pool"
+            source = "custom-pool"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "get_custom_provider_pool_key", lambda *a, **k: "custom:my-claude")
+        monkeypatch.setattr(rp, "load_pool", lambda key: _Pool())
+
+        resolved = rp._try_resolve_from_custom_pool(
+            "https://api.anthropic.com",
+            "custom",
+        )
+
+        assert resolved is not None
+        assert resolved["api_mode"] == "anthropic_messages"
+
+    def test_explicit_api_mode_override_still_wins(self, monkeypatch):
+        # The detector is only consulted as a fallback — when the
+        # custom-pool caller passes an explicit api_mode (e.g. from a
+        # ``transport: chat_completions`` config entry), that takes
+        # priority.  Pinned so the fix doesn't accidentally hijack a
+        # user who DELIBERATELY pointed a chat_completions transport
+        # at api.anthropic.com (uncommon but valid for OpenAI-compat
+        # experiments).
+        class _Entry:
+            access_token = "k"
+            runtime_api_key = "k"
+            source = "x"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "get_custom_provider_pool_key", lambda *a, **k: "custom:my-claude")
+        monkeypatch.setattr(rp, "load_pool", lambda key: _Pool())
+
+        resolved = rp._try_resolve_from_custom_pool(
+            "https://api.anthropic.com",
+            "custom",
+            api_mode_override="chat_completions",
+        )
+
+        assert resolved is not None
+        assert resolved["api_mode"] == "chat_completions"

--- a/tests/hermes_cli/test_detect_api_mode_for_url.py
+++ b/tests/hermes_cli/test_detect_api_mode_for_url.py
@@ -1,10 +1,15 @@
 """Tests for hermes_cli.runtime_provider._detect_api_mode_for_url.
 
-The helper maps base URLs to api_modes for three cases:
-  * api.openai.com  → codex_responses
-  * api.x.ai        → codex_responses
-  * */anthropic     → anthropic_messages (third-party gateways like MiniMax,
-                                          Zhipu GLM, LiteLLM proxies)
+The helper maps base URLs to api_modes for four cases:
+  * api.openai.com    → codex_responses
+  * api.x.ai          → codex_responses
+  * api.anthropic.com → anthropic_messages (Pro/Max OAuth is only billed
+                                            against /v1/messages; the
+                                            chat_completions shim counts
+                                            against a separate empty
+                                            "extra usage" pool, see #32243)
+  * */anthropic       → anthropic_messages (third-party gateways like MiniMax,
+                                            Zhipu GLM, LiteLLM proxies)
 
 Consolidating the /anthropic detection in this helper (instead of three
 inline ``endswith`` checks spread across _resolve_runtime_from_pool_entry,
@@ -36,6 +41,49 @@ class TestCodexResponsesDetection:
 
     def test_xai_host_suffix_does_not_match(self):
         assert _detect_api_mode_for_url("https://api.x.ai.example/v1") is None
+
+
+class TestDirectAnthropicHost:
+    """Native api.anthropic.com → /v1/messages. Pinned for issue #32243.
+
+    The Anthropic OpenAI-compat ``/chat/completions`` shim on the same
+    host bills against a separate "extra usage" pool that Pro/Max OAuth
+    subscriptions don't fund, so a fresh OAuth credential 400s with
+    "out of extra usage" the moment a request lands there. The detector
+    must keep ``api.anthropic.com`` on the native Messages API.
+    """
+
+    def test_bare_host(self):
+        assert _detect_api_mode_for_url("https://api.anthropic.com") == "anthropic_messages"
+
+    def test_with_trailing_slash(self):
+        assert _detect_api_mode_for_url("https://api.anthropic.com/") == "anthropic_messages"
+
+    def test_with_v1_suffix(self):
+        # The Anthropic SDK appends /v1/messages itself but the user's
+        # config may persist the /v1 form — must still resolve.
+        assert _detect_api_mode_for_url("https://api.anthropic.com/v1") == "anthropic_messages"
+
+    def test_uppercase_host_tolerated(self):
+        assert _detect_api_mode_for_url("https://API.ANTHROPIC.COM/v1") == "anthropic_messages"
+
+    def test_lookalike_subdomain_does_not_match(self):
+        # ``api.anthropic.com.attacker.test`` is an attacker-controlled
+        # host; the registrable label is ``attacker``, not Anthropic.
+        # Must NOT be routed to anthropic_messages — leaking an
+        # Anthropic OAuth token there is the worst case.
+        assert (
+            _detect_api_mode_for_url("https://api.anthropic.com.attacker.test/v1")
+            is None
+        )
+
+    def test_anthropic_path_segment_does_not_match(self):
+        # A reverse proxy under an unrelated host whose path *contains*
+        # ``api.anthropic.com`` should not be classified as native.
+        assert (
+            _detect_api_mode_for_url("https://proxy.example.test/api.anthropic.com/v1")
+            is None
+        )
 
 
 class TestAnthropicMessagesDetection:


### PR DESCRIPTION
## Description

Freshly authorized Claude Pro/Max OAuth credentials immediately fail every chat completion with HTTP 400 `"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."` — even on accounts with effectively zero consumption for the current cycle. The Max subscription is unusable through Hermes until the user manually overrides `model.api_mode`.

### Root cause

The reporter's instinct was correct: the dumped request hits `POST https://api.anthropic.com/chat/completions` instead of `/v1/messages`. Anthropic exposes an OpenAI-compatible `/chat/completions` shim on the same host as the native Messages API, but **Pro/Max OAuth subscriptions are only billed against `/v1/messages`** — the shim accounts against a separate "extra usage" pool that is empty by default, surfacing as the misleading 400.

Hermes has two URL→`api_mode` helpers:

* `hermes_cli.providers.determine_api_mode` correctly maps `api.anthropic.com` → `anthropic_messages`.
* `hermes_cli.runtime_provider._detect_api_mode_for_url` did **not** — it only matched the `*/anthropic` path suffix used by third-party gateways (MiniMax, Zhipu GLM, LiteLLM proxies). Direct `api.anthropic.com` fell through to `None`, defaulting to `chat_completions` in every URL-fallback path:

  * `_try_resolve_from_custom_pool` (user-defined `providers:` / `custom_providers:` entries)
  * `_resolve_named_custom_runtime` (direct-alias and custom-provider paths)
  * `_resolve_explicit_runtime` (api-key fallback)
  * the api-key fallback inside `resolve_runtime_provider`

The two helpers should never have disagreed; this PR realigns them.

### Related issue

Closes #32243

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

### Changes made

* `hermes_cli/runtime_provider.py` — `_detect_api_mode_for_url` now returns `anthropic_messages` for `api.anthropic.com`, matching `hermes_cli/providers.py::determine_api_mode`. Subdomain/path-segment spoofing is correctly rejected by the existing `base_url_hostname` exact-match check.
* `tests/hermes_cli/test_detect_api_mode_for_url.py` — new `TestDirectAnthropicHost` class covering host shapes (bare, trailing slash, `/v1` suffix, uppercase) **and** the two security regressions that matter: lookalike subdomains (`api.anthropic.com.attacker.test`) and path-segment spoofing (`https://proxy.example.test/api.anthropic.com/v1`) must NOT be classified as native.
* `tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py` — new file pinning the end-to-end contract across all three runtime branches (`_resolve_explicit_runtime`, `_resolve_runtime_from_pool_entry`, `_try_resolve_from_custom_pool`), so a future refactor of any single branch cannot silently revert this fix. Also pins that an explicit `api_mode_override` still wins, preserving the (unusual but valid) case of a user deliberately pointing a chat_completions transport at api.anthropic.com for OpenAI-compat experiments.

Three small commits, sole author:

| # | Commit |
| - | ------ |
| 1 | `fix(provider): route api.anthropic.com to anthropic_messages api_mode (#32243)` |
| 2 | `test(provider): pin api.anthropic.com → anthropic_messages URL detection` |
| 3 | `test(runtime): pin Anthropic OAuth → /v1/messages routing across runtime branches` |

### How to test

1. Start from a clean Claude Pro/Max account.
2. `hermes auth remove anthropic && hermes auth add anthropic --type oauth --no-browser --manual-paste`
3. Complete the standard `claude.ai/oauth/authorize` flow.
4. Restart `hermes-gateway` (or invoke `hermes -z "ping"` directly).
5. **Before this PR:** every message returns `HTTP 400: You're out of extra usage`.
6. **With this PR:** the request reaches `POST https://api.anthropic.com/v1/messages` and is billed against the Pro/Max subscription as expected.

Automated coverage:

```
scripts/run_tests.sh tests/hermes_cli/test_detect_api_mode_for_url.py \
                     tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py \
                     tests/hermes_cli/test_runtime_provider_resolution.py \
                     tests/hermes_cli/test_anthropic_oauth_flow.py \
                     tests/hermes_cli/test_anthropic_model_flow_stale_oauth.py \
                     tests/hermes_cli/test_determine_api_mode_hostname.py \
                     tests/hermes_cli/test_anthropic_provider_persistence.py \
                     tests/run_agent/test_anthropic_third_party_oauth_guard.py
# → 8 files, 182 tests passed
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
