### PR TITLE
feat(dashboard): HERMES_DASHBOARD_ALLOWED_HOSTS env for reverse-proxy / tunnel deployments

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -159,6 +159,22 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
+def _extra_allowed_hosts() -> frozenset:
+    """Hostnames explicitly allowed via HERMES_DASHBOARD_ALLOWED_HOSTS.
+
+    Comma-separated list, lowercased, port-stripped. Intended for reverse-proxy
+    / tunnel setups (e.g. Cloudflare Tunnel, nginx, Traefik) where the dashboard
+    binds to loopback but the public Host header is the proxy hostname. The
+    DNS-rebinding defence still applies for anything NOT on this list.
+    """
+    raw = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    if not raw:
+        return frozenset()
+    return frozenset(
+        h.strip().lower() for h in raw.split(",") if h.strip()
+    )
+
+
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     """True if the Host header targets the interface we bound to.
 
@@ -194,13 +210,17 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_host in {"0.0.0.0", "::"}:
         return True
 
-    # Loopback bind: accept the loopback names
+    # Loopback bind: accept the loopback names + any host explicitly
+    # allowlisted via HERMES_DASHBOARD_ALLOWED_HOSTS (for reverse-proxy
+    # / tunnel deployments).
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        if host_only in _LOOPBACK_HOST_VALUES:
+            return True
+        return host_only in _extra_allowed_hosts()
 
-    # Explicit non-loopback bind: require exact host match
-    return host_only == bound_lc
+    # Explicit non-loopback bind: require exact host match OR allowlist hit
+    return host_only == bound_lc or host_only in _extra_allowed_hosts()
 
 
 @app.middleware("http")

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -146,3 +146,47 @@ class TestHostHeaderMiddleware:
         resp = client.get("/api/status")
         # Should get through to the status endpoint, not a 400
         assert resp.status_code != 400
+
+    def test_allowlisted_host_accepted_on_loopback_bind(self, monkeypatch):
+        """HERMES_DASHBOARD_ALLOWED_HOSTS lets reverse-proxy / tunnel
+        deployments accept the public hostname while still binding to
+        loopback. Other hosts must still be rejected (DNS-rebinding defence)."""
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ALLOWED_HOSTS",
+            "hermes.example.com, dashboard.internal",
+        )
+        app.state.bound_host = "127.0.0.1"
+        try:
+            client = TestClient(app)
+
+            # Allowlisted host → pass middleware
+            resp = client.get(
+                "/api/status",
+                headers={"Host": "hermes.example.com"},
+            )
+            assert resp.status_code != 400 or (
+                "Invalid Host header" not in resp.json().get("detail", "")
+            )
+
+            # Case-insensitive match
+            resp = client.get(
+                "/api/status",
+                headers={"Host": "DASHBOARD.INTERNAL:443"},
+            )
+            assert resp.status_code != 400 or (
+                "Invalid Host header" not in resp.json().get("detail", "")
+            )
+
+            # Non-allowlisted host still rejected
+            resp = client.get(
+                "/api/status",
+                headers={"Host": "evil.example"},
+            )
+            assert resp.status_code == 400
+            assert "Invalid Host header" in resp.json()["detail"]
+        finally:
+            if hasattr(app.state, "bound_host"):
+                del app.state.bound_host


### PR DESCRIPTION
## Why

When running the Hermes dashboard behind a reverse proxy or tunnel (Cloudflare Tunnel, nginx, Traefik, Tailscale Funnel, etc.), the host-header DNS-rebinding defence (GHSA-ppp5-vxwm-4cf7) rejects requests because the public Host header (e.g. \`hermes.example.com\`) doesn't match the loopback bind.

Currently the only escape hatches are:
- \`--insecure --host 0.0.0.0\` — much bigger blast radius, the docs explicitly warn against it on untrusted networks.
- Patching the proxy to rewrite the Host header — not possible on all platforms (e.g. Cloudflare's token-managed tunnels no longer expose the HTTP Host Header field in the new Routes UI).

This is a fairly normal deployment pattern — bind to loopback, expose via an authenticated proxy/tunnel — and the defence shouldn't force users into less-safe alternatives.

## What

New opt-in env var:

    HERMES_DASHBOARD_ALLOWED_HOSTS=hermes.example.com,dashboard.internal

- Comma-separated, case-insensitive, port-stripped.
- Loopback names (\`localhost\`, \`127.0.0.1\`, \`::1\`) remain accepted unconditionally.
- Any host **not** on the allowlist (and not matching the bound host / a loopback alias) is still rejected with HTTP 400 — the DNS-rebinding defence remains in place for everything else.
- Empty / unset → no behaviour change (back-compat).

Pairs naturally with the existing \`HERMES_DASHBOARD_HOST\` (bind addr) env var.

## How

\`hermes_cli/web_server.py\`:
- New helper \`_extra_allowed_hosts()\` reads + parses the env var on each request (so a unit-file change is picked up on restart, no caching surprises).
- \`_is_accepted_host()\` extended: on a loopback bind, allowlisted hosts pass; on a non-loopback bind, allowlisted hosts pass alongside the exact bound-host match.

\`tests/hermes_cli/test_web_server_host_header.py\`:
- New \`test_allowlisted_host_accepted_on_loopback_bind\` covers allowlist hit, case-insensitive match, and confirms non-allowlisted hosts are still rejected.

## Tested

\`\`\`
$ ./venv/bin/python -m pytest tests/hermes_cli/test_web_server_host_header.py -q
.........                                                                [100%]
9 passed, 1 warning in 1.15s
\`\`\`

Also verified end-to-end on my own deployment (Cloudflare Tunnel → \`127.0.0.1:9119\` with Cloudflare Access OTP gating the hostname):

- \`Host: hermes.olavo.org\` → 200 ✅
- \`Host: evil.example.com\` → 400 ✅

## Docs

Happy to add a note to \`website/docs/user-guide/docker.md\` (where \`HERMES_DASHBOARD_HOST\` is documented) and/or a reverse-proxy section if you'd like — let me know your preference and I'll push it onto this branch.