### PR TITLE
fix(cron): clarify schedule is required for create in tool schema

### DIFF
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -566,7 +566,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run"
+                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
             },
             "job_id": {
                 "type": "string",
@@ -578,7 +578,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp"
+                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
             },
             "name": {
                 "type": "string",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -657,7 +657,18 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "description": "Optional absolute path to run the job from. When set, AGENTS.md / CLAUDE.md / .cursorrules from that directory are injected into the system prompt, and the terminal/file/code_exec tools use it as their working directory — useful for running a job inside a specific project repo. Must be an absolute path that exists. When unset (default), preserves the original behaviour: no project context files, tools use the scheduler's cwd. On update, pass an empty string to clear. Jobs with workdir run sequentially (not parallel) to keep per-job directories isolated."
             },
         },
-        "required": ["action"]
+        "required": ["action"],
+        "if": {
+            "properties": {"action": {"const": "create"}},
+            "required": ["action"]
+        },
+        "then": {
+            "required": ["action", "schedule", "prompt"],
+            "properties": {
+                "schedule": {"type": "string"},
+                "prompt": {"type": "string"}
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Grok models omit schedule when calling cronjob action=create (issue #32427).

## Two-layer fix

1. Description text: REQUIRED for action=create
2. JSON Schema if/then conditional required

Fixes #32427