### PR TITLE
[codex] fix(gateway): surface empty agent responses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1579,17 +1579,24 @@ def _normalize_empty_agent_response(
             "Try again or use /reset to start a fresh session."
         )
 
+    if agent_result.get("interrupted"):
+        return response
+
+    if agent_result.get("partial"):
+        err = agent_result.get("error", "processing incomplete")
+        return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
+
     api_calls = int(agent_result.get("api_calls", 0) or 0)
-    if api_calls > 0 and not agent_result.get("interrupted"):
-        if agent_result.get("partial"):
-            err = agent_result.get("error", "processing incomplete")
-            return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
+    if api_calls > 0:
         return (
             "⚠️ Processing completed but no response was generated. "
             "This may be a transient error — try sending your message again."
         )
 
-    return response
+    return (
+        "⚠️ No response was generated for this turn. The previous run may "
+        "have been interrupted before a model call started — please try again."
+    )
 
 
 def _should_clear_resume_pending_after_turn(agent_result: dict) -> bool:
@@ -8756,14 +8763,6 @@ class GatewayRunner:
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
-            _response_time = time.time() - _msg_start_time
-            _api_calls = agent_result.get("api_calls", 0)
-            _resp_len = len(response)
-            logger.info(
-                "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
-                _platform_name, source.chat_id or "unknown",
-                _response_time, _api_calls, _resp_len,
-            )
 
             # Successful turn — clear any stuck-loop counter for this session.
             # This ensures the counter only accumulates across CONSECUTIVE
@@ -8789,6 +8788,14 @@ class GatewayRunner:
                 agent_result, response, history_len=len(history),
             )
             response = _sanitize_gateway_final_response(source.platform, response)
+            _response_time = time.time() - _msg_start_time
+            _api_calls = agent_result.get("api_calls", 0)
+            _resp_len = len(response)
+            logger.info(
+                "response ready: platform=%s chat=%s time=%.1fs api_calls=%d response=%d chars",
+                _platform_name, source.chat_id or "unknown",
+                _response_time, _api_calls, _resp_len,
+            )
 
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -39,6 +39,7 @@ from gateway.run import (
     _coerce_gateway_timestamp,
     _is_fresh_gateway_interruption,
     _last_transcript_timestamp,
+    _normalize_empty_agent_response,
     _should_clear_resume_pending_after_turn,
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
@@ -68,6 +69,31 @@ def test_resume_pending_is_cleared_only_after_successful_turn():
     assert _should_clear_resume_pending_after_turn({"failed": True}) is False
     assert _should_clear_resume_pending_after_turn({"partial": True}) is False
     assert _should_clear_resume_pending_after_turn({"error": "boom"}) is False
+
+
+def test_empty_zero_api_call_agent_response_gets_user_visible_fallback():
+    """A normal user turn must not complete as response=0 chars.
+
+    Regression for #31884: after /stop, the next Telegram text message could
+    return an empty agent result with api_calls=0 and be silently dropped.
+    """
+    response = _normalize_empty_agent_response(
+        {"final_response": "", "messages": [], "api_calls": 0},
+        "",
+    )
+
+    assert response
+    assert "No response was generated" in response
+
+
+def test_interrupted_empty_agent_response_stays_empty():
+    """The fallback is for accepted turns, not explicit interrupted results."""
+    response = _normalize_empty_agent_response(
+        {"final_response": "", "interrupted": True, "api_calls": 0},
+        "",
+    )
+
+    assert response == ""
 
 
 def _make_source(platform=Platform.TELEGRAM, chat_id="123", user_id="u1"):


### PR DESCRIPTION
> **Upstream value:** Fixes a reproducible gateway correctness bug (#31884) where an accepted turn could complete as `response=0 chars` and silently send nothing after `/stop` — platform-agnostic, hits all gateway users.

## What does this PR do?

Prevents accepted gateway turns from completing as a silent `response=0 chars` result when the agent returns an empty, non-failed, non-interrupted response with `api_calls=0`.

This addresses the immediately actionable part of #31884: after `/stop`, a subsequent normal Telegram message could be logged as complete with an empty response and therefore send nothing. The gateway now turns that shape into a user-visible retry hint instead of returning an empty string.

The response-ready log line now records the post-normalized/sanitized response length, so logs reflect what the gateway will attempt to deliver rather than the raw empty agent payload.

## Related Issue

Refs #31884.
Builds on the planning PR stack from #32391.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Updated `_normalize_empty_agent_response()` to produce a fallback for empty accepted turns even when `api_calls == 0`.
- Kept explicit interrupted empty results empty, so `/stop` and stale interrupted runs are not converted into noisy replies.
- Moved `response ready` length logging after normalization/sanitization.
- Added regression coverage for the zero-api-call empty response shape.

## How to Test

- `pytest tests/gateway/test_restart_resume_pending.py tests/gateway/test_run_cleanup_progress.py tests/gateway/test_session_race_guard.py -q`
- `python -m py_compile gateway/run.py`

## Checklist

- [x] My PR contains only changes related to this fix.
- [x] Relevant gateway tests pass.
- [x] Empty accepted turns are user-visible instead of silent.
- [x] Explicit interrupted turns remain quiet.