### PR TITLE
fix(agent): normalize message content for strict providers (DeepSeek V4 Flash/Pro)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1072,6 +1072,13 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         api_messages = []
         for msg in messages:
             api_msg = msg.copy()
+
+            # Safety net: normalize None content to empty string (same as main
+            # loop in conversation_loop.py).  Some providers (DeepSeek V4 Flash
+            # thinking mode) reject null content.
+            if api_msg.get("content") is None:
+                api_msg["content"] = ""
+
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                 api_msg.pop(internal_field, None)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -609,8 +609,18 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     # reasoning fields are present (some models/providers embed thinking
     # directly in the content rather than returning separate API fields).
     if not reasoning_text:
-        content = assistant_message.content or ""
-        think_blocks = re.findall(r'<think>(.*?)</think>', content, flags=re.DOTALL)
+        _raw_extract = assistant_message.content
+        # Normalize list content (DeepSeek V4 thinking mode) to string
+        # before regex extraction.
+        if isinstance(_raw_extract, list):
+            _text_parts = [
+                b.get("text", "") for b in _raw_extract
+                if isinstance(b, dict) and b.get("type") == "text"
+            ]
+            _raw_extract = " ".join(_text_parts) if _text_parts else ""
+        elif not isinstance(_raw_extract, str):
+            _raw_extract = ""
+        think_blocks = re.findall(r'<think>(.*?)</think>', _raw_extract, flags=re.DOTALL)
         if think_blocks:
             combined = "\n\n".join(b.strip() for b in think_blocks if b.strip())
             reasoning_text = combined or None
@@ -635,7 +645,19 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
     # can return invalid surrogate code points that crash json.dumps() on persist.
