### PR TITLE
fix: use time.monotonic() for duration measurements (cli, tui, batch_runner)

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -907,7 +907,7 @@ class BatchRunner:
         # Aggregate statistics across all batches
         total_tool_stats = {}
         
-        start_time = time.time()
+        start_time = time.monotonic()
         
         print(f"\n🔧 Initializing {self.num_workers} worker processes...")
         
@@ -1078,7 +1078,7 @@ class BatchRunner:
             "batch_size": self.batch_size,
             "model": self.model,
             "completed_at": datetime.now().isoformat(),
-            "duration_seconds": round(time.time() - start_time, 2),
+            "duration_seconds": round(time.monotonic() - start_time, 2),
             "tool_statistics": total_tool_stats,
             "reasoning_statistics": total_reasoning_stats,
         }
@@ -1093,7 +1093,7 @@ class BatchRunner:
         print(f"✅ Prompts processed this run: {sum(r.get('processed', 0) for r in results)}")
         print(f"✅ Total trajectories in merged file: {total_entries - filtered_entries}")
         print(f"✅ Total batch files merged: {batch_files_found}")
-        print(f"⏱️  Total duration: {round(time.time() - start_time, 2)}s")
+        print(f"⏱️  Total duration: {round(time.monotonic() - start_time, 2)}s")
         print("\n📈 Tool Usage Statistics:")
         print("-" * 70)
         

--- a/cli.py
+++ b/cli.py
@@ -3158,7 +3158,7 @@ class HermesCLI:
         self._resumed = False
         # Per-prompt elapsed timer — started at the beginning of each chat turn,
         # frozen when the agent thread completes, displayed in the status bar.
-        self._prompt_start_time: Optional[float] = None  # time.time() when turn started
+        self._prompt_start_time: Optional[float] = None  # time.monotonic() when turn started
         self._prompt_duration: float = 0.0  # frozen duration of last completed turn
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
@@ -11776,7 +11776,7 @@ class HermesCLI:
             # exits the main thread and daemon threads are reaped automatically).
             # Start per-prompt elapsed timer — frozen after the agent thread
             # finishes; reset on the next turn.
-            self._prompt_start_time = time.time()
+            self._prompt_start_time = time.monotonic()
             self._prompt_duration = 0.0
             agent_thread = threading.Thread(target=run_agent, daemon=True)
             agent_thread.start()
@@ -11857,7 +11857,7 @@ class HermesCLI:
             # Freeze per-prompt elapsed timer once the agent thread has
             # exited (or been abandoned as a daemon after interrupt).
             if self._prompt_start_time is not None:
-                self._prompt_duration = max(0.0, time.time() - self._prompt_start_time)
+                self._prompt_duration = max(0.0, time.monotonic() - self._prompt_start_time)
                 self._prompt_start_time = None
 
             # Proactively clean up async clients whose event loop is dead.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1623,7 +1623,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
                 session.setdefault("edit_snapshots", {})[tool_call_id] = snapshot
         except Exception:
             pass
-        session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
+        session.setdefault("tool_started_at", {})[tool_call_id] = time.monotonic()
     if _tool_progress_enabled(sid):
         payload = {
             "tool_id": tool_call_id,
@@ -1647,7 +1647,7 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     if session is not None:
         snapshot = session.setdefault("edit_snapshots", {}).pop(tool_call_id, None)
         started_at = session.setdefault("tool_started_at", {}).pop(tool_call_id, None)
-    duration_s = time.time() - started_at if started_at else None
+    duration_s = time.monotonic() - started_at if started_at else None
     if duration_s is not None:
         payload["duration_s"] = duration_s
     summary = _tool_summary(name, result, duration_s)


### PR DESCRIPTION
## Use `time.monotonic()` for duration measurements

`time.time()` returns wall-clock time which is subject to NTP adjustments, leap seconds, and manual clock changes. For measuring elapsed durations, `time.monotonic()` is the correct clock — it never goes backward.

### Problem

When `time.time()` is used for `end - start` duration calculations:
- NTP sync can make the clock jump backward → **negative durations**
- Clock jumps forward → **wildly inaccurate measurements**
- TUI status bar shows incorrect elapsed times
- Batch runner stats report wrong durations

### Fix

Replaced `time.time()` with `time.monotonic()` in 3 files where it's used for elapsed-time subtraction:

| File | Location | What it measures |
|------|----------|-----------------|
| `cli.py` | `_prompt_start_time` / `_prompt_duration` | Per-turn elapsed timer in status bar |
| `tui_gateway/server.py` | `tool_started_at` / `duration_s` | Tool execution duration display |
| `batch_runner.py` | `start_time` / `duration_seconds` | Batch run duration + stats output |

### What's NOT changed (intentionally)

- `run_agent.py:_last_activity_ts` — used as a wall-clock timestamp in status reports and gateway timeout handler, with test implications
- `hermes_state.py` — DB timestamps are wall-clock by design
- Diagnostic logging — low impact

### Key distinction

| Use case | Correct clock |
|----------|--------------|
| Duration measurement (`end - start`) | `time.monotonic()` |
| Wall-clock timestamps (DB, logs, display) | `time.time()` |