### PR TITLE
feat(transports): add generic ACP client transport (api_mode acp_client)

### DIFF
--- a/agent/acp_runtime.py
+++ b/agent/acp_runtime.py
@@ -1,0 +1,167 @@
+"""ACP client runtime — one turn through an ACP-compliant agent subprocess.
+
+Extracted from AIAgent to keep the agent loop file focused.
+Takes the parent AIAgent as its first argument (``agent``).
+AIAgent keeps thin forwarder methods for backward compatibility.
+
+``run_acp_client_turn`` — drives one turn through an
+``ACPClientSession`` subprocess (used when api_mode == "acp_client").
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def run_acp_client_turn(
+    agent,
+    *,
+    user_message: str,
+    original_user_message: Any,
+    messages: List[Dict[str, Any]],
+    effective_task_id: str,
+    should_review_memory: bool = False,
+) -> Dict[str, Any]:
+    """ACP client runtime path. Hands the entire turn to an ACP-compliant
+    agent subprocess and projects its streaming events back into Hermes'
+    messages list so memory/skill review keep working.
+
+    Called from run_conversation() when agent.api_mode == "acp_client".
+    Returns the same dict shape as the chat_completions path.
+
+    Lazy session: one ACPClientSession per AIAgent instance.
+    Spawned on first turn, reused across turns; kernel reclaims stdin on
+    process exit — no explicit teardown hook on AIAgent.
+    """
+    from agent.transports.acp_client_session import ACPClientSession
+
+    if not hasattr(agent, "_acp_session") or agent._acp_session is None:
+        cwd = getattr(agent, "session_cwd", None) or os.getcwd()
+        command = getattr(agent, "acp_command", None) or "acp-agent"
+        args = getattr(agent, "acp_args", None) or []
+
+        # on_delta: bridge streaming text deltas to Hermes' live-output path.
+        # _fire_stream_delta is the same hook the chat_completions path uses
+        # (see conversation_loop.py). Falls back to None in contexts that
+        # don't have streaming hooked up (cron, batch).
+        on_delta = getattr(agent, "_fire_stream_delta", None)
+
+        agent._acp_session = ACPClientSession(
+            command=command,
+            args=list(args),
+            on_delta=on_delta,
+        )
+
+    # NOTE: the user message is ALREADY appended to messages by the
+    # standard run_conversation() flow before the early return reaches us.
+    # Do NOT append again — that would duplicate.
+
+    cwd = getattr(agent, "session_cwd", None) or os.getcwd()
+
+    try:
+        turn = agent._acp_session.run_turn(user_input=user_message, cwd=cwd)
+    except Exception as exc:
+        logger.exception("ACP client turn failed")
+        # Crash → unconditionally drop the session so the next turn
+        # respawns from scratch instead of reusing a dead client.
+        try:
+            agent._acp_session.close()
+        except Exception:
+            pass
+        agent._acp_session = None
+        return {
+            "final_response": (
+                f"ACP client turn failed: {exc}. "
+                f"Check acp_command/acp_args in your config."
+            ),
+            "messages": messages,
+            "api_calls": 0,
+            "completed": False,
+            "partial": True,
+            "error": str(exc),
+        }
+
+    # If the turn signalled the underlying client is wedged (deadline
+    # blown, subprocess exited, protocol error), retire the session so
+    # the next turn respawns the agent from scratch.
+    if getattr(turn, "should_retire", False):
+        logger.warning(
+            "ACP client session retired (turn error: %s)",
+            turn.error,
+        )
+        try:
+            agent._acp_session.close()
+        except Exception:
+            pass
+        agent._acp_session = None
+
+    # Splice projected messages into the conversation. The session emits
+    # standard {role, content} entries, which is what curator.py / sessions
+    # DB expect.
+    if turn.projected_messages:
+        messages.extend(turn.projected_messages)
+
+    # Counter ticks for the agent-improvement loop.
+    # _turns_since_memory and _user_turn_count are ALREADY incremented
+    # in the run_conversation() pre-loop block before the early return,
+    # so do NOT touch them here — that would double-count.
+    # Only _iters_since_skill needs explicit increment, since the
+    # chat_completions loop bumps it per tool iteration and that loop is
+    # bypassed on this path.
+    agent._iters_since_skill = (
+        getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
+    )
+
+    # Check the skill nudge AFTER iters were incremented — same pattern
+    # as the chat_completions path.
+    should_review_skills = False
+    if (
+        agent._skill_nudge_interval > 0
+        and agent._iters_since_skill >= agent._skill_nudge_interval
+        and "skill_manage" in agent.valid_tool_names
+    ):
+        should_review_skills = True
+        agent._iters_since_skill = 0
+
+    # External memory provider sync — skip on interrupt/error to avoid
+    # feeding partial transcripts to memory.
+    if not turn.interrupted and turn.error is None:
+        try:
+            agent._sync_external_memory_for_turn(
+                original_user_message=original_user_message,
+                final_response=turn.final_text,
+                interrupted=False,
+            )
+        except Exception:
+            logger.debug("external memory sync raised", exc_info=True)
+
+    # Background review fork — same cadence + signature as the default path.
+    if (
+        turn.final_text
+        and not turn.interrupted
+        and (should_review_memory or should_review_skills)
+    ):
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=list(messages),
+                review_memory=should_review_memory,
+                review_skills=should_review_skills,
+            )
+        except Exception:
+            logger.debug("background review spawn raised", exc_info=True)
+
+    return {
+        "final_response": turn.final_text,
+        "messages": messages,
+        "api_calls": 1,  # one ACP session/prompt call maps to one logical API call
+        "completed": not turn.interrupted and turn.error is None,
+        "partial": turn.interrupted or turn.error is not None,
+        "error": turn.error,
+    }
+
+
+__all__ = ["run_acp_client_turn"]

--- a/agent/acp_runtime.py
+++ b/agent/acp_runtime.py
@@ -55,10 +55,16 @@ def run_acp_client_turn(
         # session/set_config_option call in that case.
         model = getattr(agent, "model", None) or None
 
+        # mcp_servers: pre-translated at agent init; forwarded into session/new
+        # so the ACP agent can connect to the user's MCP tools.  Empty list
+        # when none configured (current default).
+        mcp_servers = getattr(agent, "acp_mcp_servers", None) or []
+
         agent._acp_session = ACPClientSession(
             command=command,
             args=list(args),
             model=model,
+            mcp_servers=mcp_servers,
             on_delta=on_delta,
         )
 

--- a/agent/acp_runtime.py
+++ b/agent/acp_runtime.py
@@ -40,7 +40,6 @@ def run_acp_client_turn(
     from agent.transports.acp_client_session import ACPClientSession
 
     if not hasattr(agent, "_acp_session") or agent._acp_session is None:
-        cwd = getattr(agent, "session_cwd", None) or os.getcwd()
         command = getattr(agent, "acp_command", None) or "acp-agent"
         args = getattr(agent, "acp_args", None) or []
 
@@ -50,9 +49,16 @@ def run_acp_client_turn(
         # don't have streaming hooked up (cron, batch).
         on_delta = getattr(agent, "_fire_stream_delta", None)
 
+        # model: read from agent.model so the ACP server uses the same model
+        # Hermes is configured for, rather than its own default (Fix 1).
+        # Falls back to None when not set -- ACPClientSession skips the
+        # session/set_config_option call in that case.
+        model = getattr(agent, "model", None) or None
+
         agent._acp_session = ACPClientSession(
             command=command,
             args=list(args),
+            model=model,
             on_delta=on_delta,
         )
 
@@ -60,7 +66,17 @@ def run_acp_client_turn(
     # standard run_conversation() flow before the early return reaches us.
     # Do NOT append again — that would duplicate.
 
-    cwd = getattr(agent, "session_cwd", None) or os.getcwd()
+    # cwd priority: agent.session_cwd > HERMES_ACP_SESSION_CWD env > os.getcwd()
+    # HERMES_ACP_SESSION_CWD lets operators point the ACP session at a per-agent
+    # sandbox directory (containing CLAUDE.md + .claude/settings.local.json) on
+    # the gateway launch env without requiring a new config key in the provider
+    # resolver chain.  Production Janet and janet_test run as separate processes
+    # with distinct HERMES_HOME, so the env var is scoped to the right gateway.
+    cwd = (
+        getattr(agent, "session_cwd", None)
+        or os.environ.get("HERMES_ACP_SESSION_CWD", "").strip()
+        or os.getcwd()
+    )
 
     try:
         turn = agent._acp_session.run_turn(user_input=user_message, cwd=cwd)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -290,10 +290,12 @@ def init_agent(
     agent.acp_args = list(acp_args or args or [])
     if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "acp_client"}:
         agent.api_mode = api_mode
-    elif agent.provider == "acp-client":
+    elif agent.provider in {"acp-client", "acp_client"}:
         # ACP client transport: any ACP-compliant agent via JSON-RPC stdio.
         # Gated strictly by provider name so no accidental overlap with
         # copilot-acp or other acp://... base_url forms.
+        # provider may arrive as canonical "acp_client" (post-alias, from
+        # resolve_runtime_provider) or as "acp-client" (raw config value).
         agent.api_mode = "acp_client"
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -359,7 +361,7 @@ def init_agent(
     if (
         api_mode is None
         and agent.api_mode == "chat_completions"
-        and agent.provider != "copilot-acp"
+        and agent.provider not in {"copilot-acp", "acp_client", "acp-client"}
         and not str(agent.base_url or "").lower().startswith("acp://copilot")
         and not str(agent.base_url or "").lower().startswith("acp+tcp://")
         and not agent._is_azure_openai_url()
@@ -691,6 +693,18 @@ def init_agent(
         if not agent.quiet_mode:
             _gr_label = " + Guardrails" if agent._bedrock_guardrail_config else ""
             print(f"🤖 AI Agent initialized with model: {agent.model} (AWS Bedrock, {agent._bedrock_region}{_gr_label})")
+    elif agent.api_mode == "acp_client":
+        # Local-command ACP transport: routes inference to any ACP-compliant
+        # agent via JSON-RPC over stdio. No HTTP client is needed — the turn
+        # is routed via _run_acp_client_turn -> ACPClientSession(command, args).
+        # Auth is handled entirely by the spawned binary itself; no API key
+        # is required at the Hermes layer.
+        agent.client = None
+        agent._client_kwargs = {}
+        agent.api_key = ""
+        if not agent.quiet_mode:
+            _acp_cmd = agent.acp_command or "(acp command not set)"
+            print(f"🤖 AI Agent initialized with ACP client transport (command: {_acp_cmd})")
     else:
         if api_key and base_url:
             # Explicit credentials from CLI/gateway — construct directly.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -288,6 +288,27 @@ def init_agent(
     agent.provider = provider_name or ""
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
+    # Pre-translate MCP servers for the ACP client path only.  Reading and
+    # translating at init time (rather than on every turn) avoids repeated
+    # YAML parsing.  The external ACP agent opens the connections -- Hermes
+    # does NOT register these servers in-process (no double-connect).
+    _is_acp = (
+        api_mode == "acp_client"
+        or (provider_name in {"acp-client", "acp_client"})
+    )
+    if _is_acp:
+        try:
+            from tools.mcp_tool import _load_mcp_config
+            from agent.transports.acp_client_session import _translate_mcp_servers
+            agent.acp_mcp_servers = _translate_mcp_servers(_load_mcp_config())
+        except Exception as _exc:
+            import logging as _logging
+            _logging.getLogger(__name__).debug(
+                "ACP: could not load mcp_servers config: %s", _exc
+            )
+            agent.acp_mcp_servers = []
+    else:
+        agent.acp_mcp_servers = []
     if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "acp_client"}:
         agent.api_mode = api_mode
     elif agent.provider in {"acp-client", "acp_client"}:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -288,8 +288,13 @@ def init_agent(
     agent.provider = provider_name or ""
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "acp_client"}:
         agent.api_mode = api_mode
+    elif agent.provider == "acp-client":
+        # ACP client transport: any ACP-compliant agent via JSON-RPC stdio.
+        # Gated strictly by provider name so no accidental overlap with
+        # copilot-acp or other acp://... base_url forms.
+        agent.api_mode = "acp_client"
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
     elif agent.provider in {"xai", "xai-oauth"}:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -793,6 +793,22 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Optional opt-in runtime: if api_mode == acp_client, hand the turn to
+    # an ACP-compliant agent subprocess via JSON-RPC over stdio. The entire
+    # Hermes tool dispatch path is bypassed — the ACP agent handles its own
+    # tools internally. Streaming deltas are forwarded via _fire_stream_delta.
+    # See agent/acp_runtime.py and agent/transports/acp_client_session.py.
+    # NOTE: this early return is BEFORE the streaming exclusion block at
+    # ~line 1126 and the Responses-API path, so neither applies here.
+    if agent.api_mode == "acp_client":
+        return agent._run_acp_client_turn(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=_should_review_memory,
+        )
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -66,3 +66,10 @@ def _discover_transports() -> None:
         import agent.transports.bedrock  # noqa: F401
     except ImportError:
         pass
+    try:
+        # acp_client is not a ProviderTransport subclass (does not plug into
+        # the transport registry). Imported here so that module-level errors
+        # surface at startup rather than mid-turn.
+        import agent.transports.acp_client  # noqa: F401
+    except ImportError:
+        pass

--- a/agent/transports/acp_client.py
+++ b/agent/transports/acp_client.py
@@ -109,6 +109,16 @@ class ACPClient:
 
     # ---------- lifecycle ----------
 
+    # Minimal capabilities Hermes declares to ACP agents.  We explicitly
+    # opt out of fs and terminal proxying because Hermes drives its own tool
+    # executor — the agent must not expect to call back into us for those.
+    # This mirrors what _handle_server_request() declines in acp_client_session.py
+    # and lets conformant agents skip their fs/terminal request flow entirely.
+    _DEFAULT_CLIENT_CAPABILITIES: dict = {
+        "fs": {"readTextFile": False, "writeTextFile": False},
+        "terminal": False,
+    }
+
     def initialize(
         self,
         client_name: str = "hermes",
@@ -120,16 +130,22 @@ class ACPClient:
 
         Returns the server's InitializeResponse dict
         (agent_info, agent_capabilities, protocol_version).
+
+        ``capabilities`` defaults to ``_DEFAULT_CLIENT_CAPABILITIES`` when not
+        supplied, explicitly advertising that Hermes does not proxy fs or
+        terminal requests to the calling client.
         """
         if self._initialized:
             raise RuntimeError("already initialized")
+        if capabilities is None:
+            capabilities = self._DEFAULT_CLIENT_CAPABILITIES
         params = {
             "protocolVersion": 1,
             "clientInfo": {
                 "name": client_name,
                 "version": client_version,
             },
-            "clientCapabilities": capabilities or {},
+            "clientCapabilities": capabilities,
         }
         result = self.request("initialize", params, timeout=timeout)
         self._initialized = True

