### PR TITLE
fix(docker): propagate env through s6 to cont-init and main CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,7 @@ COPY docker/s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 # slots from $HERMES_HOME/profiles/<name>/ after a container restart
 # (the /run/service/ scandir is tmpfs and wiped on restart). Phase 4.
 RUN mkdir -p /etc/cont-init.d && \
-    printf '#!/bin/sh\nexec /opt/hermes/docker/stage2-hook.sh\n' \
+    printf '#!/command/with-contenv sh\nexec /opt/hermes/docker/stage2-hook.sh\n' \
         > /etc/cont-init.d/01-hermes-setup && \
     chmod +x /etc/cont-init.d/01-hermes-setup
 COPY --chmod=0755 docker/cont-init.d/015-supervise-perms /etc/cont-init.d/015-supervise-perms

--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -1,8 +1,14 @@
-#!/bin/sh
+#!/command/with-contenv sh
 # /opt/hermes/docker/main-wrapper.sh — wraps the container's CMD with
 # the same argument-routing logic the pre-s6 entrypoint.sh used. Runs
 # as /init's "main program" (Docker CMD) so it inherits stdin/stdout/
 # stderr from the container.
+#
+# Shebang note: /init scrubs env before invoking CMD, so a plain
+# `#!/bin/sh` wrapper sees an empty environ and `ENV HERMES_HOME=/opt/data`
+# from the Dockerfile never reaches `hermes`. with-contenv repopulates
+# the env from /run/s6/container_environment before exec'ing, which is
+# what s6-supervised services use too (see main-hermes/run).
 #
 # Routing:
 #   no args                       → exec `hermes` (the default)
@@ -12,6 +18,12 @@
 # We drop to the hermes user via `s6-setuidgid` so the supervised
 # workload runs unprivileged (UID 10000 by default).
 set -e
+
+# HOME comes through with-contenv as /root (the /init context). Override
+# to the hermes user's home before dropping privileges so libraries that
+# resolve paths via $HOME (e.g. discord lockfile under XDG_STATE_HOME)
+# don't try to write to /root.
+export HOME=/opt/data
 
 cd /opt/data
 # shellcheck disable=SC1091


### PR DESCRIPTION
## Summary

- `s6-overlay`'s `/init` strips the environment before invoking both `/etc/cont-init.d/*` scripts and the container CMD. As a result, `ENV` directives from the Dockerfile (`HERMES_HOME=/opt/data`) and compose-time `environment:` entries (`HERMES_UID`, `HERMES_GID`) never reach the scripts that consume them.
- Three surgical changes restore correct env flow: the auto-generated `01-hermes-setup` cont-init wrapper and `docker/main-wrapper.sh` switch to `#!/command/with-contenv sh`, and the wrapper explicitly sets `HOME=/opt/data` before dropping privileges via `s6-setuidgid`.
- No behavior change for the non-buggy paths; this only repairs paths that were silently broken on every fresh container.

## Problem

Reproduced on macOS Docker Desktop 4.x with the documented quick-start (`-v ~/.hermes:/opt/data`):

1. **UID remap never fires.** `HERMES_UID=$(id -u)` in `docker compose up` is ignored. `docker/stage2-hook.sh` lines 24-26 do `usermod -u "$HERMES_UID" hermes`, but `HERMES_UID` is unset inside the cont-init script, so the hermes user stays at the baked-in UID 10000. The compose-file comment block claims this remap happens; it doesn't.

2. **Shadow data tree on the bind-mount.** `docker/stage2-hook.sh` line 138 invokes `tools/skills_sync.py` via `s6-setuidgid hermes`. With `HERMES_HOME` stripped, `hermes_constants.get_hermes_home()` falls back to `Path.home() / \".hermes\"`. The hermes user's home per `/etc/passwd` is `/opt/data`, so the resolver returns `/opt/data/.hermes`. Bundled skills get copied there, creating a `~/.hermes/.hermes/skills/` shadow tree on the host. The intended `\$HERMES_HOME/skills/` (= `~/.hermes/skills/`) is bypassed entirely.

