### PR TITLE
feat(cron): add structured audit trail for cron run debugging

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1120,6 +1120,39 @@ def save_job_output(job_id: str, output: str):
     return output_file
 
 
+def save_job_audit(job_id: str, audit: dict) -> Path:
+    """Save structured audit metadata alongside the markdown output.
+
+    Writes ``{timestamp}.audit.json`` into the same per-job output directory
+    as ``save_job_output`` so every run has a compact, machine-readable
+    decision trace for debugging missed-task scenarios.
+    """
+    ensure_dirs()
+    job_output_dir = _job_output_dir(job_id)
+    job_output_dir.mkdir(parents=True, exist_ok=True)
+    _secure_dir(job_output_dir)
+
+    timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
+    audit_file = job_output_dir / f"{timestamp}.audit.json"
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.audit_')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            json.dump(audit, f, indent=2, ensure_ascii=False, default=str)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, audit_file)
+        _secure_file(audit_file)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    return audit_file
+
+
 # =============================================================================
 # Skill reference rewriting (curator integration)
 # =============================================================================

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -147,7 +147,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import get_due_jobs, mark_job_run, save_job_output, save_job_audit, advance_next_run
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1931,22 +1931,24 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
             try:
+                job_id = job["id"]
+                start_time = _hermes_now()
                 success, output, final_response, error = run_job(job)
 
-                output_file = save_job_output(job["id"], output)
+                output_file = save_job_output(job_id, output)
                 if verbose:
                     logger.info("Output saved to: %s", output_file)
 
                 # Deliver the final response to the origin/target chat.
                 # If the agent responded with [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job_id)}' failed:\n{error}"
                 # Treat whitespace-only final responses the same as empty
                 # responses: do not deliver a blank message, and let the
                 # empty-response guard below mark the run as a soft failure.
                 should_deliver = bool(deliver_content.strip())
                 if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                    logger.info("Job '%s': agent returned %s — skipping delivery", job_id, SILENT_MARKER)
                     should_deliver = False
 
                 delivery_error = None
@@ -1955,7 +1957,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                         delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
                     except Exception as de:
                         delivery_error = str(de)
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
+                        logger.error("Delivery failed for job %s: %s", job_id, de)
 
                 # Treat empty final_response as a soft failure so last_status
                 # is not "ok" — the agent ran but produced nothing useful.
@@ -1964,11 +1966,104 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     success = False
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                # Persist a structured audit artifact alongside the markdown
+                # output so missed-task debugging doesn't require re-running
+                # collectors or reading truncated markdown logs.
+                _is_silent = bool(success and SILENT_MARKER in (final_response or "").strip().upper())
+                _silent_reason = None
+                if _is_silent:
+                    _out_upper = (output or "").upper()
+                    if "WAKEAGENT=FALSE" in _out_upper or "WAKEGENT=FALSE" in _out_upper:
+                        _silent_reason = "wake_agent_false"
+                    elif "EMPTY STDOUT" in _out_upper:
+                        _silent_reason = "empty_stdout"
+                    elif "NO OUTPUT" in _out_upper or "SCRIPT PRODUCED NO OUTPUT" in _out_upper:
+                        _silent_reason = "no_script_output"
+                    elif not final_response.strip():
+                        _silent_reason = "empty_response"
+                    else:
+                        _silent_reason = "explicit_silent"
+
+                _deliver_targets = job.get("deliver")
+                if isinstance(_deliver_targets, str):
+                    _deliver_targets = [_deliver_targets]
+                elif not _deliver_targets:
+                    _deliver_targets = ["local"]
+
+                _schedule = job.get("schedule_display") or job.get("schedule", "N/A")
+                if isinstance(_schedule, dict):
+                    _schedule = _schedule.get("value", "N/A")
+                elif not isinstance(_schedule, str):
+                    _schedule = "N/A"
+
+                audit = {
+                    "audit_version": 1,
+                    "run_id": f"cron_{job_id}_{start_time.strftime('%Y%m%d_%H%M%S')}",
+                    "job_id": job_id,
+                    "job_name": job.get("name") or job_id,
+                    "schedule": _schedule,
+                    "start_time": start_time.isoformat(),
+                    "end_time": _hermes_now().isoformat(),
+                    "status": "ok" if success else "error",
+                    "mode": "no_agent" if job.get("no_agent") else "agent",
+                    "silent": _is_silent,
+                    "silent_reason": _silent_reason,
+                    "script": {
+                        "path": job.get("script"),
+                        "output_length": len(output) if output else 0,
+                    },
+                    "delivery": {
+                        "delivered": bool(should_deliver and delivery_error is None),
+                        "targets": _deliver_targets,
+                        "error": delivery_error,
+                    },
+                    "error": (
+                        {"type": error.split(":")[0] if error and ": " in error else "Error",
+                         "message": error}
+                        if not success and error
+                        else None
+                    ),
+                }
+                if not job.get("no_agent"):
+                    audit["agent"] = {
+                        "prompt_length": None,
+                        "response_length": len(final_response) if final_response else 0,
+                    }
+                save_job_audit(job_id, audit)
+
+                mark_job_run(job_id, success, error, delivery_error=delivery_error)
                 return True
 
             except Exception as e:
                 logger.error("Error processing job %s: %s", job['id'], e)
