### PR TITLE
feat(gateway): improve webhook filtering and Slack block delivery

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -52,6 +52,60 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+
+_SLACK_BLOCK_KIT_FENCE_RE = re.compile(
+    r"```(?:slack-block-kit|block-kit)\s*\n(?P<payload>.*?)\n?```",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _parse_slack_block_kit_payload(content: str) -> Optional[Tuple[str, List[Dict[str, Any]]]]:
+    """Parse an opt-in Slack Block Kit payload embedded in a text response.
+
+    Agents and cron jobs normally return plain text.  For Slack-only rich
+    layouts they can instead include a fenced block like::
+
+        ```slack-block-kit
+        {"text": "fallback", "blocks": [{"type": "section", ...}]}
+        ```
+
+    The payload is deliberately opt-in (``slack-block-kit`` / ``block-kit``
+    fence only) so ordinary JSON snippets in assistant replies are never sent
+    as Block Kit by accident.  ``content`` may contain cron header/footer text;
+    the fenced payload is extracted from anywhere in the message.
+    """
+    if not isinstance(content, str) or not content.strip():
+        return None
+
+    match = _SLACK_BLOCK_KIT_FENCE_RE.search(content)
+    if not match:
+        return None
+
+    try:
+        payload = json.loads(match.group("payload"))
+    except Exception:
+        logger.warning("[Slack] Invalid slack-block-kit JSON payload", exc_info=True)
+        return None
+
+    if isinstance(payload, list):
+        blocks = payload
+        text = "Slack Block Kit message"
+    elif isinstance(payload, dict):
+        blocks = payload.get("blocks")
+        text = payload.get("text") or payload.get("fallback") or "Slack Block Kit message"
+    else:
+        return None
+
+    if not isinstance(blocks, list) or not blocks:
+        return None
+    if len(blocks) > 50:
+        logger.warning("[Slack] Refusing Block Kit payload with %d blocks (>50)", len(blocks))
+        return None
+    if not all(isinstance(block, dict) and isinstance(block.get("type"), str) for block in blocks):
+        return None
+
+    return str(text)[:3000], blocks
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -776,6 +830,41 @@ class SlackAdapter(BasePlatformAdapter):
             if slash_ctx:
                 return await self._send_slash_ephemeral(
                     slash_ctx, content,
+                )
+
+            block_payload = _parse_slack_block_kit_payload(content)
+            if block_payload:
+                fallback_text, blocks = block_payload
+                thread_ts = self._resolve_thread_ts(reply_to, metadata)
+                kwargs = {
+                    "channel": chat_id,
+                    "text": fallback_text,
+                    "blocks": blocks,
+                }
+                if thread_ts:
+                    kwargs["thread_ts"] = thread_ts
+                    if self.config.extra.get("reply_broadcast", False):
+                        kwargs["reply_broadcast"] = True
+
+                last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+
+                if thread_ts:
+                    await self.stop_typing(chat_id)
+
+                sent_ts = last_result.get("ts") if last_result else None
+                if sent_ts:
+                    self._bot_message_ts.add(sent_ts)
+                    if thread_ts:
+                        self._bot_message_ts.add(thread_ts)
+                    if len(self._bot_message_ts) > self._BOT_TS_MAX:
+                        excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
+                        for old_ts in list(self._bot_message_ts)[:excess]:
+                            self._bot_message_ts.discard(old_ts)
+
+                return SendResult(
+                    success=True,
+                    message_id=sent_ts,
+                    raw_response=last_result,
                 )
 
             # Convert standard markdown → Slack mrkdwn

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -33,9 +33,12 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
 import time
+import urllib.error
+import urllib.request
 from typing import Any, Dict, List, Optional
 
 try:
@@ -383,8 +386,16 @@ class WebhookAdapter(BasePlatformAdapter):
         # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,
         # not only during connect(), so direct handler reuse cannot turn a
         # network webhook route into an unauthenticated agent-dispatch surface.
+        # Some providers (for example SwitchBot) cannot send custom HMAC
+        # headers, but do allow registering a URL with query parameters. For
+        # those routes, allow a route-scoped signed-URL token while keeping the
+        # normal HMAC path for providers that support headers.
         secret = route_config.get("secret", self._global_secret)
-        if not secret:
+        query_secret = route_config.get("query_secret", "")
+        query_token_valid = bool(query_secret) and hmac.compare_digest(
+            request.query.get("token", ""), str(query_secret)
+        )
+        if not secret and not query_token_valid:
             logger.error(
                 "[webhook] Route %s has no HMAC secret; refusing request",
                 route_name,
@@ -393,7 +404,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"error": "Webhook route is missing an HMAC secret"},
                 status=403,
             )
