### PR TITLE
Add authorized-use gates to high-risk skills

### DIFF
--- a/optional-skills/research/darwinian-evolver/SKILL.md
+++ b/optional-skills/research/darwinian-evolver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: darwinian-evolver
-description: Evolve prompts/regex/SQL/code with Imbue's evolution loop.
+description: "Evolve prompts/regex/SQL/code with Imbue's evolution loop in controlled, test-owned sandboxes."
 version: 0.1.0
 author: Bihruze (Asahi0x), Hermes Agent
 license: MIT
@@ -12,6 +12,18 @@ metadata:
 ---
 
 # Darwinian Evolver
+
+## Controlled Optimization Safety Gate
+
+Use this skill only when the organism, evaluator, dataset, and execution target are **test-owned or explicitly authorized**. Evolutionary search can discover brittle, adversarial, or resource-heavy solutions; keep it contained:
+
+1. **Sandbox first:** run against local fixtures, synthetic data, or a staging target — never production databases, live customer systems, or third-party services by default.
+2. **Bounded fitness:** set max iterations, cost/time limits, rate limits, and deterministic evaluation seeds before launching a loop.
+3. **No evasion goals:** do not optimize for bypassing security controls, spam/fraud success, vulnerability exploitation, scraping protections, or policy evasion.
+4. **Review winners:** inspect evolved prompts/regex/SQL/code before reuse; reject solutions that overfit, leak data, exploit evaluator bugs, or create unsafe side effects.
+5. **Write boundary:** any generated SQL/code that mutates state, reaches networks, or touches credentials requires a separate explicit approval and dry-run evidence.
+
+If the target is not clearly authorized and sandboxed, convert the request into benchmark design or a read-only static analysis task.
 
 Run Imbue's [darwinian_evolver](https://github.com/imbue-ai/darwinian_evolver) — an
 LLM-driven evolutionary search loop — to optimize a **prompt, regex, SQL query,

--- a/skills/mlops/inference/obliteratus/SKILL.md
+++ b/skills/mlops/inference/obliteratus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obliteratus
-description: "OBLITERATUS: abliterate LLM refusals (diff-in-means)."
+description: "OBLITERATUS for authorized open-weight model-safety research and refusal-behavior analysis."
 version: 2.0.0
 author: Hermes Agent
 license: MIT
@@ -8,11 +8,23 @@ dependencies: [obliteratus, torch, transformers, bitsandbytes, accelerate, safet
 platforms: [linux, macos]
 metadata:
   hermes:
-    tags: [Abliteration, Uncensoring, Refusal-Removal, LLM, Weight-Projection, SVD, Mechanistic-Interpretability, HuggingFace, Model-Surgery]
+    tags: [Authorized-Model-Safety, Refusal-Analysis, LLM, Weight-Projection, SVD, Mechanistic-Interpretability, HuggingFace, Model-Surgery]
     related_skills: [vllm, gguf, huggingface-tokenizers]
 ---
 
 # OBLITERATUS Skill
+
+## Authorized Safety Gate
+
+Use this skill only for **authorized open-weight model research, interpretability, controlled local evaluation, or safety-differential analysis**. Before running model-surgery or refusal-ablation commands, verify all of the following:
+
+1. **Model ownership/license:** the model weights are local/open-weight and permitted for modification under their license.
+2. **Containment:** outputs stay in a private research sandbox unless a separate release review approves publication. Do not deploy altered models into user-facing, production, client, or public endpoints by default.
+3. **Purpose:** the work is to understand refusal circuits, compare safety behavior, evaluate alignment methods, or build mitigations — not to create a public harmful-content generator.
+4. **Evaluation:** run pre/post safety and capability benchmarks; label the artifact as modified and record the source model, patch method, parameters, and known risks.
+5. **Release boundary:** uploading, distributing, or serving an ablated model is a separate high-risk action requiring explicit confirmation and a written risk note.
+
+If any gate fails, stop and use safer alternatives: activation analysis, refusal-behavior measurement, policy evaluation, or benchmark-only experiments without weight modification.
 
 ## What's inside
 

--- a/skills/red-teaming/godmode/SKILL.md
+++ b/skills/red-teaming/godmode/SKILL.md
@@ -1,17 +1,29 @@
 ---
 name: godmode
-description: "Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN."
+description: "Authorized LLM red-team prompt testing: Parseltongue, GODMODE, ULTRAPLINIAN."
 version: 1.0.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [jailbreak, red-teaming, G0DM0D3, Parseltongue, GODMODE, uncensoring, safety-bypass, prompt-engineering, L1B3RT4S]
+    tags: [authorized-red-team, model-safety, prompt-robustness, G0DM0D3, Parseltongue, GODMODE, prompt-engineering, L1B3RT4S]
     related_skills: [obliteratus]
 ---
 
 # G0DM0D3 Jailbreaking Skill
+
+## Authorized Safety Gate
+
+Use this skill only for **authorized safety research, controlled red-team evaluation, or local/offline model robustness testing**. Before following any operational prompt-bypass recipe, verify all of the following:
+
+1. **Authorization:** the target system/model/account is owned by the user, explicitly assigned for testing, or a local/offline sandbox.
+2. **Purpose:** the goal is defensive evaluation, documentation, benchmarking, or mitigation — not evading a third-party service policy, committing abuse, or helping another party bypass safeguards.
+3. **Containment:** do not persist jailbreak prompts into always-on config, gateway persona, cron jobs, public content, or third-party interactions without a separate explicit approval.
+4. **No harmful payloads:** refuse requests that ask for malware, credential theft, fraud, privacy invasion, weaponization, or instructions to bypass real-world safety controls.
+5. **Reporting:** when testing succeeds, document scope, model/version, prompt class, observed behavior, and mitigation suggestions; do not publish exploit prompts publicly without responsible-disclosure review.
+
+If any gate fails, stop using this skill and switch to a defensive alternative: threat modeling, policy test design, benchmark design, or safe prompt-hardening guidance.
 
 Bypass safety filters on API-served LLMs using techniques from [G0DM0D3](https://github.com/elder-plinius/G0DM0D3) and [L1B3RT4S](https://github.com/elder-plinius/L1B3RT4S). Three attack modes plus Hermes-native configuration for persistent jailbreaking.
 


### PR DESCRIPTION
## Summary
- Reframe `godmode` as authorized LLM red-team prompt testing and add an explicit safety gate.
- Reframe `obliteratus` as authorized open-weight model-safety research and add an explicit safety gate.
- Add a controlled optimization safety gate to optional `darwinian-evolver`.

## Verification
- Parsed touched SKILL.md frontmatter with PyYAML.
- Verified each touched file contains the expected safety-gate heading.

## Notes
This PR only changes skill documentation/routing metadata; no runtime code changes.