### PR TITLE
fix(install): auto-recover install.sh update path from stale remote-tracking refs (#32384)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1206,7 +1206,33 @@ clone_repo() {
                 autostash_ref="stash@{0}"
             fi
 
-            git fetch origin
+            # Capture fetch output while still streaming to the terminal so a
+            # stale remote-tracking ref ("fatal: bad object
+            # refs/remotes/origin/<branch>") can be detected and auto-recovered
+            # via `git remote prune origin`. Without this, install.sh aborts
+            # under `set -e` and the user is left with a partly-fetched repo
+            # that even a re-run of install.sh cannot recover from — see #32384.
+            # `tee` always succeeds, so check ${PIPESTATUS[0]} for git's exit
+            # code rather than the pipeline's overall status.
+            local fetch_log
+            fetch_log=$(mktemp 2>/dev/null || mktemp -t hermes-install-fetch)
+            git fetch origin 2>&1 | tee "$fetch_log" || true
+            local fetch_rc=${PIPESTATUS[0]}
+            if [ "$fetch_rc" -ne 0 ]; then
+                if grep -q "bad object refs/remotes/origin/" "$fetch_log"; then
+                    rm -f "$fetch_log"
+                    log_warn "Detected stale remote-tracking ref; running 'git remote prune origin' and retrying..."
+                    git remote prune origin
+                    git fetch origin
+                    log_success "Stale refs cleaned up; fetch succeeded."
+                else
+                    rm -f "$fetch_log"
+                    log_error "git fetch origin failed"
+                    exit 1
+                fi
+            else
+                rm -f "$fetch_log"
+            fi
             git checkout "$BRANCH"
             git pull --ff-only origin "$BRANCH"
 

--- a/tests/test_install_sh_stale_remote_ref_recovery.py
+++ b/tests/test_install_sh_stale_remote_ref_recovery.py
@@ -1,0 +1,251 @@
+"""Regression for #32384: install.sh recovers from stale remote-tracking refs.
+
+When a remote branch is force-pushed or a dependabot/PR ref is rewritten
+upstream, ``$INSTALL_DIR/.git/refs/remotes/origin/<branch>`` can be left
+pointing at an object that no longer exists. The next ``git fetch origin``
+inside install.sh's ``clone_repo`` update path then aborts with::
+
+    fatal: bad object refs/remotes/origin/<branch>
+    error: ... did not send all necessary objects
+
+Because install.sh runs under ``set -e``, that single fetch failure tears
+the whole installer down — including the ``install.sh`` re-run the user is
+typically told to use to recover from a failed ``hermes update``.
+
+install.sh now detects ``bad object refs/remotes/origin/`` in fetch output,
+runs ``git remote prune origin`` once, and retries the fetch. This mirrors
+the equivalent recovery in ``hermes_cli/main.py::_cmd_update_impl`` (the
+``hermes update`` path) so both update surfaces survive a stale-ref
+upstream rewrite.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_update_fetch_block() -> str:
+    """Return the install.sh block that runs `git fetch origin` and recovers
+    from a stale-ref error. Bounded by the autostash setup above and the
+    `git checkout "$BRANCH"` line below — both are stable structural anchors.
+    """
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        r"(?P<block>local fetch_log.*?git checkout \"\$BRANCH\")",
+        text,
+        re.DOTALL,
+    )
+    assert match is not None, (
+        "Could not locate the fetch-with-stale-ref-recovery block in "
+        "scripts/install.sh (between `local fetch_log` and "
+        "`git checkout \"$BRANCH\"`)."
+    )
+    return match["block"]
+
+
+def test_install_sh_fetch_block_invokes_prune_on_stale_ref_error() -> None:
+    """Static guard: the recovery branch must run `git remote prune origin`
+    and a second `git fetch origin` after detecting `bad object
+    refs/remotes/origin/`. The two-step prune-then-retry shape is what makes
+    the recovery idempotent."""
+    block = _extract_update_fetch_block()
+    assert "bad object refs/remotes/origin/" in block, (
+        "fetch block must grep for the exact stale-ref error string; otherwise "
+        "the recovery branch never triggers."
+    )
+    assert "git remote prune origin" in block, (
+        "fetch block must run `git remote prune origin` to clear the stale "
+        "remote-tracking refs."
+    )
+    # Both fetch calls must be present — the initial one (which fails) and the
+    # retry after prune.
+    assert block.count("git fetch origin") >= 2, (
+        "fetch block must retry `git fetch origin` after prune; otherwise the "
+        "user still hits the bad-object error."
+    )
+    assert "${PIPESTATUS[0]}" in block, (
+        "fetch block must check ${PIPESTATUS[0]} for git's exit code rather "
+        "than the pipeline's overall status — `tee` always succeeds."
+    )
+
+
+def test_install_sh_recovers_from_stale_remote_ref(tmp_path: Path) -> None:
+    """Behavioral repro: drive the extracted fetch block with a fake `git`
+    that fails the first fetch with the canonical stale-ref error, then
+    succeeds after `git remote prune origin`. The block must:
+
+      * detect the stale-ref error,
+      * invoke `git remote prune origin` exactly once,
+      * retry `git fetch origin` exactly once,
+      * exit 0.
+    """
+    calls = tmp_path / "calls"
+    state = tmp_path / "fetch_count"
+    state.write_text("0")
+
+    fake_git = tmp_path / "git"
+    fake_git.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/bash
+            # Log every invocation (one args-line per call) so the test can
+            # assert ordering.
+            echo "$*" >> {calls!s}
+            case "$1" in
+                fetch)
+                    if [ "$2" = "origin" ]; then
+                        count=$(cat {state!s})
+                        if [ "$count" = "0" ]; then
+                            echo "1" > {state!s}
+                            echo "fatal: bad object refs/remotes/origin/bb/tui-ctrlj-newline" >&2
+                            exit 128
+                        fi
+                        exit 0
+                    fi
+                    exit 0
+                    ;;
+                remote)
+                    # `git remote prune origin` — succeed silently.
+                    exit 0
+                    ;;
+                *)
+                    exit 0
+                    ;;
+            esac
+            """
+        )
+    )
+    fake_git.chmod(fake_git.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+
+    block = _extract_update_fetch_block()
+
+    # Minimal harness that defines the log_* helpers and a stripped-down
+    # variable shape (BRANCH, etc.) used by the block. The block uses
+    # `local`, so it must run inside a function — wrap it in `_run_block()`
+    # to match install.sh's `clone_repo()` context. The fake `git` is
+    # exposed via PATH.
+    harness = textwrap.dedent(
+        """\
+        set -e
+        log_info()    { echo "[info] $1"; }
+        log_warn()    { echo "[warn] $1"; }
+        log_error()   { echo "[error] $1"; }
+        log_success() { echo "[ok] $1"; }
+        BRANCH=main
+        _run_block() {
+        """
+    ) + block + "\n}\n_run_block\n"
+
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
+    }
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, (
+        f"install.sh fetch block exited {result.returncode} — recovery did not "
+        f"complete.\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+    call_lines = calls.read_text().splitlines()
+    fetch_calls = [c for c in call_lines if c.startswith("fetch origin")]
+    prune_calls = [c for c in call_lines if c.startswith("remote prune origin")]
+
+    assert len(fetch_calls) == 2, (
+        f"expected exactly 2 `git fetch origin` calls (initial + retry); "
+        f"got {len(fetch_calls)}. calls={call_lines}"
+    )
+    assert len(prune_calls) == 1, (
+        f"expected exactly 1 `git remote prune origin` call; got "
+        f"{len(prune_calls)}. calls={call_lines}"
+    )
+    # Order: fetch (fail) → prune → fetch (retry).
+    fetch_idxs = [i for i, c in enumerate(call_lines) if c.startswith("fetch origin")]
+    prune_idx = next(
+        i for i, c in enumerate(call_lines) if c.startswith("remote prune origin")
+    )
+    assert fetch_idxs[0] < prune_idx < fetch_idxs[1], (
+        f"call order must be fetch → prune → fetch; got {call_lines}"
+    )
+    assert "Stale refs cleaned up" in result.stdout, (
+        f"recovery success message missing — user would not see that "
+        f"install.sh recovered transparently. stdout={result.stdout}"
+    )
+
+
+def test_install_sh_unrelated_fetch_error_still_aborts(tmp_path: Path) -> None:
+    """Negative test: a non-stale-ref fetch failure (e.g. network) must still
+    cause install.sh to abort with exit 1, not silently retry. Otherwise the
+    recovery branch over-applies and masks real errors."""
+    calls = tmp_path / "calls"
+    fake_git = tmp_path / "git"
+    fake_git.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/bin/bash
+            echo "$*" >> {calls!s}
+            if [ "$1 $2" = "fetch origin" ]; then
+                echo "fatal: unable to access 'https://github.com/...': Could not resolve host: github.com" >&2
+                exit 128
+            fi
+            exit 0
+            """
+        )
+    )
+    fake_git.chmod(fake_git.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP)
+
+    block = _extract_update_fetch_block()
+    harness = textwrap.dedent(
+        """\
+        set -e
+        log_info()    { echo "[info] $1"; }
+        log_warn()    { echo "[warn] $1"; }
+        log_error()   { echo "[error] $1"; }
+        log_success() { echo "[ok] $1"; }
+        BRANCH=main
+        _run_block() {
+        """
+    ) + block + "\n}\n_run_block\n"
+
+    env = {
+        **os.environ,
+        "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
+    }
+    result = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode != 0, (
+        "block must abort on non-stale-ref fetch errors — otherwise it masks "
+        "real network/auth failures.\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    call_lines = calls.read_text().splitlines()
+    fetch_calls = [c for c in call_lines if c.startswith("fetch origin")]
+    prune_calls = [c for c in call_lines if c.startswith("remote prune origin")]
+    assert len(fetch_calls) == 1, (
+        f"network errors must NOT trigger a retry; got {len(fetch_calls)} "
+        f"fetch calls. calls={call_lines}"
+    )
+    assert len(prune_calls) == 0, (
+        f"network errors must NOT run `git remote prune origin`; got "
+        f"{len(prune_calls)} prune calls. calls={call_lines}"
+    )


### PR DESCRIPTION
## What does this PR do?

When a remote branch is force-pushed or a dependabot/PR ref is rewritten upstream, `$INSTALL_DIR/.git/refs/remotes/origin/<branch>` can be left pointing at an object that no longer exists. The next `git fetch origin` inside `clone_repo`'s update path then exits 128 with:

```
fatal: bad object refs/remotes/origin/<branch>
error: ... did not send all necessary objects
```

Because `scripts/install.sh` runs under `set -e`, that single fetch failure tears the whole installer down — including the `bash install.sh` re-run users are typically told to use to recover from a failed `hermes update`. Exactly this happens in #32384: the user's `hermes update` died on `fatal: bad object refs/remotes/origin/bb/tui-ctrlj-newline`, leaving a broken venv (`ModuleNotFoundError: No module named 'hermes_cli'`), and then `bash install.sh` *also* aborted on the same stale-ref error, leaving them with no recovery path short of manual `git update-ref -d` surgery.

`clone_repo` now captures fetch output through `tee` (so the user still sees live progress), checks `${PIPESTATUS[0]}` for git's exit code, and on a `bad object refs/remotes/origin/` error runs `git remote prune origin` once and retries the fetch. Non-stale-ref failures (network, auth, etc.) still abort with exit 1 so real errors aren't masked.

Mirrors the equivalent recovery on the `hermes_cli/main.py::_cmd_update_impl` side from #27299 (the `hermes update` surface), so both update entry points survive a stale-ref upstream rewrite. The two surfaces are orthogonal: #27299 keeps `hermes update` working; this PR keeps `install.sh` working as the documented recovery escape hatch when something else has already corrupted the local refs.

## Related Issue

Fixes #32384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/install.sh` — wrap the `git fetch origin` call in `clone_repo`'s update branch with a stale-ref detector that runs `git remote prune origin` and retries the fetch when it sees `fatal: bad object refs/remotes/origin/`. Non-matching failures still exit 1.
- `tests/test_install_sh_stale_remote_ref_recovery.py` — three regression tests: (1) static guard that the recovery block contains the prune + retry shape and checks `${PIPESTATUS[0]}`, (2) behavioral test driving the extracted block with a fake `git` that fails-then-succeeds and asserts the exact `fetch → prune → fetch` call sequence, (3) negative test that an unrelated `Could not resolve host` failure still aborts with no prune or retry.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/test_install_sh_stale_remote_ref_recovery.py -v` — 3 passes.
2. To simulate the failure manually:
   ```bash
   cd ~/.hermes/hermes-agent   # or wherever Hermes is installed
   # Create a fake stale ref pointing at a non-existent object
   echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > .git/refs/remotes/origin/bb-stale-test
   bash /path/to/this/branch/scripts/install.sh
   # Should see: "⚠ Detected stale remote-tracking ref; running 'git remote prune origin' and retrying..."
   # followed by "✓ Stale refs cleaned up; fetch succeeded."
   ```
3. Adjacent suite: `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/test_install_sh_symlink_stomp.py tests/test_install_sh_pythonpath_sanitization.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_browser_install.py tests/test_install_sh_termux_network_prereqs.py -v` — all 17 still pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal recovery path)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `install.sh` is Linux/macOS/Termux only (the Windows installer is `install.ps1`); `mktemp` fallback handles both GNU and BSD invocations.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- #27299 (open) — auto-recovers from the same stale-ref error in `_cmd_update_impl` (the `hermes update` surface). This PR is the orthogonal `scripts/install.sh` half of the same root cause. The issue body for #32384 explicitly shows both surfaces failing, so both fixes are needed to fully close it.

> Audited siblings: confirmed `git pull --ff-only origin "$BRANCH"` running after the recovered fetch picks up the cleaned ref table (the stale refs were the only blocker), so no separate guard is needed on the pull line. The Windows installer (`install.ps1`) does not use a `git fetch`/`git pull` update path, so it has no equivalent recovery surface.

## Screenshots / Logs

Before (from #32384):

```
→ Existing installation found, updating...
remote: Enumerating objects: 3136, done.
...
Resolving deltas: 100% (2000/2000), completed with 867 local objects.
fatal: bad object refs/remotes/origin/bb/tui-ctrlj-newline
error: https://github.com/NousResearch/hermes-agent.git did not send all necessary objects
# install.sh exits, no recovery, user is stuck
```

After (this PR):

```
→ Existing installation found, updating...
remote: Enumerating objects: 3136, done.
...
fatal: bad object refs/remotes/origin/bb/tui-ctrlj-newline
⚠ Detected stale remote-tracking ref; running 'git remote prune origin' and retrying...
✓ Stale refs cleaned up; fetch succeeded.
# install.sh continues normally
```