-        if secret != _INSECURE_NO_AUTH:
+        if secret != _INSECURE_NO_AUTH and not query_token_valid:
             if not self._validate_signature(request, raw_body, secret):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name
@@ -433,6 +444,7 @@ class WebhookAdapter(BasePlatformAdapter):
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
+            or payload.get("eventType", "")
             or payload.get("type", "")
             or "unknown"
         )
@@ -448,10 +460,28 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "ignored", "event": event_type}
             )
 
+        filter_match, failed_filter = self._payload_filters_match(
+            route_config.get("filters", {}), payload
+        )
+        if not filter_match:
+            logger.debug(
+                "[webhook] Ignoring event %s for route %s (payload filter failed: %s)",
+                event_type,
+                route_name,
+                failed_filter,
+            )
+            return web.json_response(
+                {"status": "ignored", "event": event_type, "filter": failed_filter}
+            )
+
         # Format prompt from template
         prompt_template = route_config.get("prompt", "")
         prompt = self._render_prompt(
-            prompt_template, payload, event_type, route_name
+            prompt_template,
+            payload,
+            event_type,
+            route_name,
+            preserve_missing=not route_config.get("blank_missing_placeholders", False),
         )
 
         # Inject skill content if configured.
@@ -510,6 +540,15 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=200,
             )
         self._seen_deliveries[delivery_id] = now
+
+        if route_config.get("github_reaction"):
+            await self._apply_github_reaction(
+                route_config=route_config,
+                payload=payload,
+                event_type=event_type,
+                route_name=route_name,
+                delivery_id=delivery_id,
+            )
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
@@ -627,6 +666,120 @@ class WebhookAdapter(BasePlatformAdapter):
             status=202,
         )
 
