### PR TITLE
fix(tui_gateway): mirror /browser connect/disconnect to gateway process

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3015,6 +3015,70 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     assert ("session.info", "sid", {"model": "x"}) in emitted
 
 
+def test_mirror_slash_browser_connect_sets_env(monkeypatch):
+    """Mirror of /browser connect via slash.exec must set BROWSER_CDP_URL in
+    the gateway process so the AIAgent sees it."""
+    monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+    cleanup_calls: list[str] = []
+
+    def _cleanup_all():
+        cleanup_calls.append(os.environ.get("BROWSER_CDP_URL", ""))
+
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=_cleanup_all,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+        _stub_urlopen(monkeypatch, ok=True)
+        session = _session(running=False)
+        session["agent"] = types.SimpleNamespace(model="x")
+        warning = server._mirror_slash_side_effects(
+            "sid", session, "/browser connect http://127.0.0.1:9222"
+        )
+
+    assert warning == ""
+    assert os.environ.get("BROWSER_CDP_URL") == "http://127.0.0.1:9222"
+    assert cleanup_calls == ["", "http://127.0.0.1:9222"]
+
+
+def test_mirror_slash_browser_disconnect_clears_env(monkeypatch):
+    """Mirror of /browser disconnect via slash.exec must clear BROWSER_CDP_URL
+    in the gateway process."""
+    os.environ["BROWSER_CDP_URL"] = "http://127.0.0.1:9222"
+    cleanup_calls: list[str] = []
+
+    def _cleanup_all():
+        cleanup_calls.append(os.environ.get("BROWSER_CDP_URL", ""))
+
+    fake = types.SimpleNamespace(
+        cleanup_all_browsers=_cleanup_all,
+        _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
+    )
+    try:
+        with patch.dict(sys.modules, {"tools.browser_tool": fake}):
+            session = _session(running=False)
+            session["agent"] = types.SimpleNamespace(model="x")
+            warning = server._mirror_slash_side_effects(
+                "sid", session, "/browser disconnect"
+            )
+
+        assert warning == ""
+        assert os.environ.get("BROWSER_CDP_URL") is None
+        assert cleanup_calls == ["http://127.0.0.1:9222", ""]
+    finally:
+        os.environ.pop("BROWSER_CDP_URL", None)
+
+
+def test_mirror_slash_browser_status_is_noop(monkeypatch):
+    """Mirror of /browser status has no side effect to mirror."""
+    session = _session(running=False)
+    session["agent"] = types.SimpleNamespace(model="x")
+    warning = server._mirror_slash_side_effects(
+        "sid", session, "/browser status"
+    )
+    assert warning == ""
+
+
 # ---------------------------------------------------------------------------
 # session.create / session.close race: fast /new churn must not orphan the
 # slash_worker subprocess or the global approval-notify registration.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5476,6 +5476,54 @@ def _(rid, params: dict) -> dict:
 # ── Methods: slash.exec ──────────────────────────────────────────────
 
 
+def _mirror_browser_side_effects(arg: str) -> str:
+    """Mirror /browser connect/disconnect side effects from the slash-worker
+    subprocess to the gateway process so the AIAgent sees BROWSER_CDP_URL.
+
+    Reuses the same cleanup_all_browsers + env-var pattern as the
+    browser.manage RPC, but skips the HTTP probe — the slash-worker
+    subprocess already validated the URL is reachable.
+    """
+    parts = arg.split(None, 1)
+    subcmd = parts[0].lower() if parts else ""
+
+    if subcmd == "connect":
+        url = parts[1].strip() if len(parts) > 1 else ""
+        try:
+            from hermes_cli.browser_connect import DEFAULT_BROWSER_CDP_URL
+            from tools.browser_tool import cleanup_all_browsers
+            from urllib.parse import urlparse
+
+            if not url:
+                url = DEFAULT_BROWSER_CDP_URL
+            parsed = urlparse(url if "://" in url else f"http://{url}")
+            if _is_default_local_cdp(parsed):
+                url = DEFAULT_BROWSER_CDP_URL
+                parsed = urlparse(url)
+            normalized = _normalize_cdp_url(parsed)
+            cleanup_all_browsers()
+            os.environ["BROWSER_CDP_URL"] = normalized
+            cleanup_all_browsers()
+        except Exception as e:
+            return f"browser connect mirror failed: {e}"
+
+    elif subcmd == "disconnect":
+        try:
+            from tools.browser_tool import cleanup_all_browsers
+
+            cleanup_all_browsers()
+            os.environ.pop("BROWSER_CDP_URL", None)
+            cleanup_all_browsers()
+        except Exception as e:
+            return f"browser disconnect mirror failed: {e}"
+
+    elif subcmd == "status":
+        # No side effect to mirror
+        pass
+
+    return ""
+
+
 def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     """Apply side effects that must also hit the gateway's live agent."""
     parts = command.lstrip("/").split(None, 1)
@@ -5521,6 +5569,8 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             _emit("session.info", sid, _session_info(agent))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()
+        elif name == "browser":
+            return _mirror_browser_side_effects(arg)
         elif name == "stop":
             from tools.process_registry import process_registry
 


### PR DESCRIPTION
## What

`/browser connect` and `/browser disconnect` via `slash.exec` now properly mirror their side effects to the gateway process so that `AIAgent` sees the `BROWSER_CDP_URL` environment variable.

Previously, when a TUI client (herm, `hermes --tui`, or any Ink-based frontend) executed `/browser connect`, the CDP URL was set in the `HermesCLI` subprocess but never propagated to the `AIAgent` subprocess. Because the two run in separate processes, `os.environ` changes are isolated — the agent could not use browser tools even after the user connected a browser.

This fix adds a handler in `_mirror_slash_side_effects` that catches `/browser connect`, `/browser disconnect`, and `/browser status`, reusing the same `cleanup_all_browsers` + env-var pattern from the `browser.manage` RPC. The HTTP probe is skipped because the slash-worker subprocess already validated the URL is reachable.

## Why

This is the same subprocess-boundary bug exposed by herm TUI, reported as [liftaris/herm#82](https://github.com/liftaris/herm/issues/82). It affects any TUI client that spawns `tui_gateway` as a subprocess — including the built-in `hermes --tui` — but is invisible to `hermes chat` because CLI and agent share the same process there. #32287

Related: [#28753](https://github.com/NousResearch/hermes-agent/issues/28753) (fallback settings lost across subprocess boundary), [#26864](https://github.com/NousResearch/hermes-agent/issues/26864) (`/browser connect` IPv6 loopback).

## Changes

- **tui_gateway/server.py** (+50 lines): `_mirror_browser_side_effects()` handles connect/disconnect/status; wired into `_mirror_slash_side_effects` for the `browser` command.
- **tests/test_tui_gateway_server.py** (+64 lines): 3 tests covering connect sets env, disconnect clears env, and status is a no-op.

## Testing

- Unit tests pass via `scripts/run_tests.sh tests/test_tui_gateway_server.py -q`
- Manually tested with herm TUI: `/browser connect` now allows browser tool calls to reach the connected CDP endpoint
- Also works for the built-in `hermes --tui` (same `tui_gateway` gateway)

## Platforms

Tested on Linux (CachyOS). The change touches only environment variables and imports from `tools.browser_tool` — no platform-specific syscalls.