### PR TITLE
fix(file-tools): allow macOS var folders temp writes

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -106,6 +106,14 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
+    def test_private_var_folders_temp_allowed(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/folders/ab/cd/T/pytest-file.txt") is None
+
+    def test_var_folders_temp_allowed(self):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/var/folders/ab/cd/T/pytest-file.txt") is None
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -171,6 +171,13 @@ _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
     "/private/etc/", "/private/var/",
 )
+# macOS resolves pytest/tmpdir paths under /private/var/folders. That is a
+# user temp area, not a system config target, and blocking it breaks file-tool
+# tests plus legitimate temporary artifact writes.
+_SENSITIVE_PATH_EXEMPT_PREFIXES = (
+    "/private/var/folders/",
+    "/var/folders/",
+)
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
@@ -185,6 +192,9 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    for prefix in _SENSITIVE_PATH_EXEMPT_PREFIXES:
+        if resolved.startswith(prefix) or normalized.startswith(prefix):
+            return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err


### PR DESCRIPTION
## Summary
- exempt macOS /private/var/folders and /var/folders temp roots from the sensitive system path guard
- keep /private/var/db and other protected system paths blocked
- add regression coverage for both macOS temp spellings

## Verification
- python -m pytest tests/tools/test_file_write_safety.py -q

## Notes
- untracked local .hermes/plans files were left untouched