### PR TITLE
feat(gateway): support multi-target delivery in webhook adapter

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -12,7 +12,10 @@ Each route defines:
   - prompt: template string formatted with the webhook payload
   - skills: optional list of skills to load for the agent
   - deliver: where to send the response (github_comment, telegram, etc.)
+    Accepts a string (single target) or a list of dicts (multi-target).
+    Multi-target format: [{"type": "telegram", "chat_id": "..."}, ...]
   - deliver_extra: additional delivery config (repo, pr_number, chat_id)
+    Only used with single-target string format; ignored when deliver is a list.
   - deliver_only: if true, skip the agent — the rendered prompt IS the
     message that gets delivered.  Use for external push notifications
     (Supabase, monitoring alerts, inter-agent pings) where zero LLM cost
@@ -175,12 +178,34 @@ class WebhookAdapter(BasePlatformAdapter):
             # than on the first webhook POST.
             if route.get("deliver_only"):
                 deliver = route.get("deliver", "log")
-                if not deliver or deliver == "log":
-                    raise ValueError(
-                        f"[webhook] Route '{name}' has deliver_only=true but "
-                        f"deliver is '{deliver}'. Direct delivery requires a "
-                        f"real target (telegram, discord, slack, github_comment, etc.)."
-                    )
+                if isinstance(deliver, list):
+                    # Multi-target: every entry must have a valid type != "log"
+                    for i, item in enumerate(deliver):
+                        if not isinstance(item, dict) or "type" not in item:
+                            raise ValueError(
+                                f"[webhook] Route '{name}' deliver[{i}] is invalid. "
+                                f"Each target must be a dict with a 'type' key."
+                            )
+                        item_type = item.get("type", "log")
+                        if not item_type or item_type == "log":
+                            raise ValueError(
+                                f"[webhook] Route '{name}' has deliver_only=true but "
+                                f"deliver[{i}].type is '{item_type}'. Direct delivery "
+                                f"requires a real target (telegram, discord, slack, "
+                                f"github_comment, etc.)."
+                            )
+                    if not deliver:
+                        raise ValueError(
+                            f"[webhook] Route '{name}' has deliver_only=true but "
+                            f"deliver is an empty list."
+                        )
+                else:
+                    if not deliver or deliver == "log":
+                        raise ValueError(
+                            f"[webhook] Route '{name}' has deliver_only=true but "
+                            f"deliver is '{deliver}'. Direct delivery requires a "
+                            f"real target (telegram, discord, slack, github_comment, etc.)."
+                        )
 
         app = web.Application()
         app.router.add_get("/health", self._handle_health)
@@ -219,34 +244,68 @@ class WebhookAdapter(BasePlatformAdapter):
         self._mark_disconnected()
         logger.info("[webhook] Disconnected")
 
