### PR TITLE
fix(cli): restore fallback paste collapse + handle long single-line pastes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13352,7 +13352,10 @@ class HermesCLI:
                 line_count = pasted_text.count('\n')
                 buf = event.current_buffer
                 threshold = self.config.get("paste_collapse_threshold", 5)
-                if threshold > 0 and line_count >= threshold and not buf.text.strip().startswith('/'):
+                char_threshold = self.config.get("paste_collapse_char_threshold", 2000)
+                lines_hit = threshold > 0 and line_count >= threshold
+                chars_hit = char_threshold > 0 and len(pasted_text) >= char_threshold
+                if (lines_hit or chars_hit) and not buf.text.strip().startswith('/'):
                     _paste_counter[0] += 1
                     paste_dir = _hermes_home / "pastes"
                     paste_dir.mkdir(parents=True, exist_ok=True)
@@ -13521,8 +13524,11 @@ class HermesCLI:
             newlines_added = line_count - _prev_newline_count[0]
             _prev_newline_count[0] = line_count
             is_paste = chars_added > 1 or newlines_added >= 4
-            threshold = self.config.get("paste_collapse_threshold_fallback", 0)
-            if threshold > 0 and line_count >= threshold and is_paste and not text.startswith('/'):
+            threshold = self.config.get("paste_collapse_threshold_fallback", 5)
+            char_threshold = self.config.get("paste_collapse_char_threshold", 2000)
+            lines_hit = threshold > 0 and line_count >= threshold
+            chars_hit = char_threshold > 0 and len(text) >= char_threshold
+            if (lines_hit or chars_hit) and is_paste and not text.startswith('/'):
                 _paste_counter[0] += 1
                 paste_dir = _hermes_home / "pastes"
                 paste_dir.mkdir(parents=True, exist_ok=True)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1905,13 +1905,25 @@ DEFAULT_CONFIG = {
     },
 
     # Paste collapse thresholds (TUI + CLI).
-    # collapse_threshold: paste collapses to a file reference when line count
-    #   exceeds this value (bracketed paste, safe: appends to existing text).
-    # collapse_threshold_fallback: same but for the fallback heuristic used
-    #   by terminals without bracketed paste support (destructive: replaces
-    #   entire buffer).  0 = disabled.
+    #
+    # paste_collapse_threshold (default 5)
+    #   Bracketed-paste handler. Pastes with this many newlines or more
+    #   collapse to a file reference. Set 0 to disable.
+    #
+    # paste_collapse_threshold_fallback (default 5)
+    #   Fallback heuristic for terminals without bracketed paste support.
+    #   Same line count test but heuristically gated by chars-added /
+    #   newlines-added to avoid false positives from normal typing.
+    #   Set 0 to disable.
+    #
+    # paste_collapse_char_threshold (default 2000)
+    #   Long single-line paste guard. Pastes whose total char length
+    #   reaches this value collapse to a file reference even if line
+    #   count is below the line threshold. Catches the "8000 chars of
+    #   minified JSON / log output on one line" case. Set 0 to disable.
     "paste_collapse_threshold": 5,
