### PR TITLE
perf: add the-token-caveman result shaping controls

### DIFF
--- a/agent/token_optimization_metrics.py
+++ b/agent/token_optimization_metrics.py
@@ -1,0 +1,186 @@
+"""Measurement-only token optimization metrics."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def metrics_enabled() -> bool:
+    """Return whether opt-in Phase 1 token metrics are enabled."""
+    return os.getenv("HERMES_TOKEN_OPTIMIZATION_METRICS", "").strip().lower() in _TRUE_VALUES
+
+
+def metrics_path() -> Path:
+    """Return the profile-aware JSONL metrics path."""
+    return get_hermes_home() / "token-optimization" / "metrics.jsonl"
+
+
+def estimate_tokens(char_count: int) -> int:
+    """Estimate tokens from result size without inspecting prompt text."""
+    return int(math.ceil(char_count / 4)) if char_count > 0 else 0
+
+
+def _arg_keys(function_args: Any) -> list[str]:
+    if not isinstance(function_args, dict):
+        return []
+    return sorted(str(key) for key in function_args)
+
+
+def _json_shape(result: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(result)
+    except Exception:
+        return {
+            "is_json": False,
+            "top_level_type": "invalid_json",
+            "has_error_key": False,
+            "has_non_empty_error": False,
+            "truncated_by_tool": False,
+            "result_class": "invalid_json",
+        }
+
+    if isinstance(parsed, dict):
+        top_level_type = "object"
+        has_error_key = "error" in parsed
+        error_value = parsed.get("error")
+        has_non_empty_error = error_value not in (None, "", False)
+        truncated_by_tool = any(
+            parsed.get(key) is True
+            for key in ("truncated_by_tool", "truncated", "is_truncated")
+        )
+        if has_non_empty_error:
+            result_class = "runtime_error"
+        elif truncated_by_tool:
+            result_class = "truncated"
+        elif not parsed:
+            result_class = "empty"
+        else:
+            result_class = "success"
+    elif isinstance(parsed, list):
+        top_level_type = "array"
+        has_error_key = False
+        has_non_empty_error = False
+        truncated_by_tool = False
+        result_class = "empty" if not parsed else "success"
+    elif isinstance(parsed, str):
+        top_level_type = "string"
+        has_error_key = False
+        has_non_empty_error = False
+        truncated_by_tool = False
+        result_class = "empty" if not parsed else "success"
+    elif isinstance(parsed, bool):
+        top_level_type = "boolean"
+        has_error_key = False
+        has_non_empty_error = False
+        truncated_by_tool = False
+        result_class = "success"
+    elif isinstance(parsed, (int, float)):
+        top_level_type = "number"
+        has_error_key = False
+        has_non_empty_error = False
+        truncated_by_tool = False
+        result_class = "success"
+    elif parsed is None:
+        top_level_type = "null"
+        has_error_key = False
+        has_non_empty_error = False
+        truncated_by_tool = False
+        result_class = "empty"
+    else:
+        top_level_type = type(parsed).__name__
+        has_error_key = False
+        has_non_empty_error = False
+        truncated_by_tool = False
+        result_class = "success"
+
+    return {
+        "is_json": True,
+        "top_level_type": top_level_type,
+        "has_error_key": has_error_key,
+        "has_non_empty_error": has_non_empty_error,
+        "truncated_by_tool": truncated_by_tool,
+        "result_class": result_class,
+    }
+
+
+def build_tool_result_metric(
+    *,
+    tool_name: str,
+    function_args: Any,
+    result: Any,
+    task_id: str | None,
+    session_id: str | None,
+    tool_call_id: str | None,
+    duration_ms: int | None,
+) -> dict[str, Any]:
+    """Build metadata for a tool result without storing raw payloads.
+
+    The sha256 value identifies identical payloads; it is not anonymization.
+    """
+    result_text = result if isinstance(result, str) else str(result)
+    result_bytes = result_text.encode("utf-8", errors="replace")
+    char_count = len(result_text)
+    metric: dict[str, Any] = {
+        "schema_version": 2,
+        "event_type": "tool_result",
+        "created_at_ms": int(time.time() * 1000),
+        "session_id": session_id or "",
+        "task_id": task_id or "",
+        "tool_call_id": tool_call_id or "",
+        "tool_name": tool_name,
+        "duration_ms": duration_ms if isinstance(duration_ms, int) else None,
+        "result_char_count": char_count,
+        "result_byte_count": len(result_bytes),
+        "estimated_tokens": estimate_tokens(char_count),
+        "sha256": hashlib.sha256(result_bytes).hexdigest(),
+        "arg_keys": _arg_keys(function_args),
+    }
+    metric.update(_json_shape(result_text))
+    return metric
+
+
+def record_tool_result_metric(
+    *,
+    tool_name: str,
+    function_args: Any,
+    result: Any,
+    task_id: str | None,
+    session_id: str | None,
+    tool_call_id: str | None,
+    duration_ms: int | None,
+) -> None:
+    """Append one opt-in metric row.
+
+    This function is deliberately fail-open: metrics must never break tool
+    dispatch, and Phase 1 records measurement metadata only.
+    """
+    try:
+        if not metrics_enabled():
+            return
+
+        metric = build_tool_result_metric(
+            tool_name=tool_name,
+            function_args=function_args,
+            result=result,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            duration_ms=duration_ms,
+        )
+        path = metrics_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(metric, ensure_ascii=False, separators=(",", ":")) + "\n")
+    except Exception:
+        return

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1523,6 +1523,18 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Max iterations
         max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
 
+        # Cron jobs may pin their own fallback chain. Do not implicitly pass the
+        # default profile's global fallback_providers into scheduled jobs: the
+        # default profile is allowed to use opencode-zen for same-model
+        # continuity, but routine crons must only use explicit job-local
+        # fallback routes.
+        _job_fallback_raw = job.get("fallback_providers") or job.get("fallback_model") or None
+        fallback_model = (
+            _expand_env_vars(_job_fallback_raw)
+            if isinstance(_job_fallback_raw, (dict, list))
+            else None
+        )
+
         # Provider routing
         pr = _cfg.get("provider_routing", {})
 
@@ -1546,8 +1558,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except AuthError as auth_exc:
             # Primary provider auth failed — try fallback chain before giving up.
             logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)
-            fb = _cfg.get("fallback_providers") or _cfg.get("fallback_model")
-            fb_list = (fb if isinstance(fb, list) else [fb]) if fb else []
+            fb_list = (fallback_model if isinstance(fallback_model, list) else [fallback_model]) if fallback_model else []
             runtime = None
             for entry in fb_list:
                 if not isinstance(entry, dict):
@@ -1569,7 +1580,6 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
-        fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
         if runtime_provider:

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,6 +29,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
+from agent.token_optimization_metrics import record_tool_result_metric
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
 
@@ -845,6 +846,19 @@ def handle_function_call(
                 user_task=user_task,
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
+
+        try:
+            record_tool_result_metric(
+                tool_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=task_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                duration_ms=duration_ms,
+            )
+        except Exception as _metrics_err:
+            logger.debug("token optimization metric error: %s", _metrics_err)
 
         try:
             from hermes_cli.plugins import invoke_hook

--- a/model_tools.py
+++ b/model_tools.py
@@ -848,19 +848,6 @@ def handle_function_call(
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 
         try:
-            record_tool_result_metric(
-                tool_name=function_name,
-                function_args=function_args,
-                result=result,
-                task_id=task_id,
-                session_id=session_id,
-                tool_call_id=tool_call_id,
-                duration_ms=duration_ms,
-            )
-        except Exception as _metrics_err:
-            logger.debug("token optimization metric error: %s", _metrics_err)
-
-        try:
             from hermes_cli.plugins import invoke_hook
             invoke_hook(
                 "post_tool_call",
@@ -899,6 +886,19 @@ def handle_function_call(
                     break
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
+
+        try:
+            record_tool_result_metric(
+                tool_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=task_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                duration_ms=duration_ms,
+            )
+        except Exception as _metrics_err:
+            logger.debug("token optimization metric error: %s", _metrics_err)
 
         return result
 

--- a/scripts/token_phase2a_shadow_benchmark.py
+++ b/scripts/token_phase2a_shadow_benchmark.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Reproducible Phase 2A result-shaping benchmark.
+
+Creates a disposable fixture, runs read_file/search_files through the normal
+dispatcher with opt-in metrics enabled only for this process, and compares
+default auto-shaped output to explicit result_mode='full' output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _char_len(result: str) -> int:
+    return len(result if isinstance(result, str) else str(result))
+
+
+def _call(tool: str, args: dict, *, task_id: str, session_id: str) -> str:
+    from model_tools import handle_function_call
+
+    return handle_function_call(
+        tool,
+        args,
+        task_id=task_id,
+        session_id=session_id,
+        tool_call_id=f"{tool}-{args.get('result_mode', 'auto')}-{args.get('offset', 0)}",
+    )
+
+
+def _build_fixture(root: Path) -> tuple[Path, Path]:
+    large = root / "large_module.py"
+    lines = []
+    for i in range(1, 701):
+        marker = "PHASE2A_NEEDLE" if i % 4 == 0 else "ordinary"
+        lines.append(
+            f"def function_{i:04d}():  # {marker}\n"
+            f"    return 'line {i:04d} {'x' * 120}'\n"
+        )
+    large.write_text("".join(lines), encoding="utf-8")
+
+    for file_idx in range(18):
+        target = root / f"module_{file_idx:02d}.py"
+        target.write_text(
+            "\n".join(
+                f"value_{line_idx} = 'PHASE2A_NEEDLE {'y' * 160}'"
+                for line_idx in range(18)
+            ),
+            encoding="utf-8",
+        )
+
+    return large, root
+
+
+def _audit_metrics(path: Path) -> tuple[bool, list[str]]:
+    if not path.exists():
+        return False, ["metrics file was not created"]
+
+    raw = path.read_text(encoding="utf-8")
+    forbidden = [
+        "PHASE2A_NEEDLE",
+        "value_1 =",
+        "function_0001",
+        '"args"',
+        '"arguments"',
+        '"raw_args"',
+        '"result"',
+        '"content"',
+        '"output"',
+    ]
+    failures = [token for token in forbidden if token in raw]
+
+    for line_no, line in enumerate(raw.splitlines(), start=1):
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            failures.append(f"invalid json line {line_no}")
+            continue
+        if "sha256" not in row or "result_char_count" not in row:
+            failures.append(f"missing metadata line {line_no}")
+
+    return not failures, failures
+
+
+def main() -> int:
+    fixture_root = Path(tempfile.mkdtemp(prefix="hermes-phase2a-fixture-"))
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-phase2a-home-"))
+    old_home = os.environ.get("HERMES_HOME")
+    old_metrics = os.environ.get("HERMES_TOKEN_OPTIMIZATION_METRICS")
+
+    try:
+        os.environ["HERMES_HOME"] = str(hermes_home)
+        os.environ["HERMES_TOKEN_OPTIMIZATION_METRICS"] = "1"
+        large_file, search_root = _build_fixture(fixture_root)
+
+        calls = [
+            (
+                "read_file",
+                {"path": str(large_file), "limit": 500},
+                {"path": str(large_file), "limit": 500, "result_mode": "full"},
+            ),
+            (
+                "search_files",
+                {
+                    "pattern": "PHASE2A_NEEDLE",
+                    "path": str(search_root),
+                    "limit": 50,
+                    "output_mode": "content",
+                },
+                {
+                    "pattern": "PHASE2A_NEEDLE",
+                    "path": str(search_root),
+                    "limit": 50,
+                    "output_mode": "content",
+                    "result_mode": "full",
+                },
+            ),
+        ]
+
+        shaped_total = 0
+        full_total = 0
+        details = []
+        for index, (tool, shaped_args, full_args) in enumerate(calls, start=1):
+            shaped = _call(tool, shaped_args, task_id=f"phase2a-shaped-{index}", session_id="phase2a")
+            full = _call(tool, full_args, task_id=f"phase2a-full-{index}", session_id="phase2a")
+            shaped_len = _char_len(shaped)
+            full_len = _char_len(full)
+            shaped_total += shaped_len
+            full_total += full_len
+            details.append((tool, shaped_len, full_len))
+
+        reduction = 0.0 if full_total == 0 else (full_total - shaped_total) / full_total * 100
+        metrics_file = hermes_home / "token-optimization" / "metrics.jsonl"
+        audit_ok, audit_failures = _audit_metrics(metrics_file)
+
+        print("Phase 2A result-shaping benchmark")
+        for tool, shaped_len, full_len in details:
+            print(f"- {tool}: auto={shaped_len:,} chars full={full_len:,} chars")
+        print(f"- combined: auto={shaped_total:,} chars full={full_total:,} chars")
+        print(f"- reduction: {reduction:.2f}%")
+        print(f"- metrics_file: {metrics_file}")
+        print(f"- metrics_leakage_audit: {'PASS' if audit_ok else 'FAIL'}")
+        if audit_failures:
+            print("- audit_failures: " + ", ".join(audit_failures))
+
+        return 0 if audit_ok and reduction >= 30.0 else 1
+    finally:
+        if old_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_home
+        if old_metrics is None:
+            os.environ.pop("HERMES_TOKEN_OPTIMIZATION_METRICS", None)
+        else:
+            os.environ["HERMES_TOKEN_OPTIMIZATION_METRICS"] = old_metrics
+        shutil.rmtree(fixture_root, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/token_phase2a_shadow_benchmark.py
+++ b/scripts/token_phase2a_shadow_benchmark.py
@@ -96,10 +96,12 @@ def main() -> int:
     hermes_home = Path(tempfile.mkdtemp(prefix="hermes-phase2a-home-"))
     old_home = os.environ.get("HERMES_HOME")
     old_metrics = os.environ.get("HERMES_TOKEN_OPTIMIZATION_METRICS")
+    old_disable = os.environ.get("HERMES_DISABLE_RESULT_COMPACTION")
 
     try:
         os.environ["HERMES_HOME"] = str(hermes_home)
         os.environ["HERMES_TOKEN_OPTIMIZATION_METRICS"] = "1"
+        os.environ.pop("HERMES_DISABLE_RESULT_COMPACTION", None)
         large_file, search_root = _build_fixture(fixture_root)
 
         calls = [
@@ -162,7 +164,12 @@ def main() -> int:
             os.environ.pop("HERMES_TOKEN_OPTIMIZATION_METRICS", None)
         else:
             os.environ["HERMES_TOKEN_OPTIMIZATION_METRICS"] = old_metrics
+        if old_disable is None:
+            os.environ.pop("HERMES_DISABLE_RESULT_COMPACTION", None)
+        else:
+            os.environ["HERMES_DISABLE_RESULT_COMPACTION"] = old_disable
         shutil.rmtree(fixture_root, ignore_errors=True)
+        shutil.rmtree(hermes_home, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1532,16 +1532,45 @@ class TestRunJobConfigEnvVarExpansion:
             "config.yaml ${VAR} was not expanded in the cron execution path."
         )
 
-    def test_fallback_model_env_ref_in_config_yaml_is_expanded(self, tmp_path, monkeypatch):
-        """${VAR} in config.yaml fallback_providers model: is expanded."""
+    def test_config_fallback_providers_are_not_inherited_by_cron_jobs(self, tmp_path, monkeypatch):
+        """Cron jobs must not implicitly inherit the default profile fallback chain."""
         (tmp_path / "config.yaml").write_text(
             "fallback_providers:\n"
-            "  - provider: openrouter\n"
-            "    model: ${_HERMES_TEST_CRON_FALLBACK}\n"
+            "  - provider: opencode-zen\n"
+            "    model: gpt-5.5\n"
         )
-        monkeypatch.setenv("_HERMES_TEST_CRON_FALLBACK", "gpt-4o-fallback-test")
 
         job = {"id": "fb-job", "name": "fallback test", "prompt": "hi"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs.get("fallback_model") is None
+
+    def test_job_fallback_model_env_ref_is_expanded(self, tmp_path, monkeypatch):
+        """${VAR} in a job-local fallback_providers model is expanded."""
+        (tmp_path / "config.yaml").write_text("model: gpt-4o-mini-cron-test\n")
+        monkeypatch.setenv("_HERMES_TEST_CRON_FALLBACK", "gpt-4o-fallback-test")
+
+        job = {
+            "id": "fb-job",
+            "name": "fallback test",
+            "prompt": "hi",
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "${_HERMES_TEST_CRON_FALLBACK}"}
+            ],
+        }
         fake_db = MagicMock()
 
         with patch("cron.scheduler._hermes_home", tmp_path), \
@@ -1561,8 +1590,7 @@ class TestRunJobConfigEnvVarExpansion:
         fb_list = fb if isinstance(fb, list) else [fb]
         expanded = [e.get("model") for e in fb_list if isinstance(e, dict)]
         assert "gpt-4o-fallback-test" in expanded, (
-            f"Expected expanded fallback model in {expanded!r}. "
-            "config.yaml ${VAR} in fallback_providers was not expanded."
+            f"Expected expanded job-local fallback model in {expanded!r}."
         )
 
     def test_unexpanded_ref_passthrough_when_var_unset(self, tmp_path, monkeypatch):

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -112,7 +112,7 @@ class TestHandleFunctionCall:
         # pre_tool_call does NOT get duration_ms (nothing has run yet).
         assert "duration_ms" not in kwargs_by_hook["pre_tool_call"]
 
-    def test_token_metrics_observe_dispatch_result_before_plugin_hooks(self, monkeypatch):
+    def test_token_metrics_observe_transformed_model_visible_result(self, monkeypatch):
         events = []
 
         def fake_metric(**kwargs):
@@ -139,12 +139,12 @@ class TestHandleFunctionCall:
         assert result == '{"rewritten":true}'
         assert [event[0] for event in events] == [
             "pre_tool_call",
-            "metric",
             "post_tool_call",
             "transform_tool_result",
+            "metric",
         ]
-        assert events[1][1] == '{"ok":true}'
-        assert isinstance(events[1][2], int)
+        assert events[-1][1] == '{"rewritten":true}'
+        assert isinstance(events[-1][2], int)
         assert events[1][2] == events[2][2] == events[3][2]
 
     def test_token_metrics_failure_does_not_change_tool_result(self, monkeypatch):

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -112,6 +112,53 @@ class TestHandleFunctionCall:
         # pre_tool_call does NOT get duration_ms (nothing has run yet).
         assert "duration_ms" not in kwargs_by_hook["pre_tool_call"]
 
+    def test_token_metrics_observe_dispatch_result_before_plugin_hooks(self, monkeypatch):
+        events = []
+
+        def fake_metric(**kwargs):
+            events.append(("metric", kwargs["result"], kwargs["duration_ms"]))
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            events.append((hook_name, kwargs.get("result"), kwargs.get("duration_ms")))
+            if hook_name == "transform_tool_result":
+                return ['{"rewritten":true}']
+            return []
+
+        monkeypatch.setattr("model_tools.registry.dispatch", lambda *a, **kw: '{"ok":true}')
+        monkeypatch.setattr("model_tools.record_tool_result_metric", fake_metric)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+        result = handle_function_call(
+            "web_search",
+            {"q": "do not store this raw value"},
+            task_id="task-1",
+            session_id="session-1",
+            tool_call_id="call-1",
+        )
+
+        assert result == '{"rewritten":true}'
+        assert [event[0] for event in events] == [
+            "pre_tool_call",
+            "metric",
+            "post_tool_call",
+            "transform_tool_result",
+        ]
+        assert events[1][1] == '{"ok":true}'
+        assert isinstance(events[1][2], int)
+        assert events[1][2] == events[2][2] == events[3][2]
+
+    def test_token_metrics_failure_does_not_change_tool_result(self, monkeypatch):
+        def broken_metric(**kwargs):
+            raise RuntimeError("metrics sink unavailable")
+
+        monkeypatch.setattr("model_tools.registry.dispatch", lambda *a, **kw: '{"ok":true}')
+        monkeypatch.setattr("model_tools.record_tool_result_metric", broken_metric)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *a, **kw: [])
+
+        result = handle_function_call("web_search", {"q": "test"}, task_id="task-1")
+
+        assert result == '{"ok":true}'
+
 
 # =========================================================================
 # Agent loop tools

--- a/tests/test_token_optimization_metrics.py
+++ b/tests/test_token_optimization_metrics.py
@@ -1,0 +1,148 @@
+import json
+
+from agent.token_optimization_metrics import (
+    build_tool_result_metric,
+    estimate_tokens,
+    metrics_path,
+    record_tool_result_metric,
+)
+
+
+def test_metrics_disabled_by_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_TOKEN_OPTIMIZATION_METRICS", raising=False)
+
+    record_tool_result_metric(
+        tool_name="terminal",
+        function_args={"command": "echo secret"},
+        result='{"output":"secret"}',
+        task_id="task-1",
+        session_id="session-1",
+        tool_call_id="call-1",
+        duration_ms=3,
+    )
+
+    assert not metrics_path().exists()
+
+
+def test_truthy_gate_writes_profile_aware_jsonl(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_TOKEN_OPTIMIZATION_METRICS", "yes")
+
+    record_tool_result_metric(
+        tool_name="terminal",
+        function_args={"command": "printf", "token": "sk-secret-value"},
+        result='{"output":"SECRET_PAYLOAD","truncated":true}',
+        task_id="task-1",
+        session_id="session-1",
+        tool_call_id="call-1",
+        duration_ms=7,
+    )
+
+    path = tmp_path / "token-optimization" / "metrics.jsonl"
+    assert metrics_path() == path
+    rows = path.read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 1
+
+    raw_row = rows[0]
+    row = json.loads(raw_row)
+    assert row["schema_version"] == 2
+    assert row["event_type"] == "tool_result"
+    assert row["session_id"] == "session-1"
+    assert row["task_id"] == "task-1"
+    assert row["tool_call_id"] == "call-1"
+    assert row["tool_name"] == "terminal"
+    assert row["duration_ms"] == 7
+    assert row["arg_keys"] == ["command", "token"]
+    assert row["is_json"] is True
+    assert row["top_level_type"] == "object"
+    assert row["has_error_key"] is False
+    assert row["has_non_empty_error"] is False
+    assert row["truncated_by_tool"] is True
+    assert row["result_class"] == "truncated"
+    assert "sha256" in row
+
+    assert "SECRET_PAYLOAD" not in raw_row
+    assert "sk-secret-value" not in raw_row
+    assert "printf" not in raw_row
+
+
+def test_build_metric_records_shape_and_identifier_not_payload():
+    result = '{"error":"raw failure text","data":[1,2,3]}'
+
+    row = build_tool_result_metric(
+        tool_name="read_file",
+        function_args={"path": "/tmp/secret.txt"},
+        result=result,
+        task_id=None,
+        session_id=None,
+        tool_call_id=None,
+        duration_ms=0,
+    )
+
+    assert row["result_char_count"] == len(result)
+    assert row["result_byte_count"] == len(result.encode("utf-8"))
+    assert row["estimated_tokens"] == estimate_tokens(len(result))
+    assert row["top_level_type"] == "object"
+    assert row["has_error_key"] is True
+    assert row["has_non_empty_error"] is True
+    assert row["result_class"] == "runtime_error"
+    assert row["arg_keys"] == ["path"]
+    assert len(row["sha256"]) == 64
+    # sha256 is an identifier for equality/correlation, not anonymization.
+    assert result not in json.dumps(row)
+    assert "/tmp/secret.txt" not in json.dumps(row)
+
+
+def test_invalid_json_shape_is_metadata_only():
+    row = build_tool_result_metric(
+        tool_name="terminal",
+        function_args=["not", "a", "dict"],
+        result="plain text result",
+        task_id="task-1",
+        session_id="session-1",
+        tool_call_id="call-1",
+        duration_ms=None,
+    )
+
+    assert row["is_json"] is False
+    assert row["top_level_type"] == "invalid_json"
+    assert row["has_error_key"] is False
+    assert row["has_non_empty_error"] is False
+    assert row["truncated_by_tool"] is False
+    assert row["result_class"] == "invalid_json"
+    assert row["arg_keys"] == []
+    assert row["duration_ms"] is None
+
+
+def test_metrics_fail_open(monkeypatch, tmp_path):
+    blocked_parent = tmp_path / "not-a-directory"
+    blocked_parent.write_text("file blocks mkdir", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(blocked_parent))
+    monkeypatch.setenv("HERMES_TOKEN_OPTIMIZATION_METRICS", "on")
+
+    record_tool_result_metric(
+        tool_name="terminal",
+        function_args={},
+        result="{}",
+        task_id=None,
+        session_id=None,
+        tool_call_id=None,
+        duration_ms=1,
+    )
+
+
+def test_null_error_field_is_not_counted_as_actual_error():
+    row = build_tool_result_metric(
+        tool_name="terminal",
+        function_args={"command": "true"},
+        result='{"output":"ok","error":null}',
+        task_id="task-1",
+        session_id="session-1",
+        tool_call_id="call-1",
+        duration_ms=2,
+    )
+
+    assert row["has_error_key"] is True
+    assert row["has_non_empty_error"] is False
+    assert row["result_class"] == "success"

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -403,6 +403,30 @@ class TestResultShaping(unittest.TestCase):
         self.assertIn("result_mode='full'", result["_hint"])
         self.assertIn("output_mode='files_only'", result["_hint"])
         self.assertGreater(result["omitted_matches"], 0)
+        self.assertIn("offset=12", result["_hint"])
+
+    @patch("tools.file_tools.file_state.record_read")
+    @patch("tools.file_tools._get_file_ops")
+    def test_compacted_read_is_recorded_as_partial(self, mock_ops, mock_record_read):
+        content = "\n".join(
+            f"{i:6d}|{('large line %04d ' % i) + ('x' * 180)}"
+            for i in range(1, 260)
+        )
+        mock_ops.return_value = _make_fake_ops(
+            content=content,
+            total_lines=260,
+            file_size=len(content),
+        )
+
+        result = json.loads(read_file_tool(
+            "/tmp/large.txt",
+            limit=500,
+            task_id="large-read-partial",
+        ))
+
+        self.assertTrue(result["compacted"])
+        mock_record_read.assert_called_once()
+        self.assertTrue(mock_record_read.call_args.kwargs.get("partial"))
 
     @patch("tools.file_tools._get_file_ops")
     def test_disable_result_compaction_preserves_large_search_auto_result(self, mock_ops):

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -16,6 +16,7 @@ from unittest.mock import patch, MagicMock
 
 from tools.file_tools import (
     read_file_tool,
+    search_tool,
     write_file_tool,
     reset_file_dedup,
     _is_blocked_device,
@@ -53,6 +54,30 @@ def _make_fake_ops(content="hello\n", total_lines=1, file_size=6):
         content=content, total_lines=total_lines, file_size=file_size,
     )
     return fake
+
+
+class _FakeSearchMatch:
+    def __init__(self, path, line, content):
+        self.path = path
+        self.line_number = line
+        self.content = content
+
+
+class _FakeSearchResult:
+    def __init__(self, matches=None, total_count=None, truncated=False):
+        self.matches = matches or []
+        self.total_count = total_count if total_count is not None else len(self.matches)
+        self.truncated = truncated
+
+    def to_dict(self):
+        return {
+            "total_count": self.total_count,
+            "matches": [
+                {"path": m.path, "line": m.line_number, "content": m.content}
+                for m in self.matches
+            ],
+            "truncated": self.truncated,
+        }
 
 
 def _make_safe_tempdir(prefix: str) -> str:
@@ -205,6 +230,202 @@ class TestCharacterCountGuard(unittest.TestCase):
         result = json.loads(read_file_tool("/tmp/justunder.txt", task_id="under"))
         self.assertNotIn("error", result)
         self.assertIn("content", result)
+
+
+class TestResultShaping(unittest.TestCase):
+    """Large file/search outputs get compact previews with explicit escape hatches."""
+
+    def setUp(self):
+        _read_tracker.clear()
+        self._old_disable_compaction = os.environ.pop(
+            "HERMES_DISABLE_RESULT_COMPACTION",
+            None,
+        )
+
+    def tearDown(self):
+        _read_tracker.clear()
+        if self._old_disable_compaction is None:
+            os.environ.pop("HERMES_DISABLE_RESULT_COMPACTION", None)
+        else:
+            os.environ["HERMES_DISABLE_RESULT_COMPACTION"] = self._old_disable_compaction
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_targeted_read_stays_exact(self, mock_ops):
+        content = "\n".join(f"{i:6d}|line {i}" for i in range(1, 40))
+        mock_ops.return_value = _make_fake_ops(
+            content=content,
+            total_lines=40,
+            file_size=len(content),
+        )
+
+        result = json.loads(read_file_tool(
+            "/tmp/targeted.txt",
+            offset=10,
+            limit=40,
+            task_id="targeted-read",
+        ))
+
+        self.assertNotIn("compacted", result)
+        self.assertEqual(result["content"], content)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_large_read_auto_compacts_with_full_hint(self, mock_ops):
+        content = "\n".join(
+            f"{i:6d}|{('large line %04d ' % i) + ('x' * 180)}"
+            for i in range(1, 260)
+        )
+        mock_ops.return_value = _make_fake_ops(
+            content=content,
+            total_lines=260,
+            file_size=len(content),
+        )
+
+        result = json.loads(read_file_tool(
+            "/tmp/large.txt",
+            limit=500,
+            task_id="large-read",
+        ))
+
+        self.assertTrue(result["compacted"])
+        self.assertLess(len(result["content"]), len(content))
+        self.assertIn("result_mode='full'", result["_hint"])
+        self.assertIn("offset=", result["_hint"])
+        self.assertGreater(result["omitted_lines_from_window"], 0)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_large_read_full_mode_preserves_exact_window(self, mock_ops):
+        content = "\n".join(
+            f"{i:6d}|{('large line %04d ' % i) + ('x' * 180)}"
+            for i in range(1, 260)
+        )
+        mock_ops.return_value = _make_fake_ops(
+            content=content,
+            total_lines=260,
+            file_size=len(content),
+        )
+
+        result = json.loads(read_file_tool(
+            "/tmp/large.txt",
+            limit=500,
+            task_id="large-read-full",
+            result_mode="full",
+        ))
+
+        self.assertNotIn("compacted", result)
+        self.assertEqual(result["content"], content)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_disable_result_compaction_preserves_large_read_preview_mode(self, mock_ops):
+        content = "\n".join(
+            f"{i:6d}|{('large line %04d ' % i) + ('x' * 180)}"
+            for i in range(1, 260)
+        )
+        mock_ops.return_value = _make_fake_ops(
+            content=content,
+            total_lines=260,
+            file_size=len(content),
+        )
+
+        with patch.dict(os.environ, {"HERMES_DISABLE_RESULT_COMPACTION": " YeS "}):
+            result = json.loads(read_file_tool(
+                "/tmp/large.txt",
+                limit=500,
+                task_id="large-read-disabled",
+                result_mode="preview",
+            ))
+
+        self.assertNotIn("compacted", result)
+        self.assertEqual(result["content"], content)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_falsey_disable_result_compaction_preserves_large_read_auto_compaction(self, mock_ops):
+        content = "\n".join(
+            f"{i:6d}|{('large line %04d ' % i) + ('x' * 180)}"
+            for i in range(1, 260)
+        )
+        mock_ops.return_value = _make_fake_ops(
+            content=content,
+            total_lines=260,
+            file_size=len(content),
+        )
+
+        with patch.dict(os.environ, {"HERMES_DISABLE_RESULT_COMPACTION": "off"}):
+            result = json.loads(read_file_tool(
+                "/tmp/large.txt",
+                limit=500,
+                task_id="large-read-falsey",
+            ))
+
+        self.assertTrue(result["compacted"])
+        self.assertLess(len(result["content"]), len(content))
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_small_search_stays_exact(self, mock_ops):
+        matches = [
+            _FakeSearchMatch("/tmp/a.py", 3, "needle = 1"),
+            _FakeSearchMatch("/tmp/b.py", 7, "needle = 2"),
+        ]
+        fake = MagicMock()
+        fake.search.return_value = _FakeSearchResult(matches=matches)
+        mock_ops.return_value = fake
+
+        result = json.loads(search_tool(
+            "needle",
+            path="/tmp",
+            output_mode="content",
+            task_id="small-search",
+        ))
+
+        self.assertNotIn("compacted", result)
+        self.assertEqual(len(result["matches"]), 2)
+        self.assertEqual(result["matches"][0]["content"], "needle = 1")
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_large_search_auto_compacts_with_expansion_hint(self, mock_ops):
+        matches = [
+            _FakeSearchMatch(f"/tmp/file_{i}.py", i, "needle " + ("x" * 700))
+            for i in range(1, 45)
+        ]
+        fake = MagicMock()
+        fake.search.return_value = _FakeSearchResult(matches=matches, total_count=44)
+        mock_ops.return_value = fake
+
+        result = json.loads(search_tool(
+            "needle",
+            path="/tmp",
+            limit=50,
+            output_mode="content",
+            task_id="large-search",
+        ))
+
+        self.assertTrue(result["compacted"])
+        self.assertLess(len(result["matches"]), len(matches))
+        self.assertIn("result_mode='full'", result["_hint"])
+        self.assertIn("output_mode='files_only'", result["_hint"])
+        self.assertGreater(result["omitted_matches"], 0)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_disable_result_compaction_preserves_large_search_auto_result(self, mock_ops):
+        matches = [
+            _FakeSearchMatch(f"/tmp/file_{i}.py", i, "needle " + ("x" * 700))
+            for i in range(1, 45)
+        ]
+        fake = MagicMock()
+        fake.search.return_value = _FakeSearchResult(matches=matches, total_count=44)
+        mock_ops.return_value = fake
+
+        with patch.dict(os.environ, {"HERMES_DISABLE_RESULT_COMPACTION": "on"}):
+            result = json.loads(search_tool(
+                "needle",
+                path="/tmp",
+                limit=50,
+                output_mode="content",
+                task_id="large-search-disabled",
+            ))
+
+        self.assertNotIn("compacted", result)
+        self.assertEqual(len(result["matches"]), len(matches))
+        self.assertEqual(result["matches"][0]["content"], matches[0].content)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -405,6 +405,66 @@ class TestResultShaping(unittest.TestCase):
         self.assertGreater(result["omitted_matches"], 0)
         self.assertIn("offset=12", result["_hint"])
 
+    @patch("tools.file_tools._get_file_ops")
+    def test_compacted_truncated_search_has_single_consistent_offset_hint(self, mock_ops):
+        matches = [
+            _FakeSearchMatch(f"/tmp/file_{i}.py", i, "needle " + ("x" * 700))
+            for i in range(1, 45)
+        ]
+        fake = MagicMock()
+        fake.search.return_value = _FakeSearchResult(
+            matches=matches,
+            total_count=100,
+            truncated=True,
+        )
+        mock_ops.return_value = fake
+
+        raw = search_tool(
+            "needle",
+            path="/tmp",
+            limit=50,
+            output_mode="content",
+            task_id="large-search-truncated-compacted",
+        )
+        result = json.loads(raw)
+
+        self.assertTrue(result["compacted"])
+        self.assertIn("offset=12", result["_hint"])
+        self.assertNotIn("Results truncated", raw)
+        self.assertNotIn("offset=50", raw)
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_repeated_search_full_mode_has_distinct_identity(self, mock_ops):
+        matches = [
+            _FakeSearchMatch(f"/tmp/file_{i}.py", i, "needle " + ("x" * 700))
+            for i in range(1, 45)
+        ]
+        fake = MagicMock()
+        fake.search.return_value = _FakeSearchResult(matches=matches, total_count=44)
+        mock_ops.return_value = fake
+
+        for _ in range(4):
+            json.loads(search_tool(
+                "needle",
+                path="/tmp",
+                limit=50,
+                output_mode="content",
+                task_id="large-search-full-distinct",
+            ))
+
+        result = json.loads(search_tool(
+            "needle",
+            path="/tmp",
+            limit=50,
+            output_mode="content",
+            result_mode="full",
+            task_id="large-search-full-distinct",
+        ))
+
+        self.assertNotIn("error", result)
+        self.assertNotIn("compacted", result)
+        self.assertEqual(len(result["matches"]), len(matches))
+
     @patch("tools.file_tools.file_state.record_read")
     @patch("tools.file_tools._get_file_ops")
     def test_compacted_read_is_recorded_as_partial(self, mock_ops, mock_record_read):

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -102,6 +102,88 @@ class TestGetAndPoll:
         assert result["status"] == "exited"
         assert result["exit_code"] == 0
 
+    def test_poll_large_output_compacted_preserves_metadata(self, registry):
+        output = "HEAD\n" + ("A" * 30000) + "\nTAIL"
+        s = _make_session(output=output)
+        registry._running[s.id] = s
+
+        result = registry.poll(s.id)
+
+        assert result["status"] == "running"
+        assert result["session_id"] == s.id
+        assert result["command"] == "echo hello"
+        assert "HEAD" in result["output_preview"]
+        assert "TAIL" in result["output_preview"]
+        assert "[OUTPUT_PREVIEW COMPACTED" in result["output_preview"]
+        assert result["compacted"] is True
+        assert result["output_preview_omitted_chars"] > 0
+
+    def test_poll_result_mode_full_keeps_exact_preview_window(self, registry):
+        output = "HEAD\n" + ("A" * 30000) + "\nTAIL"
+        s = _make_session(output=output)
+        registry._running[s.id] = s
+
+        result = registry.poll(s.id, result_mode="full")
+
+        assert result["output_preview"] == output[-1000:]
+        assert "compacted" not in result
+
+
+class TestProcessResultShaping:
+    def test_read_log_large_window_compacted(self, registry):
+        lines = ["HEAD"] + [f"line {i} " + ("A" * 200) for i in range(180)] + ["TAIL"]
+        s = _make_session(output="\n".join(lines))
+        registry._running[s.id] = s
+
+        result = registry.read_log(s.id, offset=0, limit=500)
+
+        assert result["status"] == "running"
+        assert result["total_lines"] == len(lines)
+        assert "HEAD" in result["output"]
+        assert "TAIL" in result["output"]
+        assert "[OUTPUT COMPACTED" in result["output"]
+        assert result["compacted"] is True
+        assert "result_mode='full'" in result["_hint"]
+
+    def test_read_log_full_and_env_opt_out_keep_exact_window(self, registry, monkeypatch):
+        output = "HEAD\n" + ("A" * 30000) + "\nTAIL"
+        s = _make_session(output=output)
+        registry._running[s.id] = s
+
+        full_result = registry.read_log(s.id, offset=0, limit=10, result_mode="full")
+        assert full_result["output"] == output
+        assert "compacted" not in full_result
+
+        monkeypatch.setenv("HERMES_DISABLE_RESULT_COMPACTION", "on")
+        preview_result = registry.read_log(s.id, offset=0, limit=10, result_mode="preview")
+        assert preview_result["output"] == output
+        assert "compacted" not in preview_result
+
+    def test_wait_large_exited_output_compacted_preserves_exit_code(self, registry):
+        output = "HEAD\n" + ("A" * 30000) + "\nTAIL"
+        s = _make_session(exited=True, exit_code=7, output=output)
+        registry._finished[s.id] = s
+
+        result = registry.wait(s.id, timeout=1)
+
+        assert result["status"] == "exited"
+        assert result["exit_code"] == 7
+        assert "HEAD" in result["output"]
+        assert "TAIL" in result["output"]
+        assert "[OUTPUT COMPACTED" in result["output"]
+        assert result["compacted"] is True
+
+    def test_wait_full_keeps_exact_existing_tail_window(self, registry):
+        output = "HEAD\n" + ("A" * 30000) + "\nTAIL"
+        s = _make_session(exited=True, exit_code=0, output=output)
+        registry._finished[s.id] = s
+
+        result = registry.wait(s.id, timeout=1, result_mode="full")
+
+        assert result["status"] == "exited"
+        assert result["output"] == output[-2000:]
+        assert "compacted" not in result
+
 
 # =========================================================================
 # Orphaned-pipe reconciliation (issue #17327)

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -35,6 +35,7 @@ def _run_terminal(
     invoke_hook=_UNSET,
     approval=None,
     command="echo hello",
+    result_mode="auto",
 ):
     mock_env = MagicMock()
     mock_env.execute.return_value = {"output": output, "returncode": returncode}
@@ -54,7 +55,10 @@ def _run_terminal(
     if invoke_hook is not _UNSET:
         monkeypatch.setattr("hermes_cli.plugins.invoke_hook", invoke_hook)
 
-    result = json.loads(terminal_tool_module.terminal_tool(command=command))
+    result = json.loads(terminal_tool_module.terminal_tool(
+        command=command,
+        result_mode=result_mode,
+    ))
     return result, mock_env
 
 
@@ -99,7 +103,7 @@ def test_terminal_output_uses_first_valid_string_from_hooks(monkeypatch, tmp_pat
     assert result["output"] == "first"
 
 
-def test_terminal_output_transform_still_truncates_long_replacement(monkeypatch, tmp_path):
+def test_terminal_output_transform_compacts_long_replacement(monkeypatch, tmp_path):
     transformed_output = "PLUGIN-HEAD\n" + ("A" * 60000) + "\nPLUGIN-TAIL"
     result, _mock_env = _run_terminal(
         monkeypatch,
@@ -110,8 +114,40 @@ def test_terminal_output_transform_still_truncates_long_replacement(monkeypatch,
 
     assert "PLUGIN-HEAD" in result["output"]
     assert "PLUGIN-TAIL" in result["output"]
-    assert "[OUTPUT TRUNCATED" in result["output"]
+    assert "[OUTPUT COMPACTED" in result["output"]
+    assert result["compacted"] is True
+    assert result["output_omitted_chars"] > 0
+    assert "result_mode='full'" in result["_hint"]
     assert transformed_output != result["output"]
+
+
+def test_terminal_result_mode_full_keeps_existing_hard_cap(monkeypatch, tmp_path):
+    transformed_output = "PLUGIN-HEAD\n" + ("A" * 60000) + "\nPLUGIN-TAIL"
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="short output",
+        invoke_hook=lambda hook_name, **kwargs: [transformed_output],
+        result_mode="full",
+    )
+
+    assert "PLUGIN-HEAD" in result["output"]
+    assert "PLUGIN-TAIL" in result["output"]
+    assert "[OUTPUT TRUNCATED" in result["output"]
+    assert "compacted" not in result
+
+
+def test_terminal_compaction_env_opt_out(monkeypatch, tmp_path):
+    long_output = "HEAD\n" + ("A" * 30000) + "\nTAIL"
+    monkeypatch.setenv("HERMES_DISABLE_RESULT_COMPACTION", "true")
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output=long_output,
+    )
+
+    assert result["output"] == long_output
+    assert "compacted" not in result
 
 
 def test_terminal_output_transform_still_runs_strip_and_redact(monkeypatch, tmp_path):
@@ -206,4 +242,4 @@ def test_terminal_output_transform_integration_with_real_plugin(monkeypatch, tmp
 
     assert "PLUGIN-HEAD" in result["output"]
     assert "PLUGIN-TAIL" in result["output"]
-    assert "[OUTPUT TRUNCATED" in result["output"]
+    assert "[OUTPUT COMPACTED" in result["output"]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -588,7 +588,7 @@ def _compact_search_result(result_dict: dict, *, pattern: str, path: str,
 
     total_count = int(result_dict.get("total_count") or len(matches))
     omitted = max(total_count - len(preview_matches), 0)
-    next_offset = offset + min(limit, len(matches))
+    next_offset = offset + len(preview_matches)
 
     compacted = dict(result_dict)
     compacted["matches"] = preview_matches
@@ -654,7 +654,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500,
         # file hasn't been modified since, return a lightweight stub
         # instead of re-sending the same content.  Saves context tokens.
         resolved_str = str(_resolved)
-        dedup_key = (resolved_str, offset, limit)
+        dedup_key = (resolved_str, offset, limit, result_mode)
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0,
@@ -755,7 +755,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500,
             ))
 
         # ── Track for consecutive-loop detection ──────────────────────
-        read_key = ("read", path, offset, limit)
+        read_key = ("read", path, offset, limit, result_mode)
         with _read_tracker_lock:
             # Ensure "dedup" / "dedup_hits" keys exist (backward compat with
             # old tracker state from pre-dedup-guard sessions).
@@ -767,7 +767,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500,
             # reset its hit counter.  (File either changed or stat failed
             # earlier and we fell through.)
             task_data["dedup_hits"].pop(dedup_key, None)
-            task_data["read_history"].add((path, offset, limit))
+            task_data["read_history"].add((path, offset, limit, result_mode))
             if task_data["last_key"] == read_key:
                 task_data["consecutive"] += 1
             else:
@@ -789,19 +789,6 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500,
             # Bound the per-task containers so a long CLI session doesn't
             # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.
             _cap_read_tracker_data(task_data)
-
-        # Cross-agent file-state registry (separate from per-task read
-        # tracker above): records that THIS agent has read this path so
-        # write/patch can detect sibling-subagent writes that happened
-        # after our read.  Partial read when offset>1 or the read was
-        # truncated (large file with more content than limit covered).
-        # Outside the _read_tracker_lock so the registry's own locking
-        # isn't nested under ours.
-        try:
-            _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
-        except Exception:
-            logger.debug("file_state.record_read failed", exc_info=True)
 
         if count >= 4:
             # Hard block: stop returning content to break the loop
@@ -828,6 +815,19 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500,
             limit=limit,
             result_mode=result_mode,
         )
+        # Cross-agent file-state registry (separate from per-task read
+        # tracker above): records that THIS agent has read this path so
+        # write/patch can detect sibling-subagent writes that happened
+        # after our read. Partial includes compacted model-visible output.
+        try:
+            _partial = (
+                (offset > 1)
+                or bool(result_dict.get("truncated"))
+                or bool(result_dict.get("compacted"))
+            )
+            file_state.record_read(task_id, resolved_str, partial=_partial)
+        except Exception:
+            logger.debug("file_state.record_read failed", exc_info=True)
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1175,6 +1175,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             target,
             str(path),
             file_glob or "",
+            output_mode,
+            context,
+            result_mode,
             limit,
             offset,
         )
@@ -1230,7 +1233,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer
         # than relying on the model to infer it from total_count vs match count.
-        if result_dict.get("truncated"):
+        if result_dict.get("truncated") and not result_dict.get("compacted"):
             next_offset = offset + limit
             result_json += f"\n\n[Hint: Results truncated. Use offset={next_offset} to see more, or narrow with a more specific pattern or file_glob.]"
         return result_json

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -61,6 +61,13 @@ def _get_max_read_chars() -> int:
 # If the total file size exceeds this AND the caller didn't specify a narrow
 # range (limit <= 200), we include a hint encouraging targeted reads.
 _LARGE_FILE_HINT_BYTES = 512_000  # 512 KB
+_READ_COMPACT_CHAR_THRESHOLD = 20_000
+_READ_COMPACT_TARGET_LINES = 120
+_SEARCH_COMPACT_CHAR_THRESHOLD = 12_000
+_SEARCH_COMPACT_MATCH_LIMIT = 12
+_SEARCH_COMPACT_CONTENT_CHARS = 180
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+_DISABLE_RESULT_COMPACTION_ENV = "HERMES_DISABLE_RESULT_COMPACTION"
 
 # ---------------------------------------------------------------------------
 # Device path blocklist — reading these hangs the process (infinite output
@@ -253,43 +260,6 @@ _file_ops_cache: dict = {}
 #                      by the same task don't trigger false warnings.
 _read_tracker_lock = threading.Lock()
 _read_tracker: dict = {}
-
-# Track consecutive patch failures per (task_id, resolved_path).  Used to
-# escalate the hint when the model repeatedly fails to patch the same file
-# (typical cause: stale view of file contents, ambiguous old_string, or
-# the file was modified externally between the agent's read and patch
-# attempt).  Reset on a successful patch to that path.
-_patch_failure_lock = threading.Lock()
-_patch_failure_tracker: dict = {}  # {task_id: {resolved_path: count}}
-
-
-def _record_patch_failure(task_id: str, resolved_path: str) -> int:
-    """Increment and return the consecutive-failure count for this path."""
-    with _patch_failure_lock:
-        task_failures = _patch_failure_tracker.setdefault(task_id, {})
-        # Cap dict size per task to avoid unbounded growth in long sessions
-        # where the agent fails on many distinct files.  64 distinct
-        # failing files per task is generous; older entries get evicted.
-        if len(task_failures) >= 64 and resolved_path not in task_failures:
-            try:
-                first_key = next(iter(task_failures))
-                del task_failures[first_key]
-            except StopIteration:
-                pass
-        task_failures[resolved_path] = task_failures.get(resolved_path, 0) + 1
-        return task_failures[resolved_path]
-
-
-def _reset_patch_failures(task_id: str, resolved_paths: list) -> None:
-    """Clear consecutive-failure counts for the given paths."""
-    if not resolved_paths:
-        return
-    with _patch_failure_lock:
-        task_failures = _patch_failure_tracker.get(task_id)
-        if not task_failures:
-            return
-        for rp in resolved_paths:
-            task_failures.pop(rp, None)
 
 # Per-task bounds for the containers inside each _read_tracker[task_id].
 # A CLI session uses one stable task_id for its lifetime; without these
@@ -531,10 +501,118 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def _normalize_result_mode(value: str | None) -> str:
+    if isinstance(value, str) and value.lower() in {"auto", "full", "preview"}:
+        return value.lower()
+    return "auto"
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUE_ENV_VALUES
+
+
+def _result_compaction_disabled() -> bool:
+    return _env_truthy(_DISABLE_RESULT_COMPACTION_ENV)
+
+
+def _compact_read_result(result_dict: dict, *, path: str, offset: int,
+                         limit: int, result_mode: str) -> dict:
+    """Return a progressive-disclosure preview for large read_file results."""
+    if _result_compaction_disabled() or result_mode == "full" or "content" not in result_dict:
+        return result_dict
+
+    content = result_dict.get("content")
+    if not isinstance(content, str):
+        return result_dict
+
+    targeted_read = limit <= 200
+    should_compact = result_mode == "preview" or (
+        not targeted_read and len(content) > _READ_COMPACT_CHAR_THRESHOLD
+    )
+    if not should_compact:
+        return result_dict
+
+    lines = content.splitlines()
+    preview_lines = lines[:_READ_COMPACT_TARGET_LINES]
+    preview = "\n".join(preview_lines)
+    total_returned = len(lines)
+    hidden_from_window = max(total_returned - len(preview_lines), 0)
+    next_offset = offset + len(preview_lines)
+
+    compacted = dict(result_dict)
+    compacted["content"] = preview
+    compacted["compacted"] = True
+    compacted["content_preview_lines"] = len(preview_lines)
+    compacted["omitted_lines_from_window"] = hidden_from_window
+    compacted["omitted_chars_from_window"] = max(len(content) - len(preview), 0)
+    compacted["_hint"] = (
+        "Large read_file output compacted. "
+        f"Use result_mode='full' with path={path!r}, offset={offset}, limit={limit} "
+        "for the exact full window, or read a narrower range with offset and limit. "
+        f"Use offset={next_offset} to continue after this preview."
+    )
+    return compacted
+
+
+def _compact_search_result(result_dict: dict, *, pattern: str, path: str,
+                           limit: int, offset: int, output_mode: str,
+                           context: int, result_mode: str) -> dict:
+    """Return a compact preview for large search_files content results."""
+    if _result_compaction_disabled() or result_mode == "full" or output_mode != "content":
+        return result_dict
+    matches = result_dict.get("matches")
+    if not isinstance(matches, list) or not matches:
+        return result_dict
+
+    encoded_len = len(json.dumps(result_dict, ensure_ascii=False))
+    should_compact = result_mode == "preview" or encoded_len > _SEARCH_COMPACT_CHAR_THRESHOLD
+    if not should_compact:
+        return result_dict
+
+    preview_matches = []
+    files_seen: list[str] = []
+    for match in matches[:_SEARCH_COMPACT_MATCH_LIMIT]:
+        if not isinstance(match, dict):
+            continue
+        path_value = str(match.get("path", ""))
+        if path_value and path_value not in files_seen:
+            files_seen.append(path_value)
+        content = match.get("content", "")
+        if isinstance(content, str) and len(content) > _SEARCH_COMPACT_CONTENT_CHARS:
+            content = content[:_SEARCH_COMPACT_CONTENT_CHARS] + "... [truncated]"
+        preview_matches.append({
+            "path": path_value,
+            "line": match.get("line"),
+            "content": content,
+        })
+
+    total_count = int(result_dict.get("total_count") or len(matches))
+    omitted = max(total_count - len(preview_matches), 0)
+    next_offset = offset + min(limit, len(matches))
+
+    compacted = dict(result_dict)
+    compacted["matches"] = preview_matches
+    compacted["compacted"] = True
+    compacted["match_preview_count"] = len(preview_matches)
+    compacted["omitted_matches"] = omitted
+    compacted["files_with_preview_matches"] = files_seen[:25]
+    compacted["_hint"] = (
+        "Large search_files output compacted. "
+        f"Use result_mode='full' with pattern={pattern!r}, path={path!r}, "
+        f"limit={limit}, offset={offset}, output_mode='content', context={context} "
+        "for exact full match detail. Use output_mode='files_only' or 'count' "
+        "to inspect broad searches cheaply, or narrow pattern/file_glob. "
+        f"Use offset={next_offset} to page forward."
+    )
+    return compacted
+
+
+def read_file_tool(path: str, offset: int = 1, limit: int = 500,
+                   task_id: str = "default", result_mode: str = "auto") -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
+        result_mode = _normalize_result_mode(result_mode)
 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
@@ -743,6 +821,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
 
+        result_dict = _compact_read_result(
+            result_dict,
+            path=path,
+            offset=offset,
+            limit=limit,
+            result_mode=result_mode,
+        )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -1057,43 +1142,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     _r = _path_to_resolved.get(_p)
                     if _r:
                         file_state.note_write(task_id, _r)
-                # Successful patch: clear any prior consecutive-failure
-                # counters for the touched paths so a future failure on
-                # the same path starts the escalation cycle fresh.
-                _reset_patch_failures(task_id, [
-                    _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
-                ])
         # Hint when old_string not found — saves iterations where the agent
         # retries with stale content instead of re-reading the file.
         # Suppressed when patch_replace already attached a rich "Did you mean?"
         # snippet (which is strictly more useful than the generic hint).
         if result_dict.get("error") and "Could not find" in str(result_dict["error"]):
-            # Track per-file consecutive failures for replace mode.  The
-            # ``path`` arg only exists for replace mode; for V4A patches
-            # we'd need to walk the headers, but in practice V4A failures
-            # are far rarer and the existing _hint covers them adequately.
-            failure_count = 0
-            if mode == "replace" and path:
-                resolved = _path_to_resolved.get(path) or path
-                failure_count = _record_patch_failure(task_id, resolved)
-
-            if failure_count >= 3:
-                # Escalating hint after multiple consecutive failures on the
-                # same path.  Most common cause is a stale view of the file —
-                # the model is retrying with the same old_string against
-                # content that has since changed.  Surface the failure count
-                # so the model recognises it's in a loop and breaks out by
-                # re-reading or falling back to write_file.
-                result_dict["_hint"] = (
-                    f"This is failure #{failure_count} patching {path!r}. "
-                    "Stop retrying with variations of the same old_string. "
-                    "Either: (1) re-read the file fresh to verify current "
-                    "content, (2) use a longer / more unique old_string with "
-                    "surrounding context lines, or (3) use write_file to "
-                    "replace the entire file if the targeted region is hard "
-                    "to anchor."
-                )
-            elif "Did you mean one of these sections?" not in str(result_dict["error"]):
+            if "Did you mean one of these sections?" not in str(result_dict["error"]):
                 result_dict["_hint"] = (
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."
@@ -1106,10 +1160,11 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
-                task_id: str = "default") -> str:
+                task_id: str = "default", result_mode: str = "auto") -> str:
     """Search for content or files."""
     try:
         offset, limit = normalize_search_pagination(offset, limit)
+        result_mode = _normalize_result_mode(result_mode)
 
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated
@@ -1162,6 +1217,16 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 "The results have not changed. Use the information you already have."
             )
 
+        result_dict = _compact_search_result(
+            result_dict,
+            pattern=pattern,
+            path=path,
+            limit=limit,
+            offset=offset,
+            output_mode=output_mode,
+            context=context,
+            result_mode=result_mode,
+        )
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer
         # than relying on the model to infer it from total_count vs match count.
@@ -1188,13 +1253,14 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Large default windows may be compacted with continuation hints; pass result_mode='full' for exact full detail. Set HERMES_DISABLE_RESULT_COMPACTION to 1/true/yes/on to globally disable result compaction. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000},
+            "result_mode": {"type": "string", "enum": ["auto", "full", "preview"], "description": "Result detail level. auto keeps small/targeted reads exact and compacts only large outputs; full returns the exact requested window; preview requests compact output unless HERMES_DISABLE_RESULT_COMPACTION is truthy.", "default": "auto"}
         },
         "required": ["path"]
     }
@@ -1271,7 +1337,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts. Large content-match outputs may be compacted with expansion hints; pass result_mode='full' for exact full detail. Set HERMES_DISABLE_RESULT_COMPACTION to 1/true/yes/on to globally disable result compaction.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1282,7 +1348,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "result_mode": {"type": "string", "enum": ["auto", "full", "preview"], "description": "Result detail level for content searches. auto keeps small results exact and compacts only large outputs; full returns exact full match detail; preview requests compact output unless HERMES_DISABLE_RESULT_COMPACTION is truthy.", "default": "auto"}
         },
         "required": ["pattern"]
     }
@@ -1291,7 +1358,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+        result_mode=args.get("result_mode", "auto"),
+    )
 
 
 def _handle_write_file(args, **kw):
@@ -1338,7 +1411,11 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"),
+        context=args.get("context", 0),
+        task_id=tid,
+        result_mode=args.get("result_mode", "auto"),
+    )
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -972,9 +972,10 @@ class ProcessRegistry:
         )
         self._move_to_finished(session)
 
-    def poll(self, session_id: str) -> dict:
+    def poll(self, session_id: str, result_mode: str = "auto") -> dict:
         """Check status and get new output for a background process."""
         from tools.ansi_strip import strip_ansi
+        from tools.result_shaping import compact_text_output
 
         session = self.get(session_id)
         if session is None:
@@ -985,7 +986,23 @@ class ProcessRegistry:
         self._reconcile_local_exit(session)
 
         with session._lock:
-            output_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
+            full_output = strip_ansi(session.output_buffer) if session.output_buffer else ""
+            fallback_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
+
+        shaped = compact_text_output(
+            full_output,
+            result_mode=result_mode,
+            field_name="output_preview",
+            threshold_chars=20_000,
+            preview_chars=8_000,
+            hint=(
+                "Large process poll output compacted. Use result_mode='full' "
+                "for the exact poll preview window, or process(action='log', "
+                "offset=..., limit=...) to page the stored process log. Set "
+                "HERMES_DISABLE_RESULT_COMPACTION=1 to disable result compaction."
+            ),
+        )
+        output_preview = shaped.text if shaped.metadata else fallback_preview
 
         result = {
             "session_id": session.id,
@@ -995,6 +1012,7 @@ class ProcessRegistry:
             "uptime_seconds": int(time.time() - session.started_at),
             "output_preview": output_preview,
         }
+        result.update(shaped.metadata)
         if session.exited:
             result["exit_code"] = session.exit_code
             self._completion_consumed.add(session_id)
@@ -1003,9 +1021,11 @@ class ProcessRegistry:
             result["note"] = "Process recovered after restart -- output history unavailable"
         return result
 
-    def read_log(self, session_id: str, offset: int = 0, limit: int = 200) -> dict:
+    def read_log(self, session_id: str, offset: int = 0, limit: int = 200,
+                 result_mode: str = "auto") -> dict:
         """Read the full output log with optional pagination by lines."""
         from tools.ansi_strip import strip_ansi
+        from tools.result_shaping import compact_text_output
 
         session = self.get(session_id)
         if session is None:
@@ -1023,18 +1043,34 @@ class ProcessRegistry:
         else:
             selected = lines[offset:offset + limit]
 
+        selected_output = "\n".join(selected)
+        shaped = compact_text_output(
+            selected_output,
+            result_mode=result_mode,
+            field_name="output",
+            threshold_chars=20_000,
+            preview_chars=8_000,
+            hint=(
+                "Large process log output compacted. Use result_mode='full' "
+                f"with offset={offset}, limit={limit} for the exact selected "
+                "window, or narrow offset/limit. Set "
+                "HERMES_DISABLE_RESULT_COMPACTION=1 to disable result compaction."
+            ),
+        )
+
         result = {
             "session_id": session.id,
             "status": "exited" if session.exited else "running",
-            "output": "\n".join(selected),
+            "output": shaped.text,
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
+        result.update(shaped.metadata)
         if session.exited:
             self._completion_consumed.add(session_id)
         return result
 
-    def wait(self, session_id: str, timeout: int = None) -> dict:
+    def wait(self, session_id: str, timeout: int = None, result_mode: str = "auto") -> dict:
         """
         Block until a process exits, timeout, or interrupt.
 