-    async def send(
-        self,
-        chat_id: str,
-        content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> SendResult:
-        """Deliver the agent's response to the configured destination.
+    def _normalize_deliver_targets(
+        self, delivery: dict, payload: Optional[dict] = None
+    ) -> List[dict]:
+        """Normalize deliver config into a list of target dicts.
 
-        chat_id is ``webhook:{route}:{delivery_id}``.  The delivery info
-        stored during webhook receipt is read with ``.get()`` (not popped)
-        so that interim status messages emitted before the final response
-        — fallback-model notifications, context-pressure warnings, etc. —
-        do not consume the entry and silently downgrade the final response
-        to the ``log`` deliver type.  TTL cleanup happens on POST.
+        Supports two formats:
+          - Legacy (string):  deliver="telegram", deliver_extra={chat_id: "123"}
+            → [{"type": "telegram", "chat_id": "123"}]
+          - Multi (list):     deliver=[{"type": "telegram", "chat_id": "123"}, ...]
+            → returned as-is (with template rendering applied if payload given)
+
+        Each returned dict has at minimum a "type" key.
         """
-        delivery = self._delivery_info.get(chat_id, {})
-        deliver_type = delivery.get("deliver", "log")
+        raw_deliver = delivery.get("deliver", "log")
+
+        if isinstance(raw_deliver, list):
+            # New multi-target format: each item is a dict with "type" + extras
+            targets: List[dict] = []
+            for item in raw_deliver:
+                if isinstance(item, dict) and "type" in item:
+                    target = dict(item)
+                    # Render template values if payload is available
+                    if payload:
+                        rendered = {}
+                        for k, v in target.items():
+                            if k == "type":
+                                rendered[k] = v
+                            elif isinstance(v, str):
+                                rendered[k] = self._render_prompt(v, payload, "", "")
+                            else:
+                                rendered[k] = v
+                        targets.append(rendered)
+                    else:
+                        targets.append(target)
+                else:
+                    logger.warning(
+                        "[webhook] Invalid deliver target (missing 'type'): %s", item
+                    )
+            return targets if targets else [{"type": "log"}]
+
+        # Legacy single-target format: string deliver + dict deliver_extra
+        deliver_extra = delivery.get("deliver_extra", {})
+        target = {"type": raw_deliver}
+        target.update(deliver_extra)
+        return [target]
+
+    async def _deliver_single_target(
+        self, target: dict, content: str
+    ) -> SendResult:
+        """Deliver content to a single target dict ({"type": ..., ...extras})."""
+        deliver_type = target.get("type", "log")
 
         if deliver_type == "log":
-            logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
+            logger.info("[webhook] Response (log): %s", content[:200])
             return SendResult(success=True)
 
         if deliver_type == "github_comment":
-            return await self._deliver_github_comment(content, delivery)
+            # Construct a delivery-like dict for the existing helper
+            delivery_compat = {"deliver_extra": {k: v for k, v in target.items() if k != "type"}}
+            return await self._deliver_github_comment(content, delivery_compat)
 
         # Cross-platform delivery — any platform with a gateway adapter.
-        # Check both built-in names and plugin-registered platforms.
         _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
         if not _is_known_platform:
             try:
@@ -255,14 +314,91 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception:
                 pass
         if self.gateway_runner and _is_known_platform:
+            delivery_compat = {"deliver_extra": {k: v for k, v in target.items() if k != "type"}}
             return await self._deliver_cross_platform(
-                deliver_type, content, delivery
+                deliver_type, content, delivery_compat
             )
 
         logger.warning("[webhook] Unknown deliver type: %s", deliver_type)
         return SendResult(
             success=False, error=f"Unknown deliver type: {deliver_type}"
         )
+
+    async def _deliver_to_targets(
+        self, targets: List[dict], content: str
+    ) -> SendResult:
+        """Deliver content to multiple targets concurrently (best-effort).
+
+        All targets are dispatched in parallel.  Individual failures are
+        logged but do not block other deliveries.  Returns success=True if
+        at least one target succeeded; the error field summarizes failures.
+        """
+        if not targets:
+            return SendResult(success=True)
+
+        if len(targets) == 1:
+            return await self._deliver_single_target(targets[0], content)
+
+        # Concurrent delivery to all targets
+        tasks = [self._deliver_single_target(t, content) for t in targets]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        successes = []
+        failures = []
+        for i, result in enumerate(results):
+            target_type = targets[i].get("type", "unknown")
+            if isinstance(result, Exception):
+                failures.append(f"{target_type}: {result}")
+                logger.warning(
+                    "[webhook] Delivery to %s failed: %s", target_type, result
+                )
+            elif result.success:
+                successes.append(target_type)
+            else:
+                failures.append(f"{target_type}: {result.error}")
+                logger.warning(
+                    "[webhook] Delivery to %s failed: %s", target_type, result.error
+                )
+
+        if failures:
+            error_msg = f"{len(failures)} target(s) failed: {'; '.join(failures)}"
+            if successes:
+                logger.info(
+                    "[webhook] Partial delivery: %d succeeded, %d failed",
+                    len(successes), len(failures),
+                )
+            else:
+                logger.error("[webhook] All deliveries failed: %s", error_msg)
+            return SendResult(
+                success=len(successes) > 0,
+                error=error_msg if failures else None,
+            )
+
+        return SendResult(success=True)
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Deliver the agent's response to the configured destination(s).
+
+        chat_id is ``webhook:{route}:{delivery_id}``.  The delivery info
+        stored during webhook receipt is read with ``.get()`` (not popped)
+        so that interim status messages emitted before the final response
+        — fallback-model notifications, context-pressure warnings, etc. —
+        do not consume the entry and silently downgrade the final response
+        to the ``log`` deliver type.  TTL cleanup happens on POST.
+
+        Supports multiple delivery targets when ``deliver`` is a list.
+        All targets are dispatched concurrently (best-effort).
+        """
+        delivery = self._delivery_info.get(chat_id, {})
+        payload = delivery.get("payload")
+        targets = self._normalize_deliver_targets(delivery, payload)
+        return await self._deliver_to_targets(targets, content)
 
     def _prune_delivery_info(self, now: float) -> None:
         """Drop delivery_info entries older than the idempotency TTL.
@@ -518,23 +654,42 @@ class WebhookAdapter(BasePlatformAdapter):
         # to a user's chat with zero LLM cost.  Reuses the same HMAC auth,
         # rate limiting, idempotency, and template rendering as agent mode.
         if route_config.get("deliver_only"):
+            raw_deliver = route_config.get("deliver", "log")
             delivery = {
-                "deliver": route_config.get("deliver", "log"),
-                "deliver_extra": self._render_delivery_extra(
-                    route_config.get("deliver_extra", {}), payload
-                ),
+                "deliver": raw_deliver,
                 "payload": payload,
             }
+            # For legacy string format, render deliver_extra with payload
+            if isinstance(raw_deliver, str):
+                delivery["deliver_extra"] = self._render_delivery_extra(
+                    route_config.get("deliver_extra", {}), payload
+                )
+            # For list format, render template values within each target
+            # (_normalize_deliver_targets handles this when payload is in delivery)
+
+            # Build a human-readable target description for logging
+            if isinstance(raw_deliver, list):
+                target_desc = ",".join(
+                    t.get("type", "?") for t in raw_deliver if isinstance(t, dict)
+                )
+            else:
+                target_desc = raw_deliver
+
             logger.info(
                 "[webhook] direct-deliver event=%s route=%s target=%s msg_len=%d delivery=%s",
                 event_type,
                 route_name,
-                delivery["deliver"],
+                target_desc,
                 len(prompt),
                 delivery_id,
             )
             try:
-                result = await self._direct_deliver(prompt, delivery)
+                # For multi-target list, pass payload so templates get rendered
+                if isinstance(raw_deliver, list):
+                    targets = self._normalize_deliver_targets(delivery, payload)
+                    result = await self._deliver_to_targets(targets, prompt)
+                else:
+                    result = await self._direct_deliver(prompt, delivery)
             except Exception:
                 logger.exception(
                     "[webhook] direct-deliver failed route=%s delivery=%s",
@@ -551,7 +706,7 @@ class WebhookAdapter(BasePlatformAdapter):
                     {
                         "status": "delivered",
                         "route": route_name,
-                        "target": delivery["deliver"],
+                        "target": target_desc,
                         "delivery_id": delivery_id,
                     },
                     status=200,
@@ -561,7 +716,7 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.warning(
                 "[webhook] direct-deliver target rejected route=%s target=%s error=%s",
                 route_name,
-                delivery["deliver"],
+                target_desc,
                 result.error,
             )
             return web.json_response(
@@ -576,13 +731,18 @@ class WebhookAdapter(BasePlatformAdapter):
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
         # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
+        raw_deliver = route_config.get("deliver", "log")
         deliver_config = {
-            "deliver": route_config.get("deliver", "log"),
-            "deliver_extra": self._render_delivery_extra(
-                route_config.get("deliver_extra", {}), payload
-            ),
+            "deliver": raw_deliver,
             "payload": payload,
         }
+        # For legacy string format, render deliver_extra with payload
+        if isinstance(raw_deliver, str):
+            deliver_config["deliver_extra"] = self._render_delivery_extra(
+                route_config.get("deliver_extra", {}), payload
+            )
+        # For list format, _normalize_deliver_targets() handles rendering
+        # at send-time using the payload stored in deliver_config.
         self._delivery_info[session_chat_id] = deliver_config
         self._delivery_info_created[session_chat_id] = now
         self._prune_delivery_info(now)
@@ -807,23 +967,11 @@ class WebhookAdapter(BasePlatformAdapter):
         that the agent-mode ``send()`` flow uses.  All target types that
         work in agent mode work here — Telegram, Discord, Slack, GitHub
         PR comments, etc.
+
+        Supports multiple delivery targets when ``deliver`` is a list.
         """
-        deliver_type = delivery.get("deliver", "log")
-
-        if deliver_type == "log":
-            # Shouldn't reach here — startup validation rejects deliver_only
-            # with deliver=log — but guard defensively.
-            logger.info("[webhook] direct-deliver log-only: %s", content[:200])
-            return SendResult(success=True)
-
-        if deliver_type == "github_comment":
-            return await self._deliver_github_comment(content, delivery)
-
-        # Fall through to the cross-platform dispatcher, which validates the
-        # target name and routes via the gateway runner.
-        return await self._deliver_cross_platform(
-            deliver_type, content, delivery
-        )
+        targets = self._normalize_deliver_targets(delivery)
+        return await self._deliver_to_targets(targets, content)
 
     async def _deliver_github_comment(
         self, content: str, delivery: dict

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11942,13 +11942,16 @@ def main():
     )
     wh_sub.add_argument(
         "--deliver",
-        default="log",
-        help="Delivery target: log, telegram, discord, slack, etc.",
+        action="append",
+        default=None,
+        help="Delivery target(s). Use once for single target (e.g. --deliver telegram), "
+        "or multiple times for multi-target (e.g. --deliver telegram:chat_id=123 "
+        "--deliver discord:chat_id=456). Format: type[:key=value,key=value]",
     )
     wh_sub.add_argument(
         "--deliver-chat-id",
         default="",
-        help="Target chat ID for cross-platform delivery",
+        help="Target chat ID for cross-platform delivery (legacy single-target shorthand)",
     )
     wh_sub.add_argument(
         "--secret", default="", help="HMAC secret (auto-generated if omitted)"

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -158,6 +158,31 @@ def webhook_command(args):
         _cmd_test(args)
 
 
+def _parse_deliver_spec(spec: str) -> dict:
+    """Parse a CLI deliver spec string into a target dict.
+
+    Format: type[:key=value,key=value]
+    Examples:
+        "telegram" → {"type": "telegram"}
+        "telegram:chat_id=123" → {"type": "telegram", "chat_id": "123"}
+        "github_comment:repo=org/repo,pr_number=42" → {...}
+    """
+    if ":" not in spec:
+        return {"type": spec.strip()}
+
+    type_part, extras_part = spec.split(":", 1)
+    target = {"type": type_part.strip()}
+
+    if extras_part.strip():
+        for pair in extras_part.split(","):
+            pair = pair.strip()
+            if "=" in pair:
+                key, value = pair.split("=", 1)
+                target[key.strip()] = value.strip()
+
+    return target
+
+
 def _cmd_subscribe(args):
     name = args.name.strip().lower().replace(" ", "-")
     if not re.match(r'^[a-z0-9][a-z0-9_-]*$', name):
@@ -170,27 +195,67 @@ def _cmd_subscribe(args):
     secret = args.secret or secrets.token_urlsafe(32)
     events = [e.strip() for e in args.events.split(",")] if args.events else []
 
+    # Parse deliver targets
+    raw_delivers = args.deliver  # None, a list from action="append", or a string (legacy/tests)
+    if raw_delivers is None:
+        deliver_value = "log"
+    elif isinstance(raw_delivers, str):
+        # Legacy: direct string value (e.g. from tests or old arg format)
+        deliver_value = raw_delivers if raw_delivers else "log"
+    elif len(raw_delivers) == 1:
+        # Single --deliver: check if it's the simple format (no colon extras)
+        # or the extended format (type:key=val)
+        spec = raw_delivers[0]
+        if ":" not in spec:
+            # Legacy single-target: just a platform name
+            deliver_value = spec.strip()
+        else:
+            # Extended format even for single target → use list format
+            deliver_value = [_parse_deliver_spec(spec)]
+    else:
+        # Multiple --deliver flags → list format
+        deliver_value = [_parse_deliver_spec(spec) for spec in raw_delivers]
+
     route = {
         "description": args.description or f"Agent-created subscription: {name}",
         "events": events,
         "secret": secret,
         "prompt": args.prompt or "",
         "skills": [s.strip() for s in args.skills.split(",")] if args.skills else [],
-        "deliver": args.deliver or "log",
+        "deliver": deliver_value,
         "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
     }
 
     if getattr(args, "deliver_only", False):
-        if route["deliver"] == "log":
+        if isinstance(deliver_value, str) and deliver_value == "log":
             print(
                 "Error: --deliver-only requires --deliver to be a real target "
                 "(telegram, discord, slack, github_comment, etc.) — not 'log'."
             )
             return
+        if isinstance(deliver_value, list):
+            for t in deliver_value:
+                if t.get("type") == "log":
+                    print(
+                        "Error: --deliver-only requires all targets to be real "
+                        "(telegram, discord, slack, github_comment, etc.) — not 'log'."
+                    )
+                    return
         route["deliver_only"] = True
 
+    # Legacy --deliver-chat-id for single string deliver
     if args.deliver_chat_id:
-        route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
+        if isinstance(deliver_value, str):
+            route["deliver_extra"] = {"chat_id": args.deliver_chat_id}
+        elif isinstance(deliver_value, list) and len(deliver_value) == 1:
+            # Apply chat_id to the single target in the list
+            deliver_value[0]["chat_id"] = args.deliver_chat_id
+            route["deliver"] = deliver_value
+        else:
+            print(
+                "Warning: --deliver-chat-id is ignored when multiple "
+                "targets are specified. Use type:chat_id=VALUE instead."
+            )
 
     subs[name] = route
     _save_subscriptions(subs)
@@ -205,7 +270,18 @@ def _cmd_subscribe(args):
         print(f"  Events: {', '.join(events)}")
     else:
         print("  Events: (all)")
-    print(f"  Deliver: {route['deliver']}")
+
+    # Display deliver info
+    if isinstance(deliver_value, list):
+        print(f"  Deliver: {len(deliver_value)} target(s)")
+        for i, t in enumerate(deliver_value):
+            t_type = t.get("type", "?")
+            extras = {k: v for k, v in t.items() if k != "type"}
+            extra_str = f" ({', '.join(f'{k}={v}' for k, v in extras.items())})" if extras else ""
+            print(f"    [{i+1}] {t_type}{extra_str}")
+    else:
+        print(f"  Deliver: {deliver_value}")
+
     if route.get("deliver_only"):
         print("  Mode: direct delivery (no agent, zero LLM cost)")
     if route.get("prompt"):
@@ -229,15 +305,22 @@ def _cmd_list(args):
     for name, route in subs.items():
         events = ", ".join(route.get("events", [])) or "(all)"
         deliver = route.get("deliver", "log")
+        if isinstance(deliver, list):
+            deliver_str = ", ".join(
+                t.get("type", "?") for t in deliver if isinstance(t, dict)
+            )
+            deliver_str = f"[{deliver_str}]"
+        else:
+            deliver_str = deliver
         if route.get("deliver_only"):
-            deliver = f"{deliver} (direct — no agent)"
+            deliver_str = f"{deliver_str} (direct — no agent)"
         desc = route.get("description", "")
         print(f"  ◆ {name}")
         if desc:
             print(f"    {desc}")
         print(f"    URL:     {base_url}/webhooks/{name}")
         print(f"    Events:  {events}")
-        print(f"    Deliver: {deliver}")
+        print(f"    Deliver: {deliver_str}")
         print()
 
 

--- a/tests/gateway/test_webhook_multi_deliver.py
+++ b/tests/gateway/test_webhook_multi_deliver.py
@@ -1,0 +1,463 @@
+"""Tests for the webhook adapter's multi-deliver feature.
+
+Covers:
+- Legacy string format backward compatibility (single target)
+- Multi-target list format (concurrent delivery)
+- Best-effort semantics (partial failure still returns success)
+- All-fail returns failure
+- Template rendering in multi-target deliver_extra fields
+- deliver_only with multi-target
+- Startup validation for multi-target deliver_only
+- _normalize_deliver_targets() normalization logic
+"""
+
+import asyncio
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.platforms.webhook import WebhookAdapter, _INSECURE_NO_AUTH
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
+    extra = {"host": "127.0.0.1", "port": 0, "routes": routes}
+    extra.update(extra_kw)
+    config = PlatformConfig(enabled=True, extra=extra)
+    return WebhookAdapter(config)
+
+
+def _create_app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _wire_mock_targets(adapter: WebhookAdapter, platforms: list):
+    """Attach a gateway_runner with mocked target adapters for multiple platforms."""
+    mock_adapters = {}
+    for p in platforms:
+        mock_target = AsyncMock()
+        mock_target.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapters[Platform(p)] = mock_target
+
+    mock_runner = MagicMock()
+    mock_runner.adapters = mock_adapters
+    mock_runner.config.get_home_channel.return_value = None
+
+    adapter.gateway_runner = mock_runner
+    return mock_adapters
+
+
+def _wire_mock_target(adapter: WebhookAdapter, platform_name: str = "telegram"):
+    """Attach a gateway_runner with a single mocked target adapter."""
+    adapters = _wire_mock_targets(adapter, [platform_name])
+    return adapters[Platform(platform_name)]
+
+
+# ===================================================================
+# _normalize_deliver_targets()
+# ===================================================================
+
+class TestNormalizeDeliverTargets:
+    """Unit tests for the target normalization helper."""
+
+    def test_legacy_string_format(self):
+        adapter = _make_adapter({})
+        delivery = {"deliver": "telegram", "deliver_extra": {"chat_id": "123"}}
+        targets = adapter._normalize_deliver_targets(delivery)
+        assert targets == [{"type": "telegram", "chat_id": "123"}]
+
+    def test_legacy_string_default_log(self):
+        adapter = _make_adapter({})
+        delivery = {}
+        targets = adapter._normalize_deliver_targets(delivery)
+        assert targets == [{"type": "log"}]
+
+    def test_multi_target_list_format(self):
+        adapter = _make_adapter({})
+        delivery = {
+            "deliver": [
+                {"type": "telegram", "chat_id": "111"},
+                {"type": "discord", "chat_id": "222"},
+            ]
+        }
+        targets = adapter._normalize_deliver_targets(delivery)
+        assert len(targets) == 2
+        assert targets[0] == {"type": "telegram", "chat_id": "111"}
+        assert targets[1] == {"type": "discord", "chat_id": "222"}
+
+    def test_multi_target_with_payload_rendering(self):
+        adapter = _make_adapter({})
+        delivery = {
+            "deliver": [
+                {"type": "telegram", "chat_id": "{user.telegram_id}"},
+                {"type": "github_comment", "repo": "{repo.name}", "pr_number": "{pr.number}"},
+            ]
+        }
+        payload = {
+            "user": {"telegram_id": "99999"},
+            "repo": {"name": "org/project"},
+            "pr": {"number": "42"},
+        }
+        targets = adapter._normalize_deliver_targets(delivery, payload)
+        assert targets[0] == {"type": "telegram", "chat_id": "99999"}
+        assert targets[1] == {"type": "github_comment", "repo": "org/project", "pr_number": "42"}
+
+    def test_empty_list_falls_back_to_log(self):
+        adapter = _make_adapter({})
+        delivery = {"deliver": []}
+        targets = adapter._normalize_deliver_targets(delivery)
+        assert targets == [{"type": "log"}]
+
+    def test_invalid_items_skipped(self):
+        adapter = _make_adapter({})
+        delivery = {
+            "deliver": [
+                {"type": "telegram", "chat_id": "111"},
+                "invalid_string",  # should be skipped
+                {"no_type_key": True},  # should be skipped
+            ]
+        }
+        targets = adapter._normalize_deliver_targets(delivery)
+        assert len(targets) == 1
+        assert targets[0]["type"] == "telegram"
+
+
+# ===================================================================
+# send() with multi-target
+# ===================================================================
+
+class TestSendMultiTarget:
+    """Test the send() method with multi-target delivery."""
+
+    @pytest.mark.asyncio
+    async def test_send_single_legacy_target(self):
+        """Legacy format still works — backward compatible."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        chat_id = "webhook:test:delivery-1"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "123"},
+            "payload": {},
+        }
+
+        result = await adapter.send(chat_id, "Hello world")
+        assert result.success
+        mock_target.send.assert_called_once_with("123", "Hello world", metadata=None)
+
+    @pytest.mark.asyncio
+    async def test_send_multi_target_all_succeed(self):
+        """Multi-target: all succeed → success=True."""
+        adapter = _make_adapter({})
+        adapters = _wire_mock_targets(adapter, ["telegram", "discord"])
+
+        chat_id = "webhook:test:delivery-2"
+        adapter._delivery_info[chat_id] = {
+            "deliver": [
+                {"type": "telegram", "chat_id": "111"},
+                {"type": "discord", "chat_id": "222"},
+            ],
+            "payload": {},
+        }
+
+        result = await adapter.send(chat_id, "Hello multi")
+        assert result.success
+        adapters[Platform("telegram")].send.assert_called_once_with(
+            "111", "Hello multi", metadata=None
+        )
+        adapters[Platform("discord")].send.assert_called_once_with(
+            "222", "Hello multi", metadata=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_multi_target_partial_failure(self):
+        """Multi-target: one fails → success=True (best-effort), error describes failure."""
+        adapter = _make_adapter({})
+        adapters = _wire_mock_targets(adapter, ["telegram", "discord"])
+        # Make discord fail
+        adapters[Platform("discord")].send = AsyncMock(
+            return_value=SendResult(success=False, error="Connection refused")
+        )
+
+        chat_id = "webhook:test:delivery-3"
+        adapter._delivery_info[chat_id] = {
+            "deliver": [
+                {"type": "telegram", "chat_id": "111"},
+                {"type": "discord", "chat_id": "222"},
+            ],
+            "payload": {},
+        }
+
+        result = await adapter.send(chat_id, "Hello partial")
+        assert result.success  # best-effort: at least one succeeded
+        assert "discord" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_multi_target_all_fail(self):
+        """Multi-target: all fail → success=False."""
+        adapter = _make_adapter({})
+        adapters = _wire_mock_targets(adapter, ["telegram", "discord"])
+        adapters[Platform("telegram")].send = AsyncMock(
+            return_value=SendResult(success=False, error="Timeout")
+        )
+        adapters[Platform("discord")].send = AsyncMock(
+            return_value=SendResult(success=False, error="Connection refused")
+        )
+
+        chat_id = "webhook:test:delivery-4"
+        adapter._delivery_info[chat_id] = {
+            "deliver": [
+                {"type": "telegram", "chat_id": "111"},
+                {"type": "discord", "chat_id": "222"},
+            ],
+            "payload": {},
+        }
+
+        result = await adapter.send(chat_id, "Hello fail")
+        assert not result.success
+        assert "telegram" in result.error
+        assert "discord" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_log_target(self):
+        """Log target always succeeds and doesn't need gateway_runner."""
+        adapter = _make_adapter({})
+
+        chat_id = "webhook:test:delivery-5"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "log",
+            "deliver_extra": {},
+            "payload": {},
+        }
+
+        result = await adapter.send(chat_id, "Hello log")
+        assert result.success
+
+
+# ===================================================================
+# deliver_only with multi-target (via HTTP POST)
+# ===================================================================
+
+class TestDeliverOnlyMultiTarget:
+    """Test deliver_only routes with multi-target delivery."""
+
+    @pytest.mark.asyncio
+    async def test_direct_deliver_multi_target(self):
+        routes = {
+            "multi-push": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": [
+                    {"type": "telegram", "chat_id": "111"},
+                    {"type": "discord", "chat_id": "222"},
+                ],
+                "deliver_only": True,
+                "prompt": "Alert: {message}",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapters = _wire_mock_targets(adapter, ["telegram", "discord"])
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as client:
+            payload = json.dumps({"message": "Server is down"})
+            resp = await client.post(
+                "/webhooks/multi-push",
+                data=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Event": "alert",
+                },
+            )
+            assert resp.status == 200
+            body = await resp.json()
+            assert body["status"] == "delivered"
+
+        adapters[Platform("telegram")].send.assert_called_once()
+        adapters[Platform("discord")].send.assert_called_once()
+
+        # Verify the content was rendered correctly
+        tg_call = adapters[Platform("telegram")].send.call_args
+        assert "Server is down" in tg_call[0][1]
+
+    @pytest.mark.asyncio
+    async def test_direct_deliver_multi_target_with_template_extras(self):
+        """Template values in deliver target extras get rendered with payload."""
+        routes = {
+            "pr-multi": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": [
+                    {"type": "telegram", "chat_id": "{notify.telegram_id}"},
+                    {"type": "github_comment", "repo": "{repo.full_name}", "pr_number": "{pr.number}"},
+                ],
+                "deliver_only": True,
+                "prompt": "PR reviewed",
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapters = _wire_mock_targets(adapter, ["telegram"])
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as client:
+            payload = json.dumps({
+                "notify": {"telegram_id": "99999"},
+                "repo": {"full_name": "org/repo"},
+                "pr": {"number": "42"},
+            })
+            resp = await client.post(
+                "/webhooks/pr-multi",
+                data=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-GitHub-Event": "test",
+                },
+            )
+            assert resp.status == 200
+
+        # Telegram should be called with the rendered chat_id
+        adapters[Platform("telegram")].send.assert_called_once()
+        tg_call = adapters[Platform("telegram")].send.call_args
+        assert tg_call[0][0] == "99999"  # chat_id rendered from payload
+
+
+# ===================================================================
+# Startup validation for multi-target deliver_only
+# ===================================================================
+
+class TestStartupValidationMultiTarget:
+    """connect() should validate multi-target deliver_only configs."""
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_list_with_log_rejected(self):
+        """A deliver_only route with a 'log' type in the list is rejected."""
+        routes = {
+            "bad-route": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": [
+                    {"type": "telegram", "chat_id": "111"},
+                    {"type": "log"},
+                ],
+                "deliver_only": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        with pytest.raises(ValueError, match="deliver_only.*log"):
+            await adapter.connect()
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_empty_list_rejected(self):
+        """A deliver_only route with an empty deliver list is rejected."""
+        routes = {
+            "empty-route": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": [],
+                "deliver_only": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        with pytest.raises(ValueError, match="deliver_only.*empty"):
+            await adapter.connect()
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_list_missing_type_rejected(self):
+        """A deliver_only route with items missing 'type' is rejected."""
+        routes = {
+            "bad-item": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": [
+                    {"chat_id": "111"},  # missing "type"
+                ],
+                "deliver_only": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        with pytest.raises(ValueError, match="must be a dict with a 'type' key"):
+            await adapter.connect()
+
+    @pytest.mark.asyncio
+    async def test_deliver_only_valid_multi_target_accepted(self):
+        """A properly configured multi-target deliver_only route passes validation."""
+        routes = {
+            "good-multi": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": [
+                    {"type": "telegram", "chat_id": "111"},
+                    {"type": "discord", "chat_id": "222"},
+                ],
+                "deliver_only": True,
+            }
+        }
+        adapter = _make_adapter(routes)
+        # Should not raise — just test it doesn't crash during validation.
+        # (connect() will try to bind a port which may fail in test env,
+        #  so we only test that ValueError is not raised for the validation part)
+        try:
+            await adapter.connect()
+        except (OSError, ValueError) as e:
+            # OSError for port binding is fine; ValueError means validation failed
+            if isinstance(e, ValueError):
+                pytest.fail(f"Validation unexpectedly failed: {e}")
+        finally:
+            await adapter.disconnect()
+
+
+# ===================================================================
+# Backward compatibility
+# ===================================================================
+
+class TestBackwardCompatibility:
+    """Ensure existing single-deliver configs still work unchanged."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_string_deliver_with_deliver_extra(self):
+        """Old-style deliver + deliver_extra still works."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        chat_id = "webhook:compat:delivery-1"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "telegram",
+            "deliver_extra": {"chat_id": "99999", "message_thread_id": "42"},
+            "payload": {},
+        }
+
+        result = await adapter.send(chat_id, "Backward compat test")
+        assert result.success
+        mock_target.send.assert_called_once_with(
+            "99999", "Backward compat test", metadata={"thread_id": "42"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_legacy_github_comment_deliver(self):
+        """Old-style github_comment delivery still works."""
+        adapter = _make_adapter({})
+
+        chat_id = "webhook:compat:delivery-2"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "github_comment",
+            "deliver_extra": {"repo": "org/repo", "pr_number": "42"},
+            "payload": {},
+        }
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = await adapter.send(chat_id, "LGTM!")
+
+        assert result.success
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0][0]
+        assert "org/repo" in call_args
+        assert "42" in call_args

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -82,8 +82,8 @@ Routes define how different webhook sources are handled. Each route is a named e
 | `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
 | `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. |
 | `skills` | No | List of skill names to load for the agent run. |
