### PR TITLE
feat(prompt): add opt-in prompt compaction toggles

### DIFF
--- a/agent/context_prompt_compactor.py
+++ b/agent/context_prompt_compactor.py
@@ -1,0 +1,77 @@
+import re
+
+
+_URL_RE = re.compile(r"https?://\S+")
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
+_PATH_RE = re.compile(r"(?:~?/|\.?\./|/)[^\s`]+")
+_BULLET_RE = re.compile(r"^\s*[-*]\s+", re.M)
+_NUMBERED_RE = re.compile(r"^\s*\d+\.\s+", re.M)
+_FILLER_PATTERNS = [
+    (re.compile(r"\bplease\b", re.I), ""),
+    (re.compile(r"\bcarefully\b", re.I), ""),
+    (re.compile(r"\bsimply\b", re.I), ""),
+    (re.compile(r"\bbasically\b", re.I), ""),
+    (re.compile(r"\bjust\b", re.I), ""),
+    (re.compile(r"\bhelpfully\b", re.I), ""),
+    (re.compile(r"\bin order to\b", re.I), "to"),
+    (re.compile(r"\bdo not forget to\b", re.I), "remember to"),
+    (re.compile(r"\bmake sure to\b", re.I), "ensure"),
+    (re.compile(r"\bit is important to note that\b", re.I), "note:"),
+    (re.compile(r"\bthe following\b", re.I), ""),
+    (re.compile(r"\bshould be followed\b", re.I), "apply"),
+]
+
+
+def _protect(text: str):
+    protected = []
+
+    def repl(match):
+        protected.append(match.group(0))
+        return f"__CTXPROT_{len(protected)-1}__"
+
+    for pattern in (_URL_RE, _INLINE_CODE_RE, _PATH_RE):
+        text = pattern.sub(repl, text)
+    return text, protected
+
+
+def _restore(text: str, protected):
+    for i, value in enumerate(protected):
+        text = text.replace(f"__CTXPROT_{i}__", value)
+    return text
+
+
+def compact_context_prose(text: str) -> str:
+    if not text or len(text) < 80:
+        return text
+    if _BULLET_RE.search(text) or _NUMBERED_RE.search(text):
+        return text
+    if text.lstrip().startswith("## "):
+        parts = text.split("\n\n", 1)
+        if len(parts) == 2:
+            head, body = parts
+            compact_body = compact_context_prose(body)
+            return head + "\n\n" + compact_body
+        return text
+
+    working, protected = _protect(text)
+    original = working
+
+    for pattern, replacement in _FILLER_PATTERNS:
+        working = pattern.sub(replacement, working)
+
+    working = re.sub(r"[ \t]{2,}", " ", working)
+    working = re.sub(r" ?\n ?", "\n", working)
+    working = re.sub(r"\n{3,}", "\n\n", working)
+    working = re.sub(r"\s+([,.;:])", r"\1", working)
+    working = re.sub(r"\(\s+", "(", working)
+    working = re.sub(r"\s+\)", ")", working)
+    working = re.sub(r"\bNote:\s*note:\b", "note:", working, flags=re.I)
+    working = re.sub(r"\s{2,}", " ", working).strip()
+
+    if not working or len(working) >= len(original):
+        return text
+
+    restored = _restore(working, protected)
+    if len(restored) >= len(text):
+        return text
+    return restored

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -133,6 +133,10 @@ HERMES_AGENT_HELP_GUIDANCE = (
     "itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') "
     "before answering. Docs: https://hermes-agent.nousresearch.com/docs"
 )
