### PR TITLE
fix: use atomic writes for JSON state files (voice_mode, spawn_tree)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1989,9 +1989,7 @@ class GatewayRunner:
     def _save_voice_modes(self) -> None:
         try:
             self._VOICE_MODE_PATH.parent.mkdir(parents=True, exist_ok=True)
-            self._VOICE_MODE_PATH.write_text(
-                json.dumps(self._voice_mode, indent=2)
-            )
+            atomic_json_write(self._VOICE_MODE_PATH, self._voice_mode)
         except OSError as e:
             logger.warning("Failed to save voice modes: %s", e)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import is_truthy_value
+from utils import is_truthy_value, atomic_json_write
 from tui_gateway.transport import (
     StdioTransport,
     Transport,
@@ -3010,7 +3010,7 @@ def _(rid, params: dict) -> dict:
             "label": label,
             "subagents": subagents,
         }
-        path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        atomic_json_write(path, payload)
     except OSError as exc:
         return _err(rid, 5000, f"spawn_tree.save failed: {exc}")
 


### PR DESCRIPTION
## Use atomic writes for JSON state files

`Path.write_text()` truncates then writes — a crash or power loss mid-write leaves a corrupt (empty or partial) file. The codebase already has `atomic_json_write()` in `utils.py` which uses tempfile + fsync + os.replace to ensure the target file is never left in a partially-written state.

### Problem

If the process is killed (OOM, power loss, SIGKILL) while `write_text()` is executing:
1. The file is truncated to 0 bytes (old content gone)
2. Partial new content is written
3. On next read, `json.loads()` crashes with `JSONDecodeError`
4. Gateway or TUI fails to start

### Fix

Replace `write_text(json.dumps(...))` with the existing `atomic_json_write()` helper:

| File | What it stores | Impact of corruption |
|------|---------------|---------------------|
| `gateway/run.py` | Voice mode state | Voice settings lost, gateway may crash |
| `tui_gateway/server.py` | Subagent spawn tree | TUI tree view broken, subagent tracking lost |

### Note

The codebase already uses `atomic_json_write()` in 10+ locations (e.g., `gateway/run.py:3585`, `agent/prompt_builder.py`). These 2 locations were simply missed when the helper was introduced.

`gateway/delivery.py` write_text calls are NOT changed — they use timestamped unique filenames so there's no risk of corrupting existing files.