### PR TITLE
fix(setup): let users revisit messaging platform selection

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2387,25 +2387,38 @@ def setup_gateway(config: dict):
     print_info("Toggle with Space, confirm with Enter.")
     print()
 
-    platforms = _all_platforms()
+    configured_this_run = False
 
-    # Build checklist, pre-selecting already-configured platforms.
-    items = []
-    pre_selected = []
-    for i, plat in enumerate(platforms):
-        status = _platform_status(plat)
-        items.append(f"{plat['emoji']} {plat['label']}  ({status})")
-        if status == "configured":
-            pre_selected.append(i)
+    while True:
+        platforms = _all_platforms()
 
-    selected = prompt_checklist("Select platforms to configure:", items, pre_selected)
+        # Build checklist, pre-selecting already-configured platforms.
+        items = []
+        pre_selected = []
+        for i, plat in enumerate(platforms):
+            status = _platform_status(plat)
+            items.append(f"{plat['emoji']} {plat['label']}  ({status})")
+            if status == "configured":
+                pre_selected.append(i)
 
-    if not selected:
-        print_info("No platforms selected. Run 'hermes setup gateway' later to configure.")
-        return
+        selected = prompt_checklist("Select platforms to configure:", items, pre_selected)
 
-    for idx in selected:
-        _configure_platform(platforms[idx])
+        if not selected:
+            if not configured_this_run:
+                print_info("No platforms selected. Run 'hermes setup gateway' later to configure.")
+                return
+            break
+
+        for idx in selected:
+            _configure_platform(platforms[idx])
+
+        configured_this_run = True
+        print()
+        if not prompt_yes_no(
+            "Return to the messaging platform list before continuing setup?",
+            False,
+        ):
+            break
 
     # ── Gateway Service Setup ──
     # Count any platform (built-in or plugin) the user configured during this

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -237,6 +237,50 @@ def test_setup_gateway_in_container_shows_docker_guidance(monkeypatch, capsys):
     assert "restart" in out.lower()
 
 
+def test_setup_gateway_allows_returning_to_platform_selection(monkeypatch):
+    import hermes_cli.gateway as gateway_mod
+
+    configured = set()
+    configure_calls = []
+    checklist_calls = []
+    prompt_answers = iter([True, False])
+    platforms = [
+        {"key": "whatsapp", "label": "WhatsApp", "emoji": "💬"},
+        {"key": "telegram", "label": "Telegram", "emoji": "✈️"},
+    ]
+
+    def fake_prompt_checklist(question, items, pre_selected=None):
+        checklist_calls.append((question, list(items), list(pre_selected or [])))
+        if len(checklist_calls) == 1:
+            return [0]
+        return [1]
+
+    def fake_configure(platform):
+        configure_calls.append(platform["key"])
+        configured.add(platform["key"])
+
+    monkeypatch.setattr(setup_mod, "prompt_checklist", fake_prompt_checklist)
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: next(prompt_answers))
+    monkeypatch.setattr(gateway_mod, "_all_platforms", lambda: platforms)
+    monkeypatch.setattr(
+        gateway_mod,
+        "_platform_status",
+        lambda platform: "configured" if platform["key"] in configured else "not configured",
+    )
+    monkeypatch.setattr(gateway_mod, "_configure_platform", fake_configure)
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_installed", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_running", lambda: False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    setup_mod.setup_gateway({})
+
+    assert configure_calls == ["whatsapp", "telegram"]
+    assert len(checklist_calls) == 2
+    assert checklist_calls[1][2] == [0]
+
+
 def test_setup_syncs_custom_provider_removal_from_disk(tmp_path, monkeypatch):
     """Removing the last custom provider in model setup should persist."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- keep first-time and full setup in the Messaging Platforms section until the user chooses to continue
- rebuild the platform checklist after each configuration pass so users can go back and pick a different platform
- add a regression test covering the return-to-selection flow

## Testing
- uv run --frozen pytest -q -o addopts='\ tests/hermes_cli/test_setup.py -k 'setup_gateway'\n- uv run --frozen pytest -q -o addopts='\ tests/hermes_cli/test_setup_irc.py -k 'setup_gateway'\n- uv run --frozen ruff check hermes_cli/setup.py tests/hermes_cli/test_setup.py\n- git diff --check\n\nCloses #32215