### PR TITLE
feat(acp): publish effective mode updates

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -25,6 +25,7 @@ from acp.schema import (
     AvailableCommandsUpdate,
     BlobResourceContents,
     ClientCapabilities,
+    CurrentModeUpdate,
     EmbeddedResourceContentBlock,
     ForkSessionResponse,
     ImageContentBlock,
@@ -739,6 +740,25 @@ class HermesACPAgent(acp.Agent):
             )
         except Exception:
             logger.debug("Could not send ACP session info update for %s", session_id, exc_info=True)
+
+    async def _send_current_mode_update(self, session_id: str, mode_id: str) -> None:
+        """Send the ACP-native current mode notification after mode mutations."""
+        if not self._conn:
+            return
+        try:
+            await self._conn.session_update(
+                session_id=session_id,
+                update=CurrentModeUpdate(
+                    session_update="current_mode_update",
+                    current_mode_id=mode_id,
+                ),
+            )
+        except Exception:
+            logger.debug(
+                "Could not send ACP current mode update for %s",
+                session_id,
+                exc_info=True,
+            )
 
     def _schedule_usage_update(self, state: SessionState) -> None:
         """Schedule native context indicator refresh after ACP responses."""
@@ -1926,6 +1946,7 @@ class HermesACPAgent(acp.Agent):
             normalized_mode = self._MODE_DEFAULT
         setattr(state, "mode", normalized_mode)
         self.session_manager.save_session(session_id)
+        await self._send_current_mode_update(session_id, normalized_mode)
         logger.info("Session %s: mode switched to %s", session_id, normalized_mode)
         return SetSessionModeResponse()
 
@@ -1941,12 +1962,16 @@ class HermesACPAgent(acp.Agent):
         if str(config_id) == self._EDIT_APPROVAL_POLICY_CONFIG_ID:
             mode = self._EDIT_APPROVAL_POLICY_TO_MODE.get(str(value), self._MODE_DEFAULT)
             setattr(state, "mode", mode)
+            emit_current_mode = mode
         else:
+            emit_current_mode = None
             options = getattr(state, "config_options", None)
             if not isinstance(options, dict):
                 options = {}
             options[str(config_id)] = value
             setattr(state, "config_options", options)
         self.session_manager.save_session(session_id)
