### PR TITLE
Add roombook failure autorecovery workflow

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -27,13 +27,16 @@ Security:
 """
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import subprocess
 import time
+import urllib.parse
 from typing import Any, Dict, List, Optional
 
 try:
@@ -243,6 +246,9 @@ class WebhookAdapter(BasePlatformAdapter):
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
 
+        if deliver_type == "dingtalk_robot":
+            return await self._deliver_dingtalk_robot(content, delivery)
+
         # Cross-platform delivery — any platform with a gateway adapter.
         # Check both built-in names and plugin-registered platforms.
         _is_known_platform = deliver_type in _BUILTIN_DELIVER_PLATFORMS
@@ -389,12 +395,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 )
 
         # Check event type filter
-        event_type = (
-            request.headers.get("X-GitHub-Event", "")
-            or request.headers.get("X-GitLab-Event", "")
-            or payload.get("event_type", "")
-            or "unknown"
-        )
+        event_type = self._extract_event_type(request.headers, payload)
         allowed_events = route_config.get("events", [])
         if allowed_events and event_type not in allowed_events:
             logger.debug(
@@ -474,11 +475,14 @@ class WebhookAdapter(BasePlatformAdapter):
         # to a user's chat with zero LLM cost.  Reuses the same HMAC auth,
         # rate limiting, idempotency, and template rendering as agent mode.
         if route_config.get("deliver_only"):
+            state_delivery = self._resolve_delivery_from_notify_state(payload, route_config)
+            route_extra = self._render_delivery_extra(
+                route_config.get("deliver_extra", {}), payload
+            )
+            state_extra = (state_delivery or {}).get("deliver_extra") or {}
             delivery = {
-                "deliver": route_config.get("deliver", "log"),
-                "deliver_extra": self._render_delivery_extra(
-                    route_config.get("deliver_extra", {}), payload
-                ),
+                "deliver": (state_delivery or {}).get("deliver") or route_config.get("deliver", "log"),
+                "deliver_extra": {**route_extra, **state_extra},
                 "payload": payload,
             }
             logger.info(
@@ -532,11 +536,14 @@ class WebhookAdapter(BasePlatformAdapter):
         # Store delivery info for send().  Read by every send() invocation
         # for this chat_id (interim status messages and the final response),
         # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
+        state_delivery = self._resolve_delivery_from_notify_state(payload, route_config)
+        route_extra = self._render_delivery_extra(
+            route_config.get("deliver_extra", {}), payload
+        )
+        state_extra = (state_delivery or {}).get("deliver_extra") or {}
         deliver_config = {
-            "deliver": route_config.get("deliver", "log"),
-            "deliver_extra": self._render_delivery_extra(
-                route_config.get("deliver_extra", {}), payload
-            ),
+            "deliver": (state_delivery or {}).get("deliver") or route_config.get("deliver", "log"),
+            "deliver_extra": {**route_extra, **state_extra},
             "payload": payload,
         }
         self._delivery_info[session_chat_id] = deliver_config
@@ -662,6 +669,131 @@ class WebhookAdapter(BasePlatformAdapter):
 
         return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
 
+    def _extract_event_type(self, headers: Any, payload: dict) -> str:
+        """Extract provider or payload event type for route filtering.
+
+        GitHub/GitLab-style webhooks normally use headers, while internal
+        producers such as roombook often put the event at top-level `event`.
+        Keep `event_type` first for backwards compatibility, then fall back to
+        the common `event` alias before classifying as unknown.
+        """
+        event_type = (
+            headers.get("X-GitHub-Event", "")
+            or headers.get("X-GitLab-Event", "")
+            or payload.get("event_type", "")
+            or payload.get("event", "")
+            or "unknown"
+        )
+        return str(event_type) if event_type else "unknown"
+
+    def _resolve_delivery_from_notify_state(
+        self, payload: dict, route_config: Optional[dict] = None
+    ) -> Optional[dict]:
+        """Return opt-in delivery config encoded in roombook fields.notify_state.
+
+        Roombook treats notify_state as opaque and echoes it back in async
+        callbacks.  Hermes-created roombook tasks store the originating
+        conversation there so callbacks can return to the same platform/chat/
+        thread that created the task instead of a profile-wide static route.
+
+        Supported schema:
+            {"v":1,"target":{"platform":"discord","chat_id":"...","thread_id":"..."}}
+        Backwards-compatible aliases:
+            target.type / target.deliver can be used instead of platform.
+
+        Security: this is disabled unless the route sets
+        allow_notify_state_delivery=true.  Even then, targets must either match
+        the route's configured deliver/deliver_extra or appear in
+        notify_state_allowed_targets as platform:chat_id[:thread_id].
+        DingTalk robot env-var names must also be allowlisted explicitly.
+        """
+        route_config = route_config or {}
+        if not route_config.get("allow_notify_state_delivery"):
+            return None
+
+        fields = payload.get("fields") if isinstance(payload, dict) else None
+        raw_state = ""
+        if isinstance(fields, dict):
+            raw_state = fields.get("notify_state") or fields.get("notifyState") or ""
+        if not raw_state and isinstance(payload, dict):
+            raw_state = payload.get("notify_state") or payload.get("notifyState") or ""
+        if not isinstance(raw_state, str) or not raw_state.strip():
+            return None
+
+        try:
+            state = json.loads(raw_state)
+        except Exception:
+            return None
+        if not isinstance(state, dict):
+            return None
+
+        target = state.get("target")
+        if not isinstance(target, dict):
+            return None
+
+        deliver = target.get("platform") or target.get("deliver") or target.get("type")
+        if deliver == "conversation":
+            deliver = target.get("platform")
+        if not isinstance(deliver, str) or not deliver:
+            return None
+        if deliver not in _BUILTIN_DELIVER_PLATFORMS and deliver != "dingtalk_robot":
+            logger.warning("[webhook] Ignoring notify_state with unsupported deliver target: %s", deliver)
+            return None
+
+        extra: Dict[str, Any] = {}
+        if isinstance(target.get("chat_id"), str) and target.get("chat_id"):
+            extra["chat_id"] = target["chat_id"]
+        thread_id = target.get("thread_id") or target.get("message_thread_id")
+        if isinstance(thread_id, str) and thread_id:
+            extra["thread_id"] = thread_id
+        # dingtalk_robot is a durable fixed-robot route; it needs env-var names,
+        # not chat_id.  Allow these only when explicitly encoded by the creator.
+        for key in ("webhook_env", "secret_env", "keyword"):
+            if isinstance(target.get(key), str) and target.get(key):
+                extra[key] = target[key]
+
+        # A partially populated notify_state must not bypass route-level
+        # delivery policy. By default, only the route's configured target is
+        # accepted. Broader per-task return routing must be explicitly listed.
+        route_extra = route_config.get("deliver_extra", {})
+        if not isinstance(route_extra, dict):
+            route_extra = {}
+        allowed_targets = route_config.get("notify_state_allowed_targets", [])
+        if not isinstance(allowed_targets, list):
+            allowed_targets = []
+        candidate_parts = [deliver]
+        if extra.get("chat_id"):
+            candidate_parts.append(str(extra["chat_id"]))
+        if extra.get("thread_id"):
+            candidate_parts.append(str(extra["thread_id"]))
+        candidate = ":".join(candidate_parts)
+        route_match = (
+            deliver == route_config.get("deliver")
+            and (not extra.get("chat_id") or extra.get("chat_id") == route_extra.get("chat_id"))
+            and (not extra.get("thread_id") or extra.get("thread_id") == route_extra.get("thread_id"))
+        )
+        if not route_match and candidate not in allowed_targets:
+            logger.warning("[webhook] Ignoring notify_state target outside route allowlist: %s", candidate)
+            return None
+
+        if deliver == "dingtalk_robot":
+            allowed_envs = route_config.get("notify_state_allowed_envs", [])
+            if not isinstance(allowed_envs, list):
+                allowed_envs = []
+            for env_key in ("webhook_env", "secret_env"):
+                env_name = extra.get(env_key)
+                if env_name and env_name not in allowed_envs:
+                    logger.warning("[webhook] Ignoring notify_state DingTalk env outside allowlist")
+                    return None
+
+        logger.info(
+            "[webhook] notify_state routing override target=%s has_chat=%s has_thread=%s",
+            deliver,
+            bool(extra.get("chat_id") or extra.get("webhook_env")),
+            bool(extra.get("thread_id")),
+        )
+        return {"deliver": deliver, "deliver_extra": extra}
+
     def _render_delivery_extra(
         self, extra: dict, payload: dict
     ) -> dict:
@@ -699,6 +831,9 @@ class WebhookAdapter(BasePlatformAdapter):
 
         if deliver_type == "github_comment":
             return await self._deliver_github_comment(content, delivery)
+
+        if deliver_type == "dingtalk_robot":
+            return await self._deliver_dingtalk_robot(content, delivery)
 
         # Fall through to the cross-platform dispatcher, which validates the
         # target name and routes via the gateway runner.
@@ -758,6 +893,122 @@ class WebhookAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             logger.error("[webhook] github_comment delivery error: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    async def _deliver_dingtalk_robot(
+        self, content: str, delivery: dict
+    ) -> SendResult:
+        """Send a webhook response via a fixed DingTalk group robot webhook.
+
+        This is a direct HTTP POST to a DingTalk group robot webhook URL,
+        independent of any session_webhook validity constraints.
+
+        Config expects:
+            deliver_extra:
+                webhook_env: ENV_VAR_NAME  (contains full webhook URL)
+                secret_env: ENV_VAR_NAME   (optional 加签 secret)
+                keyword: TEXT              (optional keyword to include in payload)
+        """
+        extra = delivery.get("deliver_extra", {})
+        webhook_env = extra.get("webhook_env", "")
+        secret_env = extra.get("secret_env", "")
+        keyword = extra.get("keyword", "")
+
+        if not webhook_env:
+            logger.error(
+                "[webhook] dingtalk_robot delivery missing webhook_env"
+            )
+            return SendResult(
+                success=False, error="Missing webhook_env"
+            )
+
+        webhook_url = os.environ.get(webhook_env, "")
+        if not webhook_url:
+            logger.error(
+                "[webhook] dingtalk_robot webhook_env %r not found in environment",
+                webhook_env,
+            )
+            return SendResult(
+                success=False, error=f"{webhook_env} not in environment"
+            )
+
+        try:
+            import aiohttp
+
+            # DingTalk keyword-secured robots require the keyword to appear in
+            # the message content, not just in configuration metadata.
+            message = content
+            if keyword and keyword not in message:
+                message = f"{keyword}\n{message}"
+            payload = {"msgtype": "text", "text": {"content": message}}
+
+            # Compute 加签 (HMAC signature) if secret is configured, preserving
+            # any existing access_token query string on the robot URL.
+            if secret_env:
+                secret = os.environ.get(secret_env, "")
+                if secret:
+                    timestamp = str(int(time.time() * 1000))
+                    msg_to_sign = timestamp + "\n" + secret
+                    sign = base64.b64encode(
+                        hmac.new(
+                            secret.encode(),
+                            msg_to_sign.encode(),
+                            hashlib.sha256,
+                        ).digest()
+                    ).decode()
+                    parsed = urllib.parse.urlsplit(webhook_url)
+                    query = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+                    query.extend([("timestamp", timestamp), ("sign", sign)])
+                    webhook_url = urllib.parse.urlunsplit(
+                        parsed._replace(query=urllib.parse.urlencode(query))
+                    )
+
+            timeout = aiohttp.ClientTimeout(total=15)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(webhook_url, json=payload) as resp:
+                    body = await resp.text()
+                    if resp.status not in (200, 201):
+                        logger.error(
+                            "[webhook] DingTalk robot POST failed: %d %s",
+                            resp.status,
+                            body[:200],
+                        )
+                        return SendResult(
+                            success=False,
+                            error=f"HTTP {resp.status}",
+                        )
+
+                    try:
+                        result = json.loads(body) if body else {}
+                    except Exception:
+                        result = {}
+                    errcode = result.get("errcode") if isinstance(result, dict) else None
+                    if errcode not in (None, 0):
+                        errmsg = result.get("errmsg", "") if isinstance(result, dict) else ""
+                        logger.error(
+                            "[webhook] DingTalk robot returned errcode=%s errmsg=%s",
+                            errcode,
+                            errmsg,
+                        )
+                        return SendResult(
+                            success=False,
+                            error=f"DingTalk errcode {errcode}: {errmsg}",
+                        )
+
+                    logger.info(
+                        "[webhook] DingTalk robot POST succeeded: %d",
+                        resp.status,
+                    )
+                    return SendResult(success=True)
+        except ModuleNotFoundError:
+            logger.error(
+                "[webhook] aiohttp not available for dingtalk_robot delivery"
+            )
+            return SendResult(
+                success=False, error="aiohttp not installed"
+            )
+        except Exception as e:
+            logger.error("[webhook] dingtalk_robot delivery error: %s", e)
             return SendResult(success=False, error=str(e))
 
     async def _deliver_cross_platform(

--- a/skills/productivity/roombook-failure-autorecovery/SKILL.md
+++ b/skills/productivity/roombook-failure-autorecovery/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: roombook-failure-autorecovery
+description: Use when roombook / 有成会议 booking fails and a webhook should trigger automatic diagnosis, corrective re-booking, requester notification, and a Discord repair report to Kevin.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [roombook, dingtalk, webhook, incident-response, autorecovery, meeting-rooms]
+    related_skills: [roombook, webhook-subscriptions, hermes-agent]
+---
+
+# Roombook Failure Auto-Recovery
+
+## Overview
+
+This skill defines the incident workflow for 钉钉群 / 有成会议 booking failures. It is designed for a Hermes webhook route that receives `task.failed`, `task.notify_failed`, `task.cookie_expired`, or similar roombook events, then drives the agent to:
+
+1. **补任务**：if the original meeting still needs a room, create a replacement booking task or immediately book another suitable room.
+2. **通知预定人**：after recovery succeeds, proactively notify the original requester / delegatee in the appropriate DingTalk group or DM.
+3. **自动排查位置情况并修复**：diagnose whether the failure came from cookie, room availability, callback routing, DingTalk notification, DWS calendar, Hermes webhook delivery, profile/tooling, or roombook server-side notify errors; fix what is safe to fix.
+4. **Discord 汇报 Kevin**：after the issue is understood and recovery/fix is complete, send a concise Discord summary to Kevin / origin Discord thread.
+
+Load this together with `roombook` and `webhook-subscriptions` when building or operating the webhook flow.
+
+## When to Use
+
+Use this skill when:
+
+- A roombook webhook reports booking failure, notification failure, cookie expiry, callback failure, or unclear task state.
+- 钉钉群里用户 says “没订上 / 没通知 / 会议室预定失败 / 任务失败”.
+- Kevin asks for a hook-based self-healing workflow for meeting-room booking incidents.
+- You need to distinguish “任务创建成功”, “会议室正式预订成功”, “钉钉日程成功”, and “通知成功”.
+
+Do **not** use it for:
+
+- Normal one-off booking creation from user chat. Use `roombook`.
+- Pure recurring booking setup. Use `roombook` recurring-booking guidance.
+- Generic Hermes webhook routing unrelated to meeting rooms. Use `webhook-subscriptions`.
+
+## Required Capabilities / Environment
+
+The recovery agent normally needs these capabilities:
+
+- Skills: `roombook`, `webhook-subscriptions`, this skill.
+- Toolsets: `terminal`, `file`, `messaging`, optionally `session_search` and `web`.
+- CLI/tools: roombook CLI script from the `roombook` skill; `dws` for DingTalk contact/group notification and calendar checks.
+- Environment: `ROOMBOOK_API_URL`, `ROOMBOOK_SECRET_KEY`, `ROOMBOOK_NOTIFY_URL`, and, for admin repair, any project-specific roombook/server credentials already present in the runtime.
+
+For DingTalk Work isolated profile, do **not** broaden the Work bot with `terminal` or `skills` just for user-facing booking. This recovery workflow should run in the admin/Hermes profile triggered by webhook or Discord, not inside the locked-down Work group bot unless Kevin explicitly approves broader tooling.
+
+## Webhook Route Shape
+
+Create a Hermes webhook subscription whose prompt is self-contained and loads this skill plus `roombook`:
+
+```bash
+hermes webhook subscribe roombook-failure-recovery \
+  --events "task.failed,task.notify_failed,task.cookie_expired,unknown" \
+  --skills "roombook,roombook-failure-autorecovery" \
+  --deliver discord \
+  --description "Auto-diagnose and recover failed roombook bookings" \
+  --prompt "Roombook incident webhook received. Load roombook-failure-autorecovery and roombook. Payload JSON follows:\n{__raw__}\n\nGoals: (1) recover the booking if still needed and notify the requester after success; (2) diagnose room/location/notification/callback failure and fix safe issues; (3) report concise result to Kevin in Discord. Do not expose internal IDs to normal users."
+```
+
+Use `{__raw__}` for the full webhook body. The webhook adapter supports dot-notation fields plus this special raw-payload token; `{payload}` is not a built-in token and will remain literal, leaving the recovery agent without incident details.
+
+Important event-filter pitfall: older Hermes webhook adapters classified roombook top-level `event` payloads as `unknown`; keep `unknown` in route events when supporting older deployments. Current adapters map `payload.event` after `payload.event_type`.
+
+## Incident Triage: First 5 Minutes
+
+1. **Parse payload and preserve evidence**
+   - Record event type, human message, task fields, room/date/time/subject/requester/delegatee, and `fields.notify_state`.
+   - Treat `notify_state` as opaque unless it is clearly JSON.
+   - Do not show internal task/user IDs to normal DingTalk users.
+
+2. **Classify incident**
+   - Booking execution failed: room unavailable, cookie expired, API error, conflict, malformed task.
+   - Notification failed: room was booked but original DingTalk/Discord notification did not arrive.
+   - Calendar failed: room booked but DWS calendar event failed.
+   - Callback failed: roombook could not POST to Hermes webhook, or Hermes accepted it but did not deliver cross-platform.
+   - Unknown: webhook lacks enough detail; query roombook task state and logs.
+
+3. **Check current business truth**
+   - Use roombook task state to answer “did the official meeting room booking succeed?”
+   - Use `room-availability` / `free-rooms` for real room availability. Never infer availability from `list-tasks` alone.
+   - If notification failure is suspected, confirm booking success before saying “已订好”.
+
+4. **Decide whether recovery is still needed**
+   - If original meeting time has passed, do not create a replacement booking. Report and fix root cause only.
+   - If room already booked successfully, do not create a duplicate. Fix/send missing notifications.
+   - If booking failed and meeting is still future/currently actionable, create a replacement task or book an available alternative.
+
+5. **Set user-facing posture**
+   - To requester: short practical message: current status + recovered booking result + any action needed (e.g. refresh cookie).
+   - To Kevin/Discord: incident details, root cause, repair action, verification.
+
+## Recovery Decision Tree
+
+### A. Cookie expired / no cookie
+
+1. Run/check equivalent of `check-cookie` for the original booking user.
+2. If meeting booking window is future and task can wait:
+   - Create/keep a waiting task when the roombook rules allow future-task creation despite current expired cookie.
+   - Notify requester to refresh 有成会议 cookie at the correct time (usually execution前一晚 20:30 for 00:00 window).
+3. If booking needs immediate execution:
+   - Notify requester that they must open DingTalk → 有成会议 once to refresh cookie.
+   - Do not substitute Kevin/admin cookie for another requester unless this is explicitly an admin/delegated booking scenario.
+4. After cookie is refreshed, re-run booking or create replacement task and verify.
+
+### B. Target room unavailable / conflict
+
+1. Query real-time availability with `room-availability` or `free-rooms` for the exact date/time and required seat range.
+2. If the original room is now unavailable:
+   - Prefer the closest suitable available room by seat count/location/name convention.
+   - If multiple reasonable choices exist and time allows, ask requester; if webhook-run cannot ask, choose the smallest adequate room and mention the substitution.
+3. Create replacement booking task using `--room-name`, never guessed `--room-id`.
+4. Verify final task state / booking success.
+5. Notify requester of the substituted room and reason.
+
+### C. Task created but official booking not confirmed
+
+1. Query task state via roombook (`list-tasks` / task details if available).
+2. Distinguish:
+   - Waiting task: not yet official booking.
+   - Success with meetingId: official booking succeeded.
+   - Failed: official booking failed and needs recovery.
+3. If waiting but execution should have happened, inspect daemon/server logs or trigger safe retry if supported.
+4. Only say “订好了” after official success is confirmed.
+
+### D. Booking success but requester/group not notified
+
+1. Confirm official booking success first: room, date, time, subject, requester/delegatee.
+2. Identify original target:
+   - Prefer task-level `notify_state.target` if present.
+   - Otherwise inspect Hermes Work profile session/logs or roombook task metadata.
+3. For DingTalk group notification, prefer DWS group send rather than short-lived Hermes DingTalk `session_webhook`:
+   - Resolve delegatee/requester with `dws contact user search` or `dws aisearch person`.
+   - Verify target group with `dws chat conversation-info`.
+   - Send message with `<@userId>` plus `--at-users <userId>`.
+   - Verify with `dws chat message search` when possible.
+4. If notification route is broken, fix route/state/config after manual补发.
+
+### E. Roombook → Hermes webhook POST failed
+
+1. Check roombook server logs around event time for `notifyManager_*`, `EOF`, timeout, 401/403/404, or connection errors.
+2. Verify task-level `notify_url` points to a URL reachable from the roombook server/container.
+3. If using Tailscale MagicDNS and container reports EOF, test from inside container; switch to Hermes node Tailscale IPv4 if needed.
+4. Verify Hermes webhook `/health`, route secret, route events, and gateway logs.
+5. Re-send/retry notification if supported; otherwise manually notify requester and document the fix.
+
+### F. Hermes accepted webhook but did not deliver to target
+
+1. Check Hermes gateway logs for webhook route match and final cross-platform delivery.
+2. Do not confuse `[Webhook] Sending response ... to webhook:...` with target delivery success.
+3. Verify `deliver` / `deliver_extra.chat_id` and route target.
+4. If DingTalk proactive delivery relies on `session_webhook`, remember it expires quickly (about 85 safe minutes). Use fixed DingTalk robot/DWS route for durable booking-result notifications.
+5. Fix subscription config or notify-state construction, then test with `hermes webhook test` or a synthetic roombook payload.
+
+### G. DWS calendar failed after booking success
+
+1. Do not mark the meeting-room booking as failed just because calendar failed.
+2. Verify mapping of requester/delegatee:
+   - Explicit “给/帮某人订” means delegatee should receive calendar / @ notification.
+   - Do not default to Kevin just because Kevin/admin initiated the request.
+3. Use `dws calendar event create --dry-run` to validate summary, date/time, timezone, attendees, and compere before enabling real create.
+4. Repair calendar separately and mention it in Discord summary.
+
+## Safe Auto-Fix Policy
+
+The recovery agent may do these without asking Kevin first:
+
+- Query roombook task state, room list, room availability, cookie status.
+- Query Hermes webhook/gateway logs.
+- Send a missing “已订好” notice when booking success is already verified and target group/person is unambiguous.
+- Create a replacement task for the same requester/time/subject when the original failed and the new room is the same room or the only clearly suitable available alternative.
+- Fix task-level `notify_state` / webhook route if the correct target is unambiguous and change is low-risk.
+
+Ask Kevin or report needing manual decision when:
+
+- Multiple alternative rooms are plausible and no requester can be asked.
+- The meeting time, requester, or room target is ambiguous.
+- Fix requires code deployment, service restart, schema migration, or broad platform/toolset changes.
+- The recovery would impersonate another user or use admin cookie for a non-admin requester.
+
+## User Notification Templates
+
+### Booking recovered, same room
+
+```text
+已处理：刚才会议室预订失败，我已重新补订成功。
+会议：{subject}
+时间：{date} {start}-{end}
+会议室：{room}
+
+后续你不用再操作。
+```
+
+### Booking recovered, alternative room
+
+```text
+已处理：原会议室当时不可订，我已为你改订可用会议室。
+会议：{subject}
+时间：{date} {start}-{end}
+会议室：{new_room}
+说明：原会议室 {old_room} 已被占用/不可订。
+```
+
+### Cookie action needed
+
+```text
+这次没有自动补订成功，原因是你的有成会议授权已过期。
+请在钉钉里打开一次「有成会议」刷新授权；刷新后我会继续补订/你也可以再发一句“继续补订”。
+```
+
+### Manual decision needed
+
+```text
+我已排查到失败原因：{reason}。
+当前有多个可选会议室：{options}。
+请回复选哪个会议室，我再帮你补订。
+```
+
+## Discord Report Template for Kevin
+
+Use bullets, not Markdown tables:
+
+```text
+会议室预订故障已处理：{status}
+
+- 原因：{root_cause}
+- 影响：{requester/delegatee} / {date} {start}-{end} / {subject}
+- 恢复动作：{created replacement task | booked same room | changed to alternative room | resent notification | fixed webhook route}
+- 当前结果：{official booking success? room? notification delivered? calendar?}
+- 已修复：{config/code/route/cookie guidance/log evidence}
+- 仍需关注：{none | manual action}
+```
+
+If user-facing identifiers are included, prefer names. Avoid raw `dingId`, `roomId`, and task IDs unless Kevin explicitly asks for debugging details.
+
+## Implementation Checklist for the Webhook Automation
+
+- [ ] Webhook platform enabled and `/health` reachable from roombook server/container.
+- [ ] Subscription exists for failure-like events and includes `unknown` until payload event mapping is verified.
+- [ ] Subscription prompt loads `roombook` and `roombook-failure-autorecovery`.
+- [ ] Route delivery goes to Kevin’s Discord target or current origin thread for admin reports.
+- [ ] `ROOMBOOK_NOTIFY_URL` is task-level and reachable from roombook.
+- [ ] Task creation writes `notify_state` containing original platform/chat/person target when available.
+- [ ] Recovery prompt tells the agent not to expose internal IDs to normal users.
+- [ ] Synthetic webhook test covers: booking failed, booking success but notify failed, cookie expired, callback EOF.
+- [ ] DingTalk requester notification path is durable: DWS group send / fixed robot preferred over `session_webhook`.
+- [ ] Logs are checked for both roombook server notify and Hermes final cross-platform delivery.
+
+## Verification Checklist Per Incident
+
+- [ ] Official room booking state verified, not inferred from task creation alone.
+- [ ] Room availability verified with `room-availability` / `free-rooms` if changing rooms.
+- [ ] Replacement task/booking created only if still needed.
+- [ ] Requester/delegatee notified after success, with @ mention if DingTalk group and person is unambiguous.
+- [ ] Root cause categorized and safe repair applied.
+- [ ] Webhook/callback route tested after repair when relevant.
+- [ ] Kevin received Discord summary after recovery/fix.
+
+## Common Pitfalls
+
+1. **Saying “订好了” too early.** A task ID or created waiting task is not official booking success. Confirm task success / meeting ID first.
+
+2. **Using `list-tasks` as availability.** `list-tasks` is history/status only. Real availability must come from `room-availability` / `free-rooms`.
+
+3. **Fixing notification by writing `configure-webhook` byUser.** byUser is shared per dingId and can be overwritten by another agent/node. Prefer task-level `notify_url` + `notify_state`.
+
+4. **Relying on DingTalk `session_webhook` for future proactive notifications.** It expires quickly. Use DWS/fixed robot for durable booking-result notices.
+
+5. **Using Kevin/admin cookie for everyone.** In group booking, default requester is the sender; if their cookie is expired, ask them to refresh unless it is an explicit admin/delegated scenario.
+
+6. **Notifying the wrong person in delegated bookings.** “给/帮 X 订” means X is the delegatee and should be @’d / calendared when recover succeeds.
+
+7. **Only checking Hermes logs for notify failures.** If roombook POST failed before reaching Hermes, Hermes has no inbound record. Check roombook server logs too.
+
+8. **Exposing internal IDs in group messages.** Keep `dingId`, `roomId`, task IDs, meeting IDs out of normal user-facing replies.

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -229,6 +229,126 @@ class TestRenderDeliveryExtra:
         assert result["static"] == 42  # non-string left as-is
 
 
+class TestResolveNotifyStateDelivery:
+    def test_resolves_roombook_notify_state_target(self):
+        adapter = _make_adapter()
+        payload = {
+            "fields": {
+                "notify_state": json.dumps(
+                    {
+                        "v": 1,
+                        "target": {
+                            "platform": "discord",
+                            "chat_id": "1498372995712942172",
+                            "thread_id": "1508726721388740649",
+                        },
+                    }
+                )
+            }
+        }
+
+        route_config = {
+            "allow_notify_state_delivery": True,
+            "deliver": "discord",
+            "deliver_extra": {
+                "chat_id": "1498372995712942172",
+                "thread_id": "1508726721388740649",
+            },
+        }
+        result = adapter._resolve_delivery_from_notify_state(payload, route_config)
+
+        assert result == {
+            "deliver": "discord",
+            "deliver_extra": {
+                "chat_id": "1498372995712942172",
+                "thread_id": "1508726721388740649",
+            },
+        }
+
+    def test_ignores_malformed_or_unsupported_notify_state(self):
+        adapter = _make_adapter()
+        route_config = {"allow_notify_state_delivery": True, "deliver": "discord"}
+        assert adapter._resolve_delivery_from_notify_state({"fields": {"notify_state": "not-json"}}, route_config) is None
+        assert adapter._resolve_delivery_from_notify_state(
+            {"fields": {"notify_state": json.dumps({"target": {"platform": "unknown-platform"}})}},
+            route_config,
+        ) is None
+
+    def test_notify_state_delivery_is_opt_in(self):
+        adapter = _make_adapter()
+        payload = {"fields": {"notify_state": json.dumps({"target": {"platform": "discord", "chat_id": "target"}})}}
+
+        assert adapter._resolve_delivery_from_notify_state(payload, {"deliver": "discord"}) is None
+
+    def test_notify_state_rejects_unallowlisted_target(self):
+        adapter = _make_adapter()
+        payload = {"fields": {"notify_state": json.dumps({"target": {"platform": "discord", "chat_id": "evil"}})}}
+        route_config = {
+            "allow_notify_state_delivery": True,
+            "deliver": "discord",
+            "deliver_extra": {"chat_id": "safe"},
+        }
+
+        assert adapter._resolve_delivery_from_notify_state(payload, route_config) is None
+
+    def test_notify_state_allows_explicit_allowlisted_target(self):
+        adapter = _make_adapter()
+        payload = {
+            "fields": {
+                "notify_state": json.dumps(
+                    {"target": {"platform": "discord", "chat_id": "other", "thread_id": "t1"}}
+                )
+            }
+        }
+        route_config = {
+            "allow_notify_state_delivery": True,
+            "deliver": "discord",
+            "notify_state_allowed_targets": ["discord:other:t1"],
+        }
+
+        result = adapter._resolve_delivery_from_notify_state(payload, route_config)
+
+        assert result == {"deliver": "discord", "deliver_extra": {"chat_id": "other", "thread_id": "t1"}}
+
+    @pytest.mark.asyncio
+    async def test_notify_state_extra_merges_with_route_extra(self):
+        routes = {
+            "roombook": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "ok",
+                "deliver": "dingtalk_robot",
+                "deliver_extra": {
+                    "webhook_env": "DT_ROBOT_WEBHOOK",
+                    "secret_env": "DT_ROBOT_SECRET",
+                },
+                "allow_notify_state_delivery": True,
+                "notify_state_allowed_targets": ["dingtalk_robot"],
+            }
+        }
+        payload = {
+            "fields": {
+                "notify_state": json.dumps(
+                    {"target": {"platform": "dingtalk_robot", "keyword": "有成会议"}}
+                )
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/webhooks/roombook", json=payload)
+
+        assert resp.status == 202
+        delivery = next(iter(adapter._delivery_info.values()))
+        assert delivery["deliver"] == "dingtalk_robot"
+        assert delivery["deliver_extra"] == {
+            "webhook_env": "DT_ROBOT_WEBHOOK",
+            "secret_env": "DT_ROBOT_SECRET",
+            "keyword": "有成会议",
+        }
+
+
 # ===================================================================
 # Event filtering
 # ===================================================================
@@ -259,6 +379,52 @@ class TestEventFilter:
                 headers={"X-GitHub-Event": "pull_request"},
             )
             assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_payload_event_alias(self):
+        """Top-level payload.event is accepted for internal producers like roombook."""
+        routes = {
+            "roombook": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["task.failed"],
+                "prompt": "Task failed: {message}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/roombook",
+                json={"event": "task.failed", "message": "room unavailable"},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["event"] == "task.failed"
+
+    @pytest.mark.asyncio
+    async def test_event_type_field_takes_precedence_over_event_alias(self):
+        """Existing event_type semantics stay stable when both fields exist."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["preferred"],
+                "prompt": "ok",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/r",
+                json={"event_type": "preferred", "event": "fallback"},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["event"] == "preferred"
 
     @pytest.mark.asyncio
     async def test_event_filter_rejects_non_matching(self):
