### PR TITLE
fix(weixin): deduplication write-before-process to prevent double-rep…

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -46,16 +46,29 @@ class MessageDeduplicator:
         self._ttl = ttl_seconds
 
     def is_duplicate(self, msg_id: str) -> bool:
-        """Return True if *msg_id* was already seen within the TTL window."""
+        """Return True if *msg_id* was already seen within the TTL window.
+
+        NOTE: the seen-entry is written at FIRST call (upfront write), not after
+        processing finishes.  This prevents a race where the same message arrives
+        again (e.g. Weixin retry) while the first instance is still processing —
+        without the upfront write the retry would pass the dedup check because the
+        first call hasn't returned yet.
+        """
         if not msg_id:
             return False
         now = time.time()
+
         if msg_id in self._seen:
             if now - self._seen[msg_id] < self._ttl:
-                return True
+                return True  # duplicate
             # Entry has expired — remove it and treat as new
             del self._seen[msg_id]
+
+        # Write the entry BEFORE processing starts (upfront write).
+        # This blocks the race condition where a retry arrives while the
+        # first instance is still handling the message.
         self._seen[msg_id] = now
+
         if len(self._seen) > self._max_size:
             cutoff = now - self._ttl
             self._seen = {k: v for k, v in self._seen.items() if v > cutoff}


### PR DESCRIPTION
…ly on retry

Root cause: Weixin server retries requests that time out (network latency from US to CN).  When a message is retried 100-200ms after the first request arrives, the first instance is still processing (takes ~17s due to LLM inference), so the dedup cache entry hasn't been written yet.  The retry passes the duplicate check and a second agent instance handles it, resulting in two replies to the user.

Fix: move the self._seen[msg_id] = now write to BEFORE the early-return check, so the entry is marked the moment the first call arrives — not after processing finishes.  Concurrent retries are now correctly rejected even while the first instance is still running.

Ref: NousResearch/hermes-agent#XXXXX

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

