### PR TITLE
fix: add md, markdown, json, yaml, yml, toml, log to MEDIA: file regex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|md|markdown|json|yaml|yml|toml|log|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Problem

The `MEDIA:` file-attachment regex in `gateway/platforms/base.py` only matched a limited set of file extensions (images, videos, audio, archives, office docs, txt). Common text-based formats like `.md`, `.json`, `.yaml`, `.toml`, and `.log` were silently dropped — the gateway reported success but the file was never actually sent.

## Fix

Added `md|markdown|json|yaml|yml|toml|log` to the media extension regex pattern.

## Testing

- Verified that `.md` files are now correctly sent via Feishu `send_message`
- Confirmed existing extensions still match

## Changed

- `gateway/platforms/base.py` L2416: Extended the media file extension regex