### PR TITLE
fix(gateway): expand extract_media regex to common text/data/source formats

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2412,8 +2412,21 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        #
+        # Extension allowlist groups (must round-trip both the extract path and
+        # the cleanup regex on line ~3476 of this file — see comment there):
+        #   - images:    png jpe?g gif webp
+        #   - video:     mp4 mov avi mkv webm
+        #   - audio:     ogg opus mp3 wav m4a flac
+        #   - bundles:   epub pdf zip rar 7z apk ipa
+        #   - office:    docx? xlsx? pptx?
+        #   - text/data: txt md markdown json ya?ml toml csv tsv html? xml log
+        #   - source:    sh py js ts
+        # If you add an extension, update the cleanup regex too — otherwise the
+        # path gets stripped from visible text but never reaches send_document,
+        # so the user sees neither the attachment nor an error message.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|md|markdown|json|ya?ml|toml|csv|tsv|html?|xml|log|sh|py|js|ts|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_extract_media.py
+++ b/tests/gateway/test_extract_media.py
@@ -1,0 +1,137 @@
+"""Unit tests for ``BasePlatformAdapter.extract_media``.
+
+The MEDIA:<path> directive is the canonical way for an agent's text
+reply to ship a file as a native platform attachment. Hermes core
+parses the directive out, strips it from the visible text, and routes
+the path to the platform adapter's ``send_document`` /
+``send_voice`` / ``send_image_file`` based on extension.
+
+Until 2026-05-25 the regex's extension allowlist omitted several text
+formats that agents commonly emit — most notably ``.md``. The result:
+an agent that wrote ``MEDIA:/tmp/report.md`` saw the directive
+silently dropped (cleaned out of visible text by a secondary regex,
+but never extracted into ``media_files``), so the recipient got
+neither the attachment nor an error explaining why. These tests pin
+the broadened allowlist so the bug doesn't quietly come back.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+# ── Newly supported text / data / source formats ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "ext",
+    [
+        "md", "markdown",
+        "json", "yaml", "yml", "toml",
+        "csv", "tsv",
+        "html", "htm", "xml",
+        "log",
+        "sh", "py", "js", "ts",
+    ],
+)
+def test_extract_media_text_data_source_extensions(ext: str):
+    """MEDIA: paths with text/data/source extensions must extract cleanly.
+
+    These are extensions agents commonly emit (markdown reports, JSON
+    payloads, log dumps, code review files). Before this fix, the
+    extract path's allowlist silently dropped them.
+    """
+    path = f"/tmp/test.{ext}"
+    content = f"Here is the file.\nMEDIA:{path}"
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+    assert media == [(path, False)], (
+        f"extract_media dropped .{ext}; the regex's extension "
+        f"allowlist on gateway/platforms/base.py is missing it."
+    )
+    assert "MEDIA:" not in cleaned
+    assert cleaned == "Here is the file."
+
+
+# ── Regression: previously supported extensions still match ─────────────
+
+
+@pytest.mark.parametrize(
+    "ext",
+    [
+        "png", "jpg", "jpeg", "gif", "webp",   # images
+        "mp4", "mov", "avi", "mkv", "webm",    # video
+        "ogg", "opus", "mp3", "wav", "m4a", "flac",  # audio
+        "epub", "pdf", "zip", "rar", "7z",     # bundles
+        "docx", "xlsx", "pptx",                # office
+        "txt",                                  # plain text
+        "apk", "ipa",                           # mobile installers
+    ],
+)
+def test_extract_media_keeps_previously_supported_extensions(ext: str):
+    """Broadening the allowlist must not regress any prior extension."""
+    path = f"/tmp/test.{ext}"
+    media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:{path}")
+    assert media == [(path, False)]
+    assert "MEDIA:" not in cleaned
+
+
+# ── Negative: still rejects unknown extensions ──────────────────────────
+
+
+@pytest.mark.parametrize("ext", ["xyz", "exe", "dmg", "iso", "deb", "rpm"])
+def test_extract_media_rejects_unknown_extensions(ext: str):
+    """Unknown extensions must not be picked up — this guards against
+    overshooting the allowlist into platform-incompatible files.
+    """
+    media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:/tmp/x.{ext}")
+    assert media == []
+    # Unknown extensions stay in the visible text (the secondary
+    # cleanup regex in base.py:~3476 also won't match them, since
+    # that regex is greedier but only runs when paired with the
+    # extract path).
+    assert "MEDIA:" in cleaned
+
+
+# ── Real-world variants the broadened regex must keep handling ──────────
+
+
+def test_extract_media_markdown_with_caption_preserves_text():
+    """The agent's usual reply: caption + MEDIA: on its own line."""
+    content = (
+        "Aquí está el resumen del repositorio.\n"
+        "MEDIA:/Users/me/.hermes/document_cache/summary.md"
+    )
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+    assert media == [
+        ("/Users/me/.hermes/document_cache/summary.md", False),
+    ]
+    assert cleaned == "Aquí está el resumen del repositorio."
+
+
+def test_extract_media_handles_multiple_mixed_extensions():
+    """Multiple MEDIA: directives — mix of old and newly supported types."""
+    content = (
+        "Three artifacts attached.\n"
+        "MEDIA:/tmp/report.md\n"
+        "MEDIA:/tmp/data.json\n"
+        "MEDIA:/tmp/screenshot.png"
+    )
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+    assert len(media) == 3
+    paths = {p for p, _ in media}
+    assert paths == {
+        "/tmp/report.md",
+        "/tmp/data.json",
+        "/tmp/screenshot.png",
+    }
+    assert "MEDIA:" not in cleaned
+
+
+def test_extract_media_audio_voice_tag_still_honored():
+    """[[audio_as_voice]] still flips is_voice=True for any audio path."""
+    content = "[[audio_as_voice]]\nMEDIA:/tmp/reply.opus"
+    media, cleaned = BasePlatformAdapter.extract_media(content)
+    assert media == [("/tmp/reply.opus", True)]
+    assert "[[audio_as_voice]]" not in cleaned


