### PR TITLE
fix(gateway): force plugin discovery before adapter creation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -184,6 +184,25 @@ def _is_transient_network_error(exc: BaseException) -> bool:
     return False
 
 
+def _discover_gateway_plugins_for_startup() -> None:
+    """Force-load plugin adapters before gateway platform creation.
+
+    Gateway config loading can trigger plugin discovery before bundled
+    platform plugins have registered, leaving the global plugin manager in a
+    discovered-but-incomplete state. A non-forced startup discovery then becomes
+    a no-op and platforms such as Discord remain absent from
+    ``platform_registry``. Force a rescan at gateway startup so enabled
+    platforms can always create their bundled/plugin adapters.
+    """
+    try:
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins(force=True)
+    except Exception:
+        logger.warning(
+            "plugin discovery failed at gateway startup", exc_info=True,
+        )
+
+
 def _gateway_loop_exception_handler(
     loop: "asyncio.AbstractEventLoop", context: Dict[str, Any]
 ) -> None:
@@ -4635,13 +4654,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # gateway lazily imports run_agent inside per-request handlers,
         # so the discover_plugins() side-effect in model_tools.py is NOT
         # guaranteed to have run by the time we reach this point.
-        try:
-            from hermes_cli.plugins import discover_plugins
-            discover_plugins()
-        except Exception:
-            logger.warning(
-                "plugin discovery failed at gateway startup", exc_info=True,
-            )
+        _discover_gateway_plugins_for_startup()
 
         # Register declarative shell hooks from cli-config.yaml.  Gateway
         # has no TTY, so consent has to come from one of the three opt-in
@@ -5985,6 +5998,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # ── Plugin-registered platforms (checked first) ───────────────────
         try:
             from gateway.platform_registry import platform_registry
+            if not platform_registry.is_registered(platform.value):
+                _discover_gateway_plugins_for_startup()
             if platform_registry.is_registered(platform.value):
                 adapter = platform_registry.create_adapter(platform.value, config)
                 if adapter is not None:

--- a/tests/gateway/test_gateway_plugin_discovery.py
+++ b/tests/gateway/test_gateway_plugin_discovery.py
@@ -1,0 +1,56 @@
+"""Gateway plugin discovery regression tests."""
+
+
+def test_gateway_startup_forces_plugin_rescan_for_bundled_platforms(monkeypatch):
+    """A stale plugin-manager cache must not hide bundled platform adapters.
+
+    Regression coverage for gateway boots where plugin discovery had already
+    been marked complete before bundled platform adapters registered. Without a
+    forced startup rescan, Discord stays absent from platform_registry and the
+    gateway logs "No adapter available for discord" despite valid Discord
+    dependencies/config.
+    """
+    from gateway.platform_registry import platform_registry
+    from gateway.run import _discover_gateway_plugins_for_startup
+    import hermes_cli.plugins as plugins_mod
+
+    stale_manager = plugins_mod.PluginManager()
+    stale_manager._discovered = True
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", stale_manager)
+    platform_registry.unregister("discord")
+
+    assert not platform_registry.is_registered("discord")
+
+    _discover_gateway_plugins_for_startup()
+
+    assert platform_registry.is_registered("discord")
+
+
+def test_create_adapter_recovers_when_platform_registry_cache_is_stale(monkeypatch):
+    """Direct adapter creation should also recover from stale discovery state."""
+    from gateway.config import GatewayConfig, Platform, PlatformConfig
+    from gateway.platform_registry import platform_registry
+    from gateway.run import GatewayRunner
+    import hermes_cli.plugins as plugins_mod
+
+    stale_manager = plugins_mod.PluginManager()
+    stale_manager._discovered = True
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", stale_manager)
+    platform_registry.unregister("discord")
+
+    runner = GatewayRunner(
+        GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(enabled=True, token="test-token"),
+            }
+        )
+    )
+
+    adapter = runner._create_adapter(
+        Platform.DISCORD,
+        PlatformConfig(enabled=True, token="test-token"),
+    )
+
+    assert adapter is not None
+    assert type(adapter).__name__ == "DiscordAdapter"
+    assert platform_registry.is_registered("discord")


### PR DESCRIPTION
## Summary
- Force gateway plugin discovery at startup so bundled platform adapters are registered before enabled platforms connect.
- Add a defensive plugin rescan in `_create_adapter()` when a plugin platform is missing from `platform_registry`.
- Add regression coverage for stale plugin-manager discovery hiding the bundled Discord adapter.

## Why
After the Discord gateway adapter moved under the bundled platform plugin tree, a gateway process can hit a discovered-but-incomplete plugin-manager state. In that state, a non-forced `discover_plugins()` call is a no-op, `discord` remains absent from `platform_registry`, and startup logs `No adapter available for discord` even though `DISCORD_BOT_TOKEN` and `discord.py` are present.

This makes gateway startup resilient by forcing the startup rescan and by recovering at adapter-creation time as a second guardrail.

## Validation
- `HERMES_HOME=$(mktemp -d /tmp/hermes-test-home.XXXXXX) HERMES_CONFIG_DIR=$HERMES_HOME /opt/venv/bin/python -m pytest tests/gateway/test_gateway_plugin_discovery.py tests/gateway/test_discord_imports.py tests/gateway/test_discord_connect.py -q -o addopts=`
  - `19 passed`
- `/opt/venv/bin/python -m py_compile gateway/run.py tests/gateway/test_gateway_plugin_discovery.py`
- `git diff --check`

## Notes
I reproduced the failure mode locally by forcing the plugin manager into a stale discovered state, unregistering `discord`, and confirming a non-forced discovery leaves Discord unavailable while a forced rescan restores the adapter registration.

This work was done with Hermes Agent.
