### PR TITLE
fix(compressor): extract text from multimodal content in _serialize_for_summary

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1413,7 +1413,26 @@ class ContextCompressor(ContextEngine):
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = redact_sensitive_text(msg.get("content") or "")
+            raw_content = msg.get("content")
+            # Multimodal content is a list of blocks (text + image parts).
+            # Extract text explicitly so the summarizer sees the user's words
+            # instead of an unreadable Python repr of the raw list.
+            if isinstance(raw_content, list):
+                text_parts = []
+                has_images = False
+                for part in raw_content:
+                    if _is_image_part(part):
+                        has_images = True
+                    elif isinstance(part, dict):
+                        txt = part.get("text") or ""
+                        if txt:
+                            text_parts.append(txt)
+                    elif isinstance(part, str):
+                        text_parts.append(part)
+                raw_content = "\n".join(text_parts)
+                if has_images:
+                    raw_content += "\n[Attached image(s) — not included in summary]"
+            content = redact_sensitive_text(raw_content or "")
             content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
 
             # Tool results: keep enough content for the summarizer

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -712,6 +712,84 @@ class TestNonStringContent:
         assert "Treat the conversation turns below as source material" in prompt
         assert "structured checkpoint summary" in prompt
 
+    def test_multimodal_list_content_serializes_as_text_not_python_repr(self):
+        """_serialize_for_summary must not pass list content through str().
+
+        When a user message contains multimodal blocks (text + image parts),
+        the raw list must not be coerced to a Python repr string like
+        "[{'type': 'image_url', 'image_url': {'url': 'data:image/png;...'}}]"
+        — the summarizer would see unreadable garbage instead of the user's
+        actual words.  The fix extracts text parts and appends a placeholder
+        for images.
+        """
+        captured: list = []
+
+        def fake_call_llm(**kwargs):
+            captured.append(kwargs["messages"][0]["content"])
+            r = MagicMock()
+            r.choices = [MagicMock()]
+            r.choices[0].message.content = "summary"
+            return r
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        multimodal_user_msg = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What do you see in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAAAA=="}},
+            ],
+        }
+        turns = [multimodal_user_msg, {"role": "assistant", "content": "I see a cat."}]
+
+        with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+            c._generate_summary(turns)
+
+        assert captured, "call_llm was not called"
+        prompt = captured[0]
+        # The user's actual text must appear in the summarizer prompt
+        assert "What do you see in this image?" in prompt
+        # An image placeholder must appear
+        assert "[Attached image(s)" in prompt
+        # The base64 payload and Python list repr must NOT appear
+        assert "AAAAAA==" not in prompt
+        assert "image_url" not in prompt
+        assert "[{'type'" not in prompt
+
+    def test_multimodal_text_only_list_serializes_cleanly(self):
+        """A content list with only text blocks (no images) should serialize
+        to plain text without any image placeholder."""
+        captured: list = []
+
+        def fake_call_llm(**kwargs):
+            captured.append(kwargs["messages"][0]["content"])
+            r = MagicMock()
+            r.choices = [MagicMock()]
+            r.choices[0].message.content = "summary"
+            return r
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        text_only_msg = {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "World"},
+            ],
+        }
+        turns = [text_only_msg, {"role": "assistant", "content": "Hi there."}]
+
+        with patch("agent.context_compressor.call_llm", side_effect=fake_call_llm):
+            c._generate_summary(turns)
+
+        assert captured
+        prompt = captured[0]
+        assert "Hello" in prompt
+        assert "World" in prompt
+        assert "[Attached image" not in prompt
+
     def test_summary_call_passes_live_main_runtime(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]


### PR DESCRIPTION
## Problem

`_serialize_for_summary` passes every message's `content` directly to `redact_sensitive_text`:

```python
content = redact_sensitive_text(msg.get("content") or "")
```

When `content` is a multimodal list of blocks (e.g. a user message with an attached screenshot), `redact_sensitive_text` calls `str(list)` internally and turns the message into an unreadable Python repr:

```
[{'type': 'image_url', 'image_url': {'url': 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...'}}]
```

The summarizer sees this instead of the user's actual words. For conversations involving vision/screenshots where an image-bearing user message falls inside the compression window, the resulting context summary loses or garbles that part of the conversation history.

Note: `_prune_old_tool_results` (Phase 1) already handles multimodal *tool result* content correctly. `_strip_historical_media` handles images in the *assembled* output (Phase 4). But `_serialize_for_summary` (Phase 3) had no multimodal handling of its own.

## Fix

If `content` is a list, walk the parts using the existing `_is_image_part()` helper:
- Concatenate text blocks into human-readable content
- Append `[Attached image(s) — not included in summary]` when image parts are present
- Plain-string and `None` content paths are unchanged

```python
if isinstance(raw_content, list):
    text_parts = []
    has_images = False
    for part in raw_content:
        if _is_image_part(part):
            has_images = True
        elif isinstance(part, dict):
            txt = part.get("text") or ""
            if txt:
                text_parts.append(txt)
        elif isinstance(part, str):
            text_parts.append(part)
    extracted = "\n".join(text_parts)
    if has_images:
        extracted += "\n[Attached image(s) — not included in summary]"
    content = redact_sensitive_text(extracted)
else:
    content = redact_sensitive_text(raw_content or "")
```

## Tests

Two new regression tests in `TestNonStringContent`:

- `test_multimodal_list_content_serializes_as_text_not_python_repr` — verifies the user's text appears in the summarizer prompt, the image placeholder appears, and the base64 payload / Python repr does **not** appear
- `test_multimodal_text_only_list_serializes_cleanly` — verifies a text-only list serializes cleanly with no spurious image placeholder

All 85 tests pass.