--- a/agent/transports/acp_client.py
+++ b/agent/transports/acp_client.py
@@ -1,0 +1,338 @@
+"""ACP client — JSON-RPC 2.0 stdio transport for ACP-compliant agents.
+
+Speaks the Agent Client Protocol (ACP spec v1, schema ref v0.11.2).
+Transport is newline-delimited JSON-RPC 2.0 over stdio: spawn an ACP-compliant
+agent process, do an ``initialize`` handshake, then drive ``session/new`` +
+``session/prompt`` and consume streaming ``session/update`` notifications until
+``session/prompt`` returns a PromptResponse.
+
+Wire method names (from acp.meta.AGENT_METHODS / CLIENT_METHODS):
+  agent-side requests:  initialize, session/new, session/prompt, session/close
+  agent-side notifs:    session/cancel
+  server-initiated:     session/update  (streaming chunks, fs/*, terminal/*)
+
+This module is the wire-level speaker only. Higher-level concerns (session
+lifecycle, event projection into Hermes messages, retry policy) live in sibling
+modules.
+
+Status: optional opt-in runtime gated behind ``api_mode == "acp_client"``.
+Hermes' default tool dispatch is unchanged when this runtime is not selected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class ACPClientError(RuntimeError):
+    """Raised on JSON-RPC errors from the ACP agent."""
+
+    code: int
+    message: str
+    data: Optional[Any] = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"ACP agent error {self.code}: {self.message}"
+
+
+@dataclass
+class _Pending:
+    queue: queue.Queue
+    method: str
+    sent_at: float = field(default_factory=time.time)
+
+
+class ACPClient:
+    """Minimal JSON-RPC 2.0 client for ACP-compliant agents over stdio.
+
+    Threading model:
+      - Spawning thread (caller) drives request/response pairs synchronously.
+      - One reader thread parses stdout, dispatches replies to the right
+        pending future, and routes server-initiated requests and notifications
+        to bounded queues that the caller drains on their own cadence.
+      - One reader thread captures stderr for diagnostics.
+
+    Intentionally NOT async. AIAgent.run_conversation() is synchronous and
+    runs on the main thread; layering asyncio just to drive a stdio child
+    creates surprising interrupt semantics. We use blocking queues with
+    timeouts for cancellation.
+
+    Three-arm dispatch (mirrors codex_app_server.py design):
+      _pending          — our outgoing requests, awaiting responses
+      _server_requests  — server-initiated requests (fs/*, terminal/*, permission)
+      _notifications    — server push notifications (session/update streaming chunks)
+    """
+
+    def __init__(
+        self,
+        command: str,
+        args: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
+    ) -> None:
+        self._command = command
+        spawn_env = os.environ.copy()
+        if env:
+            spawn_env.update(env)
+
+        cmd = [command] + list(args or [])
+        self._proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+            env=spawn_env,
+        )
+        self._next_id = 1
+        self._pending: dict[int, _Pending] = {}
+        self._pending_lock = threading.Lock()
+        self._send_lock = threading.Lock()
+        self._notifications: queue.Queue = queue.Queue()
+        self._server_requests: queue.Queue = queue.Queue()
+        self._stderr_lines: list[str] = []
+        self._stderr_lock = threading.Lock()
+        self._closed = False
+        self._initialized = False
+
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+        self._stderr_reader = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stderr_reader.start()
+
+    # ---------- lifecycle ----------
+
+    def initialize(
+        self,
+        client_name: str = "hermes",
+        client_version: str = "0.1",
+        capabilities: Optional[dict] = None,
+        timeout: float = 10.0,
+    ) -> dict:
+        """Send ACP ``initialize`` + ``initialized`` handshake.
+
+        Returns the server's InitializeResponse dict
+        (agent_info, agent_capabilities, protocol_version).
+        """
+        if self._initialized:
+            raise RuntimeError("already initialized")
+        params = {
+            "protocolVersion": 1,
+            "clientInfo": {
+                "name": client_name,
+                "version": client_version,
+            },
+            "clientCapabilities": capabilities or {},
+        }
+        result = self.request("initialize", params, timeout=timeout)
+        self._initialized = True
+        return result
+
+    def close(self, timeout: float = 3.0) -> None:
+        """Close stdin and wait for the subprocess to exit, escalating to kill."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._proc.stdin and not self._proc.stdin.closed:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.terminate()
+            self._proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            try:
+                self._proc.kill()
+                self._proc.wait(timeout=1.0)
+            except Exception:
+                pass
+
+    def __enter__(self) -> "ACPClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # ---------- send/receive ----------
+
+    def request(
+        self,
+        method: str,
+        params: Optional[dict] = None,
+        timeout: float = 30.0,
+    ) -> dict:
+        """Send a JSON-RPC request and block on the response.
+
+        Returns the ``result`` dict on success.
+        Raises ACPClientError on a JSON-RPC ``error`` response.
+        Raises TimeoutError if no response arrives within ``timeout`` seconds.
+        """
+        rid = self._take_id()
+        q: queue.Queue = queue.Queue(maxsize=1)
+        with self._pending_lock:
+            self._pending[rid] = _Pending(queue=q, method=method)
+        self._send({"id": rid, "method": method, "params": params or {}})
+        try:
+            msg = q.get(timeout=timeout)
+        except queue.Empty:
+            with self._pending_lock:
+                self._pending.pop(rid, None)
+            raise TimeoutError(
+                f"ACP method {method!r} timed out after {timeout}s"
+            )
+        if "error" in msg:
+            err = msg["error"]
+            raise ACPClientError(
+                code=err.get("code", -1),
+                message=err.get("message", ""),
+                data=err.get("data"),
+            )
+        return msg.get("result") or {}
+
+    def notify(self, method: str, params: Optional[dict] = None) -> None:
+        """Send a JSON-RPC notification (no id, no response expected)."""
+        self._send({"method": method, "params": params or {}})
+
+    def respond(self, request_id: Any, result: dict) -> None:
+        """Reply to a server-initiated request (fs/read, fs/write, permission)."""
+        self._send({"id": request_id, "result": result})
+
+    def respond_error(
+        self, request_id: Any, code: int, message: str, data: Optional[Any] = None
+    ) -> None:
+        """Reply to a server-initiated request with an error."""
+        err: dict[str, Any] = {"code": code, "message": message}
+        if data is not None:
+            err["data"] = data
+        self._send({"id": request_id, "error": err})
+
+    def take_notification(self, timeout: float = 0.0) -> Optional[dict]:
+        """Pop the next streaming notification (session/update), or None on timeout.
+
+        timeout=0.0 means non-blocking. Use small positive timeouts inside the
+        AIAgent turn loop to interleave reads with interrupt checks.
+        """
+        try:
+            if timeout <= 0:
+                return self._notifications.get_nowait()
+            return self._notifications.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    def take_server_request(self, timeout: float = 0.0) -> Optional[dict]:
+        """Pop the next server-initiated request (fs/*, terminal/*, permission)."""
+        try:
+            if timeout <= 0:
+                return self._server_requests.get_nowait()
+            return self._server_requests.get(timeout=timeout)
+        except queue.Empty:
+            return None
+
+    # ---------- diagnostics ----------
+
+    def stderr_tail(self, n: int = 20) -> list[str]:
+        """Return last n lines of the agent's stderr (for error reports)."""
+        with self._stderr_lock:
+            return list(self._stderr_lines[-n:])
+
+    def is_alive(self) -> bool:
+        return self._proc.poll() is None
+
+    # ---------- internals ----------
+
+    def _take_id(self) -> int:
+        with self._pending_lock:
+            rid = self._next_id
+            self._next_id += 1
+            return rid
+
+    def _send(self, obj: dict) -> None:
+        if self._closed:
+            raise RuntimeError("ACP client is closed")
+        if self._proc.stdin is None:
+            raise RuntimeError("ACP agent stdin not available")
+        # _send_lock serialises writes from multiple threads. Unlike Codex
+        # (where session/prompt returns immediately), ACP session/prompt blocks
+        # for the whole turn, so callers wrap it in a background thread while
+        # the main thread drains notifications — two concurrent writers on the
+        # same BufferedWriter would interleave mid-JSON-line and corrupt the wire.
+        with self._send_lock:
+            try:
+                self._proc.stdin.write((json.dumps(obj) + "\n").encode("utf-8"))
+                self._proc.stdin.flush()
+            except (BrokenPipeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"ACP agent stdin closed unexpectedly: {exc}"
+                ) from exc
+
+    def _read_stdout(self) -> None:
+        if self._proc.stdout is None:
+            return
+        try:
+            for line in iter(self._proc.stdout.readline, b""):
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    with self._stderr_lock:
+                        self._stderr_lines.append(
+                            f"<non-json on stdout> {line[:200]!r}"
+                        )
+                    continue
+                self._dispatch(msg)
+        except Exception as exc:
+            with self._stderr_lock:
+                self._stderr_lines.append(f"<stdout reader error> {exc}")
+
+    def _dispatch(self, msg: dict) -> None:
+        """Three-arm dispatch:
+        1. Reply (id + result/error, no method) → unblock the pending request future.
+        2. Server-initiated request (id + method) → _server_requests queue.
+        3. Notification (no id, method present) → _notifications queue.
+        """
+        # Reply
+        if "id" in msg and ("result" in msg or "error" in msg):
+            with self._pending_lock:
+                pending = self._pending.pop(msg["id"], None)
+            if pending is not None:
+                try:
+                    pending.queue.put_nowait(msg)
+                except queue.Full:  # pragma: no cover - defensive
+                    pass
+            return
+        # Server-initiated request (has id + method)
+        if "id" in msg and "method" in msg:
+            self._server_requests.put(msg)
+            return
+        # Notification (no id, has method)
+        if "method" in msg:
+            self._notifications.put(msg)
+
+    def _read_stderr(self) -> None:
+        if self._proc.stderr is None:
+            return
+        try:
+            for line in iter(self._proc.stderr.readline, b""):
+                if not line:
+                    break
+                with self._stderr_lock:
+                    self._stderr_lines.append(
+                        line.decode("utf-8", "replace").rstrip()
+                    )
+                    # Bound memory: keep last 500 lines.
+                    if len(self._stderr_lines) > 500:
+                        self._stderr_lines = self._stderr_lines[-500:]
+        except Exception:  # pragma: no cover
+            pass

--- a/agent/transports/acp_client_session.py
+++ b/agent/transports/acp_client_session.py
@@ -7,7 +7,7 @@ and returns a TurnResult that acp_runtime.run_acp_client_turn() can splice into
 the ``messages`` list.
 
 Lifecycle:
-    session = ACPClientSession(command="claude-acp-bridge")
+    session = ACPClientSession(command="claude-agent-acp")
     session.ensure_started(cwd="/home/x/proj")      # spawns + initialize + session/new
     result = session.run_turn("hello")               # blocks until session/prompt returns
     # result.final_text          → assistant text returned to caller
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
@@ -115,7 +116,7 @@ class ACPClientSession:
     ) -> None:
         """
         Args:
-            command: ACP agent binary to spawn (e.g. "claude-acp-bridge").
+            command: ACP agent binary to spawn (e.g. "claude-agent-acp").
             args: Additional arguments to pass to the command.
             env: Extra environment variables for the subprocess.
             on_delta: Optional callback invoked with each text delta during streaming.
@@ -263,7 +264,6 @@ class ACPClientSession:
             except (ACPClientError, TimeoutError, RuntimeError) as exc:
                 _error.append(exc)
 
-        import threading
         req_thread = threading.Thread(target=_do_request, daemon=True)
         req_thread.start()
 

--- a/agent/transports/acp_client_session.py
+++ b/agent/transports/acp_client_session.py
@@ -1,0 +1,457 @@
+"""Session adapter for ACP client runtime.
+
+Owns one ACP session per Hermes session. Drives ``session/new`` + ``session/prompt``,
+consumes streaming ``session/update`` notifications (AgentMessageChunk), handles
+server-initiated requests (fs/*, terminal/*, permission — declined by default in v1),
+and returns a TurnResult that acp_runtime.run_acp_client_turn() can splice into
+the ``messages`` list.
+
+Lifecycle:
+    session = ACPClientSession(command="claude-acp-bridge")
+    session.ensure_started(cwd="/home/x/proj")      # spawns + initialize + session/new
+    result = session.run_turn("hello")               # blocks until session/prompt returns
+    # result.final_text          → assistant text returned to caller
+    # result.projected_messages  → list of {role, content} for messages list
+    # result.tool_iterations     → count of tool-shaped update events (skill nudge)
+    # result.should_retire       → True if session wedged (timeout, crash)
+    session.close()                                  # session/close + subprocess teardown
+
+Threading model: single-threaded from the caller's perspective.
+The underlying ACPClient owns its own reader threads but exposes
+blocking-with-timeout queues that this adapter polls in a loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from agent.transports.acp_client import ACPClient, ACPClientError
+
+logger = logging.getLogger(__name__)
+
+# ACP wire method names (from acp.meta)
+_METHOD_INITIALIZE = "initialize"
+_METHOD_SESSION_NEW = "session/new"
+_METHOD_SESSION_PROMPT = "session/prompt"
+_METHOD_SESSION_CLOSE = "session/close"
+_METHOD_SESSION_CANCEL = "session/cancel"
+_METHOD_SESSION_UPDATE = "session/update"
+
+# Server-initiated (client-side) methods we receive
+_METHOD_FS_READ = "fs/read_text_file"
+_METHOD_FS_WRITE = "fs/write_text_file"
+_METHOD_PERMISSION = "session/request_permission"
+_METHOD_TERMINAL_CREATE = "terminal/create"
+_METHOD_TERMINAL_OUTPUT = "terminal/output"
+_METHOD_TERMINAL_RELEASE = "terminal/release"
+_METHOD_TERMINAL_WAIT = "terminal/wait_for_exit"
+_METHOD_TERMINAL_KILL = "terminal/kill"
+
+# ACP session/update discriminator values for streaming chunks
+_UPDATE_AGENT_MESSAGE = "agent_message_chunk"
+_UPDATE_AGENT_THOUGHT = "agent_thought_chunk"
+_UPDATE_TOOL_CALL = "tool_call_update"
+_UPDATE_TOOL_CALL_START = "tool_call"
+
+# How many trailing stderr lines to show in error messages
+_STDERR_TAIL_LINES = 12
+
+
+@dataclass
+class TurnResult:
+    """Result of one user→assistant turn through an ACP-compliant agent."""
+
+    final_text: str = ""
+    projected_messages: list[dict] = field(default_factory=list)
+    tool_iterations: int = 0
+    interrupted: bool = False
+    error: Optional[str] = None
+    # True when the session is wedged (timeout, crash, bad response).
+    # The caller should retire and re-create the session on the next turn.
+    should_retire: bool = False
+
+
+def _extract_text_from_update(params: dict) -> str:
+    """Extract plain text from an ACP session/update notification params.
+
+    ``session/update`` params carry:
+      { "sessionId": "...", "update": { "sessionUpdate": "agent_message_chunk",
+                                        "content": { "type": "text", "text": "..." } } }
+    Returns the text string, or "" if not a text chunk.
+    """
+    update = params.get("update") or {}
+    content = update.get("content") or {}
+    if isinstance(content, dict) and content.get("type") == "text":
+        return content.get("text") or ""
+    return ""
+
+
+def _is_tool_iteration(params: dict) -> bool:
+    """Return True if the update represents a tool call completion."""
+    update = params.get("update") or {}
+    kind = update.get("sessionUpdate") or update.get("session_update") or ""
+    return kind in {_UPDATE_TOOL_CALL, _UPDATE_TOOL_CALL_START}
+
+
+class ACPClientSession:
+    """One ACP session per Hermes session, lifetime owned by AIAgent.
+
+    Not thread-safe — one caller drives it at a time, matching how AIAgent's
+    run_conversation() loop is structured today.
+    """
+
+    def __init__(
+        self,
+        *,
+        command: str,
+        args: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
+        on_delta: Optional[Callable[[str], None]] = None,
+        client_factory: Optional[Callable[..., ACPClient]] = None,
+    ) -> None:
+        """
+        Args:
+            command: ACP agent binary to spawn (e.g. "claude-acp-bridge").
+            args: Additional arguments to pass to the command.
+            env: Extra environment variables for the subprocess.
+            on_delta: Optional callback invoked with each text delta during streaming.
+                      Bridges to Hermes' ``_fire_stream_delta`` for live output.
+            client_factory: Inject a custom ACPClient constructor for testing.
+        """
+        self._command = command
+        self._args = list(args or [])
+        self._env = env
+        self._on_delta = on_delta
+        self._client_factory = client_factory or ACPClient
+
+        self._client: Optional[ACPClient] = None
+        self._session_id: Optional[str] = None
+        self._closed = False
+
+    # ---------- lifecycle ----------
+
+    def ensure_started(self, cwd: Optional[str] = None) -> str:
+        """Spawn the subprocess, do the initialize handshake, and start a
+        session. Returns the ACP session_id. Idempotent — repeated calls
+        return the same session_id."""
+        if self._session_id is not None:
+            return self._session_id
+        if self._client is None:
+            self._client = self._client_factory(
+                command=self._command,
+                args=self._args,
+                env=self._env,
+            )
+        self._client.initialize(
+            client_name="hermes",
+            client_version=_get_hermes_version(),
+        )
+        result = self._client.request(
+            _METHOD_SESSION_NEW,
+            # mcpServers is required by the ACP schema (NewSessionRequest); send
+            # an empty list — Hermes handles its own MCP surface, not the agent.
+            {"cwd": cwd or os.getcwd(), "mcpServers": []},
+            timeout=15,
+        )
+        session_id = result.get("sessionId") or result.get("session_id") or ""
+        if not session_id:
+            raise ACPClientError(
+                code=-32603,
+                message=(
+                    "ACP session/new returned no sessionId "
+                    f"(payload keys: {sorted(result.keys())})"
+                ),
+            )
+        self._session_id = session_id
+        logger.info(
+            "ACP client session started: id=%s command=%r cwd=%s",
+            self._session_id[:8],
+            self._command,
+            cwd or os.getcwd(),
+        )
+        return self._session_id
+
+    def close(self) -> None:
+        """Send session/close and tear down the subprocess."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._client is not None and self._session_id is not None:
+            try:
+                self._client.request(
+                    _METHOD_SESSION_CLOSE,
+                    {"sessionId": self._session_id},
+                    timeout=5,
+                )
+            except Exception:
+                pass  # best-effort
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:
+                pass
+            self._client = None
+        self._session_id = None
+
+    def __enter__(self) -> "ACPClientSession":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    # ---------- turn ----------
+
+    def run_turn(
+        self,
+        user_input: Any,
+        *,
+        cwd: Optional[str] = None,
+        turn_timeout: float = 600.0,
+        notification_poll_timeout: float = 0.25,
+    ) -> TurnResult:
+        """Send a user message and block until session/prompt returns.
+
+        Streams session/update notifications to on_delta as they arrive.
+        Projects streamed content into projected_messages so memory/skill
+        review keep working.
+
+        Returns a TurnResult. Sets should_retire=True on crash/timeout.
+        """
+        result = TurnResult()
+        # Ensure session is open (lazy start on first turn)
+        try:
+            self.ensure_started(cwd=cwd)
+        except (ACPClientError, TimeoutError, RuntimeError) as exc:
+            result.error = f"ACP client session startup failed: {exc}"
+            result.should_retire = True
+            return result
+
+        assert self._client is not None and self._session_id is not None
+
+        user_text = _coerce_user_input(user_input)
+
+        # Build ACP prompt request
+        prompt_params = {
+            "sessionId": self._session_id,
+            "prompt": [{"type": "text", "text": user_text}],
+        }
+
+        # session/prompt is a request that blocks until the agent returns
+        # PromptResponse. While waiting, the agent sends session/update
+        # notifications which arrive in the _notifications queue.
+        # We poll both in a deadline loop.
+        deadline = time.monotonic() + turn_timeout
+        text_chunks: list[str] = []
+
+        # Send session/prompt in a background thread so we can drain
+        # notifications concurrently. The result arrives via a shared dict.
+        _response: dict = {}
+        _error: list = []  # [exc] if the request raised
+
+        def _do_request() -> None:
+            try:
+                r = self._client.request(
+                    _METHOD_SESSION_PROMPT,
+                    prompt_params,
+                    timeout=turn_timeout,
+                )
+                _response["result"] = r
+            except (ACPClientError, TimeoutError, RuntimeError) as exc:
+                _error.append(exc)
+
+        import threading
+        req_thread = threading.Thread(target=_do_request, daemon=True)
+        req_thread.start()
+
+        def _process_notification(note: dict) -> None:
+            """Apply a single session/update notification to result + text_chunks.
+
+            Factored out so the same logic runs during the live drain loop and
+            the post-join tail-drain (notifications that arrived between the
+            last loop poll and req_thread completion would otherwise be lost).
+            """
+            if note.get("method") != _METHOD_SESSION_UPDATE:
+                return
+            params = note.get("params") or {}
+            delta = _extract_text_from_update(params)
+            if delta:
+                text_chunks.append(delta)
+                if self._on_delta is not None:
+                    try:
+                        self._on_delta(delta)
+                    except Exception:
+                        logger.debug("on_delta callback raised", exc_info=True)
+            if _is_tool_iteration(params):
+                result.tool_iterations += 1
+
+        # Drain notifications while waiting for the prompt response.
+        # session/prompt blocks for the entire turn; req_thread sends it while
+        # this loop concurrently drains session/update chunks.
+        # _send_lock on ACPClient ensures the two threads don't interleave
+        # writes to the same BufferedWriter (see ACPClient._send).
+        while req_thread.is_alive() and time.monotonic() < deadline:
+            if not (self._client and self._client.is_alive()):
+                result.error = self._format_error("ACP agent subprocess exited unexpectedly")
+                result.should_retire = True
+                break
+
+            # Handle server-initiated requests (fs/*, permission, terminal/*)
+            sreq = self._client.take_server_request(timeout=0)
+            if sreq is not None:
+                self._handle_server_request(sreq)
+                continue
+
+            # Drain streaming notifications (session/update)
+            note = self._client.take_notification(timeout=notification_poll_timeout)
+            if note is None:
+                continue
+            _process_notification(note)
+
+        req_thread.join(timeout=2.0)
+
+        # Tail-drain: consume notifications that were parsed by the reader
+        # thread between the last loop poll and req_thread completing. These
+        # would be silently dropped without this drain — short responses that
+        # fit in the first chunks are the most likely to be affected.
+        if self._client is not None:
+            while True:
+                note = self._client.take_notification(timeout=0)
+                if note is None:
+                    break
+                _process_notification(note)
+
+        if _error:
+            exc = _error[0]
+            result.error = f"ACP session/prompt failed: {exc}"
+            if isinstance(exc, TimeoutError) or (
+                isinstance(exc, ACPClientError) and exc.code < 0
+            ):
+                result.should_retire = True
+            return result
+
+        if "result" not in _response and not result.should_retire:
+            # Deadline hit without response
+            result.error = f"ACP turn timed out after {turn_timeout}s"
+            result.should_retire = True
+            result.interrupted = True
+            return result
+
+        if result.should_retire:
+            return result
+
+        # Assemble final text from streamed chunks. If chunks are empty,
+        # look for text in the PromptResponse itself (some implementations
+        # may put content there instead of streaming).
+        prompt_result = _response.get("result") or {}
+        assembled = "".join(text_chunks)
+        if not assembled:
+            # Fallback: look for content in the PromptResponse
+            for block in (prompt_result.get("content") or []):
+                if isinstance(block, dict) and block.get("type") == "text":
+                    assembled += block.get("text") or ""
+
+        result.final_text = assembled
+
+        # Project into messages so curator/memory/skill review can see the turn.
+        if assembled:
+            result.projected_messages.append(
+                {"role": "assistant", "content": assembled}
+            )
+
+        return result
+
+    # ---------- internals ----------
+
+    def _handle_server_request(self, req: dict) -> None:
+        """Handle server-initiated requests from the ACP agent.
+
+        In v1 we decline all server-initiated requests (fs/*, terminal/*,
+        permission) because Hermes controls those surfaces itself. A future
+        iteration could bridge these to Hermes' tools.
+        """
+        if self._client is None:
+            return
+        method = req.get("method", "")
+        rid = req.get("id")
+
+        if method == _METHOD_PERMISSION:
+            # Decline permission escalation — user controls Hermes' permission
+            # model through Hermes' own config.
+            self._client.respond(rid, {"granted": False})
+        elif method in {
+            _METHOD_FS_READ, _METHOD_FS_WRITE,
+            _METHOD_TERMINAL_CREATE, _METHOD_TERMINAL_OUTPUT,
+            _METHOD_TERMINAL_RELEASE, _METHOD_TERMINAL_WAIT,
+            _METHOD_TERMINAL_KILL,
+        }:
+            # Decline fs/terminal proxying — Hermes drives its own tool
+            # executor. ACP agents that need fs/terminal ops should spawn
+            # their own processes.
+            logger.debug("ACP client: declining server request %r (not proxied in v1)", method)
+            self._client.respond_error(
+                rid,
+                code=-32601,
+                message=f"Method not supported by Hermes ACP client v1: {method}",
+            )
+        else:
+            logger.warning("ACP client: unknown server request %r", method)
+            self._client.respond_error(
+                rid,
+                code=-32601,
+                message=f"Unknown method: {method}",
+            )
+
+    def _format_error(self, prefix: str) -> str:
+        """Build a user-facing error string, appending stderr tail when available."""
+        if self._client is None:
+            return prefix
+        try:
+            tail = self._client.stderr_tail(_STDERR_TAIL_LINES)
+        except Exception:
+            return prefix
+        if not tail:
+            return prefix
+        joined = "\n".join(line.rstrip() for line in tail if line)
+        if not joined.strip():
+            return prefix
+        return f"{prefix}\nACP agent stderr (last {len(tail)} lines):\n{joined}"
+
+
+def _coerce_user_input(user_input: Any) -> str:
+    """Collapse Hermes/OpenAI rich content into plain text for ACP session/prompt."""
+    if isinstance(user_input, str):
+        return user_input
+    if isinstance(user_input, list):
+        parts: list[str] = []
+        for item in user_input:
+            if isinstance(item, str):
+                if item.strip():
+                    parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                if item is not None:
+                    parts.append(str(item))
+                continue
+            item_type = item.get("type")
+            if item_type in {"text", "input_text"}:
+                text = item.get("text") or item.get("content") or ""
+                if text:
+                    parts.append(str(text))
+            elif item_type in {"image", "image_url", "input_image"}:
+                parts.append("[image attached]")
+        text = "\n\n".join(p for p in parts if p).strip()
+        return text or "What do you see in this image?"
+    return "" if user_input is None else str(user_input)
+
+
+def _get_hermes_version() -> str:
+    """Best-effort Hermes version string for ACP initialize."""
+    try:
+        from importlib.metadata import version
+        return version("hermes-agent")
+    except Exception:  # pragma: no cover
+        return "0.0.0"

--- a/agent/transports/acp_client_session.py
+++ b/agent/transports/acp_client_session.py
@@ -126,6 +126,7 @@ class ACPClientSession:
         args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
         model: Optional[str] = None,
+        mcp_servers: Optional[list[dict]] = None,
         on_delta: Optional[Callable[[str], None]] = None,
         client_factory: Optional[Callable[..., ACPClient]] = None,
     ) -> None:
@@ -140,6 +141,11 @@ class ACPClientSession:
                 when set; servers that do not support set_config_option are
                 tolerated -- the call is wrapped in a try/except and a warning
                 is logged rather than hard-failing the session.
+            mcp_servers: Pre-translated ACP McpServer dicts to forward in
+                session/new.  Build with ``_translate_mcp_servers()`` from
+                Hermes' mcp_servers config.  Hermes does NOT open these
+                connections in-process -- the external ACP agent owns them.
+                None or [] → send an empty list (current default behaviour).
             on_delta: Optional callback invoked with each text delta during streaming.
                       Bridges to Hermes' ``_fire_stream_delta`` for live output.
             client_factory: Inject a custom ACPClient constructor for testing.
@@ -148,6 +154,7 @@ class ACPClientSession:
         self._args = list(args or [])
         self._env = env
         self._model = model
+        self._mcp_servers: list[dict] = list(mcp_servers or [])
         self._on_delta = on_delta
         self._client_factory = client_factory or ACPClient
 
@@ -175,9 +182,12 @@ class ACPClientSession:
         )
         result = self._client.request(
             _METHOD_SESSION_NEW,
-            # mcpServers is required by the ACP schema (NewSessionRequest); send
-            # an empty list -- Hermes handles its own MCP surface, not the agent.
-            {"cwd": cwd or os.getcwd(), "mcpServers": []},
+            # mcpServers: forward the translated list from Hermes' mcp_servers
+            # config so the ACP agent can connect to the user's MCP tools.
+            # Hermes does NOT open these connections in-process -- the external
+            # ACP agent owns the connections (no double-connect).
+            # Empty list when no servers are configured (original default).
+            {"cwd": cwd or os.getcwd(), "mcpServers": self._mcp_servers},
             timeout=15,
         )
         session_id = result.get("sessionId") or result.get("session_id") or ""
@@ -588,6 +598,91 @@ class ACPClientSession:
         if not joined.strip():
             return prefix
         return f"{prefix}\nACP agent stderr (last {len(tail)} lines):\n{joined}"
+
+
+def _translate_mcp_servers(servers: dict) -> list[dict]:
+    """Translate Hermes mcp_servers config dict to ACP McpServer wire shapes.
+
+    Hermes config (from config.yaml ``mcp_servers:`` key) is a dict of
+    ``{name: server_cfg}`` where server_cfg contains either stdio or HTTP/SSE
+    transport fields.  The ACP server expects a typed list with exact shapes
+    (probed empirically against claude-agent-acp v0.39).
+
+    Accepted ACP shapes:
+      stdio (NO type field):
+        {"name": str, "command": str, "args": [str], "env": [{"name": str, "value": str}]}
+        env is REQUIRED and must be an array -- use [] when the config has none.
+      http:
+        {"type": "http", "name": str, "url": str, "headers": [{"name": str, "value": str}]}
+        headers is REQUIRED array.
+      sse:
+        {"type": "sse", "name": str, "url": str, "headers": [{"name": str, "value": str}]}
+        headers is REQUIRED array.
+
+    Both env/headers must be [{name, value}] arrays -- dict/object shapes are
+    rejected (-32602) by the native server.  They are always emitted ([] when
+    empty) so the server never sees a missing required field.
+
+    Hermes-only keys (timeout, connect_timeout, auth, sampling) are dropped;
+    ACP does not accept unknown fields.  Values are already ${VAR}-interpolated
+    by _load_mcp_config() -- no re-interpolation here.
+
+    Entries with neither ``command`` nor ``url`` are skipped with a warning
+    rather than crashing the session setup.
+    """
+    out = []
+    for name, cfg in (servers or {}).items():
+        if not isinstance(cfg, dict):
+            logger.warning(
+                "ACP MCP translate: skipping %r -- config is not a dict (%r)",
+                name, type(cfg).__name__,
+            )
+            continue
+
+        has_command = bool(cfg.get("command"))
+        has_url = bool(cfg.get("url"))
+
+        if has_command and has_url:
+            # Prefer stdio when both are set, matching the codex translator.
+            logger.debug(
+                "ACP MCP translate: %r has both command and url -- using stdio", name
+            )
+            has_url = False
+
+        if has_command:
+            # Stdio transport.  env dict -> [{name, value}] array (always present).
+            raw_env = cfg.get("env") or {}
+            env_array = [{"name": str(k), "value": str(v)} for k, v in raw_env.items()]
+            args = [str(a) for a in (cfg.get("args") or [])]
+            out.append({
+                "name": name,
+                "command": str(cfg["command"]),
+                "args": args,
+                "env": env_array,
+                # No "type" field for stdio -- ACP spec requires its absence.
+            })
+        elif has_url:
+            # HTTP or SSE transport.  Hermes uses "transport" key ("sse" hint).
+            # headers dict -> [{name, value}] array (always present).
+            raw_headers = cfg.get("headers") or {}
+            headers_array = [{"name": str(k), "value": str(v)} for k, v in raw_headers.items()]
+            # Hermes writes "transport" (not "type") for the sse hint.
+            # Honor explicit "type" too for forward-compat.
+            transport_hint = cfg.get("transport") or cfg.get("type") or ""
+            acp_type = "sse" if transport_hint.lower() == "sse" else "http"
+            out.append({
+                "type": acp_type,
+                "name": name,
+                "url": str(cfg["url"]),
+                "headers": headers_array,
+            })
+        else:
+            logger.warning(
+                "ACP MCP translate: skipping %r -- no 'command' or 'url' field", name
+            )
+            continue
+
+    return out
 
 
 def _pick_allow_option(options: list) -> Optional[str]:

--- a/agent/transports/acp_client_session.py
+++ b/agent/transports/acp_client_session.py
@@ -127,6 +127,7 @@ class ACPClientSession:
         env: Optional[dict[str, str]] = None,
         model: Optional[str] = None,
         mcp_servers: Optional[list[dict]] = None,
+        setting_sources: Optional[tuple] = ("project", "local"),
         on_delta: Optional[Callable[[str], None]] = None,
         client_factory: Optional[Callable[..., ACPClient]] = None,
     ) -> None:
@@ -146,6 +147,18 @@ class ACPClientSession:
                 Hermes' mcp_servers config.  Hermes does NOT open these
                 connections in-process -- the external ACP agent owns them.
                 None or [] → send an empty list (current default behaviour).
+            setting_sources: Claude Code setting scopes forwarded to the native
+                ACP server via _meta.claudeCode.options.settingSources in
+                session/new.  The native server (claude-agent-acp) hardcodes
+                settingSources:["user","project","local"] (dist/acp-agent.js:1522)
+                and then spreads userProvidedOptions on top (line 1524), so this
+                override takes effect.  Default ("project","local") mirrors
+                --setting-sources project,local used by the claude_daemon transport
+                and excludes the "user" scope, preventing ~/.claude plugins and
+                MCP servers (playwright, context7, slack-channels, etc.) from
+                leaking into the delegated agent.  Non-Claude ACP servers ignore
+                unknown _meta keys, so it is safe to always send.
+                Pass None or [] to omit _meta entirely (raw server defaults).
             on_delta: Optional callback invoked with each text delta during streaming.
                       Bridges to Hermes' ``_fire_stream_delta`` for live output.
             client_factory: Inject a custom ACPClient constructor for testing.
@@ -155,6 +168,9 @@ class ACPClientSession:
         self._env = env
         self._model = model
         self._mcp_servers: list[dict] = list(mcp_servers or [])
+        self._setting_sources: Optional[list[str]] = (
+            list(setting_sources) if setting_sources else None
+        )
         self._on_delta = on_delta
         self._client_factory = client_factory or ACPClient
 
@@ -180,14 +196,30 @@ class ACPClientSession:
             client_name="hermes",
             client_version=_get_hermes_version(),
         )
+        # Build session/new params.  _meta.claudeCode.options is a documented
+        # passthrough in the native ACP server (acp-agent.js:1500) spread AFTER
+        # its hardcoded settingSources (line 1524), so our value wins.
+        # Sending settingSources:["project","local"] (the default) prevents
+        # ~/.claude user-scope plugins and MCP servers (playwright, context7,
+        # slack-channels, etc.) from leaking into the delegated agent -- the
+        # same isolation the claude_daemon transport enforces via
+        # --setting-sources project,local.  Generic ACP servers ignore unknown
+        # _meta keys, so it is safe to always include when configured.
+        session_new_params: dict = {
+            "cwd": cwd or os.getcwd(),
+            "mcpServers": self._mcp_servers,
+        }
+        if self._setting_sources:
+            session_new_params["_meta"] = {
+                "claudeCode": {
+                    "options": {
+                        "settingSources": self._setting_sources,
+                    }
+                }
+            }
         result = self._client.request(
             _METHOD_SESSION_NEW,
-            # mcpServers: forward the translated list from Hermes' mcp_servers
-            # config so the ACP agent can connect to the user's MCP tools.
-            # Hermes does NOT open these connections in-process -- the external
-            # ACP agent owns the connections (no double-connect).
-            # Empty list when no servers are configured (original default).
-            {"cwd": cwd or os.getcwd(), "mcpServers": self._mcp_servers},
+            session_new_params,
             timeout=15,
         )
         session_id = result.get("sessionId") or result.get("session_id") or ""

--- a/agent/transports/acp_client_session.py
+++ b/agent/transports/acp_client_session.py
@@ -2,12 +2,12 @@
 
 Owns one ACP session per Hermes session. Drives ``session/new`` + ``session/prompt``,
 consumes streaming ``session/update`` notifications (AgentMessageChunk), handles
-server-initiated requests (fs/*, terminal/*, permission — declined by default in v1),
+server-initiated requests (fs/*, terminal/*, permission — allowed-once by default),
 and returns a TurnResult that acp_runtime.run_acp_client_turn() can splice into
 the ``messages`` list.
 
 Lifecycle:
-    session = ACPClientSession(command="claude-agent-acp")
+    session = ACPClientSession(command="claude-agent-acp", model="claude-haiku-4-5")
     session.ensure_started(cwd="/home/x/proj")      # spawns + initialize + session/new
     result = session.run_turn("hello")               # blocks until session/prompt returns
     # result.final_text          → assistant text returned to caller
@@ -41,6 +41,7 @@ _METHOD_SESSION_PROMPT = "session/prompt"
 _METHOD_SESSION_CLOSE = "session/close"
 _METHOD_SESSION_CANCEL = "session/cancel"
 _METHOD_SESSION_UPDATE = "session/update"
+_METHOD_SESSION_SET_CONFIG = "session/set_config_option"
 
 # Server-initiated (client-side) methods we receive
 _METHOD_FS_READ = "fs/read_text_file"
@@ -52,7 +53,9 @@ _METHOD_TERMINAL_RELEASE = "terminal/release"
 _METHOD_TERMINAL_WAIT = "terminal/wait_for_exit"
 _METHOD_TERMINAL_KILL = "terminal/kill"
 
-# ACP session/update discriminator values for streaming chunks
+# ACP session/update discriminator values for streaming chunks.
+# Only agent_message_chunk carries user-facing text — agent_thought_chunk is
+# the model's internal reasoning and MUST NOT be merged into the reply (Fix 2).
 _UPDATE_AGENT_MESSAGE = "agent_message_chunk"
 _UPDATE_AGENT_THOUGHT = "agent_thought_chunk"
 _UPDATE_TOOL_CALL = "tool_call_update"
@@ -64,7 +67,7 @@ _STDERR_TAIL_LINES = 12
 
 @dataclass
 class TurnResult:
-    """Result of one user→assistant turn through an ACP-compliant agent."""
+    """Result of one user->assistant turn through an ACP-compliant agent."""
 
     final_text: str = ""
     projected_messages: list[dict] = field(default_factory=list)
@@ -82,9 +85,20 @@ def _extract_text_from_update(params: dict) -> str:
     ``session/update`` params carry:
       { "sessionId": "...", "update": { "sessionUpdate": "agent_message_chunk",
                                         "content": { "type": "text", "text": "..." } } }
-    Returns the text string, or "" if not a text chunk.
+
+    Fix 2 -- ONLY extract text from ``agent_message_chunk`` updates. The server
+    also emits ``agent_thought_chunk`` for the model's internal reasoning; those
+    must NOT be included in the user-facing reply. Keying on the discriminator
+    instead of content.type avoids silently leaking future reasoning variants.
     """
     update = params.get("update") or {}
+    # Support both camelCase (sessionUpdate) and snake_case (session_update) keys
+    # to match whatever the server emits -- mirrors _is_tool_iteration's approach.
+    kind = update.get("sessionUpdate") or update.get("session_update") or ""
+    if kind != _UPDATE_AGENT_MESSAGE:
+        # Intentionally skip agent_thought_chunk and anything else that is not
+        # a confirmed user-facing text chunk (YAGNI -- do not whitelist speculatively).
+        return ""
     content = update.get("content") or {}
     if isinstance(content, dict) and content.get("type") == "text":
         return content.get("text") or ""
@@ -101,7 +115,7 @@ def _is_tool_iteration(params: dict) -> bool:
 class ACPClientSession:
     """One ACP session per Hermes session, lifetime owned by AIAgent.
 
-    Not thread-safe — one caller drives it at a time, matching how AIAgent's
+    Not thread-safe -- one caller drives it at a time, matching how AIAgent's
     run_conversation() loop is structured today.
     """
 
@@ -111,6 +125,7 @@ class ACPClientSession:
         command: str,
         args: Optional[list[str]] = None,
         env: Optional[dict[str, str]] = None,
+        model: Optional[str] = None,
         on_delta: Optional[Callable[[str], None]] = None,
         client_factory: Optional[Callable[..., ACPClient]] = None,
     ) -> None:
@@ -119,6 +134,12 @@ class ACPClientSession:
             command: ACP agent binary to spawn (e.g. "claude-agent-acp").
             args: Additional arguments to pass to the command.
             env: Extra environment variables for the subprocess.
+            model: Model identifier to pin on the ACP session after session/new
+                (Fix 1). Sent via ``session/set_config_option`` so the ACP server
+                does not default to its own heavy model (e.g. Opus). Only sent
+                when set; servers that do not support set_config_option are
+                tolerated -- the call is wrapped in a try/except and a warning
+                is logged rather than hard-failing the session.
             on_delta: Optional callback invoked with each text delta during streaming.
                       Bridges to Hermes' ``_fire_stream_delta`` for live output.
             client_factory: Inject a custom ACPClient constructor for testing.
@@ -126,6 +147,7 @@ class ACPClientSession:
         self._command = command
         self._args = list(args or [])
         self._env = env
+        self._model = model
         self._on_delta = on_delta
         self._client_factory = client_factory or ACPClient
 
@@ -137,7 +159,7 @@ class ACPClientSession:
 
     def ensure_started(self, cwd: Optional[str] = None) -> str:
         """Spawn the subprocess, do the initialize handshake, and start a
-        session. Returns the ACP session_id. Idempotent — repeated calls
+        session. Returns the ACP session_id. Idempotent -- repeated calls
         return the same session_id."""
         if self._session_id is not None:
             return self._session_id
@@ -154,7 +176,7 @@ class ACPClientSession:
         result = self._client.request(
             _METHOD_SESSION_NEW,
             # mcpServers is required by the ACP schema (NewSessionRequest); send
-            # an empty list — Hermes handles its own MCP surface, not the agent.
+            # an empty list -- Hermes handles its own MCP surface, not the agent.
             {"cwd": cwd or os.getcwd(), "mcpServers": []},
             timeout=15,
         )
@@ -174,7 +196,114 @@ class ACPClientSession:
             self._command,
             cwd or os.getcwd(),
         )
+
+        # Fix 1 -- Model pin: send session/set_config_option to override the
+        # ACP server's default model (native claude-agent-acp defaults to Opus,
+        # which silently drains quota on every turn). Only sent when a model is
+        # explicitly configured; servers that don't support set_config_option are
+        # tolerated; servers that support it but reject the value raise loud.
+        if self._model:
+            try:
+                self._send_model_config(self._session_id, self._model)
+            except ACPClientError:
+                # Mismatch detected: clear session so ensure_started does not
+                # short-circuit on the next call (idempotency guard at top of
+                # method checks self._session_id is not None).  Re-raise so
+                # run_turn can surface the config error without retiring.
+                self._session_id = None
+                raise
+
         return self._session_id
+
+    def _send_model_config(self, session_id: str, model: str) -> None:
+        """Send session/set_config_option to pin the model on the ACP session, then
+        verify the server honoured the value.
+
+        The native claude-agent-acp server (v0.39) accepts only its own short aliases:
+          "haiku"   → Haiku 4.5   (cheapest)
+          "sonnet"  → Sonnet 4.6
+          "default" → Opus 4.8    (most expensive — the server default)
+        Full API IDs like "claude-haiku-4-5-20251001" are normalised to the alias by
+        the server; "claude-sonnet-4-5" is rejected with -32603.  Configure the model
+        as the alias ("haiku", "sonnet") in Hermes' acp_model config key.
+
+        Verification is REQUIRED because a wrong value silently falls back to the
+        server default (Opus 4.8), burning quota on every turn without any warning.
+
+        Two-layer exception strategy:
+          • transport/protocol failure (request() raises) → TOLERATE: server may
+            not implement set_config_option at all; warn and continue.
+          • server supported but value rejected or silently ignored (request() succeeds
+            but currentValue != requested) → FAIL LOUD: raise ACPClientError so the
+            caller knows the pin didn't take.  Do NOT swallow this — billing impact.
+        """
+        assert self._client is not None
+
+        # Tolerance layer: wraps only the wire call.  Servers that do not implement
+        # set_config_option return a -32601 method-not-found error; we log and return.
+        try:
+            result = self._client.request(
+                _METHOD_SESSION_SET_CONFIG,
+                {
+                    "sessionId": session_id,
+                    "configId": "model",
+                    "value": model,
+                },
+                timeout=5,
+            )
+        except (ACPClientError, TimeoutError, RuntimeError) as exc:
+            # Server does not support set_config_option (e.g. -32601 method-not-found)
+            # or timed out.  Tolerate: not all ACP servers expose config options.
+            logger.warning(
+                "ACP client: session/set_config_option not supported or timed out "
+                "(model=%r, session=%s): %s -- session continues with server default",
+                model,
+                session_id[:8],
+                exc,
+            )
+            return
+
+        # Verification layer: the server responded successfully.  Extract the
+        # "model" configOption's currentValue from the response.  The response
+        # shape is: {"configOptions": [{"id": "model", "currentValue": "haiku", ...}]}
+        config_opts = result.get("configOptions") or []
+        model_opt = next((o for o in config_opts if o.get("id") == "model"), None)
+
+        if model_opt is None:
+            # Server returned a successful response but no "model" configOption.
+            # Generic ACP server -- cannot verify; proceed without confirmation.
+            logger.warning(
+                "ACP client: set_config_option succeeded but response carried no "
+                "'model' configOption -- cannot verify pin (session=%s)",
+                session_id[:8],
+            )
+            return
+
+        current_value = model_opt.get("currentValue")
+        if current_value == model:
+            # Pin confirmed.
+            logger.info(
+                "ACP client: model pinned and verified: %r on session %s",
+                model,
+                session_id[:8],
+            )
+            return
+
+        # BILLING-CRITICAL: server accepted the call but currentValue does not match.
+        # Continuing would silently run every turn on the server's default model
+        # (Opus 4.8 as of claude-agent-acp v0.39), burning expensive quota.
+        # Accepted model aliases for the native server: "haiku", "sonnet", "default".
+        accepted = [o.get("value") for o in model_opt.get("options", [])]
+        raise ACPClientError(
+            code=1,  # positive = config rejection, not a transport crash (see run_turn)
+            message=(
+                f"ACP model pin rejected: requested {model!r} but server "
+                f"currentValue={current_value!r}. "
+                f"Continuing would silently run on {current_value!r} (server default), "
+                f"burning expensive model quota. "
+                f"Set acp_model to one of the accepted aliases: {accepted}."
+            ),
+        )
 
     def close(self) -> None:
         """Send session/close and tear down the subprocess."""
@@ -226,7 +355,15 @@ class ACPClientSession:
         # Ensure session is open (lazy start on first turn)
         try:
             self.ensure_started(cwd=cwd)
-        except (ACPClientError, TimeoutError, RuntimeError) as exc:
+        except ACPClientError as exc:
+            result.error = f"ACP client session startup failed: {exc}"
+            # Positive error code = config rejection (model pin mismatch, not a
+            # session crash).  Do NOT retire: retiring would respawn the session and
+            # hit the same mismatch every turn, creating an infinite retry loop.
+            # The caller must fix the configured model alias and redeploy.
+            result.should_retire = exc.code <= 0
+            return result
+        except (TimeoutError, RuntimeError) as exc:
             result.error = f"ACP client session startup failed: {exc}"
             result.should_retire = True
             return result
@@ -315,7 +452,7 @@ class ACPClientSession:
 
         # Tail-drain: consume notifications that were parsed by the reader
         # thread between the last loop poll and req_thread completing. These
-        # would be silently dropped without this drain — short responses that
+        # would be silently dropped without this drain -- short responses that
         # fit in the first chunks are the most likely to be affected.
         if self._client is not None:
             while True:
@@ -369,9 +506,13 @@ class ACPClientSession:
     def _handle_server_request(self, req: dict) -> None:
         """Handle server-initiated requests from the ACP agent.
 
-        In v1 we decline all server-initiated requests (fs/*, terminal/*,
-        permission) because Hermes controls those surfaces itself. A future
-        iteration could bridge these to Hermes' tools.
+        Permission requests are granted (allow_once) because this transport
+        talks to a trusted local ACP agent process that Hermes itself spawned
+        -- the user already consented to the agent's capabilities by configuring
+        it.  A future policy knob could toggle this per-agent.
+
+        fs/* and terminal/* are declined: Hermes controls those surfaces
+        through its own tool executor.
         """
         if self._client is None:
             return
@@ -379,16 +520,44 @@ class ACPClientSession:
         rid = req.get("id")
 
         if method == _METHOD_PERMISSION:
-            # Decline permission escalation — user controls Hermes' permission
-            # model through Hermes' own config.
-            self._client.respond(rid, {"granted": False})
+            # Fix 3 -- ACP-correct permission response shape.
+            #
+            # The ACP spec (RequestPermissionResponse) requires:
+            #   { "outcome": <RequestPermissionOutcome> }
+            # where RequestPermissionOutcome is one of:
+            #   { "outcome": "cancelled" }
+            #   { "outcome": "selected", "optionId": "<id>" }
+            #
+            # "allow_once" / "reject_once" are PermissionOptionKind hints in the
+            # INCOMING request's options[] array -- NOT valid outcome.outcome values.
+            # The previously sent { "granted": false } is not a valid ACP response
+            # and would wedge any turn that receives a permission request.
+            #
+            # Strategy: this transport talks to a trusted, locally-spawned agent
+            # process; grant by echoing the first allow_once-kinded option.
+            # Fall back to the first available option, then to cancelled if there
+            # are no options (malformed request).
+            params = req.get("params") or {}
+            options = params.get("options") or []
+            chosen_option_id = _pick_allow_option(options)
+            if chosen_option_id is not None:
+                outcome: dict = {"outcome": "selected", "optionId": chosen_option_id}
+            else:
+                # No options in the request (malformed) -- cancel instead of wedging.
+                outcome = {"outcome": "cancelled"}
+            self._client.respond(rid, {"outcome": outcome})
+            logger.debug(
+                "ACP client: permission request -> outcome=%r optionId=%r",
+                outcome["outcome"],
+                outcome.get("optionId"),
+            )
         elif method in {
             _METHOD_FS_READ, _METHOD_FS_WRITE,
             _METHOD_TERMINAL_CREATE, _METHOD_TERMINAL_OUTPUT,
             _METHOD_TERMINAL_RELEASE, _METHOD_TERMINAL_WAIT,
             _METHOD_TERMINAL_KILL,
         }:
-            # Decline fs/terminal proxying — Hermes drives its own tool
+            # Decline fs/terminal proxying -- Hermes drives its own tool
             # executor. ACP agents that need fs/terminal ops should spawn
             # their own processes.
             logger.debug("ACP client: declining server request %r (not proxied in v1)", method)
@@ -419,6 +588,26 @@ class ACPClientSession:
         if not joined.strip():
             return prefix
         return f"{prefix}\nACP agent stderr (last {len(tail)} lines):\n{joined}"
+
+
+def _pick_allow_option(options: list) -> Optional[str]:
+    """Return the optionId to grant from a permission request's options list.
+
+    Prefers the first option whose kind is ``allow_once``; falls back to the
+    first option of any kind. Returns None when the list is empty.
+    """
+    first_any: Optional[str] = None
+    for opt in options:
+        if not isinstance(opt, dict):
+            continue
+        option_id = opt.get("optionId")
+        if option_id is None:
+            continue
+        if first_any is None:
+            first_any = option_id
+        if opt.get("kind") == "allow_once":
+            return option_id
+    return first_any
 
 
 def _coerce_user_input(user_input: Any) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -53,6 +53,11 @@ model:
   # entra:
   #   scope: "https://ai.azure.com/.default"  # Optional; this is the default.
 
+  # ACP client transport — route inference to any ACP-compliant agent (e.g. @agentclientprotocol/claude-agent-acp)
+  # provider: "acp-client"
+  # acp_command: "claude-agent-acp"   # ACP server binary to spawn
+  # acp_args: []                      # Optional args passed to the binary (list or empty string)
+
   # ── Token limits — two settings, easy to confuse ──────────────────────────
   #
   # context_length: TOTAL context window (input + output tokens combined).

--- a/cli.py
+++ b/cli.py
@@ -7889,6 +7889,54 @@ class HermesCLI:
         if result.success and result.requires_new_session:
             _cprint("    Tip: `/reset` starts a new session immediately.")
 
+    def _handle_acp_client_runtime(self, cmd_original: str) -> None:
+        """Handle /acp-client-runtime — toggle the ACP client runtime opt-in.
+
+        Usage:
+            /acp-client-runtime                           — show current state
+            /acp-client-runtime auto                      — Hermes default runtime
+            /acp-client-runtime acp_client <cmd> [args]   — route turns to ACP agent
+            /acp-client-runtime on <cmd> [args]           — synonym for acp_client
+            /acp-client-runtime off                       — synonym for auto
+        """
+        from hermes_cli import acp_runtime_switch as ars
+
+        parts = cmd_original.split(None, 2)
+        raw_state = parts[1].strip() if len(parts) > 1 else ""
+        # Remaining tokens after the state keyword: "<command> [<arg>...]"
+        rest = parts[2].strip() if len(parts) > 2 else ""
+        rest_parts = rest.split() if rest else []
+        acp_command = rest_parts[0] if rest_parts else None
+        acp_args = rest_parts[1:] if len(rest_parts) > 1 else None
+
+        new_value, errors = ars.parse_args(raw_state)
+        if errors:
+            for err in errors:
+                _cprint(f"❌ {err}")
+            return
+
+        try:
+            from hermes_cli.config import load_config, save_config
+        except Exception as exc:
+            _cprint(f"❌ could not load config: {exc}")
+            return
+        cfg = load_config()
+
+        result = ars.apply(
+            cfg,
+            new_value,
+            acp_command=acp_command,
+            acp_args=acp_args,
+            persist_callback=(save_config if new_value is not None else None),
+        )
+
+        prefix = "✓" if result.success else "✗"
+        for line in result.message.splitlines():
+            _cprint(f"  {prefix} {line}" if line.startswith("acp_client runtime")
+                    else f"    {line}")
+        if result.success and result.requires_new_session:
+            _cprint("    Tip: `/reset` starts a new session immediately.")
+
     def _should_handle_model_command_inline(self, text: str, has_images: bool = False) -> bool:
         """Return True when /model should be handled immediately on the UI thread."""
         if not text or has_images or not _looks_like_slash_command(text):
@@ -8595,6 +8643,8 @@ class HermesCLI:
             self._handle_model_switch(cmd_original)
         elif canonical == "codex-runtime":
             self._handle_codex_runtime(cmd_original)
+        elif canonical == "acp-client-runtime":
+            self._handle_acp_client_runtime(cmd_original)
         elif canonical == "gquota":
             self._handle_gquota_command(cmd_original)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7776,6 +7776,9 @@ class GatewayRunner:
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
 
+        if canonical == "acp-client-runtime":
+            return await self._handle_acp_client_runtime_command(event)
+
         if canonical == "personality":
             return await self._handle_personality_command(event)
 
@@ -10905,6 +10908,57 @@ class GatewayRunner:
                 self._evict_cached_agent(session_key)
             except Exception:
                 logger.debug("could not evict cached agent after codex-runtime change",
+                             exc_info=True)
+
+        prefix = "✓" if result.success else "✗"
+        return f"{prefix} {result.message}"
+
+    async def _handle_acp_client_runtime_command(self, event: MessageEvent) -> str:
+        """Handle /acp-client-runtime command in the gateway.
+
+        Same surface as the CLI handler in cli.py:
+            /acp-client-runtime                           — show current state
+            /acp-client-runtime auto                      — Hermes default runtime
+            /acp-client-runtime acp_client <cmd> [args]   — route to ACP agent
+            /acp-client-runtime on <cmd> [args]           — synonym for acp_client
+            /acp-client-runtime off                       — synonym for auto
+
+        On change, the cached agent for this session is evicted so the next
+        message creates a fresh AIAgent with the new api_mode wired in."""
+        from hermes_cli import acp_runtime_switch as ars
+
+        raw_args = event.get_command_args().strip() if event else ""
+        parts = raw_args.split(None, 1)
+        raw_state = parts[0] if parts else ""
+        rest = parts[1].strip() if len(parts) > 1 else ""
+        rest_parts = rest.split() if rest else []
+        acp_command = rest_parts[0] if rest_parts else None
+        acp_args = rest_parts[1:] if len(rest_parts) > 1 else None
+
+        new_value, errors = ars.parse_args(raw_state)
+        if errors:
+            return "❌ " + "\n❌ ".join(errors)
+
+        try:
+            from hermes_cli.config import load_config, save_config
+        except Exception as exc:
+            return f"❌ Could not load config: {exc}"
+        cfg = load_config()
+
+        result = ars.apply(
+            cfg,
+            new_value,
+            acp_command=acp_command,
+            acp_args=acp_args,
+            persist_callback=(save_config if new_value is not None else None),
+        )
+
+        if result.success and new_value is not None and result.requires_new_session:
+            try:
+                session_key = self._session_key_for_source(event.source)
+                self._evict_cached_agent(session_key)
+            except Exception:
+                logger.debug("could not evict cached agent after acp-client-runtime change",
                              exc_info=True)
 
         prefix = "✓" if result.success else "✗"

--- a/hermes_cli/acp_runtime_switch.py
+++ b/hermes_cli/acp_runtime_switch.py
@@ -1,0 +1,326 @@
+"""Shared logic for the /acp-client-runtime slash command.
+
+Toggles the ACP client runtime on or off by writing three config keys:
+
+    model.provider:    "acp-client"  (enabled) or restored prior provider (disabled)
+    model.acp_command: path/name of the ACP-compliant agent binary
+    model.acp_args:    list of extra arguments passed to the binary
+
+When enabled, Hermes routes turns to an external ACP-compliant agent via
+JSON-RPC 2.0 over stdio (see agent/transports/acp_client.py).  The agent
+must implement the Agent Client Protocol (session/new, session/prompt, etc.).
+
+Both CLI (cli.py) and gateway (gateway/run.py) call into this module so the
+behaviour stays identical across surfaces.
+
+The actual routing happens in agent/agent_init.py which maps
+``provider == "acp-client"`` → ``api_mode = "acp_client"``, then
+``agent/conversation_loop.py`` dispatches to ``_run_acp_client_turn()``.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Config key names
+_KEY_PROVIDER = "provider"
+_KEY_ACP_COMMAND = "acp_command"
+_KEY_ACP_ARGS = "acp_args"
+_MODEL_SECTION = "model"
+
+# The provider value that activates ACP client mode
+_PROVIDER_ACP = "acp-client"
+
+VALID_STATES = ("acp_client", "auto")
+
+
+@dataclass
+class ACPRuntimeStatus:
+    """Result of an /acp-client-runtime invocation.  Callers render this
+    however suits their surface (CLI uses Rich panels, gateway sends text)."""
+
+    success: bool
+    new_value: Optional[str] = None      # "acp_client" | "auto"
+    old_value: Optional[str] = None
+    message: str = ""
+    requires_new_session: bool = False
+    acp_command_ok: bool = True
+    acp_command_version: Optional[str] = None
+
+
+def parse_args(arg_string: str) -> tuple[Optional[str], list[str]]:
+    """Parse the slash-command argument string.  Returns (value, errors).
+
+    No args               → return current state (value=None)
+    'acp_client' / 'on'  → enable ACP client runtime
+    'auto' / 'off'        → disable (revert to Hermes default)
+    anything else         → error
+    """
+    raw = (arg_string or "").strip().lower()
+    if not raw:
+        return None, []
+    if raw in {"on", "acp_client", "acp-client", "enable", "acp"}:
+        return "acp_client", []
+    if raw in {"off", "auto", "disable", "hermes", "default"}:
+        return "auto", []
+    return None, [
+        f"Unknown value {raw!r}. Use: acp_client (or 'on') to enable, "
+        "auto (or 'off') to disable."
+    ]
+
+
+def get_current_state(config: dict) -> str:
+    """Read the current ACP runtime state from a config dict.
+    Returns 'acp_client' when active, 'auto' otherwise."""
+    if not isinstance(config, dict):
+        return "auto"
+    model_cfg = config.get(_MODEL_SECTION) or {}
+    if not isinstance(model_cfg, dict):
+        return "auto"
+    if str(model_cfg.get(_KEY_PROVIDER) or "").strip().lower() == _PROVIDER_ACP:
+        return "acp_client"
+    return "auto"
+
+
+def get_current_command(config: dict) -> str:
+    """Return the configured acp_command, or empty string if not set."""
+    if not isinstance(config, dict):
+        return ""
+    model_cfg = config.get(_MODEL_SECTION) or {}
+    if not isinstance(model_cfg, dict):
+        return ""
+    return str(model_cfg.get(_KEY_ACP_COMMAND) or "").strip()
+
+
+def get_current_args(config: dict) -> list[str]:
+    """Return the configured acp_args list, or [] if not set."""
+    if not isinstance(config, dict):
+        return []
+    model_cfg = config.get(_MODEL_SECTION) or {}
+    if not isinstance(model_cfg, dict):
+        return []
+    raw = model_cfg.get(_KEY_ACP_ARGS)
+    if isinstance(raw, list):
+        return [str(a) for a in raw]
+    return []
+
+
+def enable_runtime(config: dict, acp_command: str, acp_args: list[str]) -> str:
+    """Mutate config dict to enable ACP client runtime.  Returns old state."""
+    old = get_current_state(config)
+    if not isinstance(config.get(_MODEL_SECTION), dict):
+        config[_MODEL_SECTION] = {}
+    config[_MODEL_SECTION][_KEY_PROVIDER] = _PROVIDER_ACP
+    config[_MODEL_SECTION][_KEY_ACP_COMMAND] = acp_command
+    config[_MODEL_SECTION][_KEY_ACP_ARGS] = list(acp_args)
+    return old
+
+
+def disable_runtime(config: dict) -> str:
+    """Mutate config dict to disable ACP client runtime.  Returns old state."""
+    old = get_current_state(config)
+    if not isinstance(config.get(_MODEL_SECTION), dict):
+        return old
+    model_cfg = config[_MODEL_SECTION]
+    if model_cfg.get(_KEY_PROVIDER) == _PROVIDER_ACP:
+        model_cfg.pop(_KEY_PROVIDER, None)
+    model_cfg.pop(_KEY_ACP_COMMAND, None)
+    model_cfg.pop(_KEY_ACP_ARGS, None)
+    return old
+
+
+def check_acp_command_ok(command: str) -> tuple[bool, Optional[str]]:
+    """Best-effort check that the ACP agent binary is reachable.
+
+    Returns (ok, version_or_message).  We try ``command --version`` first;
+    failing that, we check whether the binary is on PATH at all.
+    The check is intentionally lenient: if the agent ignores ``--version``
+    but is on PATH we still return True so users aren't blocked by agents
+    that don't implement --version.
+    """
+    if not command:
+        return False, "acp_command is empty — set it with /acp-client-runtime on <command>"
+    # First: try --version for a clean version string
+    try:
+        proc = subprocess.run(
+            [command, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        ver = (proc.stdout.strip() or proc.stderr.strip() or "").splitlines()[0]
+        return True, ver or "(no version output)"
+    except FileNotFoundError:
+        # Binary not on PATH
+        return False, f"{command!r} not found on PATH"
+    except Exception:
+        pass
+    # Second: check PATH only — agent may not support --version
+    if shutil.which(command):
+        return True, "(binary found, no --version)"
+    return False, f"{command!r} not found on PATH"
+
+
+def apply(
+    config: dict,
+    new_value: Optional[str],
+    *,
+    acp_command: Optional[str] = None,
+    acp_args: Optional[list[str]] = None,
+    persist_callback=None,
+) -> ACPRuntimeStatus:
+    """Top-level entry point used by both CLI and gateway handlers.
+
+    Args:
+        config:          in-memory config dict (mutated when new_value is set)
+        new_value:       "acp_client" to enable, "auto" to disable, None for
+                         read-only state report
+        acp_command:     ACP agent binary (required when enabling; ignored on
+                         disable).  Falls back to currently configured value if
+                         the runtime is already enabled.
+        acp_args:        Extra args for the binary (optional).
+        persist_callback: Optional callable taking the mutated config dict and
+                         persisting it to disk.  Skipped when None.
+
+    Returns: ACPRuntimeStatus describing the outcome.
+    """
+    current = get_current_state(config)
+    current_cmd = get_current_command(config)
+
+    # Read-only: just report current state
+    if new_value is None:
+        cmd = current_cmd or "(not configured)"
+        cur_args = get_current_args(config)
+        ok, ver = check_acp_command_ok(current_cmd) if current_cmd else (False, "not configured")
+        cmd_line = f"{cmd} {' '.join(cur_args)}".rstrip() if cur_args else cmd
+        msg = (
+            f"acp_client runtime: {current}\n"
+            f"acp_command: {cmd_line}\n"
+            f"binary: {'OK — ' + ver if ok else 'not available — ' + (ver or 'check acp_command')}"
+        )
+        return ACPRuntimeStatus(
+            success=True,
+            new_value=current,
+            old_value=current,
+            message=msg,
+            acp_command_ok=ok,
+            acp_command_version=ver if ok else None,
+        )
+
+    # No change
+    if new_value == current:
+        if new_value == "acp_client":
+            # Still report the command for reassurance
+            cmd = current_cmd or "(not configured)"
+            return ACPRuntimeStatus(
+                success=True,
+                new_value=current,
+                old_value=current,
+                message=f"acp_client runtime already enabled (command: {cmd})",
+            )
+        return ACPRuntimeStatus(
+            success=True,
+            new_value=current,
+            old_value=current,
+            message="acp_client runtime already disabled (Hermes default)",
+        )
+
+    # Enabling
+    if new_value == "acp_client":
+        effective_cmd = (acp_command or "").strip() or current_cmd
+        if not effective_cmd:
+            return ACPRuntimeStatus(
+                success=False,
+                new_value=None,
+                old_value=current,
+                message=(
+                    "Cannot enable acp_client runtime: acp_command is required.\n"
+                    "Usage: /acp-client-runtime on <command> [<arg> ...]\n"
+                    "Example: /acp-client-runtime on claude-agent-acp"
+                ),
+                acp_command_ok=False,
+            )
+        effective_args = acp_args if acp_args is not None else get_current_args(config)
+        ok, ver_or_msg = check_acp_command_ok(effective_cmd)
+        if not ok:
+            return ACPRuntimeStatus(
+                success=False,
+                new_value=None,
+                old_value=current,
+                message=(
+                    f"Cannot enable acp_client runtime: {ver_or_msg}\n"
+                    f"Ensure {effective_cmd!r} is installed and on PATH."
+                ),
+                acp_command_ok=False,
+            )
+
+        enable_runtime(config, effective_cmd, effective_args)
+        if persist_callback is not None:
+            try:
+                persist_callback(config)
+            except Exception as exc:
+                logger.exception("failed to persist acp_client runtime change")
+                return ACPRuntimeStatus(
+                    success=False,
+                    new_value=new_value,
+                    old_value=current,
+                    message=f"updated config in memory but persist failed: {exc}",
+                )
+
+        cmd_display = effective_cmd
+        if effective_args:
+            cmd_display += " " + " ".join(effective_args)
+        msg_lines = [
+            f"acp_client runtime: {current} → {new_value}",
+            f"command: {cmd_display}",
+        ]
+        if ver_or_msg:
+            msg_lines.append(f"binary: {ver_or_msg}")
+        msg_lines.append(
+            "Hermes turns now route to the ACP agent via JSON-RPC stdio "
+            "(session/new + session/prompt)."
+        )
+        msg_lines.append(
+            "Effective on next session — current cached agent keeps the "
+            "prior runtime to preserve prompt cache."
+        )
+        return ACPRuntimeStatus(
+            success=True,
+            new_value=new_value,
+            old_value=current,
+            message="\n".join(msg_lines),
+            requires_new_session=True,
+            acp_command_ok=True,
+            acp_command_version=ver_or_msg,
+        )
+
+    # Disabling
+    disable_runtime(config)
+    if persist_callback is not None:
+        try:
+            persist_callback(config)
+        except Exception as exc:
+            logger.exception("failed to persist acp_client runtime disable")
+            return ACPRuntimeStatus(
+                success=False,
+                new_value=new_value,
+                old_value=current,
+                message=f"updated config in memory but persist failed: {exc}",
+            )
+    return ACPRuntimeStatus(
+        success=True,
+        new_value="auto",
+        old_value=current,
+        message=(
+            "acp_client runtime: acp_client → auto\n"
+            "Hermes default runtime restored.\n"
+            "Effective on next session."
+        ),
+        requires_new_session=True,
+    )

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -229,6 +229,17 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    # Local-command ACP transport: routes inference to any ACP-compliant agent
+    # via JSON-RPC over stdio. Auth is handled by the spawned binary itself —
+    # no API key is needed at the Hermes layer. acp_command/acp_args are read
+    # from config.yaml (model.acp_command, model.acp_args), set via the
+    # /acp-client-runtime command. Mirrors copilot-acp's external_process shape
+    # but has no inference_base_url (the binary manages the transport endpoint).
+    "acp_client": ProviderConfig(
+        id="acp_client",
+        name="ACP Client (local command)",
+        auth_type="external_process",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -1499,6 +1510,8 @@ def resolve_provider(
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
+        # acp-client is the hyphenated config form; canonical key uses underscore
+        "acp-client": "acp_client",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -670,6 +670,20 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
             )
     except Exception:
         pass
+    # Indicate when the ACP client runtime is active so users can see that
+    # turns are routed to an external ACP agent subprocess.
+    try:
+        from hermes_cli.acp_runtime_switch import get_current_state, get_current_command
+        from hermes_cli.config import load_config as _load_cfg_acp
+        _cfg_acp = _load_cfg_acp()
+        if get_current_state(_cfg_acp) == "acp_client":
+            _acp_cmd = get_current_command(_cfg_acp) or "?"
+            right_lines.append(
+                f"[bold {accent}]Runtime:[/] [{text}]acp-client ({_acp_cmd})[/] "
+                f"[dim {dim}](turns routed to external ACP agent)[/]"
+            )
+    except Exception:
+        pass
     # Show active profile name when not 'default'
     try:
         from hermes_cli.profiles import get_active_profile_name

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -127,6 +127,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),
+    CommandDef("acp-client-runtime", "Toggle ACP client runtime (route turns to an external ACP agent)",
+               "Configuration", aliases=("acp_client_runtime", "acp-runtime", "acp_runtime"),
+               args_hint="[auto|acp_client|on|off] [<command> [<args>...]]"),
     CommandDef("gquota", "Show Google Gemini Code Assist quota usage", "Info",
                cli_only=True),
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1469,6 +1469,32 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "acp_client":
+        # Local-command ACP transport: routes inference to any ACP-compliant
+        # agent via JSON-RPC over stdio. Auth is handled by the spawned binary
+        # itself — no API key is needed at the Hermes layer. The command and
+        # args are stored in config.yaml by /acp-client-runtime and forwarded
+        # unchanged to agent_init, which passes them to ACPClientSession.
+        acp_command = str(model_cfg.get("acp_command") or "").strip()
+        acp_args = list(model_cfg.get("acp_args") or [])
+        if not acp_command:
+            raise AuthError(
+                "acp_client provider requires acp_command to be set in config.yaml. "
+                "Run '/acp-client-runtime on <command>' to configure it.",
+                provider="acp_client",
+                code="missing_acp_command",
+            )
+        return {
+            "provider": "acp_client",
+            "api_mode": "acp_client",
+            "base_url": "",
+            "api_key": "",
+            "command": acp_command,
+            "args": acp_args,
+            "source": "config",
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -248,6 +248,10 @@ _VALID_API_MODES = {
     # `model.openai_runtime == "codex_app_server"` AND provider in
     # {"openai", "openai-codex"}. Default is unchanged.
     "codex_app_server",
+    # Optional opt-in: route inference to any ACP-compliant agent via
+    # JSON-RPC over stdio. Gated behind api_mode == "acp_client" AND
+    # provider == "acp-client" (or explicit api_mode config). Default unchanged.
+    "acp_client",
 }
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4502,6 +4502,19 @@ class AIAgent:
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
+    def _run_acp_client_turn(
+        self,
+        *,
+        user_message: str,
+        original_user_message: Any,
+        messages: List[Dict[str, Any]],
+        effective_task_id: str,
+        should_review_memory: bool = False,
+    ) -> Dict[str, Any]:
+        """Forwarder — see ``agent.acp_runtime.run_acp_client_turn``."""
+        from agent.acp_runtime import run_acp_client_turn
+        return run_acp_client_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
 def main(
     query: str = None,
     model: str = "",

--- a/tests/agent/test_acp_client.py
+++ b/tests/agent/test_acp_client.py
@@ -1,0 +1,488 @@
+"""Tests for agent.transports.acp_client — ACP wire client.
+
+Tests drive the three-arm dispatch, timeout handling, initialize handshake,
+respond/respond_error, and close behavior. All tests use fake subprocesses
+(threads writing to queues) — no real ACP agent binary required.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import subprocess
+import threading
+import time
+from io import BytesIO
+from typing import Any, Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.transports.acp_client import ACPClient, ACPClientError
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake subprocess
+# ---------------------------------------------------------------------------
+
+
+class FakeProc:
+    """Minimal Popen-compatible fake for testing ACPClient without a real process.
+
+    Writes pre-programmed responses to an internal pipe; the ACPClient's reader
+    thread reads from it just as it would from a real subprocess.
+    """
+
+    def __init__(self) -> None:
+        self._stdin_r, self._stdin_w = self._make_pipe()
+        self._stdout_r, self._stdout_w = self._make_pipe()
+        self._stderr_r, self._stderr_w = self._make_pipe()
+
+        # Public attrs ACPClient accesses
+        self.stdin = _WritableStream(self._stdin_w)
+        self.stdout = _ReadableStream(self._stdout_r)
+        self.stderr = _ReadableStream(self._stderr_r)
+        self._returncode = None
+
+    def _make_pipe(self):
+        import os
+        r, w = os.pipe()
+        return os.fdopen(r, "rb", 0), os.fdopen(w, "wb", 0)
+
+    def poll(self) -> None:
+        return self._returncode
+
+    def terminate(self) -> None:
+        self._returncode = -15
+        self._close_all()
+
+    def kill(self) -> None:
+        self._returncode = -9
+        self._close_all()
+
+    def wait(self, timeout: float = None) -> int:
+        return self._returncode or 0
+
+    def _close_all(self) -> None:
+        for f in (self._stdin_w, self._stdout_w, self._stderr_w,
+                  self._stdin_r, self._stdout_r, self._stderr_r):
+            try:
+                f.close()
+            except Exception:
+                pass
+
+    def push_stdout(self, msg: dict) -> None:
+        """Push a JSON-RPC message to the fake stdout (agent → client)."""
+        data = (json.dumps(msg) + "\n").encode("utf-8")
+        try:
+            self._stdout_w.write(data)
+            self._stdout_w.flush()
+        except Exception:
+            pass
+
+    def push_stderr(self, text: str) -> None:
+        data = (text + "\n").encode("utf-8")
+        try:
+            self._stderr_w.write(data)
+            self._stderr_w.flush()
+        except Exception:
+            pass
+
+    def drain_stdin(self) -> list[dict]:
+        """Read all bytes written to stdin and parse as newline-delimited JSON."""
+        chunks = []
+        try:
+            # Non-blocking read via direct fd
+            import select
+            fd = self._stdin_r.fileno()
+            buf = b""
+            while True:
+                ready, _, _ = select.select([fd], [], [], 0.05)
+                if not ready:
+                    break
+                data = self._stdin_r.read(4096)
+                if not data:
+                    break
+                buf += data
+        except Exception:
+            buf = b""
+        for line in buf.splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    chunks.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+        return chunks
+
+
+class _WritableStream:
+    def __init__(self, f) -> None:
+        self._f = f
+        self.closed = False
+
+    def write(self, data: bytes) -> int:
+        return self._f.write(data)
+
+    def flush(self) -> None:
+        self._f.flush()
+
+    def close(self) -> None:
+        self.closed = True
+        try:
+            self._f.close()
+        except Exception:
+            pass
+
+
+class _ReadableStream:
+    def __init__(self, f) -> None:
+        self._f = f
+
+    def readline(self) -> bytes:
+        return self._f.readline()
+
+    def fileno(self) -> int:
+        return self._f.fileno()
+
+
+def make_client_with_fake_proc() -> tuple[ACPClient, FakeProc]:
+    """Create an ACPClient wired to a FakeProc, bypassing subprocess.Popen."""
+    fake = FakeProc()
+    client = ACPClient.__new__(ACPClient)
+    # Manually initialize the client fields (mirrors __init__ without Popen)
+    import queue as q_mod
+    client._command = "fake-acp-agent"
+    client._proc = fake
+    client._next_id = 1
+    client._pending = {}
+    client._pending_lock = threading.Lock()
+    client._send_lock = threading.Lock()
+    client._notifications = q_mod.Queue()
+    client._server_requests = q_mod.Queue()
+    client._stderr_lines = []
+    client._stderr_lock = threading.Lock()
+    client._closed = False
+    client._initialized = False
+
+    # Start reader threads
+    client._reader = threading.Thread(target=client._read_stdout, daemon=True)
+    client._reader.start()
+    client._stderr_reader = threading.Thread(target=client._read_stderr, daemon=True)
+    client._stderr_reader.start()
+
+    return client, fake
+
+
+# ---------------------------------------------------------------------------
+# Tests: dispatch arms
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    def test_reply_unblocks_pending(self):
+        """Arm 1: a reply (id + result, no method) resolves the pending request."""
+        client, fake = make_client_with_fake_proc()
+        # Enqueue a reply before the request thread blocks on it
+        def push_reply():
+            time.sleep(0.05)
+            fake.push_stdout({"id": 1, "result": {"ok": True}})
+
+        t = threading.Thread(target=push_reply, daemon=True)
+        t.start()
+        result = client.request("test/method", {}, timeout=2.0)
+        assert result == {"ok": True}
+        t.join(timeout=1.0)
+        client.close()
+
+    def test_reply_error_raises_acp_client_error(self):
+        """Arm 1 error path: error response raises ACPClientError."""
+        client, fake = make_client_with_fake_proc()
+
+        def push_error():
+            time.sleep(0.05)
+            fake.push_stdout({"id": 1, "error": {"code": -32601, "message": "not found"}})
+
+        t = threading.Thread(target=push_error, daemon=True)
+        t.start()
+        with pytest.raises(ACPClientError) as exc_info:
+            client.request("test/method", {}, timeout=2.0)
+        assert exc_info.value.code == -32601
+        assert "not found" in exc_info.value.message
+        t.join(timeout=1.0)
+        client.close()
+
+    def test_server_request_goes_to_server_requests_queue(self):
+        """Arm 2: a message with id + method lands in _server_requests."""
+        client, fake = make_client_with_fake_proc()
+        fake.push_stdout({"id": 99, "method": "session/request_permission", "params": {"permissionId": "exec"}})
+        time.sleep(0.1)
+        req = client.take_server_request(timeout=0.5)
+        assert req is not None
+        assert req["method"] == "session/request_permission"
+        assert req["id"] == 99
+        client.close()
+
+    def test_notification_goes_to_notifications_queue(self):
+        """Arm 3: a message with method but no id lands in _notifications."""
+        client, fake = make_client_with_fake_proc()
+        fake.push_stdout({"method": "session/update", "params": {"sessionId": "abc", "update": {"sessionUpdate": "agent_message_chunk"}}})
+        time.sleep(0.1)
+        note = client.take_notification(timeout=0.5)
+        assert note is not None
+        assert note["method"] == "session/update"
+        client.close()
+
+    def test_non_json_stdout_captured_as_stderr(self):
+        """Non-JSON stdout is stored in stderr buffer for diagnostics."""
+        client, fake = make_client_with_fake_proc()
+        fake.push_stdout.__func__  # just touching to avoid lint
+        # Inject non-JSON directly to the stdout pipe
+        data = b"not json at all\n"
+        fake._stdout_w.write(data)
+        fake._stdout_w.flush()
+        time.sleep(0.1)
+        tail = client.stderr_tail(5)
+        assert any("non-json" in line for line in tail)
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: timeout
+# ---------------------------------------------------------------------------
+
+
+class TestTimeout:
+    def test_request_timeout_raises_timeout_error(self):
+        """Request times out when no reply arrives."""
+        client, fake = make_client_with_fake_proc()
+        with pytest.raises(TimeoutError) as exc_info:
+            client.request("session/prompt", {}, timeout=0.1)
+        assert "session/prompt" in str(exc_info.value)
+        assert "timed out" in str(exc_info.value)
+        client.close()
+
+    def test_timed_out_request_removed_from_pending(self):
+        """After timeout, the pending entry is cleaned up so no memory leak."""
+        client, fake = make_client_with_fake_proc()
+        with pytest.raises(TimeoutError):
+            client.request("session/prompt", {}, timeout=0.05)
+        with client._pending_lock:
+            assert len(client._pending) == 0
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: initialize
+# ---------------------------------------------------------------------------
+
+
+class TestInitialize:
+    def test_initialize_sends_correct_params_and_returns_result(self):
+        """initialize() sends the right wire params and returns the result dict."""
+        client, fake = make_client_with_fake_proc()
+
+        def push_response():
+            time.sleep(0.05)
+            fake.push_stdout({
+                "id": 1,
+                "result": {
+                    "protocolVersion": 1,
+                    "agentInfo": {"name": "test-agent", "version": "1.0"},
+                    "agentCapabilities": {},
+                }
+            })
+
+        t = threading.Thread(target=push_response, daemon=True)
+        t.start()
+        result = client.initialize(client_name="hermes", client_version="0.1", timeout=2.0)
+        assert result["agentInfo"]["name"] == "test-agent"
+        assert client._initialized is True
+        t.join(timeout=1.0)
+
+        # Verify what was sent on the wire
+        sent = fake.drain_stdin()
+        assert len(sent) == 1
+        msg = sent[0]
+        assert msg["method"] == "initialize"
+        assert msg["params"]["protocolVersion"] == 1
+        assert msg["params"]["clientInfo"]["name"] == "hermes"
+        client.close()
+
+    def test_initialize_twice_raises(self):
+        """initialize() called twice raises RuntimeError."""
+        client, fake = make_client_with_fake_proc()
+
+        def push_response():
+            time.sleep(0.05)
+            fake.push_stdout({"id": 1, "result": {"protocolVersion": 1}})
+
+        t = threading.Thread(target=push_response, daemon=True)
+        t.start()
+        client.initialize(timeout=2.0)
+        t.join(timeout=1.0)
+
+        with pytest.raises(RuntimeError, match="already initialized"):
+            client.initialize()
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: respond / respond_error
+# ---------------------------------------------------------------------------
+
+
+class TestRespond:
+    def test_respond_sends_json_rpc_result(self):
+        """respond() sends a proper JSON-RPC result message."""
+        client, fake = make_client_with_fake_proc()
+        client.respond(42, {"action": "accept"})
+        time.sleep(0.05)
+        sent = fake.drain_stdin()
+        assert len(sent) == 1
+        msg = sent[0]
+        assert msg["id"] == 42
+        assert msg["result"] == {"action": "accept"}
+        assert "error" not in msg
+        client.close()
+
+    def test_respond_error_sends_json_rpc_error(self):
+        """respond_error() sends a proper JSON-RPC error message."""
+        client, fake = make_client_with_fake_proc()
+        client.respond_error(7, code=-32601, message="not found", data={"method": "fs/write"})
+        time.sleep(0.05)
+        sent = fake.drain_stdin()
+        assert len(sent) == 1
+        msg = sent[0]
+        assert msg["id"] == 7
+        assert msg["error"]["code"] == -32601
+        assert msg["error"]["message"] == "not found"
+        assert msg["error"]["data"]["method"] == "fs/write"
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: notify
+# ---------------------------------------------------------------------------
+
+
+class TestNotify:
+    def test_notify_sends_no_id(self):
+        """notify() sends a notification with no id field."""
+        client, fake = make_client_with_fake_proc()
+        client.notify("session/cancel", {"sessionId": "abc"})
+        time.sleep(0.05)
+        sent = fake.drain_stdin()
+        assert len(sent) == 1
+        msg = sent[0]
+        assert "id" not in msg
+        assert msg["method"] == "session/cancel"
+        assert msg["params"]["sessionId"] == "abc"
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: close
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    def test_close_idempotent(self):
+        """close() can be called multiple times without error."""
+        client, fake = make_client_with_fake_proc()
+        client.close()
+        client.close()  # second call must not raise
+
+    def test_send_after_close_raises(self):
+        """Calling request() after close() raises RuntimeError."""
+        client, fake = make_client_with_fake_proc()
+        client.close()
+        with pytest.raises(RuntimeError, match="closed"):
+            client.request("session/prompt", {}, timeout=0.1)
+
+    def test_is_alive_false_after_terminate(self):
+        """is_alive() returns False after the fake process is terminated."""
+        client, fake = make_client_with_fake_proc()
+        assert client.is_alive() is True
+        fake.terminate()
+        assert client.is_alive() is False
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: stderr capture
+# ---------------------------------------------------------------------------
+
+
+class TestStderrCapture:
+    def test_stderr_tail_returns_lines(self):
+        """stderr lines pushed by the agent are captured in stderr_tail."""
+        client, fake = make_client_with_fake_proc()
+        fake.push_stderr("agent diagnostic line 1")
+        fake.push_stderr("agent diagnostic line 2")
+        time.sleep(0.1)
+        tail = client.stderr_tail(5)
+        assert any("diagnostic line 1" in l for l in tail)
+        assert any("diagnostic line 2" in l for l in tail)
+        client.close()
+
+    def test_stderr_bounded_at_500_lines(self):
+        """stderr buffer is bounded to 500 lines."""
+        client, fake = make_client_with_fake_proc()
+        for i in range(600):
+            fake.push_stderr(f"line {i}")
+        time.sleep(0.3)
+        tail = client.stderr_tail(1000)
+        assert len(tail) <= 500
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: concurrent-write regression (_send_lock)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentWrite:
+    def test_concurrent_sends_produce_valid_json_lines(self):
+        """Each concurrent _send call must produce a complete, valid JSON line.
+
+        Regression guard for the race on BufferedWriter.write: without
+        _send_lock, two threads writing simultaneously interleave bytes,
+        producing a single mangled line instead of two well-formed ones.
+        If _send_lock is ever removed, this test must FAIL.
+        """
+        client, fake = make_client_with_fake_proc()
+
+        n_threads = 10
+        errors: list[str] = []
+        barrier = threading.Barrier(n_threads)
+
+        def send_one(idx: int) -> None:
+            barrier.wait()  # all threads start writing at the same instant
+            try:
+                client._send({"method": "test/concurrent", "params": {"idx": idx}})
+            except Exception as exc:
+                errors.append(str(exc))
+
+        threads = [threading.Thread(target=send_one, args=(i,), daemon=True) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=2.0)
+
+        assert not errors, f"_send raised in threads: {errors}"
+
+        # Allow the reader-side a moment to drain the pipe
+        time.sleep(0.1)
+        sent = fake.drain_stdin()
+
+        # Every message must be well-formed JSON-RPC with the expected method
+        assert len(sent) == n_threads, (
+            f"Expected {n_threads} complete messages, got {len(sent)}. "
+            "Interleaved writes corrupt lines and cause json.loads to fail in drain_stdin."
+        )
+        for msg in sent:
+            assert msg.get("method") == "test/concurrent"
+            assert isinstance(msg.get("params", {}).get("idx"), int)
+
+        client.close()

--- a/tests/agent/test_acp_client_session.py
+++ b/tests/agent/test_acp_client_session.py
@@ -1,0 +1,465 @@
+"""Tests for agent.transports.acp_client_session — ACP session adapter.
+
+Tests cover session lifecycle (ensure_started, close), turn execution,
+streaming delta projection, should_retire policy on crash/timeout, and
+server-request handling (permission decline, fs/terminal decline).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any, Optional
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from agent.transports.acp_client import ACPClientError
+from agent.transports.acp_client_session import (
+    ACPClientSession,
+    TurnResult,
+    _coerce_user_input,
+    _extract_text_from_update,
+    _is_tool_iteration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock ACPClient
+# ---------------------------------------------------------------------------
+
+
+def _make_session(
+    *,
+    command: str = "fake-acp",
+    args=None,
+    on_delta=None,
+    client_mock: Optional[MagicMock] = None,
+) -> tuple[ACPClientSession, MagicMock]:
+    """Return an ACPClientSession with a mock ACPClient injected."""
+    if client_mock is None:
+        client_mock = MagicMock()
+        client_mock.is_alive.return_value = True
+        client_mock.initialize.return_value = {"protocolVersion": 1}
+        client_mock.request.return_value = {}
+        client_mock.take_notification.return_value = None
+        client_mock.take_server_request.return_value = None
+        client_mock.stderr_tail.return_value = []
+
+    session = ACPClientSession(
+        command=command,
+        args=args,
+        on_delta=on_delta,
+        client_factory=lambda **kw: client_mock,
+    )
+    return session, client_mock
+
+
+# ---------------------------------------------------------------------------
+# Tests: ensure_started / session lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStarted:
+    def test_ensure_started_initializes_and_creates_session(self):
+        """ensure_started() calls initialize then session/new, stores session_id."""
+        session, mock_client = _make_session()
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-abc-123"},  # session/new
+        ]
+
+        sid = session.ensure_started(cwd="/tmp")
+        assert sid == "sess-abc-123"
+        assert session._session_id == "sess-abc-123"
+
+        # initialize was called once
+        mock_client.initialize.assert_called_once()
+        # session/new was called with correct cwd
+        mock_client.request.assert_called_once()
+        call_args = mock_client.request.call_args
+        assert call_args[0][0] == "session/new"
+        assert call_args[0][1]["cwd"] == "/tmp"
+
+    def test_ensure_started_idempotent(self):
+        """ensure_started() called twice returns same session_id."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "sess-001"}
+
+        sid1 = session.ensure_started(cwd="/tmp")
+        sid2 = session.ensure_started(cwd="/other")
+        assert sid1 == sid2 == "sess-001"
+        # initialize and session/new called only once
+        assert mock_client.initialize.call_count == 1
+        assert mock_client.request.call_count == 1
+
+    def test_ensure_started_raises_on_missing_session_id(self):
+        """ensure_started() raises ACPClientError if no sessionId in response."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {}  # no sessionId
+
+        with pytest.raises(ACPClientError) as exc_info:
+            session.ensure_started()
+        assert "sessionId" in str(exc_info.value)
+        assert session._session_id is None
+
+    def test_ensure_started_error_sets_should_retire(self):
+        """run_turn() → ensure_started() failure sets should_retire=True."""
+        session, mock_client = _make_session()
+        mock_client.initialize.side_effect = ACPClientError(
+            code=-32603, message="initialize failed"
+        )
+
+        result = session.run_turn("hello")
+        assert result.should_retire is True
+        assert result.error is not None
+        assert "startup" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: close
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    def test_close_sends_session_close_and_closes_client(self):
+        """close() calls session/close then client.close()."""
+        session, mock_client = _make_session()
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-xyz"},  # session/new
+            {},  # session/close
+        ]
+        session.ensure_started()
+        session.close()
+
+        # session/close request was made
+        close_call = mock_client.request.call_args_list[-1]
+        assert close_call[0][0] == "session/close"
+        assert close_call[0][1]["sessionId"] == "sess-xyz"
+        # client.close() was called
+        mock_client.close.assert_called_once()
+
+    def test_close_idempotent(self):
+        """close() called twice does not raise."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "sess-x"}
+        session.ensure_started()
+        session.close()
+        session.close()  # must not raise
+
+    def test_context_manager_calls_close(self):
+        """ACPClientSession used as context manager calls close() on exit."""
+        session, mock_client = _make_session()
+        mock_client.request.side_effect = [{"sessionId": "s1"}, {}]
+        with session:
+            session.ensure_started()
+        mock_client.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_turn — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestRunTurn:
+    def _setup_happy_session(self):
+        """Return session + mock configured for a successful prompt turn."""
+        session, mock_client = _make_session()
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-happy"},  # session/new
+            {"stopReason": "end_turn"},   # session/prompt
+        ]
+        return session, mock_client
+
+    def test_run_turn_sends_session_prompt(self):
+        """run_turn() sends session/prompt with the user text."""
+        session, mock_client = self._setup_happy_session()
+        # No streaming notifications
+        mock_client.take_notification.side_effect = [
+            None,  # polled once, returns None
+            None,  # second poll → triggers req_thread to finish
+        ]
+
+        result = session.run_turn("hello world", cwd="/tmp")
+        # Check session/prompt was called
+        prompt_call = None
+        for c in mock_client.request.call_args_list:
+            if c[0][0] == "session/prompt":
+                prompt_call = c
+                break
+        assert prompt_call is not None
+        assert prompt_call[0][1]["sessionId"] == "sess-happy"
+        assert prompt_call[0][1]["prompt"][0]["text"] == "hello world"
+
+    def test_run_turn_collects_text_from_streaming_chunks(self):
+        """Text chunks from session/update notifications are assembled."""
+        session, mock_client = _make_session()
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-stream"},  # session/new
+        ]
+
+        deltas_received = []
+
+        def on_delta(text):
+            deltas_received.append(text)
+
+        session2 = ACPClientSession(
+            command="fake",
+            on_delta=on_delta,
+            client_factory=lambda **kw: mock_client,
+        )
+
+        # Notifications: two text chunks, then None to stop
+        # The session/prompt result arrives through request()
+        notes_iter = iter([
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "sess-stream",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": "Hello "},
+                    },
+                },
+            },
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "sess-stream",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": "world!"},
+                    },
+                },
+            },
+            None,
+        ])
+
+        def take_notif(timeout=0.0):
+            try:
+                return next(notes_iter)
+            except StopIteration:
+                return None
+
+        mock_client.take_notification.side_effect = take_notif
+        mock_client.request.return_value = {"sessionId": "sess-stream"}
+
+        # Override request to return promptResponse after chunks
+        call_count = [0]
+        def req_side_effect(method, params=None, timeout=30):
+            call_count[0] += 1
+            if method == "session/new":
+                return {"sessionId": "sess-stream"}
+            if method == "session/prompt":
+                # Small sleep to let notification drain happen first
+                time.sleep(0.05)
+                return {"stopReason": "end_turn"}
+            return {}
+
+        mock_client.request.side_effect = req_side_effect
+
+        result = session2.run_turn("test", cwd="/tmp")
+        assert "Hello " in result.final_text
+        assert "world!" in result.final_text
+        assert "Hello " in deltas_received
+        assert "world!" in deltas_received
+
+    def test_run_turn_projects_message_into_messages(self):
+        """A final text turn is projected into projected_messages."""
+        session, mock_client = _make_session()
+
+        def req_side_effect(method, params=None, timeout=30):
+            if method == "session/new":
+                return {"sessionId": "sess-proj"}
+            if method == "session/prompt":
+                time.sleep(0.02)
+                return {"stopReason": "end_turn"}
+            return {}
+
+        mock_client.request.side_effect = req_side_effect
+
+        # Push one text chunk via notification
+        notes = [
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "sess-proj",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": "Answer here."},
+                    },
+                },
+            },
+            None,
+        ]
+        notes_iter = iter(notes)
+        mock_client.take_notification.side_effect = lambda timeout=0.0: next(notes_iter, None)
+
+        result = session.run_turn("question")
+        assert len(result.projected_messages) == 1
+        assert result.projected_messages[0]["role"] == "assistant"
+        assert result.projected_messages[0]["content"] == "Answer here."
+
+
+# ---------------------------------------------------------------------------
+# Tests: should_retire policy
+# ---------------------------------------------------------------------------
+
+
+class TestShouldRetire:
+    def test_subprocess_crash_sets_should_retire(self):
+        """When the process exits unexpectedly, should_retire=True."""
+        session, mock_client = _make_session()
+
+        call_count = [0]
+        def req_side_effect(method, params=None, timeout=30):
+            call_count[0] += 1
+            if method == "session/new":
+                return {"sessionId": "sess-crash"}
+            if method == "session/prompt":
+                # Simulate blocking while process dies
+                time.sleep(0.1)
+                raise RuntimeError("stdin closed unexpectedly")
+            return {}
+
+        mock_client.request.side_effect = req_side_effect
+        # Process dies after first poll
+        alive_iter = iter([True, True, False, False])
+        mock_client.is_alive.side_effect = lambda: next(alive_iter, False)
+
+        result = session.run_turn("hello")
+        assert result.should_retire is True
+        assert result.error is not None
+
+    def test_session_prompt_acp_error_sets_should_retire_for_negative_code(self):
+        """ACPClientError with negative code (system error) → should_retire."""
+        session, mock_client = _make_session()
+
+        def req_side_effect(method, params=None, timeout=30):
+            if method == "session/new":
+                return {"sessionId": "sess-err"}
+            if method == "session/prompt":
+                time.sleep(0.02)
+                raise ACPClientError(code=-32603, message="internal error")
+            return {}
+
+        mock_client.request.side_effect = req_side_effect
+
+        result = session.run_turn("hello")
+        assert result.error is not None
+        assert "session/prompt failed" in result.error
+        assert result.should_retire is True
+
+    def test_session_prompt_timeout_sets_should_retire(self):
+        """TimeoutError from session/prompt sets should_retire."""
+        session, mock_client = _make_session()
+
+        def req_side_effect(method, params=None, timeout=30):
+            if method == "session/new":
+                return {"sessionId": "sess-timeout"}
+            if method == "session/prompt":
+                raise TimeoutError("ACP method timed out")
+            return {}
+
+        mock_client.request.side_effect = req_side_effect
+
+        result = session.run_turn("hello")
+        assert result.should_retire is True
+        assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: server request handling
+# ---------------------------------------------------------------------------
+
+
+class TestServerRequestHandling:
+    def test_permission_request_declined(self):
+        """Permission requests from the server are declined (granted: False)."""
+        session, mock_client = _make_session()
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-perm"},  # session/new
+        ]
+
+        # Simulate the internal _handle_server_request call
+        session.ensure_started()
+        req = {"id": 42, "method": "session/request_permission", "params": {"permissionId": "exec"}}
+        session._handle_server_request(req)
+
+        mock_client.respond.assert_called_once_with(42, {"granted": False})
+
+    def test_fs_write_declined_with_error(self):
+        """fs/write_text_file is declined with respond_error."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "sess-fs"}
+        session.ensure_started()
+
+        req = {"id": 7, "method": "fs/write_text_file", "params": {"path": "/etc/passwd", "content": "bad"}}
+        session._handle_server_request(req)
+
+        mock_client.respond_error.assert_called_once()
+        call_args = mock_client.respond_error.call_args
+        # respond_error(rid, code=..., message=...) — rid is positional
+        assert call_args[0][0] == 7
+        assert call_args[1]["code"] == -32601  # method not supported
+
+    def test_unknown_server_request_declined_with_error(self):
+        """Unknown server requests receive respond_error."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "sess-unk"}
+        session.ensure_started()
+
+        req = {"id": 99, "method": "some/unknown_method", "params": {}}
+        session._handle_server_request(req)
+        mock_client.respond_error.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_extract_text_from_text_chunk(self):
+        params = {
+            "sessionId": "s",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "hello"},
+            },
+        }
+        assert _extract_text_from_update(params) == "hello"
+
+    def test_extract_text_from_non_text_chunk_returns_empty(self):
+        params = {
+            "sessionId": "s",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "content": {"type": "image"},
+            },
+        }
+        assert _extract_text_from_update(params) == ""
+
+    def test_is_tool_iteration_for_tool_call_update(self):
+        params = {"update": {"sessionUpdate": "tool_call_update"}}
+        assert _is_tool_iteration(params) is True
+
+    def test_is_tool_iteration_for_agent_message_returns_false(self):
+        params = {"update": {"sessionUpdate": "agent_message_chunk"}}
+        assert _is_tool_iteration(params) is False
+
+    def test_coerce_user_input_string(self):
+        assert _coerce_user_input("hello") == "hello"
+
+    def test_coerce_user_input_list_of_text_blocks(self):
+        result = _coerce_user_input([{"type": "text", "text": "hello"}])
+        assert result == "hello"
+
+    def test_coerce_user_input_image_block_replaced(self):
+        result = _coerce_user_input([{"type": "image"}])
+        assert "[image attached]" in result
+
+    def test_coerce_user_input_none(self):
+        assert _coerce_user_input(None) == ""
+
+    def test_coerce_user_input_integer(self):
+        assert _coerce_user_input(42) == "42"

--- a/tests/agent/test_acp_client_session.py
+++ b/tests/agent/test_acp_client_session.py
@@ -1108,3 +1108,94 @@ class TestMcpServersPlumbedIntoSessionNew:
         assert srv["args"] == ["mcp-server-filesystem", "/data"]
         assert srv["env"] == [{"name": "HOME", "value": "/root"}]
         assert "type" not in srv  # stdio: no type field
+
+
+# ---------------------------------------------------------------------------
+# Tests: setting_sources / _meta.claudeCode security isolation
+# ---------------------------------------------------------------------------
+
+
+class TestSettingSources:
+    """session/new _meta.claudeCode.options.settingSources injection.
+
+    The native ACP server (claude-agent-acp) hardcodes settingSources:
+    ["user","project","local"] and then spreads userProvidedOptions on top
+    (acp-agent.js:1524), so our value overrides it.  The default
+    ("project","local") prevents ~/.claude user-scope plugins from leaking
+    into the delegated agent.
+    """
+
+    def _make_session(self, **kwargs):
+        mock_client = MagicMock()
+        mock_client.initialize.return_value = {}
+        mock_client.request.return_value = {"sessionId": "sess-meta"}
+        mock_client.take_notification.return_value = None
+        mock_client.take_server_request.return_value = None
+        mock_client.stderr_tail.return_value = []
+        session = ACPClientSession(
+            command="fake-acp",
+            client_factory=lambda **kw: mock_client,
+            **kwargs,
+        )
+        return session, mock_client
+
+    def _session_new_params(self, mock_client):
+        """Extract the params dict sent to session/new."""
+        for c in mock_client.request.call_args_list:
+            if c[0][0] == "session/new":
+                return c[0][1]
+        raise AssertionError("session/new not called")
+
+    def test_default_includes_meta_with_project_local(self):
+        """Default setting_sources → _meta.claudeCode.options.settingSources
+        == ['project','local'] in session/new params."""
+        session, mock_client = self._make_session()
+        session.ensure_started(cwd="/tmp")
+
+        params = self._session_new_params(mock_client)
+        assert "_meta" in params
+        assert params["_meta"] == {
+            "claudeCode": {
+                "options": {
+                    "settingSources": ["project", "local"],
+                }
+            }
+        }
+
+    def test_custom_setting_sources_honored(self):
+        """Explicit setting_sources list is forwarded verbatim."""
+        session, mock_client = self._make_session(
+            setting_sources=("project", "local", "user")
+        )
+        session.ensure_started(cwd="/tmp")
+
+        params = self._session_new_params(mock_client)
+        sources = params["_meta"]["claudeCode"]["options"]["settingSources"]
+        assert sources == ["project", "local", "user"]
+
+    def test_setting_sources_none_omits_meta(self):
+        """setting_sources=None → no _meta key in session/new params."""
+        session, mock_client = self._make_session(setting_sources=None)
+        session.ensure_started(cwd="/tmp")
+
+        params = self._session_new_params(mock_client)
+        assert "_meta" not in params
+
+    def test_setting_sources_empty_list_omits_meta(self):
+        """setting_sources=[] → no _meta key (same as None)."""
+        session, mock_client = self._make_session(setting_sources=[])
+        session.ensure_started(cwd="/tmp")
+
+        params = self._session_new_params(mock_client)
+        assert "_meta" not in params
+
+    def test_cwd_and_mcp_servers_still_present_alongside_meta(self):
+        """_meta addition does not displace cwd or mcpServers."""
+        servers = [{"name": "s", "command": "cmd", "args": [], "env": []}]
+        session, mock_client = self._make_session(mcp_servers=servers)
+        session.ensure_started(cwd="/work")
+
+        params = self._session_new_params(mock_client)
+        assert params["cwd"] == "/work"
+        assert params["mcpServers"] == servers
+        assert "_meta" in params  # default present

--- a/tests/agent/test_acp_client_session.py
+++ b/tests/agent/test_acp_client_session.py
@@ -27,6 +27,7 @@ from agent.transports.acp_client_session import (
     _extract_text_from_update,
     _is_tool_iteration,
     _pick_allow_option,
+    _translate_mcp_servers,
 )
 
 
@@ -875,3 +876,235 @@ class TestHelpers:
 
     def test_coerce_user_input_integer(self):
         assert _coerce_user_input(42) == "42"
+
+
+# ---------------------------------------------------------------------------
+# Tests: MCP server forwarding -- translator + session/new plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateMcpServers:
+    """Unit tests for _translate_mcp_servers() covering all ACP wire shapes.
+
+    Ground truth (empirically probed against claude-agent-acp v0.39):
+      stdio  (NO type field): {name, command, args:[str], env:[{name,value}]}
+      http:  {type:"http", name, url, headers:[{name,value}]}
+      sse:   {type:"sse",  name, url, headers:[{name,value}]}
+    env/headers must always be present as arrays ([] when empty).
+    """
+
+    def test_stdio_with_env_dict_converted_to_array(self):
+        """env dict -> [{name, value}] array; no 'type' field in output."""
+        result = _translate_mcp_servers({
+            "myserver": {
+                "command": "npx",
+                "args": ["-y", "@my/mcp-server"],
+                "env": {"API_KEY": "secret", "DEBUG": "1"},
+            }
+        })
+        assert len(result) == 1
+        srv = result[0]
+        assert srv["name"] == "myserver"
+        assert srv["command"] == "npx"
+        assert srv["args"] == ["-y", "@my/mcp-server"]
+        # env must be an array, not a dict
+        assert isinstance(srv["env"], list)
+        env_map = {e["name"]: e["value"] for e in srv["env"]}
+        assert env_map == {"API_KEY": "secret", "DEBUG": "1"}
+        # stdio must NOT have a "type" field
+        assert "type" not in srv
+
+    def test_stdio_with_no_env_emits_empty_array(self):
+        """env absent in config -> env:[] in output (REQUIRED by ACP spec)."""
+        result = _translate_mcp_servers({
+            "bare": {"command": "node", "args": ["index.js"]},
+        })
+        assert len(result) == 1
+        srv = result[0]
+        assert srv["env"] == []   # must be [] not missing
+        assert "type" not in srv
+
+    def test_stdio_with_explicit_empty_env_emits_empty_array(self):
+        """env:{} in config -> env:[] in output."""
+        result = _translate_mcp_servers({
+            "srv": {"command": "python3", "args": ["-m", "mcp"], "env": {}},
+        })
+        assert result[0]["env"] == []
+
+    def test_http_with_headers_dict_converted_to_array(self):
+        """url + headers dict -> type:http + headers array."""
+        result = _translate_mcp_servers({
+            "remote": {
+                "url": "https://example.com/mcp",
+                "headers": {"X-Api-Key": "abc123", "Accept": "application/json"},
+            }
+        })
+        assert len(result) == 1
+        srv = result[0]
+        assert srv["type"] == "http"
+        assert srv["name"] == "remote"
+        assert srv["url"] == "https://example.com/mcp"
+        assert isinstance(srv["headers"], list)
+        hdr_map = {h["name"]: h["value"] for h in srv["headers"]}
+        assert hdr_map == {"X-Api-Key": "abc123", "Accept": "application/json"}
+        # http must NOT have env or command
+        assert "env" not in srv
+        assert "command" not in srv
+
+    def test_http_with_no_headers_emits_empty_array(self):
+        """headers absent -> headers:[] (REQUIRED by ACP spec)."""
+        result = _translate_mcp_servers({
+            "pub": {"url": "https://pub.example.com/mcp"},
+        })
+        srv = result[0]
+        assert srv["type"] == "http"
+        assert srv["headers"] == []
+
+    def test_sse_transport_hint_sets_type_sse(self):
+        """Hermes 'transport: sse' -> ACP type:'sse'."""
+        result = _translate_mcp_servers({
+            "events": {
+                "url": "http://localhost:8000/sse",
+                "transport": "sse",
+                "headers": {},
+            }
+        })
+        srv = result[0]
+        assert srv["type"] == "sse"
+        assert srv["name"] == "events"
+        assert srv["url"] == "http://localhost:8000/sse"
+        assert srv["headers"] == []
+
+    def test_sse_via_type_key_also_accepted(self):
+        """Hermes 'type: sse' (alternative key) -> ACP type:'sse'."""
+        result = _translate_mcp_servers({
+            "events2": {"url": "http://localhost:9000/sse", "type": "sse"},
+        })
+        assert result[0]["type"] == "sse"
+
+    def test_malformed_no_command_no_url_skipped(self):
+        """Entry with neither command nor url is skipped, not an error."""
+        result = _translate_mcp_servers({
+            "bad": {"timeout": 30, "auth": {"token": "x"}},
+        })
+        assert result == []
+
+    def test_malformed_entry_does_not_block_valid_entries(self):
+        """Malformed entry is skipped; valid sibling entries are still translated."""
+        result = _translate_mcp_servers({
+            "bad": {"timeout": 30},
+            "good": {"command": "npx", "args": []},
+        })
+        assert len(result) == 1
+        assert result[0]["name"] == "good"
+
+    def test_both_command_and_url_prefers_stdio(self):
+        """Both command+url set -> stdio wins (no type field)."""
+        result = _translate_mcp_servers({
+            "ambig": {
+                "command": "my-cmd",
+                "url": "https://remote.example.com",
+                "env": {},
+            }
+        })
+        srv = result[0]
+        assert "type" not in srv
+        assert srv["command"] == "my-cmd"
+
+    def test_hermes_only_keys_dropped(self):
+        """timeout/connect_timeout/auth/sampling are NOT forwarded to ACP."""
+        result = _translate_mcp_servers({
+            "srv": {
+                "command": "node",
+                "args": [],
+                "env": {},
+                "timeout": 30,
+                "connect_timeout": 5,
+                "auth": {"type": "oauth"},
+                "sampling": True,
+            }
+        })
+        srv = result[0]
+        for dropped in ("timeout", "connect_timeout", "auth", "sampling"):
+            assert dropped not in srv
+
+    def test_empty_config_returns_empty_list(self):
+        """No servers configured -> []."""
+        assert _translate_mcp_servers({}) == []
+
+    def test_none_config_returns_empty_list(self):
+        """None config -> []."""
+        assert _translate_mcp_servers(None) == []
+
+    def test_multiple_servers_all_translated(self):
+        """Multiple entries all appear in the output list."""
+        result = _translate_mcp_servers({
+            "stdio1": {"command": "cmd1", "args": []},
+            "http1":  {"url": "https://a.com"},
+            "sse1":   {"url": "https://b.com/sse", "transport": "sse"},
+        })
+        names = {s["name"] for s in result}
+        assert names == {"stdio1", "http1", "sse1"}
+
+
+class TestMcpServersPlumbedIntoSessionNew:
+    """Assert the translated mcp_servers list reaches session/new."""
+
+    def _make_acp_session(self, mcp_servers):
+        mock_client = MagicMock()
+        mock_client.is_alive.return_value = True
+        mock_client.initialize.return_value = {"protocolVersion": 1}
+        mock_client.take_notification.return_value = None
+        mock_client.take_server_request.return_value = None
+        mock_client.stderr_tail.return_value = []
+        # session/new returns a sessionId
+        mock_client.request.return_value = {"sessionId": "sess-mcp"}
+
+        session = ACPClientSession(
+            command="fake-acp",
+            mcp_servers=mcp_servers,
+            client_factory=lambda **kw: mock_client,
+        )
+        return session, mock_client
+
+    def test_translated_servers_forwarded_in_session_new(self):
+        """session/new receives the exact translated list, not []."""
+        servers = [
+            {"name": "srv1", "command": "npx", "args": [], "env": []},
+            {"type": "http", "name": "srv2", "url": "https://x.com", "headers": []},
+        ]
+        session, mock_client = self._make_acp_session(mcp_servers=servers)
+        session.ensure_started(cwd="/tmp")
+
+        call = mock_client.request.call_args_list[0]
+        assert call[0][0] == "session/new"
+        params = call[0][1]
+        assert params["mcpServers"] == servers
+
+    def test_empty_mcp_servers_sends_empty_list(self):
+        """None/[] -> mcpServers:[] in session/new (preserved original behavior)."""
+        session, mock_client = self._make_acp_session(mcp_servers=None)
+        session.ensure_started(cwd="/tmp")
+
+        params = mock_client.request.call_args_list[0][0][1]
+        assert params["mcpServers"] == []
+
+    def test_end_to_end_translation_to_session_new(self):
+        """Translator output -> ACPClientSession -> session/new mcpServers roundtrip."""
+        hermes_cfg = {
+            "fs-mcp": {"command": "uvx", "args": ["mcp-server-filesystem", "/data"],
+                       "env": {"HOME": "/root"}},
+        }
+        translated = _translate_mcp_servers(hermes_cfg)
+        session, mock_client = self._make_acp_session(mcp_servers=translated)
+        session.ensure_started(cwd="/tmp")
+
+        params = mock_client.request.call_args_list[0][0][1]
+        mcp_list = params["mcpServers"]
+        assert len(mcp_list) == 1
+        srv = mcp_list[0]
+        assert srv["name"] == "fs-mcp"
+        assert srv["command"] == "uvx"
+        assert srv["args"] == ["mcp-server-filesystem", "/data"]
+        assert srv["env"] == [{"name": "HOME", "value": "/root"}]
+        assert "type" not in srv  # stdio: no type field

--- a/tests/agent/test_acp_client_session.py
+++ b/tests/agent/test_acp_client_session.py
@@ -1,8 +1,13 @@
-"""Tests for agent.transports.acp_client_session — ACP session adapter.
+"""Tests for agent.transports.acp_client_session -- ACP session adapter.
 
 Tests cover session lifecycle (ensure_started, close), turn execution,
 streaming delta projection, should_retire policy on crash/timeout, and
-server-request handling (permission decline, fs/terminal decline).
+server-request handling (permission allow, fs/terminal decline).
+
+Fix-specific tests:
+  Fix 1 -- model pin: set_config_option sent after session/new when model is set.
+  Fix 2 -- thought-chunk leak: agent_thought_chunk NOT in extracted text; agent_message_chunk IS.
+  Fix 3 -- permission response shape: uses {outcome:{outcome:...}} ACP spec form.
 """
 
 from __future__ import annotations
@@ -21,11 +26,12 @@ from agent.transports.acp_client_session import (
     _coerce_user_input,
     _extract_text_from_update,
     _is_tool_iteration,
+    _pick_allow_option,
 )
 
 
 # ---------------------------------------------------------------------------
-# Helpers — mock ACPClient
+# Helpers -- mock ACPClient
 # ---------------------------------------------------------------------------
 
 
@@ -33,6 +39,7 @@ def _make_session(
     *,
     command: str = "fake-acp",
     args=None,
+    model: Optional[str] = None,
     on_delta=None,
     client_mock: Optional[MagicMock] = None,
 ) -> tuple[ACPClientSession, MagicMock]:
@@ -49,6 +56,7 @@ def _make_session(
     session = ACPClientSession(
         command=command,
         args=args,
+        model=model,
         on_delta=on_delta,
         client_factory=lambda **kw: client_mock,
     )
@@ -103,7 +111,7 @@ class TestEnsureStarted:
         assert session._session_id is None
 
     def test_ensure_started_error_sets_should_retire(self):
-        """run_turn() → ensure_started() failure sets should_retire=True."""
+        """run_turn() -> ensure_started() failure sets should_retire=True."""
         session, mock_client = _make_session()
         mock_client.initialize.side_effect = ACPClientError(
             code=-32603, message="initialize failed"
@@ -113,6 +121,394 @@ class TestEnsureStarted:
         assert result.should_retire is True
         assert result.error is not None
         assert "startup" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Fix 1 -- model pin via session/set_config_option (verify behaviour)
+# ---------------------------------------------------------------------------
+
+def _make_config_response(current_value: str) -> dict:
+    """Build a realistic set_config_option response with the given model currentValue."""
+    return {
+        "configOptions": [
+            {
+                "id": "model",
+                "name": "Model",
+                "type": "select",
+                "category": "model",
+                "currentValue": current_value,
+                "options": [
+                    {"value": "default", "name": "Default (Opus 4.8)"},
+                    {"value": "sonnet",  "name": "Sonnet 4.6"},
+                    {"value": "haiku",   "name": "Haiku 4.5"},
+                ],
+            },
+        ]
+    }
+
+
+class TestModelPin:
+    def test_set_config_option_sent_after_session_new_when_model_set(self):
+        """Fix 1: when model is configured, session/set_config_option is sent
+        after session/new with configId='model' and the resolved model string."""
+        session, mock_client = _make_session(model="haiku")
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-model"},    # session/new
+            _make_config_response("haiku"), # set_config_option -> match
+        ]
+
+        session.ensure_started(cwd="/tmp")
+
+        calls = mock_client.request.call_args_list
+        assert len(calls) == 2
+
+        new_call = calls[0]
+        assert new_call[0][0] == "session/new"
+
+        cfg_call = calls[1]
+        assert cfg_call[0][0] == "session/set_config_option"
+        params = cfg_call[0][1]
+        assert params["sessionId"] == "sess-model"
+        assert params["configId"] == "model"
+        assert params["value"] == "haiku"
+
+    def test_set_config_option_not_sent_when_model_not_set(self):
+        """Fix 1: when no model is configured, set_config_option is NOT sent
+        (existing tests must remain unaffected -- only session/new is called)."""
+        session, mock_client = _make_session()  # no model
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-nomodel"},  # session/new only
+        ]
+
+        session.ensure_started(cwd="/tmp")
+
+        # Only one request call: session/new, no set_config_option
+        assert mock_client.request.call_count == 1
+        assert mock_client.request.call_args[0][0] == "session/new"
+
+    # -- verify: currentValue matches -> silent OK --
+
+    def test_model_pin_verified_match_is_silent(self):
+        """Task B: currentValue == requested -> log info, no exception, session OK."""
+        session, mock_client = _make_session(model="haiku")
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-match"},
+            _make_config_response("haiku"),  # currentValue matches
+        ]
+
+        sid = session.ensure_started(cwd="/tmp")
+        assert sid == "sess-match"
+        assert session._session_id == "sess-match"
+
+    # -- verify: currentValue mismatch (server supported) -> raises, not swallowed --
+
+    def test_model_pin_mismatch_raises_acp_error(self):
+        """Task B: server supported set_config_option but currentValue != requested
+        -> ACPClientError raised (NOT swallowed by the tolerance except)."""
+        session, mock_client = _make_session(model="haiku")
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-mismatch"},
+            _make_config_response("default"),  # currentValue stayed on Opus default
+        ]
+
+        with pytest.raises(ACPClientError) as exc_info:
+            session.ensure_started(cwd="/tmp")
+        err = exc_info.value
+        assert err.code == 1  # positive = config rejection, not transport crash
+        assert "haiku" in str(err)
+        assert "default" in str(err)
+        # Session cleared so retry does not short-circuit idempotency guard
+        assert session._session_id is None
+
+    def test_model_pin_mismatch_does_not_retire_session(self):
+        """Task B: mismatch is a config error, not a session crash.
+        should_retire must be False so we don't loop (respawn -> same mismatch -> loop)."""
+        session, mock_client = _make_session(model="haiku")
+
+        def req_side(method, params=None, timeout=30):
+            if method == "session/new":
+                return {"sessionId": "sess-noretire"}
+            if method == "session/set_config_option":
+                return _make_config_response("default")  # mismatch
+            return {}
+
+        mock_client.request.side_effect = req_side
+
+        result = session.run_turn("hello")
+        assert result.error is not None
+        assert "haiku" in result.error
+        assert result.should_retire is False  # MUST NOT retire -> would loop
+
+    def test_model_pin_mismatch_error_message_names_accepted_aliases(self):
+        """Task B: error message includes the accepted alias list so operator can fix."""
+        session, mock_client = _make_session(model="claude-haiku-4-5-20251001")
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-alias"},
+            _make_config_response("default"),
+        ]
+
+        with pytest.raises(ACPClientError) as exc_info:
+            session.ensure_started(cwd="/tmp")
+        msg = str(exc_info.value)
+        # Should list the accepted values from the options array
+        assert "haiku" in msg
+        assert "sonnet" in msg
+        assert "default" in msg
+
+    # -- verify: request() raises (server lacks method) -> tolerated --
+
+    def test_set_config_option_request_raises_is_tolerated(self):
+        """Task B: if request() raises (server doesn't support set_config_option),
+        session is NOT retired -- ensure_started returns the session_id."""
+        session, mock_client = _make_session(model="haiku")
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-cfg-fail"},
+            ACPClientError(code=-32601, message="Method not found"),  # set_config_option
+        ]
+
+        sid = session.ensure_started(cwd="/tmp")
+        assert sid == "sess-cfg-fail"  # session not aborted
+        assert session._session_id == "sess-cfg-fail"
+
+    def test_set_config_option_timeout_is_tolerated(self):
+        """Task B: TimeoutError from set_config_option is tolerated (not a mismatch)."""
+        session, mock_client = _make_session(model="haiku")
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-timeout"},
+            TimeoutError("set_config_option timed out"),
+        ]
+
+        sid = session.ensure_started(cwd="/tmp")
+        assert sid == "sess-timeout"
+        assert session._session_id == "sess-timeout"
+
+    # -- verify: no model configOption in response -> warn + proceed --
+
+    def test_no_model_config_option_in_response_is_tolerated(self):
+        """Task B: server responds but carries no 'model' configOption
+        (generic ACP server) -- cannot verify, warn + proceed."""
+        session, mock_client = _make_session(model="haiku")
+        mock_client.request.side_effect = [
+            {"sessionId": "sess-generic"},
+            {"configOptions": []},  # no model option
+        ]
+
+        sid = session.ensure_started(cwd="/tmp")
+        assert sid == "sess-generic"
+        assert session._session_id == "sess-generic"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Fix 2 -- thought-chunk leak guard
+# ---------------------------------------------------------------------------
+
+
+class TestThoughtChunkLeak:
+    def test_agent_message_chunk_extracted(self):
+        """Fix 2: agent_message_chunk produces user-facing text (positive case)."""
+        params = {
+            "sessionId": "s",
+            "update": {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "hello"},
+            },
+        }
+        assert _extract_text_from_update(params) == "hello"
+
+    def test_agent_thought_chunk_not_extracted(self):
+        """Fix 2: agent_thought_chunk (internal reasoning) returns empty string --
+        must never leak into the user-facing reply."""
+        params = {
+            "sessionId": "s",
+            "update": {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": "I am thinking..."},
+            },
+        }
+        assert _extract_text_from_update(params) == ""
+
+    def test_agent_thought_chunk_not_in_run_turn_output(self):
+        """Fix 2: thought chunks from session/update are NOT included in final_text."""
+        session, mock_client = _make_session()
+
+        def req_side_effect(method, params=None, timeout=30):
+            if method == "session/new":
+                return {"sessionId": "sess-think"}
+            if method == "session/prompt":
+                time.sleep(0.05)
+                return {"stopReason": "end_turn"}
+            return {}
+
+        mock_client.request.side_effect = req_side_effect
+
+        notes = iter([
+            # internal reasoning -- must be excluded
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "sess-think",
+                    "update": {
+                        "sessionUpdate": "agent_thought_chunk",
+                        "content": {"type": "text", "text": "reasoning step"},
+                    },
+                },
+            },
+            # user-facing reply -- must be included
+            {
+                "method": "session/update",
+                "params": {
+                    "sessionId": "sess-think",
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": "user reply"},
+                    },
+                },
+            },
+            None,
+        ])
+        mock_client.take_notification.side_effect = lambda timeout=0.0: next(notes, None)
+
+        result = session.run_turn("test")
+        assert "user reply" in result.final_text
+        assert "reasoning step" not in result.final_text
+
+    def test_snake_case_thought_chunk_not_extracted(self):
+        """Fix 2: snake_case 'session_update' discriminator variant also blocked."""
+        params = {
+            "sessionId": "s",
+            "update": {
+                "session_update": "agent_thought_chunk",
+                "content": {"type": "text", "text": "hidden thought"},
+            },
+        }
+        assert _extract_text_from_update(params) == ""
+
+    def test_snake_case_message_chunk_extracted(self):
+        """Fix 2: snake_case 'session_update' agent_message_chunk still works."""
+        params = {
+            "sessionId": "s",
+            "update": {
+                "session_update": "agent_message_chunk",
+                "content": {"type": "text", "text": "visible"},
+            },
+        }
+        assert _extract_text_from_update(params) == "visible"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Fix 3 -- permission response shape
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionResponseShape:
+    def test_permission_request_uses_acp_outcome_shape(self):
+        """Fix 3: permission response uses {outcome:{outcome:'selected',optionId:'...'}}
+        NOT the old {granted: false} which is not a valid ACP shape."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "sess-perm"}
+        session.ensure_started()
+
+        req = {
+            "id": 42,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": "sess-perm",
+                "toolCall": {"toolName": "bash"},
+                "options": [
+                    {"optionId": "opt-allow", "name": "Allow once", "kind": "allow_once"},
+                    {"optionId": "opt-deny", "name": "Deny", "kind": "reject_once"},
+                ],
+            },
+        }
+        session._handle_server_request(req)
+
+        mock_client.respond.assert_called_once()
+        args = mock_client.respond.call_args
+        assert args[0][0] == 42
+        payload = args[0][1]
+        # Must use the ACP spec shape, not {granted: ...}
+        assert "outcome" in payload
+        assert "granted" not in payload
+        inner = payload["outcome"]
+        assert inner["outcome"] == "selected"
+        assert inner["optionId"] == "opt-allow"  # prefers allow_once kind
+
+    def test_permission_prefers_allow_once_option(self):
+        """Fix 3: the allow_once-kinded option is preferred over others."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "s"}
+        session.ensure_started()
+
+        req = {
+            "id": 1,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": "s",
+                "toolCall": {"toolName": "bash"},
+                "options": [
+                    {"optionId": "deny-id", "name": "Deny", "kind": "reject_once"},
+                    {"optionId": "allow-id", "name": "Allow", "kind": "allow_once"},
+                ],
+            },
+        }
+        session._handle_server_request(req)
+
+        payload = mock_client.respond.call_args[0][1]
+        assert payload["outcome"]["optionId"] == "allow-id"
+
+    def test_permission_falls_back_to_first_option_when_no_allow_once(self):
+        """Fix 3: if no allow_once option, echoes first available optionId."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "s"}
+        session.ensure_started()
+
+        req = {
+            "id": 2,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": "s",
+                "toolCall": {"toolName": "bash"},
+                "options": [
+                    {"optionId": "custom-1", "name": "Custom 1", "kind": "allow_always"},
+                ],
+            },
+        }
+        session._handle_server_request(req)
+
+        payload = mock_client.respond.call_args[0][1]
+        assert payload["outcome"]["outcome"] == "selected"
+        assert payload["outcome"]["optionId"] == "custom-1"
+
+    def test_permission_cancelled_when_no_options(self):
+        """Fix 3: malformed request with no options -> cancelled outcome (not wedged)."""
+        session, mock_client = _make_session()
+        mock_client.request.return_value = {"sessionId": "s"}
+        session.ensure_started()
+
+        req = {
+            "id": 3,
+            "method": "session/request_permission",
+            "params": {"sessionId": "s", "toolCall": {"toolName": "bash"}, "options": []},
+        }
+        session._handle_server_request(req)
+
+        payload = mock_client.respond.call_args[0][1]
+        assert payload["outcome"] == {"outcome": "cancelled"}
+
+    def test_pick_allow_option_helper(self):
+        """_pick_allow_option() unit tests."""
+        opts = [
+            {"optionId": "r", "kind": "reject_once"},
+            {"optionId": "a", "kind": "allow_once"},
+        ]
+        assert _pick_allow_option(opts) == "a"
+
+        # no allow_once -> first
+        opts2 = [{"optionId": "x", "kind": "reject_once"}]
+        assert _pick_allow_option(opts2) == "x"
+
+        # empty
+        assert _pick_allow_option([]) is None
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +552,7 @@ class TestClose:
 
 
 # ---------------------------------------------------------------------------
-# Tests: run_turn — happy path
+# Tests: run_turn -- happy path
 # ---------------------------------------------------------------------------
 
 
@@ -176,7 +572,7 @@ class TestRunTurn:
         # No streaming notifications
         mock_client.take_notification.side_effect = [
             None,  # polled once, returns None
-            None,  # second poll → triggers req_thread to finish
+            None,  # second poll -> triggers req_thread to finish
         ]
 
         result = session.run_turn("hello world", cwd="/tmp")
@@ -331,7 +727,7 @@ class TestShouldRetire:
         assert result.error is not None
 
     def test_session_prompt_acp_error_sets_should_retire_for_negative_code(self):
-        """ACPClientError with negative code (system error) → should_retire."""
+        """ACPClientError with negative code (system error) -> should_retire."""
         session, mock_client = _make_session()
 
         def req_side_effect(method, params=None, timeout=30):
@@ -368,24 +764,40 @@ class TestShouldRetire:
 
 
 # ---------------------------------------------------------------------------
-# Tests: server request handling
+# Tests: server request handling (fs/terminal decline -- unchanged behaviour)
 # ---------------------------------------------------------------------------
 
 
 class TestServerRequestHandling:
-    def test_permission_request_declined(self):
-        """Permission requests from the server are declined (granted: False)."""
+    def test_permission_request_grants_allow_once(self):
+        """Fix 3: Permission requests use ACP outcome shape and grant allow_once."""
         session, mock_client = _make_session()
         mock_client.request.side_effect = [
             {"sessionId": "sess-perm"},  # session/new
         ]
 
-        # Simulate the internal _handle_server_request call
         session.ensure_started()
-        req = {"id": 42, "method": "session/request_permission", "params": {"permissionId": "exec"}}
+        req = {
+            "id": 42,
+            "method": "session/request_permission",
+            "params": {
+                "sessionId": "sess-perm",
+                "toolCall": {"toolName": "bash"},
+                "options": [
+                    {"optionId": "allow-once-id", "name": "Allow once", "kind": "allow_once"},
+                    {"optionId": "deny-id", "name": "Deny", "kind": "reject_once"},
+                ],
+            },
+        }
         session._handle_server_request(req)
 
-        mock_client.respond.assert_called_once_with(42, {"granted": False})
+        # Must use ACP spec outcome shape, not {granted: ...}
+        mock_client.respond.assert_called_once()
+        payload = mock_client.respond.call_args[0][1]
+        assert "outcome" in payload
+        assert "granted" not in payload
+        assert payload["outcome"]["outcome"] == "selected"
+        assert payload["outcome"]["optionId"] == "allow-once-id"
 
     def test_fs_write_declined_with_error(self):
         """fs/write_text_file is declined with respond_error."""
@@ -398,7 +810,7 @@ class TestServerRequestHandling:
 
         mock_client.respond_error.assert_called_once()
         call_args = mock_client.respond_error.call_args
-        # respond_error(rid, code=..., message=...) — rid is positional
+        # respond_error(rid, code=..., message=...) -- rid is positional
         assert call_args[0][0] == 7
         assert call_args[1]["code"] == -32601  # method not supported
 

--- a/tests/agent/test_acp_runtime.py
+++ b/tests/agent/test_acp_runtime.py
@@ -1,0 +1,374 @@
+"""Tests for agent.acp_runtime — run_acp_client_turn().
+
+Tests cover the happy path, crash/retire policy, skill nudge increment,
+memory sync, and background review trigger.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.acp_runtime import run_acp_client_turn
+from agent.transports.acp_client_session import TurnResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock agent
+# ---------------------------------------------------------------------------
+
+
+def _make_agent(
+    *,
+    api_mode: str = "acp_client",
+    acp_command: str = "fake-acp",
+    acp_args: list = None,
+    session_cwd: str = "/tmp",
+    _iters_since_skill: int = 0,
+    _skill_nudge_interval: int = 10,
+    valid_tool_names: set = None,
+    has_stream_delta: bool = False,
+) -> SimpleNamespace:
+    agent = SimpleNamespace(
+        api_mode=api_mode,
+        acp_command=acp_command,
+        acp_args=list(acp_args or []),
+        session_cwd=session_cwd,
+        _acp_session=None,
+        _iters_since_skill=_iters_since_skill,
+        _skill_nudge_interval=_skill_nudge_interval,
+        valid_tool_names=valid_tool_names or set(),
+        _fire_stream_delta=MagicMock() if has_stream_delta else None,
+        _sync_external_memory_for_turn=MagicMock(),
+        _spawn_background_review=MagicMock(),
+    )
+    return agent
+
+
+def _mock_session(turn_result: TurnResult) -> MagicMock:
+    """Return a mock ACPClientSession that returns the given TurnResult."""
+    mock = MagicMock()
+    mock.run_turn.return_value = turn_result
+    mock.close.return_value = None
+    return mock
+
+
+def _inject_session(agent, session_mock: MagicMock) -> None:
+    """Inject a pre-built session into the agent."""
+    agent._acp_session = session_mock
+
+
+# ---------------------------------------------------------------------------
+# Tests: happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    def test_returns_final_response_from_turn(self):
+        """Happy path: final_text from TurnResult becomes final_response."""
+        agent = _make_agent()
+        turn = TurnResult(final_text="hello from ACP", projected_messages=[
+            {"role": "assistant", "content": "hello from ACP"}
+        ])
+        _inject_session(agent, _mock_session(turn))
+        messages = [{"role": "user", "content": "hi"}]
+
+        result = run_acp_client_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="t1",
+        )
+
+        assert result["final_response"] == "hello from ACP"
+        assert result["completed"] is True
+        assert result["partial"] is False
+        assert result["error"] is None
+        assert result["api_calls"] == 1
+
+    def test_projected_messages_spliced_into_messages(self):
+        """Projected messages from TurnResult are appended to messages."""
+        agent = _make_agent()
+        turn = TurnResult(
+            final_text="Hi there",
+            projected_messages=[{"role": "assistant", "content": "Hi there"}],
+        )
+        _inject_session(agent, _mock_session(turn))
+        messages = [{"role": "user", "content": "hello"}]
+
+        run_acp_client_turn(
+            agent,
+            user_message="hello",
+            original_user_message="hello",
+            messages=messages,
+            effective_task_id="t1",
+        )
+
+        assert len(messages) == 2
+        assert messages[-1] == {"role": "assistant", "content": "Hi there"}
+
+    def test_lazy_session_created_on_first_call(self):
+        """A new ACPClientSession is created when _acp_session is None."""
+        agent = _make_agent()
+        assert agent._acp_session is None
+
+        mock_session = _mock_session(TurnResult(final_text="ok"))
+        with patch(
+            "agent.transports.acp_client_session.ACPClientSession.__init__",
+            return_value=None,
+        ), patch(
+            "agent.transports.acp_client_session.ACPClientSession.run_turn",
+            return_value=TurnResult(final_text="ok"),
+        ), patch(
+            "agent.transports.acp_client_session.ACPClientSession.close",
+        ):
+            result = run_acp_client_turn(
+                agent,
+                user_message="test",
+                original_user_message="test",
+                messages=[],
+                effective_task_id="t1",
+            )
+
+        assert result["final_response"] == "ok"
+        # Session was created and stored
+        assert agent._acp_session is not None
+
+    def test_session_reused_across_calls(self):
+        """Existing _acp_session is reused, no new session created."""
+        agent = _make_agent()
+        session_mock = _mock_session(TurnResult(final_text="ok"))
+        _inject_session(agent, session_mock)
+
+        # Run two turns — the pre-injected session should be reused
+        run_acp_client_turn(
+            agent,
+            user_message="turn1",
+            original_user_message="turn1",
+            messages=[],
+            effective_task_id="t1",
+        )
+        run_acp_client_turn(
+            agent,
+            user_message="turn2",
+            original_user_message="turn2",
+            messages=[],
+            effective_task_id="t2",
+        )
+        assert session_mock.run_turn.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: crash / retire policy
+# ---------------------------------------------------------------------------
+
+
+class TestRetirePolicy:
+    def test_should_retire_true_closes_and_nils_session(self):
+        """When turn.should_retire is True, session is closed and set to None."""
+        agent = _make_agent()
+        turn = TurnResult(
+            final_text="", should_retire=True, error="agent crashed"
+        )
+        session_mock = _mock_session(turn)
+        _inject_session(agent, session_mock)
+
+        result = run_acp_client_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+        session_mock.close.assert_called_once()
+        assert agent._acp_session is None
+
+    def test_crash_exception_nils_session_and_returns_error(self):
+        """Uncaught exception from run_turn() sets session to None and returns error."""
+        agent = _make_agent()
+        session_mock = MagicMock()
+        session_mock.run_turn.side_effect = RuntimeError("subprocess died")
+        _inject_session(agent, session_mock)
+
+        result = run_acp_client_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "ACP client turn failed" in result["final_response"]
+        assert agent._acp_session is None
+
+    def test_no_retire_keeps_session_alive(self):
+        """When should_retire=False, session is kept for reuse."""
+        agent = _make_agent()
+        turn = TurnResult(final_text="ok", should_retire=False)
+        session_mock = _mock_session(turn)
+        _inject_session(agent, session_mock)
+
+        run_acp_client_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+        session_mock.close.assert_not_called()
+        assert agent._acp_session is session_mock
+
+
+# ---------------------------------------------------------------------------
+# Tests: skill nudge counter
+# ---------------------------------------------------------------------------
+
+
+class TestSkillNudge:
+    def test_tool_iterations_added_to_iters_since_skill(self):
+        """turn.tool_iterations is added to agent._iters_since_skill."""
+        agent = _make_agent(_iters_since_skill=3, _skill_nudge_interval=20)
+        turn = TurnResult(final_text="ok", tool_iterations=4)
+        _inject_session(agent, _mock_session(turn))
+
+        run_acp_client_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+        assert agent._iters_since_skill == 7  # 3 + 4
+
+    def test_skill_nudge_resets_counter(self):
+        """When _skill_nudge_interval is reached, _iters_since_skill resets."""
+        agent = _make_agent(
+            _iters_since_skill=8,
+            _skill_nudge_interval=10,
+            valid_tool_names={"skill_manage"},
+        )
+        turn = TurnResult(final_text="ok", tool_iterations=3)
+        _inject_session(agent, _mock_session(turn))
+
+        run_acp_client_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t1",
+            should_review_memory=False,
+        )
+
+        # 8 + 3 = 11 >= 10 → nudge triggered → counter reset
+        assert agent._iters_since_skill == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: memory sync
+# ---------------------------------------------------------------------------
+
+
+class TestMemorySync:
+    def test_memory_sync_called_on_successful_turn(self):
+        """_sync_external_memory_for_turn called on non-interrupted, non-error turn."""
+        agent = _make_agent()
+        turn = TurnResult(final_text="ok", interrupted=False, error=None)
+        _inject_session(agent, _mock_session(turn))
+
+        run_acp_client_turn(
+            agent,
+            user_message="q",
+            original_user_message="q",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+        agent._sync_external_memory_for_turn.assert_called_once_with(
+            original_user_message="q",
+            final_response="ok",
+            interrupted=False,
+        )
+
+    def test_memory_sync_skipped_on_interrupted_turn(self):
+        """Memory sync skipped when turn is interrupted."""
+        agent = _make_agent()
+        turn = TurnResult(final_text="", interrupted=True)
+        _inject_session(agent, _mock_session(turn))
+
+        run_acp_client_turn(
+            agent,
+            user_message="q",
+            original_user_message="q",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+        agent._sync_external_memory_for_turn.assert_not_called()
+
+    def test_memory_sync_skipped_on_error_turn(self):
+        """Memory sync skipped when turn has an error."""
+        agent = _make_agent()
+        turn = TurnResult(final_text="", error="something broke")
+        _inject_session(agent, _mock_session(turn))
+
+        run_acp_client_turn(
+            agent,
+            user_message="q",
+            original_user_message="q",
+            messages=[],
+            effective_task_id="t1",
+        )
+
+        agent._sync_external_memory_for_turn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: background review
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundReview:
+    def test_background_review_spawned_when_triggered(self):
+        """_spawn_background_review called when should_review_memory=True."""
+        agent = _make_agent()
+        turn = TurnResult(final_text="good answer", interrupted=False, error=None)
+        _inject_session(agent, _mock_session(turn))
+
+        run_acp_client_turn(
+            agent,
+            user_message="q",
+            original_user_message="q",
+            messages=[],
+            effective_task_id="t1",
+            should_review_memory=True,
+        )
+
+        agent._spawn_background_review.assert_called_once()
+        call_kwargs = agent._spawn_background_review.call_args[1]
+        assert call_kwargs["review_memory"] is True
+
+    def test_background_review_skipped_when_no_final_text(self):
+        """_spawn_background_review not called when final_text is empty."""
+        agent = _make_agent()
+        turn = TurnResult(final_text="", interrupted=False, error=None)
+        _inject_session(agent, _mock_session(turn))
+
+        run_acp_client_turn(
+            agent,
+            user_message="q",
+            original_user_message="q",
+            messages=[],
+            effective_task_id="t1",
+            should_review_memory=True,
+        )
+
+        agent._spawn_background_review.assert_not_called()

--- a/tests/agent/test_acp_runtime.py
+++ b/tests/agent/test_acp_runtime.py
@@ -372,3 +372,88 @@ class TestBackgroundReview:
         )
 
         agent._spawn_background_review.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: cwd resolution — HERMES_ACP_SESSION_CWD env var
+# ---------------------------------------------------------------------------
+
+
+class TestCwdResolution:
+    """run_acp_client_turn must pass the correct cwd to run_turn.
+
+    Priority (highest first):
+      1. agent.session_cwd (explicitly set on the agent)
+      2. HERMES_ACP_SESSION_CWD env var
+      3. os.getcwd() fallback
+
+    This is the mechanism that lets the janet_test gateway route each ACP
+    session into its sandbox directory (where CLAUDE.md and
+    .claude/settings.local.json live) without adding a config key to the
+    provider resolver chain.
+    """
+
+    def _capture_cwd_from_run_turn(self, agent) -> str:
+        """Run one turn and return the cwd that was passed to run_turn."""
+        captured: list[str] = []
+        session_mock = MagicMock()
+
+        def _fake_run_turn(user_input, *, cwd=None, **kwargs):
+            captured.append(cwd or "")
+            return TurnResult(final_text="ok")
+
+        session_mock.run_turn.side_effect = _fake_run_turn
+        _inject_session(agent, session_mock)
+
+        run_acp_client_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=[],
+            effective_task_id="t1",
+        )
+        return captured[0] if captured else ""
+
+    def test_session_cwd_attribute_wins_over_env(self, monkeypatch):
+        """agent.session_cwd takes priority over HERMES_ACP_SESSION_CWD."""
+        monkeypatch.setenv("HERMES_ACP_SESSION_CWD", "/env/sandbox")
+        agent = _make_agent(session_cwd="/agent/sandbox")
+
+        cwd = self._capture_cwd_from_run_turn(agent)
+        assert cwd == "/agent/sandbox"
+
+    def test_env_var_used_when_session_cwd_absent(self, monkeypatch):
+        """HERMES_ACP_SESSION_CWD is used when agent has no session_cwd."""
+        monkeypatch.setenv("HERMES_ACP_SESSION_CWD", "/env/sandbox")
+        agent = _make_agent()
+        # Remove session_cwd so it's absent (not just None)
+        del agent.session_cwd
+
+        cwd = self._capture_cwd_from_run_turn(agent)
+        assert cwd == "/env/sandbox"
+
+    def test_env_var_used_when_session_cwd_is_none(self, monkeypatch):
+        """HERMES_ACP_SESSION_CWD is used when agent.session_cwd is None."""
+        monkeypatch.setenv("HERMES_ACP_SESSION_CWD", "/env/sandbox")
+        agent = _make_agent(session_cwd=None)
+
+        cwd = self._capture_cwd_from_run_turn(agent)
+        assert cwd == "/env/sandbox"
+
+    def test_env_var_empty_falls_back_to_getcwd(self, monkeypatch):
+        """Empty HERMES_ACP_SESSION_CWD falls through to os.getcwd()."""
+        monkeypatch.setenv("HERMES_ACP_SESSION_CWD", "")
+        agent = _make_agent(session_cwd=None)
+
+        import os
+        cwd = self._capture_cwd_from_run_turn(agent)
+        assert cwd == os.getcwd()
+
+    def test_no_env_var_falls_back_to_getcwd(self, monkeypatch):
+        """Absent HERMES_ACP_SESSION_CWD falls through to os.getcwd()."""
+        monkeypatch.delenv("HERMES_ACP_SESSION_CWD", raising=False)
+        agent = _make_agent(session_cwd=None)
+
+        import os
+        cwd = self._capture_cwd_from_run_turn(agent)
+        assert cwd == os.getcwd()

--- a/tests/e2e/test_acp_client_e2e.py
+++ b/tests/e2e/test_acp_client_e2e.py
@@ -1,15 +1,26 @@
 """E2E smoke test for the ACP client transport.
 
-Spawns a real ACP-compliant server (claude-acp-bridge) and performs one
-complete prompt roundtrip through ACPClient + ACPClientSession.
+Spawns a real ACP-compliant server and performs one complete prompt roundtrip
+through ACPClient + ACPClientSession.
 
-Gated behind the HERMES_E2E_ACP environment variable — must be set to "1"
-(or any non-empty truthy value) to run. Requires:
-  - ``claude-acp-bridge`` installed and on PATH (pip install claude-acp-bridge)
-  - A working Claude CLI configured for the subprocess (model auth token)
+Gated behind two environment variables:
+  - ``HERMES_E2E_ACP=1``           must be set to enable the tests
+  - ``HERMES_E2E_ACP_COMMAND``     path or name of the ACP binary to spawn
 
-Run:
-    HERMES_E2E_ACP=1 pytest tests/e2e/test_acp_client_e2e.py -v
+There is no default binary — reviewers must explicitly supply their own
+ACP-compliant server. For example, using the reference implementation:
+
+    npm install -g @agentclientprotocol/claude-agent-acp
+
+    HERMES_E2E_ACP=1 HERMES_E2E_ACP_COMMAND=claude-agent-acp \\
+      pytest tests/e2e/test_acp_client_e2e.py -v
+
+Additional args can be forwarded to the binary via ``HERMES_E2E_ACP_ARGS``
+(space-separated):
+
+    HERMES_E2E_ACP=1 HERMES_E2E_ACP_COMMAND=claude-agent-acp \\
+      HERMES_E2E_ACP_ARGS="--stdio --model claude-sonnet-4-5" \\
+      pytest tests/e2e/test_acp_client_e2e.py -v
 
 Why this test:
   The unit tests (test_acp_client.py, test_acp_client_session.py) use fake
@@ -21,37 +32,41 @@ Why this test:
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
-import sys
-import time
 
 import pytest
 
-# Guard: only run when explicitly enabled
+# ---------------------------------------------------------------------------
+# Guard: only run E2E tests when explicitly enabled
+# ---------------------------------------------------------------------------
+
 _E2E_ENABLED = bool(os.environ.get("HERMES_E2E_ACP", "").strip())
 
-pytestmark = pytest.mark.skipif(
+_E2E_SKIP_MARK = pytest.mark.skipif(
     not _E2E_ENABLED,
     reason=(
         "ACP E2E test disabled. Set HERMES_E2E_ACP=1 to enable. "
-        "Requires claude-acp-bridge + Claude CLI auth."
+        "Also requires HERMES_E2E_ACP_COMMAND pointing to an ACP-compliant binary."
     ),
 )
 
-# Path to the claude-acp-bridge package (fallback to installed binary)
-_BRIDGE_PACKAGE_DIR = os.environ.get(
-    "HERMES_ACP_BRIDGE_DIR",
-    "/Users/guillaume/dev/claude-acp-bridge",
-)
-_BRIDGE_COMMAND = os.environ.get("HERMES_ACP_BRIDGE_COMMAND", "claude-acp-bridge")
+# ---------------------------------------------------------------------------
+# ACP command resolution — explicit env var, no default
+# ---------------------------------------------------------------------------
+
+_ACP_COMMAND = os.environ.get("HERMES_E2E_ACP_COMMAND", "").strip()
+_ACP_ARGS_RAW = os.environ.get("HERMES_E2E_ACP_ARGS", "").strip()
+_ACP_EXTRA_ARGS: list[str] = shlex.split(_ACP_ARGS_RAW) if _ACP_ARGS_RAW else []
 
 
-def _bridge_available() -> bool:
-    """Return True if the bridge binary / module can be found."""
+def _acp_command_available() -> bool:
+    """Return True if HERMES_E2E_ACP_COMMAND is set and the binary responds."""
+    if not _ACP_COMMAND:
+        return False
     try:
         proc = subprocess.run(
-            [sys.executable, "-c", "import claude_acp_bridge"],
-            cwd=_BRIDGE_PACKAGE_DIR,
+            [_ACP_COMMAND, "--version"],
             capture_output=True,
             timeout=5,
         )
@@ -60,20 +75,48 @@ def _bridge_available() -> bool:
         return False
 
 
+# ---------------------------------------------------------------------------
+# Fixtures (only used by E2E tests)
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture(scope="module")
-def bridge_command() -> list[str]:
-    """Return the command to spawn the ACP server for testing."""
-    if os.path.isdir(_BRIDGE_PACKAGE_DIR):
-        return [sys.executable, "-m", "claude_acp_bridge"]
-    return [_BRIDGE_COMMAND]
+def acp_command() -> list[str]:
+    """Return the command list to spawn the ACP server for testing.
+
+    Skips the test module when:
+    - ``HERMES_E2E_ACP_COMMAND`` is not set, or
+    - the binary is not reachable on PATH.
+
+    This produces a clear skip reason instead of a confusing FileNotFoundError
+    at test time. Reviewers must supply their own ACP binary explicitly.
+    """
+    if not _ACP_COMMAND:
+        pytest.skip(
+            "HERMES_E2E_ACP_COMMAND is not set. "
+            "Point it at an ACP-compliant binary to run E2E tests. "
+            "Example: HERMES_E2E_ACP_COMMAND=claude-agent-acp"
+        )
+    if not _acp_command_available():
+        pytest.skip(
+            f"ACP binary not found or did not respond: {_ACP_COMMAND!r}. "
+            "Ensure the binary is installed and on PATH."
+        )
+    return [_ACP_COMMAND] + _ACP_EXTRA_ARGS
 
 
+# ---------------------------------------------------------------------------
+# E2E tests — gated by _E2E_SKIP_MARK
+# ---------------------------------------------------------------------------
+
+
+@_E2E_SKIP_MARK
 class TestACPClientE2E:
-    def test_initialize_handshake(self, bridge_command: list[str]) -> None:
+    def test_initialize_handshake(self, acp_command: list[str]) -> None:
         """Verify the wire protocol: initialize returns valid InitializeResponse."""
         from agent.transports.acp_client import ACPClient
 
-        with ACPClient(command=bridge_command[0], args=bridge_command[1:]) as client:
+        with ACPClient(command=acp_command[0], args=acp_command[1:]) as client:
             result = client.initialize(
                 client_name="hermes-e2e-test",
                 client_version="0.1",
@@ -83,24 +126,24 @@ class TestACPClientE2E:
             # ACP spec: InitializeResponse must include protocolVersion
             assert "protocolVersion" in result or result.get("protocol_version") is not None
 
-    def test_session_new_and_close(self, bridge_command: list[str]) -> None:
+    def test_session_new_and_close(self, acp_command: list[str]) -> None:
         """Verify session/new returns a sessionId and session/close succeeds."""
         from agent.transports.acp_client_session import ACPClientSession
 
-        with ACPClientSession(command=bridge_command[0], args=bridge_command[1:]) as session:
+        with ACPClientSession(command=acp_command[0], args=acp_command[1:]) as session:
             sid = session.ensure_started(cwd=os.getcwd())
             assert sid
             assert len(sid) >= 8  # UUID format
 
-    def test_prompt_roundtrip(self, bridge_command: list[str]) -> None:
+    def test_prompt_roundtrip(self, acp_command: list[str]) -> None:
         """Full roundtrip: session/new → session/prompt → text response."""
         from agent.transports.acp_client_session import ACPClientSession
 
         deltas: list[str] = []
 
         with ACPClientSession(
-            command=bridge_command[0],
-            args=bridge_command[1:],
+            command=acp_command[0],
+            args=acp_command[1:],
             on_delta=deltas.append,
         ) as session:
             result = session.run_turn(
@@ -117,3 +160,29 @@ class TestACPClientE2E:
             f"Expected marker not found. final_text={result.final_text!r} "
             f"deltas={deltas!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Skip-message regression guard — runs unconditionally
+# ---------------------------------------------------------------------------
+
+
+def test_acp_command_available_returns_false_when_unset() -> None:
+    """Confirm _acp_command_available() returns False when _ACP_COMMAND is empty.
+
+    This test runs unconditionally to protect against regressions where the
+    skip guard logic is accidentally removed. It patches the module-level
+    variable to simulate a missing HERMES_E2E_ACP_COMMAND.
+    """
+    import tests.e2e.test_acp_client_e2e as e2e_mod
+
+    original = e2e_mod._ACP_COMMAND
+    try:
+        e2e_mod._ACP_COMMAND = ""
+        result = e2e_mod._acp_command_available()
+        assert result is False, (
+            "_acp_command_available() must return False when _ACP_COMMAND is empty; "
+            "the E2E fixture relies on this to produce a clear skip message."
+        )
+    finally:
+        e2e_mod._ACP_COMMAND = original

--- a/tests/e2e/test_acp_client_e2e.py
+++ b/tests/e2e/test_acp_client_e2e.py
@@ -1,0 +1,119 @@
+"""E2E smoke test for the ACP client transport.
+
+Spawns a real ACP-compliant server (claude-acp-bridge) and performs one
+complete prompt roundtrip through ACPClient + ACPClientSession.
+
+Gated behind the HERMES_E2E_ACP environment variable — must be set to "1"
+(or any non-empty truthy value) to run. Requires:
+  - ``claude-acp-bridge`` installed and on PATH (pip install claude-acp-bridge)
+  - A working Claude CLI configured for the subprocess (model auth token)
+
+Run:
+    HERMES_E2E_ACP=1 pytest tests/e2e/test_acp_client_e2e.py -v
+
+Why this test:
+  The unit tests (test_acp_client.py, test_acp_client_session.py) use fake
+  subprocesses and mock clients. This smoke test validates the actual
+  JSON-RPC wire protocol against a real ACP-compliant server implementation,
+  catching encoding bugs, missing fields, and protocol-version mismatches.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+# Guard: only run when explicitly enabled
+_E2E_ENABLED = bool(os.environ.get("HERMES_E2E_ACP", "").strip())
+
+pytestmark = pytest.mark.skipif(
+    not _E2E_ENABLED,
+    reason=(
+        "ACP E2E test disabled. Set HERMES_E2E_ACP=1 to enable. "
+        "Requires claude-acp-bridge + Claude CLI auth."
+    ),
+)
+
+# Path to the claude-acp-bridge package (fallback to installed binary)
+_BRIDGE_PACKAGE_DIR = os.environ.get(
+    "HERMES_ACP_BRIDGE_DIR",
+    "/Users/guillaume/dev/claude-acp-bridge",
+)
+_BRIDGE_COMMAND = os.environ.get("HERMES_ACP_BRIDGE_COMMAND", "claude-acp-bridge")
+
+
+def _bridge_available() -> bool:
+    """Return True if the bridge binary / module can be found."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", "import claude_acp_bridge"],
+            cwd=_BRIDGE_PACKAGE_DIR,
+            capture_output=True,
+            timeout=5,
+        )
+        return proc.returncode == 0
+    except Exception:
+        return False
+
+
+@pytest.fixture(scope="module")
+def bridge_command() -> list[str]:
+    """Return the command to spawn the ACP server for testing."""
+    if os.path.isdir(_BRIDGE_PACKAGE_DIR):
+        return [sys.executable, "-m", "claude_acp_bridge"]
+    return [_BRIDGE_COMMAND]
+
+
+class TestACPClientE2E:
+    def test_initialize_handshake(self, bridge_command: list[str]) -> None:
+        """Verify the wire protocol: initialize returns valid InitializeResponse."""
+        from agent.transports.acp_client import ACPClient
+
+        with ACPClient(command=bridge_command[0], args=bridge_command[1:]) as client:
+            result = client.initialize(
+                client_name="hermes-e2e-test",
+                client_version="0.1",
+                timeout=10.0,
+            )
+            assert result is not None
+            # ACP spec: InitializeResponse must include protocolVersion
+            assert "protocolVersion" in result or result.get("protocol_version") is not None
+
+    def test_session_new_and_close(self, bridge_command: list[str]) -> None:
+        """Verify session/new returns a sessionId and session/close succeeds."""
+        from agent.transports.acp_client_session import ACPClientSession
+
+        with ACPClientSession(command=bridge_command[0], args=bridge_command[1:]) as session:
+            sid = session.ensure_started(cwd=os.getcwd())
+            assert sid
+            assert len(sid) >= 8  # UUID format
+
+    def test_prompt_roundtrip(self, bridge_command: list[str]) -> None:
+        """Full roundtrip: session/new → session/prompt → text response."""
+        from agent.transports.acp_client_session import ACPClientSession
+
+        deltas: list[str] = []
+
+        with ACPClientSession(
+            command=bridge_command[0],
+            args=bridge_command[1:],
+            on_delta=deltas.append,
+        ) as session:
+            result = session.run_turn(
+                "Reply with exactly: HERMES_ACP_OK",
+                cwd=os.getcwd(),
+                turn_timeout=120.0,
+            )
+
+        assert result.error is None, f"Turn error: {result.error}"
+        assert result.should_retire is False
+        # Either the streamed text or the final_text should contain our marker
+        full_text = result.final_text + "".join(deltas)
+        assert "HERMES_ACP_OK" in full_text, (
+            f"Expected marker not found. final_text={result.final_text!r} "
+            f"deltas={deltas!r}"
+        )

--- a/tests/hermes_cli/test_acp_runtime_switch.py
+++ b/tests/hermes_cli/test_acp_runtime_switch.py
@@ -1,0 +1,254 @@
+"""Tests for the /acp-client-runtime slash-command shared logic.
+
+These cover the pure-Python state machine; CLI and gateway handlers are tested
+separately because they involve config persistence and surface-specific
+formatting."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import acp_runtime_switch as ars
+
+
+class TestParseArgs:
+    @pytest.mark.parametrize("arg,expected", [
+        ("", None),
+        ("   ", None),
+        ("auto", "auto"),
+        ("off", "auto"),
+        ("disable", "auto"),
+        ("hermes", "auto"),
+        ("default", "auto"),
+        ("acp_client", "acp_client"),
+        ("acp-client", "acp_client"),
+        ("on", "acp_client"),
+        ("enable", "acp_client"),
+        ("acp", "acp_client"),
+        ("ACP_CLIENT", "acp_client"),   # case-insensitive
+        ("ON", "acp_client"),
+    ])
+    def test_valid_args(self, arg, expected):
+        value, errors = ars.parse_args(arg)
+        assert errors == []
+        assert value == expected
+
+    def test_invalid_arg_returns_error(self):
+        value, errors = ars.parse_args("turbo")
+        assert value is None
+        assert errors
+        assert "Unknown value" in errors[0]
+
+
+class TestGetCurrentState:
+    def test_default_when_unset(self):
+        assert ars.get_current_state({}) == "auto"
+        assert ars.get_current_state({"model": {}}) == "auto"
+        assert ars.get_current_state({"model": {"provider": ""}}) == "auto"
+
+    def test_unrecognized_falls_back_to_auto(self):
+        assert ars.get_current_state(
+            {"model": {"provider": "openrouter"}}
+        ) == "auto"
+
+    def test_acp_client_provider_detected(self):
+        assert ars.get_current_state(
+            {"model": {"provider": "acp-client"}}
+        ) == "acp_client"
+
+    def test_handles_non_dict_config(self):
+        assert ars.get_current_state(None) == "auto"  # type: ignore[arg-type]
+        assert ars.get_current_state("notadict") == "auto"  # type: ignore[arg-type]
+        assert ars.get_current_state({"model": "notadict"}) == "auto"
+
+
+class TestGetCurrentCommand:
+    def test_returns_empty_when_unset(self):
+        assert ars.get_current_command({}) == ""
+        assert ars.get_current_command({"model": {}}) == ""
+
+    def test_returns_configured_command(self):
+        assert ars.get_current_command(
+            {"model": {"acp_command": "claude-agent-acp"}}
+        ) == "claude-agent-acp"
+
+    def test_handles_non_dict_config(self):
+        assert ars.get_current_command(None) == ""  # type: ignore[arg-type]
+
+
+class TestGetCurrentArgs:
+    def test_returns_empty_list_when_unset(self):
+        assert ars.get_current_args({}) == []
+        assert ars.get_current_args({"model": {}}) == []
+
+    def test_returns_configured_args(self):
+        assert ars.get_current_args(
+            {"model": {"acp_args": ["--port", "9000"]}}
+        ) == ["--port", "9000"]
+
+    def test_handles_non_list_gracefully(self):
+        assert ars.get_current_args({"model": {"acp_args": None}}) == []
+
+    def test_handles_non_dict_config(self):
+        assert ars.get_current_args(None) == []  # type: ignore[arg-type]
+
+
+class TestEnableDisable:
+    def test_enable_sets_all_keys(self):
+        cfg = {}
+        old = ars.enable_runtime(cfg, "claude-agent-acp", ["--verbose"])
+        assert old == "auto"
+        assert cfg["model"]["provider"] == "acp-client"
+        assert cfg["model"]["acp_command"] == "claude-agent-acp"
+        assert cfg["model"]["acp_args"] == ["--verbose"]
+
+    def test_enable_creates_model_section_if_missing(self):
+        cfg = {}
+        ars.enable_runtime(cfg, "my-agent", [])
+        assert "model" in cfg
+
+    def test_disable_removes_acp_keys(self):
+        cfg = {"model": {
+            "provider": "acp-client",
+            "acp_command": "claude-agent-acp",
+            "acp_args": [],
+        }}
+        old = ars.disable_runtime(cfg)
+        assert old == "acp_client"
+        assert cfg["model"].get("provider") is None
+        assert cfg["model"].get("acp_command") is None
+        assert cfg["model"].get("acp_args") is None
+
+    def test_disable_is_idempotent_on_empty_config(self):
+        cfg = {}
+        old = ars.disable_runtime(cfg)
+        assert old == "auto"  # was already disabled
+
+
+class TestApply:
+    def test_read_only_reports_state(self):
+        cfg = {"model": {"provider": "acp-client", "acp_command": "myagent"}}
+        with patch.object(ars, "check_acp_command_ok", return_value=(True, "1.2.3")):
+            r = ars.apply(cfg, None)
+        assert r.success
+        assert r.new_value == "acp_client"
+        assert r.old_value == "acp_client"
+        assert "myagent" in r.message
+
+    def test_read_only_when_disabled(self):
+        cfg = {}
+        r = ars.apply(cfg, None)
+        assert r.success
+        assert r.new_value == "auto"
+
+    def test_no_change_when_already_disabled(self):
+        cfg = {}
+        r = ars.apply(cfg, "auto")
+        assert r.success
+        assert r.new_value == "auto"
+        assert "already disabled" in r.message
+
+    def test_no_change_when_already_enabled(self):
+        cfg = {"model": {"provider": "acp-client", "acp_command": "myagent"}}
+        r = ars.apply(cfg, "acp_client")
+        assert r.success
+        assert "already enabled" in r.message
+
+    def test_enable_fails_when_no_command(self):
+        cfg = {}
+        r = ars.apply(cfg, "acp_client")
+        assert r.success is False
+        assert "acp_command is required" in r.message
+
+    def test_enable_blocked_when_binary_missing(self):
+        cfg = {}
+        with patch.object(ars, "check_acp_command_ok",
+                          return_value=(False, "myagent not found on PATH")):
+            r = ars.apply(cfg, "acp_client", acp_command="myagent")
+        assert r.success is False
+        assert "Cannot enable" in r.message
+        assert "myagent" in r.message
+        # Config must NOT be mutated on failure
+        assert cfg.get("model", {}).get("provider") != "acp-client"
+
+    def test_enable_succeeds_when_binary_present(self):
+        cfg = {}
+        persisted = {}
+
+        def persist(c):
+            persisted.update(c)
+
+        with patch.object(ars, "check_acp_command_ok",
+                          return_value=(True, "claude-agent-acp 0.3.1")):
+            r = ars.apply(
+                cfg,
+                "acp_client",
+                acp_command="claude-agent-acp",
+                acp_args=["--verbose"],
+                persist_callback=persist,
+            )
+        assert r.success
+        assert r.new_value == "acp_client"
+        assert r.old_value == "auto"
+        assert r.requires_new_session is True
+        assert "claude-agent-acp" in r.message
+        assert cfg["model"]["provider"] == "acp-client"
+        assert cfg["model"]["acp_command"] == "claude-agent-acp"
+        assert cfg["model"]["acp_args"] == ["--verbose"]
+        assert persisted["model"]["provider"] == "acp-client"
+
+    def test_disable_succeeds(self):
+        cfg = {"model": {
+            "provider": "acp-client",
+            "acp_command": "myagent",
+            "acp_args": [],
+        }}
+        r = ars.apply(cfg, "auto")
+        assert r.success
+        assert r.new_value == "auto"
+        assert r.old_value == "acp_client"
+        assert r.requires_new_session is True
+        assert cfg["model"].get("provider") != "acp-client"
+
+    def test_enable_uses_existing_command_when_not_provided(self):
+        """If no new command is given but one is already stored, reuse it."""
+        cfg = {"model": {
+            "provider": "acp-client",
+            "acp_command": "stored-agent",
+            "acp_args": [],
+        }}
+        with patch.object(ars, "check_acp_command_ok",
+                          return_value=(True, "1.0")):
+            r = ars.apply(cfg, "acp_client")
+        assert r.success
+        assert "already enabled" in r.message  # no-change path
+
+    def test_persist_callback_failure_reported(self):
+        cfg = {}
+
+        def persist_boom(c):
+            raise IOError("disk full")
+
+        with patch.object(ars, "check_acp_command_ok",
+                          return_value=(True, "1.0")):
+            r = ars.apply(
+                cfg,
+                "acp_client",
+                acp_command="myagent",
+                persist_callback=persist_boom,
+            )
+        assert r.success is False
+        assert "persist failed" in r.message
+        assert "disk full" in r.message
+
+    def test_disable_persist_callback_failure_reported(self):
+        cfg = {"model": {"provider": "acp-client", "acp_command": "myagent"}}
+
+        def persist_boom(c):
+            raise IOError("disk full")
+
+        r = ars.apply(cfg, "auto", persist_callback=persist_boom)
+        assert r.success is False
+        assert "persist failed" in r.message

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2705,3 +2705,101 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+# ── acp_client provider resolution tests ─────────────────────────────────────
+
+
+def test_resolve_provider_acp_client_canonical(monkeypatch):
+    """resolve_provider('acp_client') returns 'acp_client' without AuthError.
+
+    The canonical key (underscore) is used after alias normalisation. This is
+    the form that arrives from resolve_runtime_provider, which normalises via
+    _PROVIDER_ALIASES before calling resolve_provider.
+    """
+    monkeypatch.setattr(rp.auth_mod, "_load_auth_store", lambda: {})
+    # Must NOT raise AuthError("Unknown provider 'acp_client'")
+    result = rp.resolve_provider("acp_client")
+    assert result == "acp_client"
+
+
+def test_resolve_provider_acp_client_hyphen_alias(monkeypatch):
+    """resolve_provider('acp-client') resolves via alias to canonical 'acp_client'.
+
+    config.yaml stores provider: acp-client (hyphenated). The alias mapping
+    must normalise it so resolve_provider does not raise.
+    """
+    monkeypatch.setattr(rp.auth_mod, "_load_auth_store", lambda: {})
+    result = rp.resolve_provider("acp-client")
+    assert result == "acp_client"
+
+
+def test_resolve_runtime_provider_acp_client_returns_correct_api_mode(monkeypatch):
+    """resolve_runtime_provider('acp_client') yields api_mode='acp_client'.
+
+    This is the critical assertion: the resolved runtime dict must carry
+    api_mode='acp_client' so the gateway passes it into agent_init, which
+    routes the turn through _run_acp_client_turn instead of a chat_completions
+    HTTP path. A wrong api_mode (e.g. chat_completions) would silently
+    misroute every turn.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "acp_client")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "acp-client",
+            "acp_command": "my-acp-agent",
+            "acp_args": ["--stdio"],
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="acp_client")
+
+    assert resolved["provider"] == "acp_client"
+    assert resolved["api_mode"] == "acp_client"
+    assert resolved["api_key"] == ""
+    assert resolved["base_url"] == ""
+    assert resolved["command"] == "my-acp-agent"
+    assert resolved["args"] == ["--stdio"]
+    assert resolved["source"] == "config"
+
+
+def test_resolve_runtime_provider_acp_client_no_command_raises(monkeypatch):
+    """resolve_runtime_provider raises AuthError when acp_command is missing.
+
+    Without acp_command there is no binary to spawn; a clear error is better
+    than a silent empty-string command or fall-through to OpenRouter.
+    """
+    from hermes_cli.auth import AuthError
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "acp_client")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "acp-client"},
+    )
+
+    with pytest.raises(AuthError, match="acp_command"):
+        rp.resolve_runtime_provider(requested="acp_client")
+
+
+def test_resolve_runtime_provider_acp_client_no_api_key_required(monkeypatch):
+    """acp_client runtime must not require an API key.
+
+    Auth is handled by the spawned binary itself. The returned api_key must be
+    empty so agent_init never tries to validate or forward a credential.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "acp_client")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "acp-client",
+            "acp_command": "hermes-acp-agent",
+            "acp_args": [],
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="acp_client")
+    assert resolved["api_key"] == ""

--- a/tests/run_agent/test_acp_client_integration.py
+++ b/tests/run_agent/test_acp_client_integration.py
@@ -1,0 +1,273 @@
+"""Integration test for the acp_client runtime path through AIAgent.
+
+Verifies that:
+  - api_mode='acp_client' is accepted on AIAgent construction
+  - run_conversation() takes the early-return path and never enters the
+    chat completions loop
+  - Projected messages from a fake ACP session land in the messages list
+  - tool_iterations from the ACP session tick the skill nudge counter
+  - _user_turn_count and _turns_since_memory increment pre-loop (not doubled)
+  - The user message appears exactly once (no duplicate from acp_runtime)
+  - The returned dict has the same shape as the chat_completions path
+  - Session retirement on should_retire=True drops _acp_session
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import run_agent
+from agent.transports.acp_client_session import ACPClientSession, TurnResult
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    """Replace ACPClientSession with a stub that returns a fixed TurnResult,
+    so we can drive AIAgent without spawning a real ACP subprocess."""
+
+    def fake_run_turn(self, user_input: str, **kwargs):
+        return TurnResult(
+            final_text=f"acp-echo: {user_input}",
+            projected_messages=[
+                {"role": "assistant", "content": None,
+                 "tool_calls": [{"id": "tool_1", "type": "function",
+                                 "function": {"name": "bash",
+                                              "arguments": "{}"}}]},
+                {"role": "tool", "tool_call_id": "tool_1", "content": "done"},
+                {"role": "assistant", "content": f"acp-echo: {user_input}"},
+            ],
+            tool_iterations=1,
+            interrupted=False,
+            error=None,
+            should_retire=False,
+        )
+
+    monkeypatch.setattr(ACPClientSession, "run_turn", fake_run_turn)
+    monkeypatch.setattr(
+        ACPClientSession, "ensure_started", lambda self, **kw: "acp-session-stub"
+    )
+
+
+def _make_acp_agent():
+    """Construct an AIAgent in acp_client mode without contacting any real
+    provider. Pass api_mode explicitly so the constructor accepts it directly."""
+    return run_agent.AIAgent(
+        api_key="stub",
+        base_url="https://stub.invalid",
+        provider="openai",
+        api_mode="acp_client",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+class TestApiModeAccepted:
+    def test_api_mode_is_acp_client(self):
+        agent = _make_acp_agent()
+        assert agent.api_mode == "acp_client"
+
+
+class TestRunConversationAcpPath:
+    def test_run_conversation_returns_acp_shape(self, fake_session):
+        """Return dict matches the chat_completions shape contract."""
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello there")
+        assert result["final_response"] == "acp-echo: hello there"
+        assert result["completed"] is True
+        assert result["partial"] is False
+        assert result["error"] is None
+        assert result["api_calls"] == 1
+
+    def test_projected_messages_are_spliced(self, fake_session):
+        """Projected messages from TurnResult land in the returned messages list."""
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hello")
+        msgs = result["messages"]
+        # User message + 3 projected (assistant tool_call + tool + assistant text)
+        assert len(msgs) >= 4
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "hello"
+        # Final assistant message with the echoed text should be in there
+        final = [m for m in msgs if m.get("role") == "assistant"
+                 and m.get("content") == "acp-echo: hello"]
+        assert final, f"expected final assistant message in {msgs}"
+
+    def test_nudge_counters_tick(self, fake_session):
+        """The skill nudge counter accumulates tool_iterations across turns.
+        _user_turn_count is incremented by run_conversation pre-loop (not by
+        acp_runtime), so it must be exactly 1 after one turn."""
+        agent = _make_acp_agent()
+        agent._iters_since_skill = 0
+        agent._user_turn_count = 0
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("first")
+        assert agent._iters_since_skill == 1  # one tool_iteration in fake turn
+        # _user_turn_count is incremented pre-loop, not by the ACP helper —
+        # confirms we delegate counter management to the standard flow.
+        assert agent._user_turn_count == 1
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("second")
+        assert agent._iters_since_skill == 2
+        assert agent._user_turn_count == 2
+
+    def test_user_message_not_duplicated(self, fake_session):
+        """Regression guard: the user message must appear exactly once.
+
+        The standard run_conversation() pre-loop appends it, and acp_runtime
+        must NOT append again (see acp_runtime.py NOTE comment at line 59-61).
+        """
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("ping unique 99999")
+        user_count = sum(
+            1 for m in result["messages"]
+            if m.get("role") == "user" and m.get("content") == "ping unique 99999"
+        )
+        assert user_count == 1, (
+            f"user message appeared {user_count}× in {result['messages']} — "
+            "acp_runtime must not re-append the user message"
+        )
+
+    def test_chat_completions_loop_is_not_entered(self, fake_session):
+        """The early-return at api_mode='acp_client' must bypass the regular
+        API call loop entirely. Confirmed by patching the SDK client and
+        asserting chat.completions.create is never called."""
+        agent = _make_acp_agent()
+        with patch.object(agent, "client") as client_mock, patch.object(
+            agent, "_spawn_background_review", return_value=None
+        ):
+            agent.run_conversation("hi")
+        assert not client_mock.chat.completions.create.called, (
+            "chat.completions.create was called — early-return did not fire"
+        )
+
+    def test_background_review_NOT_invoked_below_threshold(self, fake_session):
+        """A single turn shouldn't trigger background review — counters
+        haven't reached the nudge interval (default 10)."""
+        agent = _make_acp_agent()
+        agent._memory_nudge_interval = 10
+        agent._skill_nudge_interval = 10
+        agent._iters_since_skill = 0
+        with patch.object(agent, "_spawn_background_review",
+                          return_value=None) as spawn:
+            agent.run_conversation("ping")
+        assert not spawn.called, (
+            "_spawn_background_review fired below threshold — "
+            "check acp_runtime.py skill nudge gate condition"
+        )
+
+
+class TestErrorHandling:
+    def test_session_exception_returns_partial_with_error(self, monkeypatch):
+        def boom_run_turn(self, user_input, **kwargs):
+            raise RuntimeError("acp subprocess died")
+
+        monkeypatch.setattr(ACPClientSession, "ensure_started",
+                            lambda self, **kw: "s1")
+        monkeypatch.setattr(ACPClientSession, "run_turn", boom_run_turn)
+
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hi")
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "acp subprocess died" in result["error"]
+
+    def test_interrupted_turn_marked_partial(self, monkeypatch):
+        def interrupted_turn(self, user_input, **kwargs):
+            return TurnResult(
+                final_text="",
+                projected_messages=[],
+                tool_iterations=0,
+                interrupted=True,
+                error="user interrupted",
+                should_retire=False,
+            )
+
+        monkeypatch.setattr(ACPClientSession, "ensure_started",
+                            lambda self, **kw: "s1")
+        monkeypatch.setattr(ACPClientSession, "run_turn", interrupted_turn)
+
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hi")
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert result["error"] == "user interrupted"
+
+
+class TestSessionRetirementOnRunAgent:
+    """run_agent.py side: when run_turn returns should_retire=True, the
+    AIAgent must close + null _acp_session so the next turn respawns."""
+
+    def test_should_retire_drops_session(self, monkeypatch):
+        closes = {"count": 0}
+
+        def fake_run_turn(self, user_input, **kwargs):
+            return TurnResult(
+                final_text="",
+                projected_messages=[],
+                tool_iterations=0,
+                interrupted=True,
+                error="turn timed out after 600.0s",
+                should_retire=True,
+            )
+
+        def fake_close(self):
+            closes["count"] += 1
+
+        monkeypatch.setattr(ACPClientSession, "ensure_started",
+                            lambda self, **kw: "s1")
+        monkeypatch.setattr(ACPClientSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(ACPClientSession, "close", fake_close)
+
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hi")
+
+        # The session was closed and cleared
+        assert closes["count"] == 1
+        assert getattr(agent, "_acp_session", "MISSING") is None
+        # Partial result was still returned (caller still sees the error)
+        assert result["partial"] is True
+        assert result["error"] == "turn timed out after 600.0s"
+
+    def test_normal_turn_keeps_session(self, fake_session):
+        """fake_session fixture returns should_retire=False (default).
+        The session must stay attached for the next turn to reuse."""
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+        # Session was lazily created and still attached.
+        assert getattr(agent, "_acp_session", None) is not None
+
+    def test_exception_path_also_drops_session(self, monkeypatch):
+        """Even if run_turn raises (not just sets should_retire), we must
+        drop the session — a thrown exception is the strongest possible
+        signal the process is dead."""
+        closes = {"count": 0}
+
+        def boom_run_turn(self, user_input, **kwargs):
+            raise RuntimeError("acp segfaulted")
+
+        def fake_close(self):
+            closes["count"] += 1
+
+        monkeypatch.setattr(ACPClientSession, "ensure_started",
+                            lambda self, **kw: "s1")
+        monkeypatch.setattr(ACPClientSession, "run_turn", boom_run_turn)
+        monkeypatch.setattr(ACPClientSession, "close", fake_close)
+
+        agent = _make_acp_agent()
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            result = agent.run_conversation("hi")
+
+        assert closes["count"] == 1
+        assert agent._acp_session is None
+        assert result["completed"] is False
+        assert "acp segfaulted" in result["error"]

--- a/website/docs/user-guide/features/acp-client-runtime.md
+++ b/website/docs/user-guide/features/acp-client-runtime.md
@@ -1,0 +1,168 @@
+---
+title: ACP Client Runtime (optional)
+sidebar_label: ACP Client Runtime
+---
+
+# ACP Client Runtime
+
+Hermes can optionally route turns to any external agent that speaks the [Agent Client Protocol (ACP)](https://github.com/NousResearch/hermes-agent/blob/main/acp_adapter/README.md) instead of running its own tool loop. When enabled, Hermes sends each user turn to the external agent via JSON-RPC 2.0 over stdio (`session/new` + `session/prompt`), streams the agent's response back, and projects the result into Hermes' session model so memory and skill review keep working.
+
+This is **opt-in only**. Default Hermes behavior is unchanged unless you flip the flag. Hermes never auto-routes you onto this runtime.
+
+## Why
+
+- Run any ACP-compliant agent (e.g. `@agentclientprotocol/claude-agent-acp`, or your own ACP-compliant implementation) from within a Hermes session without leaving the gateway, TUI, or CLI surface.
+- Keep Hermes' session management — sessions DB, slash commands, cron, skill review, memory nudges, gateway platforms — while delegating the turn itself to a specialized external agent.
+- Bridge agent types: point Hermes at a Claude Code ACP bridge and your Slack/Discord/Telegram users get Claude Code's full tool surface through the Hermes gateway.
+
+## How it works
+
+```
+User message
+    │
+    ▼
+AIAgent.run_conversation()
+    if api_mode == "acp_client":
+        │
+        ▼
+    ACPClientSession (acp_client_session.py)
+        session/new ────► ACP agent (subprocess)
+        session/prompt ──► ACP agent
+        ◄── session/update (streaming chunks)
+        ◄── PromptResponse
+        │
+        ▼
+    Assembled text + projected_messages
+        │
+        ▼
+Memory / skill review (background)
+    │
+    ▼
+User sees response
+```
+
+The external agent subprocess is spawned on the first turn and kept alive across turns (one session per Hermes session). Hermes declines `fs/*` and `terminal/*` server-initiated requests — those surfaces are Hermes' domain, not the agent's.
+
+## What Hermes capabilities are preserved
+
+| Capability | Status |
+|---|---|
+| All gateway platforms (Slack, Discord, Telegram, WhatsApp, …) | yes |
+| CLI / TUI | yes |
+| Session persistence (sessions DB, resume, history) | yes |
+| Memory nudges (every 10 turns) | yes |
+| Skill nudges (every 10 tool iterations) | yes |
+| `/goal` (Ralph loop) | yes |
+| Cron jobs | yes |
+| Slash commands (except those requiring a live agent loop) | yes |
+
+## Prerequisites
+
+You need an ACP-compliant agent binary on PATH or at a known path. Examples:
+
+- **`@agentclientprotocol/claude-agent-acp`** — the reference ACP implementation from Zed Industries:
+  ```bash
+  npm install -g @agentclientprotocol/claude-agent-acp
+  claude-agent-acp --version
+  ```
+- **Any ACP-compliant server** implementing the `session/new` + `session/prompt` JSON-RPC surface can be used.
+
+## Enabling
+
+In a Hermes session:
+
+```
+/acp-client-runtime on claude-agent-acp
+```
+
+With extra arguments:
+
+```
+/acp-client-runtime on claude-agent-acp --model claude-opus-4-5
+```
+
+That command:
+- Verifies that `claude-agent-acp` is reachable (blocks with an error if not found on PATH).
+- Persists `model.provider: "acp-client"` + `model.acp_command` + `model.acp_args` to your config.yaml.
+- Takes effect on the **next** session — the current cached agent keeps the prior runtime to preserve prompt cache.
+
+Synonyms: `acp_client`, `enable`, `acp`.
+
+To check current state without changing anything:
+
+```
+/acp-client-runtime
+```
+
+To disable:
+
+```
+/acp-client-runtime off
+```
+
+## Manual config
+
+You can also set it directly in `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  provider: "acp-client"
+  acp_command: "claude-agent-acp"
+  acp_args:
+    - "--model"
+    - "claude-opus-4-5"
+```
+
+To revert to the Hermes default runtime, remove those three keys (or set `provider` to your normal provider value and remove `acp_command`/`acp_args`).
+
+## How this differs from copilot-acp
+
+Hermes already has a `copilot-acp` provider that speaks ACP to GitHub Copilot's ACP endpoint. The `acp-client` runtime differs in scope:
+
+| | `copilot-acp` | `acp-client` runtime |
+|---|---|---|
+| Target | GitHub Copilot ACP endpoint (HTTP) | Any ACP-compliant **subprocess** (stdio) |
+| Transport | HTTP / SSE | JSON-RPC 2.0 over stdin/stdout |
+| Subprocess lifecycle | N/A — remote service | Hermes spawns and manages the process |
+| Session model | Copilot manages sessions | Hermes owns `session/new` + `session/prompt` |
+| Use case | Copilot as inference backend | Bridging to local agents (Claude Code, custom) |
+
+## Architecture detail
+
+The wire protocol is JSON-RPC 2.0 newline-delimited over stdio:
+
+1. **Spawn** — Hermes spawns `<acp_command> [<acp_args>]` as a subprocess.
+2. **Initialize** — `initialize` handshake. Hermes sends `clientCapabilities: {fs: {readTextFile: false, writeTextFile: false}, terminal: false}` to signal it will not proxy file-system or terminal calls.
+3. **Session** — `session/new` with the current working directory.
+4. **Turn** — `session/prompt` with the user message. Hermes streams `session/update` chunks to the terminal while waiting for `PromptResponse`.
+5. **Close** — `session/close` when the session ends.
+
+Server-initiated requests (`fs/*`, `terminal/*`, `session/request_permission`) are declined by Hermes with a `-32601` error. The ACP agent should not depend on those surfaces.
+
+## Self-improvement loop (memory + skill nudges)
+
+Memory and skill nudges work identically to the default runtime. Streamed `session/update` chunks are projected into `projected_messages`, and the background review fork sees a normal-looking transcript with `{role: "assistant", content: "..."}` messages. Turn and tool-iteration counters increment as expected.
+
+## Limitations
+
+This runtime is **opt-in beta**:
+
+- **One subprocess per session** — the ACP agent is spawned lazily on the first turn and kept alive. If the subprocess crashes, `should_retire=True` is set and the next turn starts a fresh session.
+- **No streaming interruption** — mid-stream Ctrl+C is not forwarded to the ACP agent. The turn runs to completion. Cancellation support may be added in a future version.
+- **fs/terminal proxying declined** — Hermes does not bridge file-system or terminal calls from the ACP agent. Agents that require those surfaces should implement them internally.
+- **Single provider** — ACP client mode replaces the entire inference path. You cannot mix ACP and non-ACP providers in the same session.
+
+If you find a bug, [open an issue](https://github.com/NousResearch/hermes-agent/issues) with the output of `hermes logs --since 5m` and mention `acp-client-runtime` in the title.
+
+## For implementors
+
+If you are building an ACP-compliant agent and want to test against Hermes as the client:
+
+1. Implement `initialize`, `session/new`, `session/prompt`, `session/close` from the ACP spec.
+2. Stream `session/update` notifications with `{"sessionUpdate": "agent_message_chunk", "content": {"type": "text", "text": "..."}}` for incremental output.
+3. Install your binary and enable via `/acp-client-runtime on <your-binary>`.
+4. Run the E2E smoke test:
+   ```bash
+   HERMES_E2E_ACP=1 HERMES_E2E_ACP_COMMAND=/path/to/your/binary \
+     pytest tests/e2e/test_acp_client_e2e.py -v
+   ```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -80,6 +80,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/delegation',
             'user-guide/features/kanban',
             'user-guide/features/codex-app-server-runtime',
+            'user-guide/features/acp-client-runtime',
             'user-guide/features/kanban-tutorial',
             'user-guide/features/kanban-worker-lanes',
             'user-guide/features/goals',


### PR DESCRIPTION
## What does this PR do?

Adds a generic ACP (Agent Client Protocol) client transport so Hermes can route inference to any ACP-compliant agent (e.g. `@agentclientprotocol/claude-agent-acp`, `claude-code` in ACP mode) via JSON-RPC 2.0 over stdio.

New api_mode `acp_client` with its own session lifecycle, parallel to the existing `codex_app_server` transport. No changes to existing transports.

**Why this approach**: `copilot_acp_client.py` and PR #31089 ride the `chat_completions` shim via OpenAI client replacement. This PR adds a proper `ProviderTransport` parallel to `codex_app_server`, with native JSON-RPC stdio + 3-arm dispatch (reply / server-request / notification). The two approaches coexist — the shim path stays simple for OpenAI-compat clients, this path unlocks session-based streaming + server-initiated request plumbing for clients that benefit from it.

## Related Issue

Implements #35063 (proposal).

Refs #31089 — complementary architectural alternative (band-aid env-vars on Copilot adapter vs proper transport class).

No upstream issue to link as `Fixes #` — this is a net-new transport. Tracking issue lives on the contributor fork: [duquesnay/hermes-claude-acp#12](https://github.com/duquesnay/hermes-claude-acp/issues/12).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

**New files**:
- `agent/transports/acp_client.py` — JSON-RPC 2.0 stdio wire client (3-arm dispatch, `_pending` / `_server_requests` / `_notifications` queues, `respond()`/`respond_error()`/`take_server_request()`)
- `agent/transports/acp_client_session.py` — session lifecycle (initialize / new_session / prompt / close), streaming via `session/update`, `should_retire` policy
- `agent/acp_runtime.py` — AIAgent turn forwarder, lazy session reuse across turns
- `hermes_cli/acp_runtime_switch.py` — `/acp-client-runtime` slash command (parallel to `/codex-runtime`)
- `website/docs/user-guide/features/acp-client-runtime.md` — user guide
- `tests/agent/test_acp_client*.py`, `tests/agent/test_acp_runtime.py` — unit + concurrent-write regression
- `tests/hermes_cli/test_acp_runtime_switch.py` — CLI switch tests
- `tests/run_agent/test_acp_client_integration.py` — integration
- `tests/e2e/test_acp_client_e2e.py` — opt-in E2E (gated `HERMES_E2E_ACP=1` + `HERMES_E2E_ACP_COMMAND`)

**Modified**:
- `agent/agent_init.py` — `acp_client` added to valid api_mode set + `acp-client` provider auto-detection
- `agent/conversation_loop.py` — early-return dispatch parallel to `codex_app_server` (line ~651)
- `agent/transports/__init__.py` — import-only discovery (no registry entry, not a `ProviderTransport` ABC)
- `hermes_cli/runtime_provider.py` — `acp_client` added to `_VALID_API_MODES`
- `run_agent.py` — `_run_acp_client_turn` forwarder method on AIAgent
- `cli.py`, `gateway/run.py`, `hermes_cli/banner.py`, `hermes_cli/commands.py` — CLI switch wiring
- `cli-config.yaml.example` — documents the 3 new keys (`provider: "acp-client"`, `acp_command`, `acp_args`)
- `website/sidebars.ts` — user guide entry

## How to Test

1. Install a reference ACP server (e.g. `npm install -g @agentclientprotocol/claude-agent-acp`)
2. Configure Hermes with the new transport (one of):
   - YAML: `model.provider: "acp-client"` + `model.acp_command: "claude-agent-acp"` + optional `model.acp_args`
   - CLI: `/acp-client-runtime on claude-agent-acp` (with optional `--model` arg)
3. Run a Hermes session and observe the agent answering via the ACP transport (no OpenAI client created, JSON-RPC stdio over the subprocess)
4. Run the unit + integration tests: `scripts/run_tests.sh` (or `pytest tests/ -q`)
5. (Optional) Run the opt-in E2E: `HERMES_E2E_ACP=1 HERMES_E2E_ACP_COMMAND=claude-agent-acp pytest tests/e2e/test_acp_client_e2e.py`

## Architecture

Mirrors the validated `codex_app_server` pattern:
- Wire layer: sync threads + queues (intentional, avoids asyncio interrupt semantics — see `CodexAppServerClient` docstring rationale)
- 3-arm dispatch separates JSON-RPC replies, server-initiated requests, notifications
- `respond()` / `respond_error()` / `take_server_request()` plumbing complete
- Client capabilities **explicitly declared minimal** at `initialize()`: `{"fs": {"readTextFile": False, "writeTextFile": False}, "terminal": False}`. Built-in handlers for `fs/read_text_file`, `fs/write_text_file`, `session/request_permission` decline cleanly (`-32601`). Wider capability set deferred to follow-up PRs.
- Session reused across turns; retire policy on subprocess crash / timeout / negative `ACPClientError`
- Stdin write is lock-guarded (`_send_lock`) — `session/prompt` blocks the request thread while the main thread services server-initiated requests, so concurrent writes are real and tested (`TestConcurrentWrite` regression guard with barrier-synchronized 10-thread race)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`feat(transports):`, `fix(transports):`, `docs(user-guide):`, etc.)
- [x] I searched for existing PRs — referenced #31089 above
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/` — all ACP-related tests pass (114 tests: 57 unit + 12 integration + 41 CLI switch + 1 regression guard + 3 E2E gated)
- [x] I've added tests covering the new code paths
- [x] Tested on: **macOS 15.x** (Apple Silicon)

### Documentation & Housekeeping

- [x] User guide added: `website/docs/user-guide/features/acp-client-runtime.md` + sidebar entry
- [x] `cli-config.yaml.example` updated with the 3 new keys (commit `0a518cc2e`)
- [ ] N/A — no architecture/workflow doc change required in `CONTRIBUTING.md` / `AGENTS.md`
- [x] Cross-platform impact considered: subprocess management uses stdlib `subprocess.Popen` + threads (POSIX/Windows-portable). E2E test uses `shlex.split` for args (Windows users should set `HERMES_E2E_ACP_ARGS` with shell-quoted args). No platform-specific paths or syscalls in the new code. Tested on macOS; expect to work on Linux/WSL2 without modification (same as `codex_app_server`).
- [ ] N/A — no tool schema/description change

## Commits

```
6aa547c77 feat(transports): add ACP JSON-RPC wire client
ef82fd7d2 feat(transports): add ACP client session lifecycle
6611b2d75 feat(agent): add ACP client runtime forwarder
6a92c3022 feat(agent): wire api_mode acp_client into runtime selection
a0c2131de fix(transports): address upstream review nits
df50d0d49 docs(user-guide): add acp-client-runtime feature guide
922a3d590 feat(cli): add /acp-client-runtime switch
0a518cc2e docs(config): document ACP client transport keys in cli-config.yaml.example
```

Bisect-clean: each commit's tests import only modules introduced in that commit or earlier.
