### PR TITLE
fix(schema): sanitize Gemini tool schemas in the chat-completions transport (#30676)

### DIFF
--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 # Gemini's ``FunctionDeclaration.parameters`` field accepts the ``Schema``
 # object, which is only a subset of OpenAPI 3.0 / JSON Schema.  Strip fields
@@ -75,6 +75,31 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
             continue
         cleaned[key] = value
 
+    # Gemini's Schema object requires ``type`` to be a single string, not an
+    # array.  JSON Schema allows union type arrays like ``["number", "string"]``
+    # or nullable shorthands like ``["string", "null"]``, but Gemini rejects
+    # them with HTTP 400.  Collapse to the most permissive non-null scalar:
+    #   ["string", "null"]         → type: "string", nullable: true
+    #   ["number", "string"]       → type: "string"  (string is most permissive)
+    #   ["integer", "null"]        → type: "integer", nullable: true
+    #   ["null"]                   → type: "string"   (fallback)
+    # This MUST run before the enum rule below: that rule does a ``set``
+    # membership test on ``type``, and an array (list) type there raises
+    # ``TypeError: unhashable type: 'list'`` for a schema that carries both an
+    # array type and an enum (e.g. ``{"type": ["integer", "null"], "enum": [1]}``).
+    type_val = cleaned.get("type")
+    if isinstance(type_val, list):
+        non_null = [t for t in type_val if isinstance(t, str) and t != "null"]
+        has_null = any(t == "null" for t in type_val if isinstance(t, str))
+        if not non_null:
+            cleaned["type"] = "string"
+        elif len(non_null) == 1:
+            cleaned["type"] = non_null[0]
+        else:
+            cleaned["type"] = "string" if "string" in non_null else non_null[0]
+        if has_null:
+            cleaned["nullable"] = True
+
     # Gemini's Schema validator requires every ``enum`` entry to be a string,
     # even when the parent ``type`` is ``integer`` / ``number`` / ``boolean``.
     # Preserve those constraints by stringifying scalar values while keeping
@@ -138,3 +163,28 @@ def sanitize_gemini_tool_parameters(parameters: Any) -> Dict[str, Any]:
     if not cleaned:
         return {"type": "object", "properties": {}}
     return cleaned
+
+
+def sanitize_gemini_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Sanitize an OpenAI-format tool list for Gemini's strict schema subset.
+
+    Applies ``sanitize_gemini_tool_parameters`` to each tool's ``parameters``
+    field.  Used in the chat-completions transport for Gemini models reached
+    via OpenAI-compatible endpoints (Copilot, Google AI Studio /openai, etc.)
+    that enforce the same schema restrictions as the native Gemini API.
+    """
+    result: List[Dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            result.append(tool)
+            continue
+        fn = tool.get("function")
+        if not isinstance(fn, dict):
+            result.append(tool)
+            continue
+        params = fn.get("parameters")
+        if params is None:
+            result.append(tool)
+            continue
+        result.append({**tool, "function": {**fn, "parameters": sanitize_gemini_tool_parameters(params)}})
+    return result

--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from tools.schema_sanitizer import _normalize_type_array
 
@@ -112,3 +112,28 @@ def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
 def sanitize_gemini_tool_parameters(parameters: Any) -> Dict[str, Any]:
     """Normalize tool parameters to a valid Gemini object schema."""
     return sanitize_gemini_schema(parameters) or {"type": "object", "properties": {}}
+
+
+def sanitize_gemini_tools(tools: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Sanitize an OpenAI-format tool list for Gemini's strict schema subset.
+
+    Applies ``sanitize_gemini_tool_parameters`` to each tool's ``parameters``
+    field.  Used in the chat-completions transport for Gemini models reached
+    via OpenAI-compatible endpoints (Copilot, Google AI Studio /openai, etc.)
+    that enforce the same schema restrictions as the native Gemini API.
+    """
+    result: List[Dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict):
+            result.append(tool)
+            continue
+        fn = tool.get("function")
+        if not isinstance(fn, dict):
+            result.append(tool)
+            continue
+        params = fn.get("parameters")
+        if params is None:
+            result.append(tool)
+            continue
+        result.append({**tool, "function": {**fn, "parameters": sanitize_gemini_tool_parameters(params)}})
+    return result

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -11,6 +11,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 
 from typing import Any, Dict
 
+from agent.gemini_schema import sanitize_gemini_tools
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
@@ -126,6 +127,20 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     """
     m = str(model or "").lower()
     return "gemini" in m or "gemma" in m
+
+
+def _is_gemini_chat_completions_model(model: str) -> bool:
+    """True for Gemini models reaching the chat-completions transport.
+
+    Applies to direct endpoints (Copilot, Google AI Studio /openai) and
+    aggregators (OpenRouter, Nous) that forward the model name unchanged.
+    The sanitizer only drops schema constructs Gemini rejects — it is safe
+    to apply even on tolerant aggregators that would accept the richer form.
+    """
+    m = (model or "").strip().lower()
+    if m.startswith("google/"):
+        m = m[7:]
+    return m.startswith("gemini-")
 
 
 class ChatCompletionsTransport(ProviderTransport):
@@ -371,6 +386,8 @@ class ChatCompletionsTransport(ProviderTransport):
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            elif _is_gemini_chat_completions_model(model):
+                tools = sanitize_gemini_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > provider default
@@ -552,10 +569,12 @@ class ChatCompletionsTransport(ProviderTransport):
         if timeout is not None:
             api_kwargs["timeout"] = timeout
 
-        # Tools — apply Moonshot/Kimi schema sanitization regardless of path
+        # Tools — apply model-specific schema sanitization regardless of path
         if tools:
             if is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
+            elif _is_gemini_chat_completions_model(model):
+                tools = sanitize_gemini_tools(tools)
             api_kwargs["tools"] = tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -8,6 +8,7 @@ import json
 from typing import Any
 from urllib.parse import urlparse
 
+from agent.gemini_schema import sanitize_gemini_tools
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.reasoning_effort import (
     KIMI_K3_EFFORTS, KIMI_K3_OVERRIDES, OPENAI_COMPAT_WIRE_EFFORTS, TOKENHUB_EFFORTS, clamp_effort,
@@ -217,6 +218,20 @@ def _attr_or_model_extra(obj: Any, name: str) -> Any:
     return value
 
 
+def _is_gemini_chat_completions_model(model: str) -> bool:
+    """True for Gemini models reaching the chat-completions transport.
+
+    Applies to direct endpoints (Copilot, Google AI Studio /openai) and
+    aggregators (OpenRouter, Nous) that forward the model name unchanged.
+    The sanitizer only drops schema constructs Gemini rejects — it is safe
+    to apply even on tolerant aggregators that would accept the richer form.
+    """
+    m = (model or "").strip().lower()
+    if m.startswith("google/"):
+        m = m[7:]
+    return m.startswith("gemini-")
+
+
 def _dump_extra_content(extra: Any) -> Any:
     """Plain-dict form of a pydantic ``extra_content``; older pydantic lacks ``warnings=``, so retry without it."""
     if hasattr(extra, "model_dump"):
@@ -279,8 +294,13 @@ def _base_kwargs(model: str, sanitized: list, tools: Any, params: dict, profile:
     if params.get("timeout") is not None:
         api_kwargs["timeout"] = params["timeout"]
     if tools:
-        # Moonshot/Kimi uses a stricter JSON Schema flavor; rewriting here also covers aggregator routes.
-        api_kwargs["tools"] = sanitize_moonshot_tools(tools) if is_moonshot_model(model) else tools
+        # Moonshot/Kimi and Gemini each need a stricter JSON Schema flavor; rewriting here also
+        # covers aggregator routes (Nous, OpenRouter) that forward the model name unchanged.
+        if is_moonshot_model(model):
+            tools = sanitize_moonshot_tools(tools)
+        elif _is_gemini_chat_completions_model(model):
+            tools = sanitize_gemini_tools(tools)
+        api_kwargs["tools"] = tools
     return api_kwargs
 
 

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -3,6 +3,7 @@
 from agent.gemini_schema import (
     sanitize_gemini_schema,
     sanitize_gemini_tool_parameters,
+    sanitize_gemini_tools,
 )
 
 
@@ -76,6 +77,84 @@ class TestSanitizeGeminiSchema:
         assert sanitize_gemini_schema(None) == {}
         assert sanitize_gemini_schema("not a schema") == {}
         assert sanitize_gemini_schema([1, 2, 3]) == {}
+
+    # --- union type array collapsing ---
+
+    def test_nullable_string_shorthand_collapses_to_string_nullable(self):
+        """["string", "null"] → type: string, nullable: true."""
+        schema = {"type": ["string", "null"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "string"
+        assert cleaned["nullable"] is True
+
+    def test_nullable_integer_collapses_correctly(self):
+        """["integer", "null"] → type: integer, nullable: true."""
+        schema = {"type": ["integer", "null"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "integer"
+        assert cleaned["nullable"] is True
+
+    def test_union_without_null_picks_string_when_present(self):
+        """["number", "string"] → type: string (most permissive)."""
+        schema = {"type": ["number", "string"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "string"
+        assert "nullable" not in cleaned
+
+    def test_union_without_null_picks_first_when_no_string(self):
+        """["integer", "number"] → type: integer (first in list)."""
+        schema = {"type": ["integer", "number"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "integer"
+        assert "nullable" not in cleaned
+
+    def test_null_only_type_falls_back_to_string(self):
+        """["null"] → type: string (degenerate case)."""
+        schema = {"type": ["null"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "string"
+
+    def test_array_type_with_integer_enum_does_not_raise_and_stringifies_enum(self):
+        """An array type paired with an integer enum must not raise.
+
+        The enum rule does a ``set`` membership test on ``type``; a list type
+        there raised ``TypeError: unhashable type: 'list'`` before the array
+        collapse was reordered ahead of it. After collapsing to ``integer`` the
+        integer enum is stringified per Gemini's string-only enum rule. (repro
+        from #55643)
+        """
+        schema = {"type": ["integer", "null"], "enum": [1, 2, 3]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "integer"
+        assert cleaned["nullable"] is True
+        assert cleaned["enum"] == ["1", "2", "3"]
+
+    def test_array_type_with_string_enum_preserves_enum(self):
+        """A nullable string union keeps a valid string enum after collapsing."""
+        schema = {"type": ["string", "null"], "enum": ["a", "b"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "string"
+        assert cleaned["nullable"] is True
+        assert cleaned["enum"] == ["a", "b"]
+
+    def test_union_type_array_inside_properties(self):
+        """The fix recurses into properties — the lcm_grep repro case."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "time_from": {"type": ["number", "string"]},
+            },
+            "required": ["query"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["properties"]["query"]["type"] == "string"
+        assert cleaned["properties"]["time_from"]["type"] == "string"
+
+    def test_scalar_type_string_unchanged(self):
+        """A plain string ``type`` must not be touched."""
+        schema = {"type": "string"}
+        assert sanitize_gemini_schema(schema)["type"] == "string"
 
 
 class TestRequiredPropertyPruning:
@@ -167,3 +246,81 @@ class TestSanitizeGeminiToolParameters:
         assert "1440" in aad["description"]
         # And the string-enum sibling is untouched.
         assert cleaned["properties"]["action"]["enum"] == ["create_thread"]
+
+
+class TestSanitizeGeminiTools:
+    """Tests for the OpenAI-format tool-list wrapper used by chat_completions."""
+
+    def test_lcm_grep_union_type_fixed(self):
+        """End-to-end: the exact schema reported in #30676 repro 2."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lcm_grep",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "time_from": {"type": ["number", "string"]},
+                        },
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        result = sanitize_gemini_tools(tools)
+        props = result[0]["function"]["parameters"]["properties"]
+        assert props["query"]["type"] == "string"
+        assert props["time_from"]["type"] == "string"
+        assert "nullable" not in props["time_from"]
+
+    def test_discord_integer_enum_fixed(self):
+        """End-to-end: the exact schema reported in #30676 repro 1."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "discord",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "action": {"type": "string", "enum": ["create_thread"]},
+                            "auto_archive_duration": {
+                                "type": "integer",
+                                "enum": [60, 1440, 4320, 10080],
+                            },
+                        },
+                        "required": ["action"],
+                    },
+                },
+            }
+        ]
+        result = sanitize_gemini_tools(tools)
+        props = result[0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
+        assert props["action"]["enum"] == ["create_thread"]
+
+    def test_non_dict_tool_passed_through_unchanged(self):
+        tools = ["not-a-tool", 42]
+        assert sanitize_gemini_tools(tools) == ["not-a-tool", 42]
+
+    def test_tool_without_function_key_passed_through(self):
+        tool = {"type": "function"}
+        assert sanitize_gemini_tools([tool]) == [tool]
+
+    def test_original_tool_list_not_mutated(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {"type": "object", "properties": {"x": {"type": ["string", "null"]}}},
+                },
+            }
+        ]
+        original_type = tools[0]["function"]["parameters"]["properties"]["x"]["type"]
+        sanitize_gemini_tools(tools)
+        assert tools[0]["function"]["parameters"]["properties"]["x"]["type"] == original_type

