### PR TITLE
fix(tools): require send_message delivery fields in schema

### DIFF
--- a/tests/tools/test_send_message_tool_schema.py
+++ b/tests/tools/test_send_message_tool_schema.py
@@ -1,0 +1,25 @@
+import json
+
+from tools.send_message_tool import SEND_MESSAGE_SCHEMA, send_message_tool
+
+
+def _params():
+    return SEND_MESSAGE_SCHEMA["parameters"]
+
+
+def test_send_message_schema_keeps_action_optional_for_default_send():
+    assert _params()["required"] == []
+
+
+def test_send_message_schema_requires_delivery_fields_unless_listing_targets():
+    assert _params()["anyOf"] == [
+        {"properties": {"action": {"const": "list"}}, "required": ["action"]},
+        {"required": ["target", "message"]},
+    ]
+
+
+def test_send_message_list_action_still_accepts_no_target_or_message():
+    result = json.loads(send_message_tool({"action": "list"}))
+
+    assert "targets" in result
+    assert "error" not in result

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -142,7 +142,11 @@ SEND_MESSAGE_SCHEMA = {
                 "description": "The message text to send. To send an image or file, include MEDIA:<local_path> for a file under a Hermes media cache or HERMES_MEDIA_ALLOW_DIRS — the platform will deliver it as a native media attachment."
             }
         },
-        "required": []
+        "required": [],
+        "anyOf": [
+            {"properties": {"action": {"const": "list"}}, "required": ["action"]},
+            {"required": ["target", "message"]},
+        ]
     }
 }
 


### PR DESCRIPTION
## Summary
- Add JSON Schema `anyOf` validation so `send_message` requires `target` and `message` for send/default-send calls.
- Preserve the existing argument-free `action: "list"` flow and the default-send behavior when `action` is omitted but delivery fields are present.
- Add focused coverage for the schema shape and list action behavior.

## Test Plan
- [x] `python -m pytest -o addopts='' tests/tools/test_send_message_tool_schema.py -q`
- [x] `python -m ruff check tools/send_message_tool.py tests/tools/test_send_message_tool_schema.py`
- [x] `python - <<'PY' ... jsonschema.validate(...) ... PY` schema smoke check for valid/invalid send/list payloads

Closes #32376