-| `deliver` | No | Where to send the response: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). |
-| `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. |
+| `deliver` | No | Where to send the response. Accepts a **string** (single target) or a **list** (multi-target). Supported targets: `github_comment`, `telegram`, `discord`, `slack`, `signal`, `sms`, `whatsapp`, `matrix`, `mattermost`, `homeassistant`, `email`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`, or `log` (default). See [Multi-Target Delivery](#multi-target-delivery). |
+| `deliver_extra` | No | Additional delivery config — keys depend on `deliver` type (e.g. `repo`, `pr_number`, `chat_id`). Values support the same `{dot.notation}` templates as `prompt`. Only used with single-target string format; ignored when `deliver` is a list. |
 | `deliver_only` | No | If `true`, skip the agent entirely — the rendered `prompt` template becomes the literal message that gets delivered. Zero LLM cost, sub-second delivery. See [Direct Delivery Mode](#direct-delivery-mode) for use cases. Requires `deliver` to be a real target (not `log`). |
 
 ### Full example
@@ -250,6 +250,88 @@ The `deliver` field controls where the agent's response goes after processing th
 | `bluebubbles` | Routes the response to BlueBubbles (iMessage). Uses the home channel, or specify `chat_id` in `deliver_extra`. |
 
 For cross-platform delivery, the target platform must also be enabled and connected in the gateway. If no `chat_id` is provided in `deliver_extra`, the response is sent to that platform's configured home channel.
+
+---
+
+## Multi-Target Delivery {#multi-target-delivery}
+
+A single webhook route can deliver responses to **multiple platforms simultaneously**. Instead of a string, set `deliver` to a list of target objects. Each target specifies its `type` and any platform-specific config (replacing `deliver_extra`).
+
+### Configuration
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        pr-review:
+          events: ["pull_request"]
+          secret: "webhook-secret"
+          prompt: "Review PR #{number}: {pull_request.title}"
+          deliver:
+            - type: "github_comment"
+              repo: "{repository.full_name}"
+              pr_number: "{number}"
+            - type: "telegram"
+              chat_id: "{notify.telegram_chat_id}"
+            - type: "discord"
+              chat_id: "987654321"
+```
+
+Each target object must include a `type` field. All other fields are target-specific extras (equivalent to `deliver_extra` in the single-target format). Template values use the same `{dot.notation}` syntax and are rendered with the webhook payload.
+
+### Backward compatibility
+
+The single-target string format continues to work unchanged:
+
+```yaml
+# This still works exactly as before
+deliver: "telegram"
+deliver_extra:
+  chat_id: "123456"
+```
+
+When `deliver` is a list, the `deliver_extra` field is ignored (extras are inlined into each target object).
+
+### Delivery semantics
+
+- All targets are dispatched **concurrently** (not sequentially)
+- **Best-effort**: if one target fails, the others still receive the message
+- The agent's response is delivered to all targets — it is not transformed per-target
+- `send()` returns success if **at least one** target succeeded; failures are logged as warnings
+
+### Multi-target with direct delivery
+
+Multi-target works with `deliver_only: true` as well:
+
+```yaml
+routes:
+  alert-fanout:
+    secret: "alert-secret"
+    deliver_only: true
+    prompt: "🚨 Alert: {alert.message}"
+    deliver:
+      - type: "telegram"
+        chat_id: "{alert.telegram_id}"
+      - type: "discord"
+        chat_id: "channel-id"
+      - type: "slack"
+        chat_id: "C0123456789"
+```
+
+Startup validation ensures every target in the list has a valid `type` (not `log`) when `deliver_only` is enabled.
+
+### CLI multi-target
+
+Use `--deliver` multiple times with the `type:key=value,key=value` format:
+
+```bash
+hermes webhook subscribe pr-review \
+  --deliver "github_comment:repo=org/repo,pr_number=42" \
+  --deliver "telegram:chat_id=123456" \
+  --deliver "discord:chat_id=987654"
+```
 
 ---
 


### PR DESCRIPTION
## What does this PR do?
  Add multi-target delivery support to the webhook adapter, enabling a single webhook route to deliver responses to multiple platforms simultaneously (e.g., Telegram + Discord + GitHub comment from one webhook POST).

  Previously, each route could only deliver to a single platform. Users needing fan-out had to duplicate routes — each triggering independent agent runs, wasting LLM tokens and adding latency. This change enables "process once → deliver everywhere" with concurrent best-effort
  semantics.

  The deliver field now accepts either a string (fully backward compatible) or a list of target objects:

```
  deliver:
    - type: "telegram"
      chat_id: "{user.telegram_id}"
    - type: "discord"
      chat_id: "456"
    - type: "github_comment"
      repo: "{repository.full_name}"
      pr_number: "{number}"
```
## Related Issue

  Support: [#32430](https://github.com/NousResearch/hermes-agent/issues/32403)

## Type of Change
  - ✨ New feature (non-breaking change that adds functionality)

## Changes Made

  - gateway/platforms/webhook.py: Add _normalize_deliver_targets() to unify string/list config formats; add _deliver_single_target() and _deliver_to_targets() for concurrent best-effort dispatch via asyncio.gather; refactor send() and _direct_deliver() to use new multi-target
  path; extend connect() startup validation for list-format deliver_only routes
  - hermes_cli/main.py: Change --deliver argument to action="append" for multi-target support
  - hermes_cli/webhook.py: Add _parse_deliver_spec() to parse type:key=value,key=value CLI format; update _cmd_subscribe() and _cmd_list() for multi-target display
  - tests/gateway/test_webhook_multi_deliver.py: 19 new test cases (normalization, concurrent delivery, partial failure, all-fail, deliver_only multi-target, startup validation, backward compatibility)
  - website/docs/user-guide/messaging/webhooks.md: New "Multi-Target Delivery" section with config examples, CLI usage, and delivery semantics

## How to Test

  1. Apply old single-target config (deliver: "telegram" + deliver_extra) — verify it works identically (backward compat)
  2. Configure a multi-target route:
 ```
  routes:
    test-multi:
      secret: "test-secret"
      deliver:
        - type: "telegram"
          chat_id: "YOUR_CHAT_ID"
        - type: "discord"
          chat_id: "YOUR_CHANNEL_ID"
      prompt: "Event: {__raw__}"
```
  4. Send a webhook POST and verify both platforms receive the message
  5. Run tests: pytest tests/gateway/test_webhook_multi_deliver.py tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py tests/hermes_cli/test_webhook_cli.py -v
  6. Test CLI: hermes webhook subscribe multi-test --deliver "telegram:chat_id=123" --deliver "discord:chat_id=456"

## Checklist

### Code

  - I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - My PR contains only changes related to this fix/feature (no unrelated commits)
  - I've run pytest tests/ -q and all tests pass
  - I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - I've tested on my platform: Ubuntu 22.04 (Python 3.12)

### Documentation & Housekeeping

  - I've updated relevant documentation (README, docs/, docstrings)

### Screenshots / Logs

```bash
  $ pytest tests/gateway/test_webhook_multi_deliver.py -v -o "addopts="
  ============================= test session starts ==============================
  collected 19 items

  test_webhook_multi_deliver.py::TestNormalizeDeliverTargets::test_legacy_string_format PASSED
  test_webhook_multi_deliver.py::TestNormalizeDeliverTargets::test_legacy_string_default_log PASSED
  test_webhook_multi_deliver.py::TestNormalizeDeliverTargets::test_multi_target_list_format PASSED
  test_webhook_multi_deliver.py::TestNormalizeDeliverTargets::test_multi_target_with_payload_rendering PASSED
  test_webhook_multi_deliver.py::TestNormalizeDeliverTargets::test_empty_list_falls_back_to_log PASSED
  test_webhook_multi_deliver.py::TestNormalizeDeliverTargets::test_invalid_items_skipped PASSED
  test_webhook_multi_deliver.py::TestSendMultiTarget::test_send_single_legacy_target PASSED
  test_webhook_multi_deliver.py::TestSendMultiTarget::test_send_multi_target_all_succeed PASSED
  test_webhook_multi_deliver.py::TestSendMultiTarget::test_send_multi_target_partial_failure PASSED
  test_webhook_multi_deliver.py::TestSendMultiTarget::test_send_multi_target_all_fail PASSED
  test_webhook_multi_deliver.py::TestSendMultiTarget::test_send_log_target PASSED
  test_webhook_multi_deliver.py::TestDeliverOnlyMultiTarget::test_direct_deliver_multi_target PASSED
  test_webhook_multi_deliver.py::TestDeliverOnlyMultiTarget::test_direct_deliver_multi_target_with_template_extras PASSED
  test_webhook_multi_deliver.py::TestStartupValidationMultiTarget::test_deliver_only_list_with_log_rejected PASSED
  test_webhook_multi_deliver.py::TestStartupValidationMultiTarget::test_deliver_only_empty_list_rejected PASSED
  test_webhook_multi_deliver.py::TestStartupValidationMultiTarget::test_deliver_only_list_missing_type_rejected PASSED
  test_webhook_multi_deliver.py::TestStartupValidationMultiTarget::test_deliver_only_valid_multi_target_accepted PASSED
  test_webhook_multi_deliver.py::TestBackwardCompatibility::test_legacy_string_deliver_with_deliver_extra PASSED
  test_webhook_multi_deliver.py::TestBackwardCompatibility::test_legacy_github_comment_deliver PASSED

  ============================== 19 passed in 0.33s ==============================
 Full webhook suite: 134 passed in 0.85s (zero regressions)
```