### PR TITLE
fix: operator precedence — parenthesize `or` before `[:N]` truncation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7897,7 +7897,7 @@ class HermesCLI:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10582,7 +10582,7 @@ class GatewayRunner:
             lines.append(t("gateway.personality.none_option"))
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(t("gateway.personality.item", name=name, preview=preview))

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1584,7 +1584,7 @@ class SlashCommandCompleter(Completer):
             for name, prompt in personalities.items():
                 if name.startswith(sub_lower) and name != sub_lower:
                     if isinstance(prompt, dict):
-                        meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                        meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                     else:
                         meta = str(prompt)[:50]
                     yield Completion(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -383,7 +383,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
-    name = str(job.get("name") or prompt[:50] or (skills[0] if skills else "") or job_id or "cron job")
+    name = str(job.get("name") or prompt or (skills[0] if skills else "") or job_id or "cron job")[:50]
     result = {
         "job_id": job_id,
         "name": name,

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1461,7 +1461,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
             detail = ""
             try:
                 err_body = response.json()
-                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+                detail = (err_body.get("error", {}).get("message", "") or response.text)[:300]
             except Exception:
                 detail = response.text[:300]
             return {

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1431,7 +1431,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         # Surface the API error message when present
         try:
             err = response.json().get("error", {})
-            detail = err.get("message") or response.text[:300]
+            detail = (err.get("message") or response.text)[:300]
         except Exception:
             detail = response.text[:300]
         raise RuntimeError(


### PR DESCRIPTION
## Operator precedence — `or` + `[:N]` truncation

Python's slice operator `[:N]` binds tighter than `or`, so expressions like `x or y[:50]` only truncate `y`, not the final result. When `x` is truthy (e.g. a long description or error message), it is returned untruncated, breaking personality list layout and error display.

### Before
```python
preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
# If description is 200 chars → returned verbatim, not truncated
```

### After
```python
preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
# Always truncated to 50 chars regardless of which source wins
```

### Files changed (6 locations across 5 files)

| File | Line | Context |
|------|------|---------|
| `gateway/run.py` | 10585 | Personality preview in `/personality` list |
| `cli.py` | 7900 | Personality list display |
| `hermes_cli/commands.py` | 1587 | Autocomplete meta preview |
| `tools/cronjob_tools.py` | 386 | Cron job name truncation |
| `tools/transcription_tools.py` | 1464 | Error detail in transcription API |
| `tools/tts_tool.py` | 1434 | Error detail in TTS API |

### Impact
- Personality list layout is consistent — no more long descriptions breaking alignment
- Error messages displayed to users are properly truncated
- Cron job names are consistently formatted

Each fix is a one-line parenthesization: `(x or y)[:N]` to ensure truncation applies to the final resolved value.