-    _raw_content = assistant_message.content or ""
+    _raw_content = assistant_message.content
+    # DeepSeek V4 Pro/Flash thinking mode may return content as a list of typed
+    # blocks ([{"type":"thinking",...}, {"type":"text",...}]).  Extract text from
+    # the list; fall back to empty string for any non-string type so that
+    # _sanitize_surrogates() (which expects str) does not crash.
+    if isinstance(_raw_content, list):
+        _text_parts = [
+            b.get("text", "") for b in _raw_content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        _raw_content = " ".join(_text_parts) if _text_parts else ""
+    elif not isinstance(_raw_content, str):
+        _raw_content = ""
     _san_content = _sanitize_surrogates(_raw_content)
     if reasoning_text:
         reasoning_text = _sanitize_surrogates(reasoning_text)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1095,11 +1095,14 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         for msg in messages:
             api_msg = msg.copy()
 
-            # Safety net: normalize None content to empty string (same as main
-            # loop in conversation_loop.py).  Some providers (DeepSeek V4 Flash
-            # thinking mode) reject null content.
-            if api_msg.get("content") is None:
+            # Safety net: normalize invalid content types to valid strings.
+            # (same as main loop in conversation_loop.py).  Some providers
+            # (DeepSeek V4 Flash thinking mode) reject non-string/non-list content.
+            _c = api_msg.get("content")
+            if _c is None:
                 api_msg["content"] = ""
+            elif not isinstance(_c, (str, list)):
+                api_msg["content"] = json.dumps(_c, ensure_ascii=False)
 
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -789,6 +789,15 @@ def run_conversation(
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
 
+            # Safety net: normalize None content to empty string.  Some
+            # providers (DeepSeek V4 Flash thinking mode, etc.) reject null
+            # content with "content should be a string or a list".  All roles
+            # accept empty string as valid content.  Covers edge cases where
+            # tool messages or assistant(tool_calls) messages were persisted
+            # with null content from older sessions.
+            if api_msg.get("content") is None:
+                api_msg["content"] = ""
+
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks
             # with target="user_message" (the default).  Both are

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -789,14 +789,17 @@ def run_conversation(
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
 
-            # Safety net: normalize None content to empty string.  Some
-            # providers (DeepSeek V4 Flash thinking mode, etc.) reject null
-            # content with "content should be a string or a list".  All roles
-            # accept empty string as valid content.  Covers edge cases where
-            # tool messages or assistant(tool_calls) messages were persisted
-            # with null content from older sessions.
-            if api_msg.get("content") is None:
+            # Safety net: normalize invalid content types to valid strings.
+            # Some providers (DeepSeek V4 Flash thinking mode) reject content
+            # that is not a string or a list.  Catches:
+            #   - None (from old session DB records)
+            #   - dict (from tool handlers returning raw dicts)
+            #   - int / bool / other unexpected types
+            _c = api_msg.get("content")
+            if _c is None:
                 api_msg["content"] = ""
+            elif not isinstance(_c, (str, list)):
+                api_msg["content"] = json.dumps(_c, ensure_ascii=False)
 
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1937,6 +1937,12 @@ class SessionDB:
         messages = []
         for row in rows:
             content = self._decode_content(row["content"])
+            # Normalize None content to empty string — some strict providers
+            # (DeepSeek V4 Flash thinking mode, etc.) reject null content with
+            # "content should be a string or a list".  All roles accept empty
+            # string as valid content.  Refs #<tbd>.
+            if content is None:
+                content = ""
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1937,12 +1937,13 @@ class SessionDB:
         messages = []
         for row in rows:
             content = self._decode_content(row["content"])
-            # Normalize None content to empty string — some strict providers
-            # (DeepSeek V4 Flash thinking mode, etc.) reject null content with
-            # "content should be a string or a list".  All roles accept empty
-            # string as valid content.  Refs #<tbd>.
+            # Normalize invalid content types — strict providers (DeepSeek
+            # V4 Flash thinking mode) reject non-string/non-list content.
+            # Refs #<tbd>.
             if content is None:
                 content = ""
+            elif not isinstance(content, (str, list)):
+                content = json.dumps(content, ensure_ascii=False)
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}

--- a/run_agent.py
+++ b/run_agent.py
@@ -1332,7 +1332,7 @@ class AIAgent:
                             _txt.append(str(p.get("text", "")))
                         elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
                             _txt.append("[screenshot]")
-                    content = "\n".join(_txt) if _txt else None
+                    content = "\n".join(_txt) if _txt else ""
                 tool_calls_data = None
                 if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:
                     tool_calls_data = [


### PR DESCRIPTION
## What changed and why

DeepSeek V4 Flash thinking mode enforces strict OpenAI schema validation and rejects `content: null` or other non-string/non-list values in messages with "content should be a string or a list". MiniMax and other providers are lenient.

**Root cause**: The tool execution pipeline passes handler return values directly into `content` without type validation. The OpenAI schema requires `content` to be a `string | array`, but:

1. Handler results may be `dict` (e.g., plugin handlers that return `Dict[str, Any]`)
2. DB-replayed messages may have `None` content from older sessions (assistant tool-call messages persisted with `content: null`)
3. DeepSeek V4 may return `content` as a list of typed blocks (`[{"type":"thinking",…}, {"type":"text",…}]`), which crashes `_sanitize_surrogates()`

**Trigger observed with**: the sagtask plugin's tool handlers, which return raw dicts — but the same class of bug can be triggered by any handler or any DB-replayed message with non-string content.

**Fix**: Add type normalization at the API boundary (before serialization) and at the DB read boundary, making the system robust regardless of what any individual handler returns.

## How to test

Use DeepSeek V4 Flash with thinking mode in a tool-calling conversation with any plugin that returns dict-shaped tool results. Previously fails with HTTP 400 "content should be a string or a list". MiniMax-2.7 and other lenient providers continue to work normally.

## Platforms tested

macOS 26.3.1. Changes are pure Python data transformations (type normalization and string formatting) with zero platform-specific operations — identical behavior on Linux, macOS, and Windows.

## Files changed (4 + 1 separate)

| File | Change |
|------|--------|
| `hermes_state.py` | `get_messages_as_conversation()`: normalize None/dict/other non-string types to valid string on DB load |
| `run_agent.py` | `_flush_messages_to_session_db()`: prevent `None` writes for list-type tool content |
| `agent/conversation_loop.py` | Safety net: normalize invalid content types before API call |
| `agent/chat_completion_helpers.py` | Same safety net + handle DeepSeek V4 list content in `build_assistant_message()` |
| _(third-party plugin, not in this repo)_ | sagtask's `__init__.py`: wrap handler results with `json.dumps()` |

## Tests

```
tests/test_hermes_state.py:               215 passed
tests/run_agent/test_run_agent.py:        338 passed
tests/tools/test_session_search.py:        87 passed
Total:                                    559 passed
```

## Priority

Bug fix (Priority 1) — incorrect behavior, HTTP 400 on valid message format.

## Related

References #15250, #17341 (reasoning_content echo-back), #21944 (content-as-list format)
