### PR TITLE
fix(security): include AWS credential vars in bedrock subprocess blocklist (#32314)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -444,7 +444,22 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="AWS Bedrock",
         auth_type="aws_sdk",
         inference_base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
-        api_key_env_vars=(),
+        # Listed here so tools/environments/local.py's subprocess blocklist
+        # strips them — otherwise AWS creds leak into terminal/execute_code.
+        # Mirrors agent/bedrock_adapter.py::_AWS_CREDENTIAL_ENV_VARS plus the
+        # paired secret/session vars boto3 also reads via its default chain.
+        api_key_env_vars=(
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_PROFILE",
+            "AWS_ROLE_ARN",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+        ),
         base_url_env_var="BEDROCK_BASE_URL",
     ),
     "azure-foundry": ProviderConfig(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -444,22 +444,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="AWS Bedrock",
         auth_type="aws_sdk",
         inference_base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
-        # Listed here so tools/environments/local.py's subprocess blocklist
-        # strips them — otherwise AWS creds leak into terminal/execute_code.
-        # Mirrors agent/bedrock_adapter.py::_AWS_CREDENTIAL_ENV_VARS plus the
-        # paired secret/session vars boto3 also reads via its default chain.
-        api_key_env_vars=(
-            "AWS_BEARER_TOKEN_BEDROCK",
-            "AWS_ACCESS_KEY_ID",
-            "AWS_SECRET_ACCESS_KEY",
-            "AWS_SESSION_TOKEN",
-            "AWS_PROFILE",
-            "AWS_ROLE_ARN",
-            "AWS_WEB_IDENTITY_TOKEN_FILE",
-            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
-            "AWS_CONTAINER_AUTHORIZATION_TOKEN",
-        ),
+        api_key_env_vars=(),
         base_url_env_var="BEDROCK_BASE_URL",
     ),
     "azure-foundry": ProviderConfig(

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -111,6 +111,30 @@ class TestProviderEnvBlocklist:
         for var in extra_provider_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    def test_aws_credential_vars_are_stripped(self):
+        """AWS SDK credentials must be stripped from subprocess env.
+
+        Regression for #32314: bedrock uses ``auth_type='aws_sdk'`` so its
+        credentials live in standard AWS env vars (``AWS_ACCESS_KEY_ID`` etc.)
+        rather than a Hermes-style ``*_API_KEY`` variable. Before #32314 the
+        ``bedrock`` ``ProviderConfig`` had an empty ``api_key_env_vars`` tuple
+        and these variables leaked into terminal/execute_code subprocesses.
+        """
+        aws_vars = {
+            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer-secret",
+            "AWS_ACCESS_KEY_ID": "AKIA-fake",
+            "AWS_SECRET_ACCESS_KEY": "fake-secret",
+            "AWS_SESSION_TOKEN": "fake-session",
+            "AWS_PROFILE": "prod",
+            "AWS_ROLE_ARN": "arn:aws:iam::123:role/x",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/tmp/token",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc",
+        }
+        result_env = _run_with_env(extra_os_env=aws_vars)
+
+        for var in aws_vars:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+
     def test_tool_and_gateway_vars_are_stripped(self):
         """Tool and gateway secrets/config must not leak into subprocess env."""
         leaked_vars = {
@@ -212,6 +236,21 @@ class TestBlocklistCoverage:
                     f"Registry base_url_env_var {pconfig.base_url_env_var} "
                     f"(provider={pconfig.id}) missing from blocklist"
                 )
+
+    def test_aws_sdk_provider_vars_covered(self):
+        """Bedrock (``auth_type='aws_sdk'``) must contribute AWS env vars to
+        the blocklist. Regression for #32314 — empty tuple let creds leak."""
+        aws_must_block = {
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_PROFILE",
+            "AWS_ROLE_ARN",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        }
+        assert aws_must_block.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
 
     def test_extra_auth_vars_covered(self):
         """Non-registry auth vars (ANTHROPIC_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -160,6 +160,23 @@ def _build_provider_env_blocklist() -> frozenset:
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
         "DAYTONA_API_KEY",
+        # AWS Bedrock uses ``auth_type="aws_sdk"`` so its credentials live in
+        # the standard AWS env vars rather than a Hermes-style ``*_API_KEY``,
+        # meaning the registry-derived branch above contributes nothing for
+        # this provider. List them explicitly so terminal/execute_code
+        # subprocesses don't see AWS creds. Mirrors
+        # ``agent/bedrock_adapter.py::_AWS_CREDENTIAL_ENV_VARS`` plus the
+        # paired secret/session vars boto3 also reads via its default chain.
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_PROFILE",
+        "AWS_ROLE_ARN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN",
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
## What does this PR do?

The built-in `bedrock` provider uses `auth_type=\"aws_sdk\"` and previously declared `api_key_env_vars=()` — an empty tuple. The subprocess sanitization in `tools/environments/local.py::_build_provider_env_blocklist()` iterates each provider's `api_key_env_vars` to derive its blocklist, so AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_BEARER_TOKEN_BEDROCK`, `AWS_PROFILE`, …) were never blocked and inherited into agent-spawned terminal/`execute_code`/MCP subprocesses. Any subprocess that auto-discovers AWS credentials (e.g. `opencode models`) silently saw the user's full Bedrock catalog and could make Bedrock or other AWS API calls the agent did not intend to expose.

This populates `bedrock.api_key_env_vars` with the canonical AWS SDK credential set so the existing blocklist mechanism strips them. The set mirrors `agent/bedrock_adapter.py::_AWS_CREDENTIAL_ENV_VARS` (the runtime detector used by `resolve_aws_auth_env_var()`) plus the paired secret/session vars boto3 reads via its default credential chain.

> Mirrors `agent/bedrock_adapter.py::_AWS_CREDENTIAL_ENV_VARS` precedence: `AWS_BEARER_TOKEN_BEDROCK > AWS_ACCESS_KEY_ID(+AWS_SECRET_ACCESS_KEY,+AWS_SESSION_TOKEN) > AWS_PROFILE > AWS_CONTAINER_CREDENTIALS_RELATIVE_URI > AWS_WEB_IDENTITY_TOKEN_FILE`.

The `_HERMES_PROVIDER_ENV_FORCE_` opt-in path still works for legitimate AWS-aware subprocesses that need to inherit credentials (the standard escape hatch for the rest of the blocklist).

## Related Issue

Fixes #32314

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`hermes_cli/auth.py\` — populate \`bedrock.api_key_env_vars\` with the canonical AWS SDK credential set (10 vars: bearer token, access-key pair + session token, profile, role-ARN, web-identity, container-credential URIs and authorization token).
- \`tests/tools/test_local_env_blocklist.py\` — add two regression tests: one asserts AWS vars are stripped from a LocalEnvironment subprocess env via the existing harness; the other asserts the same vars are present in \`_HERMES_PROVIDER_ENV_BLOCKLIST\`. Both fail on \`main\` without the auth.py change.

## How to Test

1. \`uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/tools/test_local_env_blocklist.py -v\` → 20 passed (was 18, added 2).
2. End-to-end repro: configure \`provider: bedrock\`, export \`AWS_BEARER_TOKEN_BEDROCK=...\`, run a terminal session via Hermes, \`env | grep AWS\` → before: full set leaked; after: empty.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(security):\`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the blocklist is internal mechanism; behavior is documented by the regression tests)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure registry data change, OS-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- #31959 (Tranquil-Flow, open) introduces a centralized \`hermes_subprocess_env()\` helper as a broader credential-safety refactor. That PR replaces \`{**os.environ}\` patterns at subprocess boundaries with a strip-by-default helper but does not touch the per-provider \`api_key_env_vars\` data. This PR is orthogonal — it fills the registry data so both the existing \`LocalEnvironment\` blocklist AND any future centralized helper that consumes \`PROVIDER_REGISTRY\` get the AWS vars for free. The two are compatible and address the same issue from different layers.
- #7990 / #22647 — broader cloud-credential subprocess blocklist effort; #22647 was closed without merge. This PR closes the bedrock-specific gap that's been latent since.

## Audited siblings

Only one provider in `PROVIDER_REGISTRY` declares `auth_type=\"aws_sdk\"` today (bedrock at \`hermes_cli/auth.py:450\`); the other two non-`api_key`/non-oauth providers are \`external_process\` and \`oauth_minimax\`, which use their own credential surfaces. No widening needed.