### PR TITLE
chore: add krislidimo to AUTHOR_MAP for PR #29775

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1316,6 +1316,7 @@ AUTHOR_MAP = {
     "chenglunhu@gmail.com": "hclsys",  # PR #31985 (TUI /q alias regression test)
     "dearmayo@localhost": "ffr31mr",  # PR #32103 (SubdirectoryHintTracker workspace boundary)
     "TheOnlyMika@users.noreply.github.com": "TheOnlyMika",  # PR #32155 (dashboard XSS + defusedxml)
+    "krislidimo@gmail.com": "krislidimo",  # PR #29775 (tighten Telegram table row-group spacing; drop redundant first bullet)
 }
 
 


### PR DESCRIPTION
Adds AUTHOR_MAP entry for @krislidimo (krislidimo@gmail.com) so the contributor audit passes when #32433 (salvage of #29775) merges. Must land before #32433.