### PR TITLE
fix: correct operator precedence in or-expression truncation (7 locations)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7897,7 +7897,7 @@ class HermesCLI:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -652,7 +652,7 @@ def create_job(
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
     job = {
         "id": job_id,
-        "name": name or label_source[:50].strip(),
+        "name": (name or label_source)[:50].strip(),
         "prompt": prompt_text,
         "skills": normalized_skills,
         "skill": normalized_skills[0] if normalized_skills else None,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10582,7 +10582,7 @@ class GatewayRunner:
             lines.append(t("gateway.personality.none_option"))
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(t("gateway.personality.item", name=name, preview=preview))

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1584,7 +1584,7 @@ class SlashCommandCompleter(Completer):
             for name, prompt in personalities.items():
                 if name.startswith(sub_lower) and name != sub_lower:
                     if isinstance(prompt, dict):
-                        meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                        meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                     else:
                         meta = str(prompt)[:50]
                     yield Completion(

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -383,7 +383,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
-    name = str(job.get("name") or prompt[:50] or (skills[0] if skills else "") or job_id or "cron job")
+    name = str(job.get("name") or prompt or (skills[0] if skills else "") or job_id or "cron job")[:50]
     result = {
         "job_id": job_id,
         "name": name,

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1461,7 +1461,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
             detail = ""
             try:
                 err_body = response.json()
-                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+                detail = (err_body.get("error", {}).get("message", "") or response.text)[:300]
             except Exception:
                 detail = response.text[:300]
             return {

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1431,7 +1431,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         # Surface the API error message when present
         try:
             err = response.json().get("error", {})
-            detail = err.get("message") or response.text[:300]
+            detail = (err.get("message") or response.text)[:300]
         except Exception:
             detail = response.text[:300]
         raise RuntimeError(


### PR DESCRIPTION
## Summary

Fixes operator precedence bug in 7 locations where Python's slice operator `[:N]` binds tighter than `or`, causing only the fallback value to be truncated while the primary value passes through untruncated.

### Bug Pattern

```python
# BEFORE (bug): only system_prompt gets truncated, description passes through at full length
preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]

# AFTER (fixed): truncation applies to whichever value resolves
preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
```

### Files Fixed

| File | Location | Description |
|------|----------|-------------|
| `cli.py` | line 7900 | Personality preview in `/personality` list |
| `gateway/run.py` | line 10585 | Personality preview in gateway help |
| `hermes_cli/commands.py` | line 1587 | Personality preview in autocomplete |
| `cron/jobs.py` | line 655 | Cron job display name |
| `tools/cronjob_tools.py` | line 386 | Cron job display name in `_format_job` |
| `tools/tts_tool.py` | line 1434 | Error detail truncation |
| `tools/transcription_tools.py` | line 1464 | Error detail truncation |

### Impact

- Personality list display could overflow terminal width with long descriptions
- Cron job names could be arbitrarily long in UI display
- Error messages could dump full HTTP response bodies without truncation

### Test Plan

- [x] All 7 modified files pass `py_compile`
- [ ] Manual test: `/personality list` with long description personalities
- [ ] Manual test: cron job creation with long prompts
