### PR TITLE
fix(send_message): declare required params in schema so model-side validator catches malformed calls

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -142,7 +142,13 @@ SEND_MESSAGE_SCHEMA = {
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> for a file under a Hermes media cache or HERMES_MEDIA_ALLOW_DIRS — the platform will deliver it as a native media attachment."
             }
         },
-        "required": []
+        "required": ["action"],
+        "allOf": [
+            {
+                "if": {"properties": {"action": {"const": "send"}}},
+                "then": {"required": ["target", "message"]}
+            }
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary

The `SEND_MESSAGE_SCHEMA` in `tools/send_message_tool.py` declared `required: []` (no required parameters), but `_handle_send()` enforces `target` and `message` imperatively at runtime when `action='send'`. This mismatch means:

- Model-side schema validators can't catch malformed calls — they only fail inside the tool body
- Failures surface as `[Tool loop warning: repeated_exact_failure_warning]` entries in gateway logs
- Models retry the same bad call multiple times, consuming the tool-loop budget

## Fix

Replace `"required": []` with conditional schema validation:

```json
"required": ["action"],
"allOf": [
    {
        "if": {"properties": {"action": {"const": "send"}}},
        "then": {"required": ["target", "message"]}
    }
]
```

- When `action='send'`: schema declares `target` and `message` as required — the model validator catches bad calls upstream
- When `action='list'`: no extra parameters required — valid to call argument-free

The imperative guards in `_handle_send()` (lines 173-174) are preserved as a defense-in-depth layer.

## Test plan

- [x] `send_message(action='list')` — still valid without `target`/`message`
- [x] `send_message(action='send', target='telegram', message='hi')` — valid
- [x] `send_message(action='send')` — now rejected at schema validation level by the model, before hitting the tool-loop guard

Closes #32376