3. **Gateway can't acquire Discord lockfile.** The container CMD (`gateway run`) is launched by `/init` → `main-wrapper.sh` → `s6-setuidgid hermes hermes gateway run`. The wrapper's `#!/bin/sh` shebang skips env restoration, and `s6-setuidgid` drops UID/GID but does not update `HOME`. The gateway process inherits `HOME=/root` from the `/init` context. Libraries resolving XDG state paths via `\$HOME` (e.g. the Discord adapter's bot-token lock at `\${XDG_STATE_HOME:-\$HOME/.local/state}/hermes/gateway-locks/`) try to write to `/root/.local/state/hermes/gateway-locks/` and fail with `PermissionError [Errno 13]`. Result:

   ```
   ERROR gateway.run: ✗ discord error: [Errno 13] Permission denied:
   '/root/.local/state/hermes/gateway-locks/discord-bot-token-…lock'
   WARNING gateway.run: No adapter could be created for any of the 1
   configured platform(s).
   ```

## Root cause

s6-overlay's `/init` deliberately sanitizes the env before invoking children, then exposes the container-level env (Dockerfile `ENV` + compose `environment:`) via files under `/run/s6/container_environment/`. Scripts opt in to that env by using the `with-contenv` execline binary as their interpreter (or sourcing it). The existing s6-supervised services in this repo already do this — see `docker/s6-rc.d/main-hermes/run` and `docker/cont-init.d/02-reconcile-profiles`, both of which use `#!/command/with-contenv sh`.

The two scripts touched by this PR didn't:

- `/etc/cont-init.d/01-hermes-setup` is generated inline in the Dockerfile with a plain `#!/bin/sh` shebang and just `exec`s `docker/stage2-hook.sh`.
- `docker/main-wrapper.sh` is a `#!/bin/sh` script that runs the container CMD.

Both ran with the stripped env, defeating the Dockerfile's `ENV HERMES_HOME=/opt/data` and the compose file's `environment: HERMES_UID/HERMES_GID` entries.

The `HOME=/opt/data` override is a second, related fix. Even with the wrapper switched to `with-contenv`, `HOME` in `/run/s6/container_environment/` is `/root` (the `/init` context). `s6-setuidgid` does not update `HOME` when dropping privileges, so the gateway would still see `HOME=/root`. The override pins `HOME` to the hermes user's actual home dir (per `/etc/passwd`: `hermes:x:10000:10000::/opt/data:/bin/sh`).

## Fix

Three lines of substantive change across two files:

- **`Dockerfile`** — the `printf` that generates `/etc/cont-init.d/01-hermes-setup` now writes `#!/command/with-contenv sh` instead of `#!/bin/sh`.
- **`docker/main-wrapper.sh`** — shebang changed to `#!/command/with-contenv sh`; `export HOME=/opt/data` added before the `s6-setuidgid` exec, with comments explaining both choices.

After the fix, `docker compose up -d` produces:

| Concern | Before | After |
|---|---|---|
| `id` of the gateway process | UID 10000 | **UID matches `$HERMES_UID`** (e.g. 501) |
| `HERMES_HOME` reaching the gateway | unset | `/opt/data` |
| `HOME` reaching the gateway | `/root` | `/opt/data` |
| Skills sync destination | `/opt/data/.hermes/skills/` (shadow) | `/opt/data/skills/` |
| Discord lockfile path | `/root/.local/state/…` (EACCES) | `/opt/data/.local/state/…` (OK) |
| `~/.hermes/.hermes/` on host | created | **never created** |

## Test plan

Reproduced and verified on macOS Docker Desktop with the documented quick-start mount layout.

- [x] `HERMES_UID=\$(id -u) HERMES_GID=\$(id -g) docker compose up -d` — gateway container starts cleanly.
- [x] `docker exec hermes ps -eo pid,user,uid,cmd | grep gateway` shows the gateway running under the host user's UID, not 10000.
- [x] `docker exec -u hermes hermes cat /proc/\$(pgrep -f \"gateway run\")/environ | tr '\\0' '\\n' | grep -E '^(HERMES|HOME)'` shows `HERMES_HOME=/opt/data`, `HOME=/opt/data`, `HERMES_UID=<host UID>`.
- [x] Container log shows `[Discord] Connected as <bot>#<tag>` and `✓ discord connected` (was failing with EACCES before).
- [x] No `~/.hermes/.hermes/` directory created on the host after a fresh `docker compose up`.
- [x] `~/.hermes/skills/` populated with bundled skills (was empty before; bundled skills went into the shadow tree).
- [x] `~/.hermes/.local/state/hermes/gateway-locks/<token-hash>.lock` exists after Discord connects.
- [x] `docker compose down && docker compose up -d` is idempotent — no stray shadow directories on the second boot.

## Platforms tested

- **macOS** (Darwin 25.5.0, Apple Silicon, Docker Desktop 29.3.1, Docker Engine 29.4.0, Compose v5.1.1) — virtiofs bind mount.

Should be a no-op improvement on Linux Docker installs: those typically run with `HERMES_UID=$(id -u)` matching a host user, but the same env-stripping issue prevents the explicit UID/GID remap and the explicit `HERMES_HOME` from being honored. The fix makes both layers work as the existing comments and CONTRIBUTING.md docs describe.

## Backward compatibility

- No public API or CLI change.
- No new dependencies; `with-contenv` is already part of the s6-overlay base layer and is already used by the supervised services in this repo.
- `HOME=/opt/data` matches the hermes user's `/etc/passwd` entry — code that already used `Path.home()` was assuming this directory; the explicit override just makes the assumption consistent across the `s6-setuidgid` boundary.

## Related

- `docker/s6-rc.d/main-hermes/run` and `docker/cont-init.d/02-reconcile-profiles` already use `#!/command/with-contenv sh` — this PR brings the remaining two script entry points in line.
- The Discord lockfile path resolution and `HERMES_HOME` propagation are documented in `website/docs/user-guide/docker.md`; that doc continues to work as written after this fix (it didn't on `main`).