### PR TITLE
fix(gateway): prefer copilot ACP in Telegram picker

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10271,9 +10271,15 @@ class GatewayRunner:
                         # Store model note + session override
                         if not hasattr(_self, "_pending_model_notes"):
                             _self._pending_model_notes = {}
+                        plabel = result.provider_label or result.target_provider
+                        provider_display = (
+                            plabel
+                            if plabel == result.target_provider
+                            else f"{plabel} ({result.target_provider})"
+                        )
                         _self._pending_model_notes[_session_key] = (
                             f"[Note: model was just switched from {_cur_model} to {result.new_model} "
-                            f"via {result.provider_label or result.target_provider}. "
+                            f"via {provider_display}. "
                             f"Adjust your self-identification accordingly.]"
                         )
                         _self._session_model_overrides[_session_key] = {
@@ -10290,9 +10296,10 @@ class GatewayRunner:
                         _self._evict_cached_agent(_session_key)
 
                         # Build confirmation text
-                        plabel = result.provider_label or result.target_provider
                         lines = [t("gateway.model.switched", model=result.new_model)]
-                        lines.append(t("gateway.model.provider_label", provider=plabel))
+                        lines.append(
+                            t("gateway.model.provider_label", provider=provider_display)
+                        )
                         mi = result.model_info
                         from hermes_cli.model_switch import resolve_display_context_length
                         _sw_config_ctx = None

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1796,4 +1796,22 @@ def list_picker_providers(
             continue
         filtered.append(p)
 
+    def _picker_family_penalty(provider: dict) -> int:
+        slug = str(provider.get("slug", "")).lower()
+        # GitHub Copilot and Copilot ACP expose the same live catalog, but the
+        # ACP path is the less confusing Telegram/Discord picker default when
+        # both are available. Keep the familiar current-first / model-count
+        # ordering, and only break ties within the Copilot family.
+        if slug == "copilot":
+            return 1
+        return 0
+
+    filtered.sort(
+        key=lambda p: (
+            not bool(p.get("is_current")),
+            -int(p.get("total_models", len(p.get("models", []))) or 0),
+            _picker_family_penalty(p),
+        )
+    )
+
     return filtered

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -1,5 +1,7 @@
 """Regression tests for gateway /model support of config.yaml custom_providers."""
 
+from types import SimpleNamespace
+
 import yaml
 import pytest
 
@@ -14,6 +16,12 @@ def _make_runner():
     runner.adapters = {}
     runner._voice_mode = {}
     runner._session_model_overrides = {}
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._evict_cached_agent = lambda *_a, **_kw: None
+    runner._thread_metadata_for_source = lambda *_a, **_kw: {}
+    runner._reply_anchor_for_event = lambda *_a, **_kw: None
     return runner
 
 
@@ -61,3 +69,108 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+class _PickerAdapter:
+    def __init__(self):
+        self.providers = None
+        self.callback_result = None
+
+    async def send_model_picker(
+        self,
+        chat_id,
+        providers,
+        current_model,
+        current_provider,
+        session_key,
+        on_model_selected,
+        metadata=None,
+    ):
+        self.providers = providers
+        chosen = providers[0]
+        self.callback_result = await on_model_selected(
+            chat_id, "gpt-5-mini", chosen["slug"]
+        )
+        return SimpleNamespace(success=True, message_id="101")
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_picker_prefers_copilot_acp_and_shows_slug(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "model": {
+                "default": "gpt-5.5",
+                "provider": "openai-codex",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            },
+            "providers": {},
+        },
+    )
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_authenticated_providers",
+        lambda **kw: [
+            {
+                "slug": "copilot",
+                "name": "GitHub Copilot",
+                "is_current": False,
+                "models": ["gpt-5-mini", "claude-sonnet-4.6"],
+                "total_models": 2,
+                "source": "hermes",
+            },
+            {
+                "slug": "copilot-acp",
+                "name": "GitHub Copilot ACP",
+                "is_current": False,
+                "models": ["gpt-5-mini", "claude-sonnet-4.6"],
+                "total_models": 2,
+                "source": "hermes",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_openrouter_models",
+        lambda *a, **kw: [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kw: ModelSwitchResult(
+            success=True,
+            new_model="gpt-5-mini",
+            target_provider="copilot-acp",
+            provider_changed=True,
+            api_key="copilot-acp",
+            base_url="",
+            api_mode="responses",
+            provider_label="GitHub Copilot ACP",
+            model_info=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_display_context_length",
+        lambda *a, **kw: None,
+    )
+
+    adapter = _PickerAdapter()
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is None
+    assert [p["slug"] for p in adapter.providers] == ["copilot-acp", "copilot"]
+    assert "GitHub Copilot ACP (copilot-acp)" in adapter.callback_result
+    assert any(
+        "GitHub Copilot ACP (copilot-acp)" in note
+        for note in runner._pending_model_notes.values()
+    )

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -230,6 +230,8 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
     monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
                         lambda *a, **kw: [])
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models",
+                        lambda *a, **kw: [])
 
     result = model_switch.list_picker_providers(
         current_provider="custom:ollama",
@@ -259,3 +261,25 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     assert row["slug"] == "custom:ollama"
     assert row["is_current"] is True
     assert row["models"] == ["glm-5.1", "qwen3"]
+
+
+def test_picker_prefers_copilot_acp_over_plain_copilot_on_ties(monkeypatch):
+    """When both GitHub Copilot rows expose the same catalog, show ACP first."""
+    base = [
+        _make_provider("copilot", name="GitHub Copilot", models=["gpt-5-mini", "claude-sonnet-4.6"]),
+        _make_provider("copilot-acp", name="GitHub Copilot ACP", models=["gpt-5-mini", "claude-sonnet-4.6"]),
+    ]
+
+    monkeypatch.setattr(
+        model_switch,
+        "list_authenticated_providers",
+        lambda **kw: list(base),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_openrouter_models",
+        lambda *a, **kw: pytest.fail("should not be called"),
+    )
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert [p["slug"] for p in result] == ["copilot-acp", "copilot"]


### PR DESCRIPTION
Closes #32051

## Summary
- prefer `copilot-acp` ahead of plain `copilot` in interactive Telegram/Discord `/model` pickers when both expose the same catalog
- include the provider slug in gateway model-switch confirmations and pending model notes so picker-driven switches are unambiguous
- add regressions for picker ordering and gateway callback text

## Proof
- `uv run --frozen pytest -q -o addopts= tests/hermes_cli/test_list_picker_providers.py tests/gateway/test_model_command_custom_providers.py`\n- `uv run --frozen ruff check hermes_cli/model_switch.py gateway/run.py tests/hermes_cli/test_list_picker_providers.py tests/gateway/test_model_command_custom_providers.py`\n- `git diff --check`