### PR TITLE
fix(web): hide desktop chat sidebar on mobile

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -844,7 +844,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             id="chat-side-panel"
             role="complementary"
             aria-label={modelToolsLabel}
-            className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-80"
+            className="hidden min-h-0 shrink-0 flex-col overflow-hidden lg:flex lg:h-full lg:w-80"
           >
             <div className="min-h-0 flex-1 overflow-hidden">
               <ChatSidebar channel={channel} />


### PR DESCRIPTION
## Summary
- hide the desktop chat side panel by default and only reveal it at the `lg` breakpoint
- keep the existing `!narrow` render guard, but add a CSS fallback for viewport/query mismatches on mobile
- preserve the existing mobile slide-over panel behavior

## Testing
- git diff --check
- ./node_modules/.bin/eslint src/pages/ChatPage.tsx
- npm run build

Closes #32137