### PR TITLE
fix(agent): trigger fallback when content filter terminates stream mid-delivery (#32421)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -65,6 +65,27 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+_CONTENT_FILTER_STREAM_ERROR_PATTERNS = (
+    "new_sensitive",
+    "content_filter",
+    "content filtered",
+    "guardrail_intervened",
+    "safety filter",
+    "safety",
+    "output sensitive",
+    "recitation",
+    "refusal",
+)
+
+
+def is_content_filter_stream_error(error: Any) -> bool:
+    """Return True when a stream error looks like provider output filtering."""
+    message = str(error).lower()
+    return "1027" in message or any(
+        pattern in message for pattern in _CONTENT_FILTER_STREAM_ERROR_PATTERNS
+    )
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -2284,7 +2305,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,
             )
-            return SimpleNamespace(
+            # Detect content-filter termination: when the provider's output
+            # safety filter (e.g. MiniMax "new_sensitive", Azure/Gemini
+            # content_filter, Bedrock guardrail_intervened) kills the stream
+            # mid-delivery, the error message contains distinctive keywords.
+            # Tagging the stub lets the conversation loop trigger fallback
+            # instead of futile continuation retries against the same provider.
+            _content_filter_terminated = is_content_filter_stream_error(result["error"])
+
+            _stub = SimpleNamespace(
                 id=PARTIAL_STREAM_STUB_ID,
                 model=getattr(agent, "model", "unknown"),
                 choices=[SimpleNamespace(
@@ -2293,6 +2322,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 usage=None,
                 _dropped_tool_names=_partial_names or None,
             )
+            if _content_filter_terminated:
+                _stub._content_filter_terminated = True
+            return _stub
         raise result["error"]
     return result["response"]
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1556,6 +1556,39 @@ def run_conversation(
                                     response, "_dropped_tool_names", None
                                 )
 
+                                # ── Content-filter termination → fallback ──────
+                                # When the provider's output safety filter (e.g.
+                                # MiniMax "new_sensitive", Azure "content_filter")
+                                # killed the stream, continuation retries against
+                                # the SAME provider are futile — the same content
+                                # will hit the same filter.  Trigger fallback
+                                # immediately instead of burning retries.
+                                if _is_partial_stream_stub and getattr(
+                                    response, "_content_filter_terminated", False
+                                ):
+                                    agent._vprint(
+                                        f"{agent.log_prefix}🛡️  Content filter "
+                                        f"terminated stream — activating fallback "
+                                        f"provider...",
+                                        force=True,
+                                    )
+                                    if agent._try_activate_fallback():
+                                        retry_count = 0
+                                        compression_attempts = 0
+                                        primary_recovery_attempted = False
+                                        # Continue the outer loop with the new
+                                        # provider — don't restart the continuation
+                                        # retry chain.
+                                        continue
+                                    # No fallback available — fall through to
+                                    # normal continuation (best-effort retry).
+                                    agent._vprint(
+                                        f"{agent.log_prefix}⚠️  No fallback "
+                                        f"provider configured — retrying with "
+                                        f"same provider (may loop)...",
+                                        force=True,
+                                    )
+
                                 if _is_partial_stream_stub and _dropped_tools:
                                     _tool_list = ", ".join(_dropped_tools[:3])
                                     agent._vprint(

--- a/tests/agent/test_32421_content_filter_fallback.py
+++ b/tests/agent/test_32421_content_filter_fallback.py
@@ -1,0 +1,202 @@
+"""Tests for content-filter stream termination → fallback detection.
+
+Covers #32421: when a provider's output safety filter (MiniMax "new_sensitive",
+Azure content_filter, Bedrock guardrail_intervened) kills a streaming response
+mid-delivery, the partial stream stub should be tagged with
+_content_filter_terminated=True, and the conversation loop should trigger
+fallback instead of continuation retries.
+"""
+
+import pytest
+from types import SimpleNamespace
+
+from agent.chat_completion_helpers import (
+    PARTIAL_STREAM_STUB_ID,  # re-exported from constants
+    is_content_filter_stream_error,
+)
+
+
+# ── Content-filter detection in stream stub creation ────────────────────
+
+# NOTE: The production detection logic is intentionally exposed as a small
+# helper so tests call the real implementation instead of copying it.
+
+
+@pytest.mark.parametrize("error_msg,expected", [
+    # MiniMax — output new_sensitive with error code
+    ("output new_sensitive (1027) — provider content safety filter", True),
+    ("Error code: 1027 — content filtered", True),
+    # Azure / OpenAI content_filter
+    ("content_filter: response was filtered by Azure OpenAI content filter", True),
+    ("Your request was rejected due to content_filter", True),
+    ("content filtered by safety system", True),
+    # Bedrock
+    ("guardrail_intervened — Amazon Bedrock guardrail", True),
+    ("Content was blocked by guardrail_intervened", True),
+    # Gemini — SAFETY finish reason mapped to "content_filter" at transport level
+    ("finish_reason: content_filter (SAFETY)", True),
+    ("recitation detected — response terminated", True),
+    ("response was refused: refusal", True),
+    # Non-content-filter errors — should NOT trigger
+    ("timeout error", False),
+    ("rate limit exceeded (429)", False),
+    ("connection reset by peer", False),
+    ("network error", False),
+    ("HTTPError: 500 Internal Server Error", False),
+    ("Stream interrupted by unknown error", False),
+])
+def test_content_filter_detection_patterns(error_msg, expected):
+    """Content-filter keywords are detected; unrelated errors are not."""
+    assert is_content_filter_stream_error(error_msg) == expected, \
+        f"Expected {expected} for: {error_msg}"
+
+
+def test_content_filter_tag_on_stub_construction():
+    """Verify the tag pattern that the conversation loop reads."""
+    # Simulate what chat_completion_helpers.py does: tag the stub
+    stub = SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        model="MiniMax-M2.7",
+        choices=[],
+        usage=None,
+        _dropped_tool_names=None,
+        _content_filter_terminated=True,
+    )
+    assert getattr(stub, "_content_filter_terminated", False) is True
+
+    # Normal stub (no content filter) shouldn't have the tag
+    normal_stub = SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        model="MiniMax-M2.7",
+        choices=[],
+        usage=None,
+        _dropped_tool_names=None,
+    )
+    assert getattr(normal_stub, "_content_filter_terminated", False) is False
+
+
+# ── Conversation-loop handling of tagged stubs ──────────────────────────
+
+def test_loop_reads_content_filter_tag(monkeypatch):
+    """The fallback trigger in conversation_loop.py reads the tag correctly."""
+    # Simulate the response object with the tag
+    response = SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        model="MiniMax-M2.7",
+        choices=[],
+        usage=None,
+        _dropped_tool_names=None,
+        _content_filter_terminated=True,
+    )
+    _is_partial_stream_stub = getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+    _content_filter_terminated = getattr(response, "_content_filter_terminated", False)
+
+    assert _is_partial_stream_stub is True
+    assert _content_filter_terminated is True
+    # This is the exact condition check in conversation_loop.py:
+    assert _is_partial_stream_stub and _content_filter_terminated
+
+
+class FakeAgent:
+    """Minimal agent mock for testing fallback trigger logic."""
+
+    def __init__(self, has_fallback=True):
+        self._has_fallback = has_fallback
+        self.fallback_activated = False
+        self.log_messages = []
+        self.log_prefix = "[test] "
+        self._fallback_chain = []
+        self._fallback_index = 0
+
+    def _vprint(self, msg, force=False):
+        self.log_messages.append(msg)
+
+    def _try_activate_fallback(self):
+        if self._has_fallback:
+            self.fallback_activated = True
+            self._has_fallback = False  # Only works once
+            return True
+        return False
+
+
+def test_fallback_triggered_on_content_filter_tag():
+    """When a stub has _content_filter_terminated, fallback is attempted."""
+    agent = FakeAgent(has_fallback=True)
+
+    response = SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        _content_filter_terminated=True,
+        _dropped_tool_names=None,
+    )
+
+    _is_partial_stream_stub = getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+    content_filter_terminated = getattr(response, "_content_filter_terminated", False)
+
+    if _is_partial_stream_stub and content_filter_terminated:
+        agent._vprint("content filter terminated", force=True)
+        if agent._try_activate_fallback():
+            assert agent.fallback_activated is True
+            agent._vprint("fallback activated", force=True)
+            # The loop would `continue` here — simulated by the flag check
+
+    assert agent.fallback_activated is True
+    assert "fallback activated" in agent.log_messages[-1]
+
+
+def test_no_fallback_gives_warning():
+    """When no fallback is configured, agent logs a warning and continues."""
+    agent = FakeAgent(has_fallback=False)
+
+    response = SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        _content_filter_terminated=True,
+        _dropped_tool_names=None,
+    )
+
+    _is_partial_stream_stub = getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+    content_filter_terminated = getattr(response, "_content_filter_terminated", False)
+
+    if _is_partial_stream_stub and content_filter_terminated:
+        agent._vprint("content filter terminated", force=True)
+        if not agent._try_activate_fallback():
+            agent._vprint("no fallback — retrying same provider", force=True)
+
+    assert agent.fallback_activated is False
+    assert any("no fallback" in msg for msg in agent.log_messages)
+
+
+def test_normal_stub_no_content_filter_does_not_trigger():
+    """A normal partial stream stub without the tag should not trigger fallback."""
+    agent = FakeAgent(has_fallback=True)
+
+    response = SimpleNamespace(
+        id=PARTIAL_STREAM_STUB_ID,
+        _content_filter_terminated=False,
+        _dropped_tool_names=["write_file"],
+    )
+
+    _is_partial_stream_stub = getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+    content_filter_terminated = getattr(response, "_content_filter_terminated", False)
+
+    # This condition should evaluate to False for normal stubs
+    triggers_fallback = _is_partial_stream_stub and content_filter_terminated
+    assert triggers_fallback is False
+
+    # Normal handling would proceed to continuation retry — fallback NOT called
+    assert agent.fallback_activated is False
+
+
+def test_non_stub_does_not_trigger():
+    """A response without PARTIAL_STREAM_STUB_ID must not trigger fallback."""
+    response = SimpleNamespace(
+        id="chatcmpl-abc123",
+        _content_filter_terminated=True,  # Tag present but not a stub!
+    )
+
+    _is_partial_stream_stub = getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID
+    content_filter_terminated = getattr(response, "_content_filter_terminated", False)
+
+    # The combined condition requires BOTH to be True
+    triggers_fallback = _is_partial_stream_stub and content_filter_terminated
+    assert triggers_fallback is False
+    # This guards against false positives on non-stub responses