+    async def _apply_github_reaction(
+        self,
+        *,
+        route_config: dict,
+        payload: dict,
+        event_type: str,
+        route_name: str,
+        delivery_id: str,
+    ) -> None:
+        """Add a GitHub reaction before direct-delivery or agent dispatch.
+
+        This is a lightweight acknowledgement that the webhook reached Hermes
+        and passed filters.  Failures are logged but never block the webhook
+        response or the subsequent agent run.
+        """
+        content = str(route_config.get("github_reaction") or "eyes")
+        repo = self._get_payload_value(payload, "repository.full_name")
+        if not repo:
+            logger.warning(
+                "[webhook] Cannot add GitHub reaction for route=%s delivery=%s: missing repository.full_name",
+                route_name,
+                delivery_id,
+            )
+            return
+
+        comment_id = self._get_payload_value(payload, "comment.id")
+        issue_number = self._get_payload_value(payload, "issue.number")
+        if comment_id:
+            endpoint = f"https://api.github.com/repos/{repo}/issues/comments/{comment_id}/reactions"
+        elif issue_number:
+            endpoint = f"https://api.github.com/repos/{repo}/issues/{issue_number}/reactions"
+        else:
+            logger.warning(
+                "[webhook] Cannot add GitHub reaction for route=%s delivery=%s event=%s: missing issue.number/comment.id",
+                route_name,
+                delivery_id,
+                event_type,
+            )
+            return
+
+        token = self._get_github_token()
+        if not token:
+            logger.warning(
+                "[webhook] Cannot add GitHub reaction for route=%s delivery=%s: GITHUB_TOKEN/gh auth token unavailable",
+                route_name,
+                delivery_id,
+            )
+            return
+
+        try:
+            status = await asyncio.to_thread(
+                self._post_github_reaction,
+                endpoint,
+                token,
+                content,
+            )
+            logger.info(
+                "[webhook] Added GitHub :%s: reaction route=%s delivery=%s status=%s",
+                content,
+                route_name,
+                delivery_id,
+                status,
+            )
+        except Exception as e:
+            logger.warning(
+                "[webhook] Failed to add GitHub :%s: reaction route=%s delivery=%s: %s",
+                content,
+                route_name,
+                delivery_id,
+                e,
+            )
+
+    def _get_github_token(self) -> str:
+        token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+        if token:
+            return token.strip()
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=5,
+            )
+        except Exception:
+            return ""
+        if result.returncode == 0:
+            return result.stdout.strip()
+        return ""
+
+    def _post_github_reaction(self, endpoint: str, token: str, content: str) -> int:
+        body = json.dumps({"content": content}).encode("utf-8")
+        request = urllib.request.Request(
+            endpoint,
+            data=body,
+            method="POST",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "User-Agent": "Hermes-Agent-Webhook",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                return int(response.status)
+        except urllib.error.HTTPError as e:
+            # A duplicate reaction can be reported as 200/201 by GitHub in
+            # normal use, but keep 4xx/5xx visible in logs for auth/scope bugs.
+            detail = e.read().decode("utf-8", errors="replace")[:300]
+            raise RuntimeError(f"GitHub API HTTP {e.code}: {detail}") from e
+
     # ------------------------------------------------------------------
     # Signature validation
     # ------------------------------------------------------------------
@@ -741,12 +894,98 @@ class WebhookAdapter(BasePlatformAdapter):
     # Prompt rendering
     # ------------------------------------------------------------------
 
+    def _get_payload_value(self, payload: dict, dotted_key: str) -> Any:
+        """Return a nested payload value addressed by dot notation.
+
+        Missing keys return ``None`` so route filters can treat absent fields
+        as non-matches without raising during webhook handling.
+        """
+        value: Any = payload
+        for part in dotted_key.split("."):
+            if not isinstance(value, dict) or part not in value:
+                return None
+            value = value[part]
+        return value
+
+    def _payload_filters_match(self, filters: Any, payload: dict) -> tuple[bool, Optional[str]]:
+        """Return whether all configured payload filters match.
+
+        Supported route config formats:
+
+        Exact scalar/list match, ANDed across keys::
+
+            filters: {"context.deviceType": ["WoCamera", "WoPanTiltCam"]}
+
+        Substring match, ORed across rules::
+
+            filters: {
+                "contains_any": [
+                    {"path": "issue.body", "text": "/hermes"},
+                    {"path": "comment.body", "text": "/hermes"},
+                ]
+            }
+
+        The substring form is evaluated before prompt rendering / agent dispatch,
+        so ignored webhooks do not start an LLM run.
+        """
+        if not filters:
+            return True, None
+        if not isinstance(filters, dict):
+            logger.warning("[webhook] Ignoring invalid filters config: %r", filters)
+            return True, None
+
+        contains_any = filters.get("contains_any")
+        if contains_any is not None:
+            if not self._contains_any_filter_matches(contains_any, payload):
+                return False, "contains_any"
+
+        for key, expected in filters.items():
+            if key == "contains_any":
+                continue
+            actual = self._get_payload_value(payload, str(key))
+            allowed = expected if isinstance(expected, list) else [expected]
+            if actual not in allowed:
+                return False, str(key)
+        return True, None
+
+    def _contains_any_filter_matches(self, rules: Any, payload: dict) -> bool:
+        """Return True if any substring filter rule matches the payload.
+
+        Invalid rules are treated as non-matches and logged.  Matching is
+        case-sensitive by default, which is appropriate for explicit bot
+        mentions such as ``@hermes``.
+        """
+        if isinstance(rules, dict):
+            rules = [rules]
+        if not isinstance(rules, list):
+            logger.warning("[webhook] Ignoring invalid contains_any filter: %r", rules)
+            return True
+
+        for rule in rules:
+            if not isinstance(rule, dict):
+                logger.warning("[webhook] Ignoring invalid contains_any rule: %r", rule)
+                continue
+            path = str(rule.get("path", ""))
+            needle = rule.get("text", rule.get("contains", ""))
+            if not path or needle in (None, ""):
+                logger.warning("[webhook] Ignoring incomplete contains_any rule: %r", rule)
+                continue
+
+            actual = self._get_payload_value(payload, path)
+            if actual is None:
+                continue
+            haystack = actual if isinstance(actual, str) else json.dumps(actual, ensure_ascii=False)
+            if str(needle) in haystack:
+                return True
+        return False
+
     def _render_prompt(
         self,
         template: str,
         payload: dict,
         event_type: str,
         route_name: str,
+        preserve_missing: bool = True,
     ) -> str:
         """Render a prompt template with the webhook payload.
 
@@ -772,9 +1011,12 @@ class WebhookAdapter(BasePlatformAdapter):
             value: Any = payload
             for part in key.split("."):
                 if isinstance(value, dict):
-                    value = value.get(part, f"{{{key}}}")
+                    if part in value:
+                        value = value[part]
+                    else:
+                        return f"{{{key}}}" if preserve_missing else ""
                 else:
-                    return f"{{{key}}}"
+                    return f"{{{key}}}" if preserve_missing else ""
             if isinstance(value, (dict, list)):
                 return json.dumps(value, indent=2)[:2000]
             return str(value)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -63,7 +63,7 @@ _ensure_slack_mock()
 import gateway.platforms.slack as _slack_mod
 _slack_mod.SLACK_AVAILABLE = True
 
-from gateway.platforms.slack import SlackAdapter  # noqa: E402
+from gateway.platforms.slack import SlackAdapter, _parse_slack_block_kit_payload  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -2474,6 +2474,29 @@ class TestMessageSplitting:
         await adapter.send("C123", "See [Foo](https://en.wikipedia.org/wiki/Foo_(bar))")
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_send_slack_block_kit_payload(self, adapter):
+        """A fenced slack-block-kit payload is sent via Slack blocks."""
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+        payload = '''Cronjob Response: pokemon-card-x-trends
+```slack-block-kit
+{"text":"ポケカまとめ","blocks":[{"type":"header","text":{"type":"plain_text","text":"🃏 ポケカX話題まとめ"}},{"type":"section","text":{"type":"mrkdwn","text":"*要点*\\n• 大会結果あり"}}]}
+```
+footer'''
+
+        result = await adapter.send("C123", payload, metadata={"thread_id": "parent_ts"})
+
+        assert result.success
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert kwargs["text"] == "ポケカまとめ"
+        assert kwargs["thread_ts"] == "parent_ts"
+        assert kwargs["blocks"][0]["type"] == "header"
+        assert "Cronjob Response" not in str(kwargs["blocks"])
+
+    def test_parse_slack_block_kit_ignores_plain_json(self):
+        assert _parse_slack_block_kit_payload('{"blocks": []}') is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -343,6 +343,18 @@ class TestRenderPrompt:
         )
         assert "{nonexistent}" in result
 
+    def test_render_prompt_missing_key_can_be_blank(self):
+        """Routes can opt into blanking missing keys for multi-device templates."""
+        adapter = _make_adapter()
+        result = adapter._render_prompt(
+            "Lock={context.lockState} Open={context.openState}",
+            {"context": {"lockState": "LOCKED"}},
+            "changeReport",
+            "switchbot-events",
+            preserve_missing=False,
+        )
+        assert result == "Lock=LOCKED Open="
+
     def test_render_prompt_no_template_dumps_json(self):
         """Empty template → JSON dump fallback with event/route context."""
         adapter = _make_adapter()

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -179,10 +179,241 @@ class TestDeliverOnlyBypassesAgent:
 
 
 # ===================================================================
+# Payload filters
+# ===================================================================
+class TestDeliverOnlyPayloadFilters:
+
+    @pytest.mark.asyncio
+    async def test_matching_payload_filter_delivers_notification(self):
+        routes = {
+            "switchbot": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["changeReport"],
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "SwitchBot {context.deviceType}",
+                "filters": {
+                    "context.deviceType": ["WoCamera", "WoPanTiltCam", "WoVideoDoorbell"],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/switchbot",
+                json={
+                    "eventType": "changeReport",
+                    "context": {"deviceType": "WoCamera"},
+                },
+                headers={"X-GitHub-Delivery": "filter-match-1"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "delivered"
+
+        mock_target.send.assert_awaited_once()
+        assert mock_target.send.await_args.args[1] == "SwitchBot WoCamera"
+
+    @pytest.mark.asyncio
+    async def test_non_matching_payload_filter_is_ignored_without_delivery(self):
+        routes = {
+            "switchbot": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["changeReport"],
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "SwitchBot {context.deviceType}",
+                "filters": {
+                    "context.deviceType": ["WoCamera", "WoPanTiltCam", "WoVideoDoorbell"],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/switchbot",
+                json={
+                    "eventType": "changeReport",
+                    "context": {"deviceType": "Meter"},
+                },
+                headers={"X-GitHub-Delivery": "filter-ignore-1"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {
+                "status": "ignored",
+                "event": "changeReport",
+                "filter": "context.deviceType",
+            }
+
+        mock_target.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_contains_any_payload_filter_matches_github_mention(self):
+        routes = {
+            "github": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "Issue {issue.number}: {issue.body}",
+                "filters": {
+                    "contains_any": [
+                        {"path": "issue.body", "text": "@hermes"},
+                        {"path": "comment.body", "text": "@hermes"},
+                    ],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/github",
+                json={"issue": {"number": 12, "body": "please handle this @hermes"}},
+                headers={"X-GitHub-Event": "issues", "X-GitHub-Delivery": "mention-1"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "delivered"
+
+        mock_target.send.assert_awaited_once()
+        assert mock_target.send.await_args.args[1] == "Issue 12: please handle this @hermes"
+
+    @pytest.mark.asyncio
+    async def test_contains_any_payload_filter_ignores_without_invoking_agent(self):
+        routes = {
+            "github": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "deliver": "slack",
+                "prompt": "Issue {issue.number}: {issue.body}",
+                "filters": {
+                    "contains_any": [
+                        {"path": "issue.body", "text": "@hermes"},
+                        {"path": "comment.body", "text": "@hermes"},
+                    ],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        handle_message = AsyncMock()
+        adapter.handle_message = handle_message
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/github",
+                json={"issue": {"number": 13, "body": "no bot mention here"}},
+                headers={"X-GitHub-Event": "issues", "X-GitHub-Delivery": "mention-2"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {
+                "status": "ignored",
+                "event": "issues",
+                "filter": "contains_any",
+            }
+
+        handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_github_reaction_runs_before_agent_dispatch(self):
+        routes = {
+            "github": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "deliver": "slack",
+                "prompt": "Issue {issue.number}: {issue.body}",
+                "github_reaction": "eyes",
+                "filters": {
+                    "contains_any": [
+                        {"path": "issue.body", "text": "/hermes"},
+                    ],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        handle_message = AsyncMock()
+        reaction = AsyncMock()
+        adapter.handle_message = handle_message
+        adapter._apply_github_reaction = reaction
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/github",
+                json={
+                    "repository": {"full_name": "pokeca-chips/test"},
+                    "issue": {"number": 14, "body": "/hermes please handle"},
+                },
+                headers={"X-GitHub-Event": "issues", "X-GitHub-Delivery": "reaction-1"},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["status"] == "accepted"
+
+        reaction.assert_awaited_once()
+        await asyncio.sleep(0.05)
+        handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_github_reaction_not_run_when_filter_ignores(self):
+        routes = {
+            "github": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["issues"],
+                "deliver": "slack",
+                "prompt": "Issue {issue.number}: {issue.body}",
+                "github_reaction": "eyes",
+                "filters": {
+                    "contains_any": [
+                        {"path": "issue.body", "text": "/hermes"},
+                    ],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        handle_message = AsyncMock()
+        reaction = AsyncMock()
+        adapter.handle_message = handle_message
+        adapter._apply_github_reaction = reaction
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/github",
+                json={
+                    "repository": {"full_name": "pokeca-chips/test"},
+                    "issue": {"number": 15, "body": "no slash command"},
+                },
+                headers={"X-GitHub-Event": "issues", "X-GitHub-Delivery": "reaction-2"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+            assert data["filter"] == "contains_any"
+
+        reaction.assert_not_awaited()
+        handle_message.assert_not_awaited()
+
+
+# ===================================================================
 # HTTP status codes
 # ===================================================================
-
 class TestDeliverOnlyStatusCodes:
+
 
     @pytest.mark.asyncio
     async def test_delivery_failure_returns_502(self):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -564,7 +564,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     """
     from gateway.config import Platform
     from gateway.platforms.base import BasePlatformAdapter, utf16_len
-    from gateway.platforms.slack import SlackAdapter
+    from gateway.platforms.slack import SlackAdapter, _parse_slack_block_kit_payload
 
     # Telegram adapter import is optional (requires python-telegram-bot)
     try:
@@ -582,7 +582,11 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     media_files = media_files or []
 
-    if platform == Platform.SLACK and message:
+    is_slack_block_kit_message = bool(
+        platform == Platform.SLACK and message and _parse_slack_block_kit_payload(message)
+    )
+
+    if platform == Platform.SLACK and message and not is_slack_block_kit_message:
         try:
             slack_adapter = SlackAdapter.__new__(SlackAdapter)
             message = slack_adapter.format_message(message)
@@ -612,7 +616,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     # For short messages or platforms without a known limit this is a no-op.
     # Telegram measures length in UTF-16 code units, not Unicode codepoints.
     max_len = _MAX_LENGTHS.get(platform)
-    if max_len:
+    if is_slack_block_kit_message:
+        chunks = [message]
+    elif max_len:
         _len_fn = utf16_len if platform == Platform.TELEGRAM else None
         chunks = BasePlatformAdapter.truncate_message(message, max_len, len_fn=_len_fn)
     else:
@@ -752,7 +758,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1034,10 +1040,11 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
+        from gateway.platforms.slack import _parse_slack_block_kit_payload
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
@@ -1047,7 +1054,14 @@ async def _send_slack(token, chat_id, message):
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
-            payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            block_payload = _parse_slack_block_kit_payload(message)
+            if block_payload:
+                fallback_text, blocks = block_payload
+                payload = {"channel": chat_id, "text": fallback_text, "blocks": blocks}
+            else:
+                payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = thread_id
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## Summary
- resolve rebase conflicts against the latest origin/main while preserving webhook signed URL support and fail-closed HMAC behavior
- add webhook payload filters, GitHub reaction acknowledgements, and eventType/type fallback handling
- support opt-in Slack Block Kit fenced payloads in Slack adapter and send_message delivery

## Tests
- python -m pytest tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_adapter.py tests/gateway/test_slack.py -q -o 'addopts='
- python -m pytest tests/tools/test_send_message_tool.py tests/tools/test_send_message_missing_platforms.py -q -o 'addopts='