### PR TITLE
fix(kanban): close leaked decompose connections + don't mask I/O error on rollback

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1345,7 +1345,14 @@ def write_txn(conn: sqlite3.Connection):
     try:
         yield conn
     except Exception:
-        conn.execute("ROLLBACK")
+        # SQLite auto-aborts the transaction on some errors (e.g. SQLITE_IOERR),
+        # so an explicit ROLLBACK can raise "cannot rollback - no transaction is
+        # active". Swallow that secondary failure so it can't mask the original
+        # exception, which is the one the caller needs to see.
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
         raise
     else:
         conn.execute("COMMIT")

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -36,6 +36,7 @@ Design notes
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -281,7 +282,7 @@ def decompose_task(
     configured, API error, malformed response, decomposer returned
     fanout=true with empty task list) — those surface via ``ok=False``.
     """
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         task = kb.get_task(conn, task_id)
     if task is None:
         return DecomposeOutcome(task_id, False, "unknown task id")
@@ -370,7 +371,7 @@ def decompose_task(
             return DecomposeOutcome(
                 task_id, False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect() as conn:
+        with contextlib.closing(kb.connect()) as conn:
             ok = kb.specify_triage_task(
                 conn,
                 task_id,
@@ -439,7 +440,7 @@ def decompose_task(
         })
 
     try:
-        with kb.connect() as conn:
+        with contextlib.closing(kb.connect()) as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
@@ -467,7 +468,7 @@ def decompose_task(
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
     """Return task ids currently in the triage column."""
-    with kb.connect() as conn:
+    with contextlib.closing(kb.connect()) as conn:
         rows = kb.list_tasks(
             conn,
             status="triage",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2981,3 +2981,56 @@ def test_detect_stale_does_not_tick_failure_counter(kanban_home, monkeypatch):
         assert "stale" in kinds, (
             f"Expected 'stale' event in task_events; got {kinds!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# write_txn rollback robustness (regression for #kanban-db-corruption)
+# ---------------------------------------------------------------------------
+
+class _RollbackFailsConn:
+    """Minimal conn stub whose ROLLBACK fails like an already-aborted txn.
+
+    SQLite auto-aborts the transaction on errors such as SQLITE_IOERR, so a
+    later explicit ROLLBACK raises "cannot rollback - no transaction is
+    active". This stub reproduces that so we can assert write_txn does not
+    let the rollback failure mask the original exception.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def execute(self, sql, *args):
+        self.calls.append(sql)
+        if sql == "ROLLBACK":
+            raise sqlite3.OperationalError(
+                "cannot rollback - no transaction is active"
+            )
+        return None
+
+
+class _SentinelError(Exception):
+    pass
+
+
+def test_write_txn_rollback_failure_does_not_mask_original_error():
+    conn = _RollbackFailsConn()
+    with pytest.raises(_SentinelError):
+        with kb.write_txn(conn):
+            raise _SentinelError("the real failure, e.g. disk I/O error")
+    # The rollback was attempted (and its failure swallowed), and the original
+    # exception — not the rollback OperationalError — propagated.
+    assert "BEGIN IMMEDIATE" in conn.calls
+    assert "ROLLBACK" in conn.calls
+    assert "COMMIT" not in conn.calls
+
+
+def test_write_txn_commits_on_success(kanban_home):
+    with kb.connect() as conn:
+        # CREATE runs in autocommit (isolation_level=None) before the txn.
+        conn.execute("CREATE TABLE IF NOT EXISTS _wt_probe (v TEXT)")
+        with kb.write_txn(conn):
+            conn.execute("INSERT INTO _wt_probe (v) VALUES ('x')")
+    # A fresh connection sees the committed row.
+    with kb.connect() as conn:
+        row = conn.execute("SELECT v FROM _wt_probe").fetchone()
+    assert row is not None and row["v"] == "x"

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -347,3 +347,73 @@ def test_decompose_no_aux_client_configured(kanban_home):
 
     assert outcome.ok is False
     assert "no auxiliary client" in outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle (regression for #kanban-db-corruption)
+#
+# `with kb.connect() as conn:` only manages the transaction, not the
+# connection — sqlite3's context manager never closes it. decompose_task
+# now wraps connect() in contextlib.closing, so every connection it opens
+# must be closed (releasing the WAL -wal/-shm file descriptors).
+# ---------------------------------------------------------------------------
+
+class _TrackingConn:
+    """Delegating proxy that records whether close() was called."""
+
+    def __init__(self, real):
+        object.__setattr__(self, "_real", real)
+        object.__setattr__(self, "closed", False)
+
+    def close(self):
+        object.__setattr__(self, "closed", True)
+        self._real.close()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._real, name, value)
+
+
+def test_decompose_closes_every_connection_it_opens(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="single thing", triage=True)
+
+    real_connect = kb.connect
+    opened: list[_TrackingConn] = []
+
+    def _tracking_connect(*args, **kwargs):
+        wrapper = _TrackingConn(real_connect(*args, **kwargs))
+        opened.append(wrapper)
+        return wrapper
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Tightened",
+        "body": "Do the thing.",
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "fallback"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"default_assignee": "fallback"}},
+        ), patch("hermes_cli.kanban_decompose.kb.connect", _tracking_connect):
+            outcome = decomp.decompose_task(tid, author="me")
+
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    # decompose_task opened at least the get_task + specify_triage_task
+    # connections, and every one of them was closed.
+    assert len(opened) >= 2
+    assert all(w.closed for w in opened), (
+        "decompose_task leaked a connection: "
+        f"{[i for i, w in enumerate(opened) if not w.closed]}"
+    )


