### PR TITLE
feat(telegram): localize bot command descriptions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -221,6 +221,79 @@ COMMAND_REGISTRY: list[CommandDef] = [
 ]
 
 
+RUSSIAN_TELEGRAM_COMMAND_DESCRIPTIONS: dict[str, str] = {
+    "new": "Новая сессия",
+    "topic": "Темы Telegram",
+    "clear": "Очистить экран",
+    "redraw": "Перерисовать интерфейс",
+    "history": "История диалога",
+    "save": "Сохранить диалог",
+    "retry": "Повторить последнее сообщение",
+    "undo": "Удалить последний обмен",
+    "title": "Назвать текущую сессию",
+    "handoff": "Передать сессию в мессенджер",
+    "branch": "Ответвить текущую сессию",
+    "compress": "Сжать контекст диалога",
+    "rollback": "Откатить файловый снимок",
+    "snapshot": "Снимки состояния Hermes",
+    "stop": "Остановить фоновые процессы",
+    "approve": "Одобрить ожидающую команду",
+    "deny": "Отклонить ожидающую команду",
+    "background": "Запустить задачу в фоне",
+    "agents": "Показать активные агенты",
+    "queue": "Поставить запрос в очередь",
+    "steer": "Вставить подсказку после tool-call",
+    "goal": "Задать постоянную цель",
+    "subgoal": "Добавить подцель",
+    "status": "Информация о сессии",
+    "whoami": "Показать права команд",
+    "profile": "Активный профиль",
+    "sethome": "Сделать этот чат домашним",
+    "resume": "Возобновить сессию",
+    "sessions": "Просмотр прошлых сессий",
+    "config": "Показать конфигурацию",
+    "model": "Сменить модель",
+    "codex_runtime": "Режим runtime для Codex",
+    "gquota": "Квота Google Gemini",
+    "personality": "Сменить личность",
+    "statusbar": "Переключить строку статуса",
+    "verbose": "Подробность вывода инструментов",
+    "footer": "Футер с метаданными шлюза",
+    "yolo": "Режим без подтверждений",
+    "reasoning": "Настроить рассуждения",
+    "fast": "Быстрый режим",
+    "skin": "Тема интерфейса",
+    "indicator": "Индикатор занятости",
+    "voice": "Голосовой режим",
+    "busy": "Поведение Enter при работе",
+    "tools": "Управление инструментами",
+    "toolsets": "Список наборов инструментов",
+    "skills": "Управление навыками",
+    "bundles": "Наборы навыков",
+    "cron": "Планировщик задач",
+    "curator": "Обслуживание навыков",
+    "kanban": "Доска задач Kanban",
+    "reload": "Перезагрузить переменные .env",
+    "reload_mcp": "Перезагрузить MCP-серверы",
+    "reload_skills": "Пересканировать навыки",
+    "browser": "Подключить браузер через CDP",
+    "plugins": "Список плагинов",
+    "commands": "Список команд и навыков",
+    "help": "Показать команды",
+    "restart": "Перезапустить шлюз",
+    "usage": "Расход токенов и лимиты",
+    "insights": "Аналитика использования",
+    "platforms": "Статус платформ",
+    "platform": "Управление платформой шлюза",
+    "copy": "Скопировать последний ответ",
+    "paste": "Прикрепить изображение из буфера",
+    "image": "Прикрепить локальное изображение",
+    "update": "Обновить Hermes Agent",
+    "debug": "Отправить debug-отчёт",
+    "quit": "Выйти из CLI",
+}
+
+
 # ---------------------------------------------------------------------------
 # Derived lookups -- rebuilt once at import time, refreshed by rebuild_lookups()
 # ---------------------------------------------------------------------------
@@ -498,7 +571,8 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
-            result.append((tg_name, cmd.description))
+            description = RUSSIAN_TELEGRAM_COMMAND_DESCRIPTIONS.get(tg_name, cmd.description)
+            result.append((tg_name, description))
     for name, description, args_hint in _iter_plugin_command_entries():
         if _requires_argument(args_hint):
             continue

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -258,6 +258,27 @@ class TestTelegramBotCommands:
         assert "codex_runtime" in names
         assert "codex-runtime" not in names
 
+    def test_builtin_telegram_menu_descriptions_are_russian(self):
+        """The Telegram bot menu should be localized for Russian-speaking users."""
+        descriptions = dict(telegram_bot_commands())
+        assert descriptions["new"] == "Новая сессия"
+        assert descriptions["background"] == "Запустить задачу в фоне"
+        assert descriptions["codex_runtime"] == "Режим runtime для Codex"
+        assert descriptions["help"] == "Показать команды"
+        assert descriptions["restart"] == "Перезапустить шлюз"
+
+    def test_every_gateway_builtin_has_russian_telegram_description(self):
+        """Any built-in command exposed in Telegram must have an explicit Russian label."""
+        from hermes_cli.commands import RUSSIAN_TELEGRAM_COMMAND_DESCRIPTIONS
+
+        for cmd in COMMAND_REGISTRY:
+            if cmd.cli_only and not cmd.gateway_config_gate:
+                continue
+            tg_name = cmd.name.replace("-", "_")
+            assert tg_name in RUSSIAN_TELEGRAM_COMMAND_DESCRIPTIONS, (
+                f"/{cmd.name} is exposed in Telegram but lacks a Russian menu description"
+            )
+
 
 class TestSlackSubcommandMap:
     def test_returns_dict(self):


### PR DESCRIPTION
## Summary
- add Russian Telegram bot command descriptions for built-in slash commands
- keep plugin command descriptions unchanged
- cover localization and coverage for every built-in command exposed in Telegram

## Tests
- python -m pytest tests/hermes_cli/test_commands.py -q -o 'addopts='
- git diff --check
- py_compile for hermes_cli/commands.py and tests/hermes_cli/test_commands.py