+                # Attempt to write an audit entry for the crashed run so the
+                # failure is visible in the structured trail.
+                try:
+                    _job_id = job.get("id", "unknown")
+                    _schedule = job.get("schedule_display") or job.get("schedule", "N/A")
+                    if isinstance(_schedule, dict):
+                        _schedule = _schedule.get("value", "N/A")
+                    elif not isinstance(_schedule, str):
+                        _schedule = "N/A"
+                    audit = {
+                        "audit_version": 1,
+                        "run_id": f"cron_{_job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
+                        "job_id": _job_id,
+                        "job_name": job.get("name") or _job_id,
+                        "schedule": _schedule,
+                        "start_time": _hermes_now().isoformat(),
+                        "end_time": _hermes_now().isoformat(),
+                        "status": "error",
+                        "mode": "no_agent" if job.get("no_agent") else "agent",
+                        "silent": False,
+                        "silent_reason": None,
+                        "script": {"path": job.get("script"), "output_length": 0},
+                        "delivery": {"delivered": False, "targets": [], "error": None},
+                        "error": {"type": type(e).__name__, "message": str(e)},
+                    }
+                    save_job_audit(_job_id, audit)
+                except Exception:
+                    pass
                 mark_job_run(job["id"], False, str(e))
                 return False
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -282,6 +282,94 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
     return 0
 
 
+def cron_inspect(args):
+    """Display the latest run audit for a cron job."""
+    job_id = args.job_id
+    from cron.jobs import OUTPUT_DIR
+
+    job_output_dir = OUTPUT_DIR / job_id
+    if not job_output_dir.is_dir():
+        print(color(f"No output directory found for job: {job_id}", Colors.RED))
+        print(f"Expected: {job_output_dir}")
+        return 1
+
+    audit_files = sorted(job_output_dir.glob("*.audit.json"))
+    if not audit_files:
+        print(color(f"No audit files found for job: {job_id}", Colors.YELLOW))
+        print(f"Directory: {job_output_dir}")
+        print("Audit files are created when cron jobs run.")
+        return 1
+
+    latest = audit_files[-1]
+    try:
+        with open(latest, "r", encoding="utf-8") as f:
+            audit = json.load(f)
+    except Exception as e:
+        print(color(f"Failed to read audit file: {e}", Colors.RED))
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(audit, indent=2, ensure_ascii=False))
+        return 0
+
+    # Human-readable display
+    print()
+    run_id = audit.get("run_id", "?")
+    print(color(f"Run Audit: {run_id}", Colors.CYAN))
+    print()
+
+    status = audit.get("status", "?")
+    status_color = Colors.GREEN if status == "ok" else Colors.RED
+    print(f"  Status:      {color(status, status_color)}")
+    print(f"  Job:         {audit.get('job_name', '?')} ({audit.get('job_id', '?')})")
+    print(f"  Schedule:    {audit.get('schedule', '?')}")
+    print(f"  Mode:        {audit.get('mode', '?')}")
+    print(f"  Start:       {audit.get('start_time', '?')}")
+    print(f"  End:         {audit.get('end_time', '?')}")
+
+    silent = audit.get("silent", False)
+    silent_reason = audit.get("silent_reason")
+    if silent:
+        print(f"  Silent:      {color('yes', Colors.YELLOW)} (reason: {silent_reason})")
+    else:
+        print(f"  Silent:      no")
+
+    script = audit.get("script") or {}
+    if script.get("path"):
+        print(f"  Script:      {script['path']}")
+        print(f"  Script out:  {script.get('output_length', 0)} bytes")
+
+    agent = audit.get("agent")
+    if agent:
+        resp_len = agent.get("response_length", 0)
+        if resp_len:
+            print(f"  Response:    {resp_len} chars")
+        else:
+            print(f"  Response:    (empty)")
+
+    delivery = audit.get("delivery") or {}
+    delivered = delivery.get("delivered", False)
+    targets = delivery.get("targets", [])
+    print(f"  Delivered:   {color('yes', Colors.GREEN) if delivered else color('no', Colors.DIM)}")
+    if targets:
+        print(f"  Targets:     {', '.join(str(t) for t in targets)}")
+    delivery_err = delivery.get("error")
+    if delivery_err:
+        print(f"  Delivery err: {color(delivery_err, Colors.RED)}")
+
+    error = audit.get("error")
+    if error:
+        print(f"  Error:       {color(error.get('type', 'Error') + ': ' + error.get('message', ''), Colors.RED)}")
+
+    print()
+    print(color(f"  Audit file: {latest}", Colors.DIM))
+    other_count = len(audit_files) - 1
+    if other_count > 0:
+        print(color(f"  ({other_count} earlier audit(s) available)", Colors.DIM))
+    print()
+    return 0
+
+
 def cron_command(args):
     """Handle cron subcommands."""
     subcmd = getattr(args, 'cron_command', None)
