### PR TITLE
fix(agent): inject Pincher-first guidance when tools are loaded

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -172,6 +172,17 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+PINCHER_FIRST_GUIDANCE = (
+    "[Pincher Router — code navigation directive]\n"
+    "For ALL code lookups, follow this order:\n"
+    "  1. mcp_pincher_search   — find a symbol by name or keyword\n"
+    "  2. mcp_pincher_context  — read a symbol + its imports before editing\n"
+    "  3. mcp_pincher_trace    — check callers before changing a signature\n"
+    "  4. mcp_pincher_changes  — blast-radius check before finalising edits\n"
+    "Do NOT call Read / Grep / Glob for code navigation until Pincher returns no result. "
+    "Every Pincher call generates a routing signal that reduces your cost per turn."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -34,6 +34,7 @@ from agent.prompt_builder import (
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    PINCHER_FIRST_GUIDANCE,
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
@@ -108,6 +109,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    if any(name.startswith("mcp_pincher_") for name in agent.valid_tool_names):
+        tool_guidance.append(PINCHER_FIRST_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/tests/run_agent/test_pincher_first_prompt_guidance.py
+++ b/tests/run_agent/test_pincher_first_prompt_guidance.py
@@ -1,0 +1,64 @@
+"""Regression tests for Pincher-first prompt guidance injection."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    """Build minimal tool definitions accepted by AIAgent.__init__."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent_with_tools(*tool_names: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def test_pincher_first_guidance_injected_when_pincher_mcp_tools_loaded():
+    agent = _make_agent_with_tools(
+        "mcp_pincher_search",
+        "mcp_pincher_context",
+        "mcp_pincher_trace",
+        "mcp_pincher_changes",
+        "read_file",
+    )
+
+    prompt = agent._build_system_prompt()
+
+    assert "mcp_pincher_search" in prompt
+    assert "mcp_pincher_context" in prompt
+    assert "mcp_pincher_trace" in prompt
+    assert "mcp_pincher_changes" in prompt
+    assert "Do NOT call Read / Grep / Glob for code navigation until Pincher returns no result" in prompt
+
+
+def test_pincher_first_guidance_not_injected_without_pincher_mcp_tools():
+    agent = _make_agent_with_tools("read_file", "search_files", "terminal")
+
+    prompt = agent._build_system_prompt()
+
+    assert "mcp_pincher_search" not in prompt
+    assert "Do NOT call Read / Grep / Glob for code navigation until Pincher returns no result" not in prompt


### PR DESCRIPTION
## Summary
- Add reusable Pincher-first prompt guidance text for code navigation
- Inject it only when Pincher MCP tools are available
- Add regression coverage for both injected and non-injected cases

## Test Plan
- python -m pytest tests/run_agent/test_pincher_first_prompt_guidance.py tests/agent/test_system_prompt_restore.py