### PR TITLE
fix(agency): gate gateway kanban dispatch by board

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5332,6 +5332,39 @@ class GatewayRunner:
         interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
         interval = max(interval, 1.0)  # sanity floor — tighter than this is a footgun
 
+        raw_dispatch_boards = kanban_cfg.get("dispatch_boards")
+        dispatch_board_allowlist: set[str] | None = None
+        if isinstance(raw_dispatch_boards, str):
+            dispatch_board_allowlist = {
+                slug.strip() for slug in raw_dispatch_boards.split(",") if slug.strip()
+            }
+        elif isinstance(raw_dispatch_boards, (list, tuple, set)):
+            dispatch_board_allowlist = {
+                str(slug).strip() for slug in raw_dispatch_boards if str(slug).strip()
+            }
+        elif raw_dispatch_boards is not None:
+            logger.warning(
+                "kanban dispatcher: invalid kanban.dispatch_boards=%r; dispatching all boards",
+                raw_dispatch_boards,
+            )
+        if dispatch_board_allowlist:
+            logger.info(
+                "kanban dispatcher: dispatch_boards=%s",
+                ",".join(sorted(dispatch_board_allowlist)),
+            )
+
+        def _list_dispatch_boards() -> list[dict]:
+            try:
+                boards = _kb.list_boards(include_archived=False)
+            except Exception:
+                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            if dispatch_board_allowlist is None:
+                return boards
+            return [
+                b for b in boards
+                if (b.get("slug") or _kb.DEFAULT_BOARD) in dispatch_board_allowlist
+            ]
+
         # Read max_spawn config to limit concurrent kanban tasks
         max_spawn = kanban_cfg.get("max_spawn", None)
         if max_spawn is not None:
@@ -5494,10 +5527,7 @@ class GatewayRunner:
             when users create a new board mid-run: no restart required,
             the next tick picks it up automatically.
             """
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            boards = _list_dispatch_boards()
             out: list[tuple[str, "Optional[object]"]] = []
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
@@ -5516,10 +5546,7 @@ class GatewayRunner:
             here keeps the stuck-warn fire only on real failures (broken
             PATH, missing venv, credential loss for a real Hermes profile).
             """
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            boards = _list_dispatch_boards()
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
                 conn = None
@@ -5567,10 +5594,7 @@ class GatewayRunner:
                     "kanban auto-decompose: import failed (%s); skipping", exc,
                 )
                 return 0
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            boards = _list_dispatch_boards()
             attempted = 0
             successes = 0
             for b in boards:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3602,6 +3602,68 @@ def test_gateway_dispatcher_watcher_env_truthy_uses_config(monkeypatch):
     )
 
 
+def test_gateway_dispatcher_watcher_respects_dispatch_board_allowlist(monkeypatch):
+    """dispatch_boards limits embedded gateway dispatch to named boards only."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    dispatched: list[str | None] = []
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "auto_decompose": False,
+                "dispatch_boards": ["canary"],
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [
+            {"slug": "canary"},
+            {"slug": "production"},
+        ],
+    )
+    monkeypatch.setattr(_kb, "connect", lambda board=None: SimpleNamespace(close=lambda: None))
+
+    def _dispatch_once(conn, *, board=None, **kwargs):
+        dispatched.append(board)
+        runner._running = False
+        return SimpleNamespace(
+            spawned=[], reclaimed=0, crashed=[], timed_out=[], promoted=0, auto_blocked=[]
+        )
+
+    async def _to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(_kb, "dispatch_once", _dispatch_once)
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    asyncio.run(
+        asyncio.wait_for(
+            runner._kanban_dispatcher_watcher(),
+            timeout=3.0,
+        )
+    )
+
+    assert dispatched == ["canary"]
+
+
 def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     monkeypatch, tmp_path, caplog
 ):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -171,6 +171,10 @@ _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
     "/private/etc/", "/private/var/",
 )
+# Normal macOS temp files resolve under /private/var/folders. They are not
+# system config targets, and blocking them breaks pytest tmp_path plus ordinary
+# file-tool writes in temporary workspaces.
+_SENSITIVE_PATH_EXEMPT_PREFIXES = ("/private/var/folders/",)
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
@@ -185,6 +189,9 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    for exempt_prefix in _SENSITIVE_PATH_EXEMPT_PREFIXES:
+        if resolved.startswith(exempt_prefix) or normalized.startswith(exempt_prefix):
+            return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err


### PR DESCRIPTION
## Summary
- Add `kanban.dispatch_boards` allowlist support to the embedded gateway Kanban dispatcher so Level 3 canaries can be constrained to specific boards.
- Add a regression test proving the gateway dispatcher only dispatches the allowlisted board.
- Preserve macOS `/private/var/db` sensitive-path blocking while allowing normal `/private/var/folders` temp workspaces, which unblocks pytest/tmp_path and file-tool safety tests.

## Verification
- `python -m pytest tests/tools/test_cross_profile_guard.py tests/tools/test_file_write_safety.py -q -o addopts=`
- `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_gateway_dispatcher_watcher_respects_dispatch_board_allowlist -q -o addopts=`
- `python -m pytest tests/hermes_cli/test_profiles.py tests/hermes_cli/test_profile_describer.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_cross_profile_guard.py tests/tools/test_file_write_safety.py -o addopts= -q`
- `python3 ~/.hermes/agency/scripts/agency_healthcheck.py --home ~/.hermes`
