### PR TITLE
fix(bedrock): register AWS credential env vars in subprocess credential blocklist

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -452,7 +452,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         name="AWS Bedrock",
         auth_type="aws_sdk",
         inference_base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
-        api_key_env_vars=(),
+        api_key_env_vars=(
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "AWS_PROFILE",
+            "AWS_DEFAULT_REGION",
+            "AWS_ROLE_ARN",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+        ),
         base_url_env_var="BEDROCK_BASE_URL",
     ),
     "azure-foundry": ProviderConfig(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -505,6 +505,7 @@ AUTHOR_MAP = {
     "xiahu889889@proton.me": "xiahu88988",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
+    "hiddenpuppy@users.noreply.github.com": "HiddenPuppy",
     "tsuijinglei@gmail.com": "hiddenpuppy",
     "buraysandro9@gmail.com": "ygd58",
     "jerome@clawwork.ai": "HiddenPuppy",

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -27,11 +27,17 @@ class TestProviderRegistry:
         pconfig = PROVIDER_REGISTRY["bedrock"]
         assert pconfig.auth_type == "aws_sdk"
 
-    def test_bedrock_has_no_api_key_env_vars(self):
-        """Bedrock uses the AWS SDK credential chain, not API keys."""
+    def test_bedrock_has_aws_sdk_env_vars_in_api_key_env_vars(self):
+        """Bedrock registers AWS SDK env vars in api_key_env_vars for subprocess blocklisting."""
         from hermes_cli.auth import PROVIDER_REGISTRY
         pconfig = PROVIDER_REGISTRY["bedrock"]
-        assert pconfig.api_key_env_vars == ()
+        aws_vars = pconfig.api_key_env_vars
+        assert "AWS_ACCESS_KEY_ID" in aws_vars
+        assert "AWS_SECRET_ACCESS_KEY" in aws_vars
+        assert "AWS_SESSION_TOKEN" in aws_vars
+        assert "AWS_BEARER_TOKEN_BEDROCK" in aws_vars
+        assert "AWS_PROFILE" in aws_vars
+        assert "AWS_DEFAULT_REGION" in aws_vars
 
     def test_bedrock_base_url_env_var(self):
         from hermes_cli.auth import PROVIDER_REGISTRY


### PR DESCRIPTION
## Summary

This PR fixes a security issue where AWS credential environment variables leak to agent-spawned subprocesses (terminal, execute_code, MCP servers) when using AWS Bedrock as the inference provider.

## Root Cause

In `hermes_cli/auth.py`, the built-in Bedrock `ProviderConfig` is defined with `api_key_env_vars=()` (empty tuple). The subprocess environment blocklist builder in `tools/environments/local.py` (`_build_provider_env_blocklist()`) only consumes `api_key_env_vars` from each provider config:

```python
for pconfig in PROVIDER_REGISTRY.values():
    blocked.update(pconfig.api_key_env_vars)
```

Since bedrock's tuple was empty, none of the standard AWS SDK credential environment variables were ever added to `_HERMES_PROVIDER_ENV_BLOCKLIST`, causing them to leak to all subprocesses.

## Impact

- Subprocesses (terminal, `execute_code`, MCP servers, agent delegations) silently inherit AWS credentials
- Tools that enumerate available models (e.g., `opencode models`) show Bedrock models inadvertently
- If `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` leak, subprocesses inherit all of the user's AWS capabilities
- Cost-incurring API calls may occur without the user's awareness

## Fix

Add the standard AWS SDK credential environment variables to the Bedrock `ProviderConfig.api_key_env_vars`:

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`  
- `AWS_SESSION_TOKEN`
- `AWS_BEARER_TOKEN_BEDROCK`
- `AWS_PROFILE`
- `AWS_DEFAULT_REGION`
- `AWS_ROLE_ARN`
- `AWS_WEB_IDENTITY_TOKEN_FILE`

The `auth_type=\"aws_sdk\"` field is already defined on the bedrock config; the blocklist builder already iterates all providers. The only gap was that no AWS credential env vars were listed.

Closes #32314