### PR TITLE
feat: add image generation fallback controls

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7986,6 +7986,20 @@ class HermesCLI:
                 return
             self._close_model_picker()
 
+    def _handle_image_model_switch(self, cmd_original: str):
+        """Handle /image_model — switch image generation provider/model globally."""
+        from hermes_cli.image_model_switch import apply_image_model_switch
+
+        parts = cmd_original.split(None, 1)
+        raw_args = parts[1].strip() if len(parts) > 1 else ""
+        result = apply_image_model_switch(raw_args)
+        prefix = "  " if result.success else "  ✗ "
+        for idx, line in enumerate(result.message.splitlines() or [""]):
+            if result.success:
+                _cprint(f"  {line}")
+            else:
+                _cprint(f"{prefix}{line}" if idx == 0 else f"    {line}")
+
     def _handle_model_switch(self, cmd_original: str):
         """Handle /model command — switch model for this session.
 
@@ -8916,6 +8930,8 @@ class HermesCLI:
             self._handle_sessions_command(cmd_original)
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
+        elif canonical == "image_model":
+            self._handle_image_model_switch(cmd_original)
         elif canonical == "codex-runtime":
             self._handle_codex_runtime(cmd_original)
         elif canonical == "gquota":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8199,6 +8199,9 @@ class GatewayRunner:
         if canonical == "model":
             return await self._handle_model_command(event)
 
+        if canonical == "image_model":
+            return await self._handle_image_model_command(event)
+
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
 
@@ -10966,6 +10969,14 @@ class GatewayRunner:
             "\n".join(lines),
             getattr(getattr(event, "source", None), "platform", None),
         )
+
+    async def _handle_image_model_command(self, event: MessageEvent) -> str:
+        """Handle /image_model command — switch image generation provider/model."""
+        from hermes_cli.image_model_switch import apply_image_model_switch
+
+        raw_args = event.get_command_args().strip() if event else ""
+        result = apply_image_model_switch(raw_args)
+        return result.message
 
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model for this session.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -125,6 +125,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration",
                args_hint="[model] [--provider name] [--global] [--refresh]"),
+    CommandDef("image_model", "Switch image generation provider/model", "Configuration",
+               aliases=("image-model",), args_hint="[provider|provider/model|model --provider provider]"),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),
@@ -341,6 +343,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "commands",
         "deny",
         "help",
+        "image_model",
         "new",
         "profile",
         "queue",
@@ -520,6 +523,7 @@ _TELEGRAM_MENU_PRIORITY = (
     "resume",
     "sessions",
     "model",
+    "image_model",
     # Maintenance / diagnostics — the ones that prompted this priority list.
     "debug",
     "restart",
@@ -1017,6 +1021,9 @@ _SLACK_RESERVED_COMMANDS = frozenset({
     "topic", "mute", "pro", "shortcuts",
 })
 
+_SLACK_ALIAS_PRIORITY = ("reset", "bg", "btw", "q")
+"""Common aliases that should survive Slack's 50-command cap."""
+
 
 def _sanitize_slack_name(raw: str) -> str:
     """Convert a command name to a valid Slack slash command name.
@@ -1077,16 +1084,26 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
             continue
         _add(cmd.name, cmd.description, cmd.args_hint or "")
 
-    # Second pass: aliases.
+    # Second pass: high-value aliases that should survive the 50-command cap.
+    priority_aliases = set(_SLACK_ALIAS_PRIORITY)
+    for alias in _SLACK_ALIAS_PRIORITY:
+        cmd = resolve_command(alias)
+        if not cmd or not _is_gateway_available(cmd, overrides):
+            continue
+        _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")
+
+    # Third pass: remaining aliases.
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
         for alias in cmd.aliases:
+            if alias in priority_aliases:
+                continue
             # Skip aliases that only differ from canonical by case/punctuation
             # normalization (already covered by _add dedup).
             _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")
 
-    # Third pass: plugin commands.
+    # Fourth pass: plugin commands.
     for name, description, args_hint in _iter_plugin_command_entries():
         _add(name, description, args_hint or "")
 

--- a/hermes_cli/image_model_switch.py
+++ b/hermes_cli/image_model_switch.py
@@ -1,0 +1,317 @@
+"""Shared /image_model command logic for CLI and gateway.
+
+Image generation backends are plugin-registered providers selected via
+``image_gen.provider`` and ``image_gen.model`` in config.yaml. This module keeps
+parsing, catalog lookup, formatting, and persistence in one place so the local
+CLI and messaging gateway expose the same command surface.
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ImageModelSwitchResult:
+    """Result of an image model switch attempt."""
+
+    success: bool
+    message: str
+    provider: str = ""
+    model: str = ""
+
+
+def _ensure_discovered() -> None:
+    """Discover image generation plugins best-effort."""
+    try:
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("image_model plugin discovery skipped: %s", exc)
+
+
+def _providers() -> dict[str, Any]:
+    _ensure_discovered()
+    try:
+        from agent.image_gen_registry import list_providers
+
+        return {p.name: p for p in list_providers()}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("image_model provider list failed: %s", exc)
+        return {}
+
+
+def _load_image_config() -> tuple[dict[str, Any], dict[str, Any]]:
+    from hermes_cli.config import load_config
+
+    cfg = load_config()
+    if not isinstance(cfg, dict):
+        cfg = {}
+    img_cfg = cfg.setdefault("image_gen", {})
+    if not isinstance(img_cfg, dict):
+        img_cfg = {}
+        cfg["image_gen"] = img_cfg
+    return cfg, img_cfg
+
+
+def _provider_models(provider: Any) -> list[dict[str, Any]]:
+    try:
+        raw = provider.list_models() or []
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("image_model %s.list_models failed: %s", getattr(provider, "name", "?"), exc)
+        return []
+    models: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, dict) and isinstance(item.get("id"), str) and item["id"].strip():
+            models.append(item)
+        elif isinstance(item, str) and item.strip():
+            models.append({"id": item.strip(), "display": item.strip()})
+    return models
+
+
+def _default_model(provider: Any, models: list[dict[str, Any]]) -> str:
+    try:
+        default = provider.default_model()
+        if isinstance(default, str) and default.strip():
+            return default.strip()
+    except Exception:  # noqa: BLE001
+        pass
+    if models:
+        return str(models[0]["id"])
+    return ""
+
+
+def _current_provider_and_model(img_cfg: dict[str, Any], providers: dict[str, Any]) -> tuple[str, str]:
+    provider = img_cfg.get("provider")
+    provider_name = provider.strip() if isinstance(provider, str) and provider.strip() else ""
+    if not provider_name and "fal" in providers:
+        provider_name = "fal"
+    model = ""
+    if provider_name:
+        nested = img_cfg.get(provider_name)
+        if isinstance(nested, dict):
+            raw_nested = nested.get("model")
+            if isinstance(raw_nested, str) and raw_nested.strip():
+                model = raw_nested.strip()
+    raw_model = img_cfg.get("model")
+    if not model and isinstance(raw_model, str) and raw_model.strip():
+        model = raw_model.strip()
+    if provider_name and not model and provider_name in providers:
+        models = _provider_models(providers[provider_name])
+        model = _default_model(providers[provider_name], models)
+    return provider_name, model
+
+
+def _persist_image_model_switch(target_provider: str, target_model: str) -> None:
+    """Persist only the user-owned image_gen keys needed for the switch."""
+    from hermes_cli.config import (
+        ensure_hermes_home,
+        format_managed_message,
+        get_config_path,
+        is_managed,
+        read_raw_config,
+    )
+    from utils import atomic_yaml_write
+
+    if is_managed():
+        raise RuntimeError(format_managed_message("switch image generation model"))
+
+    cfg = read_raw_config()
+    if not isinstance(cfg, dict):
+        cfg = {}
+    img_section = cfg.get("image_gen")
+    if not isinstance(img_section, dict):
+        img_section = {}
+        cfg["image_gen"] = img_section
+
+    img_section["provider"] = target_provider
+    provider_section = img_section.get(target_provider)
+    if not isinstance(provider_section, dict):
+        provider_section = {}
+
+    if target_model:
+        img_section["model"] = target_model
+        provider_section["model"] = target_model
+        img_section[target_provider] = provider_section
+    else:
+        img_section.pop("model", None)
+        provider_section.pop("model", None)
+        if provider_section:
+            img_section[target_provider] = provider_section
+        else:
+            img_section.pop(target_provider, None)
+
+    ensure_hermes_home()
+    atomic_yaml_write(get_config_path(), cfg, sort_keys=False)
+
+
+def _split_args(raw_args: str) -> tuple[str, str]:
+    """Return (model_input, explicit_provider) for /image_model args."""
+    import re as _re
+
+    normalized = _re.sub(r"[\u2012\u2013\u2014\u2015](provider|global)", r"--\1", raw_args or "")
+    try:
+        parts = shlex.split(normalized)
+    except ValueError:
+        parts = normalized.split()
+
+    explicit_provider = ""
+    filtered: list[str] = []
+    i = 0
+    while i < len(parts):
+        part = parts[i]
+        if part == "--global":
+            i += 1
+            continue
+        if part == "--provider" and i + 1 < len(parts):
+            explicit_provider = parts[i + 1].strip()
+            i += 2
+            continue
+        filtered.append(part)
+        i += 1
+    return " ".join(filtered).strip(), explicit_provider
+
+
+def _parse_target(raw_args: str, current_provider: str, providers: dict[str, Any]) -> tuple[str, str]:
+    """Resolve target provider/model from user args.
+
+    Accepted forms:
+      provider
+      model
+      model --provider provider
+      provider/model
+      provider:model
+    """
+    model_input, explicit_provider = _split_args(raw_args)
+    provider_name = explicit_provider.strip()
+    model = model_input.strip()
+
+    if model and not provider_name:
+        if ":" in model:
+            left, right = model.split(":", 1)
+            if left in providers and right.strip():
+                provider_name = left.strip()
+                model = right.strip()
+        elif "/" in model:
+            left, right = model.split("/", 1)
+            if left in providers and right.strip():
+                provider_name = left.strip()
+                model = right.strip()
+
+    if model and not provider_name and model in providers:
+        provider_name = model
+        model = ""
+
+    if not provider_name:
+        provider_name = current_provider
+
+    return provider_name, model
+
+
+def format_image_model_status(max_models_per_provider: int = 8) -> str:
+    """Return current image generation provider/model plus usage examples."""
+    providers = _providers()
+    _cfg, img_cfg = _load_image_config()
+    current_provider, current_model = _current_provider_and_model(img_cfg, providers)
+
+    lines = [
+        "Image generation model",
+        f"Current provider: `{current_provider or 'unset'}`",
+        f"Current model: `{current_model or 'default'}`",
+        "",
+    ]
+
+    if providers:
+        lines.append("Available providers:")
+        for name, provider in sorted(providers.items()):
+            tag = " ← current" if name == current_provider else ""
+            lines.append(f"- `{name}`{tag}")
+            models = _provider_models(provider)
+            shown = [str(m["id"]) for m in models[:max_models_per_provider]]
+            if shown:
+                suffix = f" (+{len(models) - len(shown)} more)" if len(models) > len(shown) else ""
+                lines.append(f"  models: {', '.join(f'`{m}`' for m in shown)}{suffix}")
+            default = _default_model(provider, models)
+            if default:
+                lines.append(f"  default: `{default}`")
+    else:
+        lines.append("No image generation providers are registered.")
+
+    lines.extend(
+        [
+            "",
+            "Usage:",
+            "- `/image_model <provider>`",
+            "- `/image_model <model> --provider <provider>`",
+            "- `/image_model <provider>/<model>`",
+            "- `/image_model <provider>:<model>`",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def apply_image_model_switch(raw_args: str) -> ImageModelSwitchResult:
+    """Persist an image generation provider/model switch to config.yaml."""
+    providers = _providers()
+    cfg, img_cfg = _load_image_config()
+    current_provider, _current_model = _current_provider_and_model(img_cfg, providers)
+
+    if not (raw_args or "").strip():
+        return ImageModelSwitchResult(True, format_image_model_status(), current_provider, _current_model)
+
+    target_provider, target_model = _parse_target(raw_args, current_provider, providers)
+    if not target_provider:
+        return ImageModelSwitchResult(
+            False,
+            "No image generation provider selected. Run `/image_model` to see available providers.",
+        )
+
+    provider = providers.get(target_provider)
+    if provider is None:
+        available = ", ".join(f"`{name}`" for name in sorted(providers)) or "none"
+        return ImageModelSwitchResult(
+            False,
+            f"Unknown image generation provider `{target_provider}`. Available providers: {available}.",
+            target_provider,
+            target_model,
+        )
+
+    models = _provider_models(provider)
+    model_ids = {str(m["id"]) for m in models}
+    if not target_model:
+        target_model = _default_model(provider, models)
+
+    if target_model and model_ids and target_model not in model_ids:
+        sample = ", ".join(f"`{mid}`" for mid in list(sorted(model_ids))[:8])
+        more = f" (+{len(model_ids) - 8} more)" if len(model_ids) > 8 else ""
+        return ImageModelSwitchResult(
+            False,
+            f"Provider `{target_provider}` has no image model `{target_model}`. Available: {sample}{more}.",
+            target_provider,
+            target_model,
+        )
+
+    try:
+        _persist_image_model_switch(target_provider, target_model)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to save image model switch: %s", exc)
+        return ImageModelSwitchResult(
+            False,
+            f"Failed to save image model switch: {exc}",
+            target_provider,
+            target_model,
+        )
+
+    model_display = target_model or "provider default"
+    return ImageModelSwitchResult(
+        True,
+        f"✓ Image model switched: `{target_provider}` / `{model_display}`\nSaved to config.yaml.",
+        target_provider,
+        target_model,
+    )

--- a/plugins/image_gen/fal/__init__.py
+++ b/plugins/image_gen/fal/__init__.py
@@ -113,9 +113,11 @@ class FalImageGenProvider(ImageGenProvider):
         import tools.image_generation_tool as _it
 
         aspect = resolve_aspect_ratio(aspect_ratio)
+        model_override = kwargs.get("model")
         passthrough = {
             key: kwargs[key]
             for key in (
+                "model",
                 "num_inference_steps",
                 "guidance_scale",
                 "num_images",
@@ -165,7 +167,7 @@ class FalImageGenProvider(ImageGenProvider):
         # internally, so query it after the fact for the response shape.
         if "model" not in response:
             try:
-                model_id, _meta = _it._resolve_fal_model()
+                model_id, _meta = _it._resolve_fal_model(model_override)
                 response["model"] = model_id
             except Exception:  # noqa: BLE001
                 pass

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -99,9 +99,14 @@ def _load_image_gen_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model(model_override: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
     """Decide which tier to use and return ``(model_id, meta)``."""
     import os
+
+    if isinstance(model_override, str):
+        explicit = model_override.strip()
+        if explicit in _MODELS:
+            return explicit, _MODELS[explicit]
 
     env_override = os.environ.get("OPENAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
@@ -365,7 +370,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
+        tier_id, meta = _resolve_model(kwargs.get("model"))
         size = _SIZES.get(aspect, _SIZES["square"])
 
         token = _read_codex_access_token()

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -93,8 +93,13 @@ def _load_openai_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model(model_override: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
     """Decide which tier to use and return ``(model_id, meta)``."""
+    if isinstance(model_override, str):
+        explicit = model_override.strip()
+        if explicit in _MODELS:
+            return explicit, _MODELS[explicit]
+
     env_override = os.environ.get("OPENAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
         return env_override, _MODELS[env_override]
@@ -210,7 +215,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        tier_id, meta = _resolve_model()
+        tier_id, meta = _resolve_model(kwargs.get("model"))
         size = _SIZES.get(aspect, _SIZES["square"])
 
         # gpt-image-2 returns b64_json unconditionally and REJECTS

--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -91,8 +91,13 @@ def _load_xai_config() -> Dict[str, Any]:
         return {}
 
 
-def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+def _resolve_model(model_override: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
     """Decide which model to use and return ``(model_id, meta)``."""
+    if isinstance(model_override, str):
+        explicit = model_override.strip()
+        if explicit in _MODELS:
+            return explicit, _MODELS[explicit]
+
     env_override = os.environ.get("XAI_IMAGE_MODEL")
     if env_override and env_override in _MODELS:
         return env_override, _MODELS[env_override]
@@ -176,7 +181,7 @@ class XAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect_ratio,
             )
 
-        model_id, meta = _resolve_model()
+        model_id, meta = _resolve_model(kwargs.get("model"))
         aspect = resolve_aspect_ratio(aspect_ratio)
         xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
         resolution = _resolve_resolution()

--- a/tests/gateway/test_image_model_command.py
+++ b/tests/gateway/test_image_model_command.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), emit_collect=AsyncMock(return_value=[]), loaded_hooks=False)
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    return runner
+
+
+def test_image_model_command_is_registered_for_cli_and_gateway():
+    from hermes_cli.commands import is_gateway_known_command, resolve_command
+
+    cmd = resolve_command("image_model")
+
+    assert cmd is not None
+    assert cmd.name == "image_model"
+    assert is_gateway_known_command("image_model") is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_dispatch_routes_image_model(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    sentinel = "image model handler reached"
+    runner._handle_image_model_command = AsyncMock(return_value=sentinel)  # type: ignore[attr-defined]
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_run_from_gateway_async",
+        AsyncMock(return_value={"final": "agent should not run"}),
+        raising=False,
+    )
+
+    out = await runner._handle_message(_make_event("/image_model openai/gpt-image-2-medium"))
+
+    assert out == sentinel
+    runner._handle_image_model_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_gateway_image_model_handler_returns_switch_result(monkeypatch):
+    from gateway.run import GatewayRunner
+    from hermes_cli.image_model_switch import ImageModelSwitchResult
+
+    runner = _make_runner()
+    event = _make_event("/image_model openai/gpt-image-2-medium")
+
+    monkeypatch.setattr(
+        "hermes_cli.image_model_switch.apply_image_model_switch",
+        lambda raw_args: ImageModelSwitchResult(
+            success=True,
+            message="✓ Image model switched: openai / gpt-image-2-medium",
+            provider="openai",
+            model="gpt-image-2-medium",
+        ),
+    )
+
+    out = await GatewayRunner._handle_image_model_command(runner, event)
+
+    assert "openai" in out
+    assert "gpt-image-2-medium" in out

--- a/tests/hermes_cli/test_image_model_switch.py
+++ b/tests/hermes_cli/test_image_model_switch.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import yaml
+
+from agent import image_gen_registry
+from agent.image_gen_provider import ImageGenProvider
+
+
+class _CatalogProvider(ImageGenProvider):
+    def __init__(self, name: str, models: list[str], default: str | None = None):
+        self._name = name
+        self._models = models
+        self._default = default or (models[0] if models else None)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def display_name(self) -> str:
+        return self._name.title()
+
+    def list_models(self):
+        return [{"id": mid, "display": mid.upper()} for mid in self._models]
+
+    def default_model(self):
+        return self._default
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        raise AssertionError("switch tests should not generate images")
+
+
+def setup_function():
+    image_gen_registry._reset_for_tests()
+
+
+def teardown_function():
+    image_gen_registry._reset_for_tests()
+
+
+def test_cli_process_command_routes_image_model(monkeypatch):
+    import cli as cli_module
+
+    calls = []
+    instance = object.__new__(cli_module.HermesCLI)
+    monkeypatch.setattr(
+        cli_module.HermesCLI,
+        "_handle_image_model_switch",
+        lambda self, command: calls.append(command),
+    )
+
+    assert cli_module.HermesCLI.process_command(instance, "/image_model openai/gpt-image-2-medium") is True
+    assert calls == ["/image_model openai/gpt-image-2-medium"]
+
+
+def test_apply_image_model_switch_persists_provider_and_model(monkeypatch, tmp_path):
+    from hermes_cli import plugins as plugins_module
+    from hermes_cli.image_model_switch import apply_image_model_switch
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "image_gen:\n"
+        "  provider: fal\n"
+        "  model: flux-dev\n"
+    )
+    image_gen_registry.register_provider(_CatalogProvider("fal", ["flux-dev"]))
+    image_gen_registry.register_provider(_CatalogProvider("openai", ["gpt-image-2-low", "gpt-image-2-medium"]))
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+    result = apply_image_model_switch("gpt-image-2-medium --provider openai")
+
+    assert result.success is True
+    assert result.provider == "openai"
+    assert result.model == "gpt-image-2-medium"
+    cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert cfg["image_gen"]["provider"] == "openai"
+    assert cfg["image_gen"]["model"] == "gpt-image-2-medium"
+    assert cfg["image_gen"]["openai"]["model"] == "gpt-image-2-medium"
+
+
+def test_apply_image_model_switch_accepts_provider_slash_model(monkeypatch, tmp_path):
+    from hermes_cli import plugins as plugins_module
+    from hermes_cli.image_model_switch import apply_image_model_switch
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("image_gen:\n  provider: fal\n")
+    image_gen_registry.register_provider(_CatalogProvider("fal", ["flux-dev"]))
+    image_gen_registry.register_provider(_CatalogProvider("xai", ["grok-imagine-image-quality"]))
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+    result = apply_image_model_switch("xai/grok-imagine-image-quality")
+
+    assert result.success is True
+    assert result.provider == "xai"
+    assert result.model == "grok-imagine-image-quality"
+
+
+def test_apply_image_model_switch_reports_available_providers_for_unknown_provider(monkeypatch, tmp_path):
+    from hermes_cli import plugins as plugins_module
+    from hermes_cli.image_model_switch import apply_image_model_switch
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("image_gen:\n  provider: fal\n")
+    image_gen_registry.register_provider(_CatalogProvider("fal", ["flux-dev"]))
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+    result = apply_image_model_switch("--provider missing")
+
+    assert result.success is False
+    assert "missing" in result.message
+    assert "fal" in result.message
+
+
+def test_format_image_model_status_lists_current_and_usage(monkeypatch, tmp_path):
+    from hermes_cli import plugins as plugins_module
+    from hermes_cli.image_model_switch import format_image_model_status
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "image_gen:\n"
+        "  provider: openai\n"
+        "  openai:\n"
+        "    model: gpt-image-2-medium\n"
+    )
+    image_gen_registry.register_provider(_CatalogProvider("openai", ["gpt-image-2-low", "gpt-image-2-medium"]))
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+    message = format_image_model_status()
+
+    assert "openai" in message
+    assert "gpt-image-2-medium" in message
+    assert "/image_model" in message
+
+
+def test_apply_image_model_switch_clears_stale_global_model_for_model_less_provider(monkeypatch, tmp_path):
+    from hermes_cli import plugins as plugins_module
+    from hermes_cli.image_model_switch import apply_image_model_switch
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "image_gen:\n"
+        "  provider: openai\n"
+        "  model: stale-model\n"
+    )
+    image_gen_registry.register_provider(_CatalogProvider("openai", ["stale-model"]))
+    image_gen_registry.register_provider(_CatalogProvider("noop", [], default=""))
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+    result = apply_image_model_switch("noop")
+
+    assert result.success is True
+    assert result.provider == "noop"
+    assert result.model == ""
+    cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert cfg["image_gen"]["provider"] == "noop"
+    assert "model" not in cfg["image_gen"]
+    assert "noop" not in cfg["image_gen"]
+
+
+def test_apply_image_model_switch_reports_managed_config_error(monkeypatch, tmp_path):
+    from hermes_cli import plugins as plugins_module
+    from hermes_cli.image_model_switch import apply_image_model_switch
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_MANAGED", "homebrew")
+    for subdir in ("cron", "sessions", "logs", "memories"):
+        (tmp_path / subdir).mkdir()
+    (tmp_path / "config.yaml").write_text("image_gen:\n  provider: fal\n")
+    image_gen_registry.register_provider(_CatalogProvider("openai", ["gpt-image-2-medium"]))
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+    result = apply_image_model_switch("openai/gpt-image-2-medium")
+
+    assert result.success is False
+    assert "managed by Homebrew" in result.message
+    cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert cfg["image_gen"]["provider"] == "fal"

--- a/tests/plugins/image_gen/test_fal_provider.py
+++ b/tests/plugins/image_gen/test_fal_provider.py
@@ -114,7 +114,7 @@ class TestFalImageGenProviderGenerate:
 
         monkeypatch.setattr(image_tool, "image_generate_tool", fake_image_generate_tool)
         monkeypatch.setattr(image_tool, "_resolve_fal_model",
-                            lambda: ("fal-ai/flux-2/klein/9b", {}))
+                            lambda model_override=None: ("fal-ai/flux-2/klein/9b", {}))
 
         result = FalImageGenProvider().generate(
             "a serene mountain landscape",
@@ -133,6 +133,35 @@ class TestFalImageGenProviderGenerate:
         assert result["aspect_ratio"] == "square"
         assert result["model"] == "fal-ai/flux-2/klein/9b"
 
+    def test_generate_passes_model_override_to_legacy_pipeline(self, monkeypatch):
+        import tools.image_generation_tool as image_tool
+        from plugins.image_gen.fal import FalImageGenProvider
+
+        captured = {}
+
+        def fake_image_generate_tool(prompt, aspect_ratio, **kwargs):
+            captured.update(kwargs)
+            return json.dumps({"success": True, "image": "https://fake/image.png"})
+
+        seen_model = {}
+
+        def fake_resolve(model_override=None):
+            seen_model["value"] = model_override
+            return "fal-ai/gpt-image-2", {}
+
+        monkeypatch.setattr(image_tool, "image_generate_tool", fake_image_generate_tool)
+        monkeypatch.setattr(image_tool, "_resolve_fal_model", fake_resolve)
+
+        result = FalImageGenProvider().generate(
+            "a serene mountain landscape",
+            aspect_ratio="square",
+            model="fal-ai/gpt-image-2",
+        )
+
+        assert captured["model"] == "fal-ai/gpt-image-2"
+        assert seen_model["value"] == "fal-ai/gpt-image-2"
+        assert result["model"] == "fal-ai/gpt-image-2"
+
     def test_generate_invalid_aspect_ratio_is_coerced(self, monkeypatch):
         import tools.image_generation_tool as image_tool
         from plugins.image_gen.fal import FalImageGenProvider
@@ -145,7 +174,7 @@ class TestFalImageGenProviderGenerate:
 
         monkeypatch.setattr(image_tool, "image_generate_tool", fake)
         monkeypatch.setattr(image_tool, "_resolve_fal_model",
-                            lambda: ("fal-ai/flux-2/klein/9b", {}))
+                            lambda model_override=None: ("fal-ai/flux-2/klein/9b", {}))
 
         FalImageGenProvider().generate("p", aspect_ratio="not-a-real-ratio")
         # ``resolve_aspect_ratio`` clamps to landscape.
@@ -163,7 +192,7 @@ class TestFalImageGenProviderGenerate:
 
         monkeypatch.setattr(image_tool, "image_generate_tool", fake)
         monkeypatch.setattr(image_tool, "_resolve_fal_model",
-                            lambda: ("fal-ai/flux-2/klein/9b", {}))
+                            lambda model_override=None: ("fal-ai/flux-2/klein/9b", {}))
 
         FalImageGenProvider().generate(
             "p",
@@ -200,7 +229,7 @@ class TestFalImageGenProviderGenerate:
 
         monkeypatch.setattr(image_tool, "image_generate_tool", lambda **kw: "not-json")
         monkeypatch.setattr(image_tool, "_resolve_fal_model",
-                            lambda: ("fal-ai/flux-2/klein/9b", {}))
+                            lambda model_override=None: ("fal-ai/flux-2/klein/9b", {}))
 
         result = FalImageGenProvider().generate("p")
         assert result["success"] is False

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -90,6 +90,20 @@ class TestAvailability:
         assert codex_plugin.OpenAICodexImageGenProvider().is_available() is False
 
 
+# ── Model resolution ────────────────────────────────────────────────────────
+
+
+class TestModelResolution:
+    def test_explicit_model_override_wins_over_config(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"openai-codex": {"model": "gpt-image-2-high"}}})
+        )
+        model_id, meta = codex_plugin._resolve_model("gpt-image-2-low")
+        assert model_id == "gpt-image-2-low"
+        assert meta["quality"] == "low"
+
+
 # ── Generate ────────────────────────────────────────────────────────────────
 
 

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -120,6 +120,15 @@ class TestModelResolution:
         assert model_id == "gpt-image-2-high"
         assert meta["quality"] == "high"
 
