### PR TITLE
fix(compression): mark pruned skill_view summaries (#32106)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -412,7 +412,14 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
             code_preview += "..."
         return f"[execute_code] `{code_preview}` ({line_count} lines output)"
 
-    if tool_name in {"skill_view", "skills_list", "skill_manage"}:
+    if tool_name == "skill_view":
+        name = args.get("name", "?")
+        return (
+            f"[{tool_name}] name={name} ({content_len:,} chars) "
+            "[SKILL_PRUNED: content lost in compression; reload with skill_view before relying on it]"
+        )
+
+    if tool_name in {"skills_list", "skill_manage"}:
         name = args.get("name", "?")
         return f"[{tool_name}] name={name} ({content_len:,} chars)"
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3,7 +3,11 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.context_compressor import (
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    _summarize_tool_result,
+)
 
 
 @pytest.fixture()
@@ -98,6 +102,29 @@ class TestCompress:
         # (head=assistant, tail=user in this fixture).  Verify the
         # original content is present in either case.
         assert msgs[-2]["content"] in result[-2]["content"]
+
+
+class TestToolResultSummaries:
+    def test_skill_view_summary_marks_pruned_content(self):
+        summary = _summarize_tool_result(
+            "skill_view",
+            '{"name":"docker-management"}',
+            "x" * 1234,
+        )
+
+        assert summary.startswith("[skill_view] name=docker-management (1,234 chars)")
+        assert "[SKILL_PRUNED:" in summary
+        assert "reload with skill_view" in summary
+
+    def test_other_skill_tool_summaries_remain_metadata_only(self):
+        summary = _summarize_tool_result(
+            "skills_list",
+            '{"name":"docker-management"}',
+            "x" * 128,
+        )
+
+        assert summary == "[skills_list] name=docker-management (128 chars)"
+        assert "[SKILL_PRUNED:" not in summary
 
 
 class TestGenerateSummaryNoneContent:


### PR DESCRIPTION
## Summary
- mark compressed `skill_view` tool results with an explicit `[SKILL_PRUNED]` reload marker
- keep `skills_list` and `skill_manage` summaries metadata-only
- add targeted compressor tests for the new `skill_view` marker behavior

## Testing
- `uv run --frozen pytest -q -o addopts= tests/agent/test_context_compressor.py -k 'skill_view_summary_marks_pruned_content or other_skill_tool_summaries_remain_metadata_only'`\n- `uv run --frozen ruff check agent/context_compressor.py tests/agent/test_context_compressor.py`\n- `git diff --check`