### PR TITLE
fix(skills): reject symlinks in skill bundles before install

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1314,6 +1314,8 @@ AUTHOR_MAP = {
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",  # PR #27518 (bracketed-paste timeout)
     "8bit64k@pm.me": "8bit64k",  # PR #14681 (TUI /q alias from quit to queue)
     "chenglunhu@gmail.com": "hclsys",  # PR #31985 (TUI /q alias regression test)
+    "dearmayo@localhost": "ffr31mr",  # PR #32103 (SubdirectoryHintTracker workspace boundary)
+    "TheOnlyMika@users.noreply.github.com": "TheOnlyMika",  # PR #32155 (dashboard XSS + defusedxml)
 }
 
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1913,3 +1913,50 @@ class TestInstallPathSafety:
         assert ok is False
         assert victim.exists()
         assert (victim / "important").read_text() == "don't delete me"
+
+    def test_install_from_quarantine_rejects_symlinks(self, tmp_path):
+        """Skill install must not follow symlinks that leak file contents
+        from outside the quarantine directory."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        skills_dir = tmp_path / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        (q_dir / "SKILL.md").write_text("---\nname: bad-skill\n---\n")
+
+        secret = tmp_path / "secret.txt"
+        secret.write_text("data exfiltration payload\n")
+
+        leak = q_dir / "leak.txt"
+        try:
+            leak.symlink_to(secret)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        bundle = hub.SkillBundle(
+            name="bad-skill",
+            files={"SKILL.md": "---\nname: bad-skill\n---\n"},
+            source="community",
+            identifier="x",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="bad-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root):
+            with pytest.raises(ValueError, match="symlink"):
+                hub.install_from_quarantine(
+                    q_dir, "bad-skill", "", bundle, scan_result,
+                )
+
+        assert not (skills_dir / "bad-skill" / "leak.txt").exists()
+        assert secret.read_text() == "data exfiltration payload\n"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3040,6 +3040,21 @@ def install_from_quarantine(
         except OSError:
             pass
 
+    # Reject symlinks inside the quarantined skill before moving it.
+    # A malicious skill bundle could include a symlink pointing outside the
+    # skills tree; its target contents would then be copied into skills/ and
+    # leaked to the agent on the next skill_view call.
+    for entry in quarantine_path.rglob("*"):
+        if not _is_path_redirect(entry):
+            continue
+        try:
+            rel = entry.relative_to(quarantine_resolved)
+        except ValueError:
+            rel = entry
+        raise ValueError(
+            f"Installed skill contains symlinks, which is not allowed: {rel}"
+        )
+
     install_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(quarantine_path), str(install_dir))
 


### PR DESCRIPTION
Salvage of #32186 (@MorAlekss). Includes a chore commit mapping ffr31mr + TheOnlyMika in AUTHOR_MAP (pre-prep for the rest of the must-have security cluster).

## What it fixes
`install_from_quarantine` calls `shutil.move` to relocate a scanned bundle into `skills/`. `shutil.move` follows symlinks, so a quarantined bundle containing a symlink at `leak.txt → ~/.ssh/id_rsa` would land in `skills/<skill>/leak.txt` with the secret's contents — readable by the agent on its next `skill_view`.

## Mechanism
Before `shutil.move`, `quarantine_path.rglob("*")` walks the source tree (pathlib rglob does NOT follow symlinks → yields the symlink entry itself). `_is_path_redirect()` from #32080 handles both symlinks and Windows junctions. Refuses with a clear error before any disk write.

## Pairs with #32080
Different threat vectors, same primitive:
- #32080 guarded the **destination** (`uninstall_skill`'s rmtree target) against symlink-redirected deletion
- This guards the **source** (`install_from_quarantine`'s move target) against symlink-redirected reads

Clean reuse — `_is_path_redirect` lives in skills_hub already from #32080.

## Validation
- 125/125 tests in `tests/tools/test_skills_hub.py` pass
- E2E: hand-crafted malicious bundle with `leak.txt → /tmp/secret.txt` refused with `ValueError: Installed skill contains symlinks, which is not allowed: leak.txt`. Secret intact. Legit bundle still installs. Nested symlink inside `scripts/` subdir also refused.

Closes #32186.