+    def test_explicit_model_override_wins_over_config(self, tmp_path):
+        import yaml
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"image_gen": {"model": "gpt-image-2-high"}})
+        )
+        model_id, meta = openai_plugin._resolve_model("gpt-image-2-low")
+        assert model_id == "gpt-image-2-low"
+        assert meta["quality"] == "low"
+
 
 # ── Generate ────────────────────────────────────────────────────────────────
 

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -93,6 +93,12 @@ class TestConfig:
         model_id, meta = _resolve_model()
         assert model_id == "grok-imagine-image"
 
+    def test_explicit_model_override(self):
+        from plugins.image_gen.xai import _resolve_model
+
+        model_id, _ = _resolve_model("grok-imagine-image")
+        assert model_id == "grok-imagine-image"
+
     def test_default_resolution(self):
         from plugins.image_gen.xai import _resolve_resolution
 

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -337,6 +337,13 @@ class TestModelResolution:
             mid, _ = image_tool._resolve_fal_model()
         assert mid == "fal-ai/nano-banana-pro"
 
+    def test_explicit_model_override_wins_over_config_and_env(self, image_tool, monkeypatch):
+        monkeypatch.setenv("FAL_IMAGE_MODEL", "fal-ai/z-image/turbo")
+        with patch("hermes_cli.config.load_config",
+                   return_value={"image_gen": {"model": "fal-ai/nano-banana-pro"}}):
+            mid, _ = image_tool._resolve_fal_model("fal-ai/gpt-image-2")
+        assert mid == "fal-ai/gpt-image-2"
+
 
 # ---------------------------------------------------------------------------
 # Aspect ratio handling

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -30,7 +30,26 @@ class _FakeCodexProvider(ImageGenProvider):
         }
 
 
