### PR TITLE
fix: ignore WhatsApp messages addressed to others

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -420,6 +420,37 @@ class WhatsAppAdapter(BasePlatformAdapter):
         body = str(data.get("body") or "")
         return any(pattern.search(body) for pattern in self._mention_patterns)
 
+    def _message_mentions_non_bot(self, data: Dict[str, Any]) -> bool:
+        """Return true when the WhatsApp payload mentions participants other than the bot."""
+        bot_ids = self._bot_ids_from_message(data)
+        mentioned_ids = {
+            nid
+            for candidate in (data.get("mentionedIds") or [])
+            if (nid := self._normalize_whatsapp_id(candidate))
+        }
+        return bool(mentioned_ids - bot_ids)
+
+    def _message_starts_with_mention_token(self, data: Dict[str, Any]) -> bool:
+        """Detect messages visibly addressed with a leading @mention token."""
+        body = str(data.get("body") or "")
+        return bool(re.match(r"^\s*@\S+", body))
+
+    def _message_is_addressed_to_other_participant(self, data: Dict[str, Any]) -> bool:
+        """
+        In free-response WhatsApp groups, do not treat a message that starts by
+        tagging another participant as addressed to Hermes unless the bot is also
+        directly mentioned or a configured wake-word pattern matches.
+        """
+        if not self._message_starts_with_mention_token(data):
+            return False
+        if not self._message_mentions_non_bot(data):
+            return False
+        if self._message_mentions_bot(data):
+            return False
+        if self._message_matches_mention_patterns(data):
+            return False
+        return True
+
     def _clean_bot_mention_text(self, text: str, data: Dict[str, Any]) -> str:
         if not text:
             return text
@@ -443,6 +474,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 return False
             # DMs that pass the policy gate are always processed
             return True
+        # Group messages: check whether the message is explicitly addressed to
+        # someone else before applying free-response / mention bypasses.
+        if self._message_is_addressed_to_other_participant(data):
+            return False
         # Group messages: check mention / free-response settings
         chat_id = str(data.get("chatId") or "")
         if chat_id in self._whatsapp_free_response_chats():

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -138,6 +138,45 @@ def test_free_response_chats_bypass_mention_gating():
     assert adapter._should_process_message(_group_message("hello everyone")) is True
 
 
+def test_group_message_addressed_to_other_participant_is_ignored_even_in_free_response_chat():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["120363001234567890@g.us"],
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "@159420612870255 masuk pakai google account admin@amrta-spa.com",
+            mentionedIds=["159420612870255@s.whatsapp.net"],
+        )
+    ) is False
+
+
+def test_group_message_addressed_to_other_participant_allows_bot_when_bot_also_mentioned():
+    adapter = _make_adapter(require_mention=False)
+
+    assert adapter._should_process_message(
+        _group_message(
+            "@159420612870255 @15551230000 please help",
+            mentionedIds=["159420612870255@s.whatsapp.net", "15551230000@s.whatsapp.net"],
+        )
+    ) is True
+
+
+def test_group_message_addressed_to_other_participant_allows_wake_word():
+    adapter = _make_adapter(
+        require_mention=False,
+        mention_patterns=[r"\bfrodo\b"],
+    )
+
+    assert adapter._should_process_message(
+        _group_message(
+            "@159420612870255 ini untuk frodo juga",
+            mentionedIds=["159420612870255@s.whatsapp.net"],
+        )
+    ) is True
+
+
 def test_free_response_chats_does_not_bypass_other_groups():
     adapter = _make_adapter(
         require_mention=True,


### PR DESCRIPTION
## Summary
- Ignore free-response WhatsApp group messages that start with an @mention to a non-bot participant
- Still allow messages when Hermes is also mentioned or a configured wake word matches
- Add focused group-gating tests for those paths

## Test plan
- scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py -q
- scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_whatsapp_formatting.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_reply_prefix.py -q (one unrelated flaky live-lock failure in test_whatsapp_connect.py, isolated rerun passed)
- scripts/run_tests.sh tests/gateway/test_whatsapp_connect.py::TestBridgeRuntimeFailure::test_closed_on_unexpected_exception -q