### PR TITLE
[codex] security(runtime): centralize credential exposure policy

### DIFF
--- a/agent/credential_exposure_policy.py
+++ b/agent/credential_exposure_policy.py
@@ -1,0 +1,362 @@
+"""Credential exposure policy for Hermes-managed subprocesses.
+
+This module owns the env-var rules that prevent Hermes provider, tool, and
+gateway credentials from leaking into child processes.  Callers choose the
+execution shape they need:
+
+* terminal subprocesses preserve normal env vars and strip known credentials;
+* execute_code children use a small allowlist plus the same credential block.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Mapping
+
+logger = logging.getLogger(__name__)
+
+HERMES_CREDENTIAL_FORCE_PREFIX = "_HERMES_FORCE_"
+
+SAFE_SANDBOX_ENV_PREFIXES = (
+    "PATH",
+    "HOME",
+    "USER",
+    "LANG",
+    "LC_",
+    "TERM",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "SHELL",
+    "LOGNAME",
+    "XDG_",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+    "CONDA",
+)
+
+# NB: the broad "HERMES_" prefix was deliberately removed (#27303) — it leaked
+# HERMES_*-named config that lacks a secret substring (e.g. HERMES_BASE_URL,
+# HERMES_KANBAN_DB, HERMES_*_WEBHOOK).  The sandbox child only needs the few
+# operational location/profile vars in HERMES_SANDBOX_CHILD_ALLOWED below;
+# everything else HERMES_-named is dropped (and logged once) by
+# sanitize_sandbox_env.
+HERMES_SANDBOX_CHILD_ALLOWED = frozenset({
+    "HERMES_HOME",
+    "HERMES_PROFILE",
+    "HERMES_CONFIG",
+    "HERMES_ENV",
+})
+
+SECRET_ENV_SUBSTRINGS = (
+    "KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "CREDENTIAL",
+    "PASSWD",
+    "AUTH",
+    "DSN",
+    "WEBHOOK",
+)
+
+# Windows-only: a handful of variables are required by the OS/CRT itself.
+WINDOWS_ESSENTIAL_ENV_VARS = frozenset({
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "OS",
+    "PROCESSOR_ARCHITECTURE",
+    "NUMBER_OF_PROCESSORS",
+    "PUBLIC",
+    "ALLUSERSPROFILE",
+    "PROGRAMDATA",
+    "PROGRAMFILES",
+    "PROGRAMFILES(X86)",
+    "PROGRAMW6432",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "USERPROFILE",
+    "USERDOMAIN",
+    "USERNAME",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "COMPUTERNAME",
+})
+
+# Hermes-managed AWS *inference* credentials for ``auth_type="aws_sdk"``
+# providers (Bedrock).  Scoped DELIBERATELY NARROW: this lists only the
+# Bedrock-specific bearer token, which is a Hermes inference secret exactly
+# analogous to ``OPENAI_API_KEY`` — nobody drives the ``aws``/``terraform``/
+# ``boto3`` toolchain off it, so stripping it from terminal/execute_code
+# subprocesses costs no user capability.
+#
+# The GENERAL AWS credential chain (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+# AWS_SESSION_TOKEN, AWS_PROFILE, and the config/role pointers) is INTENTIONALLY
+# left out of the terminal blocklist.  Per SECURITY.md §3.2 the local terminal
+# is the user's trusted operator shell; the agent having the same general AWS
+# access the user's own shell has is the intended posture, not a leak.  Hard-
+# blocklisting those vars would (a) regress every user who runs aws/terraform/
+# cdk/boto3 in the agent terminal and (b) be unrecoverable, because
+# env_passthrough.py refuses to re-allow anything in this blocklist
+# (GHSA-rhgp-j443-p4rf).  See #32314.  (The execute_code sandbox still scrubs
+# the general chain via SECRET_ENV_SUBSTRINGS + its allowlist-only model.)
+AWS_BEDROCK_INFERENCE_ENV_VARS = frozenset({
+    "AWS_BEARER_TOKEN_BEDROCK",
+})
+
+_STATIC_HERMES_CREDENTIAL_ENV_VARS = frozenset({
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "HERMES_DASHBOARD_SESSION_TOKEN",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_KEY",
+    "OPENAI_API_BASE",
+    "OPENAI_ORG_ID",
+    "OPENAI_ORGANIZATION",
+    "OPENROUTER_API_KEY",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "LLM_MODEL",
+    "GOOGLE_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "MISTRAL_API_KEY",
+    "GROQ_API_KEY",
+    "TOGETHER_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "COHERE_API_KEY",
+    "FIREWORKS_API_KEY",
+    "XAI_API_KEY",
+    "HELICONE_API_KEY",
+    "PARALLEL_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "FIRECRAWL_API_URL",
+    "TELEGRAM_HOME_CHANNEL",
+    "TELEGRAM_HOME_CHANNEL_NAME",
+    "DISCORD_HOME_CHANNEL",
+    "DISCORD_HOME_CHANNEL_NAME",
+    "DISCORD_REQUIRE_MENTION",
+    "DISCORD_FREE_RESPONSE_CHANNELS",
+    "DISCORD_AUTO_THREAD",
+    "SLACK_HOME_CHANNEL",
+    "SLACK_HOME_CHANNEL_NAME",
+    "SLACK_ALLOWED_USERS",
+    "WHATSAPP_ENABLED",
+    "WHATSAPP_MODE",
+    "WHATSAPP_ALLOWED_USERS",
+    "SIGNAL_HTTP_URL",
+    "SIGNAL_ACCOUNT",
+    "SIGNAL_ALLOWED_USERS",
+    "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL",
+    "SIGNAL_HOME_CHANNEL_NAME",
+    "SIGNAL_IGNORE_STORIES",
+    "HASS_TOKEN",
+    "HASS_URL",
+    "EMAIL_ADDRESS",
+    "EMAIL_PASSWORD",
+    "EMAIL_IMAP_HOST",
+    "EMAIL_SMTP_HOST",
+    "EMAIL_HOME_ADDRESS",
+    "EMAIL_HOME_ADDRESS_NAME",
+    "GATEWAY_ALLOWED_USERS",
+    "GH_TOKEN",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_PRIVATE_KEY_PATH",
+    "GITHUB_APP_INSTALLATION_ID",
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
+    "DAYTONA_API_KEY",
+    "VERCEL_OIDC_TOKEN",
+    "VERCEL_TOKEN",
+    "VERCEL_PROJECT_ID",
+    "VERCEL_TEAM_ID",
+})
+
+
+def build_credential_env_blocklist() -> frozenset[str]:
+    """Derive the credential blocklist from provider, tool, and gateway config."""
+    blocked: set[str] = set(_STATIC_HERMES_CREDENTIAL_ENV_VARS)
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        for pconfig in PROVIDER_REGISTRY.values():
+            blocked.update(pconfig.api_key_env_vars)
+            if pconfig.base_url_env_var:
+                blocked.add(pconfig.base_url_env_var)
+            if pconfig.auth_type == "aws_sdk":
+                # Only the Hermes-managed Bedrock inference token — NOT the
+                # user's general AWS chain (see #32314 / GHSA-rhgp-j443-p4rf).
+                blocked.update(AWS_BEDROCK_INFERENCE_ENV_VARS)
+    except ImportError:
+        pass
+
+    try:
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        for name, metadata in OPTIONAL_ENV_VARS.items():
+            category = metadata.get("category")
+            if category in {"tool", "messaging"}:
+                blocked.add(name)
+            elif category == "setting" and metadata.get("password"):
+                blocked.add(name)
+    except ImportError:
+        pass
+
+    return frozenset(blocked)
+
+
+HERMES_CREDENTIAL_ENV_BLOCKLIST = build_credential_env_blocklist()
+
+
+def is_hermes_credential_env_var(name: str) -> bool:
+    """Return True when *name* is a Hermes-managed credential source."""
+    return name in HERMES_CREDENTIAL_ENV_BLOCKLIST
+
+
+def _default_passthrough(_name: str) -> bool:
+    return False
+
+
+@dataclass(frozen=True)
+class CredentialExposurePolicy:
+    """Sanitize child-process environments without exposing Hermes secrets."""
+
+    blocked_env_vars: frozenset[str] = field(
+        default_factory=lambda: HERMES_CREDENTIAL_ENV_BLOCKLIST
+    )
+    force_prefix: str = HERMES_CREDENTIAL_FORCE_PREFIX
+    safe_sandbox_prefixes: tuple[str, ...] = SAFE_SANDBOX_ENV_PREFIXES
+    secret_substrings: tuple[str, ...] = SECRET_ENV_SUBSTRINGS
+    sandbox_child_allowed: frozenset[str] = field(
+        default_factory=lambda: HERMES_SANDBOX_CHILD_ALLOWED
+    )
+    windows_essential_env_vars: frozenset[str] = field(
+        default_factory=lambda: WINDOWS_ESSENTIAL_ENV_VARS
+    )
+
+    def is_blocked(self, name: str) -> bool:
+        return name in self.blocked_env_vars
+
+    def sanitize_terminal_env(
+        self,
+        base_env: Mapping[str, str] | None,
+        extra_env: Mapping[str, str] | None = None,
+        *,
+        is_passthrough: Callable[[str], bool] | None = None,
+    ) -> dict[str, str]:
+        """Strip Hermes credentials while preserving ordinary terminal env."""
+        passthrough = is_passthrough or _default_passthrough
+        sanitized: dict[str, str] = {}
+
+        for key, value in (base_env or {}).items():
+            if key.startswith(self.force_prefix):
+                continue
+            if self._terminal_var_allowed(key, passthrough):
+                sanitized[key] = value
+
+        for key, value in (extra_env or {}).items():
+            if key.startswith(self.force_prefix):
+                real_key = key[len(self.force_prefix):]
+                sanitized[real_key] = value
+                logger.info(
+                    "credential exposure policy: force-exposed env var %s "
+                    "to terminal subprocess",
+                    real_key,
+                )
+                continue
+            if self._terminal_var_allowed(key, passthrough):
+                sanitized[key] = value
+
+        return sanitized
+
+    def sanitize_sandbox_env(
+        self,
+        source_env: Mapping[str, str],
+        *,
+        is_passthrough: Callable[[str], bool] | None = None,
+        is_windows: bool = False,
+    ) -> dict[str, str]:
+        """Build the minimal environment used by execute_code children.
+
+        Rules (order matters):
+          1. ``_HERMES_FORCE_``-prefixed vars are dropped (sandbox never honors
+             the terminal force-exposure escape hatch).
+          2. Hermes-managed credentials (blocklist) are always blocked.
+          3. Passthrough vars (skill- or config-declared) pass.
+          4. Secret-substring names (KEY/TOKEN/DSN/WEBHOOK/etc.) are blocked.
+          5. Names matching a safe prefix pass.
+          6. Operational HERMES_* vars (HERMES_SANDBOX_CHILD_ALLOWED) pass by
+             exact name; every other HERMES_* is dropped (#27303 — the broad
+             "HERMES_" prefix was removed because it leaked config like
+             HERMES_BASE_URL / HERMES_KANBAN_DB).
+          7. On Windows, a small OS-essential allowlist passes by exact name.
+        """
+        passthrough = is_passthrough or _default_passthrough
+        scrubbed: dict[str, str] = {}
+        dropped_hermes: list[str] = []
+
+        for key, value in source_env.items():
+            if key.startswith(self.force_prefix):
+                continue
+            if self.is_blocked(key):
+                if passthrough(key):
+                    logger.warning(
+                        "credential exposure policy: refusing passthrough "
+                        "for Hermes credential env var %s",
+                        key,
+                    )
+                continue
+            if passthrough(key):
+                scrubbed[key] = value
+                continue
+            if any(s in key.upper() for s in self.secret_substrings):
+                continue
+            if any(key.startswith(p) for p in self.safe_sandbox_prefixes):
+                scrubbed[key] = value
+                continue
+            if key in self.sandbox_child_allowed:
+                scrubbed[key] = value
+                continue
+            if is_windows and key.upper() in self.windows_essential_env_vars:
+                scrubbed[key] = value
+                continue
+            if key.startswith("HERMES_"):
+                # Non-secret (secrets were dropped above) and not allowlisted —
+                # a deliberately-dropped HERMES_* var (#27303).
+                dropped_hermes.append(key)
+
+        if dropped_hermes:
+            logger.debug(
+                "execute_code: dropped %d non-allowlisted HERMES_* var(s) from "
+                "the sandbox child env (%s). This is intentional hardening "
+                "(#27303); if a sandbox script legitimately needs one, declare "
+                "it via env_passthrough in the skill/config so it passes by "
+                "explicit opt-in.",
+                len(dropped_hermes),
+                ", ".join(sorted(dropped_hermes)),
+            )
+
+        return scrubbed
+
+    def _terminal_var_allowed(
+        self,
+        key: str,
+        passthrough: Callable[[str], bool],
+    ) -> bool:
+        if self.is_blocked(key):
+            if passthrough(key):
+                logger.warning(
+                    "credential exposure policy: refusing passthrough for "
+                    "Hermes credential env var %s",
+                    key,
+                )
+            return False
+        return True
+
+
+DEFAULT_CREDENTIAL_EXPOSURE_POLICY = CredentialExposurePolicy()

--- a/tests/tools/test_code_execution_windows_env.py
+++ b/tests/tools/test_code_execution_windows_env.py
@@ -32,6 +32,7 @@ from tools.code_execution_tool import (
     _WINDOWS_ESSENTIAL_ENV_VARS,
     _scrub_child_env,
 )
+from agent.credential_exposure_policy import HERMES_CREDENTIAL_ENV_BLOCKLIST
 
 
 def _no_passthrough(_name):
@@ -205,6 +206,38 @@ class TestScrubChildEnvPassthroughInteraction:
         assert scrubbed.get("SYSTEMROOT") == r"C:\Windows"
         assert "OPENAI_API_KEY" not in scrubbed
 
+    def test_passthrough_cannot_override_hermes_credential_blocklist(self):
+        # AWS_BEARER_TOKEN_BEDROCK is a Hermes-managed inference credential
+        # (blocklisted). The general AWS chain is NOT — AWS_PROFILE belongs to
+        # the user and stays inheritable per #32314 / GHSA-rhgp-j443-p4rf.
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer",
+            "OPENAI_API_KEY": "sk-secret",
+            "TENOR_API_KEY": "tenor",
+            "PATH": "/bin",
+        }
+        scrubbed = _scrub_child_env(
+            env,
+            is_passthrough=lambda _k: True,
+            is_windows=False,
+        )
+
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in scrubbed
+        assert "OPENAI_API_KEY" not in scrubbed
+        assert scrubbed["TENOR_API_KEY"] == "tenor"
+        assert scrubbed["PATH"] == "/bin"
+
+    def test_aws_profile_blocked_without_secret_substring(self):
+        env = {"AWS_PROFILE": "prod-admin", "PATH": "/bin"}
+        scrubbed = _scrub_child_env(
+            env,
+            is_passthrough=_no_passthrough,
+            is_windows=False,
+        )
+
+        assert "AWS_PROFILE" not in scrubbed
+        assert scrubbed["PATH"] == "/bin"
+
 
 @pytest.mark.skipif(
     sys.platform != "win32",
@@ -257,11 +290,12 @@ def _legacy_posix_scrubber(source_env, is_passthrough):
     _scrub_child_env's POSIX behavior, used to prove the production helper does
     what we think it does.
 
-    Deliberately updated for #27303 (the broad ``HERMES_`` prefix was dropped
-    in favor of an explicit operational allowlist, and DSN/WEBHOOK were added
-    to the secret substrings).  The original docstring said: if POSIX behavior
-    legitimately needs to evolve, adjust this oracle on purpose so the churn is
-    visible in review — that is what this change is.
+    Applies the shared Hermes credential blocklist first, then the explicit
+    prefix/substring rules.  Reflects #27303 (the broad ``HERMES_`` prefix was
+    dropped in favor of an explicit operational allowlist, and DSN/WEBHOOK were
+    added to the secret substrings).  If execute_code's POSIX behavior
+    legitimately evolves, update this oracle in the same PR so the churn is
+    visible in review.
     """
     _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                           "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
