### PR TITLE
fix(slack): clear stuck assistant status on /stop

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -932,9 +932,15 @@ class SlackAdapter(BasePlatformAdapter):
         """Clear the assistant thread status indicator."""
         if not self._app:
             return
-        thread_ts = self._active_status_threads.pop(chat_id, None)
+        tracked_thread_ts = self._active_status_threads.get(chat_id)
+        requested_thread_ts = None
+        if metadata:
+            requested_thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
+        thread_ts = requested_thread_ts or tracked_thread_ts
         if not thread_ts:
             return
+        if tracked_thread_ts == thread_ts:
+            self._active_status_threads.pop(chat_id, None)
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9811,6 +9811,22 @@ class GatewayRunner:
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        adapter = self.adapters.get(source.platform)
+
+        async def _clear_typing_indicator() -> None:
+            if not adapter or not hasattr(adapter, "stop_typing"):
+                return
+            try:
+                if source.platform == Platform.SLACK:
+                    metadata = self._thread_metadata_for_source(
+                        source,
+                        self._reply_anchor_for_event(event),
+                    )
+                    await adapter.stop_typing(source.chat_id, metadata=metadata)
+                else:
+                    await adapter.stop_typing(source.chat_id)
+            except Exception:
+                pass
 
         agent = self._running_agents.get(session_key)
         if agent is _AGENT_PENDING_SENTINEL:
@@ -9821,6 +9837,7 @@ class GatewayRunner:
                 interrupt_reason=_INTERRUPT_REASON_STOP,
                 invalidation_reason="stop_command_pending",
             )
+            await _clear_typing_indicator()
             logger.info("STOP (pending) for session %s — sentinel cleared", session_key)
             return EphemeralReply(t("gateway.stop.stopped_pending"))
         if agent:
@@ -9832,8 +9849,10 @@ class GatewayRunner:
                 interrupt_reason=_INTERRUPT_REASON_STOP,
                 invalidation_reason="stop_command_handler",
             )
+            await _clear_typing_indicator()
             return EphemeralReply(t("gateway.stop.stopped"))
         else:
+            await _clear_typing_indicator()
             return t("gateway.stop.no_active")
 
     async def _handle_platform_command(self, event: MessageEvent) -> str:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1313,6 +1313,19 @@ class TestSendTyping:
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_stop_typing_uses_metadata_when_tracking_missing(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "parent_ts"})
+
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
     async def test_stop_typing_handles_api_error_gracefully(self, adapter):
         adapter._active_status_threads["C123"] = "parent_ts"
         adapter._app.client.assistant_threads_setStatus = AsyncMock(

--- a/tests/gateway/test_slack_stop_command.py
+++ b/tests/gateway/test_slack_stop_command.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_event() -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.SLACK,
+        user_id="U123",
+        chat_id="C123",
+        user_name="tester",
+        chat_type="group",
+        thread_id="1716412345.6789",
+    )
+    return MessageEvent(text="/stop", source=source, message_id="1716412350.0001")
+
+
+def _make_runner(event: MessageEvent):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.SLACK: MagicMock(stop_typing=AsyncMock())}
+    runner._running_agents = {}
+    runner._interrupt_and_clear_session = AsyncMock()
+    runner._voice_mode = {}
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(event.source),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="group",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_stop_command_clears_slack_status_without_active_agent():
+    event = _make_event()
+    runner = _make_runner(event)
+
+    result = await runner._handle_stop_command(event)
+
+    runner.adapters[Platform.SLACK].stop_typing.assert_awaited_once_with(
+        "C123",
+        metadata={"thread_id": "1716412345.6789"},
+    )
+    assert "active" in result.lower()


### PR DESCRIPTION
Fixes #32295

## Summary
- clear Slack assistant thread status from `/stop` even when no running agent is registered
- let `SlackAdapter.stop_typing()` clear a thread from explicit metadata when the in-memory `chat_id -> thread_ts` map is gone
- add regression tests for the metadata fallback and the Slack `/stop` no-active path

## Testing
- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_slack.py -k 'stop_typing'`
- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_slack_stop_command.py`
- `git diff --check`
- `uv run --frozen ruff check gateway/platforms/slack.py gateway/run.py tests/gateway/test_slack.py tests/gateway/test_slack_stop_command.py`