+        if emit_current_mode is not None:
+            await self._send_current_mode_update(session_id, emit_current_mode)
         logger.info("Session %s: config option %s updated", session_id, config_id)
         return SetSessionConfigOptionResponse(config_options=[])

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -16,6 +16,7 @@ from acp.schema import (
     AgentThoughtChunk,
     AuthenticateResponse,
     AvailableCommandsUpdate,
+    CurrentModeUpdate,
     Implementation,
     InitializeResponse,
     ListSessionsResponse,
@@ -901,6 +902,101 @@ class TestSessionConfiguration:
 
         assert isinstance(resp, SetSessionModeResponse)
         assert getattr(state, "mode", None) == "accept_edits"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("requested_mode", "effective_mode"),
+        [
+            ("accept_edits", "accept_edits"),
+            ("Accept_edits", "default"),
+            ("dont_ask ", "dont_ask"),
+        ],
+    )
+    async def test_set_session_mode_emits_effective_current_mode_update(
+        self,
+        agent,
+        requested_mode,
+        effective_mode,
+    ):
+        new_resp = await agent.new_session(cwd="/tmp")
+        mock_conn = MagicMock()
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.set_session_mode(
+            mode_id=requested_mode,
+            session_id=new_resp.session_id,
+        )
+
+        assert isinstance(resp, SetSessionModeResponse)
+        mock_conn.session_update.assert_awaited_once()
+        call = mock_conn.session_update.await_args
+        assert call.kwargs["session_id"] == new_resp.session_id
+        update = call.kwargs["update"]
+        assert isinstance(update, CurrentModeUpdate)
+        assert update.session_update == "current_mode_update"
+        assert update.current_mode_id == effective_mode
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("policy_value", "effective_mode"),
+        [
+            ("workspace_session", "accept_edits"),
+            ("workspace_session ", "default"),
+        ],
+    )
+    async def test_edit_approval_policy_config_emits_effective_current_mode_update(
+        self,
+        agent,
+        policy_value,
+        effective_mode,
+    ):
+        new_resp = await agent.new_session(cwd="/tmp")
+        mock_conn = MagicMock()
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.set_config_option(
+            config_id="edit_approval_policy",
+            session_id=new_resp.session_id,
+            value=policy_value,
+        )
+
+        assert isinstance(resp, SetSessionConfigOptionResponse)
+        mock_conn.session_update.assert_awaited_once()
+        call = mock_conn.session_update.await_args
+        assert call.kwargs["session_id"] == new_resp.session_id
+        update = call.kwargs["update"]
+        assert isinstance(update, CurrentModeUpdate)
+        assert update.session_update == "current_mode_update"
+        assert update.current_mode_id == effective_mode
+
+    @pytest.mark.asyncio
+    async def test_missing_session_mode_update_does_not_emit_current_mode_update(self, agent):
+        mock_conn = MagicMock()
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.set_session_mode(mode_id="accept_edits", session_id="missing")
+
+        assert resp is None
+        mock_conn.session_update.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_mode_config_option_does_not_emit_current_mode_update(self, agent):
+        new_resp = await agent.new_session(cwd="/tmp")
+        mock_conn = MagicMock()
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        resp = await agent.set_config_option(
+            config_id="approval_mode",
+            session_id=new_resp.session_id,
+            value="auto",
+        )
+
+        assert isinstance(resp, SetSessionConfigOptionResponse)
+        mock_conn.session_update.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_router_accepts_stable_session_config_methods(self, agent):


### PR DESCRIPTION
## What does this PR do?

Publishes the effective ACP session mode after mode-changing requests so clients do not have to guess whether Hermes accepted, normalized, or mapped the requested value.

`session/set_mode` and `session/set_config_option` already persist the effective mode, but they returned protocol-minimal responses without notifying clients of the final state. This PR emits ACP's native `CurrentModeUpdate` notification after successful mode mutations while preserving the existing response shapes.

## Related Issue

Fixes #32419.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`
  - imports ACP `CurrentModeUpdate`.
  - adds `_send_current_mode_update(...)` with best-effort client notification behavior.
  - emits `current_mode_update` from `session/set_mode` using the normalized effective mode.
  - emits `current_mode_update` from `session/set_config_option` only when `configId == "edit_approval_policy"`, using the mapped effective mode.
  - preserves existing protocol-minimal direct responses and existing fallback behavior for unknown/whitespace config values.
- `tests/acp/test_server.py`
  - covers valid, invalid, and whitespace-normalized `session/set_mode` requests.
  - covers `edit_approval_policy` mapping to `accept_edits` and current whitespace fallback to `default`.
  - covers missing-session and unrelated-config no-notification cases.

## How to Test

1. `python -m pytest tests/acp/test_server.py::TestSessionConfiguration -q -o 'addopts='`
2. `scripts/run_tests.sh tests/acp/test_server.py`
3. `scripts/run_tests.sh tests/acp`
4. `python scripts/check-windows-footguns.py --diff origin/main`
5. `git diff --check origin/main...HEAD`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
  - Searched open upstream PRs/issues for `current_mode_update set_session_mode OR edit_approval_policy`; no direct match found.
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Not run locally; focused ACP suite passed via `scripts/run_tests.sh tests/acp`.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux / Arch (`7.0.10-arch1-1`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, behavior is covered by tests and existing ACP mode surface
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — no OS-specific paths/process behavior added; Windows footgun checker passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

N/A — ACP notification behavior is covered by unit tests.