@@ -273,6 +307,8 @@ def _legacy_posix_scrubber(source_env, is_passthrough):
     })
     out = {}
     for k, v in source_env.items():
+        if k in HERMES_CREDENTIAL_ENV_BLOCKLIST:
+            continue
         if is_passthrough(k):
             out[k] = v
             continue
@@ -326,6 +362,7 @@ class TestPosixEquivalence:
         "OPENAI_API_KEY": "sk-xxx",
         "GITHUB_TOKEN": "ghp_xxx",
         "AWS_SECRET_ACCESS_KEY": "yyy",
+        "AWS_PROFILE": "prod-admin",
         "MY_PASSWORD": "hunter2",
         "SENTRY_DSN": "https://abc@sentry.io/1",     # DSN substring → blocked
         "SLACK_WEBHOOK": "https://hooks.slack/x",    # WEBHOOK substring → blocked

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -368,7 +368,7 @@ def test_env_scrub_logs_dropped_hermes_vars(caplog):
         "HERMES_API_KEY": "sk",       # secret → dropped silently (not logged)
         "PATH": "/usr/bin",           # safe prefix → kept
     }
-    with caplog.at_level(logging.DEBUG, logger="tools.code_execution_tool"):
+    with caplog.at_level(logging.DEBUG, logger="agent.credential_exposure_policy"):
         out = _scrub_child_env(env, is_passthrough=lambda _: False, is_windows=False)
 
     assert "HERMES_HOME" in out and "PATH" in out
