### PR TITLE
fix(slack): hydrate nearby top-level context for deictic references (#31755)

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -52,6 +52,11 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+_SLACK_NEARBY_CONTEXT_HINT_RE = re.compile(
+    r"\b(?:this|that|above|below|previous|prior|earlier|bug report|report above|this report|that report|the report)\b",
+    re.IGNORECASE,
+)
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -250,6 +255,96 @@ def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> st
         payload = payload[: max_chars - 18].rstrip() + "\n... [truncated]"
 
     return f"[Slack Block Kit payload for this message]\n```json\n{payload}\n```"
+
+
+def _render_slack_attachments_for_agent(
+    attachments: list,
+    *,
+    existing_text: str = "",
+    allow_msg_unfurls: bool = False,
+) -> str:
+    """Return readable attachment/unfurl text for the agent."""
+    if not attachments:
+        return ""
+
+    att_parts: list[str] = []
+    for att in attachments:
+        att_title = att.get("title", "")
+        att_url = att.get("title_link", "") or att.get("from_url", "")
+        att_text = att.get("text", "")
+        att_footer = att.get("footer", "")
+        att_fallback = att.get("fallback", "")
+
+        if att.get("is_msg_unfurl") and not allow_msg_unfurls:
+            continue
+
+        if att_title and att_url:
+            header = f"📎 [{att_title}]({att_url})"
+        elif att_title:
+            header = f"📎 {att_title}"
+        elif att_url:
+            header = f"📎 {att_url}"
+        else:
+            header = None
+
+        body = att_text or att_fallback or ""
+        if body:
+            body = body.strip()
+            if len(body) > 500:
+                body = body[:497] + "..."
+
+        if header and body:
+            section = f"{header}\n   {body}"
+        elif header:
+            section = header
+        elif body:
+            section = f"📎 {body}"
+        else:
+            continue
+
+        if section in existing_text or section in att_parts:
+            continue
+
+        if att_footer:
+            section = f"{section}\n   _{att_footer}_"
+
+        att_parts.append(section)
+
+    return "\n\n".join(att_parts)
+
+
+def _merge_slack_message_text(
+    text: str,
+    *,
+    blocks: Optional[list] = None,
+    attachments: Optional[list] = None,
+    include_block_payload: bool = False,
+    allow_msg_unfurls: bool = False,
+) -> str:
+    """Merge Slack text, rich-text blocks, and attachment previews."""
+    merged = text or ""
+
+    if blocks:
+        blocks_text = _extract_text_from_slack_blocks(blocks)
+        if blocks_text:
+            stripped_blocks = blocks_text.strip()
+            if stripped_blocks and stripped_blocks not in merged.strip():
+                merged = (merged.strip() + "\n" + stripped_blocks).strip()
+
+        if include_block_payload:
+            blocks_payload = _serialize_slack_blocks_for_agent(blocks)
+            if blocks_payload:
+                merged = (merged.strip() + "\n\n" + blocks_payload).strip()
+
+    attachment_text = _render_slack_attachments_for_agent(
+        attachments or [],
+        existing_text=merged,
+        allow_msg_unfurls=allow_msg_unfurls,
+    )
+    if attachment_text:
+        merged = (merged.strip() + "\n\n" + attachment_text).strip()
+
+    return merged
 
 
 def _apply_slack_proxy(client: Any, proxy_url: Optional[str]) -> None:
@@ -1820,94 +1915,15 @@ class SlackAdapter(BasePlatformAdapter):
 
         text = original_text
 
-        # Extract quoted/forwarded content from Slack blocks.
-        # Slack's modern composer embeds forwarded messages in the ``blocks``
-        # array as ``rich_text_quote`` elements, which are NOT reflected in
-        # the plain ``text`` field.  Merge block text so the agent sees the
-        # full message content.
-        blocks = event.get("blocks")
-        if blocks:
-            blocks_text = _extract_text_from_slack_blocks(blocks)
-            if blocks_text:
-                # Only append if the blocks contain text not already present
-                # in the plain text field (avoids duplication).
-                stripped_blocks = blocks_text.strip()
-                if stripped_blocks and stripped_blocks not in text.strip():
-                    logger.debug(
-                        "Slack: extracted additional text from blocks "
-                        "(likely quoted/forwarded content): %s",
-                        stripped_blocks[:300],
-                    )
-                    text = (text.strip() + "\n" + stripped_blocks).strip()
-
-            blocks_payload = _serialize_slack_blocks_for_agent(blocks)
-            if blocks_payload:
-                text = (text.strip() + "\n\n" + blocks_payload).strip()
-
-        # Extract link unfurls / rich attachments (e.g. Notion previews).
-        # Slack places unfurled link previews in the ``attachments`` array with
-        # fields like title, title_link/from_url, text, footer, and fallback.
-        # Without reading these, the agent never sees shared link previews.
-        slack_attachments = event.get("attachments") or []
-        if slack_attachments:
-            att_parts: list[str] = []
-            for att in slack_attachments:
-                att_title = att.get("title", "")
-                att_url = att.get("title_link", "") or att.get("from_url", "")
-                att_text = att.get("text", "")
-                att_footer = att.get("footer", "")
-                att_fallback = att.get("fallback", "")
-
-                # Skip message-type attachments (e.g. Slack bot messages with
-                # is_msg_unfurl) to avoid echoing our own content.
-                if att.get("is_msg_unfurl"):
-                    continue
-
-                # Build a readable representation.
-                if att_title and att_url:
-                    header = f"📎 [{att_title}]({att_url})"
-                elif att_title:
-                    header = f"📎 {att_title}"
-                elif att_url:
-                    header = f"📎 {att_url}"
-                else:
-                    header = None
-
-                # Prefer preview text, fall back to fallback description.
-                body = att_text or att_fallback or ""
-                if body:
-                    body = body.strip()
-                    if len(body) > 500:
-                        body = body[:497] + "..."
-
-                if header and body:
-                    section = f"{header}\n   {body}"
-                elif header:
-                    section = header
-                elif body:
-                    section = f"📎 {body}"
-                else:
-                    continue
-
-                # Deduplicate only when the fully rendered section is already
-                # present. The shared URL often already appears in the user's
-                # message text, and skipping on URL/title alone would hide the
-                # preview body we actually want the agent to see.
-                if section in text:
-                    continue
-
-                if att_footer:
-                    section = f"{section}\n   _{att_footer}_"
-
-                att_parts.append(section)
-
-            if att_parts:
-                attachment_text = "\n\n".join(att_parts)
-                text = (text.strip() + "\n\n" + attachment_text).strip()
-                logger.debug(
-                    "Slack: appended %d link unfurl(s) to message text",
-                    len(att_parts),
-                )
+        # Merge quoted/forwarded rich text plus safe link unfurls into the
+        # visible message text before any routing or session logic.
+        text = _merge_slack_message_text(
+            text,
+            blocks=event.get("blocks"),
+            attachments=event.get("attachments"),
+            include_block_payload=True,
+            allow_msg_unfurls=False,
+        )
 
         channel_id = event.get("channel", "")
         ts = event.get("ts", "")
@@ -2023,6 +2039,25 @@ class SlackAdapter(BasePlatformAdapter):
             )
             if thread_context:
                 text = thread_context + text
