### PR TITLE
fix(tools): add Gemini 2.0/2.5 to multimodal tool-result allowlist (#30704)

### DIFF
--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -52,8 +52,18 @@ class TestSupportsMediaInToolResults:
     def test_gemini_3_yes(self):
         assert _supports_media_in_tool_results("google", "gemini-3-flash-preview") is True
 
-    def test_gemini_2_no(self):
-        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
+    def test_gemini_25_yes(self):
+        # Gemini 2.5 supports multimodal functionResponse (#30704)
+        assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is True
+        assert _supports_media_in_tool_results("google", "gemini-2.5-flash") is True
+
+    def test_gemini_20_yes(self):
+        # Gemini 2.0 supports multimodal functionResponse (#30704)
+        assert _supports_media_in_tool_results("google", "gemini-2.0-flash") is True
+
+    def test_gemini_1x_no(self):
+        # Gemini 1.x did not support multimodal functionResponse
+        assert _supports_media_in_tool_results("google", "gemini-1.5-pro") is False
 
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -461,12 +461,14 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         return True
 
     # Gemini — gate on model name; older Gemini variants did not support
-    # multimodal functionResponse. Gemini 3.x does.
+    # multimodal functionResponse. Gemini 2.0+/2.5+/3.x do.
     if p in {"google", "gemini", "google-gemini", "google-vertex-gemini"}:
         if not isinstance(model, str):
             return False
         m = model.strip().lower()
         if "gemini-3" in m or "gemini-pro-3" in m or "gemini-flash-3" in m:
+            return True
+        if "gemini-2.5" in m or "gemini-2.0" in m:
             return True
         return False
 


### PR DESCRIPTION
## Summary

- `_supports_media_in_tool_results` only returned `True` for `gemini-3*` models, leaving Gemini 2.0 and 2.5 on the text-only fast path despite both families supporting multimodal `functionResponse`
- Add substring checks for `"gemini-2.5"` and `"gemini-2.0"` alongside the existing `gemini-3` check

Fixes #30704

## Test plan

- [ ] `test_gemini_25_yes` — `gemini-2.5-pro` and `gemini-2.5-flash` return `True`
- [ ] `test_gemini_20_yes` — `gemini-2.0-flash` returns `True`
- [ ] `test_gemini_1x_no` — `gemini-1.5-pro` still returns `False` (Gemini 1.x unsupported)
- [ ] All 20 vision fast-path tests pass

Tested on macOS (arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)