### PR TITLE
feat: auto-allow safe sqlite schema inspection

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1329,6 +1329,155 @@ class TestEtcPatternsUnaffectedByRefactor:
 # =========================================================================
 
 
+class TestSafeLocalInspectionAutoAllow:
+    """Routine read-only local inspections should not require Cal approval."""
+
+    SESSION_KEY = "test-safe-local-inspection"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._session_approved.clear()
+        mod._permanent_approved.clear()
+        mod._pending.clear()
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_SESSION_KEY", "HERMES_INTERACTIVE")
+        }
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        os.environ["HERMES_GATEWAY_SESSION"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_python_c_sqlite_schema_only_readonly_is_auto_allowed(self):
+        from tools import approval as mod
+
+        command = """python3 -c '\nimport os, sqlite3\ndb_path = "/home/v0iidbox/.hermes/state.db"\nconn = sqlite3.connect(f"file:{db_path}?mode=ro&immutable=1", uri=True)\nconn.execute("PRAGMA query_only = ON")\nrows = conn.execute("SELECT name, sql FROM sqlite_master WHERE type=\\\"table\\\" ORDER BY name").fetchall()\nconn.close()\n'"""
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result = mod.check_all_command_guards(command, "local")
+
+        assert result["approved"] is True
+        assert result.get("auto_allowed") is True
+        assert result.get("auto_allow_class") == "sqlite_schema_inspection"
+        assert notified == []
+        assert not mod._gateway_queues.get(self.SESSION_KEY)
+
+    def test_python_heredoc_sqlite_schema_only_readonly_is_auto_allowed(self):
+        from tools import approval as mod
+
+        command = """python3 << 'EOF'
+import os
+import sqlite3
+
+db_path = '/home/v0iidbox/.hermes/state.db'
+conn = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True)
+conn.execute("PRAGMA query_only = ON")
+conn.execute("PRAGMA schema_version")
+conn.execute("SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name")
+conn.close()
+EOF"""
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result = mod.check_all_command_guards(command, "local")
+
+        assert result["approved"] is True
+        assert result.get("auto_allow_class") == "sqlite_schema_inspection"
+        assert notified == []
+
+    def test_user_reported_heredoc_schema_dump_with_cursor_is_auto_allowed(self):
+        from tools import approval as mod
+
+        command = """python3 << 'EOF'
+import os
+import sqlite3
+
+db_path = '/home/v0iidbox/.hermes/state.db'
+
+if not os.path.exists(db_path):
+    raise FileNotFoundError(f"DB not found: {db_path}")
+
+conn = sqlite3.connect(f'file:{db_path}?mode=ro', uri=True)
+conn.row_factory = sqlite3.Row
+cursor = conn.cursor()
+conn.execute("PRAGMA query_only = ON")
+
+cursor.execute("SELECT name, sql FROM sqlite_master WHERE type='table' ORDER BY name")
+tables = cursor.fetchall()
+
+print("=== DATABASE SCHEMA ONLY ===")
+for table in tables:
+    print(f"-- {table['name']} --")
+    print(table['sql'])
+
+conn.close()
+EOF"""
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result = mod.check_all_command_guards(command, "local")
+
+        assert result["approved"] is True
+        assert result.get("auto_allow_class") == "sqlite_schema_inspection"
+        assert notified == []
+
+    def test_python_c_sqlite_table_row_read_still_requires_approval(self):
+        from tools import approval as mod
+
+        command = """python3 -c 'import sqlite3; conn = sqlite3.connect("file:/tmp/x.db?mode=ro", uri=True); conn.execute("PRAGMA query_only = ON"); conn.execute("SELECT content FROM messages LIMIT 1")'"""
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result_holder = {}
+        def _check():
+            result_holder["r"] = mod.check_all_command_guards(command, "local")
+        t = threading.Thread(target=_check)
+        t.start()
+
+        for _ in range(50):
+            if mod._gateway_queues.get(self.SESSION_KEY):
+                break
+            time.sleep(0.02)
+        assert notified, "unsafe sqlite row read should still ask for approval"
+        mod.resolve_gateway_approval(self.SESSION_KEY, "deny")
+        t.join(timeout=5)
+        assert result_holder["r"]["approved"] is False
+
+    def test_python_c_sqlite_write_still_requires_approval(self):
+        from tools import approval as mod
+
+        command = """python3 -c 'import sqlite3; conn = sqlite3.connect("file:/tmp/x.db?mode=ro", uri=True); conn.execute("PRAGMA query_only = ON"); conn.execute("DROP TABLE messages")'"""
+        notified = []
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        result_holder = {}
+        def _check():
+            result_holder["r"] = mod.check_all_command_guards(command, "local")
+        t = threading.Thread(target=_check)
+        t.start()
+
+        for _ in range(50):
+            if mod._gateway_queues.get(self.SESSION_KEY):
+                break
+            time.sleep(0.02)
+        assert notified, "sqlite writes should still ask for approval"
+        mod.resolve_gateway_approval(self.SESSION_KEY, "deny")
+        t.join(timeout=5)
+        assert result_holder["r"]["approved"] is False
+
+
 class TestApprovalTimeoutIsNotConsent:
     """The gateway approval contract: silence is not consent (#24912)."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -8,14 +8,17 @@ This module is the single source of truth for the dangerous command system:
 - Permanent allowlist persistence (config.yaml)
 """
 
+import ast
 import contextvars
 import logging
 import os
 import re
+import shlex
 import sys
 import threading
 import time
 import unicodedata
+from pathlib import PurePath
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -1050,6 +1053,158 @@ def _format_tirith_description(tirith_result: dict) -> str:
     return "Security scan — " + "; ".join(parts)
 
 
+def _string_static_value(node: ast.AST) -> str | None:
+    """Return static string content for literals/f-strings, ignoring dynamic slots."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                parts.append("{}")
+            else:
+                return None
+        return "".join(parts)
+    return None
+
+
+def _normalize_sql(sql: str) -> str:
+    return " ".join(sql.strip().rstrip(";").split()).upper()
+
+
+def _is_schema_metadata_sql(sql: str) -> bool:
+    """Allow only SQLite schema metadata reads, never table-row reads/writes."""
+    normalized = _normalize_sql(sql)
+    if normalized == "PRAGMA QUERY_ONLY = ON":
+        return True
+    if normalized == "PRAGMA SCHEMA_VERSION":
+        return True
+    if normalized.startswith("PRAGMA TABLE_INFO(") and normalized.endswith(")"):
+        return True
+    dangerous_sql = re.search(
+        r"\b(DROP|DELETE|UPDATE|INSERT|ALTER|CREATE|VACUUM|ATTACH|DETACH|REINDEX|REPLACE)\b",
+        normalized,
+    )
+    if dangerous_sql:
+        return False
+    if normalized.startswith("SELECT "):
+        from_targets = re.findall(r"\bFROM\s+([A-Z_][A-Z0-9_]*)", normalized)
+        return bool(from_targets) and set(from_targets) <= {"SQLITE_MASTER"}
+    return False
+
+
+def _extract_python_inspection_script(command: str) -> str | None:
+    """Extract a python -c / simple heredoc script for static inspection."""
+    try:
+        parts = shlex.split(command, posix=True)
+    except ValueError:
+        parts = []
+    if parts:
+        exe = PurePath(parts[0]).name.lower()
+        if exe in {"python", "python3"} or re.fullmatch(r"python3?\.\d+", exe):
+            if "-c" in parts:
+                idx = parts.index("-c")
+                if idx + 1 < len(parts):
+                    return parts[idx + 1]
+    heredoc = re.search(
+        r"(?:^|[;&|\n]\s*)(?:python|python3|python3?\.\d+)\s+<<\s*['\"]?(\w+)['\"]?\s*\n(?P<body>.*?)(?:\n\1\s*$)",
+        command,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if heredoc:
+        return heredoc.group("body")
+    return None
+
+
+def _python_script_is_sqlite_schema_inspection(script: str) -> bool:
+    """Static allowlist for read-only SQLite schema-inspection snippets."""
+    try:
+        tree = ast.parse(script)
+    except SyntaxError:
+        return False
+
+    allowed_import_roots = {"sqlite3", "os", "pathlib"}
+    forbidden_import_roots = {
+        "subprocess", "socket", "requests", "urllib", "http", "ftplib",
+        "paramiko", "asyncio", "shutil",
+    }
+    forbidden_call_names = {
+        "eval", "exec", "compile", "input", "open", "printenv",
+    }
+    forbidden_attrs = {
+        "executescript", "commit", "rollback", "backup",
+        "enable_load_extension", "load_extension", "remove", "unlink",
+        "rmdir", "removedirs", "rename", "replace", "renames", "system",
+        "popen", "spawn", "fork", "chmod", "chown", "truncate", "write_text",
+        "write_bytes", "touch", "mkdir",
+    }
+
+    saw_sqlite_connect = False
+    saw_query_only = False
+    saw_schema_query = False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".", 1)[0]
+                if root in forbidden_import_roots or root not in allowed_import_roots:
+                    return False
+        elif isinstance(node, ast.ImportFrom):
+            root = (node.module or "").split(".", 1)[0]
+            if root in forbidden_import_roots or root not in allowed_import_roots:
+                return False
+        elif isinstance(node, ast.Attribute):
+            if node.attr in {"environ", "getenv"}:
+                return False
+        elif isinstance(node, ast.Call):
+            func = node.func
+            func_name = func.id if isinstance(func, ast.Name) else ""
+            attr_name = func.attr if isinstance(func, ast.Attribute) else ""
+            if func_name in forbidden_call_names or attr_name in forbidden_attrs:
+                return False
+            if func_name == "open":
+                return False
+            if attr_name == "connect":
+                target = _string_static_value(node.args[0]) if node.args else None
+                uri_kw = next((kw for kw in node.keywords if kw.arg == "uri"), None)
+                uri_true = isinstance(uri_kw, ast.keyword) and isinstance(uri_kw.value, ast.Constant) and uri_kw.value.value is True
+                if not target or not uri_true:
+                    return False
+                target_lower = target.lower()
+                if not target_lower.startswith("file:"):
+                    return False
+                if "mode=ro" not in target_lower and "immutable=1" not in target_lower:
+                    return False
+                saw_sqlite_connect = True
+            if attr_name == "execute":
+                sql = _string_static_value(node.args[0]) if node.args else None
+                if not sql or not _is_schema_metadata_sql(sql):
+                    return False
+                sql_norm = _normalize_sql(sql)
+                if sql_norm == "PRAGMA QUERY_ONLY = ON":
+                    saw_query_only = True
+                else:
+                    saw_schema_query = True
+        elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+            lowered = node.value.lower()
+            if ".env" in lowered or "api_key" in lowered or "token" in lowered or "secret" in lowered:
+                return False
+
+    return saw_sqlite_connect and saw_query_only and saw_schema_query
+
+
+def _known_safe_local_inspection(command: str, env_type: str) -> str | None:
+    """Return an auto-allow class for deterministic, read-only local checks."""
+    if env_type != "local":
+        return None
+    script = _extract_python_inspection_script(command)
+    if script and _python_script_is_sqlite_schema_inspection(script):
+        return "sqlite_schema_inspection"
+    return None
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
@@ -1082,6 +1237,20 @@ def check_all_command_guards(command: str, env_type: str,
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
+
+    # Deterministic safe-inspection allowlist: these commands are read-only by
+    # construction and should not ask the human to act as a technical safety
+    # reviewer.  Keep this after hardline/sudo guards so catastrophic patterns
+    # remain blocked, and before Tirith/dangerous-pattern prompts so benign
+    # python -c schema probes don't stall gateway sessions.
+    safe_inspection_class = _known_safe_local_inspection(command, env_type)
+    if safe_inspection_class:
+        return {
+            "approved": True,
+            "message": None,
+            "auto_allowed": True,
+            "auto_allow_class": safe_inspection_class,
+        }
 
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1621,6 +1621,15 @@ approvals:
 
 Smart mode is particularly useful for reducing approval fatigue — it lets the agent work more autonomously on safe operations while still catching genuinely destructive commands.
 
+Hermes also has a small deterministic safe-inspection allowlist that applies before manual or smart approval prompts. This is not YOLO mode: hardline blocks and destructive patterns still apply. The current allowlist covers read-only SQLite schema inspection through local `python -c` or simple Python heredoc snippets when all of these are true:
+
+- the SQLite connection URI uses `mode=ro` and/or `immutable=1`, with `uri=True`
+- the script enables `PRAGMA query_only = ON`
+- SQL is limited to schema metadata: `sqlite_master`, `PRAGMA table_info(...)`, or `PRAGMA schema_version`
+- there are no table row reads, writes, migrations, `VACUUM`, `ATTACH`, secrets/env access, network modules, or filesystem mutation calls
+
+Routine read-only commands such as `git status`, `git diff`, `git log`, `git show`, `git branch --show-current`, `py_compile`, targeted tests, full test suites, static grep/search, read-only helper imports, and `/tmp` inspection output are expected to run without human approval unless they include a separately flagged dangerous construct. Authority-level actions still require the user: commits, pushes, merges, deletes/moves, branch deletion, `git clean`, `git reset`, force-push, `.env`/secrets/config/Railway changes, DB writes/schema/storage mutation, raw X export changes, app runtime startup, Telegram/runtime/external-service actions, and ambiguous product decisions.
+
 :::warning
 Setting `approvals.mode: off` disables all safety checks for terminal commands. Only use this in trusted, sandboxed environments.
 :::


### PR DESCRIPTION
## Summary
- Auto-allows only deterministic read-only SQLite schema inspection through narrowly recognized Python `-c` / simple heredoc patterns.
- Keeps hardline and sudo guards ahead of the allowlist, so destructive constructs are still blocked before any safe-inspection classification.
- Leaves writes, mutations, destructive commands, runtime startup, config/secrets/Railway changes, and other risky actions blocked behind existing approval paths.
- Does not auto-allow row-content database reads; metadata-only `sqlite_master` / supported `PRAGMA` inspection is the limit.
- Preserves owner authority for commit, push, merge, delete, config, runtime, and other high-authority actions.

## Tests
- `python3 -m pytest tests/tools/test_approval.py tests/acp/test_approval_isolation.py -q`
- `python3 -m py_compile tools/approval.py`
- `git diff --check`

## Runtime / gateway follow-up
- One runtime/gateway smoke is needed after merge and restart to verify the Telegram approval UX no longer prompts for the deterministic schema-only inspection path.
