### PR TITLE
fix(dashboard): prevent crash when custom provider models use dict format

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3260,12 +3260,20 @@ def _normalize_custom_provider_entry(
         normalized["models"] = models
     elif isinstance(models, list) and models:
         # Hand-edited configs (and older Hermes versions) write ``models`` as
-        # a plain list of model ids. Preserve them by converting to the dict
-        # shape downstream code expects; otherwise normalize silently drops
-        # the list and /model shows the provider with (0) models.
-        normalized["models"] = {
-            str(m): {} for m in models if isinstance(m, str) and m.strip()
-        }
+        # a plain list of model ids.  v12+ ``providers:`` entries use dicts
+        # with ``id`` / ``name`` keys.  Normalise both forms to the dict shape
+        # downstream code expects; otherwise the Dashboard model picker
+        # receives opaque objects it can't render.
+        result: Dict[str, Dict] = {}
+        for m in models:
+            if isinstance(m, dict):
+                mid = str(m.get("id", "") or "").strip()
+                if mid:
+                    result[mid] = {}
+            elif isinstance(m, str) and m.strip():
+                result[m.strip()] = {}
+        if result:
+            normalized["models"] = result
 
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1044,6 +1044,25 @@ def switch_model(
 # Authenticated providers listing (for /model no-args display)
 # ---------------------------------------------------------------------------
 
+def _extract_model_id(entry) -> str:
+    """Extract a model id string from a config entry.
+
+    The ``providers:`` and ``custom_providers:`` schemas accept model entries
+    as either a plain string (``"qwen36-mtp"``) or a dict with ``id`` and
+    ``name`` keys (``{id: qwen36-mtp, name: Qwen3.6 MTP}``).  This helper
+    normalises both forms to a plain id string so downstream consumers
+    (including the Dashboard model picker) never receive an opaque dict.
+    """
+    if isinstance(entry, dict):
+        mid = str(entry.get("id", "") or "").strip()
+        if mid:
+            return mid
+        return ""
+    if isinstance(entry, str):
+        return entry.strip()
+    return ""
+
+
 def list_authenticated_providers(
     current_provider: str = "",
     current_base_url: str = "",
@@ -1503,8 +1522,9 @@ def list_authenticated_providers(
                         models_list.append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in models_list:
-                        models_list.append(m)
+                    mid = _extract_model_id(m)
+                    if mid and mid not in models_list:
+                        models_list.append(mid)
 
             # Official OpenAI API rows in providers: often have base_url but no
             # explicit models: dict — avoid a misleading zero count in /model.
@@ -1643,8 +1663,9 @@ def list_authenticated_providers(
                         groups[group_key]["models"].append(m)
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
-                    if m and m not in groups[group_key]["models"]:
-                        groups[group_key]["models"].append(m)
+                    mid = _extract_model_id(m)
+                    if mid and mid not in groups[group_key]["models"]:
+                        groups[group_key]["models"].append(mid)
 
         _section4_emitted_slugs: set = set()
         for grp_key, grp in groups.items():

--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -105,7 +105,12 @@ export function ModelPickerDialog(props: Props) {
     promise
       .then((r) => {
         if (closedRef.current) return;
-        const next = r?.providers ?? [];
+        const next = (r?.providers ?? []).map((p) => ({
+          ...p,
+          models: (p.models ?? []).map((m: unknown) =>
+            typeof m === "string" ? m : String(m),
+          ),
+        }));
         setProviders(next);
         setCurrentModel(String(r?.model ?? ""));
         setCurrentProviderSlug(String(r?.provider ?? ""));


### PR DESCRIPTION
## Summary

Fixes #32334 — Dashboard "SET MAIN MODEL" freezes/black screens when selecting a named custom provider.

## Root Cause

When v12+ `providers:` config entries declare models as dicts with `id`/`name` keys:
```yaml
providers:
  qwen36mtp8081:
    type: openai
    base_url: http://127.0.0.1:8081/v1
    api_key: ""
    models:
      - id: qwen36-mtp
        name: Qwen3.6 MTP
```

The inventory code in `list_authenticated_providers()` passed the raw dicts through to the Dashboard model picker. React then threw `"Objects are not valid as a React child"` when rendering the `ModelColumn`, crashing the entire Dashboard into a black screen.

## Fix

Normalise model entries to plain id strings at three layers:

1. **`hermes_cli/model_switch.py`** — Added `_extract_model_id()` helper that handles both string and dict model entries. Applied it in section 3 (`user_providers`) and section 4 (`custom_providers`).
2. **`hermes_cli/config.py`** — Updated `_normalize_custom_provider_entry()` to extract model IDs from dict entries instead of silently dropping them.
3. **`web/src/components/ModelPickerDialog.tsx`** — Added defensive coercion of non-string model values as a fallback.

## Test Plan

- [x] `_extract_model_id()` unit tests pass (string, dict, dict-without-id, empty, whitespace)
- [x] `_normalize_custom_provider_entry()` handles list-of-dicts, list-of-strings, and mixed formats
- [x] End-to-end simulation with the exact config from #32334 returns `['qwen36-mtp']` (strings) instead of `[{'id': 'qwen36-mtp', 'name': 'Qwen3.6 MTP'}]` (dicts)