+class _FakeProvider(ImageGenProvider):
+    def __init__(self, name: str, result=None, exc: Exception | None = None):
+        self._name = name
+        self.result = result
+        self.exc = exc
+        self.calls = []
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        self.calls.append({"prompt": prompt, "aspect_ratio": aspect_ratio, **kwargs})
+        if self.exc is not None:
+            raise self.exc
+        return self.result
+
+
 class TestPluginDispatch:
+
     def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool
         from agent import image_gen_registry as registry_module
@@ -97,3 +116,180 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_dispatch_falls_back_to_configured_provider_when_primary_returns_error(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n"
+            "  provider: primary\n"
+            "  fallback_providers:\n"
+            "    - backup\n"
+        )
+        primary = _FakeProvider(
+            "primary",
+            {
+                "success": False,
+                "image": None,
+                "error": "quota exceeded",
+                "error_type": "quota",
+                "provider": "primary",
+            },
+        )
+        backup = _FakeProvider(
+            "backup",
+            {
+                "success": True,
+                "image": "/tmp/backup.png",
+                "model": "backup-model",
+                "provider": "backup",
+            },
+        )
+        image_gen_registry.register_provider(primary)
+        image_gen_registry.register_provider(backup)
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw fox", "portrait")
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert payload["provider"] == "backup"
+        assert payload["image"] == "/tmp/backup.png"
+        assert [call["prompt"] for call in primary.calls] == ["draw fox"]
+        assert [call["aspect_ratio"] for call in backup.calls] == ["portrait"]
+
+    def test_dispatch_passes_explicit_fallback_model(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n"
+            "  provider: primary\n"
+            "  fallback_providers:\n"
+            "    - provider: backup\n"
+            "      model: backup-model-explicit\n"
+        )
+        primary = _FakeProvider(
+            "primary",
+            {"success": False, "image": None, "error": "primary quota", "provider": "primary"},
+        )
+        backup = _FakeProvider(
+            "backup",
+            {"success": True, "image": "/tmp/backup.png", "provider": "backup"},
+        )
+        image_gen_registry.register_provider(primary)
+        image_gen_registry.register_provider(backup)
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw fox", "square")
+        assert dispatched is not None
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert backup.calls == [{"prompt": "draw fox", "aspect_ratio": "square", "model": "backup-model-explicit"}]
+
+    def test_dispatch_aggregates_errors_when_all_fallback_providers_fail(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n"
+            "  provider: primary\n"
+            "  fallback_providers: [backup]\n"
+        )
+        primary = _FakeProvider("primary", exc=RuntimeError("primary down"))
+        backup = _FakeProvider(
+            "backup",
+            {
+                "success": False,
+                "image": None,
+                "error": "backup quota",
+                "error_type": "quota",
+                "provider": "backup",
+            },
+        )
+        image_gen_registry.register_provider(primary)
+        image_gen_registry.register_provider(backup)
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw fox", "square")
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is False
+        assert payload["error_type"] == "provider_fallback_failed"
+        assert "primary" in payload["error"]
+        assert "primary down" in payload["error"]
+        assert "backup" in payload["error"]
+        assert "backup quota" in payload["error"]
+
+    def test_dispatch_does_not_fallback_on_non_retryable_policy_failure(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n"
+            "  provider: primary\n"
+            "  fallback_providers: [backup]\n"
+        )
+        primary = _FakeProvider(
+            "primary",
+            {
+                "success": False,
+                "image": None,
+                "error": "content policy rejected prompt",
+                "error_type": "content_policy",
+                "provider": "primary",
+            },
+        )
+        backup = _FakeProvider(
+            "backup",
+            {"success": True, "image": "/tmp/backup.png", "provider": "backup"},
+        )
+        image_gen_registry.register_provider(primary)
+        image_gen_registry.register_provider(backup)
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw fox", "square")
+        assert dispatched is not None
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is False
+        assert payload["provider"] == "primary"
+        assert payload["error_type"] == "content_policy"
+        assert backup.calls == []
+
+    def test_dispatch_allows_same_provider_with_distinct_fallback_model(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n"
+            "  provider: primary\n"
+            "  model: fast-model\n"
+            "  fallback_providers:\n"
+            "    - provider: primary\n"
+            "      model: quality-model\n"
+        )
+        provider = _FakeProvider(
+            "primary",
+            {"success": False, "image": None, "error": "quota exceeded", "error_type": "quota", "provider": "primary"},
+        )
+        image_gen_registry.register_provider(provider)
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw fox", "square")
+        assert dispatched is not None
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is False
+        assert payload["error_type"] == "provider_fallback_failed"
+        assert provider.calls == [
+            {"prompt": "draw fox", "aspect_ratio": "square", "model": "fast-model"},
+            {"prompt": "draw fox", "aspect_ratio": "square", "model": "quality-model"},
+        ]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -476,21 +476,22 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
 # ---------------------------------------------------------------------------
 # Model resolution + payload construction
 # ---------------------------------------------------------------------------
