### PR TITLE
fix(xai-oauth): strip service_tier and add gated slash-enum safety-net (#28490)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -825,6 +825,26 @@ def _preflight_codex_api_kwargs(
     elif "stream" in api_kwargs:
         raise ValueError("Codex Responses stream flag is only allowed in fallback streaming requests.")
 
+    # Safety-net sanitization for xAI Responses (#28490): defense-in-depth
+    # for the same slash-enum strip that ``chat_completion_helpers`` and
+    # ``auxiliary_client`` apply at request-build time.  If a future code
+    # path forgets to sanitize before calling us, this catches the bypass
+    # so xAI doesn't 400 with ``Invalid arguments passed to the model``
+    # (HuggingFace IDs like ``Qwen/Qwen3.5-0.8B`` from MCP tool schemas).
+    #
+    # Gated on the model name pattern because native Codex (OpenAI) DOES
+    # accept slash-containing enum values — stripping them there would
+    # silently degrade tool-schema constraints.  xAI is the only
+    # Responses-API surface that rejects the shape.
+    model_name_for_provider_check = str(api_kwargs.get("model") or "").lower()
+    is_xai_model = model_name_for_provider_check.startswith(("grok-", "x-ai/grok-"))
+    if is_xai_model and normalized.get("tools"):
+        try:
+            from tools.schema_sanitizer import strip_slash_enum
+            normalized["tools"], _ = strip_slash_enum(normalized["tools"])
+        except Exception:
+            pass  # Best-effort — the caller-level sanitization should have handled it
+
     unexpected = sorted(key for key in api_kwargs if key not in allowed_keys)
     if unexpected:
         raise ValueError(

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -144,6 +144,17 @@ class ResponsesApiTransport(ProviderTransport):
         if request_overrides:
             kwargs.update(request_overrides)
 
+        # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
+        # supported: service_tier") — hit when ``/fast`` priority-processing
+        # mode lingers from a prior model in the same session, or when a
+        # user explicitly sets ``agent.service_tier`` in config.yaml.  The
+        # main-loop guard (``resolve_fast_mode_overrides`` only returns
+        # ``service_tier`` for OpenAI fast-eligible models) doesn't cover
+        # those leak paths, so strip defensively when targeting xAI.  See
+        # #28490 for the original report.
+        if is_xai_responses:
+            kwargs.pop("service_tier", None)
+
         # Forward per-request timeout to the SDK so OpenAI/Anthropic clients
         # honor it.  Without this, ``providers.<id>.request_timeout_seconds``
         # is silently dropped on the main agent Codex path while the

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -242,6 +242,7 @@ AUTHOR_MAP = {
     "harryykyle1@gmail.com": "hharry11",
     "wysie@users.noreply.github.com": "wysie",
     "ronhi@buildabear1.localdomain": "RonHillDev",  # PR #29523 salvage (machine-local commit email)
+    "hello@nami4d.tech": "Nami4D",  # PR #28490 salvage
     "jkausel@gmail.com": "jkausel-ai",
     "e.silacandmr@gmail.com": "Es1la",
     "51599529+stephen0110@users.noreply.github.com": "stephen0110",

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -513,3 +513,145 @@ class TestCodexTransportTimeout:
             request_overrides={"timeout": 450.0},
         )
         assert kw.get("timeout") == 450.0
+
+
+class TestCodexTransportXaiServiceTierStrip:
+    """xAI Responses API rejects ``service_tier`` (#28490).
+
+    ``resolve_fast_mode_overrides`` only returns ``service_tier`` for
+    OpenAI fast-eligible models, so on paper the field should never
+    reach a Grok request.  But ``self.service_tier`` lingers across
+    model switches and can also be set directly via ``agent.service_tier``
+    in config.yaml — both leak paths plumb through ``request_overrides``
+    and would 400 against xAI's ``/v1/responses``.
+    Strip defensively when targeting xAI.
+    """
+
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    def test_xai_strips_service_tier_from_request_overrides(self, transport):
+        """Headline #28490 case: service_tier=priority leaks through
+        request_overrides, must not reach the xAI request body."""
+        kw = transport.build_kwargs(
+            model="grok-4.3",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=True,
+            request_overrides={"service_tier": "priority"},
+        )
+        assert "service_tier" not in kw, (
+            f"service_tier must be stripped on xAI requests, "
+            f"got {kw.get('service_tier')!r}"
+        )
+
+    def test_non_xai_codex_preserves_service_tier(self, transport):
+        """The strip is xAI-only — native Codex DOES accept
+        service_tier=priority (OpenAI Priority Processing).  Stripping
+        it elsewhere would silently disable the user's fast-mode opt-in.
+        """
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_xai_responses=False,
+            is_codex_backend=True,
+            request_overrides={"service_tier": "priority"},
+        )
+        assert kw.get("service_tier") == "priority", (
+            "non-xAI codex_responses providers must keep service_tier"
+        )
+
+    def test_github_responses_preserves_service_tier(self, transport):
+        """GitHub Models (Copilot) is another codex_responses surface
+        that should not be affected by the xAI strip."""
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_github_responses=True,
+            request_overrides={"service_tier": "priority"},
+        )
+        assert kw.get("service_tier") == "priority"
+
+
+class TestPreflightSlashEnumStrip:
+    """xAI Responses safety-net: strip slash-containing enum values
+    when the model name indicates a Grok target (#28490).
+
+    Native Codex accepts ``/``-containing enums; xAI rejects them with
+    HTTP 400 "Invalid arguments passed to the model".  The main agent
+    loop and the auxiliary client already sanitize at request-build
+    time; this preflight catches any future code path that bypasses
+    those — gated on model name so we don't unnecessarily strip on
+    non-xAI providers.
+    """
+
+    def _make_kwargs(self, model: str, enum_values: list[str]) -> dict:
+        return {
+            "model": model,
+            "instructions": "test",
+            "input": [{"role": "user", "content": "hi"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "pick_model",
+                    "description": "pick a model",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "model_id": {
+                                "type": "string",
+                                "enum": enum_values,
+                            },
+                        },
+                    },
+                },
+            ],
+        }
+
+    def test_grok_model_strips_slash_enum_values(self):
+        """When the model name is Grok-family, slash-containing enum
+        values are stripped so xAI doesn't 400 on the tool schema."""
+        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+        kwargs = self._make_kwargs(
+            "grok-4.3",
+            ["Qwen/Qwen3.5-0.8B", "openai/gpt-oss-20b", "plain-id"],
+        )
+        result = _preflight_codex_api_kwargs(kwargs)
+        # The enum keyword itself is stripped (per strip_slash_enum's
+        # semantics — it removes the constraint entirely when any value
+        # contains /).
+        params = result["tools"][0]["parameters"]
+        assert "enum" not in params["properties"]["model_id"], (
+            "slash-containing enum must be stripped on Grok"
+        )
+
+    def test_aggregator_prefixed_grok_also_strips(self):
+        """Aggregator-prefixed (x-ai/grok-*) names hit the same path."""
+        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+        kwargs = self._make_kwargs(
+            "x-ai/grok-4.3",
+            ["Qwen/Qwen3.5-0.8B"],
+        )
+        result = _preflight_codex_api_kwargs(kwargs)
+        assert "enum" not in result["tools"][0]["parameters"]["properties"]["model_id"]
+
+    def test_non_grok_model_preserves_slash_enum_values(self):
+        """Native Codex / GitHub Models DO accept slash-containing
+        enums.  The safety-net must NOT strip there or we silently
+        degrade tool-schema constraints on every codex_responses
+        provider that isn't xAI."""
+        from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+        kwargs = self._make_kwargs(
+            "gpt-5.5",
+            ["Qwen/Qwen3.5-0.8B", "plain-id"],
+        )
+        result = _preflight_codex_api_kwargs(kwargs)
+        params = result["tools"][0]["parameters"]
+        # The enum must survive on non-xAI providers.
+        assert params["properties"]["model_id"].get("enum") == [
+            "Qwen/Qwen3.5-0.8B", "plain-id"
+        ]