+        elif self._should_fetch_nearby_channel_context(
+            event=event,
+            text=text,
+            channel_id=channel_id,
+            current_ts=ts,
+            user_id=user_id,
+            team_id=team_id,
+            is_dm=is_dm,
+            is_thread_reply=is_thread_reply,
+        ):
+            nearby_context, nearby_notice = await self._fetch_nearby_channel_context(
+                channel_id=channel_id,
+                current_ts=ts,
+                team_id=team_id,
+            )
+            if nearby_context:
+                text = nearby_context + text
+            elif nearby_notice:
+                text = (nearby_notice.strip() + "\n\n" + text.strip()).strip()
 
         # Determine message type
         msg_type = MessageType.TEXT
@@ -2753,6 +2788,141 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("[Slack] Failed to fetch thread parent text: %s", exc)
             return ""
+
+    def _should_fetch_nearby_channel_context(
+        self,
+        *,
+        event: dict,
+        text: str,
+        channel_id: str,
+        current_ts: str,
+        user_id: str,
+        team_id: str,
+        is_dm: bool,
+        is_thread_reply: bool,
+    ) -> bool:
+        """Return True when a top-level message likely refers to nearby context."""
+        if is_dm or is_thread_reply or not channel_id or not current_ts:
+            return False
+
+        if self._has_active_session_for_thread(
+            channel_id=channel_id,
+            thread_ts=current_ts,
+            user_id=user_id,
+        ):
+            return False
+
+        if _SLACK_NEARBY_CONTEXT_HINT_RE.search(text or ""):
+            return True
+
+        attachments = event.get("attachments") or []
+        return any(
+            att.get("is_msg_unfurl")
+            or att.get("message")
+            or att.get("message_blocks")
+            or att.get("from_url")
+            for att in attachments
+        )
+
+    def _render_slack_context_message_text(self, message: dict, *, team_id: str = "") -> str:
+        """Render a nearby/thread Slack message into readable agent text."""
+        rendered = _merge_slack_message_text(
+            message.get("text", ""),
+            blocks=message.get("blocks"),
+            attachments=message.get("attachments"),
+            include_block_payload=False,
+            allow_msg_unfurls=True,
+        ).strip()
+
+        bot_uid = self._team_bot_user_ids.get(
+            message.get("team") or team_id or self._channel_team.get(message.get("channel", ""), ""),
+            self._bot_user_id,
+        )
+        if bot_uid and rendered:
+            rendered = rendered.replace(f"<@{bot_uid}>", "").strip()
+        return rendered
+
+    def _describe_nearby_context_failure(self, exc: Exception) -> str:
+        """Translate Slack history fetch failures into prompt-visible diagnostics."""
+        response = getattr(exc, "response", None)
+        if hasattr(response, "get"):
+            error = str(response.get("error", "") or "").strip()
+            needed = str(response.get("needed", "") or "").strip()
+            if error == "missing_scope" and needed:
+                return f"[Slack nearby context fetch failed: missing {needed} permission]"
+            if error:
+                return f"[Slack nearby context fetch failed: {error}]"
+
+        message = str(exc).strip() or exc.__class__.__name__
+        return f"[Slack nearby context fetch failed: {message}]"
+
+    async def _fetch_nearby_channel_context(
+        self,
+        *,
+        channel_id: str,
+        current_ts: str,
+        team_id: str = "",
+        limit: int = 3,
+    ) -> Tuple[str, str]:
+        """Fetch a small bounded window of channel history before a top-level turn."""
+        try:
+            client = self._get_client(channel_id)
+            result = None
+            for attempt in range(3):
+                try:
+                    result = await client.conversations_history(
+                        channel=channel_id,
+                        latest=current_ts,
+                        inclusive=False,
+                        limit=limit,
+                    )
+                    break
+                except Exception as exc:
+                    err_str = str(exc).lower()
+                    is_rate_limit = (
+                        "ratelimited" in err_str
+                        or "429" in err_str
+                        or "rate_limited" in err_str
+                    )
+                    if is_rate_limit and attempt < 2:
+                        retry_after = 1.0 * (2 ** attempt)
+                        logger.warning(
+                            "[Slack] conversations.history rate limited; retrying in %.1fs (attempt %d/3)",
+                            retry_after, attempt + 1,
+                        )
+                        await asyncio.sleep(retry_after)
+                        continue
+                    raise
+
+            messages = (result or {}).get("messages", [])
+            if not messages:
+                return "", ""
+
+            context_parts = []
+            for msg in reversed(messages):
+                msg_text = self._render_slack_context_message_text(msg, team_id=team_id)
+                if not msg_text:
+                    continue
+
+                is_bot = bool(msg.get("bot_id")) or msg.get("subtype") == "bot_message"
+                msg_user = msg.get("user", "") or "unknown"
+                if is_bot and not msg.get("user"):
+                    msg_user = msg.get("username", "") or "bot"
+                name = await self._resolve_user_name(msg_user, chat_id=channel_id)
+                context_parts.append(f"{name}: {msg_text}")
+
+            if not context_parts:
+                return "", ""
+
+            content = (
+                "[Slack nearby context — messages immediately before this request (not yet in conversation history):]\n"
+                + "\n".join(context_parts)
+                + "\n[End of Slack nearby context]\n\n"
+            )
+            return content, ""
+        except Exception as exc:
+            logger.warning("[Slack] Failed to fetch nearby channel context: %s", exc)
+            return "", self._describe_nearby_context_failure(exc)
 
     async def _handle_slash_command(self, command: dict) -> None:
         """Handle Slack slash commands.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2113,6 +2113,122 @@ class TestThreadReplyHandling:
         adapter.handle_message.assert_not_called()
 
 
+class TestSlackNearbyChannelContext:
+    """Top-level deictic references should recover a small nearby context window."""
+
+    @pytest.mark.asyncio
+    async def test_top_level_reference_fetches_nearby_context(self, adapter):
+        adapter._team_bot_user_ids = {"T_TEAM": "U_BOT"}
+        adapter._app.client.conversations_history = AsyncMock(return_value={
+            "messages": [
+                {
+                    "ts": "123.455",
+                    "user": "U_REPORTER",
+                    "text": "Bug report: worker pool exhausted after retries spike",
+                }
+            ]
+        })
+
+        event = {
+            "text": "<@U_BOT> please identify the root cause of this bug report",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "123.456",
+            "team": "T_TEAM",
+        }
+
+        async def _name_lookup(user_id, chat_id=None):
+            return {
+                "U_REPORTER": "Baxter Black",
+                "U_USER": "Alice",
+            }.get(user_id, user_id)
+
+        with patch.object(adapter, "_resolve_user_name", new=AsyncMock(side_effect=_name_lookup)):
+            await adapter._handle_slack_message(event)
+
+        adapter._app.client.conversations_history.assert_awaited_once_with(
+            channel="C123",
+            latest="123.456",
+            inclusive=False,
+            limit=3,
+        )
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Slack nearby context" in msg_event.text
+        assert "Baxter Black: Bug report: worker pool exhausted after retries spike" in msg_event.text
+        assert "<@U_BOT>" not in msg_event.text
+        assert "please identify the root cause of this bug report" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_nearby_context_permission_failure_is_surfaced(self, adapter):
+        adapter._team_bot_user_ids = {"T_TEAM": "U_BOT"}
+
+        class _SlackHistoryError(Exception):
+            def __init__(self):
+                super().__init__("missing_scope")
+                self.response = {
+                    "error": "missing_scope",
+                    "needed": "channels:history",
+                    "provided": "chat:write",
+                }
+
+        adapter._app.client.conversations_history = AsyncMock(side_effect=_SlackHistoryError())
+
+        event = {
+            "text": "<@U_BOT> please identify the root cause of this bug report",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "123.456",
+            "team": "T_TEAM",
+        }
+
+        with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="Alice")):
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text.startswith(
+            "[Slack nearby context fetch failed: missing channels:history permission]"
+        )
+        assert "please identify the root cause of this bug report" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_thread_reply_still_uses_thread_context_only(self, adapter):
+        adapter._team_bot_user_ids = {"T_TEAM": "U_BOT"}
+        adapter._app.client.conversations_replies = AsyncMock(return_value={
+            "messages": [
+                {"ts": "123.000", "user": "U_REPORTER", "text": "Bug report: thread parent"},
+                {"ts": "123.456", "user": "U_USER", "text": "<@U_BOT> please fix this bug report"},
+            ]
+        })
+        adapter._app.client.conversations_history = AsyncMock()
+
+        event = {
+            "text": "<@U_BOT> please fix this bug report",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "123.456",
+            "thread_ts": "123.000",
+            "team": "T_TEAM",
+        }
+
+        async def _name_lookup(user_id, chat_id=None):
+            return {
+                "U_REPORTER": "Baxter Black",
+                "U_USER": "Alice",
+            }.get(user_id, user_id)
+
+        with patch.object(adapter, "_resolve_user_name", new=AsyncMock(side_effect=_name_lookup)):
+            await adapter._handle_slack_message(event)
+
+        adapter._app.client.conversations_replies.assert_awaited_once()
+        adapter._app.client.conversations_history.assert_not_called()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Thread context" in msg_event.text
+        assert "[Slack nearby context" not in msg_event.text
+
+
 # ---------------------------------------------------------------------------
 # TestAssistantThreadLifecycle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fetch a bounded nearby Slack channel context window for top-level deictic references like "this bug report"
- surface an explicit prompt marker when Slack context fetch fails instead of silently dropping the reference
- keep thread-reply context behavior unchanged and cover the new path with Slack gateway tests

## Testing
- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py`
- `uv run --frozen ruff check gateway/platforms/slack.py tests/gateway/test_slack.py`
- `git diff --check`
