### PR TITLE
fix(disk-cleanup): protect cron/jobs.json from deletion

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -481,6 +481,9 @@ def guess_category(path: Path) -> Optional[str]:
         }:
             return None
         if top == "cron" or top == "cronjobs":
+            # Protect the live cron registry; only output/log files are ephemeral.
+            if path.name == "jobs.json" and len(rel.parts) == 2:
+                return None
             return "cron-output"
         if top == "cache":
             return "temp"


### PR DESCRIPTION
## Summary

`guess_category()` in `disk_cleanup.py` classifies **every** file under `$HERMES_HOME/cron/` and `cronjobs/` as `cron-output`, which gets pruned after 14 days:

```python
if top == "cron" or top == "cronjobs":
    return "cron-output"   # ← catches jobs.json too
```

`cron/jobs.json` is the **live cron registry** — losing it silently deletes all scheduled jobs. It is a persistent config file, not ephemeral output.

**Fix:** Exempt `jobs.json` when it sits at depth 2 (direct child of `cron/`). All other files under `cron/` remain classified as ephemeral output.

```python
if top == "cron" or top == "cronjobs":
    if path.name == "jobs.json" and len(rel.parts) == 2:
        return None   # protected registry
    return "cron-output"
```

## Test plan

- [ ] Create `$HERMES_HOME/cron/jobs.json` and a dummy `$HERMES_HOME/cron/run_12345.log`
- [ ] Run cleanup with age > 14 days simulated
- [ ] `jobs.json` is **not** deleted; `run_12345.log` is deleted

Closes #32164

🤖 Contributed via [Claude Code](https://claude.ai/claude-code)