### PR TITLE
fix(pricing): track cost for direct Gemini providers + add Gemini 3.x entries (#32400)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -456,6 +456,17 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-05",
     ),
+    (
+        "google",
+        "gemini-3.1-flash-lite-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.25"),
+        output_cost_per_million=Decimal("1.50"),
+        cache_read_cost_per_million=Decimal("0.025"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05",
+    ),
     # AWS Bedrock — pricing per the Bedrock pricing page.
     # Bedrock charges the same per-token rates as the model provider but
     # through AWS billing.  These are the on-demand prices (no commitment).
@@ -590,12 +601,12 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
-    if provider_name in {"gemini", "google-gemini-cli"}:
-        # Direct Google AI Studio and OAuth (`hermes login google`) both
-        # hit Google's published per-token pricing.  Normalize to
-        # provider="google" so the lookup in _OFFICIAL_DOCS_PRICING (keyed
-        # under "google") resolves.  Without this branch every native
-        # Gemini session lands billing_mode="unknown" and cost stays $0.
+    if provider_name in {"gemini", "google", "google-gemini", "google-ai-studio", "google-gemini-cli"}:
+        # Direct Google AI Studio (api-key), aliases, and OAuth (`hermes login google`)
+        # all hit Google's published per-token pricing.  Normalize to provider="google"
+        # so the lookup in _OFFICIAL_DOCS_PRICING (keyed under "google") resolves.
+        # Without this branch every native Gemini session lands billing_mode="unknown"
+        # and cost stays $0.
         return BillingRoute(provider="google", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -412,6 +412,50 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source_url="https://ai.google.dev/pricing",
         pricing_version="google-pricing-2026-03-16",
     ),
