### PR TITLE
fix(security): strip AWS credential env vars from subprocesses for bedrock provider (#32314)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -179,6 +179,13 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # Extra credential-bearing env vars to strip from subprocess environments
+    # for this provider. Used when credentials don't live in api_key_env_vars
+    # (e.g. aws_sdk auth_type, where boto3 resolves credentials from a chain
+    # of vars not used as direct API keys). Separate from api_key_env_vars so
+    # that hint strings (agent_init.py) and credential probes (credential_pool)
+    # are not polluted with non-api-key entries. See #32314.
+    subprocess_env_blocklist: tuple = ()
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -454,6 +461,19 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://bedrock-runtime.us-east-1.amazonaws.com",
         api_key_env_vars=(),
         base_url_env_var="BEDROCK_BASE_URL",
+        # AWS credentials are resolved via the boto3 credential chain; declare
+        # the full set so _HERMES_PROVIDER_ENV_BLOCKLIST strips them from
+        # subprocess env. Covers bearer token + static keys + session token +
+        # named profile + container/web-identity sources. See #32314.
+        subprocess_env_blocklist=(
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_PROFILE",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+        ),
     ),
     "azure-foundry": ProviderConfig(
         id="azure-foundry",

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -93,6 +93,29 @@ class TestProviderEnvBlocklist:
         for var in registry_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    def test_aws_sdk_provider_vars_are_stripped(self):
+        """AWS Bedrock (auth_type=aws_sdk) credentials must be stripped even
+        though api_key_env_vars=(); they're declared via subprocess_env_blocklist.
+
+        Regression test for #32314 — before the fix, AWS_BEARER_TOKEN_BEDROCK
+        and friends leaked into terminal / execute_code subprocesses because
+        bedrock's api_key_env_vars is empty and the blocklist builder only
+        consulted that field.
+        """
+        aws_credential_vars = {
+            "AWS_BEARER_TOKEN_BEDROCK": "fake-bearer",
+            "AWS_ACCESS_KEY_ID": "AKIAFAKE",
+            "AWS_SECRET_ACCESS_KEY": "fake-secret",
+            "AWS_SESSION_TOKEN": "fake-session-token",
+            "AWS_PROFILE": "fake-profile",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/fake/uri",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/fake/token",
+        }
+        result_env = _run_with_env(extra_os_env=aws_credential_vars)
+
+        for var in aws_credential_vars:
+            assert var not in result_env, f"{var} leaked into subprocess env (see #32314)"
+
     def test_non_registry_provider_vars_are_stripped(self):
         """Extra provider vars not in PROVIDER_REGISTRY must also be blocked."""
         extra_provider_vars = {

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -86,6 +86,10 @@ def _build_provider_env_blocklist() -> frozenset:
             blocked.update(pconfig.api_key_env_vars)
             if pconfig.base_url_env_var:
                 blocked.add(pconfig.base_url_env_var)
+            # Providers whose credentials don't flow through api_key_env_vars
+            # (notably aws_sdk auth_type) declare extra strip targets here.
+            # See #32314.
+            blocked.update(getattr(pconfig, "subprocess_env_blocklist", ()))
     except ImportError:
         pass
 


### PR DESCRIPTION
Fixes #32314.

`PROVIDER_REGISTRY["bedrock"]` declares `api_key_env_vars=()` because AWS
Bedrock uses `auth_type="aws_sdk"` — credentials are resolved through the
boto3 chain, not loaded from a single API key env var. The subprocess
blocklist (`_HERMES_PROVIDER_ENV_BLOCKLIST` in `tools/environments/local.py`)
is derived from `api_key_env_vars`, so AWS credentials are never registered
and all agent-spawned terminal / `execute_code` / MCP / delegation
subprocesses inherit them.

As the reporter observed, `opencode models` run inside a Hermes terminal
silently enumerates the entire Bedrock catalog because `AWS_BEARER_TOKEN_BEDROCK`
leaks through. Worse, if `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` are
the active credentials, the subprocess inherits the user's full AWS
capabilities.

## Approach

Adds a new field `ProviderConfig.subprocess_env_blocklist: tuple = ()` and
the blocklist builder consults it alongside `api_key_env_vars`. The bedrock
entry declares the full set boto3 looks at for credential resolution
(bearer token, static keys + session token, named profile,
container/web-identity sources).

The field is kept separate from `api_key_env_vars` because three call
sites — `agent_init.py:783` (hint string shown in error messages),
`auxiliary_client.py:3573` (tried_sources list), and
`credential_pool.py:1905` (API-key probe) — treat that list as
"env vars that *hold* an API key". Adding AWS vars there would surface
`AWS_BEARER_TOKEN_BEDROCK` as an API-key hint and have `credential_pool`
attempt to read it as an API-key string.

## Why not import `_AWS_CREDENTIAL_ENV_VARS` from `agent/bedrock_adapter.py`

That list is for **presence detection** (`has_aws_credentials()` — does
any credential signal exist?) and intentionally omits
`AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` because those are silent
companions to `AWS_ACCESS_KEY_ID`. The blocklist needs **all** vars boto3
reads, paired or not. Sharing one list would either weaken detection or
under-strip the subprocess env. Happy to consolidate behind a shared
module-level constant if maintainers prefer that direction.

## Related

- #7990 — broader cloud-credential blocklist initiative
- PR #22647 — earlier attempt at AWS coverage, closed without merge
- PR #31959 — `hermes_subprocess_env()` helper that uses
  `_HERMES_PROVIDER_ENV_BLOCKLIST`; this PR extends what the blocklist
  contains, not how it's consumed

## Test

Added `TestProviderEnvBlocklist::test_aws_sdk_provider_vars_are_stripped`
asserting all 7 AWS credential vars are stripped from subprocess env.

Verified locally on Windows native Python 3.12:

```
tests/tools/test_local_env_blocklist.py ........ 18 passed
```

(One unrelated `TestSanePathIncludesHomebrew` failure pre-dates this change
— confirmed by stashing the patch and re-running on clean main.)
