### PR TITLE
fix(signal): detect and warn about bbernhard/signal-cli-rest-api incompatibility

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -272,6 +272,15 @@ class SignalAdapter(BasePlatformAdapter):
             # Health check — verify signal-cli daemon is reachable
             try:
                 resp = await self.client.get(f"{self.http_url}/api/v1/check", timeout=10.0)
+                if resp.status_code == 404:
+                    logger.error(
+                        "Signal: health check returned 404 at %s/api/v1/check. "
+                        "If you are using the bbernhard/signal-cli-rest-api Docker image "
+                        "it is API-incompatible with Hermes — use the native signal-cli "
+                        "daemon instead: signal-cli --account +YOURNUMBER daemon --http 127.0.0.1:8080. "
+                        "See https://hermes-agent.nousresearch.com/docs/user-guide/messaging/signal",
+                    )
+                    return False
                 if resp.status_code != 200:
                     logger.error("Signal: health check failed (status %d)", resp.status_code)
                     return False
@@ -417,6 +426,13 @@ class SignalAdapter(BasePlatformAdapter):
                         # avoid repeated warnings (connection may just be quiet)
                         self._last_sse_activity = time.time()
                         logger.debug("Signal: daemon healthy, SSE idle")
+                    elif resp.status_code == 404:
+                        logger.warning(
+                            "Signal: health check returned 404 — "
+                            "bbernhard/signal-cli-rest-api is API-incompatible with Hermes. "
+                            "Use the native signal-cli daemon instead.",
+                        )
+                        self._force_reconnect()
                     else:
                         logger.warning("Signal: health check failed (%d), forcing reconnect", resp.status_code)
                         self._force_reconnect()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4647,7 +4647,7 @@ def _setup_signal():
         print_info("  Install options:")
         print_info("    Linux:  download from https://github.com/AsamK/signal-cli/releases")
         print_info("    macOS:  brew install signal-cli")
-        print_info("    Docker: bbernhard/signal-cli-rest-api")
+        print_info("    Docker: run signal-cli in a container and expose port 8080")
         print()
         print_info("  After installing, link your account and start the daemon:")
         print_info("    signal-cli link -n \"HermesAgent\"")
@@ -4671,6 +4671,13 @@ def _setup_signal():
         resp = httpx.get(f"{url.rstrip('/')}/api/v1/check", timeout=10.0)
         if resp.status_code == 200:
             print_success("  signal-cli daemon is reachable!")
+        elif resp.status_code == 404:
+            print_warning(f"  Health check returned 404 at {url.rstrip('/')}/api/v1/check.")
+            print_warning("  bbernhard/signal-cli-rest-api is API-incompatible with Hermes.")
+            print_info("  Use the native signal-cli daemon instead:")
+            print_info("    signal-cli --account +YOURNUMBER daemon --http 127.0.0.1:8080")
+            if not prompt_yes_no("  Save this URL anyway?", False):
+                return
         else:
             print_warning(f"  signal-cli responded with status {resp.status_code}.")
             if not prompt_yes_no("  Continue anyway?", False):

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -8,6 +8,10 @@ description: "Set up Hermes Agent as a Signal messenger bot via signal-cli daemo
 
 Hermes connects to Signal through the [signal-cli](https://github.com/AsamK/signal-cli) daemon running in HTTP mode. The adapter streams messages in real-time via SSE (Server-Sent Events) and sends responses via JSON-RPC.
 
+:::danger bbernhard/signal-cli-rest-api is incompatible
+The popular [bbernhard/signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) Docker image exposes a **different** REST API (`/v1/health`, `/v2/send`, etc.) and is **not compatible** with the Hermes Signal adapter. Hermes requires the native `signal-cli daemon --http` API (`/api/v1/check`, `/api/v1/events`, `/api/v1/rpc`). Using the bbernhard wrapper will result in health-check 404 errors and the adapter will never connect.
+:::
+
 Signal is the most privacy-focused mainstream messenger — end-to-end encrypted by default, open-source protocol, minimal metadata collection. This makes it ideal for security-sensitive agent workflows.
 
 :::info No New Python Dependencies
@@ -219,7 +223,8 @@ The adapter monitors the SSE connection and automatically reconnects if:
 | **"Cannot reach signal-cli"** during setup | Ensure signal-cli daemon is running: `signal-cli --account +YOUR_NUMBER daemon --http 127.0.0.1:8080` |
 | **Messages not received** | Check that `SIGNAL_ALLOWED_USERS` includes the sender's number in E.164 format (with `+` prefix) |
 | **"signal-cli not found on PATH"** | Install signal-cli and ensure it's in your PATH, or use Docker |
-| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 17+ is installed. |
+| **Health check returns 404** | You may be using bbernhard/signal-cli-rest-api, which is API-incompatible. Use the native signal-cli daemon instead. |
+| **Connection keeps dropping** | Check signal-cli logs for errors. Ensure Java 25+ is installed (0.14.x requires Java 25). |
 | **Group messages ignored** | Configure `SIGNAL_GROUP_ALLOWED_USERS` with specific group IDs, or `*` to allow all groups. |
 | **Bot responds to no one** | Configure `SIGNAL_ALLOWED_USERS`, use DM pairing, or explicitly allow all users through gateway policy if you want broader access. |
 | **Duplicate messages** | Ensure only one signal-cli instance is listening on your phone number |


### PR DESCRIPTION
## Summary

Fixes #32337 — The `bbernhard/signal-cli-rest-api` Docker image is API-incompatible with the Hermes Signal adapter. The health check at `/api/v1/check` returns 404, and even if it didn't, the SSE event stream and JSON-RPC schema are completely different.

## Root Cause

Hermes's Signal adapter (`gateway/platforms/signal.py`) speaks to the **native** `signal-cli daemon --http` API:

| Endpoint | Method | Purpose |
|---|---|---|
| `/api/v1/check` | GET | Health check |
| `/api/v1/events` | GET SSE | Inbound message stream |
| `/api/v1/rpc` | POST | JSON-RPC (send, react, etc.) |

The `bbernhard/signal-cli-rest-api` Docker image exposes a **different** REST API:

| Endpoint | Method |
|---|---|
| `/v1/health` | GET (204) |
| `/v2/send` | POST |
| `/v1/about` | GET |

These are completely incompatible at every layer — health check, SSE receive, and JSON-RPC send.

## Changes

1. **`gateway/platforms/signal.py`** — `connect()` and `_health_monitor()` now detect HTTP 404 specifically and log a clear error message explaining the bbernhard incompatibility with a pointer to the docs.

2. **`hermes_cli/gateway.py`** — Removed the incorrect "Docker: bbernhard/signal-cli-rest-api" recommendation from the interactive setup wizard. Added 404-specific guidance during the connectivity test step.

3. **`website/docs/user-guide/messaging/signal.md`** — Added a `:::danger` banner at the top of the page warning about bbernhard incompatibility. Added a troubleshooting table entry for 404 health checks. Updated Java requirement from 17 to 25 (signal-cli 0.14.x requirement, from #31674).

## Related Issues

- #31674 — Documented bbernhard incompatibility as one of four Signal setup pitfalls
- #2409 — Earlier report of the same issue (closed without fix)

## Test Plan

- [x] All 109 existing Signal adapter tests pass
- [x] Health check 404 detection and error message verified