+    (
+        "google",
+        "gemini-3.5-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("1.50"),
+        output_cost_per_million=Decimal("9.00"),
+        cache_read_cost_per_million=Decimal("0.15"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05",
+    ),
+    (
+        "google",
+        "gemini-3-flash-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.50"),
+        output_cost_per_million=Decimal("3.00"),
+        cache_read_cost_per_million=Decimal("0.05"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05",
+    ),
+    (
+        "google",
+        "gemini-3.1-pro-preview",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("2.00"),
+        output_cost_per_million=Decimal("12.00"),
+        cache_read_cost_per_million=Decimal("0.20"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05",
+    ),
+    (
+        "google",
+        "gemini-3.1-flash-lite",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.25"),
+        output_cost_per_million=Decimal("1.50"),
+        cache_read_cost_per_million=Decimal("0.025"),
+        source="official_docs_snapshot",
+        source_url="https://ai.google.dev/pricing",
+        pricing_version="google-pricing-2026-05",
+    ),
     # AWS Bedrock — pricing per the Bedrock pricing page.
     # Bedrock charges the same per-token rates as the model provider but
     # through AWS billing.  These are the on-demand prices (no commitment).
@@ -546,6 +590,13 @@ def resolve_billing_route(
         return BillingRoute(provider="anthropic", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name == "openai":
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name in {"gemini", "google-gemini-cli"}:
+        # Direct Google AI Studio and OAuth (`hermes login google`) both
+        # hit Google's published per-token pricing.  Normalize to
+        # provider="google" so the lookup in _OFFICIAL_DOCS_PRICING (keyed
+        # under "google") resolves.  Without this branch every native
+        # Gemini session lands billing_mode="unknown" and cost stays $0.
+        return BillingRoute(provider="google", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
 
+import pytest
+
 from agent.usage_pricing import (
     CanonicalUsage,
     estimate_usage_cost,
@@ -244,6 +246,14 @@ def test_resolve_billing_route_maps_gemini_provider_to_google():
 def test_resolve_billing_route_maps_google_gemini_cli_to_google():
     """OAuth provider `google-gemini-cli` shares the same per-token pricing."""
     route = resolve_billing_route("gemini-2.5-flash", provider="google-gemini-cli")
+    assert route.provider == "google"
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+@pytest.mark.parametrize("alias", ["google", "google-gemini", "google-ai-studio"])
+def test_resolve_billing_route_maps_gemini_aliases_to_google(alias):
+    """All gemini profile aliases must also resolve to the google pricing table."""
+    route = resolve_billing_route("gemini-2.5-flash", provider=alias)
     assert route.provider == "google"
     assert route.billing_mode == "official_docs_snapshot"
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -5,6 +5,7 @@ from agent.usage_pricing import (
     estimate_usage_cost,
     get_pricing_entry,
     normalize_usage,
+    resolve_billing_route,
 )
 
 
@@ -224,3 +225,58 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+# --- Direct Gemini cost tracking (#32400) ---
+
+def test_resolve_billing_route_maps_gemini_provider_to_google():
+    """`provider=gemini` must resolve to google + official_docs_snapshot.
+
+    Before #32400 every native-Gemini session fell through to billing_mode
+    "unknown", which short-circuited _lookup_official_docs_pricing and
+    caused estimated_cost_usd to stay $0 for every Gemini model.
+    """
+    route = resolve_billing_route("gemini-2.5-flash", provider="gemini")
+    assert route.provider == "google"
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+def test_resolve_billing_route_maps_google_gemini_cli_to_google():
+    """OAuth provider `google-gemini-cli` shares the same per-token pricing."""
+    route = resolve_billing_route("gemini-2.5-flash", provider="google-gemini-cli")
+    assert route.provider == "google"
+    assert route.billing_mode == "official_docs_snapshot"
+
+
+def test_gemini_3_5_flash_pricing_entry_exists():
+    """Regression: gemini-3.5-flash must have a pricing entry (#32400)."""
+    entry = get_pricing_entry("gemini-3.5-flash", provider="gemini")
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.50
+    assert float(entry.output_cost_per_million) == 9.00
+    assert float(entry.cache_read_cost_per_million) == 0.15
+
+
+def test_gemini_2_5_flash_cost_no_longer_zero():
+    """Existing gemini-2.5-flash table entry must now be reachable from `provider=gemini`."""
+    result = estimate_usage_cost(
+        "gemini-2.5-flash",
+        CanonicalUsage(input_tokens=1000000, output_tokens=500000),
+        provider="gemini",
+    )
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    # 1M × $0.15/M + 500K × $0.60/M = $0.15 + $0.30 = $0.45
+    assert float(result.amount_usd) == 0.45
+
+
+def test_gemini_3_5_flash_estimate_usage_cost():
+    """End-to-end: a typical Gemini 3.5-flash turn must produce a real $ amount."""
+    result = estimate_usage_cost(
+        "gemini-3.5-flash",
+        CanonicalUsage(input_tokens=22106, output_tokens=239, cache_read_tokens=16266),
+        provider="gemini",
+    )
+    assert result.status == "estimated"
+    assert result.amount_usd is not None
+    assert float(result.amount_usd) > 0


### PR DESCRIPTION
Closes #32400.

## Problem

`estimated_cost_usd` is always **$0.00** for every session using `provider: gemini` or `provider: google-gemini-cli`, on every Gemini model (including ones with existing pricing entries like `gemini-2.5-flash`). Token counts are recorded correctly (after #15253 / commit `ba8337464`), but the cost-calculation chain never fires.

### Root cause (two layers)

1. **`resolve_billing_route()` has no Gemini branch.** Native Gemini falls through to `billing_mode="unknown"`, which skips `_lookup_official_docs_pricing` entirely. Affects every Gemini model, not just 3.5-flash.
2. **No pricing entry for `gemini-3.5-flash`.** Even after fixing the route, the static table only has Gemini 2.5 / 2.0 entries.

## Changes

### `agent/usage_pricing.py`

- Added a branch in `resolve_billing_route()` that maps `provider="gemini"` and `provider="google-gemini-cli"` to `provider="google"` (matching the existing `_OFFICIAL_DOCS_PRICING` key prefix), with `billing_mode="official_docs_snapshot"`.
- Added pricing entries for:
  - `gemini-3.5-flash` — $1.50 / $9.00 / M; cache_read $0.15/M
  - `gemini-3-flash-preview` — $0.50 / $3.00 / M; cache_read $0.05/M
  - `gemini-3.1-pro-preview` — $2.00 / $12.00 / M; cache_read $0.20/M
  - `gemini-3.1-flash-lite` — $0.25 / $1.50 / M; cache_read $0.025/M

Source: `https://ai.google.dev/pricing` (cross-referenced with OpenRouter's `GET /api/v1/models` for the same model IDs). Marked `pricing_version="google-pricing-2026-05"`.

### `tests/agent/test_usage_pricing.py`

5 new regression tests:
- `resolve_billing_route` maps `gemini` → google with `official_docs_snapshot` mode
- Same for `google-gemini-cli`
- `gemini-3.5-flash` has a pricing entry
- `gemini-2.5-flash` (existing entry) now reachable from `provider="gemini"`
- End-to-end `estimate_usage_cost` for a typical 3.5-flash turn produces a real $ amount

## Live end-to-end verification

Same gemini-3.5-flash session before / after on Hermes CLI:

```
$ sqlite3 ~/.hermes/profiles/gemini35/state.db \
    "SELECT input_tokens, output_tokens, estimated_cost_usd, cost_status \
     FROM sessions ORDER BY started_at DESC LIMIT 1" -header

# Before this PR:
input_tokens=22106  output_tokens=239  estimated_cost_usd=0.0       cost_status=unknown

# With this PR:
input_tokens=19914  output_tokens=9    estimated_cost_usd=0.029952  cost_status=estimated
```

Math check: `19914 × $1.50/M + 9 × $9.00/M = $0.029952` ✅ matches stored value exactly.

## Relationship to #15253

#15253 ("token counts always 0") is **already fixed** in commit `ba8337464`; the remaining symptom (cost = 0) has a different root cause documented here. Recommend closing #15253 as stale and tracking the cost issue under #32400 instead.

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_usage_pricing.py` — 16/16 pass (5 new + 11 existing)
- [x] `scripts/run_tests.sh tests/agent/` — only pre-existing failures (`test_anthropic_adapter.py` OAuth-env issues on macOS, unrelated)
- [x] Live verification on `gemini-3.5-flash` — see above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