### PR DESCRIPTION
## Summary

The MEDIA:<path> directive lets an agent's text reply ship a file as a
native platform attachment. \`BasePlatformAdapter.extract_media\`
(\`gateway/platforms/base.py:~2415\`) gates extraction on a hard-coded
extension allowlist that was missing several formats agents commonly
emit — most notably \`.md\`.

This PR widens the allowlist and adds dedicated test coverage.

## The bug, in one paragraph

The failure mode is silent and confusing:

1. Agent generates \`/tmp/report.md\` and replies with \`Here you go.\nMEDIA:/tmp/report.md\`.
2. \`extract_media()\` runs the regex; \`.md\` doesn't match the allowlist → \`media_files\` stays empty → \`send_document\` is never invoked.
3. The cleanup regex further down the same code path (\`base.py:~3476\`, \`re.sub(r\"MEDIA:\\s*\\S+\", \"\", text_content)\`) still strips the \`MEDIA:...\` line from visible text.
4. Net effect: the recipient sees a reply **without** the MEDIA line **and** without the attachment, and the agent's logic thinks it succeeded. No log, no warning — just a quietly missing file.

I hit this dogfooding a Carbon Voice plugin where the agent reliably generated \`.md\` reports that never reached the user. Once \`send_document\` was confirmed working with \`.pdf\` (which was already in the allowlist), the gap narrowed to this regex.

## What this PR adds to the allowlist

| Group | New extensions | Rationale |
|---|---|---|
| text | \`md\`, \`markdown\` | reports, READMEs, agent-generated docs |
| data | \`json\`, \`yaml\`, \`yml\`, \`toml\`, \`tsv\` | config dumps, API payloads, structured exports |
| markup | \`html\`, \`htm\`, \`xml\` | rendered HTML, OPML, SVG-less XML |
| logs | \`log\` | log slices the agent pulls for the user |
| source | \`sh\`, \`py\`, \`js\`, \`ts\` | code review files, scripts the agent wrote |

Already supported (untouched here): \`txt\`, \`csv\`, \`pdf\`, all images / audio / video, office formats, \`apk\` / \`ipa\`.

## Test plan

New file \`tests/gateway/test_extract_media.py\` (52 cases):

- ✅ All 16 newly-supported extensions extract cleanly via a parametrized test
- ✅ All 26 previously-supported extensions still extract (regression guard)
- ✅ Unknown extensions (\`xyz\`, \`exe\`, \`dmg\`, \`iso\`, \`deb\`, \`rpm\`) still rejected
- ✅ Real-world variants: \`.md\` with caption preserves the caption text
- ✅ Multiple mixed-extension MEDIA: directives in one reply (\`.md\` + \`.json\` + \`.png\`)
- ✅ \`[[audio_as_voice]]\` flag still flips \`is_voice=True\` on audio paths

All 52 pass locally. Existing tests in \`tests/gateway/test_signal.py\` that exercise \`extract_media\` for \`.png\`/\`.ogg\` continue to pass.

## Companion comment in the code

Added a comment on the regex calling out the dependency with the cleanup regex on \`base.py:~3476\` — they share an implicit allowlist, and the silent-drop bug happens whenever they drift. Future contributors who add an extension to one regex will see the note pointing at the other.

## Notes

- No public API change — same function signature, same return shape, only the regex is broader.
- No behavior change for any extension that already worked.
- The widened regex doesn't overshoot into platform-incompatible types (negative tests cover \`.exe\`, \`.dmg\`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)