### PR TITLE
fix(dashboard): unfreeze SET MAIN MODEL on list-of-dict `models:` (#32334)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from hermes_cli.providers import (
     custom_provider_slug,
@@ -1044,6 +1044,57 @@ def switch_model(
 # Authenticated providers listing (for /model no-args display)
 # ---------------------------------------------------------------------------
 
+def _model_entry_id(entry: Any) -> str:
+    """Coerce a config ``models:`` element into a plain model-id string.
+
+    Hermes accepts three on-disk shapes for the per-provider model list,
+    all of which must funnel down into the picker as plain strings — the
+    Dashboard's ``ModelPickerDialog`` (and the TUI's parallel picker)
+    calls ``.toLowerCase()`` on every entry while filtering, so a dict
+    leaking through unmasks as a TypeError / "objects are not valid as
+    a React child" crash that blanks the picker.  See issue #32334.
+
+    Accepted shapes:
+
+    * Plain string — ``"qwen3.5-coder"``
+    * Dict keyed by id, taking ``id`` (preferred) then ``model`` /
+      ``name`` as fallbacks for hand-edited configs.  Empty / missing
+      ids return ``""`` so callers can drop the entry instead of
+      surfacing a blank line in the picker.
+
+    Anything else (None, list, number, …) is coerced via ``str()`` only
+    when it actually round-trips back as a non-empty string; otherwise
+    ``""`` is returned.
+    """
+    if isinstance(entry, str):
+        return entry.strip()
+    if isinstance(entry, dict):
+        for key in ("id", "model", "name"):
+            val = entry.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+        return ""
+    if entry is None:
+        return ""
+    # Containers (list, tuple, set) and similar collections never
+    # represent a single model id — ``str([...])`` round-trips to a
+    # readable but bracket-prefixed value that would still render as
+    # junk in the picker. Reject explicitly so the caller drops the
+    # entry instead.
+    if isinstance(entry, (list, tuple, set, frozenset, bytes, bytearray)):
+        return ""
+    try:
+        text = str(entry).strip()
+    except Exception:
+        return ""
+    # Guard against ``str()`` round-trips that produce angle-bracket /
+    # repr-style noise like ``<object at 0x…>`` — never useful as a
+    # model id and would still crash the picker on display.
+    if not text or text.startswith("<"):
+        return ""
+    return text
+
+
 def list_authenticated_providers(
     current_provider: str = "",
     current_base_url: str = "",
@@ -1490,21 +1541,27 @@ def list_authenticated_providers(
 
             # Build models list from both default_model and full models array
             models_list = []
-            if default_model:
-                models_list.append(default_model)
+            default_model_id = _model_entry_id(default_model)
+            if default_model_id:
+                models_list.append(default_model_id)
             # Also include the full models list from config.
-            # Hermes writes ``models:`` as a dict keyed by model id
-            # (see hermes_cli/main.py::_save_custom_provider); older
-            # configs or hand-edited files may still use a list.
+            # Hermes writes ``models:`` as a dict keyed by model id (see
+            # hermes_cli/main.py::_save_custom_provider); hand-edited or
+            # imported configs may still use a list of strings OR a list
+            # of dicts like ``- {id: qwen36-mtp, name: Qwen3.6 MTP}``.
+            # Normalise every shape down to a plain id string here — the
+            # picker UI assumes strings end-to-end (#32334).
             cfg_models = ep_cfg.get("models", [])
             if isinstance(cfg_models, dict):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    mid = _model_entry_id(m)
+                    if mid and mid not in models_list:
+                        models_list.append(mid)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    mid = _model_entry_id(m)
+                    if mid and mid not in models_list:
+                        models_list.append(mid)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
@@ -1632,19 +1689,24 @@ def list_authenticated_providers(
             # stores every configured model as a dict under ``models:``;
             # downstream readers (agent/models_dev.py, gateway/run.py,
             # run_agent.py, hermes_cli/config.py) already consume that dict.
-            default_model = (entry.get("model") or "").strip()
+            # As in section 3, normalise every shape down to a plain id
+            # string so list-of-dict entries never reach the picker
+            # (#32334).
+            default_model = _model_entry_id(entry.get("model"))
             if default_model and default_model not in groups[group_key]["models"]:
                 groups[group_key]["models"].append(default_model)
 
             cfg_models = entry.get("models", {})
             if isinstance(cfg_models, dict):
                 for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
+                    mid = _model_entry_id(m)
+                    if mid and mid not in groups[group_key]["models"]:
+                        groups[group_key]["models"].append(mid)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
+                    mid = _model_entry_id(m)
+                    if mid and mid not in groups[group_key]["models"]:
+                        groups[group_key]["models"].append(mid)
 
         _section4_emitted_slugs: set = set()
         for grp_key, grp in groups.items():

--- a/tests/hermes_cli/test_model_entry_id_normalizer.py
+++ b/tests/hermes_cli/test_model_entry_id_normalizer.py
@@ -1,0 +1,90 @@
+"""Unit tests for ``hermes_cli.model_switch._model_entry_id``.
+
+The normalizer is the source of truth for collapsing every config
+``models:`` entry shape Hermes accepts down to a plain id string.
+Locked down here so the picker UI (Dashboard + TUI) can keep relying
+on string-only model lists end-to-end.  See issue #32334 for the
+crash the list-of-dicts shape used to cause.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.model_switch import _model_entry_id
+
+
+class TestStringInput:
+    def test_returns_plain_string(self):
+        assert _model_entry_id("gpt-4") == "gpt-4"
+
+    def test_strips_whitespace(self):
+        assert _model_entry_id("  gpt-4  ") == "gpt-4"
+
+    def test_empty_returns_empty(self):
+        assert _model_entry_id("") == ""
+
+    def test_whitespace_only_returns_empty(self):
+        assert _model_entry_id("   \t  ") == ""
+
+
+class TestDictInput:
+    """Hand-edited / imported configs commonly use list-of-dict shape,
+    e.g. ``models: [{id: qwen36-mtp, name: Qwen3.6 MTP}]`` — issue #32334.
+    """
+
+    def test_id_field_preferred(self):
+        assert _model_entry_id({"id": "qwen36-mtp", "name": "Qwen3.6 MTP"}) == "qwen36-mtp"
+
+    def test_model_field_fallback(self):
+        assert _model_entry_id({"model": "gpt-4", "context_length": 8192}) == "gpt-4"
+
+    def test_name_field_last_resort(self):
+        # Some legacy export tools only set ``name``.
+        assert _model_entry_id({"name": "claude-opus-4-7"}) == "claude-opus-4-7"
+
+    def test_id_wins_over_model_and_name(self):
+        assert (
+            _model_entry_id({"id": "winner", "model": "loser", "name": "loser"})
+            == "winner"
+        )
+
+    def test_empty_id_falls_through_to_model(self):
+        # An empty/whitespace ``id`` MUST NOT be picked over a real
+        # fallback — otherwise we'd silently insert blank picker rows.
+        assert _model_entry_id({"id": "  ", "model": "claude-opus-4-7"}) == "claude-opus-4-7"
+
+    def test_no_string_fields_returns_empty(self):
+        assert _model_entry_id({"context_length": 8192}) == ""
+
+    def test_non_string_id_returns_empty(self):
+        # ``id: 42`` (number) shouldn't be silently stringified — it
+        # almost certainly indicates a malformed config that the user
+        # should fix, and inserting "42" as a model id would be worse.
+        assert _model_entry_id({"id": 42}) == ""
+
+    def test_empty_dict_returns_empty(self):
+        assert _model_entry_id({}) == ""
+
+
+class TestEdgeCases:
+    def test_none_returns_empty(self):
+        assert _model_entry_id(None) == ""
+
+    def test_list_returns_empty(self):
+        # Lists are never valid model entries (they'd nest the list shape).
+        # str(list) round-trips fine but the result is repr-style noise.
+        assert _model_entry_id(["gpt-4"]) == ""
+
+    def test_int_coerces_to_string(self):
+        # Numeric scalars don't appear in practice but the str-fallback
+        # should still produce a non-bracketed value rather than crash.
+        assert _model_entry_id(42) == "42"
+
+    def test_repr_style_string_rejected(self):
+        # Anything beginning with ``<`` is repr noise (``<object at 0x…>``).
+        # Letting it through would render as garbage in the picker.
+        class _Custom:
+            pass
+
+        assert _model_entry_id(_Custom()) == ""

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -212,6 +212,132 @@ def test_list_authenticated_providers_dict_models_without_default_model(monkeypa
     assert set(user_prov["models"]) == {"alpha", "beta"}
 
 
+def test_list_authenticated_providers_list_of_dict_models_normalises_ids(monkeypatch):
+    """Hand-edited / imported configs commonly use ``models: [{id, name}]``.
+
+    Regression for #32334: the Dashboard picker freezes/blanks the entire
+    Models page the moment a user selects a custom provider whose
+    ``models:`` is a list of dicts, because the column filter calls
+    ``.toLowerCase()`` on every entry and React refuses to render plain
+    objects as children. The fix collapses every list-of-dict element
+    down to its ``id`` (or ``model`` / ``name``) string here at the
+    payload-builder layer so the picker UI never has to defend against
+    it.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    # Exact shape from the issue reporter's config.yaml.
+    user_providers = {
+        "qwen36mtp8081": {
+            "type": "openai",
+            "base_url": "http://127.0.0.1:8081/v1",
+            "api_key": "",
+            "models": [
+                {"id": "qwen36-mtp", "name": "Qwen3.6 MTP"},
+            ],
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="qwen36mtp8081",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("slug") == "qwen36mtp8081"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["models"] == ["qwen36-mtp"], (
+        "models list MUST be plain strings — the dashboard picker calls "
+        ".toLowerCase() on every entry while filtering and React refuses "
+        "to render objects as children. See #32334."
+    )
+    # Every element must be a string — a single non-string slips past
+    # the picker filter and blanks the Models page.
+    for m in user_prov["models"]:
+        assert isinstance(m, str), f"non-string model entry leaked through: {m!r}"
+
+
+def test_list_authenticated_providers_list_of_mixed_string_and_dict_models(monkeypatch):
+    """List entries can be a mix of strings and dicts — picker must
+    surface every recognisable id and skip unrecognisable entries
+    rather than crashing the whole payload."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "mixed": {
+            "base_url": "http://example.com/v1",
+            "models": [
+                "plain-string-model",
+                {"id": "dict-with-id", "name": "Dict-with-id Display"},
+                {"model": "dict-with-model-field"},  # fallback path
+                {"context_length": 8192},  # unrecognisable → skipped
+                "",  # blank → skipped
+            ],
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next((p for p in providers if p.get("slug") == "mixed"), None)
+    assert user_prov is not None
+    assert user_prov["models"] == [
+        "plain-string-model",
+        "dict-with-id",
+        "dict-with-model-field",
+    ]
+    assert user_prov["total_models"] == 3
+
+
+def test_list_authenticated_providers_custom_providers_list_of_dict_models(monkeypatch):
+    """Same #32334 regression on the legacy ``custom_providers:`` list
+    path (section 4 of list_authenticated_providers).
+
+    ``custom_providers`` is a list whose entries each have their own
+    ``models`` field — the same list-of-dict shape that crashes the
+    picker via the keyed ``providers:`` path must be normalised here
+    too, or users on the legacy schema still hit the black screen.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    custom_providers = [
+        {
+            "name": "My Local vLLM",
+            "base_url": "http://127.0.0.1:9000/v1",
+            "api_key": "",
+            "models": [
+                {"id": "qwen3.5-coder", "name": "Qwen3.5 Coder"},
+                {"id": "glm-4.6", "name": "GLM 4.6"},
+            ],
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers={},
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    row = next((p for p in providers if "vllm" in p["name"].lower()), None)
+    assert row is not None
+    assert row["models"] == ["qwen3.5-coder", "glm-4.6"]
+    for m in row["models"]:
+        assert isinstance(m, str)
+
+
 def test_list_authenticated_providers_dict_models_dedupe_with_default(monkeypatch):
     """When ``default_model`` is also a key in the ``models:`` dict, it must
     appear exactly once (list already had this for list-format models)."""

--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -46,6 +46,50 @@ interface ModelOptionsResponse {
   providers?: ModelOptionProvider[];
 }
 
+/**
+ * Coerce one element of a provider's `models` payload into a plain id
+ * string. The backend already normalises every config shape down to
+ * strings (see `_model_entry_id` in hermes_cli/model_switch.py for the
+ * full table), but a hand-edited config can still trigger schema
+ * variants this dashboard hasn't seen yet — issue #32334 was a YAML
+ * `models: [{id, name}, ...]` list-of-dicts shape that crashed the
+ * picker the moment the user selected the affected provider, because
+ * the column filter calls `.toLowerCase()` on every entry and React
+ * refuses to render plain objects as children.
+ *
+ * Accept the same shapes the backend does (string, dict with
+ * `id`/`model`/`name`) and drop anything that doesn't reduce to a
+ * non-empty string. Defence-in-depth — the picker should *degrade*
+ * (skip the bad row) rather than black-screen the entire Models page.
+ */
+function normalizeModelEntry(entry: unknown): string | null {
+  if (typeof entry === "string") {
+    const trimmed = entry.trim();
+    return trimmed || null;
+  }
+  if (entry && typeof entry === "object") {
+    const rec = entry as Record<string, unknown>;
+    for (const key of ["id", "model", "name"] as const) {
+      const val = rec[key];
+      if (typeof val === "string" && val.trim()) return val.trim();
+    }
+  }
+  return null;
+}
+
+function normalizeProviderModels(
+  provider: ModelOptionProvider,
+): ModelOptionProvider {
+  const raw = provider.models;
+  if (!Array.isArray(raw)) return { ...provider, models: [] };
+  const cleaned: string[] = [];
+  for (const entry of raw) {
+    const id = normalizeModelEntry(entry);
+    if (id && !cleaned.includes(id)) cleaned.push(id);
+  }
+  return { ...provider, models: cleaned };
+}
+
 interface Props {
   /** Chat-mode: when present, picker emits a slash command via onSubmit. */
   gw?: GatewayClient;
@@ -105,7 +149,11 @@ export function ModelPickerDialog(props: Props) {
     promise
       .then((r) => {
         if (closedRef.current) return;
-        const next = r?.providers ?? [];
+        // Defence-in-depth: normalise every row's `models` to plain
+        // strings before they reach the column filter / renderer.
+        // Without this a single malformed entry (#32334) crashes the
+        // picker mid-render and blanks the surrounding Models page.
+        const next = (r?.providers ?? []).map(normalizeProviderModels);
         setProviders(next);
         setCurrentModel(String(r?.model ?? ""));
         setCurrentProviderSlug(String(r?.provider ?? ""));


### PR DESCRIPTION
## Description

Selecting a named custom provider on the Dashboard **SET MAIN MODEL** screen freezes the picker into a black screen — the rest of the Models page goes blank too and the user has to fall back to hand-editing `~/.hermes/config.yaml` + `hermes gateway restart` to switch models. Default providers (`xai-oauth`, `gemini`, …) are unaffected.

### Root cause

The reporter's `providers:` entry uses a perfectly reasonable but previously-unhandled `models:` shape — a YAML **list of dicts**:

```yaml
providers:
  qwen36mtp8081:
    type: openai
    base_url: http://127.0.0.1:8081/v1
    api_key: ""
    models:
      - id: qwen36-mtp
        name: Qwen3.6 MTP
```

`hermes_cli.model_switch.list_authenticated_providers` already accepted three on-disk shapes (`"gpt-4"`, `{"gpt-4": {context_length: …}}`, `["gpt-4", "claude-3"]`) but the list-iteration branch appended every element verbatim:

```python
elif isinstance(cfg_models, list):
    for m in cfg_models:
        if m and m not in models_list:
            models_list.append(m)   # ← m may be {"id": …, "name": …}
```

The dict then rode through `build_models_payload` → `/api/model/options` and reached the Dashboard. `ModelPickerDialog` column filter calls `.toLowerCase()` on every entry and renders them as React children:

```tsx
models.filter((m) => m.toLowerCase().includes(needle))   // TypeError
<span>{m}</span>                                          // objects-are-not-valid-as-a-React-child
```

React unwinds the tree on the unhandled error → the entire Models page goes black. The bug surfaces the **moment** the user selects the affected provider, exactly as reported.

The same list-of-dict path exists on the legacy `custom_providers:` section, so users on the older schema hit the same crash with the same root cause.

### Related issue

Closes #32334

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

### Changes made

* **`hermes_cli/model_switch.py`** — new `_model_entry_id()` helper that funnels every accepted shape (plain string, dict with `id` / `model` / `name`, anything else → drop) down to a plain id string. Applied symmetrically to **section 3** (keyed `providers:` dict) and **section 4** (legacy `custom_providers:` list) so both schema paths benefit.
* **`tests/hermes_cli/test_model_entry_id_normalizer.py`** — new file unit-testing every accepted and rejected shape: strings (with/without whitespace), dicts (id wins over model wins over name; empty id falls through to fallbacks; non-string ids rejected), None, lists/tuples, repr-style objects.
* **`tests/hermes_cli/test_user_providers_model_switch.py`** — two new integration tests that pin the exact `providers:` fragment from the bug report **and** the symmetrical `custom_providers:` list-of-dicts shape. Each asserts every emitted `models` element is `isinstance(_, str)`.
* **`web/src/components/ModelPickerDialog.tsx`** — defence-in-depth: a `normalizeProviderModels()` pass at the response boundary so even a malformed payload (hand-edited config, future schema variant) **degrades** to a missing row instead of crashing the whole Models page.

Three small commits, sole author:

| # | Commit |
| - | ------ |
| 1 | `fix(model-picker): normalise list-of-dict models: entries to ids (#32334)` |
| 2 | `test(model-picker): pin _model_entry_id + list-of-dict shape regression` |
| 3 | `fix(dashboard): defensively coerce picker model entries to strings` |

### How to test

1. Replace `~/.hermes/config.yaml` with a stanza using the reporter's exact shape:

   ```yaml
   providers:
     qwen36mtp8081:
       type: openai
       base_url: http://127.0.0.1:8081/v1
       api_key: ""
       models:
         - id: qwen36-mtp
           name: Qwen3.6 MTP
   ```

2. `hermes dashboard` → **Models** → **SET MAIN MODEL** → click **Change**.
3. Click the **qwen36mtp8081** row in the provider column.
4. **Before this PR:** the picker freezes, the model column never renders, the whole Models page blanks out, and the browser console shows a React "Objects are not valid as a React child" error / `m.toLowerCase is not a function`.
5. **With this PR:** the model column renders `qwen36-mtp` (the normalised id) and the **Switch** button activates as expected.

Automated coverage:

```
scripts/run_tests.sh tests/hermes_cli/test_model_entry_id_normalizer.py \
                     tests/hermes_cli/test_user_providers_model_switch.py \
                     tests/hermes_cli/test_custom_provider_model_switch.py \
                     tests/hermes_cli/test_inventory.py \
                     tests/hermes_cli/test_list_picker_providers.py \
                     tests/hermes_cli/test_model_switch_custom_providers.py \
                     tests/hermes_cli/test_model_provider_persistence.py \
                     tests/hermes_cli/test_bedrock_model_picker.py \
                     tests/hermes_cli/test_overlay_slug_resolution.py \
                     tests/hermes_cli/test_model_catalog.py
# → 10 files, 169 tests passed

cd web && ./node_modules/.bin/tsc --noEmit
# → exit 0
```

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