@@ -387,7 +387,7 @@ def test_env_scrub_no_log_when_nothing_dropped(caplog):
 
     from tools.code_execution_tool import _scrub_child_env
 
-    with caplog.at_level(logging.DEBUG, logger="tools.code_execution_tool"):
+    with caplog.at_level(logging.DEBUG, logger="agent.credential_exposure_policy"):
         _scrub_child_env(
             {"HERMES_HOME": "/h", "PATH": "/usr/bin"},
             is_passthrough=lambda _: False,

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -192,6 +192,16 @@ class TestProviderEnvBlocklist:
         for var in leaked_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    def test_aws_region_is_preserved(self):
+        """Non-credential AWS settings can still flow to ordinary tools."""
+        result_env = _run_with_env(extra_os_env={
+            "AWS_REGION": "us-east-1",
+            "AWS_DEFAULT_REGION": "us-east-1",
+        })
+
+        assert result_env["AWS_REGION"] == "us-east-1"
+        assert result_env["AWS_DEFAULT_REGION"] == "us-east-1"
+
     def test_safe_vars_are_preserved(self):
         """Standard env vars (PATH, HOME, USER) must still be passed through."""
         result_env = _run_with_env()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -43,6 +43,13 @@ import threading
 import time
 import uuid
 
+from agent.credential_exposure_policy import (
+    DEFAULT_CREDENTIAL_EXPOSURE_POLICY,
+    SAFE_SANDBOX_ENV_PREFIXES,
+    SECRET_ENV_SUBSTRINGS,
+    WINDOWS_ESSENTIAL_ENV_VARS,
+)
+
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
 
@@ -75,31 +82,13 @@ MAX_STDOUT_BYTES = 50_000    # 50 KB
 MAX_STDERR_BYTES = 10_000    # 10 KB
 
 # Environment variable scrubbing rules (shared between the local + remote
-# backends).  Secret-substring block is applied first; anything left must
-# match a safe prefix, the operational HERMES_ allowlist, or (on Windows) an
-# OS-essential name.
-#
-# NB: the broad "HERMES_" prefix was deliberately removed (#27303) — it leaked
-# HERMES_*-named config that lacks a secret substring (e.g. HERMES_BASE_URL,
-# HERMES_KANBAN_DB, HERMES_*_WEBHOOK).  The child only needs the few
-# location/profile vars in _HERMES_CHILD_ALLOWED below; HERMES_RPC_SOCKET /
-# HERMES_RPC_DIR / TZ / HOME are injected explicitly after scrubbing.
-_SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
-                      "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                      "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
-_SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
-                      "PASSWD", "AUTH", "DSN", "WEBHOOK")
-
-# Operational HERMES_* vars the child legitimately needs by exact name — these
-# are non-secret runtime-location flags (the same set hermes_cli treats as the
-# runtime location) that repo-root modules a sandbox script imports may read at
-# import time.  None match _SECRET_SUBSTRINGS.
-_HERMES_CHILD_ALLOWED = frozenset({
-    "HERMES_HOME",
-    "HERMES_PROFILE",
-    "HERMES_CONFIG",
-    "HERMES_ENV",
-})
+# backends).  Hermes-managed credentials are blocked first; anything left
+# must be passthrough, match a safe prefix, be the operational HERMES_*
+# allowlist, or be an OS-essential Windows name.  The detailed rules (incl.
+# the #27303 HERMES_ tightening and the DSN/WEBHOOK secret substrings) live in
+# agent/credential_exposure_policy.py.
+_SAFE_ENV_PREFIXES = SAFE_SANDBOX_ENV_PREFIXES
+_SECRET_SUBSTRINGS = SECRET_ENV_SUBSTRINGS
 
 # Windows-only: a handful of variables are required by the OS/CRT itself.
 # Without them, even stdlib calls like ``socket.socket()`` fail with