-    "paste_collapse_threshold_fallback": 0,
+    "paste_collapse_threshold_fallback": 5,
+    "paste_collapse_char_threshold": 2000,
 
 
     # Config schema version - bump this when adding new required fields

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -106,6 +106,7 @@ export interface UiState {
   inlineDiffs: boolean
   mouseTracking: MouseTrackingMode
   pasteCollapseLines: number
+  pasteCollapseChars: number
 
   sections: SectionVisibility
   showCost: boolean

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -18,6 +18,7 @@ const buildUiState = (): UiState => ({
   inlineDiffs: true,
   mouseTracking: MOUSE_TRACKING,
   pasteCollapseLines: 5,
+  pasteCollapseChars: 2000,
   sections: {},
   showCost: false,
   showReasoning: false,

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -190,8 +190,11 @@ export function useComposerState({
 
       const lineCount = cleanedText.split('\n').length
       const pasteCollapseLines = getUiState().pasteCollapseLines
+      const pasteCollapseChars = getUiState().pasteCollapseChars
+      const linesHit = pasteCollapseLines > 0 && lineCount >= pasteCollapseLines
+      const charsHit = pasteCollapseChars > 0 && cleanedText.length >= pasteCollapseChars
 
-      if (pasteCollapseLines === 0 || lineCount < pasteCollapseLines) {
+      if (!linesHit && !charsHit) {
         return {
           cursor: cursor + cleanedText.length,
           value: value.slice(0, cursor) + cleanedText + value.slice(cursor)

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -153,6 +153,17 @@ const _pasteCollapseLinesFromConfig = (cfg: ConfigFullResponse | null): number =
   return 5
 }
 
+const _pasteCollapseCharsFromConfig = (cfg: ConfigFullResponse | null): number => {
+  if (!cfg?.config) return 2000
+  const raw = cfg.config.paste_collapse_char_threshold
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) return Math.round(raw)
+  if (typeof raw === 'string') {
+    const n = parseInt(raw, 10)
+    if (Number.isFinite(n) && n >= 0) return n
+  }
+  return 2000
+}
+
 /** Fetch ``config.get full`` and fan the result through ``applyDisplay``.
  *
  * Extracted so the mtime-reload path can be exercised by the test
@@ -200,6 +211,7 @@ export const applyDisplay = (
     inlineDiffs: d.inline_diffs !== false,
     mouseTracking: normalizeMouseTracking(d),
     pasteCollapseLines: _pasteCollapseLinesFromConfig(cfg),
+    pasteCollapseChars: _pasteCollapseCharsFromConfig(cfg),
     sections: resolveSections(d.sections),
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -82,7 +82,7 @@ export interface ConfigVoiceConfig {
 }
 
 export interface ConfigFullResponse {
-  config?: { display?: ConfigDisplayConfig; voice?: ConfigVoiceConfig; paste_collapse_threshold?: number }
+  config?: { display?: ConfigDisplayConfig; voice?: ConfigVoiceConfig; paste_collapse_threshold?: number; paste_collapse_char_threshold?: number }
 }
 
 export interface ConfigMtimeResponse {


### PR DESCRIPTION
Follow-up to #32087 after community report from @ethernet that 8000-char single-line pastes get dumped raw into the input box.

> **ethernet — 8:10 AM**
> this one seems to have removed the long-paste detection for long single line stuff... if there's no newlines in like 8000 chars itll just dump it right in the textbox

Two things in one commit, since they're tightly coupled to the same paste-handling code path.

## A) Fallback regression revert

`paste_collapse_threshold_fallback`: default `0` → `5`.

#32087 made the fallback handler opt-in (default 0 = disabled). The fallback path has been always-on with `line_count >= 5` since #3065 (March 2026); disabling it by default doesn't match pre-existing behavior for terminals without bracketed paste support (Windows terminals, some SSH setups). Restored to on-by-default.

## B) Long single-line paste guard

New config key: **`paste_collapse_char_threshold`** (default `2000`).

Bracketed-paste handler and fallback handler now BOTH collapse when:
- `line_count >= line_threshold` **OR**
- `total_char_length >= char_threshold`

Catches the case ethernet hit — ~8000 chars of minified JSON / log output on a single line getting dumped raw into the buffer. TUI mirrors the same config via `uiStore.pasteCollapseChars`. Set 0 to disable.

## Defaults

| Key | Default | Notes |
|---|---|---|
| `paste_collapse_threshold` | `5` | unchanged |
| `paste_collapse_threshold_fallback` | `5` | was `0` in #32087, restored to pre-#32087 behavior |
| `paste_collapse_char_threshold` | `2000` | new — single-line guard |

## Validation

- `tests/hermes_cli/test_config.py`: 87/87 pass
- `ui-tui useConfigSync.test.ts`: 34/34 pass
- `ui-tui useComposerState.test.ts`: 9/9 pass
- `tsc`: zero new errors in touched files (interfaces.ts, uiStore.ts, useComposerState.ts, useConfigSync.ts, gatewayTypes.ts)
- `DEFAULT_CONFIG` loads with all three keys at correct defaults

No `_config_version` bump needed — only adding new keys + changing one default, which `_deep_merge` handles correctly on existing user configs.

## Infographic

![long-paste-handling-followup](https://v3b.fal.media/files/b/0a9bb983/MtyWcu9kSCu8GJn_hTqLk_PabG9VYN.png)