@@ -692,6 +858,83 @@ class TestRawTemplateToken:
         assert result.startswith("Action=closed Raw=")
         assert '"action": "closed"' in result
         assert '"number": 7' in result
+
+
+# ===================================================================
+# DingTalk robot delivery
+# ===================================================================
+
+
+class TestDingTalkRobotDelivery:
+    @pytest.mark.asyncio
+    async def test_send_routes_agent_mode_dingtalk_robot(self):
+        adapter = _make_adapter()
+        chat_id = "webhook:test:dt"
+        adapter._delivery_info[chat_id] = {
+            "deliver": "dingtalk_robot",
+            "deliver_extra": {"webhook_env": "DUMMY"},
+        }
+        adapter._deliver_dingtalk_robot = AsyncMock(return_value=SendResult(success=True))
+
+        result = await adapter.send(chat_id, "hello")
+
+        assert result.success is True
+        adapter._deliver_dingtalk_robot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dingtalk_robot_success_includes_keyword_and_signature(self, monkeypatch):
+        adapter = _make_adapter()
+        received = []
+
+        async def robot_handler(request):
+            received.append({"query": dict(request.query), "body": await request.json()})
+            return web.json_response({"errcode": 0, "errmsg": "ok"})
+
+        app = web.Application()
+        app.router.add_post("/robot", robot_handler)
+        async with TestClient(TestServer(app)) as cli:
+            monkeypatch.setenv("DT_ROBOT_WEBHOOK", str(cli.make_url("/robot?access_token=abc")))
+            monkeypatch.setenv("DT_ROBOT_SECRET", "sign-secret")
+
+            result = await adapter._deliver_dingtalk_robot(
+                "booking recovered",
+                {
+                    "deliver_extra": {
+                        "webhook_env": "DT_ROBOT_WEBHOOK",
+                        "secret_env": "DT_ROBOT_SECRET",
+                        "keyword": "有成会议",
+                    }
+                },
+            )
+
+        assert result.success is True
+        assert received[0]["query"]["access_token"] == "abc"
+        assert "timestamp" in received[0]["query"]
+        assert "sign" in received[0]["query"]
+        assert received[0]["body"] == {
+            "msgtype": "text",
+            "text": {"content": "有成会议\nbooking recovered"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_dingtalk_robot_200_errcode_is_failure(self, monkeypatch):
+        adapter = _make_adapter()
+
+        async def robot_handler(request):
+            return web.json_response({"errcode": 310000, "errmsg": "keywords not in content"})
+
+        app = web.Application()
+        app.router.add_post("/robot", robot_handler)
+        async with TestClient(TestServer(app)) as cli:
+            monkeypatch.setenv("DT_ROBOT_WEBHOOK", str(cli.make_url("/robot")))
+
+            result = await adapter._deliver_dingtalk_robot(
+                "booking recovered",
+                {"deliver_extra": {"webhook_env": "DT_ROBOT_WEBHOOK"}},
+            )
+
+        assert result.success is False
+        assert "DingTalk errcode 310000" in (result.error or "")
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary
- add roombook failure auto-recovery skill for webhook-triggered incident handling
- teach webhook routes to classify internal payload.event values while preserving provider header support
- gate notify_state delivery overrides behind route-level opt-in/allowlists and add DingTalk robot delivery support

## Verification
- python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_deliver_only.py tests/gateway/test_webhook_dynamic_routes.py tests/hermes_cli/test_webhook_cli.py -q
- ruff check gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py
- skill frontmatter/token validation
- staged security grep for hardcoded secrets/dangerous code patterns
- independent reviewer pass