@@ -317,6 +405,9 @@ def cron_command(args):
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")
 
+    if subcmd == "inspect":
+        return cron_inspect(args)
+
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick|inspect]")
     sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11913,6 +11913,16 @@ def main():
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     _add_accept_hooks_flag(cron_tick)
+
+    # cron inspect
+    cron_inspect = cron_subparsers.add_parser(
+        "inspect", help="Show the latest run audit for a job"
+    )
+    cron_inspect.add_argument("job_id", help="Job ID to inspect")
+    cron_inspect.add_argument(
+        "--json", action="store_true", help="Output raw audit JSON"
+    )
+
     _add_accept_hooks_flag(cron_parser)
     cron_parser.set_defaults(func=cmd_cron)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1295,6 +1295,7 @@ class TestRunJobSessionPersistence:
              patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.mark_job_run") as mock_mark, \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
             tick(verbose=False)
@@ -1808,6 +1809,7 @@ class TestSilentDelivery:
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT]", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
@@ -1820,6 +1822,7 @@ class TestSilentDelivery:
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
@@ -1832,6 +1835,7 @@ class TestSilentDelivery:
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
@@ -1842,6 +1846,7 @@ class TestSilentDelivery:
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
@@ -1853,6 +1858,7 @@ class TestSilentDelivery:
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(False, "# output", "", "some error")), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
@@ -1863,6 +1869,7 @@ class TestSilentDelivery:
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# full output", "[SILENT]", None)), \
              patch("cron.scheduler.save_job_output") as save_mock, \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             save_mock.return_value = "/tmp/out.md"
@@ -1876,6 +1883,7 @@ class TestSilentDelivery:
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "   \n\t  ", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run") as mark_mock:
             from cron.scheduler import tick
@@ -2306,6 +2314,7 @@ class TestParallelTick:
              patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
@@ -2351,6 +2360,7 @@ class TestParallelTick:
              patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
@@ -2380,6 +2390,7 @@ class TestParallelTick:
              patch("cron.scheduler.advance_next_run"), \
              patch("cron.scheduler.run_job", side_effect=mock_run_job), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler.save_job_audit"), \
              patch("cron.scheduler._deliver_result", return_value=None), \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick


### PR DESCRIPTION
## Summary

When a cron job returns `[SILENT]` or skips expected tasks, today the only diagnostic artifact is a markdown output file that contains the full prompt and a large truncated source snapshot — not a concise decision trace. This makes "why was this task skipped?" hard to answer without re-running collectors manually.

This PR adds a structured audit trail:

- Each cron run now writes a `{timestamp}.audit.json` alongside the existing `{timestamp}.md` output file in `~/.hermes/cron/output/{job_id}/`
- The audit JSON captures: run id, job id, timestamps, status, mode (agent/no_agent), silent decision with reason, script path/output length, agent stats (for LLM jobs), delivery result, and error details
- `[SILENT]` runs still suppress delivery but the audit file is always written
- A new `hermes cron inspect <job_id>` command surfaces the latest audit from the CLI, with optional `--json` flag for raw output

## Changes

| File | Change |
|------|--------|
| `cron/jobs.py` | New `save_job_audit()` — atomically writes structured JSON alongside markdown output |
| `cron/scheduler.py` | `_process_job()` builds an audit dict from run results and calls `save_job_audit()`; also writes audit on crash |
| `hermes_cli/cron.py` | New `cron_inspect()` — reads latest `.audit.json` and displays human-readable summary |
| `hermes_cli/main.py` | Register `cron inspect` subcommand with `--json` flag |
| `tests/cron/test_scheduler.py` | Add `save_job_audit` mock alongside existing `save_job_output` mocks |

## Audit JSON structure

```json
{
  "audit_version": 1,
  "run_id": "cron_{job_id}_{timestamp}",
  "job_id": "...",
  "job_name": "...",
  "schedule": "...",
  "start_time": "ISO8601",
  "end_time": "ISO8601",
  "status": "ok|error",
  "mode": "agent|no_agent",
  "silent": true/false,
  "silent_reason": "wake_agent_false|empty_stdout|no_script_output|empty_response|explicit_silent|null",
  "script": {"path": null, "output_length": 0},
  "delivery": {"delivered": true/false, "targets": [], "error": null},
  "error": {"type": "...", "message": "..."} | null,
  "agent": {"prompt_length": null, "response_length": 123}  // agent mode only
}
```

## Test plan

- [x] 263 cron tests pass (test_jobs, test_scheduler, test_cron_no_agent, test_cron_script)
- [x] Audit file is written for successful, silent, and failed runs
- [x] `[SILENT]` still suppresses delivery but audit is written
- [x] `hermes cron inspect <job_id>` displays audit summary
- [x] `hermes cron inspect <job_id> --json` outputs raw JSON
- [x] Crash path also writes a best-effort audit entry

Closes #32386