--- a/tests/agent/test_gemini_schema.py
+++ b/tests/agent/test_gemini_schema.py
@@ -3,6 +3,7 @@
 from agent.gemini_schema import (
     sanitize_gemini_schema,
     sanitize_gemini_tool_parameters,
+    sanitize_gemini_tools,
 )
 
 
@@ -76,6 +77,78 @@ class TestSanitizeGeminiSchema:
         assert sanitize_gemini_schema(None) == {}
         assert sanitize_gemini_schema("not a schema") == {}
         assert sanitize_gemini_schema([1, 2, 3]) == {}
+
+    # --- union type array collapsing ---
+
+    def test_nullable_string_shorthand_collapses_to_string_nullable(self):
+        """["string", "null"] → type: string, nullable: true."""
+        schema = {"type": ["string", "null"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "string"
+        assert cleaned["nullable"] is True
+
+    def test_nullable_integer_collapses_correctly(self):
+        """["integer", "null"] → type: integer, nullable: true."""
+        schema = {"type": ["integer", "null"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "integer"
+        assert cleaned["nullable"] is True
+
+    def test_union_without_null_becomes_anyof_branches(self):
+        """["number", "string"] → anyOf branches (union alternatives are preserved
+        as Gemini-valid anyOf rather than lossy-collapsed to one scalar)."""
+        cleaned = sanitize_gemini_schema({"type": ["number", "string"]})
+        assert cleaned == {"anyOf": [{"type": "number"}, {"type": "string"}]}
+        assert "type" not in cleaned
+
+    def test_union_without_null_preserves_all_alternatives(self):
+        """["integer", "number"] → anyOf preserving both branches in order."""
+        cleaned = sanitize_gemini_schema({"type": ["integer", "number"]})
+        assert cleaned == {"anyOf": [{"type": "integer"}, {"type": "number"}]}
+
+    def test_array_type_with_integer_enum_does_not_raise_and_stringifies_enum(self):
+        """An array type paired with an integer enum must not raise.
+
+        The enum rule does a ``set`` membership test on ``type``; a list type
+        there raised ``TypeError: unhashable type: 'list'`` before the array
+        collapse was reordered ahead of it. After collapsing to ``integer`` the
+        integer enum is stringified per Gemini's string-only enum rule. (repro
+        from #55643)
+        """
+        schema = {"type": ["integer", "null"], "enum": [1, 2, 3]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "integer"
+        assert cleaned["nullable"] is True
+        assert cleaned["enum"] == ["1", "2", "3"]
+
+    def test_array_type_with_string_enum_preserves_enum(self):
+        """A nullable string union keeps a valid string enum after collapsing."""
+        schema = {"type": ["string", "null"], "enum": ["a", "b"]}
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["type"] == "string"
+        assert cleaned["nullable"] is True
+        assert cleaned["enum"] == ["a", "b"]
+
+    def test_union_type_array_inside_properties(self):
+        """The fix recurses into properties — the lcm_grep repro case."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "time_from": {"type": ["number", "string"]},
+            },
+            "required": ["query"],
+        }
+        cleaned = sanitize_gemini_schema(schema)
+        assert cleaned["properties"]["query"]["type"] == "string"
+        assert cleaned["properties"]["time_from"] == {
+            "anyOf": [{"type": "number"}, {"type": "string"}]
+        }
+
+    def test_scalar_type_string_unchanged(self):
+        """A plain string ``type`` must not be touched."""
+        schema = {"type": "string"}
+        assert sanitize_gemini_schema(schema)["type"] == "string"
 
 
 class TestRequiredPropertyPruning:
@@ -167,3 +240,81 @@ class TestSanitizeGeminiToolParameters:
         assert "1440" in aad["description"]
         # And the string-enum sibling is untouched.
         assert cleaned["properties"]["action"]["enum"] == ["create_thread"]
+
+
+class TestSanitizeGeminiTools:
+    """Tests for the OpenAI-format tool-list wrapper used by chat_completions."""
+
+    def test_lcm_grep_union_type_fixed(self):
+        """End-to-end: the exact schema reported in #30676 repro 2."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lcm_grep",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "time_from": {"type": ["number", "string"]},
+                        },
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        result = sanitize_gemini_tools(tools)
+        props = result[0]["function"]["parameters"]["properties"]
+        assert props["query"]["type"] == "string"
+        # The union type is preserved as Gemini-valid anyOf branches.
+        assert props["time_from"] == {"anyOf": [{"type": "number"}, {"type": "string"}]}
+
+    def test_discord_integer_enum_fixed(self):
+        """End-to-end: the exact schema reported in #30676 repro 1."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "discord",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "action": {"type": "string", "enum": ["create_thread"]},
+                            "auto_archive_duration": {
+                                "type": "integer",
+                                "enum": [60, 1440, 4320, 10080],
+                            },
+                        },
+                        "required": ["action"],
+                    },
+                },
+            }
+        ]
+        result = sanitize_gemini_tools(tools)
+        props = result[0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
+        assert props["action"]["enum"] == ["create_thread"]
+
+    def test_non_dict_tool_passed_through_unchanged(self):
+        tools = ["not-a-tool", 42]
+        assert sanitize_gemini_tools(tools) == ["not-a-tool", 42]
+
+    def test_tool_without_function_key_passed_through(self):
+        tool = {"type": "function"}
+        assert sanitize_gemini_tools([tool]) == [tool]
+
+    def test_original_tool_list_not_mutated(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {"type": "object", "properties": {"x": {"type": ["string", "null"]}}},
+                },
+            }
+        ]
+        original_type = tools[0]["function"]["parameters"]["properties"]["x"]["type"]
+        sanitize_gemini_tools(tools)
+        assert tools[0]["function"]["parameters"]["properties"]["x"]["type"] == original_type

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -354,6 +354,103 @@ class TestChatCompletionsKimi:
         # The parameters dict is passed through untouched (no synthetic type)
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
+    def test_gemini_tool_schemas_sanitized_union_type(self, transport):
+        """Gemini models via chat_completions get union type arrays collapsed (#30676)."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lcm_grep",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "time_from": {"type": ["number", "string"]},
+                        },
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        kw = transport.build_kwargs(
+            model="gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["time_from"]["type"] == "string"
+
+    def test_gemini_tool_schemas_sanitized_integer_enum(self, transport):
+        """Gemini models via chat_completions get non-string enums stringified (#30676)."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "discord",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "action": {"type": "string", "enum": ["create_thread"]},
+                            "auto_archive_duration": {
+                                "type": "integer",
+                                "enum": [60, 1440, 4320, 10080],
+                            },
+                        },
+                        "required": ["action"],
+                    },
+                },
+            }
+        ]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
+        assert props["action"]["enum"] == ["create_thread"]
+
+    def test_gemini_tool_schemas_sanitized_on_profile_route_copilot(self, transport):
+        """Registered-provider traffic (Copilot) takes the profile route; the
+        Gemini sanitizer must apply there too, not just on the legacy path (#30676)."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("copilot")
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "discord",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "auto_archive_duration": {
+                                "type": "integer",
+                                "enum": [60, 1440, 4320, 10080],
+                            },
+                            "time_from": {"type": ["number", "string"]},
+                        },
+                        "required": ["auto_archive_duration"],
+                    },
+                },
+            }
+        ]
+        kw = transport.build_kwargs(
+            model="gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            provider_profile=profile,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
+        assert props["time_from"]["type"] == "string"
+
 
 class TestChatCompletionsLmStudioReasoning:
     """LM Studio publishes per-model reasoning ``allowed_options``. When the

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -543,6 +543,103 @@ class TestChatCompletionsKimi:
         # The parameters dict is passed through untouched (no synthetic type)
         assert "type" not in kw["tools"][0]["function"]["parameters"]["properties"]["q"]
 
+    def test_gemini_tool_schemas_sanitized_union_type(self, transport):
+        """Gemini models via chat_completions get union type arrays collapsed (#30676)."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lcm_grep",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "time_from": {"type": ["number", "string"]},
+                        },
+                        "required": ["query"],
+                    },
+                },
+            }
+        ]
+        kw = transport.build_kwargs(
+            model="gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["time_from"] == {"anyOf": [{"type": "number"}, {"type": "string"}]}
+
+    def test_gemini_tool_schemas_sanitized_integer_enum(self, transport):
+        """Gemini models via chat_completions get non-string enums stringified (#30676)."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "discord",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "action": {"type": "string", "enum": ["create_thread"]},
+                            "auto_archive_duration": {
+                                "type": "integer",
+                                "enum": [60, 1440, 4320, 10080],
+                            },
+                        },
+                        "required": ["action"],
+                    },
+                },
+            }
+        ]
+        kw = transport.build_kwargs(
+            model="google/gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
+        assert props["action"]["enum"] == ["create_thread"]
+
+    def test_gemini_tool_schemas_sanitized_on_profile_route_copilot(self, transport):
+        """Registered-provider traffic (Copilot) takes the profile route; the
+        Gemini sanitizer must apply there too, not just on the legacy path (#30676)."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("copilot")
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "discord",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "auto_archive_duration": {
+                                "type": "integer",
+                                "enum": [60, 1440, 4320, 10080],
+                            },
+                            "time_from": {"type": ["number", "string"]},
+                        },
+                        "required": ["auto_archive_duration"],
+                    },
+                },
+            }
+        ]
+        kw = transport.build_kwargs(
+            model="gemini-3.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=tools,
+            provider_profile=profile,
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        props = kw["tools"][0]["function"]["parameters"]["properties"]
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
+        assert props["time_from"] == {"anyOf": [{"type": "number"}, {"type": "string"}]}
+
 
 class TestChatCompletionsLmStudioReasoning:
     """LM Studio publishes per-model reasoning ``allowed_options``. When the


### PR DESCRIPTION
Closes #30676.

## Problem

GitHub Copilot (and any other OpenAI-compat Gemini endpoint) rejects tool payloads containing:

1. **Non-string enum values** — e.g. `discord`'s `auto_archive_duration: {type: integer, enum: [60, 1440, 4320, 10080]}`
2. **Union `type` arrays** — e.g. `lcm_grep`'s `time_from: {type: ["number", "string"]}`

The native Gemini adapter (`gemini_native_adapter.py`, `gemini_cloudcode_adapter.py`) already applied `sanitize_gemini_schema` to tool parameters. The **chat-completions transport** used for Copilot, Google AI Studio `/openai`, and Gemini models via aggregators did not — causing HTTP 400 on every tool-enabled turn.

## Changes

### `agent/gemini_schema.py`

- **Union type array collapsing** (new):
  - `["string", "null"]` → `type: string, nullable: true`
  - `["integer", "null"]` → `type: integer, nullable: true`
  - `["number", "string"]` → `type: string` (most permissive non-null)
  - `["null"]` → `type: string` (degenerate fallback)
- **`sanitize_gemini_tools(tools)`** (new): applies `sanitize_gemini_tool_parameters` to each tool's `parameters` in an OpenAI-format tool list — mirrors `sanitize_moonshot_tools`.

### `agent/transports/chat_completions.py`

- **`_is_gemini_chat_completions_model(model)`** (new): detects any `gemini-*` model, stripping the `google/` prefix if present.
- Applied `sanitize_gemini_tools()` in both the legacy `build_kwargs` path and `_build_kwargs_from_profile` — the same `elif` slot used by the Moonshot sanitizer.

## Test plan

- [x] `tests/agent/test_gemini_schema.py` — 8 new tests: nullable string/integer collapsing, union without null, first-wins, null-only fallback, recursive property fix (exact lcm_grep repro), scalar type unchanged; `TestSanitizeGeminiTools` — 5 end-to-end tests covering both repros from the issue
- [x] `tests/agent/transports/test_chat_completions.py` — 2 new tests: `test_gemini_tool_schemas_sanitized_union_type` and `test_gemini_tool_schemas_sanitized_integer_enum`
- [x] `scripts/run_tests.sh tests/agent/ tests/tools/` — 94 new + existing tests pass; only pre-existing unrelated failures (anthropic adapter OAuth credentials, LSP E2E)
- [x] `scripts/check-windows-footguns.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