+HERMES_AGENT_HELP_GUIDANCE_COMPACT = (
+    "For Hermes Agent config/setup/use/troubleshooting, load `hermes-agent` before answering. "
+    "Docs: https://hermes-agent.nousresearch.com/docs"
+)
 
 MEMORY_GUIDANCE = (
     "You have persistent memory across sessions. Save durable facts using the memory "
@@ -156,11 +160,19 @@ MEMORY_GUIDANCE = (
     "cause repeated work or override the user's current request. Procedures and "
     "workflows belong in skills, not memory."
 )
+MEMORY_GUIDANCE_COMPACT = (
+    "You have persistent memory across sessions. Save only durable facts with `memory`: user preferences, stable environment facts, and tool quirks.\n"
+    "Do NOT save task progress, completed-work logs, PRs/SHAs/file counts, or other stale artifacts; use `session_search` for past-session recall.\n"
+    "Write memories as facts, not directives. Procedures belong in skills, not memory."
+)
 
 SESSION_SEARCH_GUIDANCE = (
     "When the user references something from a past conversation or you suspect "
     "relevant cross-session context exists, use session_search to recall it before "
     "asking them to repeat themselves."
+)
+SESSION_SEARCH_GUIDANCE_COMPACT = (
+    "If the user references a past conversation, use `session_search` before asking them to repeat it."
 )
 
 SKILLS_GUIDANCE = (
@@ -170,6 +182,19 @@ SKILLS_GUIDANCE = (
     "When using a skill and finding it outdated, incomplete, or wrong, "
     "patch it immediately with skill_manage(action='patch') — don't wait to be asked. "
     "Skills that aren't maintained become liabilities."
+)
+SKILLS_GUIDANCE_COMPACT = (
+    "After complex or tricky work, save reusable workflows with `skill_manage`. Patch stale skills immediately; unmaintained skills become liabilities."
+)
+
+SEARCH_ROUTER_GUIDANCE = (
+    "When a task involves non-trivial public/external search — such as broad web research, "
+    "official-source verification, latest developments, policy/result summaries, or multi-source "
+    "cross-checks — prefer `search_router` over direct `web_search`. Use direct `web_search` for "
+    "simple one-hop lookups or quick candidate URL discovery, and use `web_extract` once the URL is known."
+)
+SEARCH_ROUTER_GUIDANCE_COMPACT = (
+    "For non-trivial public/external research, prefer `search_router` over direct `web_search`. Use `web_search` for simple one-hop lookups and `web_extract` once the URL is known."
 )
 
 KANBAN_GUIDANCE = (
@@ -832,6 +857,93 @@ _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 _SKILLS_SNAPSHOT_VERSION = 1
 
 
+def _compact_skills_prompt_enabled() -> bool:
+    """Return True when config enables compact rendering of the skills index."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        return bool(cfg_get(cfg, "display", "compact_skills_prompt", default=False))
+    except Exception:
+        return False
+
+
+def _compact_guidance_blocks_enabled() -> bool:
+    """Return True when config enables compact rendering of stable guidance blocks."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        return bool(cfg_get(cfg, "display", "compact_guidance_blocks", default=False))
+    except Exception:
+        return False
+
+
+def _compact_context_files_enabled() -> bool:
+    """Return True when config enables prose-only compaction for context files."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        return bool(cfg_get(cfg, "display", "compact_context_files", default=False))
+    except Exception:
+        return False
+
+
+def _compact_context_content(content: str) -> str:
+    if not _compact_context_files_enabled():
+        return content
+    try:
+        from agent.context_prompt_compactor import compact_context_prose
+
+        return compact_context_prose(content)
+    except Exception:
+        return content
+
+
+def _build_skills_prompt_preamble(*, compact: bool) -> str:
+    if compact:
+        return (
+            "## Skills (mandatory)\n"
+            "Scan the skill index below before replying. If a skill is relevant, load it with `skill_view(name)` and follow it. "
+            "Prefer loading over guessing.\n"
+            "For Hermes Agent setup/config/tools/providers/gateway/skills/plugins/troubleshooting, load `hermes-agent` first.\n"
+            "If a loaded skill is stale or wrong, fix it with `skill_manage(action='patch')`.\n"
+            "\n"
+            "<available_skills>\n"
+        )
+    return (
+        "## Skills (mandatory)\n"
+        "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+        "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+        "Err on the side of loading — it is always better to have context you don't need "
+        "than to miss critical steps, pitfalls, or established workflows. "
+        "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+        "and proven workflows that outperform general-purpose approaches. Load the skill "
+        "even if you think you could handle the task with basic tools like web_search or terminal. "
+        "Skills also encode the user's preferred approach, conventions, and quality standards "
+        "for tasks like code review, planning, and testing — load them even for tasks you "
+        "already know how to do, because the skill defines how it should be done here.\n"
+        "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
+        "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
+        "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
+        "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
+        "`hermes setup`) so you don't have to guess or invent workarounds.\n"
+        "If a skill has issues, fix it with skill_manage(action='patch').\n"
+        "After difficult/iterative tasks, offer to save as a skill. "
+        "If a skill you loaded was missing steps, had wrong commands, or needed "
+        "pitfalls you discovered, update it before finishing.\n"
+        "\n"
+        "<available_skills>\n"
+    )
+
+
+def _build_skills_prompt_tail(*, compact: bool) -> str:
+    if compact:
+        return "</available_skills>\n\nOnly proceed without loading a skill if genuinely none are relevant."
+    return "</available_skills>\n\nOnly proceed without loading a skill if genuinely none are relevant to the task."
+
+
 def _skills_prompt_snapshot_path() -> Path:
     return get_hermes_home() / ".skills_prompt_snapshot.json"
 
@@ -1015,6 +1127,7 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    compact = _compact_skills_prompt_enabled()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -1022,6 +1135,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        compact,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1176,34 +1290,7 @@ def build_skills_system_prompt(
                 else:
                     index_lines.append(f"    - {name}")
 
-        result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
-        )
+        result = _build_skills_prompt_preamble(compact=compact) + "\n".join(index_lines) + "\n" + _build_skills_prompt_tail(compact=compact)
 
     # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:
@@ -1318,6 +1405,7 @@ def load_soul_md() -> Optional[str]:
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")
+        content = _compact_context_content(content)
         content = _truncate_content(content, "SOUL.md")
         return content
     except Exception as e:
@@ -1341,6 +1429,7 @@ def _load_hermes_md(cwd_path: Path) -> str:
         except ValueError:
             pass
         content = _scan_context_content(content, rel)
+        content = _compact_context_content(content)
         result = f"## {rel}\n\n{content}"
         return _truncate_content(result, ".hermes.md")
     except Exception as e:
@@ -1357,6 +1446,7 @@ def _load_agents_md(cwd_path: Path) -> str:
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
+                    content = _compact_context_content(content)
                     result = f"## {name}\n\n{content}"
                     return _truncate_content(result, "AGENTS.md")
             except Exception as e:
@@ -1373,6 +1463,7 @@ def _load_claude_md(cwd_path: Path) -> str:
                 content = candidate.read_text(encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, name)
+                    content = _compact_context_content(content)
                     result = f"## {name}\n\n{content}"
                     return _truncate_content(result, "CLAUDE.md")
             except Exception as e:
@@ -1389,6 +1480,7 @@ def _load_cursorrules(cwd_path: Path) -> str:
             content = cursorrules_file.read_text(encoding="utf-8").strip()
             if content:
                 content = _scan_context_content(content, ".cursorrules")
+                content = _compact_context_content(content)
                 cursorrules_content += f"## .cursorrules\n\n{content}\n\n"
         except Exception as e:
             logger.debug("Could not read .cursorrules: %s", e)
@@ -1401,6 +1493,7 @@ def _load_cursorrules(cwd_path: Path) -> str:
                 content = mdc_file.read_text(encoding="utf-8").strip()
                 if content:
                     content = _scan_context_content(content, f".cursor/rules/{mdc_file.name}")
+                    content = _compact_context_content(content)
                     cursorrules_content += f"## .cursor/rules/{mdc_file.name}\n\n{content}\n\n"
             except Exception as e:
                 logger.debug("Could not read %s: %s", mdc_file, e)

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -31,14 +31,21 @@ from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
+    HERMES_AGENT_HELP_GUIDANCE_COMPACT,
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
+    MEMORY_GUIDANCE_COMPACT,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PLATFORM_HINTS,
+    SEARCH_ROUTER_GUIDANCE,
+    SEARCH_ROUTER_GUIDANCE_COMPACT,
     SESSION_SEARCH_GUIDANCE,
+    SESSION_SEARCH_GUIDANCE_COMPACT,
     SKILLS_GUIDANCE,
+    SKILLS_GUIDANCE_COMPACT,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
+    _compact_guidance_blocks_enabled,
 )
 
 
@@ -97,17 +104,23 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
 
+    compact_guidance = _compact_guidance_blocks_enabled()
+
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    stable_parts.append(
+        HERMES_AGENT_HELP_GUIDANCE_COMPACT if compact_guidance else HERMES_AGENT_HELP_GUIDANCE
+    )
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
     if "memory" in agent.valid_tool_names:
-        tool_guidance.append(MEMORY_GUIDANCE)
+        tool_guidance.append(MEMORY_GUIDANCE_COMPACT if compact_guidance else MEMORY_GUIDANCE)
     if "session_search" in agent.valid_tool_names:
-        tool_guidance.append(SESSION_SEARCH_GUIDANCE)
+        tool_guidance.append(SESSION_SEARCH_GUIDANCE_COMPACT if compact_guidance else SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
-        tool_guidance.append(SKILLS_GUIDANCE)
+        tool_guidance.append(SKILLS_GUIDANCE_COMPACT if compact_guidance else SKILLS_GUIDANCE)
+    if "search_router" in agent.valid_tool_names and "web_search" in agent.valid_tool_names:
+        tool_guidance.append(SEARCH_ROUTER_GUIDANCE_COMPACT if compact_guidance else SEARCH_ROUTER_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see
@@ -163,7 +176,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             # Also applied to xAI Grok — same failure modes (claims completion
             # without tool calls, suggests workarounds instead of using
             # existing tools, replies with plans instead of executing).
-            if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
+            if any(p in _model_lower for p in ("gpt", "codex", "grok", "qwen", "deepseek")):
                 stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])

--- a/agent/tool_description_compactor.py
+++ b/agent/tool_description_compactor.py
@@ -1,0 +1,130 @@
+"""Conservative prose compaction for tool descriptions.
+
+Goal: shrink verbose natural-language descriptions without changing tool names,
+URLs, paths, inline code, CLI flags, or numeric limits. This is intentionally
+lighter than full caveman persona rewriting: preserve meaning, only trim prose.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+_URL_RE = re.compile(r"https?://[^\s)]+")
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
+_PATH_RE = re.compile(
+    r"(?:\./|\.\./|/|~\/|[A-Za-z]:\\)[\w\-./\\]+|[\w\-.]+/[\w\-./]+"
+)
+_FLAG_RE = re.compile(r"--?[A-Za-z0-9][A-Za-z0-9_-]*")
+
+_FILLER_PATTERNS = [
+    (re.compile(r"\bplease\b", re.IGNORECASE), ""),
+    (re.compile(r"\b(?:simply|basically|carefully|helpfully|clearly|really|just)\b", re.IGNORECASE), ""),
+    (re.compile(r"\b(?:you can|you may)\b", re.IGNORECASE), ""),
+    (re.compile(r"\b(?:used to|use this to)\b", re.IGNORECASE), "to"),
+    (re.compile(r"\b(?:allows you to)\b", re.IGNORECASE), "lets you"),
+    (re.compile(r"\b(?:in order to)\b", re.IGNORECASE), "to"),
+    (re.compile(r"\b(?:for the purpose of)\b", re.IGNORECASE), "for"),
+    (re.compile(r"\b(?:that you can)\b", re.IGNORECASE), "that can"),
+    (re.compile(r"\b(?:there is|there are)\b", re.IGNORECASE), ""),
+    (re.compile(r"\b(?:it is important to note that)\b", re.IGNORECASE), ""),
+    (re.compile(r"\b(?:keep in mind that)\b", re.IGNORECASE), ""),
+    (re.compile(r"\b(?:note that)\b", re.IGNORECASE), ""),
+    (re.compile(r"\b(?:in the current page|on the current page)\b", re.IGNORECASE), "on the page"),
+    (re.compile(r"\b(?:identified by its)\b", re.IGNORECASE), "by its"),
+    (re.compile(r"\b(?:requires browser_navigate and browser_snapshot to be called first)\b", re.IGNORECASE), "Requires browser_navigate and browser_snapshot first"),
+    (re.compile(r"\b(?:requires browser_navigate to be called first)\b", re.IGNORECASE), "Requires browser_navigate first"),
+]
+
+_SENTENCE_CLEANUPS = [
+    (re.compile(r"\s+,", re.IGNORECASE), ","),
+    (re.compile(r"\s+\.", re.IGNORECASE), "."),
+    (re.compile(r"\(\s+", re.IGNORECASE), "("),
+    (re.compile(r"\s+\)", re.IGNORECASE), ")"),
+    (re.compile(r"\s{2,}"), " "),
+]
+
+
+def _protect(text: str) -> tuple[str, dict[str, str]]:
+    protected: dict[str, str] = {}
+    counter = 0
+
+    def _sub(pattern: re.Pattern[str], src: str) -> str:
+        nonlocal counter
+
+        def repl(match: re.Match[str]) -> str:
+            nonlocal counter
+            key = f"__CPTK_{counter}__"
+            counter += 1
+            protected[key] = match.group(0)
+            return key
+
+        return pattern.sub(repl, src)
+
+    out = text
+    for pattern in (_URL_RE, _INLINE_CODE_RE, _PATH_RE, _FLAG_RE):
+        out = _sub(pattern, out)
+    return out, protected
+
+
+def _restore(text: str, protected: dict[str, str]) -> str:
+    out = text
+    for key, value in protected.items():
+        out = out.replace(key, value)
+    return out
+
+
+def compact_description(text: str) -> str:
+    if not isinstance(text, str):
+        return text
+    original = text
+    stripped = text.strip()
+    if len(stripped) < 40:
+        return original
+
+    working, protected = _protect(original)
+
+    for pattern, repl in _FILLER_PATTERNS:
+        working = pattern.sub(repl, working)
+
+    # Tighten a few verbose constructions while keeping meaning stable.
+    working = re.sub(r"\b[Aa]sk the user a question when you need\b", "Ask the user when you need", working)
+    working = re.sub(r"\bReturns up to ([0-9]+) results by default\b", r"Returns up to \1 results", working)
+    working = re.sub(r"\bOptional:?\s+", "", working)
+    working = re.sub(r"\bDefault:?\s+", "", working)
+
+    for pattern, repl in _SENTENCE_CLEANUPS:
+        working = pattern.sub(repl, working)
+
+    # Clean repeated punctuation/space artifacts from aggressive substitutions.
+    working = re.sub(r"\s*;\s*;", ";", working)
+    working = re.sub(r"\s*\.\s*\.\s*", ". ", working)
+    working = re.sub(r"\s+([:;!?])", r"\1", working)
+    working = re.sub(r"([:;!?])(\w)", r"\1 \2", working)
+    working = working.strip()
+
+    out = _restore(working, protected)
+    out = re.sub(r"\s{2,}", " ", out).strip()
+
+    # Safety: never return empty, never expand a lot, and require a small win.
+    if not out:
+        return original
+    if len(out) >= len(original) - 4:
+        return original
+    if len(out) < max(16, int(len(original) * 0.45)):
+        # Too aggressive for a conservative v1.
+        return original
+    return out
+
+
+def compact_tool_definitions(tool_defs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out = copy.deepcopy(tool_defs)
+    for tool in out:
+        fn = tool.get("function")
+        if not isinstance(fn, dict):
+            continue
+        desc = fn.get("description")
+        if isinstance(desc, str) and desc:
+            fn["description"] = compact_description(desc)
+    return out

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,6 +29,8 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
+from agent.tool_description_compactor import compact_tool_definitions
+
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
 
@@ -254,6 +256,17 @@ _LEGACY_TOOLSET_MAP = {
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 
+def _compact_tool_descriptions_enabled() -> bool:
+    """Return True when config enables conservative tool-description compaction."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        return bool(cfg_get(cfg, "display", "compact_tool_descriptions", default=False))
+    except Exception:
+        return False
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -301,6 +314,7 @@ def get_tool_definitions(
             registry._generation,
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
+            _compact_tool_descriptions_enabled(),
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -468,6 +482,9 @@ def _compute_tool_definitions(
 
     global _last_resolved_tool_names
     _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
+
+    if _compact_tool_descriptions_enabled():
+        filtered_tools = compact_tool_definitions(filtered_tools)
 
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build

--- a/tests/acp/test_edit_approval.py
+++ b/tests/acp/test_edit_approval.py
@@ -6,6 +6,10 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
+acp = pytest.importorskip("acp")
+
 from acp_adapter.edit_approval import (
     EditProposal,
     build_acp_edit_tool_call,

--- a/tests/agent/test_context_files_compaction.py
+++ b/tests/agent/test_context_files_compaction.py
@@ -1,0 +1,48 @@
+from agent.prompt_builder import build_context_files_prompt
+
+
+def test_context_files_prompt_compaction_disabled(monkeypatch, tmp_path):
+    import agent.prompt_builder as pb
+
+    monkeypatch.setattr(pb, '_compact_context_files_enabled', lambda: False)
+    long_text = (
+        'Please carefully make sure to use pytest for tests. '
+        'It is important to note that this project simply uses Ruff. '
+        'Do not forget to add type hints. '
+    ) * 30
+    (tmp_path / 'AGENTS.md').write_text(long_text)
+    result = build_context_files_prompt(cwd=str(tmp_path))
+    assert 'Please carefully make sure to use pytest for tests.' in result
+
+
+def test_context_files_prompt_compaction_enabled(monkeypatch, tmp_path):
+    import agent.prompt_builder as pb
+
+    monkeypatch.setattr(pb, '_compact_context_files_enabled', lambda: True)
+    long_text = (
+        'Please carefully make sure to use pytest for tests. '
+        'It is important to note that this project simply uses Ruff. '
+        'Do not forget to add type hints. '
+    ) * 30
+    (tmp_path / 'AGENTS.md').write_text(long_text)
+    result = build_context_files_prompt(cwd=str(tmp_path))
+    assert 'pytest' in result
+    assert 'Ruff' in result
+    assert 'type hints' in result
+    assert 'context files have been loaded' in result
+    assert len(result) < len('# Project Context\n\nLoaded context files:\n\n## AGENTS.md\n\n' + long_text)
+
+
+def test_context_files_prompt_preserves_url_code_and_path(monkeypatch, tmp_path):
+    import agent.prompt_builder as pb
+
+    monkeypatch.setattr(pb, '_compact_context_files_enabled', lambda: True)
+    text = (
+        'Please review `pytest -q` and see https://example.com/docs carefully before editing /tmp/demo/file.py. '
+        'It is important to note that this project simply uses Ruff. '
+    ) * 20
+    (tmp_path / 'AGENTS.md').write_text(text)
+    result = build_context_files_prompt(cwd=str(tmp_path))
+    assert '`pytest -q`' in result
+    assert 'https://example.com/docs' in result
+    assert '/tmp/demo/file.py' in result

--- a/tests/agent/test_context_prompt_compactor.py
+++ b/tests/agent/test_context_prompt_compactor.py
@@ -1,0 +1,49 @@
+from agent.context_prompt_compactor import compact_context_prose
+
+
+def test_compact_context_prose_reduces_filler_text():
+    text = (
+        "Please carefully make sure to use pytest for tests. "
+        "It is important to note that this project simply uses Ruff. "
+        "Do not forget to add type hints."
+    )
+    out = compact_context_prose(text)
+    assert len(out) < len(text)
+    assert "pytest" in out
+    assert "Ruff" in out
+    assert "type hints" in out
+
+
+def test_compact_context_prose_preserves_url_code_and_path():
+    text = (
+        "Please review `pytest -q` and see https://example.com/docs carefully before editing /tmp/demo/file.py. "
+        "It is important to note that this project uses tools from there."
+    )
+    out = compact_context_prose(text)
+    assert "`pytest -q`" in out
+    assert "https://example.com/docs" in out
+    assert "/tmp/demo/file.py" in out
+
+
+def test_compact_context_prose_skips_bullets():
+    text = "- Please use pytest\n- Please use Ruff\n- Please use mypy"
+    out = compact_context_prose(text)
+    assert out == text
+
+
+def test_compact_context_prose_skips_short_text():
+    text = "Please use pytest."
+    assert compact_context_prose(text) == text
+
+
+def test_compact_context_prose_preserves_heading_and_compacts_body():
+    text = (
+        "## AGENTS.md\n\n"
+        "Please carefully make sure to use pytest for tests. "
+        "It is important to note that this project simply uses Ruff. "
+    ) * 5
+    out = compact_context_prose(text)
+    assert out.startswith("## AGENTS.md\n\n")
+    assert len(out) < len(text)
+    assert "pytest" in out
+    assert "Ruff" in out

--- a/tests/agent/test_guidance_blocks_compaction.py
+++ b/tests/agent/test_guidance_blocks_compaction.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+from agent.system_prompt import build_system_prompt
+
+
+def _agent_with_tools(valid_tool_names):
+    return SimpleNamespace(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=set(valid_tool_names),
+        provider="openrouter",
+        model="test-model",
+        platform="cli",
+        memory_provider=None,
+        _memory_store=None,
+        _memory_nudge_interval=0,
+        _turns_since_memory=0,
+        workdir=None,
+        skip_memory=True,
+        user_id=None,
+        user_name=None,
+        chat_id=None,
+        chat_name=None,
+        chat_type=None,
+        thread_id=None,
+        session_id="test-session",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="chat_completions",
+        _cached_system_prompt=None,
+        ephemeral_system_prompt=None,
+        tools=[],
+        memory_context="",
+        user_profile="",
+        status_callback=None,
+        _tool_use_enforcement=False,
+        is_tui=False,
+        supports_session_search=False,
+        supports_session_search_exact=False,
+        _context_files_prompt_cache=None,
+        _skills_system_prompt_cache=None,
+        _soul_md_cache=None,
+        service_tier=None,
+        request_overrides=None,
+        user_profile_store=None,
+        _memory_manager=None,
+        _cached_environment_hints="",
+        pass_session_id=False,
+        _memory_enabled=False,
+        _user_profile_enabled=False,
+    )
+
+
+def _stub_ra():
+    return SimpleNamespace(
+        load_soul_md=lambda: None,
+        build_nous_subscription_prompt=lambda valid_tool_names: "",
+        build_skills_system_prompt=lambda **kwargs: "",
+        build_environment_hints=lambda: "",
+        build_context_files_prompt=lambda *args, **kwargs: "",
+        get_toolset_for_tool=lambda *args, **kwargs: None,
+    )
+
+
+def test_guidance_blocks_compact_mode_shortens_system_prompt(monkeypatch):
+    import agent.system_prompt as sp
+
+    monkeypatch.setattr(sp, "_ra", _stub_ra)
+    monkeypatch.setattr(sp, "_compact_guidance_blocks_enabled", lambda: False)
+    full = build_system_prompt(_agent_with_tools({"memory", "session_search", "skill_manage", "web_search", "search_router"}))
+
+    monkeypatch.setattr(sp, "_compact_guidance_blocks_enabled", lambda: True)
+    compact = build_system_prompt(_agent_with_tools({"memory", "session_search", "skill_manage", "web_search", "search_router"}))
+
+    assert len(compact) < len(full)
+    assert "Save only durable facts with `memory`" in compact
+    assert "For Hermes Agent config/setup/use/troubleshooting" in compact
+    assert "Save durable facts using the memory tool" in full
+
+
+def test_guidance_blocks_compact_mode_preserves_key_tool_rules(monkeypatch):
+    import agent.system_prompt as sp
+
+    monkeypatch.setattr(sp, "_ra", _stub_ra)
+    monkeypatch.setattr(sp, "_compact_guidance_blocks_enabled", lambda: True)
+    prompt = build_system_prompt(_agent_with_tools({"memory", "session_search", "skill_manage", "web_search", "search_router"}))
+
+    assert "`hermes-agent`" in prompt
+    assert "`memory`" in prompt
+    assert "`session_search`" in prompt
+    assert "`skill_manage`" in prompt
+    assert "`search_router`" in prompt
+    assert "`web_search`" in prompt
+
+
+def test_guidance_blocks_default_mode_keeps_full_copy(monkeypatch):
+    import agent.system_prompt as sp
+
+    monkeypatch.setattr(sp, "_ra", _stub_ra)
+    monkeypatch.setattr(sp, "_compact_guidance_blocks_enabled", lambda: False)
+    prompt = build_system_prompt(_agent_with_tools({"memory"}))
+
+    assert "Save durable facts using the memory tool" in prompt
+    assert "Save only durable facts with `memory`" not in prompt

--- a/tests/agent/test_model_tools_compact_tool_descriptions.py
+++ b/tests/agent/test_model_tools_compact_tool_descriptions.py
@@ -1,0 +1,68 @@
+from copy import deepcopy
+
+import model_tools
+
+
+def _demo_tools():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "demo_tool",
+                "description": "Please use this tool to carefully inspect the current page and helpfully return the result.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "Exact path"},
+                    },
+                },
+            },
+        }
+    ]
+
+
+def test_get_tool_definitions_compaction_disabled(monkeypatch):
+    base = _demo_tools()
+    monkeypatch.setattr(model_tools, "_compact_tool_descriptions_enabled", lambda: False)
+    monkeypatch.setattr(model_tools.registry, "get_definitions", lambda tools_to_include, quiet=False: deepcopy(base))
+    monkeypatch.setattr(model_tools, "resolve_toolset", lambda name: ["demo_tool"])
+    monkeypatch.setattr(model_tools, "validate_toolset", lambda name: True)
+
+    out = model_tools._compute_tool_definitions(enabled_toolsets=["demo"], disabled_toolsets=[], quiet_mode=True)
+    assert out[0]["function"]["description"] == base[0]["function"]["description"]
+    assert out[0]["function"]["name"] == "demo_tool"
+
+
+def test_get_tool_definitions_compaction_enabled(monkeypatch):
+    base = _demo_tools()
+    monkeypatch.setattr(model_tools, "_compact_tool_descriptions_enabled", lambda: True)
+    monkeypatch.setattr(model_tools.registry, "get_definitions", lambda tools_to_include, quiet=False: deepcopy(base))
+    monkeypatch.setattr(model_tools, "resolve_toolset", lambda name: ["demo_tool"])
+    monkeypatch.setattr(model_tools, "validate_toolset", lambda name: True)
+
+    out = model_tools._compute_tool_definitions(enabled_toolsets=["demo"], disabled_toolsets=[], quiet_mode=True)
+    assert out[0]["function"]["name"] == "demo_tool"
+    assert out[0]["function"]["parameters"] == base[0]["function"]["parameters"]
+    assert len(out[0]["function"]["description"]) < len(base[0]["function"]["description"])
+
+
+def test_get_tool_definitions_cache_key_reflects_toggle(monkeypatch):
+    calls = {"n": 0}
+    base = _demo_tools()
+
+    monkeypatch.setattr(model_tools.registry, "_generation", 999, raising=False)
+    monkeypatch.setattr(model_tools.registry, "get_definitions", lambda tools_to_include, quiet=False: calls.__setitem__("n", calls["n"] + 1) or deepcopy(base))
+    monkeypatch.setattr(model_tools, "resolve_toolset", lambda name: ["demo_tool"])
+    monkeypatch.setattr(model_tools, "validate_toolset", lambda name: True)
+    monkeypatch.setattr(model_tools, "_tool_defs_cache", {})
+    monkeypatch.setattr(model_tools, "_compact_tool_descriptions_enabled", lambda: False)
+
+    first = model_tools.get_tool_definitions(enabled_toolsets=["demo"], quiet_mode=True)
+    second = model_tools.get_tool_definitions(enabled_toolsets=["demo"], quiet_mode=True)
+    assert calls["n"] == 1
+    assert first[0]["function"]["description"] == second[0]["function"]["description"]
+
+    monkeypatch.setattr(model_tools, "_compact_tool_descriptions_enabled", lambda: True)
+    third = model_tools.get_tool_definitions(enabled_toolsets=["demo"], quiet_mode=True)
+    assert calls["n"] == 2
+    assert len(third[0]["function"]["description"]) < len(base[0]["function"]["description"])

--- a/tests/agent/test_skills_prompt_compaction.py
+++ b/tests/agent/test_skills_prompt_compaction.py
@@ -1,0 +1,70 @@
+from agent.prompt_builder import build_skills_system_prompt, clear_skills_system_prompt_cache
+
+
+def _make_skill(tmp_path, rel_path, body):
+    p = tmp_path / rel_path
+    p.mkdir(parents=True, exist_ok=True)
+    (p / 'SKILL.md').write_text(body)
+
+
+def test_skills_prompt_default_mode_keeps_full_guidance(monkeypatch, tmp_path):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    _make_skill(
+        tmp_path,
+        'skills/coding/python-debug',
+        '---\nname: python-debug\ndescription: Debug Python scripts\n---\n',
+    )
+
+    import agent.prompt_builder as pb
+    monkeypatch.setattr(pb, '_compact_skills_prompt_enabled', lambda: False)
+
+    result = build_skills_system_prompt()
+    assert 'Before replying, scan the skills below.' in result
+    assert 'python-debug' in result
+    assert 'Debug Python scripts' in result
+
+
+def test_skills_prompt_compact_mode_shortens_preamble(monkeypatch, tmp_path):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    _make_skill(
+        tmp_path,
+        'skills/coding/python-debug',
+        '---\nname: python-debug\ndescription: Debug Python scripts\n---\n',
+    )
+
+    import agent.prompt_builder as pb
+    monkeypatch.setattr(pb, '_compact_skills_prompt_enabled', lambda: True)
+
+    compact = build_skills_system_prompt()
+    monkeypatch.setattr(pb, '_compact_skills_prompt_enabled', lambda: False)
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    full = build_skills_system_prompt()
+
+    assert 'Scan the skill index below before replying.' in compact
+    assert 'Before replying, scan the skills below.' not in compact
+    assert 'For Hermes Agent setup/config/tools/providers/gateway/skills/plugins/troubleshooting, load `hermes-agent` first.' in compact
+    assert 'python-debug' in compact
+    assert 'Debug Python scripts' in compact
+    assert len(compact) < len(full)
+
+
+def test_skills_prompt_cache_key_reflects_compact_toggle(monkeypatch, tmp_path):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    _make_skill(
+        tmp_path,
+        'skills/coding/python-debug',
+        '---\nname: python-debug\ndescription: Debug Python scripts\n---\n',
+    )
+
+    import agent.prompt_builder as pb
+    monkeypatch.setattr(pb, '_compact_skills_prompt_enabled', lambda: False)
+    full = build_skills_system_prompt()
+
+    monkeypatch.setattr(pb, '_compact_skills_prompt_enabled', lambda: True)
+    compact = build_skills_system_prompt()
+
+    assert full != compact
+    assert len(compact) < len(full)

--- a/tests/agent/test_tool_description_compactor.py
+++ b/tests/agent/test_tool_description_compactor.py
@@ -1,0 +1,50 @@
+from agent.tool_description_compactor import compact_description, compact_tool_definitions
+
+
+def test_compact_description_removes_filler_but_keeps_core_instruction():
+    text = "Please use this tool to carefully inspect the current page and helpfully return the result."
+    out = compact_description(text)
+    assert len(out) < len(text)
+    assert "Please" not in out
+    assert "carefully" not in out
+    assert "helpfully" not in out
+    assert "tool" in out
+    assert "page" in out
+
+
+def test_compact_description_preserves_url_path_inline_code_and_flag():
+    text = (
+        "Use this tool to inspect `/tmp/demo.py` and open https://example.com/docs "
+        "with `python run.py` using --verbose for additional detail."
+    )
+    out = compact_description(text)
+    assert "`/tmp/demo.py`" in out
+    assert "https://example.com/docs" in out
+    assert "`python run.py`" in out
+    assert "--verbose" in out
+
+
+def test_compact_description_returns_original_when_too_short():
+    text = "Read file path exactly."
+    assert compact_description(text) == text
+
+
+def test_compact_tool_definitions_only_changes_description_field():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "demo_tool",
+                "description": "Please use this tool to carefully inspect the current page and helpfully return the result.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "description": "Exact path"}},
+                },
+            },
+        }
+    ]
+    out = compact_tool_definitions(tools)
+    assert out[0]["function"]["name"] == "demo_tool"
+    assert out[0]["function"]["parameters"] == tools[0]["function"]["parameters"]
+    assert len(out[0]["function"]["description"]) < len(tools[0]["function"]["description"])
+    assert tools[0]["function"]["description"].startswith("Please use this tool")


### PR DESCRIPTION
Re-cut of #32335 from current main to avoid stale whole-file regressions.

Adds opt-in prompt compaction toggles for skills prompt, guidance blocks, context-file prose, and tool descriptions. Defaults remain off.

Local validation:
- `python -m pytest -o addopts='' tests/agent/test_context_prompt_compactor.py tests/agent/test_tool_description_compactor.py tests/agent/test_context_files_compaction.py tests/agent/test_guidance_blocks_compaction.py tests/agent/test_skills_prompt_compaction.py tests/agent/test_model_tools_compact_tool_descriptions.py tests/run_agent/test_run_agent.py::TestBuildSystemPrompt::test_datetime_is_date_only_not_minute_precision tests/tools/test_kanban_tools.py::test_kanban_worker_env_overrides_profile_toolset_filter tests/tools/test_cross_profile_guard.py::TestSystemPromptActiveProfile::test_named_profile_line_in_prompt_text tests/acp/test_edit_approval.py -q` -> 24 passed, 1 skipped
- `python -m pytest -o addopts='' tests/agent/test_prompt_builder.py::TestToolUseEnforcementGuidance::test_enforcement_models_includes_qwen tests/agent/test_prompt_builder.py::TestToolUseEnforcementGuidance::test_enforcement_models_includes_deepseek tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig::test_auto_injects_execution_guidance_for_grok tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig::test_auto_injects_execution_guidance_for_xai_oauth_model -q` -> 4 passed