-def _resolve_fal_model() -> tuple:
+def _resolve_fal_model(model_override: Optional[str] = None) -> tuple:
     """Resolve the active FAL model from config.yaml (primary) or default.
 
     Returns (model_id, metadata_dict). Falls back to DEFAULT_MODEL if the
     configured model is unknown (logged as a warning).
     """
-    model_id = ""
+    model_id = model_override.strip() if isinstance(model_override, str) else ""
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        img_cfg = cfg.get("image_gen") if isinstance(cfg, dict) else None
-        if isinstance(img_cfg, dict):
-            raw = img_cfg.get("model")
-            if isinstance(raw, str):
-                model_id = raw.strip()
+        if not model_id:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            img_cfg = cfg.get("image_gen") if isinstance(cfg, dict) else None
+            if isinstance(img_cfg, dict):
+                raw = img_cfg.get("model")
+                if isinstance(raw, str):
+                    model_id = raw.strip()
     except Exception as exc:
         logger.debug("Could not load image_gen.model from config: %s", exc)
 
@@ -609,6 +610,7 @@ def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, A
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    model: Optional[str] = None,
     num_inference_steps: Optional[int] = None,
     guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None,
@@ -617,21 +619,23 @@ def image_generate_tool(
 ) -> str:
     """Generate an image from a text prompt using the configured FAL model.
 
-    The agent-facing schema exposes only ``prompt`` and ``aspect_ratio``; the
-    remaining kwargs are overrides for direct Python callers and are filtered
-    per-model via the ``supports`` whitelist (unsupported overrides are
-    silently dropped so legacy callers don't break when switching models).
+    The agent-facing schema exposes only ``prompt`` and ``aspect_ratio``;
+    ``model`` and the remaining kwargs are overrides for direct Python callers
+    and are filtered per-model via the ``supports`` whitelist (unsupported
+    overrides are silently dropped so legacy callers don't break when switching
+    models).
 
     Returns a JSON string with ``{"success": bool, "image": url | None,
     "error": str, "error_type": str}``.
     """