### PR DESCRIPTION
## Summary

Fixes a SQLite data-corruption bug on Hermes Kanban boards (observed on `novadeck-atlas`, ending in `database disk image is malformed`). Two compounding bugs in the gateway auto-decompose path:

- **Leaked connections** — `decompose_task` opened the DB with `with kb.connect() as conn:`, but `sqlite3.Connection`'s context manager only ends the *transaction* and never closes the connection. `kb.connect()` returns a raw `sqlite3.connect(...)`, so each block leaked a live WAL connection (with `-wal`/`-shm` FDs) until GC. Sustained auto-decompose accumulated open handles, and FD/`-shm` open failures surfaced to SQLite as `SQLITE_IOERR` ("disk I/O error") even with free disk — the observed trigger. Fixed by wrapping all four `kb.connect()` sites in `contextlib.closing`.
- **`write_txn` masked the real error** — on `SQLITE_IOERR` SQLite has already aborted the transaction, so the unconditional `conn.execute("ROLLBACK")` raised *"cannot rollback - no transaction is active"* (the exact production stack), hiding the original I/O error. Fixed by swallowing the rollback failure and re-raising the original exception.

Ruled out: legacy NovaDeck code (none exists — the name is just a user-created board), WAL/DELETE mixed-mode (ext4 always gets WAL), and write contention (WAL serializes writers; that yields `SQLITE_BUSY`, not `SQLITE_IOERR`).

Scope kept tight to the evidenced gateway/decompose path. The dashboard plugin (`plugins/kanban/dashboard/plugin_api.py`) has a similar non-closing pattern but is not in the production stack — noted as a follow-up, not touched here.

## Changes
- `hermes_cli/kanban_db.py` — robust `write_txn` rollback (try/except + re-raise original).
- `hermes_cli/kanban_decompose.py` — `import contextlib`; wrap 4 `kb.connect()` sites in `contextlib.closing`. Behavior-preserving: all writes already run inside their own `write_txn` (incl. `recompute_ready`), so the dropped implicit-commit was a no-op.
- Regression tests in `tests/hermes_cli/test_kanban_db.py` and `tests/hermes_cli/test_kanban_decompose.py`.

## Test plan
- [x] `pytest tests/hermes_cli/{test_kanban_db,test_kanban_decompose,test_kanban_specify_db,test_kanban_core_functionality}.py` — 346 passed
- [x] New tests verified as genuine guards (fail against un-fixed code)
- [ ] **Live repair still required**: this prevents recurrence but does not repair the already-malformed on-disk `novadeck-atlas/kanban.db` — operator-driven recovery (`.recover` into a fresh DB, or re-init) is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)