### PR TITLE
fix: resolve custom provider API keys from models.providers fallback

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -505,6 +505,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
+    # Fallback: v24+ config may store custom providers under models.providers
+    # (e.g. when configured via dashboard or setup wizard without explicit
+    # top-level providers key). Both schemas share the same fields: api_key,
+    # base_url, key_env, name, default_model.
+    if not isinstance(providers, dict):
+        providers = (config.get("models") or {}).get("providers")
     if isinstance(providers, dict):
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):


### PR DESCRIPTION
## Problem

The TUI gateway (`--tui` dashboard WebChat) shows "No API key configured for provider 'custom'" even when valid credentials exist in `models.providers.custom.api_key`.

## Root Cause

`_get_named_custom_provider()` in `hermes_cli/runtime_provider.py` only checks `config.get("providers")` (a top-level key). The v24 config schema stores custom provider credentials under `models.providers.<name>.api_key`, but the config migration (v11→v12) only creates the `providers` key from the legacy `custom_providers` list — it does not populate `providers` from `models.providers`.

The CLI chat (`hermes chat`) does not have this bug because it uses a different resolution path (`resolve_provider_full` → `models.dev` catalog fallback via `providers.py`).

## Steps to Reproduce

1. Configure a custom provider via the dashboard or config.yaml under `models.providers`:
```yaml
models:
  providers:
    custom:
      base_url: "http://localhost:11434/v1"
      api_key: "ollama-local"
```
2. Start dashboard with `--tui`
3. Open WebChat → see "No API key configured for provider 'custom'" and "Chat unavailable: 1"

## Fix

Add a fallback to `models.providers` when the top-level `providers` key is absent (6 lines including comment in `_get_named_custom_provider`):

```python
providers = config.get("providers")
# Fallback: v24+ config may store custom providers under models.providers
if not isinstance(providers, dict):
    providers = (config.get("models") or {}).get("providers")
```

## Why This Is Safe

- `config.get("providers")` returns `None` when absent → `isinstance(None, dict)` is `False` → fallback activates
- `config.get("models", {})` returns the models dict or empty dict → `.get("providers")` safely returns `None` if also absent
- Both schemas share the same fields: `api_key`, `base_url`, `key_env`, `name`, `default_model`
- The existing `isinstance(providers, dict)` guard already handles `None` from missing keys
- Zero behavioral change when `providers` already exists

## Related

- #32239 — Cron scheduler has similar missing propagation of `model.api_key`/`model.base_url` to `resolve_runtime_provider()`
- #20815 — Dashboard shows API key warning for local providers (symptom, not root cause)

Note for maintainer: The "right" fix would be in the config migration (v24 should populate providers from models.providers), but this runtime fallback protects against hand-edited configs regardless of migration version. Consider this a safety net — the migration fix can follow separately.