### PR TITLE
[codex] fix(web): honor registered provider availability

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -396,6 +396,15 @@ class TestBackendSelection:
              patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             assert _get_backend() == "parallel"
 
+    def test_config_custom_registered_backend(self):
+        """web.backend=<plugin> → custom registry provider is accepted."""
+        from tools.web_tools import _get_backend
+
+        fake_provider = MagicMock()
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "kagi"}), \
+             patch("agent.web_search_registry.get_provider", return_value=fake_provider):
+            assert _get_backend() == "kagi"
+
 
 class TestParallelClientConfig:
     """Test suite for Parallel client initialization."""
@@ -679,6 +688,43 @@ class TestCheckWebApiKey:
                 with patch.dict(os.environ, {"FIRECRAWL_GATEWAY_URL": "http://127.0.0.1:3002"}, clear=False):
                     from tools.web_tools import check_web_api_key
                     assert check_web_api_key() is True
+
+    def test_registry_backend_satisfies_configured_availability(self):
+        """A configured third-party provider can expose web tools."""
+        from tools.web_tools import check_web_api_key
+
+        fake_provider = MagicMock()
+        fake_provider.is_available.return_value = True
+
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "kagi"}), \
+             patch("agent.web_search_registry.get_provider", return_value=fake_provider):
+            assert check_web_api_key() is True
+
+        fake_provider.is_available.assert_called()
+
+    def test_configured_registry_backend_does_not_fallback_to_legacy(self):
+        """Explicit custom provider config must match an available provider."""
+        from tools.web_tools import check_web_api_key
+
+        fake_provider = MagicMock()
+        fake_provider.is_available.return_value = False
+
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "kagi"}), \
+             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
+             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+            assert check_web_api_key() is False
+
+    def test_is_backend_available_delegates_unknown_names_to_registry(self):
+        """Unknown backend names are probed through the provider registry."""
+        from tools.web_tools import _is_backend_available
+
+        fake_provider = MagicMock()
+        fake_provider.is_available.return_value = True
+
+        with patch("agent.web_search_registry.get_provider", return_value=fake_provider):
+            assert _is_backend_available("kagi") is True
+
+        fake_provider.is_available.assert_called_once_with()
 
 
 def test_web_requires_env_includes_exa_key():

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -130,6 +130,29 @@ def _env_value(name: str) -> str:
     return (val or "").strip()
 
 
+_LEGACY_WEB_BACKENDS = {
+    "exa",
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "searxng",
+    "brave-free",
+    "ddgs",
+    "xai",
+}
+
+_LEGACY_AUTO_DETECT_BACKENDS = (
+    "exa",
+    "parallel",
+    "firecrawl",
+    "tavily",
+    "searxng",
+    "brave-free",
+    "ddgs",
+    "xai",
+)
+
+
 def _has_env(name: str) -> bool:
     return bool(_env_value(name))
 
@@ -141,6 +164,32 @@ def _load_web_config() -> dict:
     except (ImportError, Exception):
         return {}
 
+
+def _get_registered_web_provider(backend: str):
+    """Return a plugin-registered web provider by name, or None."""
+    if not backend:
+        return None
+    try:
+        from agent.web_search_registry import get_provider
+
+        return get_provider(backend)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not consult web provider registry for %s: %s", backend, exc)
+        return None
+
+
+def _registered_web_provider_available(backend: str):
+    """Return provider availability when *backend* is registered, else None."""
+    provider = _get_registered_web_provider(backend)
+    if provider is None:
+        return None
+    try:
+        return bool(provider.is_available())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("web provider %s.is_available() raised %s", backend, exc)
+        return False
+
+
 def _get_backend() -> str:
     """Determine which web backend to use (shared fallback).
 
@@ -149,7 +198,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in _LEGACY_WEB_BACKENDS or _get_registered_web_provider(configured) is not None:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -213,6 +262,11 @@ def _get_capability_backend(capability: str) -> str:
 
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
+    backend = (backend or "").lower().strip()
+    if backend not in _LEGACY_WEB_BACKENDS:
+        registered_available = _registered_web_provider_available(backend)
+        if registered_available is not None:
+            return registered_available
     if backend == "exa":
         return _has_env("EXA_API_KEY")
     if backend == "parallel":
@@ -1181,12 +1235,24 @@ async def web_extract_tool(
 # Convenience function to check Firecrawl credentials
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
-        return _is_backend_available(configured)
+    cfg = _load_web_config()
+    configured_backends = [
+        str(cfg.get(key) or "").lower().strip()
+        for key in ("backend", "search_backend", "extract_backend")
+    ]
+    configured_backends = [backend for backend in configured_backends if backend]
+    if configured_backends:
+        recognized_configured = False
+        for backend in configured_backends:
+            if backend in _LEGACY_WEB_BACKENDS or _get_registered_web_provider(backend) is not None:
+                recognized_configured = True
+                if _is_backend_available(backend):
+                    return True
+        if recognized_configured:
+            return False
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+        for backend in _LEGACY_AUTO_DETECT_BACKENDS
     )
 
 


### PR DESCRIPTION
> **Upstream value:** Makes web-backend detection registry-aware so plugin-registered providers are no longer falsely reported as unavailable — a fix for the provider-plugin architecture that affects anyone using custom or third-party search backends.

## Summary

Fixes #31873 by letting the web tool availability gate recognize provider names registered through `agent.web_search_registry` instead of only accepting the built-in backend list.

## Changes

- Accept configured third-party web providers in `_get_backend()` when they are present in the registry.
- Delegate unknown backend availability checks to the registered provider's `is_available()` method.
- Make `check_web_api_key()` consider configured `web.backend`, `web.search_backend`, and `web.extract_backend` provider names before falling back to legacy built-in auto-detection.
- Add regression coverage for a fake `kagi` provider proving custom providers can expose `web_search` / `web_extract`, and that unavailable explicit custom providers do not silently fall back to another backend.

## Validation

- `pytest tests/tools/test_web_tools_config.py::TestBackendSelection tests/tools/test_web_tools_config.py::TestCheckWebApiKey -q`
- `pytest tests/tools/test_web_providers.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_providers_xai.py tests/plugins/web/test_web_search_provider_plugins.py -q`
- `pytest tests/tools/test_web_tools_config.py -q`
- `python -m py_compile tools/web_tools.py`
- `git diff --check`