### PR TITLE
feat(plugins/spotify): Web Playback dashboard widget (#15182)

### DIFF
--- a/plugins/spotify/dashboard/dist/index.js
+++ b/plugins/spotify/dashboard/dist/index.js
@@ -1,0 +1,494 @@
+/* Spotify Web Playback dashboard widget — MVP skeleton (issue #15182).
+ *
+ * Hand-written IIFE that uses the Hermes Plugin SDK globals so the
+ * bundle ships without an upstream build step.  All UI is composed
+ * with React.createElement; shared layout primitives come from
+ * SDK.components (Card / Button / Badge).
+ *
+ * Loads Spotify's Web Playback SDK from sdk.scdn.co at mount time and
+ * registers the browser tab itself as a Connect device named
+ * "Hermes Dashboard".  Once registered, any tool call that targets
+ * that device by id plays audio in this tab.
+ *
+ * Backend (plugin_api.py):
+ *   GET /api/plugins/spotify/status — login-state probe (no token)
+ *   GET /api/plugins/spotify/token  — fresh access token; auto-refreshes
+ *
+ * Premium-only:
+ *   Spotify's SDK fires `account_error` if you try to initialise it on a
+ *   Free account.  We intercept that and render a clear message instead
+ *   of leaving the widget half-functional.
+ *
+ * Out of scope for this MVP (open to follow-ups):
+ *   - playlist/library browsing
+ *   - offline playback (SDK doesn't support it)
+ *   - bringing audio over to other tabs / multi-tab device dedup
+ */
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK || !window.__HERMES_PLUGINS__) return;
+
+  const React = SDK.React;
+  const { useState, useEffect, useRef, useCallback } = SDK.hooks;
+  const C = SDK.components;
+  const cn = (SDK.utils && SDK.utils.cn) || ((...xs) => xs.filter(Boolean).join(" "));
+  const fetchJSON = SDK.fetchJSON || ((url, opts) =>
+    fetch(url, opts).then((r) => (r.ok ? r.json() : r.json().then((d) => Promise.reject(d))))
+  );
+
+  const h = React.createElement;
+
+  const SDK_SCRIPT_ID = "spotify-web-playback-sdk";
+  const SDK_SCRIPT_SRC = "https://sdk.scdn.co/spotify-player.js";
+  const DEVICE_NAME = "Hermes Dashboard";
+
+  // ---------------------------------------------------------------------------
+  // SDK loader — loads once per page, then resolves on every subsequent call.
+  // ---------------------------------------------------------------------------
+
+  let _sdkLoadPromise = null;
+
+  function loadSpotifySdk() {
+    if (window.Spotify && window.Spotify.Player) return Promise.resolve();
+    if (_sdkLoadPromise) return _sdkLoadPromise;
+
+    _sdkLoadPromise = new Promise((resolve, reject) => {
+      // The SDK only signals ready by calling
+      // window.onSpotifyWebPlaybackSDKReady — that's the documented hook.
+      const prevReady = window.onSpotifyWebPlaybackSDKReady;
+      window.onSpotifyWebPlaybackSDKReady = function () {
+        if (typeof prevReady === "function") {
+          try { prevReady(); } catch (_) { /* ignore */ }
+        }
+        resolve();
+      };
+      // Some browsers may have the script already injected by another
+      // copy of the widget — fall back to the load event in that case.
+      const existing = document.getElementById(SDK_SCRIPT_ID);
+      if (existing) {
+        if (window.Spotify && window.Spotify.Player) resolve();
+        existing.addEventListener("load", () => resolve());
+        existing.addEventListener("error", () => reject(new Error("Spotify SDK failed to load")));
+        return;
+      }
+      const script = document.createElement("script");
+      script.id = SDK_SCRIPT_ID;
+      script.src = SDK_SCRIPT_SRC;
+      script.async = true;
+      script.onerror = () => {
+        _sdkLoadPromise = null;
+        reject(new Error("Spotify SDK failed to load"));
+      };
+      document.head.appendChild(script);
+    });
+
+    return _sdkLoadPromise;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  function formatMs(ms) {
+    if (!Number.isFinite(ms) || ms < 0) return "0:00";
+    const total = Math.floor(ms / 1000);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return m + ":" + (s < 10 ? "0" : "") + s;
+  }
+
+  function trackArtists(state) {
+    try {
+      const t = state && state.track_window && state.track_window.current_track;
+      if (!t || !Array.isArray(t.artists)) return "";
+      return t.artists.map((a) => a.name).filter(Boolean).join(", ");
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function trackName(state) {
+    try {
+      return (state && state.track_window && state.track_window.current_track && state.track_window.current_track.name) || "";
+    } catch (_) {
+      return "";
+    }
+  }
+
+  function trackArtUrl(state) {
+    try {
+      const images = state && state.track_window && state.track_window.current_track && state.track_window.current_track.album && state.track_window.current_track.album.images;
+      if (!Array.isArray(images) || images.length === 0) return null;
+      // Prefer ~300px image when available, else the first.
+      const mid = images.find((i) => i && i.width >= 240 && i.width <= 360);
+      return (mid || images[0]).url || null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Main component
+  // ---------------------------------------------------------------------------
+
+  function SpotifyPage() {
+    // phase: "init" | "logged_out" | "loading_sdk" | "ready" | "not_premium" | "error"
+    const [phase, setPhase] = useState("init");
+    const [errorMessage, setErrorMessage] = useState("");
+    const [reloginRequired, setReloginRequired] = useState(false);
+    const [deviceId, setDeviceId] = useState(null);
+    const [playerState, setPlayerState] = useState(null);
+    const [localPositionMs, setLocalPositionMs] = useState(0);
+    const [volume, setVolumeState] = useState(0.5);
+
+    const playerRef = useRef(null);
+    const lastStateAtRef = useRef(0);
+    const lastPositionRef = useRef(0);
+    const mountedRef = useRef(true);
+
+    // ---- Bootstrap: check login, load SDK, init Player -----------------------
+
+    const init = useCallback(async () => {
+      setPhase("init");
+      setErrorMessage("");
+      setReloginRequired(false);
+      try {
+        const status = await fetchJSON("/api/plugins/spotify/status");
+        if (!status || !status.logged_in) {
+          if (!mountedRef.current) return;
+          setPhase("logged_out");
+          return;
+        }
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setErrorMessage("Could not check Spotify login: " + (err && err.message ? err.message : "unknown error"));
+        setPhase("error");
+        return;
+      }
+
+      if (!mountedRef.current) return;
+      setPhase("loading_sdk");
+      try {
+        await loadSpotifySdk();
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setErrorMessage("Could not load Spotify SDK: " + (err && err.message ? err.message : "unknown error"));
+        setPhase("error");
+        return;
+      }
+
+      if (!mountedRef.current) return;
+      if (!window.Spotify || !window.Spotify.Player) {
+        setErrorMessage("Spotify SDK loaded but global is missing.");
+        setPhase("error");
+        return;
+      }
+
+      const player = new window.Spotify.Player({
+        name: DEVICE_NAME,
+        getOAuthToken: (cb) => {
+          // Called once on init and again whenever a token expires.
+          fetchJSON("/api/plugins/spotify/token")
+            .then((data) => {
+              if (data && data.access_token) {
+                cb(data.access_token);
+              } else {
+                cb("");
+              }
+            })
+            .catch((err) => {
+              if (mountedRef.current) {
+                const detail = (err && err.detail) || err;
+                setReloginRequired(Boolean(detail && detail.relogin_required));
+                setErrorMessage(
+                  "Spotify token refresh failed: " +
+                  ((detail && detail.message) || (err && err.message) || "unknown")
+                );
+                setPhase("error");
+              }
+              cb("");
+            });
+        },
+        volume: 0.5,
+      });
+
+      player.addListener("ready", ({ device_id }) => {
+        if (!mountedRef.current) return;
+        setDeviceId(device_id);
+        setPhase("ready");
+      });
+
+      player.addListener("not_ready", ({ device_id }) => {
+        // SDK marks the device as not_ready when the tab is backgrounded
+        // for long enough that Spotify garbage-collects the connection.
+        // The SDK reconnects on its own; we just surface that to the UI.
+        if (!mountedRef.current) return;
+        if (deviceId === device_id) setDeviceId(null);
+      });
+
+      player.addListener("initialization_error", ({ message }) => {
+        if (!mountedRef.current) return;
+        setErrorMessage("SDK init error: " + message);
+        setPhase("error");
+      });
+      player.addListener("authentication_error", ({ message }) => {
+        if (!mountedRef.current) return;
+        // Token is bad or revoked — treat as needs-relogin so the UI
+        // shows the right call-to-action.
+        setReloginRequired(true);
+        setErrorMessage("Spotify auth error: " + message);
+        setPhase("error");
+      });
+      player.addListener("account_error", ({ message }) => {
+        // This is the canonical signal for a non-Premium account.
+        if (!mountedRef.current) return;
+        setErrorMessage(message || "Spotify Premium is required for Web Playback.");
+        setPhase("not_premium");
+      });
+      player.addListener("playback_error", ({ message }) => {
+        if (!mountedRef.current) return;
+        setErrorMessage("Playback error: " + message);
+      });
+
+      player.addListener("player_state_changed", (state) => {
+        if (!mountedRef.current || !state) return;
+        setPlayerState(state);
+        lastStateAtRef.current = Date.now();
+        lastPositionRef.current = state.position || 0;
+        setLocalPositionMs(state.position || 0);
+      });
+
+      playerRef.current = player;
+      try {
+        const connected = await player.connect();
+        if (!connected && mountedRef.current) {
+          setErrorMessage("Spotify SDK refused to connect.");
+          setPhase("error");
+        }
+      } catch (err) {
+        if (mountedRef.current) {
+          setErrorMessage("Spotify SDK connect threw: " + (err && err.message ? err.message : "unknown"));
+          setPhase("error");
+        }
+      }
+    }, []);
+
+    useEffect(() => {
+      mountedRef.current = true;
+      init();
+      return () => {
+        mountedRef.current = false;
+        const p = playerRef.current;
+        if (p && typeof p.disconnect === "function") {
+          // Tear the SDK connection down on unmount so we don't leave
+          // a zombie 'Hermes Dashboard' device hanging in the user's
+          // Spotify Connect list.
+          try { p.disconnect(); } catch (_) { /* ignore */ }
+        }
+        playerRef.current = null;
+      };
+    }, [init]);
+
+    // ---- Local progress ticking (between SDK state updates) ----------------
+
+    useEffect(() => {
+      if (phase !== "ready" || !playerState || playerState.paused) return;
+      const id = setInterval(() => {
+        if (!mountedRef.current) return;
+        const elapsed = Date.now() - lastStateAtRef.current;
+        setLocalPositionMs(lastPositionRef.current + elapsed);
+      }, 500);
+      return () => clearInterval(id);
+    }, [phase, playerState]);
+
+    // ---- Transport controls -------------------------------------------------
+
+    const togglePlay = useCallback(() => {
+      const p = playerRef.current;
+      if (p) p.togglePlay().catch(() => undefined);
+    }, []);
+    const nextTrack = useCallback(() => {
+      const p = playerRef.current;
+      if (p) p.nextTrack().catch(() => undefined);
+    }, []);
+    const prevTrack = useCallback(() => {
+      const p = playerRef.current;
+      if (p) p.previousTrack().catch(() => undefined);
+    }, []);
+    const onSeek = useCallback((e) => {
+      const p = playerRef.current;
+      const ms = Number(e.target.value);
+      if (p && Number.isFinite(ms)) {
+        lastPositionRef.current = ms;
+        lastStateAtRef.current = Date.now();
+        setLocalPositionMs(ms);
+        p.seek(ms).catch(() => undefined);
+      }
+    }, []);
+    const onVolume = useCallback((e) => {
+      const p = playerRef.current;
+      const v = Number(e.target.value);
+      if (p && Number.isFinite(v)) {
+        setVolumeState(v);
+        p.setVolume(v).catch(() => undefined);
+      }
+    }, []);
+    const copyDeviceId = useCallback(() => {
+      if (!deviceId) return;
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(deviceId).catch(() => undefined);
+      }
+    }, [deviceId]);
+
+    // ---- Render -------------------------------------------------------------
+
+    const title = h(C.CardTitle, null, "Spotify Web Playback");
+
+    if (phase === "init" || phase === "loading_sdk") {
+      return h(C.Card, null,
+        h(C.CardHeader, null, title),
+        h(C.CardContent, null,
+          h("p", { className: "text-sm text-muted-foreground" },
+            phase === "init" ? "Checking Spotify login…" : "Loading Spotify Web Playback SDK…"
+          )
+        )
+      );
+    }
+
+    if (phase === "logged_out") {
+      return h(C.Card, null,
+        h(C.CardHeader, null, title),
+        h(C.CardContent, { className: "space-y-3" },
+          h("p", { className: "text-sm" },
+            "Spotify isn't connected yet. Run ",
+            h("code", null, "hermes auth spotify"),
+            " in a terminal, then reload this tab."
+          ),
+          h(C.Button, { variant: "outline", onClick: init }, "Retry")
+        )
+      );
+    }
+
+    if (phase === "not_premium") {
+      return h(C.Card, null,
+        h(C.CardHeader, null, title),
+        h(C.CardContent, { className: "space-y-3" },
+          h("p", { className: "text-sm" },
+            "Spotify Premium is required for in-browser playback. ",
+            "You can still control existing Spotify clients (phone, desktop, Sonos) via the ",
+            h("code", null, "spotify_playback"),
+            " agent tools."
+          ),
+          errorMessage ? h("p", { className: "text-xs text-muted-foreground" }, errorMessage) : null
+        )
+      );
+    }
+
+    if (phase === "error") {
+      return h(C.Card, null,
+        h(C.CardHeader, null, title),
+        h(C.CardContent, { className: "space-y-3" },
+          h("p", { className: "text-sm text-destructive" }, errorMessage || "Something went wrong."),
+          reloginRequired
+            ? h("p", { className: "text-xs" },
+                "Run ",
+                h("code", null, "hermes auth spotify"),
+                " to re-authenticate, then reload."
+              )
+            : null,
+          h(C.Button, { variant: "outline", onClick: init }, "Retry")
+        )
+      );
+    }
+
+    // phase === "ready"
+    const isPlaying = playerState && !playerState.paused;
+    const durationMs = (playerState && playerState.duration) || 0;
+    const positionMs = Math.min(localPositionMs, durationMs || localPositionMs);
+    const name = trackName(playerState) || "—";
+    const artists = trackArtists(playerState) || "—";
+    const art = trackArtUrl(playerState);
+
+    return h(C.Card, null,
+      h(C.CardHeader, { className: "flex flex-row items-center justify-between gap-2" },
+        title,
+        deviceId ? h(C.Badge, { variant: "secondary" }, DEVICE_NAME + " · ready") : h(C.Badge, null, "registering…")
+      ),
+      h(C.CardContent, { className: "space-y-4" },
+        h("div", { className: "flex items-center gap-4" },
+          art
+            ? h("img", {
+                src: art,
+                alt: "Album art",
+                className: "h-20 w-20 rounded shadow",
+              })
+            : h("div", {
+                className: "h-20 w-20 rounded bg-muted flex items-center justify-center text-xs text-muted-foreground",
+              }, "no art"),
+          h("div", { className: "flex-1 min-w-0" },
+            h("div", { className: "truncate text-base font-medium" }, name),
+            h("div", { className: "truncate text-sm text-muted-foreground" }, artists),
+            h("div", { className: "mt-2 flex items-center gap-2 text-xs text-muted-foreground" },
+              h("span", null, formatMs(positionMs)),
+              h("input", {
+                type: "range",
+                min: 0,
+                max: Math.max(durationMs, 1),
+                step: 1000,
+                value: positionMs,
+                onChange: onSeek,
+                disabled: !durationMs,
+                className: "flex-1",
+                "aria-label": "Seek",
+              }),
+              h("span", null, formatMs(durationMs))
+            )
+          )
+        ),
+        h("div", { className: "flex items-center gap-2" },
+          h(C.Button, { variant: "outline", size: "sm", onClick: prevTrack, "aria-label": "Previous" }, "⏮"),
+          h(C.Button, {
+            variant: isPlaying ? "secondary" : "default",
+            size: "sm",
+            onClick: togglePlay,
+            "aria-label": isPlaying ? "Pause" : "Play",
+          }, isPlaying ? "⏸ Pause" : "▶ Play"),
+          h(C.Button, { variant: "outline", size: "sm", onClick: nextTrack, "aria-label": "Next" }, "⏭"),
+          h("div", { className: "ml-auto flex items-center gap-2 text-xs text-muted-foreground" },
+            h("span", null, "Vol"),
+            h("input", {
+              type: "range",
+              min: 0,
+              max: 1,
+              step: 0.01,
+              value: volume,
+              onChange: onVolume,
+              className: "w-24",
+              "aria-label": "Volume",
+            })
+          )
+        ),
+        h("div", { className: "text-xs text-muted-foreground" },
+          deviceId
+            ? h(React.Fragment, null,
+                "Tab registered as ",
+                h("code", null, DEVICE_NAME),
+                ". Agent tool calls that target ",
+                h("code", null, "device_id=" + deviceId),
+                " play here. ",
+                h("button", {
+                  type: "button",
+                  onClick: copyDeviceId,
+                  className: cn("underline underline-offset-2"),
+                }, "Copy device id")
+              )
+            : "Registering as a Spotify Connect device…"
+        )
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("spotify", SpotifyPage);
+})();

--- a/plugins/spotify/dashboard/manifest.json
+++ b/plugins/spotify/dashboard/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "spotify",
+  "label": "Spotify",
+  "description": "Web Playback widget — this browser tab becomes a Spotify Connect device the agent can target.",
+  "icon": "Music",
+  "version": "0.1.0",
+  "tab": { "path": "/spotify", "position": "end" },
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/spotify/dashboard/plugin_api.py
+++ b/plugins/spotify/dashboard/plugin_api.py
@@ -1,0 +1,121 @@
+"""Spotify Web Playback dashboard plugin — backend API routes.
+
+Mounted at ``/api/plugins/spotify/`` by ``hermes_cli/web_server.py`` (see
+``_mount_plugin_api_routes``).  The browser-side Web Playback SDK can't
+read ``~/.hermes/auth.json`` directly; it asks our endpoint for a fresh
+Spotify access token on init and again whenever its previous token
+expires (the SDK calls a user-supplied ``getOAuthToken`` callback on
+demand).  This module is the entire backend surface that callback needs.
+
+The heavy lifting lives in ``hermes_cli/auth.py`` —
+``resolve_spotify_runtime_credentials`` already handles "load state →
+refresh if expiring → persist → return access_token".  We just expose
+its result to a same-origin browser fetch and translate ``AuthError``
+into HTTP status codes the JS layer can branch on.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _serialise_credentials(creds: Dict[str, Any]) -> Dict[str, Any]:
+    """Strip the refresh_token before returning to the browser.
+
+    The browser only needs the short-lived access token; the refresh
+    token is a long-lived secret that never leaves the host process.
+    """
+    return {
+        "access_token": creds["access_token"],
+        "token_type": creds.get("token_type", "Bearer"),
+        "scope": creds.get("scope", ""),
+        "expires_at": creds.get("expires_at"),
+    }
+
+
+@router.get("/token")
+async def get_spotify_token() -> Dict[str, Any]:
+    """Return a fresh Spotify access token for the Web Playback SDK.
+
+    Refreshes via the existing OAuth state if the cached token is
+    within the skew window of expiry.  Same code path as every other
+    Spotify tool call, so the refresh stays consistent with the agent
+    side.
+    """
+    try:
+        from hermes_cli.auth import (
+            AuthError,
+            resolve_spotify_runtime_credentials,
+        )
+    except ImportError as exc:
+        logger.warning("Spotify auth helpers unavailable: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "code": "spotify_auth_unavailable",
+                "message": "Spotify auth helpers are not available in this install.",
+            },
+        ) from exc
+
+    try:
+        creds = resolve_spotify_runtime_credentials(refresh_if_expiring=True)
+    except AuthError as exc:
+        # AuthError carries a stable `code` and a `relogin_required` flag
+        # that the JS layer uses to decide between "show a refresh button"
+        # vs. "tell the user to re-run `hermes auth spotify`".
+        status = 401 if getattr(exc, "relogin_required", False) else 502
+        raise HTTPException(
+            status_code=status,
+            detail={
+                "code": getattr(exc, "code", "spotify_auth_failed"),
+                "message": str(exc),
+                "relogin_required": bool(getattr(exc, "relogin_required", False)),
+            },
+        ) from exc
+    except Exception as exc:
+        logger.exception("Unexpected error resolving Spotify credentials")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "spotify_auth_internal",
+                "message": str(exc),
+            },
+        ) from exc
+
+    return _serialise_credentials(creds)
+
+
+@router.get("/status")
+async def get_spotify_status() -> Dict[str, Any]:
+    """Lightweight login-state probe — no token returned.
+
+    The widget calls this before attempting SDK init so it can render
+    the right initial state (logged out vs. logged in vs. config error)
+    without exposing the access token in the status response.
+    """
+    try:
+        from hermes_cli.auth import get_spotify_auth_status
+    except ImportError:
+        return {"logged_in": False, "available": False}
+
+    try:
+        status = get_spotify_auth_status()
+    except Exception as exc:
+        logger.warning("get_spotify_auth_status failed: %s", exc)
+        return {"logged_in": False, "available": True, "error": str(exc)}
+
+    return {
+        "logged_in": bool(status.get("logged_in")),
+        "available": True,
+        # Pass through fields useful to the widget for diagnostic display,
+        # but never the tokens themselves.
+        "scope": status.get("scope") or status.get("granted_scope"),
+        "expires_at": status.get("expires_at"),
+    }


### PR DESCRIPTION
## Summary

Adds a dashboard plugin that makes the browser tab itself a Spotify Connect device named **\"Hermes Dashboard\"**. Once registered, every existing \`spotify_playback\`/\`spotify_devices\` tool call that targets that device id plays audio in this tab — no new agent-side code needed.

Closes #15182.

## What's in this PR

```
plugins/spotify/dashboard/
├── manifest.json     # dashboard plugin manifest (tab + entry + api)
├── plugin_api.py     # FastAPI router (GET /token, GET /status)
└── dist/index.js     # hand-written IIFE bundle (no upstream build step)
```

### `plugin_api.py` — thin wrapper over existing auth

Just delegates to \`hermes_cli.auth.resolve_spotify_runtime_credentials\` (the same helper used by the agent-side \`spotify_playback\` tools). That function already implements \"load → refresh-if-expiring → persist → return\" — the dashboard shares those refresh semantics for free, so the cache stays consistent across the agent and the widget.

- \`GET /token\` — fresh access token, refresh-if-expiring. AuthError → 401 (\`relogin_required\`) or 502 (transient), with a stable \`code\` field the JS layer can branch on. **\`refresh_token\` never leaves the host process.**
- \`GET /status\` — login-state probe, no token in the response.

### `dist/index.js` — vanilla IIFE, matches existing bundle contract

Uses \`window.__HERMES_PLUGIN_SDK__\` (React, hooks, UI primitives) and registers via \`window.__HERMES_PLUGINS__.register(\"spotify\", Component)\` — exactly the same shape as the existing \`hermes-achievements\` and \`kanban\` dashboard bundles. No JSX (\`React.createElement\` throughout), no bundled React, **no upstream build step**.

- Loads Spotify Web Playback SDK from \`sdk.scdn.co\` lazily on mount; idempotent across multi-mounts.
- Disconnects the SDK on unmount so the device doesn't linger as a zombie in the user's Spotify Connect list.
- Premium detection via the SDK's \`account_error\` event — Free users see a clear \"Premium required\" message that points them at the still-functional \`spotify_playback\` tools for non-browser Connect devices.
- \`authentication_error\` flips the UI to a re-login prompt referencing \`hermes auth spotify\`.

UI:
- track / artist / album-art card
- local-ticking progress + seek bar
- prev / play-pause / next transport controls
- volume slider
- device-id banner with copy-to-clipboard so the user can paste it into \`spotify_playback play --device <id>\` agent calls

## Acceptance criteria (from #15182)

| Criterion | This PR |
|---|---|
| User opens dashboard → sees Spotify widget showing login state | ✅ `/status` probe before SDK init |
| Tab shows 'Hermes Dashboard' as active device after login | ✅ on SDK `ready` event |
| Agent 'play X' → music plays in the tab | ✅ no plugin code needed; Spotify routes by device_id |
| Skip/pause buttons work and agent sees state change via `get_currently_playing` | ✅ SDK calls hit the same Spotify state |
| Free users see clear 'Spotify Premium required' message | ✅ on SDK `account_error` |
| Graceful degradation on focus loss / network / SDK disconnect | ✅ `not_ready` listener clears device id; SDK reconnects on its own |

## Out of scope (open follow-ups)

- Library / playlist browsing UI — the agent handles that through tools (issue marks it as a non-goal)
- Multi-tab device dedup (the SDK already namespaces device ids per browser session)
- PKCE login flow inside the widget — defers to the existing \`hermes auth spotify\` CLI command

## Verification

Done locally:
- \`manifest.json\` parses; \`name=spotify\`; points at the two other files
- \`plugin_api.py\` imports cleanly under fastapi; router exposes \`GET /token\` and \`GET /status\` (mounted at \`/api/plugins/spotify/*\` per \`web_server.py::_mount_plugin_api_routes\`)
- \`dist/index.js\` passes \`node --check\` syntax validation; only uses SDK globals that the existing \`hermes-achievements\` bundle uses

**Not verified locally — I don't have the infra** (and I'm flagging this explicitly):
- End-to-end login + playback with a real Spotify Premium account
- Behavior across long tab-background → SDK reconnect cycles
- Visual fidelity in the running dashboard SPA

Happy to iterate on review feedback. If you'd prefer a TypeScript+Vite build pipeline alongside this MVP, point me at the build conventions for the other bundles and I'll convert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)