### PR TITLE
fix(agent): preserve config context_length when fallback/switch uses same model

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1360,6 +1360,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    _saved_config_ctx = getattr(agent, "_config_context_length", None)
 
     # Clear the per-config context_length override so the new model's
     # actual context window is resolved via get_model_context_length()
@@ -1469,12 +1470,19 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # length normally resolves via config or static catalogs and
         # never hits a probe, but coerce to empty string defensively.
         _ctx_api_key = agent.api_key if isinstance(agent.api_key, str) else ""
+        # If the switched model is the same as the previous model,
+        # restore the user's explicit config override so the resolution
+        # chain doesn't fall through to DEFAULT_FALLBACK_CONTEXT (256K).
+        # See #32423.
+        _effective_config_ctx = getattr(agent, "_config_context_length", None)
+        if _saved_config_ctx and new_model == old_model:
+            _effective_config_ctx = _saved_config_ctx
         new_context_length = get_model_context_length(
             agent.model,
             base_url=agent.base_url,
             api_key=_ctx_api_key,
             provider=agent.provider,
-            config_context_length=getattr(agent, "_config_context_length", None),
+            config_context_length=_effective_config_ctx,
             custom_providers=_sm_custom_providers,
         )
         agent.context_compressor.update_model(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1006,6 +1006,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
+        _saved_config_ctx = getattr(agent, "_config_context_length", None)
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -1086,6 +1087,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # the fallback activation drops to 128K even when config says 204800.
         if hasattr(agent, 'context_compressor') and agent.context_compressor:
             from agent.model_metadata import get_model_context_length
+            # If the fallback model is the same as the primary, restore
+            # the user's explicit config override so the resolution chain
+            # doesn't fall through to DEFAULT_FALLBACK_CONTEXT (256K).
+            # See #32423.
+            _effective_config_ctx = getattr(agent, "_config_context_length", None)
+            if _saved_config_ctx and fb_model == old_model:
+                _effective_config_ctx = _saved_config_ctx
             # ``agent.api_key`` may be callable (Entra ID); the
             # context-length resolver expects a string for live
             # probes. Foundry typically resolves via config/static
@@ -1094,7 +1102,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_context_length = get_model_context_length(
                 agent.model, base_url=agent.base_url,
                 api_key=_fb_ctx_api_key, provider=agent.provider,
-                config_context_length=getattr(agent, "_config_context_length", None),
+                config_context_length=_effective_config_ctx,
                 custom_providers=getattr(agent, "_custom_providers", None),
             )
             agent.context_compressor.update_model(


### PR DESCRIPTION
## Summary

When a fallback provider is activated or `/model` switch is triggered, `_config_context_length` is unconditionally cleared (set to `None`). The subsequent `get_model_context_length()` call then resolves the context window from scratch. If the model isn't in any static table (`DEFAULT_CONTEXT_LENGTHS`) and live probing fails, the resolution falls through all 10 steps to `DEFAULT_FALLBACK_CONTEXT` (**256K**).

This causes the status bar to show `97.9K/256K` even though the user configured `context_length: 1000000` in config.yaml — most visible after a compaction interruption + resume cycle.

## Root Cause

In `try_activate_fallback()` (`chat_completion_helpers.py:1013`) and `switch_model()` (`agent_runtime_helpers.py:1367`):

```python
agent._config_context_length = None  # ← cleared unconditionally
```

Then `get_model_context_length(config_context_length=None, ...)` is called. Without the explicit config override, resolution falls through to 256K for custom endpoints that don't advertise context_length via `/models`.

## Fix

Save the original `_config_context_length` before clearing it. When the fallback/switched model is the **same** as the primary (common for custom providers where the fallback is the same endpoint accessed via a different credential), restore the saved override so the resolution chain receives it at Step 0:

```python
_effective_config_ctx = getattr(agent, "_config_context_length", None)
if _saved_config_ctx and fb_model == old_model:
    _effective_config_ctx = _saved_config_ctx
```

When the fallback model is **different** from the primary, the override is NOT restored — the new model should resolve its own context window.

## Changes

| File | Change |
|------|--------|
| `agent/chat_completion_helpers.py` | Save `_config_context_length` before fallback activation; restore it for same-model fallback |
| `agent/agent_runtime_helpers.py` | Same fix for the `switch_model()` path |

## Test plan

- [x] 401 agent tests pass
- [x] Same-model fallback preserves user's `model.context_length`
- [x] Different-model fallback resolves fresh context_length (doesn't inherit override)
- [x] `restore_primary_runtime()` continues to work correctly (restores from snapshot)

Closes #32423