-    model_id, meta = _resolve_fal_model()
+    model_id, meta = _resolve_fal_model(model)
 
     debug_call_data = {
         "model": model_id,
         "parameters": {
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
+            "model": model,
             "num_inference_steps": num_inference_steps,
             "guidance_scale": guidance_scale,
             "num_images": num_images,
@@ -912,22 +916,59 @@ IMAGE_GENERATE_SCHEMA = {
 }
 
 
-def _read_configured_image_model():
-    """Return the value of ``image_gen.model`` from config.yaml, or None."""
+def _read_image_gen_config() -> Dict[str, Any]:
+    """Return the ``image_gen`` config section as a dict."""
     try:
         from hermes_cli.config import load_config
+
         cfg = load_config()
         section = cfg.get("image_gen") if isinstance(cfg, dict) else None
         if isinstance(section, dict):
-            value = section.get("model")
-            if isinstance(value, str) and value.strip():
-                return value.strip()
+            return section
     except Exception as exc:
-        logger.debug("Could not read image_gen.model: %s", exc)
+        logger.debug("Could not read image_gen config: %s", exc)
+    return {}
+
+
+def _image_model_for_provider(
+    provider_name: str,
+    section: Optional[Dict[str, Any]] = None,
+    *,
+    primary: bool = True,
+    explicit_model: Optional[str] = None,
+    provider_obj: Any = None,
+) -> Optional[str]:
+    """Resolve the model to pass to an image provider."""
+    if isinstance(explicit_model, str) and explicit_model.strip():
+        return explicit_model.strip()
+    section = section if isinstance(section, dict) else _read_image_gen_config()
+    provider_cfg = section.get(provider_name) if provider_name else None
+    if isinstance(provider_cfg, dict):
+        value = provider_cfg.get("model")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if primary:
+        value = section.get("model")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    if provider_obj is not None:
+        try:
+            default = provider_obj.default_model()
+            if isinstance(default, str) and default.strip():
+                return default.strip()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Could not read %s.default_model(): %s", provider_name, exc)
     return None
 
 
-def _read_configured_image_provider():
+def _read_configured_image_model():
+    """Return the active image model from config.yaml, or None."""
+    section = _read_image_gen_config()
+    provider = _read_configured_image_provider(section)
+    return _image_model_for_provider(provider or "", section, primary=True)
+
+
+def _read_configured_image_provider(section: Optional[Dict[str, Any]] = None):
     """Return the value of ``image_gen.provider`` from config.yaml, or None.
 
     We only consult the plugin registry when this is explicitly set — an
@@ -938,21 +979,142 @@ def _read_configured_image_provider():
     back into this module's pipeline via call-time indirection — see
     issue #26241).
     """
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
-        if isinstance(section, dict):
-            value = section.get("provider")
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    except Exception as exc:
-        logger.debug("Could not read image_gen.provider: %s", exc)
+    section = section if isinstance(section, dict) else _read_image_gen_config()
+    value = section.get("provider") if isinstance(section, dict) else None
+    if isinstance(value, str) and value.strip():
+        return value.strip()
     return None
 
 
+def _read_configured_image_fallbacks(section: Optional[Dict[str, Any]] = None) -> list[Dict[str, str]]:
+    """Return configured image provider fallbacks from ``image_gen.fallback_providers``.
+
+    Entries may be provider strings or dicts with ``provider`` and optional
+    ``model`` keys.
+    """
+    section = section if isinstance(section, dict) else _read_image_gen_config()
+    raw = section.get("fallback_providers") if isinstance(section, dict) else None
+    if isinstance(raw, (str, dict)):
+        raw_entries = [raw]
+    elif isinstance(raw, list):
+        raw_entries = raw
+    else:
+        raw_entries = []
+
+    entries: list[Dict[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in raw_entries:
+        provider = ""
+        model = ""
+        if isinstance(item, str):
+            provider = item.strip()
+        elif isinstance(item, dict):
+            raw_provider = item.get("provider")
+            raw_model = item.get("model")
+            if isinstance(raw_provider, str):
+                provider = raw_provider.strip()
+            if isinstance(raw_model, str):
+                model = raw_model.strip()
+        if not provider:
+            continue
+        key = (provider, model)
+        if key in seen:
+            continue
+        seen.add(key)
+        entry = {"provider": provider}
+        if model:
+            entry["model"] = model
+        entries.append(entry)
+    return entries
+
+
+_RETRYABLE_IMAGE_ERROR_TYPES = {
+    "auth_required",
+    "connection_error",
+    "empty_response",
+    "invalid_response",
+    "io_error",
+    "missing_api_key",
+    "missing_dependency",
+    "provider_contract",
+    "provider_exception",
+    "provider_not_registered",
+    "quota",
+    "rate_limit",
+    "timeout",
+}
+
+_NON_RETRYABLE_IMAGE_ERROR_TYPES = {
+    "bad_request",
+    "content_policy",
+    "invalid_argument",
+    "moderation",
+    "policy_violation",
+    "safety",
+}
+
+_RETRYABLE_IMAGE_ERROR_MARKERS = (
+    "429",
+    "500",
+    "502",
+    "503",
+    "504",
+    "connection",
+    "overload",
+    "quota",
+    "rate limit",
+    "rate_limit",
+    "server error",
+    "temporar",
+    "timeout",
+    "timed out",
+    "too many requests",
+    "unavailable",
+)
+
+_NON_RETRYABLE_IMAGE_ERROR_MARKERS = (
+    "400",
+    "bad request",
+    "content policy",
+    "disallowed",
+    "invalid prompt",
+    "invalid request",
+    "moderation",
+    "policy violation",
+    "safety",
+)
+
+
+def _sanitize_image_provider_error(error: Any) -> str:
+    """Redact and bound provider error text before user-facing aggregation."""
+    text = str(error or "unknown error")
+    try:
+        from agent.redact import redact_sensitive_text
+
+        text = redact_sensitive_text(text, force=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Image provider error redaction skipped: %s", exc)
+    return text if len(text) <= 500 else f"{text[:497]}..."
+
+
+def _image_provider_failure_is_retryable(result: Dict[str, Any]) -> bool:
+    """Return True when a failed provider result may safely try a fallback."""
+    error_type = str(result.get("error_type") or "provider_error").strip().lower()
+    error = str(result.get("error") or "").strip().lower()
+
+    if error_type in _NON_RETRYABLE_IMAGE_ERROR_TYPES:
+        return False
+    if any(marker in error for marker in _NON_RETRYABLE_IMAGE_ERROR_MARKERS):
+        return False
+    if error_type in _RETRYABLE_IMAGE_ERROR_TYPES:
+        return True
+    if error_type == "api_error":
+        return any(marker in error for marker in _RETRYABLE_IMAGE_ERROR_MARKERS)
+    return any(marker in error for marker in _RETRYABLE_IMAGE_ERROR_MARKERS)
+
+
 def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
-    """Route the call to a plugin-registered provider when one is selected.
+    """Route the call to plugin-registered providers when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
     in-tree FAL fallback in ``image_generate_tool``.
@@ -961,14 +1123,14 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     ``"fal"`` itself, which now resolves to the
     ``plugins/image_gen/fal/`` plugin (the plugin re-enters this module's
     pipeline via ``_it`` indirection so behavior is identical to the
-    direct call, just routed through the registry).
+    direct call, just routed through the registry). When
+    ``image_gen.fallback_providers`` is configured, failed providers are tried
+    in order before returning an error.
     """
+    section = _read_image_gen_config()
     configured = _read_configured_image_provider()
     if not configured:
         return None
-
-    # Also read configured model so we can pass it to the plugin
-    configured_model = _read_configured_image_model()
 
     try:
         # Import locally so plugin discovery isn't triggered just by
@@ -977,57 +1139,131 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         from hermes_cli.plugins import _ensure_plugins_discovered
 
         _ensure_plugins_discovered()
-        provider = get_provider(configured)
     except Exception as exc:
         logger.debug("image_gen plugin dispatch skipped: %s", exc)
         return None
 
-    if provider is None:
-        try:
-            # Long-lived sessions may have discovered plugins before a bundled
-            # backend was patched in or before config changed. Retry once with
-            # a forced refresh before surfacing a missing-provider error.
-            _ensure_plugins_discovered(force=True)
-            provider = get_provider(configured)
-        except Exception as exc:
-            logger.debug("image_gen plugin force-refresh skipped: %s", exc)
+    def _resolve_provider(name: str):
+        provider_obj = get_provider(name)
+        if provider_obj is None:
+            try:
+                # Long-lived sessions may have discovered plugins before a bundled
+                # backend was patched in or before config changed. Retry once with
+                # a forced refresh before surfacing a missing-provider error.
+                _ensure_plugins_discovered(force=True)
+                provider_obj = get_provider(name)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("image_gen plugin force-refresh skipped: %s", exc)
+        return provider_obj
 
-    if provider is None:
-        return json.dumps({
+    primary_model = _image_model_for_provider(configured, section, primary=True) or ""
+    attempts: list[Dict[str, str]] = [{"provider": configured}]
+    attempts[0]["model"] = primary_model
+    for fallback in _read_configured_image_fallbacks(section):
+        fallback_provider = fallback.get("provider", "")
+        fallback_model = fallback.get("model", "")
+        if not fallback_provider:
+            continue
+        if fallback_provider == configured and (not fallback_model or fallback_model == primary_model):
+            continue
+        attempts.append(fallback)
+
+    failures: list[Dict[str, str]] = []
+    has_fallbacks = len(attempts) > 1
+
+    def _failure_result(error: str, error_type: str, provider_name: str) -> Dict[str, Any]:
+        return {
             "success": False,
             "image": None,
-            "error": (
-                f"image_gen.provider='{configured}' is set but no plugin "
-                f"registered that name. Run `hermes plugins list` to see "
-                f"available image gen backends."
-            ),
-            "error_type": "provider_not_registered",
-        })
+            "error": error,
+            "error_type": error_type,
+            "provider": provider_name,
+        }
 
-    try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
-        if configured_model:
-            kwargs["model"] = configured_model
-        result = provider.generate(**kwargs)
-    except Exception as exc:
-        logger.warning(
-            "Image gen provider '%s' raised: %s",
-            getattr(provider, "name", "?"), exc,
+    for idx, attempt in enumerate(attempts):
+        provider_name = attempt.get("provider", "")
+        provider = _resolve_provider(provider_name)
+        if provider is None:
+            result = _failure_result(
+                (
+                    f"image_gen.provider='{provider_name}' is set but no plugin "
+                    f"registered that name. Run `hermes plugins list` to see "
+                    f"available image gen backends."
+                ),
+                "provider_not_registered",
+                provider_name,
+            )
+        else:
+            try:
+                kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+                model = _image_model_for_provider(
+                    provider_name,
+                    section,
+                    primary=(idx == 0),
+                    explicit_model=attempt.get("model"),
+                    provider_obj=provider,
+                )
+                if model:
+                    kwargs["model"] = model
+                result = provider.generate(**kwargs)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "Image gen provider '%s' raised: %s",
+                    getattr(provider, "name", provider_name), exc,
+                )
+                result = _failure_result(
+                    f"Provider '{getattr(provider, 'name', provider_name)}' error: {exc}",
+                    "provider_exception",
+                    getattr(provider, "name", provider_name),
+                )
+
+        if not isinstance(result, dict):
+            result = _failure_result(
+                "Provider returned a non-dict result",
+                "provider_contract",
+                provider_name,
+            )
+
+        if result.get("success") is not False:
+            return json.dumps(result)
+
+        sanitized_error = _sanitize_image_provider_error(result.get("error") or "unknown error")
+        result["error"] = sanitized_error
+        failures.append(
+            {
+                "provider": str(result.get("provider") or provider_name),
+                "error_type": str(result.get("error_type") or "provider_error"),
+                "error": sanitized_error,
+            }
         )
-        return json.dumps({
-            "success": False,
-            "image": None,
-            "error": f"Provider '{getattr(provider, 'name', '?')}' error: {exc}",
-            "error_type": "provider_exception",
-        })
-    if not isinstance(result, dict):
-        return json.dumps({
-            "success": False,
-            "image": None,
-            "error": "Provider returned a non-dict result",
-            "error_type": "provider_contract",
-        })
-    return json.dumps(result)
+        if not has_fallbacks:
+            return json.dumps(result)
+        has_next_fallback = idx + 1 < len(attempts)
+        if has_next_fallback and not _image_provider_failure_is_retryable(result):
+            logger.info(
+                "Image gen provider '%s' failed with non-retryable %s; skipping fallbacks",
+                failures[-1]["provider"],
+                failures[-1]["error_type"],
+            )
+            return json.dumps(result)
+        logger.info(
+            "Image gen provider '%s' failed (%s); %s",
+            failures[-1]["provider"],
+            failures[-1]["error_type"],
+            "trying fallback" if has_next_fallback else "no fallback left",
+        )
+
+    summary = "; ".join(
+        f"{item['provider']} ({item['error_type']}): {item['error']}"
+        for item in failures
+    ) or "no providers attempted"
+    return json.dumps({
+        "success": False,
+        "image": None,
+        "error": f"All configured image generation providers failed: {summary}",
+        "error_type": "provider_fallback_failed",
+        "provider_errors": failures,
+    })
 
 
 def _handle_image_generate(args, **kw):
@@ -1036,8 +1272,7 @@ def _handle_image_generate(args, **kw):
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
 
-    # Route to a plugin-registered provider if one is active (and it's
-    # not the in-tree FAL path).
+    # Route to a plugin-registered provider if one is active.
     dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
     if dispatched is not None:
         return dispatched


### PR DESCRIPTION
## What does this PR do?

Adds first-class image generation fallback controls:

- `image_gen.fallback_providers` support for image provider fallback.
- `/image_model` CLI/gateway command for switching image provider/model.
- Explicit fallback model override propagation through OpenAI, OpenAI-Codex, xAI, and FAL providers.
- Retry gating so fallback only triggers for retryable provider failures.
- Aggregated provider errors with sensitive details redacted.

This implements the image generation provider-fallback slice of the broader tool-level fallback request. The wider issue also discusses vision fallback, script fallback, and other tool categories, so this PR links it as a partial implementation.

Closest related work checked:

- #30455 tracks general tool-level fallback for `image_gen`, vision, and other non-LLM services.
- #31498 covers custom Responses image providers, which is adjacent provider support rather than fallback routing.
- #29923 covers per-turn/per-image model overrides, which overlaps model selection but not provider fallback chains.

## Related Issue

Partially addresses #30455 for `image_gen` provider fallback and image model switching.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/image_generation_tool.py`
  - Adds image generation fallback-provider resolution and retry orchestration.
  - Restricts fallback retries to retryable provider failures.
  - Redacts aggregated provider errors before returning them to the agent/user.
- `hermes_cli/image_model_switch.py`
  - Adds image provider/model switch support used by CLI and gateway command paths.
- `cli.py`, `gateway/run.py`, `hermes_cli/commands.py`
  - Wires `/image_model` into command dispatch.
- `plugins/image_gen/fal/__init__.py`
- `plugins/image_gen/openai-codex/__init__.py`
- `plugins/image_gen/openai/__init__.py`
- `plugins/image_gen/xai/__init__.py`
  - Propagates explicit fallback model overrides through each provider.
- Tests added/updated:
  - `tests/hermes_cli/test_image_model_switch.py`
  - `tests/gateway/test_image_model_command.py`
  - `tests/tools/test_image_generation.py`
  - `tests/tools/test_image_generation_plugin_dispatch.py`
  - `tests/plugins/image_gen/test_fal_provider.py`
  - `tests/plugins/image_gen/test_openai_provider.py`
  - `tests/plugins/image_gen/test_xai_provider.py`
  - `tests/plugins/image_gen/test_openai_codex_provider.py`

## How to Test

1. Run formatting/diff checks:

```bash
git diff --cached --check
```

2. Run the targeted image fallback and command test suite:

```bash
uv run pytest -q tests/hermes_cli/test_image_model_switch.py \
                 tests/gateway/test_image_model_command.py \
                 tests/tools/test_image_generation.py \
                 tests/tools/test_image_generation_plugin_dispatch.py \
                 tests/plugins/image_gen/test_fal_provider.py \
                 tests/plugins/image_gen/test_openai_provider.py \
                 tests/plugins/image_gen/test_xai_provider.py \
                 tests/plugins/image_gen/test_openai_codex_provider.py \
                 tests/gateway/test_command_bypass_active_session.py
```

Expected result from the branch:

```text
196 passed
```

3. Run lint on the touched implementation and test files:

```bash
uv run ruff check cli.py gateway/run.py hermes_cli/commands.py \
                  hermes_cli/image_model_switch.py tools/image_generation_tool.py \
                  plugins/image_gen/fal/__init__.py \
                  plugins/image_gen/openai/__init__.py \
                  plugins/image_gen/xai/__init__.py \
                  plugins/image_gen/openai-codex/__init__.py \
                  tests/gateway/test_image_model_command.py \
                  tests/hermes_cli/test_image_model_switch.py \
                  tests/tools/test_image_generation.py \
                  tests/tools/test_image_generation_plugin_dispatch.py \
                  tests/plugins/image_gen/test_fal_provider.py \
                  tests/plugins/image_gen/test_openai_provider.py \
                  tests/plugins/image_gen/test_xai_provider.py \
                  tests/plugins/image_gen/test_openai_codex_provider.py
```

Expected result:

```text
All checks passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS with the targeted tests above; GitHub CI is green

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted tests and lint:

```text
$ uv run pytest -q tests/hermes_cli/test_image_model_switch.py tests/gateway/test_image_model_command.py tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/plugins/image_gen/test_fal_provider.py tests/plugins/image_gen/test_openai_provider.py tests/plugins/image_gen/test_xai_provider.py tests/plugins/image_gen/test_openai_codex_provider.py tests/gateway/test_command_bypass_active_session.py
196 passed

$ uv run ruff check cli.py gateway/run.py hermes_cli/commands.py hermes_cli/image_model_switch.py tools/image_generation_tool.py plugins/image_gen/fal/__init__.py plugins/image_gen/openai/__init__.py plugins/image_gen/xai/__init__.py plugins/image_gen/openai-codex/__init__.py tests/gateway/test_image_model_command.py tests/hermes_cli/test_image_model_switch.py tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/plugins/image_gen/test_fal_provider.py tests/plugins/image_gen/test_openai_provider.py tests/plugins/image_gen/test_xai_provider.py tests/plugins/image_gen/test_openai_codex_provider.py
All checks passed
```