@@ -1048,6 +1084,7 @@ class ProcessRegistry:
         """
         from tools.ansi_strip import strip_ansi
         from tools.interrupt import is_interrupted as _is_interrupted
+        from tools.result_shaping import compact_text_output
 
         try:
             default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
@@ -1080,31 +1117,81 @@ class ProcessRegistry:
             self._reconcile_local_exit(session)
             if session.exited:
                 self._completion_consumed.add(session_id)
+                full_output = strip_ansi(session.output_buffer)
+                fallback_output = strip_ansi(session.output_buffer[-2000:])
+                shaped = compact_text_output(
+                    full_output,
+                    result_mode=result_mode,
+                    field_name="output",
+                    threshold_chars=20_000,
+                    preview_chars=8_000,
+                    hint=(
+                        "Large process wait output compacted. Use "
+                        "result_mode='full' for the exact wait output window, "
+                        "or process(action='log', offset=..., limit=...) to page "
+                        "the stored process log. Set "
+                        "HERMES_DISABLE_RESULT_COMPACTION=1 to disable result compaction."
+                    ),
+                )
                 result = {
                     "status": "exited",
                     "exit_code": session.exit_code,
-                    "output": strip_ansi(session.output_buffer[-2000:]),
+                    "output": shaped.text if shaped.metadata else fallback_output,
                 }
+                result.update(shaped.metadata)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
 
             if _is_interrupted():
+                full_output = strip_ansi(session.output_buffer)
+                fallback_output = strip_ansi(session.output_buffer[-1000:])
+                shaped = compact_text_output(
+                    full_output,
+                    result_mode=result_mode,
+                    field_name="output",
+                    threshold_chars=20_000,
+                    preview_chars=8_000,
+                    hint=(
+                        "Large process wait output compacted. Use "
+                        "result_mode='full' for the exact wait output window, "
+                        "or process(action='log', offset=..., limit=...) to page "
+                        "the stored process log. Set "
+                        "HERMES_DISABLE_RESULT_COMPACTION=1 to disable result compaction."
+                    ),
+                )
                 result = {
                     "status": "interrupted",
-                    "output": strip_ansi(session.output_buffer[-1000:]),
+                    "output": shaped.text if shaped.metadata else fallback_output,
                     "note": "User sent a new message -- wait interrupted",
                 }
+                result.update(shaped.metadata)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
 
             time.sleep(1)
 
+        full_output = strip_ansi(session.output_buffer)
+        fallback_output = strip_ansi(session.output_buffer[-1000:])
+        shaped = compact_text_output(
+            full_output,
+            result_mode=result_mode,
+            field_name="output",
+            threshold_chars=20_000,
+            preview_chars=8_000,
+            hint=(
+                "Large process wait output compacted. Use result_mode='full' "
+                "for the exact wait output window, or process(action='log', "
+                "offset=..., limit=...) to page the stored process log. Set "
+                "HERMES_DISABLE_RESULT_COMPACTION=1 to disable result compaction."
+            ),
+        )
         result = {
             "status": "timeout",
-            "output": strip_ansi(session.output_buffer[-1000:]),
+            "output": shaped.text if shaped.metadata else fallback_output,
         }
+        result.update(shaped.metadata)
         if timeout_note:
             result["timeout_note"] = timeout_note
         else:
@@ -1553,6 +1640,12 @@ PROCESS_SCHEMA = {
                 "type": "integer",
                 "description": "Max lines to return for 'log' action",
                 "minimum": 1
+            },
+            "result_mode": {
+                "type": "string",
+                "enum": ["auto", "full", "preview"],
+                "description": "Output detail level for poll/log/wait. auto compacts large process output with head/tail preview; full preserves the action's exact output window; preview compacts whenever possible. HERMES_DISABLE_RESULT_COMPACTION=1/true/yes/on disables compaction.",
+                "default": "auto"
             }
         },
         "required": ["action"]
@@ -1571,13 +1664,16 @@ def _handle_process(args, **kw):
     elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
         if not session_id:
             return tool_error(f"session_id is required for {action}")
+        result_mode = args.get("result_mode", "auto")
         if action == "poll":
-            return json.dumps(process_registry.poll(session_id), ensure_ascii=False)
+            return json.dumps(process_registry.poll(session_id, result_mode=result_mode), ensure_ascii=False)
         elif action == "log":
             return json.dumps(process_registry.read_log(
-                session_id, offset=args.get("offset", 0), limit=args.get("limit", 200)), ensure_ascii=False)
+                session_id, offset=args.get("offset", 0), limit=args.get("limit", 200),
+                result_mode=result_mode), ensure_ascii=False)
         elif action == "wait":
-            return json.dumps(process_registry.wait(session_id, timeout=args.get("timeout")), ensure_ascii=False)
+            return json.dumps(process_registry.wait(
+                session_id, timeout=args.get("timeout"), result_mode=result_mode), ensure_ascii=False)
         elif action == "kill":
             return json.dumps(process_registry.kill_process(session_id), ensure_ascii=False)
         elif action == "write":

--- a/tools/result_shaping.py
+++ b/tools/result_shaping.py
@@ -1,0 +1,85 @@
+"""Shared helpers for compacting large model-facing tool outputs."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+_DISABLE_RESULT_COMPACTION_ENV = "HERMES_DISABLE_RESULT_COMPACTION"
+
+
+def normalize_result_mode(value: str | None) -> str:
+    if isinstance(value, str) and value.lower() in {"auto", "full", "preview"}:
+        return value.lower()
+    return "auto"
+
+
+def result_compaction_disabled() -> bool:
+    return os.getenv(_DISABLE_RESULT_COMPACTION_ENV, "").strip().lower() in _TRUE_ENV_VALUES
+
+
+@dataclass(frozen=True)
+class CompactedText:
+    text: str
+    metadata: dict
+
+
+def compact_text_output(
+    text: str,
+    *,
+    result_mode: str = "auto",
+    field_name: str = "output",
+    threshold_chars: int = 20_000,
+    preview_chars: int = 8_000,
+    head_ratio: float = 0.45,
+    hint: str = "",
+) -> CompactedText:
+    """Return head/tail text plus metadata when output should be compacted.
+
+    The input text is never stored in metadata. Counts and a continuation hint
+    are safe to expose even when the omitted content may contain sensitive data.
+    """
+    result_mode = normalize_result_mode(result_mode)
+    if result_compaction_disabled() or result_mode == "full" or not isinstance(text, str):
+        return CompactedText(text=text, metadata={})
+
+    if preview_chars < 200:
+        preview_chars = 200
+    should_compact = result_mode == "preview" or len(text) > threshold_chars
+    if not should_compact or len(text) <= preview_chars:
+        return CompactedText(text=text, metadata={})
+
+    head_chars = max(1, int(preview_chars * head_ratio))
+    tail_chars = max(1, preview_chars - head_chars)
+    omitted_chars = max(len(text) - head_chars - tail_chars, 0)
+    if omitted_chars <= 0:
+        return CompactedText(text=text, metadata={})
+
+    total_lines = text.count("\n") + (1 if text else 0)
+    omitted_text = text[head_chars:-tail_chars]
+    omitted_lines = omitted_text.count("\n")
+    notice = (
+        f"\n\n... [{field_name.upper()} COMPACTED - {omitted_chars} chars"
+        f" omitted from {len(text)} total"
+    )
+    if total_lines:
+        notice += f"; {omitted_lines} lines omitted from {total_lines} total"
+    notice += "] ...\n\n"
+
+    metadata = {
+        "compacted": True,
+        f"{field_name}_original_chars": len(text),
+        f"{field_name}_preview_chars": len(text[:head_chars] + notice + text[-tail_chars:]),
+        f"{field_name}_omitted_chars": omitted_chars,
+        f"{field_name}_total_lines": total_lines,
+        f"{field_name}_omitted_lines": omitted_lines,
+    }
+    if hint:
+        metadata["_hint"] = hint
+
+    return CompactedText(
+        text=text[:head_chars] + notice + text[-tail_chars:],
+        metadata=metadata,
+    )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1666,6 +1666,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    result_mode: str = "auto",
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -1680,6 +1681,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        result_mode: Output detail level: auto compacts large foreground output, full preserves exact output subject to hard safety caps, preview forces compaction when possible.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2125,9 +2127,30 @@ def terminal_tool(
             except Exception:
                 pass
             
-            # Truncate output if too long, keeping both head and tail
+            # Strip ANSI escape sequences so the model never sees terminal
+            # formatting — prevents it from copying escapes into file writes.
+            from tools.ansi_strip import strip_ansi
+            output = strip_ansi(output)
+
+            from tools.result_shaping import compact_text_output
             from tools.tool_output_limits import get_max_bytes
             MAX_OUTPUT_CHARS = get_max_bytes()
+            shaped = compact_text_output(
+                output,
+                result_mode=result_mode,
+                field_name="output",
+                threshold_chars=min(20_000, MAX_OUTPUT_CHARS),
+                preview_chars=min(8_000, max(200, MAX_OUTPUT_CHARS)),
+                hint=(
+                    "Large terminal output compacted. Use result_mode='full' "
+                    "to request the exact foreground output, subject to the "
+                    "terminal hard safety cap, or set "
+                    "HERMES_DISABLE_RESULT_COMPACTION=1 to disable result compaction."
+                ),
+            )
+            output = shaped.text
+
+            # Final hard cap remains as a safety net, especially for full mode.
             if len(output) > MAX_OUTPUT_CHARS:
                 head_chars = int(MAX_OUTPUT_CHARS * 0.4)  # 40% head (error messages often appear early)
                 tail_chars = MAX_OUTPUT_CHARS - head_chars  # 60% tail (most recent/relevant output)
@@ -2137,11 +2160,6 @@ def terminal_tool(
                     f"out of {len(output)} total] ...\n\n"
                 )
                 output = output[:head_chars] + truncated_notice + output[-tail_chars:]
-
-            # Strip ANSI escape sequences so the model never sees terminal
-            # formatting — prevents it from copying escapes into file writes.
-            from tools.ansi_strip import strip_ansi
-            output = strip_ansi(output)
 
             # Redact secrets from command output (catches env/printenv leaking keys)
             from agent.redact import redact_sensitive_text
@@ -2156,6 +2174,7 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
+            result_dict.update(shaped.metadata)
             if approval_note:
                 result_dict["approval"] = approval_note
             if exit_note:
@@ -2374,6 +2393,12 @@ TERMINAL_SCHEMA = {
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "Strings to watch for in background process output. HARD RATE LIMIT: at most 1 notification per 15 seconds per process — matches arriving inside the cooldown are dropped. After 3 consecutive 15-second windows with dropped matches, watch_patterns is automatically disabled for that process and promoted to notify_on_complete behavior (one notification on exit, no more mid-process spam). USE ONLY for truly rare, one-shot mid-process signals on LONG-LIVED processes that will never exit on their own — e.g. ['Application startup complete'] on a server so you know when to hit its endpoint, or ['migration done'] on a daemon. DO NOT use for: (1) end-of-run markers like 'DONE'/'PASS' — use notify_on_complete instead; (2) error patterns like 'ERROR'/'Traceback' in loops or multi-item batch jobs — they fire on every iteration and you'll hit the strike limit fast; (3) anything you'd ever combine with notify_on_complete. When in doubt, choose notify_on_complete. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both."
+            },
+            "result_mode": {
+                "type": "string",
+                "enum": ["auto", "full", "preview"],
+                "description": "Foreground output detail level. auto compacts large outputs with head/tail preview; full requests exact output subject to the terminal hard safety cap; preview compacts whenever possible. HERMES_DISABLE_RESULT_COMPACTION=1/true/yes/on disables compaction.",
+                "default": "auto"
             }
         },
         "required": ["command"]
@@ -2391,6 +2416,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        result_mode=args.get("result_mode", "auto"),
     )
 
 


### PR DESCRIPTION
## Summary
- Add **the-token-caveman**: compact result shaping for high-volume file/search tool outputs.
- Add token optimization metrics coverage and opt-out/debug path for full payloads.
- Add Phase 2A shadow benchmark script for repeatable reduction/leakage checks.

## Validation
- [x] `./scripts/run_tests.sh tests/tools/test_file_read_guards.py tests/test_token_optimization_metrics.py tests/test_model_tools.py`
  - 79/79 passed
- [x] `python3 scripts/token_phase2a_shadow_benchmark.py`
  - reduction: 65.73%
  - metrics leakage audit: PASS

## Notes
- Internal codename: **the-token-caveman** — result shaping that bonks oversized tool output before it floods context.
- This PR intentionally excludes unrelated local diffs in `cron/scheduler.py` and `tests/cron/test_scheduler.py`.
- Runtime deployment is separate: this branch is pushed for review/CI and is not yet merged to `main`.