### PR TITLE
fix(gateway): populate source.is_bot in Telegram adapter

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5721,6 +5721,7 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id=thread_id_str,
             chat_topic=chat_topic,
             message_id=str(message.message_id),
+            is_bot=getattr(user, "is_bot", False),
         )
         
         # Extract reply context if this message is a reply.


### PR DESCRIPTION
## Summary

The Telegram adapter's `build_source()` call never passed `is_bot`, so `source.is_bot` was always `False` for every incoming Telegram message. As a result, messages from bots bypassed the `is_bot` auth filter and could trigger the agent loop.

Compare to Discord and Slack adapters which correctly set this field:
```python
# discord.py
is_bot=getattr(message.author, "bot", False),

# slack.py  
is_bot = bool(msg.get("bot_id")) or msg.get("subtype") == "bot_message"
```

**Fix:** Pass `is_bot=getattr(user, "is_bot", False)` to `build_source()`. Using `getattr` keeps the call safe when `user` is `None` (channel posts, anonymous group senders).

## Test plan

- [ ] Send a message from a bot account to a Telegram chat monitored by Hermes
- [ ] Confirm the agent does **not** respond (bot message filtered)
- [ ] Send a message from a human account → agent responds normally
- [ ] Confirm `source.is_bot` is `True` in session logs for bot senders

Closes #32188

🤖 Contributed via [Claude Code](https://claude.ai/claude-code)