### PR DESCRIPTION
## What does this PR do?

When a provider's output safety filter (e.g. MiniMax `new_sensitive`, Azure `content_filter`, Bedrock `guardrail_intervened`) kills a streaming response mid-delivery, the partial stream stub is now tagged with `_content_filter_terminated=True`. The conversation loop detects this tag and immediately activates `fallback_providers` instead of retrying against the same provider (which would hit the same filter).

**Root cause:** `interruptible_streaming_api_call` already handled stream errors by building a partial `SimpleNamespace` stub, but it didn't distinguish content-filter errors from transient network errors. The loop then retried against the same provider, which produced the same filter rejection.

**Fix:**
1. `agent/chat_completion_helpers.py`: Extract `is_content_filter_stream_error()` helper that matches known provider content-filter error keywords (`new_sensitive`, `content_filter`, `guardrail_intervened`, `safety`, `recitation`, `refusal`) and error code `1027`.
2. `agent/conversation_loop.py`: Check `_content_filter_terminated` flag on partial stream stubs before continuation retry; if set, trigger `try_activate_fallback()`.

## Related Issue

Fixes #32421

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: Added `_CONTENT_FILTER_STREAM_ERROR_PATTERNS` and `is_content_filter_stream_error()` helper
- `agent/conversation_loop.py`: Added content-filter tag check before continuation retry, with fallback activation
- `tests/agent/test_32421_content_filter_fallback.py`: 22 tests covering keyword detection (16 parametrized positive + negative cases), stub tagging, loop tag reading, fallback activation, no-fallback warning, and false-positive guards

## How to Test

1. `pytest tests/agent/test_32421_content_filter_fallback.py -v`
2. All 22 tests should pass
3. Fail-without-fix: revert `agent/chat_completion_helpers.py` and `agent/conversation_loop.py` to upstream/main → tests fail with `ImportError: cannot import name 'is_content_filter_stream_error'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
