### PR TITLE
fix(tools): validate send_message send args in schema (#32376)

### DIFF
--- a/tests/tools/test_send_message_schema.py
+++ b/tests/tools/test_send_message_schema.py
@@ -1,0 +1,30 @@
+import json
+from unittest.mock import patch
+
+from tools.send_message_tool import SEND_MESSAGE_SCHEMA, send_message_tool
+
+
+def test_send_message_schema_requires_send_fields_unless_listing():
+    params = SEND_MESSAGE_SCHEMA["parameters"]
+
+    assert params["required"] == []
+    assert params["allOf"] == [
+        {
+            "if": {
+                "properties": {"action": {"const": "list"}},
+                "required": ["action"],
+            },
+            "then": {},
+            "else": {"required": ["target", "message"]},
+        }
+    ]
+
+
+def test_list_action_still_accepts_no_target_or_message():
+    with patch(
+        "gateway.channel_directory.format_directory_for_display",
+        return_value="telegram:home",
+    ):
+        result = json.loads(send_message_tool({"action": "list"}))
+
+    assert result == {"targets": "telegram:home"}

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -142,7 +142,17 @@ SEND_MESSAGE_SCHEMA = {
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> for a file under a Hermes media cache or HERMES_MEDIA_ALLOW_DIRS — the platform will deliver it as a native media attachment."
             }
         },
-        "required": []
+        "required": [],
+        "allOf": [
+            {
+                "if": {
+                    "properties": {"action": {"const": "list"}},
+                    "required": ["action"],
+                },
+                "then": {},
+                "else": {"required": ["target", "message"]},
+            }
+        ],
     }
 }
 


### PR DESCRIPTION
## Summary
- make `send_message` require `target` and `message` unless `action` is explicitly `list`
- preserve argument-free `send_message(action="list")` calls
- add a focused schema regression test

Closes #32376

## Testing
- uv run --frozen pytest -q -o addopts= tests/tools/test_send_message_schema.py\n- uv run --frozen ruff check tools/send_message_tool.py tests/tools/test_send_message_schema.py\n- git diff --check