@@ -107,41 +96,19 @@ _HERMES_CHILD_ALLOWED = frozenset({
 # can't resolve cmd.exe.  These are well-known OS paths, not secrets, so
 # we allow them through by exact name.  The _SECRET_SUBSTRINGS block
 # still runs as a safety net (none of these names match those substrings).
-_WINDOWS_ESSENTIAL_ENV_VARS = frozenset({
-    "SYSTEMROOT",       # %SYSTEMROOT%\System32 — Winsock needs this
-    "SYSTEMDRIVE",      # C: (or wherever Windows lives)
-    "WINDIR",           # usually same as SYSTEMROOT
-    "COMSPEC",          # cmd.exe path — subprocess shell=True needs it
-    "PATHEXT",          # .COM;.EXE;.BAT;... — shell lookup
-    "OS",               # "Windows_NT" — some tools gate on this
-    "PROCESSOR_ARCHITECTURE",
-    "NUMBER_OF_PROCESSORS",
-    "PUBLIC",           # C:\Users\Public
-    "ALLUSERSPROFILE",  # C:\ProgramData — some stdlib paths use it
-    "PROGRAMDATA",      # C:\ProgramData
-    "PROGRAMFILES",
-    "PROGRAMFILES(X86)",
-    "PROGRAMW6432",
-    "APPDATA",          # %USERPROFILE%\AppData\Roaming — Python uses it
-    "LOCALAPPDATA",     # %USERPROFILE%\AppData\Local
-    "USERPROFILE",      # C:\Users\<name> — Python's expanduser uses it
-    "USERDOMAIN",
-    "USERNAME",
-    "HOMEDRIVE",        # C:
-    "HOMEPATH",         # \Users\<name>
-    "COMPUTERNAME",
-})
+_WINDOWS_ESSENTIAL_ENV_VARS = WINDOWS_ESSENTIAL_ENV_VARS
 
 
 def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
     """Produce the scrubbed child-process env for execute_code.
 
     Rules (order matters):
-      1. Passthrough vars (skill- or config-declared) always pass.
-      2. Secret-substring names (KEY/TOKEN/DSN/WEBHOOK/etc.) are blocked.
-      3. Names matching a safe prefix pass.
-      4. Operational HERMES_* vars (_HERMES_CHILD_ALLOWED) pass by exact name.
-      5. On Windows, a small OS-essential allowlist passes by exact name
+      1. Hermes-managed credentials are always blocked.
+      2. Passthrough vars (skill- or config-declared) pass.
+      3. Secret-substring names (KEY/TOKEN/DSN/WEBHOOK/etc.) are blocked.
+      4. Names matching a safe prefix pass.
+      5. Operational HERMES_* vars pass by exact name; other HERMES_* dropped.
+      6. On Windows, a small OS-essential allowlist passes by exact name
          — without these the child can't even create a socket or spawn a
          subprocess.
 
@@ -157,44 +124,11 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
     if is_windows is None:
         is_windows = _IS_WINDOWS
 
-    scrubbed = {}
-    # Non-secret HERMES_* vars dropped by the tightened allowlist (#27303). The
-    # broad "HERMES_" prefix used to pass these through; now only the
-    # operational set does. The drop is intentional (those vars can carry
-    # config like HERMES_KANBAN_DB / HERMES_BASE_URL), but a sandbox script
-    # that imports a repo module reading one at import time would otherwise see
-    # it silently unset. Surface the drop once so the behavior change is
-    # diagnosable and points at the env_passthrough opt-in escape hatch.
-    _dropped_hermes = []
-    for k, v in source_env.items():
-        if is_passthrough(k):
-            scrubbed[k] = v
-            continue
-        if any(s in k.upper() for s in _SECRET_SUBSTRINGS):
-            continue
-        if any(k.startswith(p) for p in _SAFE_ENV_PREFIXES):
-            scrubbed[k] = v
-            continue
-        if k in _HERMES_CHILD_ALLOWED:
-            scrubbed[k] = v
-            continue
-        if is_windows and k.upper() in _WINDOWS_ESSENTIAL_ENV_VARS:
-            scrubbed[k] = v
-            continue
-        if k.startswith("HERMES_"):
-            # Non-secret (secrets were already dropped above) and not in any
-            # allowlist — a deliberately-dropped HERMES_* var.
-            _dropped_hermes.append(k)
-    if _dropped_hermes:
-        logger.debug(
-            "execute_code: dropped %d non-allowlisted HERMES_* var(s) from the "
-            "sandbox child env (%s). This is intentional hardening (#27303); if "
-            "a sandbox script legitimately needs one, declare it via "
-            "env_passthrough in the skill/config so it passes by explicit opt-in.",
-            len(_dropped_hermes),
-            ", ".join(sorted(_dropped_hermes)),
-        )
-    return scrubbed
+    return DEFAULT_CREDENTIAL_EXPOSURE_POLICY.sanitize_sandbox_env(
+        source_env,
+        is_passthrough=is_passthrough,
+        is_windows=is_windows,
+    )
 
 
 def check_sandbox_requirements() -> bool:

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -47,7 +47,7 @@ _config_passthrough: frozenset[str] | None = None
 
 def _is_hermes_provider_credential(name: str) -> bool:
     """True if ``name`` is a Hermes-managed provider credential (API key,
-    token, or similar) per ``_HERMES_PROVIDER_ENV_BLOCKLIST``.
+    token, or similar) per the shared credential exposure policy.
 
     Skill-declared ``required_environment_variables`` frontmatter must
     not be able to override this list — that was the bypass in
@@ -61,10 +61,10 @@ def _is_hermes_provider_credential(name: str) -> bool:
     wrap third-party APIs still work.
     """
     try:
-        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+        from agent.credential_exposure_policy import is_hermes_credential_env_var
     except Exception:
         return False
-    return name in _HERMES_PROVIDER_ENV_BLOCKLIST
+    return is_hermes_credential_env_var(name)
 
 
 def register_env_passthrough(var_names: Iterable[str]) -> None:
@@ -73,7 +73,7 @@ def register_env_passthrough(var_names: Iterable[str]) -> None:
     Typically called when a skill declares ``required_environment_variables``.
 
     Variables that are Hermes-managed provider credentials (from
-    ``_HERMES_PROVIDER_ENV_BLOCKLIST``) are rejected here to preserve
+    the shared credential exposure policy are rejected here to preserve
     the ``execute_code`` sandbox's credential-scrubbing guarantee per
     GHSA-rhgp-j443-p4rf. A skill that needs to talk to a Hermes-managed
     provider should do so via the agent's main-process tools (web_search,
@@ -90,7 +90,7 @@ def register_env_passthrough(var_names: Iterable[str]) -> None:
         if _is_hermes_provider_credential(name):
             logger.warning(
                 "env passthrough: refusing to register Hermes provider "
-                "credential %r (blocked by _HERMES_PROVIDER_ENV_BLOCKLIST). "
+                "credential %r (blocked by credential exposure policy). "
                 "Skills must not override the execute_code sandbox's "
                 "credential scrubbing; see GHSA-rhgp-j443-p4rf.",
                 name,
@@ -125,7 +125,7 @@ def _load_config_passthrough() -> frozenset[str]:
                     logger.warning(
                         "env passthrough: refusing to register Hermes "
                         "provider credential %r from config.yaml (blocked "
-                        "by _HERMES_PROVIDER_ENV_BLOCKLIST). Operator "
+                        "by credential exposure policy). Operator "
                         "configuration must not override the execute_code "
                         "sandbox's credential scrubbing; see "
                         "GHSA-rhgp-j443-p4rf.",
@@ -159,5 +159,3 @@ def get_all_passthrough() -> frozenset[str]:
 def clear_env_passthrough() -> None:
     """Reset the skill-scoped allowlist (e.g. on session reset)."""
     _get_allowed().clear()
-
-

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -11,6 +11,11 @@ import tempfile
 import time
 from pathlib import Path
 
+from agent.credential_exposure_policy import (
+    DEFAULT_CREDENTIAL_EXPOSURE_POLICY,
+    HERMES_CREDENTIAL_ENV_BLOCKLIST,
+    HERMES_CREDENTIAL_FORCE_PREFIX,
+)
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
 
@@ -73,122 +78,12 @@ def _resolve_safe_cwd(cwd: str) -> str:
 
 
 # Hermes-internal env vars that should NOT leak into terminal subprocesses.
-_HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
-
-# Hermes-managed AWS *inference* credentials for ``auth_type="aws_sdk"``
-# providers (Bedrock).  Scoped DELIBERATELY NARROW: this lists only the
-# Bedrock-specific bearer token, which is a Hermes inference secret exactly
-# analogous to ``OPENAI_API_KEY`` — nobody drives the ``aws``/``terraform``/
-# ``boto3`` toolchain off it, so stripping it from terminal/execute_code
-# subprocesses costs no user capability.
-#
-# The GENERAL AWS credential chain (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
-# AWS_SESSION_TOKEN, AWS_PROFILE, and the config/role pointers) is INTENTIONALLY
-# left inheritable.  Per SECURITY.md §3.2 the local terminal is the user's
-# trusted operator shell; the agent having the same general AWS access the
-# user's own shell has is the intended posture, not a leak.  Hard-blocklisting
-# those vars would (a) regress every user who runs aws/terraform/cdk/boto3 in
-# the agent terminal — not just Bedrock users, since the registry is iterated
-# unconditionally — and (b) be unrecoverable, because env_passthrough.py
-# refuses to re-allow anything in this blocklist (GHSA-rhgp-j443-p4rf).  See
-# issue #32314 discussion.
-_AWS_SDK_CREDENTIAL_ENV_VARS = frozenset({
-    "AWS_BEARER_TOKEN_BEDROCK",
-})
-
-
-def _build_provider_env_blocklist() -> frozenset:
-    """Derive the blocklist from provider, tool, and gateway config."""
-    blocked: set[str] = set()
-
-    try:
-        from hermes_cli.auth import PROVIDER_REGISTRY
-        for pconfig in PROVIDER_REGISTRY.values():
-            blocked.update(pconfig.api_key_env_vars)
-            if pconfig.auth_type == "aws_sdk":
-                blocked.update(_AWS_SDK_CREDENTIAL_ENV_VARS)
-            if pconfig.base_url_env_var:
-                blocked.add(pconfig.base_url_env_var)
-    except ImportError:
-        pass
-
-    try:
-        from hermes_cli.config import OPTIONAL_ENV_VARS
-        for name, metadata in OPTIONAL_ENV_VARS.items():
-            category = metadata.get("category")
-            if category in {"tool", "messaging"}:
-                blocked.add(name)
-            elif category == "setting" and metadata.get("password"):
-                blocked.add(name)
-    except ImportError:
-        pass
-
-    blocked.update({
-        "OPENAI_BASE_URL",
-        "OPENAI_API_KEY",
-        "OPENAI_API_BASE",
-        "OPENAI_ORG_ID",
-        "OPENAI_ORGANIZATION",
-        "OPENROUTER_API_KEY",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_TOKEN",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "LLM_MODEL",
-        "GOOGLE_API_KEY",
-        "DEEPSEEK_API_KEY",
-        "MISTRAL_API_KEY",
-        "GROQ_API_KEY",
-        "TOGETHER_API_KEY",
-        "PERPLEXITY_API_KEY",
-        "COHERE_API_KEY",
-        "FIREWORKS_API_KEY",
-        "XAI_API_KEY",
-        "HELICONE_API_KEY",
-        "PARALLEL_API_KEY",
-        "FIRECRAWL_API_KEY",
-        "FIRECRAWL_API_URL",
-        "TELEGRAM_HOME_CHANNEL",
-        "TELEGRAM_HOME_CHANNEL_NAME",
-        "DISCORD_HOME_CHANNEL",
-        "DISCORD_HOME_CHANNEL_NAME",
-        "DISCORD_REQUIRE_MENTION",
-        "DISCORD_FREE_RESPONSE_CHANNELS",
-        "DISCORD_AUTO_THREAD",
-        "SLACK_HOME_CHANNEL",
-        "SLACK_HOME_CHANNEL_NAME",
-        "SLACK_ALLOWED_USERS",
-        "WHATSAPP_ENABLED",
-        "WHATSAPP_MODE",
-        "WHATSAPP_ALLOWED_USERS",
-        "SIGNAL_HTTP_URL",
-        "SIGNAL_ACCOUNT",
-        "SIGNAL_ALLOWED_USERS",
-        "SIGNAL_GROUP_ALLOWED_USERS",
-        "SIGNAL_HOME_CHANNEL",
-        "SIGNAL_HOME_CHANNEL_NAME",
-        "SIGNAL_IGNORE_STORIES",
-        "HASS_TOKEN",
-        "HASS_URL",
-        "EMAIL_ADDRESS",
-        "EMAIL_PASSWORD",
-        "EMAIL_IMAP_HOST",
-        "EMAIL_SMTP_HOST",
-        "EMAIL_HOME_ADDRESS",
-        "EMAIL_HOME_ADDRESS_NAME",
-        "HERMES_DASHBOARD_SESSION_TOKEN",
-        "GATEWAY_ALLOWED_USERS",
-        "GH_TOKEN",
-        "GITHUB_APP_ID",
-        "GITHUB_APP_PRIVATE_KEY_PATH",
-        "GITHUB_APP_INSTALLATION_ID",
-        "MODAL_TOKEN_ID",
-        "MODAL_TOKEN_SECRET",
-        "DAYTONA_API_KEY",
-    })
-    return frozenset(blocked)
-
-
-_HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+# The credential blocklist and force-prefix now live in the shared
+# agent/credential_exposure_policy.py.  Note the AWS scoping decision (#32314 /
+# GHSA-rhgp-j443-p4rf): only the Hermes-managed Bedrock bearer token is
+# blocked; the user's general AWS chain stays inheritable in the terminal.
+_HERMES_PROVIDER_ENV_FORCE_PREFIX = HERMES_CREDENTIAL_FORCE_PREFIX
+_HERMES_PROVIDER_ENV_BLOCKLIST = HERMES_CREDENTIAL_ENV_BLOCKLIST
 
 
 def _inject_context_hermes_home(env: dict) -> None:
@@ -210,30 +105,24 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
 
-    sanitized: dict[str, str] = {}
+    sanitized = DEFAULT_CREDENTIAL_EXPOSURE_POLICY.sanitize_terminal_env(
+        base_env,
+        extra_env,
+        is_passthrough=_is_passthrough,
+    )
+    _apply_local_subprocess_env_overrides(sanitized)
+    return sanitized
 
-    for key, value in (base_env or {}).items():
-        if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
-            continue
-        if key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
-            sanitized[key] = value
 
-    for key, value in (extra_env or {}).items():
-        if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
-            real_key = key[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
-            sanitized[real_key] = value
-        elif key not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(key):
-            sanitized[key] = value
-
-    _inject_context_hermes_home(sanitized)
+def _apply_local_subprocess_env_overrides(env: dict) -> None:
+    """Apply Hermes runtime overrides after credential filtering."""
+    _inject_context_hermes_home(env)
 
     # Per-profile HOME isolation for background processes (same as _make_run_env).
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
     if _profile_home:
-        sanitized["HOME"] = _profile_home
-
-    return sanitized
+        env["HOME"] = _profile_home
 
 
 def _find_bash() -> str:
@@ -307,14 +196,11 @@ def _make_run_env(env: dict) -> dict:
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
 
-    merged = dict(os.environ | env)
-    run_env = {}
-    for k, v in merged.items():
-        if k.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
-            real_key = k[len(_HERMES_PROVIDER_ENV_FORCE_PREFIX):]
-            run_env[real_key] = v
-        elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
-            run_env[k] = v
+    run_env = DEFAULT_CREDENTIAL_EXPOSURE_POLICY.sanitize_terminal_env(
+        os.environ,
+        env,
+        is_passthrough=_is_passthrough,
+    )
     existing_path = run_env.get("PATH", "")
     # The "/usr/bin not already present → inject sane POSIX path" heuristic
     # only makes sense on POSIX.  On Windows the PATH separator is ";"
@@ -327,15 +213,7 @@ def _make_run_env(env: dict) -> dict:
     if not _IS_WINDOWS and "/usr/bin" not in existing_path.split(":"):
         run_env["PATH"] = f"{existing_path}:{_SANE_PATH}" if existing_path else _SANE_PATH
 
-    _inject_context_hermes_home(run_env)
-
-    # Per-profile HOME isolation: redirect system tool configs (git, ssh, gh,
-    # npm …) into {HERMES_HOME}/home/ when that directory exists.  Only the
-    # subprocess sees the override — the Python process keeps the real HOME.
-    from hermes_constants import get_subprocess_home
-    _profile_home = get_subprocess_home()
-    if _profile_home:
-        run_env["HOME"] = _profile_home
+    _apply_local_subprocess_env_overrides(run_env)
 
     # Inject ContextVar-based session vars into subprocess env.
     # ContextVars don't propagate to child processes, so we bridge them here.


### PR DESCRIPTION
> **Upstream value:** Single-source credential scrubbing that fixes a real secret leak (the Bedrock SDK inference token) while preserving the user's general AWS access — pure runtime security infra with no platform-specific coupling.

> ## ⚠️ Updated after rebase onto latest `main`
>
> This branch was originally cut from an older `main` and has been **rebased onto the current `main`**, which since then landed two deliberate hardenings that this PR's first revision would have *reverted*. The conflicts were resolved to **keep the centralization while preserving both upstream decisions** — so some behavior described in the original "Changes Made" below has intentionally changed:
>
> **1. AWS scope corrected (honors #32314 / GHSA-rhgp-j443-p4rf).**
> The original revision added the **full** AWS chain (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_PROFILE`, shared-credentials/config files, web-identity token, container-credential endpoints) to the **terminal** blocklist. `main` had already decided the opposite: only the Hermes-managed Bedrock inference token (`AWS_BEARER_TOKEN_BEDROCK`) is blocked; the **general AWS chain stays inheritable** in the terminal, because the local terminal is the user's trusted operator shell (SECURITY.md §3.2) and blocklisting those vars is *unrecoverable* (`env_passthrough` refuses to re-allow blocklisted vars).
> → The centralized policy now blocks **only** `AWS_BEARER_TOKEN_BEDROCK`. The `execute_code` **sandbox** still scrubs the general AWS chain via secret-substring matching + its allowlist-only model, so the sandbox is unchanged.
>
> **2. Restored the `#27303` sandbox HERMES_ tightening.**
> The broad `HERMES_` sandbox safe-prefix (which leaked `HERMES_BASE_URL` / `HERMES_KANBAN_DB` / `HERMES_*_WEBHOOK`) is **not** reintroduced. The centralized policy keeps the tight operational allowlist (`HERMES_HOME`/`PROFILE`/`CONFIG`/`ENV`) + one-shot drop-logging, and re-adds `DSN` / `WEBHOOK` to the secret substrings.
>
> **3. Test reconciliation.**
> The auto-merge produced contradictory tests (some asserting the full AWS chain blocked, others — from `main` — asserting it must stay inheritable). Removed the three PR-only tests that asserted the now-reverted full-AWS-block, updated two sandbox tests to use a genuinely-blocklisted var (`AWS_BEARER_TOKEN_BEDROCK`), and repointed `#27303`'s drop-log tests at the centralized policy logger. Also added `HERMES_DASHBOARD_SESSION_TOKEN` to the static blocklist so nothing regressed.
>
> **Net effect:** centralization is preserved; no `main` hardening is regressed. Full affected-suite sweep: **157 passed, 3 skipped.**

---

## What does this PR do?

Centralizes subprocess credential filtering behind `agent.credential_exposure_policy` and routes the existing terminal and `execute_code` env sanitizers through that policy.

This closes the SDK-auth gap where the Hermes-managed Bedrock inference token (`AWS_BEARER_TOKEN_BEDROCK`) could flow into terminal or generated-code child processes because Bedrock uses `auth_type="aws_sdk"` rather than `api_key_env_vars`. (See the rebase note above: the **general** AWS chain is intentionally *not* blocklisted per #32314.)

## Related Issue

Refs #32314.

## Type of Change

- [x] Security fix
- [x] Refactor (no behavior change intended outside credential filtering)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Added `CredentialExposurePolicy` as the shared module for terminal and sandbox env filtering.
- Moved Hermes provider/tool/gateway credential env blocklist construction into the shared policy module.
- Scoped AWS blocking to the Hermes-managed Bedrock inference token (`AWS_BEARER_TOKEN_BEDROCK`) only; the general AWS chain stays inheritable in the terminal (#32314 / GHSA-rhgp-j443-p4rf).
- Preserved the `#27303` sandbox `HERMES_` tightening (tight operational allowlist + drop-logging; `DSN`/`WEBHOOK` secret substrings).
- Kept old compatibility exports in `tools.environments.local` for existing tests and callers.
- Updated `execute_code` env scrubbing so passthrough cannot override Hermes-managed credential vars.
- Updated `tools.env_passthrough` to consult the shared policy instead of importing terminal internals.

## How to Test

- `pytest tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py tests/tools/test_code_execution_windows_env.py -q`
- `pytest tests/tools/test_execute_code_approval_cluster.py tests/tools/test_docker_environment.py -q`
- `python -m py_compile agent/credential_exposure_policy.py tools/environments/local.py tools/code_execution_tool.py tools/env_passthrough.py`

Note: existing tests using mocked `Popen` still emit known thread warnings from fake stdout objects; assertions pass.

## Checklist

- [x] My PR contains only changes related to this fix/feature.
- [x] I've run the relevant targeted pytest suites.
- [x] Credential filtering is covered for local terminal and execute_code.
- [x] Cross-platform Windows execute_code env behavior remains covered by existing tests.
- [x] Rebased onto latest `main`; no #27303 / #32314 hardening regressed.