### PR TITLE
fix(cli): strip leaked bracketed-paste markers from input (\\x1b[200~ / \\x1b[201~)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2458,6 +2458,13 @@ _SGR_MOUSE_VISIBLE_RE = re.compile(r"\^\[\[<\d+;\d+;\d+[Mm]")
 # these fragments are extremely unlikely to be intentional user input, and
 # stripping them is better than sending corrupted prompts.
 _SGR_MOUSE_BARE_RE = re.compile(r"<\d+;\d+;\d+[Mm]")
+
+# Bracketed paste mode markers — terminals wrap pasted content in
+# ``\x1b[200~`` (begin) / ``\x1b[201~`` (end) when bracketed paste mode is
+# active. prompt_toolkit normally consumes these on entry; when raw mode
+# degrades on WSL + Windows Terminal they leak into the input buffer as
+# visible ``^[[200~``/``^[[201~`` text (Hermes issue #22976, #19280).
+_BRACKETED_PASTE_ESC_RE = re.compile(r"\x1b\[20[01]~")
 _TERMINAL_INPUT_MODE_RESET_SEQ = (
     "\x1b[?1006l"  # disable SGR mouse
     "\x1b[?1003l"  # disable any-motion tracking
@@ -2561,6 +2568,7 @@ def _strip_leaked_terminal_responses_with_meta(text: str) -> tuple[str, bool]:
         text = _DSR_CPR_ESC_RE.sub("", text)
         text, count = _SGR_MOUSE_ESC_RE.subn("", text)
         had_mouse_reports = had_mouse_reports or count > 0
+        text = _BRACKETED_PASTE_ESC_RE.sub("", text)
 
     if has_visible:
         text = _DSR_CPR_VISIBLE_RE.sub("", text)


### PR DESCRIPTION
## Summary

Terminals in bracketed paste mode wrap pasted content in `\x1b[200~` (begin) and `\x1b[201~` (end) markers. When prompt_toolkit's raw mode degrades on WSL + Windows Terminal, these markers bypass the normal paste handler and leak into the input buffer as visible `^[[200~/``^[[201~` text.

## Changes

1. Add `_BRACKETED_PASTE_ESC_RE = re.compile(r"\\x1b\\[20[01]~")` alongside the existing CPR / DSR / SGR mouse regexes in `cli.py`
2. Apply it in `_strip_leaked_terminal_responses_with_meta()` to strip bracketed-paste markers from user input before they reach the agent

## Related

Follows the same pattern as the CPR response stripping (\#14692) and SGR mouse report stripping. Addresses the WSL + Windows Terminal bracketed-paste class of escape-sequence leaks (\#22976, \#19280).

## Testing

- `_strip_leaked_terminal_responses_with_meta("\\x1b[200~pasted text\\x1b[201~")` → `"pasted text"`
- `_strip_leaked_terminal_responses_with_meta("\\x1b[200~\\x1b[201~ \\x1b[200~\\x1b[201~")` → `" "`
- No change to normal input paths