### PR TITLE
fix(model-picker): use live Copilot catalog for openai-codex, copilot, copilot-acp

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1052,11 +1052,13 @@ def list_authenticated_providers(
     max_models: int = 8,
     current_model: str = "",
 ) -> List[dict]:
-    """Detect which providers have credentials and list their curated models.
+    """Detect which providers have credentials and list their model catalogs.
 
-    Uses the curated model lists from hermes_cli/models.py (OPENROUTER_MODELS,
-    _PROVIDER_MODELS) — NOT the full models.dev catalog.  These are hand-picked
-    agentic models that work well as agent backends.
+    Most providers use curated model lists from hermes_cli/models.py
+    (OPENROUTER_MODELS, _PROVIDER_MODELS) — hand-picked agentic models that
+    work well as agent backends. Providers whose catalog is account/tier
+    dependent (Codex/Copilot) use live authenticated discovery with curated
+    fallback.
 
     Returns a list of dicts, each with:
       - slug: str — the --provider value to use
@@ -1239,13 +1241,22 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list, falling back to models.dev if no curated list.
-        # For preferred providers, merge models.dev entries into the curated
-        # catalog so newly released models (e.g. mimo-v2.5-pro on opencode-go)
-        # show up in the picker without requiring a Hermes release.
-        model_ids = curated.get(hermes_id, [])
-        if hermes_id in _MODELS_DEV_PREFERRED:
-            model_ids = _merge_with_models_dev(hermes_id, model_ids)
+        if hermes_id in {"openai-codex", "copilot", "copilot-acp"}:
+            # Prefer the live authenticated catalog for backends whose model
+            # set changes by account/tier. ``provider_model_ids()`` already
+            # falls back to the curated static list when the live endpoint is
+            # unavailable, so the picker stays useful offline while surfacing
+            # newly-enabled Copilot/Codex models as soon as the backend lists
+            # them.
+            model_ids = provider_model_ids(hermes_id)
+        else:
+            # Use curated list, falling back to models.dev if no curated list.
+            # For preferred providers, merge models.dev entries into the curated
+            # catalog so newly released models (e.g. mimo-v2.5-pro on opencode-go)
+            # show up in the picker without requiring a Hermes release.
+            model_ids = curated.get(hermes_id, [])
+            if hermes_id in _MODELS_DEV_PREFERRED:
+                model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
 

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -29,7 +29,13 @@ def test_copilot_picker_keeps_curated_copilot_models_when_live_catalog_unavailab
 def test_copilot_picker_uses_live_catalog_when_available():
     live_models = ["gpt-5.4", "claude-sonnet-4.6", "gemini-3.1-pro-preview"]
 
-    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+    # Include the models.dev provider row so this exercises the first
+    # PROVIDER_TO_MODELS_DEV loop, not only the Hermes-overlay fallback path.
+    # Regression: that earlier loop used the checked-in static list directly,
+    # causing the Copilot row to be emitted before the later live-catalog branch
+    # could run.
+    models_dev = {"github-copilot": {"env": ["GH_TOKEN"]}}
+    with patch("agent.models_dev.fetch_models_dev", return_value=models_dev), \
          patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value="gh-token"), \
          patch("hermes_cli.models._fetch_github_models", return_value=live_models):
         providers = list_authenticated_providers(current_provider="openrouter", max_models=50)


### PR DESCRIPTION
## Summary

The `/model` picker (and `hermes model`) was showing the **static checked-in** Copilot model catalog instead of the **live authenticated** Copilot catalog. New models that GitHub adds to Copilot — e.g. `claude-opus-4.7`, `claude-opus-4.7-1m-internal`, `gpt-5.5` — weren't selectable until the next Hermes release shipped an updated `_PROVIDER_MODELS["copilot"]` list.

## Root cause

In `hermes_cli/model_switch.py:list_authenticated_providers()`, three providers were being emitted from the first `PROVIDER_TO_MODELS_DEV` loop using the checked-in `_PROVIDER_MODELS[...]` list:

- `openai-codex`
- `copilot`
- `copilot-acp`

That happened **before** the later Hermes-overlay path could call `provider_model_ids(...)` to fetch the live catalog. The overlay was effectively dead code for these three providers — picker output was always the static list.

## Fix

For those three providers, swap the first loop to use `provider_model_ids(hermes_id)` directly. That helper already does live-fetch-first with curated/static fallback when the live fetch fails, so we keep the existing fallback safety.

Updated the docstring so it no longer claims to use live discovery when it doesn't.

## Test

Strengthened `tests/hermes_cli/test_copilot_in_model_list.py` to exercise the exact failing path: Copilot present in `PROVIDER_TO_MODELS_DEV`, not just the overlay fallback path.

```
tests/hermes_cli/test_copilot_in_model_list.py ..   [100%]
2 passed in 0.73s
```

Live verification on my setup:
- `picker_matches_effective True`
- Live-only models now surfaced (previously hidden behind static list):
  `claude-opus-4.7`, `claude-opus-4.7-1m-internal`, `claude-opus-4.6`,
  `claude-opus-4.5`, `gpt-5.5`, `gpt-5.2`