### PR DESCRIPTION
## Summary

xAI Responses API requests no longer 400 with `"Argument not supported: service_tier"` when `/fast` (Priority Processing) state lingers from a prior model switch, and the preflight gains a defense-in-depth slash-enum strip gated on Grok model names.

Salvages PR #28490 (@Nami4D) + tightens the slash-enum scope so we don't silently degrade tool-schema constraints on non-xAI providers.

## Two fixes

### 1. `service_tier` strip in `transports/codex.py:build_kwargs`

xAI's `/v1/responses` rejects `service_tier` outright. On paper `resolve_fast_mode_overrides` only emits `service_tier` for OpenAI fast-eligible models, so on paper it should never reach a Grok request. But two real leak paths exist:

- Stale `self.service_tier` on the agent that persists across model switches in the same session.
- Direct `agent.service_tier: priority` in `config.yaml` plumbing through unchanged.

Strip defensively when `is_xai_responses=True`. Native Codex / GitHub Models / etc. keep their `service_tier` untouched.

### 2. Slash-enum safety-net in `codex_responses_adapter._preflight_codex_api_kwargs`

xAI rejects tool schemas whose `enum` keyword carries slash-containing values (`Qwen/Qwen3.5-0.8B`, `openai/gpt-oss-20b` — common from MCP servers). The main agent loop (`chat_completion_helpers.py:483-490`) and the auxiliary client (`auxiliary_client.py:710-719`) both already sanitize, but a future bypass path would silently 400.

The preflight runs on every codex_responses request — adding the strip there catches any future bypass. **Critically gated on the model name pattern** (`grok-` / `x-ai/grok-`) because:

- Native OpenAI Codex DOES accept slash-containing enums.
- Stripping the enum keyword removes the constraint entirely; the model can then generate any string.
- An un-gated strip would silently degrade tool-schema correctness on every codex_responses provider that isn't xAI.

## Changes vs. @Nami4D's original

1. Resolved a merge conflict in `transports/codex.py` (a timeout-forwarding block landed on main between the PR's branch point and now).
2. Added the model-name gate around the slash-enum strip (the original PR stripped on all codex_responses requests).
3. Six new regression tests covering both fixes and both directions (strip-applies-to-xAI + strip-doesn't-apply-elsewhere).

## Validation

```
scripts/run_tests.sh tests/agent/transports/test_codex_transport.py
=== 51 tests passed, 0 failed in 1.1s ===
```

| Test class | Tests | Locks in |
|---|---|---|
| `TestCodexTransportXaiServiceTierStrip` | 3 | xAI strips `service_tier`; native Codex + GitHub Models keep it |
| `TestPreflightSlashEnumStrip` | 3 | Grok + aggregator-prefixed Grok strip slash enums; non-Grok models preserve them |

## Credit

@Nami4D diagnosed both bugs against api.x.ai with 23 request variants, identified the right intervention points, and shipped a working patch. Salvage just adds the model-name gate to the second fix (to avoid affecting non-xAI providers) and locks the contract in with tests.
