### PR TITLE
fix(agent): separate HTTP 402 billing from rate-limit in user-facing messages

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2475,15 +2475,15 @@ def run_conversation(
                     # Fall through to normal error handling if compression
                     # is exhausted or didn't help.
 
-                # Eager fallback for rate-limit errors (429 or quota exhaustion).
+                # Eager fallback for rate-limit errors (429 or quota exhaustion)
+                # and billing/credit exhaustion (402).
                 # When a fallback model is configured, switch immediately instead
                 # of burning through retries with exponential backoff -- the
                 # primary provider won't recover within the retry window.
-                is_rate_limited = classified.reason in {
-                    FailoverReason.rate_limit,
-                    FailoverReason.billing,
-                }
-                if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
+                is_rate_limited = classified.reason == FailoverReason.rate_limit
+                is_billing = classified.reason == FailoverReason.billing
+                is_rate_or_billing = is_rate_limited or is_billing
+                if is_rate_or_billing and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
@@ -2494,7 +2494,10 @@ def run_conversation(
                         base_url=getattr(agent, "base_url", None),
                     )
                     if not pool_may_recover:
-                        agent._emit_status("⚠️ Rate limited — switching to fallback provider...")
+                        if is_billing:
+                            agent._emit_status("⚠️ Billing/credit exhausted — switching to fallback provider...")
+                        else:
+                            agent._emit_status("⚠️ Rate limited — switching to fallback provider...")
                         if agent._try_activate_fallback(reason=classified.reason):
                             retry_count = 0
                             compression_attempts = 0
@@ -2870,7 +2873,10 @@ def run_conversation(
                 if is_client_error:
                     # Try fallback before aborting — a different provider
                     # may not have the same issue (rate limit, auth, etc.)
-                    agent._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                    if is_billing:
+                        agent._emit_status(f"⚠️ Billing/credit exhausted (HTTP {status_code}) — trying fallback...")
+                    else:
+                        agent._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -2880,15 +2886,30 @@ def run_conversation(
                         agent._dump_api_request_debug(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,
                         )
-                    agent._emit_status(
-                        f"❌ Non-retryable error (HTTP {status_code}): "
-                        f"{agent._summarize_api_error(api_error)}"
-                    )
+                    if is_billing:
+                        agent._emit_status(
+                            f"❌ Credit/spend limit error (HTTP {status_code}): "
+                            f"{agent._summarize_api_error(api_error)}"
+                        )
+                    else:
+                        agent._emit_status(
+                            f"❌ Non-retryable error (HTTP {status_code}): "
+                            f"{agent._summarize_api_error(api_error)}"
+                        )
                     agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
+                    # Actionable guidance for billing / spend-limit errors
+                    if classified.reason == FailoverReason.billing:
+                        agent._vprint(f"{agent.log_prefix}   💡 This is a billing / spend-limit error. Your API key is valid but has", force=True)
+                        agent._vprint(f"{agent.log_prefix}      reached its spending cap or your account balance is exhausted.", force=True)
+                        agent._vprint(f"{agent.log_prefix}      To fix:", force=True)
+                        agent._vprint(f"{agent.log_prefix}      1. Check your provider billing dashboard and raise the spend limit, or", force=True)
+                        agent._vprint(f"{agent.log_prefix}      2. Top up your account balance.", force=True)
+                        if base_url_host_matches(str(_base), "openrouter.ai"):
+                            agent._vprint(f"{agent.log_prefix}      3. Check credits: https://openrouter.ai/settings/credits", force=True)
                     # Actionable guidance for common auth errors
-                    if classified.is_auth or classified.reason == FailoverReason.billing:
+                    elif classified.is_auth:
                         if _provider in {"openai-codex", "xai-oauth", "nous"} and status_code == 401:
                             if _provider == "openai-codex":
                                 agent._vprint(f"{agent.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). Your token may have been", force=True)
@@ -2959,7 +2980,9 @@ def run_conversation(
                         primary_recovery_attempted = False
                         continue
                     _final_summary = agent._summarize_api_error(api_error)
-                    if is_rate_limited:
+                    if is_billing:
+                        agent._emit_status(f"💳 Credit/spend limit reached after {max_retries} retries — {_final_summary}")
+                    elif is_rate_limited:
                         agent._emit_status(f"❌ Rate limited after {max_retries} retries — {_final_summary}")
                     else:
                         agent._emit_status(f"❌ API failed after {max_retries} retries — {_final_summary}")
@@ -3023,9 +3046,9 @@ def run_conversation(
                         "error": _final_summary,
                     }
 
-                # For rate limits, respect the Retry-After header if present
+                # For rate limits and billing, respect the Retry-After header if present
                 _retry_after = None
-                if is_rate_limited:
+                if is_rate_or_billing:
                     _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
                     if _resp_headers and hasattr(_resp_headers, "get"):
                         _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
@@ -3035,7 +3058,9 @@ def run_conversation(
                             except (TypeError, ValueError):
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
-                if is_rate_limited:
+                if is_billing:
+                    agent._emit_status(f"💳 Credit/spend limit reached. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
+                elif is_rate_limited:
                     agent._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
                 else:
                     agent._emit_status(f"⏳ Retrying in {wait_time:.1f}s (attempt {retry_count}/{max_retries})...")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -124,6 +124,11 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_BILLING_RE = re.compile(
+    r"(billing|credit\s*(exhausted|limit|cap)|spend\s*limit)",
+    re.IGNORECASE,
+)
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -240,6 +245,11 @@ def _gateway_provider_error_reply(text: str) -> str:
         )
     if _GATEWAY_RATE_LIMIT_RE.search(text):
         return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+    if _GATEWAY_BILLING_RE.search(text):
+        return (
+            "💳 The model provider rejected the request due to billing or credit "
+            "limits. Check your provider dashboard to raise spend limits or top up."
+        )
     return (
         "⚠️ The model provider failed after retries. I kept raw provider details "
         "out of chat; check gateway logs for diagnostics."


### PR DESCRIPTION
## Summary

The error classifier (`agent/error_classifier.py`) already correctly identifies `reason=billing` for HTTP 402 responses. However, `conversation_loop.py` used a single `is_rate_limited` variable that lumped both `FailoverReason.rate_limit` and `FailoverReason.billing` together, causing:

1. **"⚠️ Rate limited — switching to fallback provider..."** shown for spend-limit exhaustion
2. **"⏱️ Rate limited. Waiting Xs..."** shown while waiting for billing errors to clear
3. **"💡 Your API key was rejected. Is the key valid? Run: hermes setup"** — wrong advice for valid keys hitting spend caps
4. **Gateway users** only see "rate-limiting" with no way to discover the real billing cause

Closes #32420

## Fix

Split `is_rate_limited` into three variables:
- `is_rate_limited` — only `FailoverReason.rate_limit`
- `is_billing` — only `FailoverReason.billing`  
- `is_rate_or_billing` — both (for gates like eager fallback that should still apply)

| Location | Change |
|----------|--------|
| Eager fallback gate | Uses `is_rate_or_billing` (both trigger immediate switch) |
| Fallback status message | `"⚠️ Billing/credit exhausted — switching to fallback..."` for billing, `"⚠️ Rate limited"` for rate_limit |
| Retry wait message | `"💳 Credit/spend limit reached. Waiting Xs..."` for billing |
| Final failure message | `"💳 Credit/spend limit reached after N retries"` for billing |
| Non-retryable abort | Billing-specific variants throughout |
| Auth/billing guidance | **Separated**: billing gets spend-limit advice ("check provider dashboard"), auth gets key-validity advice ("run hermes setup") |
| Gateway message | New `_GATEWAY_BILLING_RE` regex + billing-specific user message |

## Test plan

- [x] 145 classifier + 402-not-retried tests pass
- [x] HTTP 402 with spend-limit message → classified as billing, shows billing messages
- [x] HTTP 429 → still classified as rate_limit, shows rate-limit messages
- [x] Auth errors (401) still show auth guidance, not billing guidance
- [x] Gateway users see billing-specific message instead of "rate-limiting"