### PR TITLE
fix(dashboard): surface Copilot gh auth login

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1423,6 +1423,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": _claude_code_only_status,
     },
     {
+        "id": "copilot",
+        "name": "GitHub Copilot",
+        "flow": "external",
+        "cli_command": "gh auth login",
+        "docs_url": "https://docs.github.com/en/copilot",
+        "status_fn": None,  # dispatched via auth.get_api_key_provider_status
+    },
+    {
         "id": "nous",
         "name": "Nous Portal",
         "flow": "device_code",
@@ -1491,6 +1499,23 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "expires_at": None,
                 "has_refresh_token": False,
                 "last_refresh": raw.get("last_refresh"),
+            }
+        if provider_id == "copilot":
+            raw = hauth.get_api_key_provider_status("copilot")
+            token_preview = None
+            if raw.get("logged_in"):
+                try:
+                    creds = hauth.resolve_api_key_provider_credentials("copilot")
+                    token_preview = _truncate_token(creds.get("api_key"))
+                except Exception:
+                    token_preview = None
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": "copilot_token",
+                "source_label": raw.get("key_source") or "GitHub token",
+                "token_preview": token_preview,
+                "expires_at": None,
+                "has_refresh_token": False,
             }
         if provider_id == "qwen-oauth":
             raw = hauth.get_qwen_auth_status()

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -313,3 +313,28 @@ def test_unknown_pkce_provider_rejected_cleanly():
     # 4xx — what we MUST NOT see is a 200 with claude.ai in the body.
     assert resp.status_code >= 400, resp.text
     assert "claude.ai" not in resp.text.lower()
+
+
+def test_oauth_providers_list_includes_copilot_when_gh_cli_token_exists():
+    """Dashboard provider list must surface Copilot when ``gh auth token`` is usable.
+
+    Bug history (2026-05-26): Copilot runtime auth already supported
+    ``gh auth token`` via ``resolve_copilot_token()``, but
+    ``/api/providers/oauth`` omitted any ``copilot`` entry entirely. The
+    dashboard therefore could not show GitHub Copilot as connected even
+    when a valid CLI-backed token existed.
+    """
+    with patch(
+        "hermes_cli.copilot_auth._try_gh_cli_token",
+        return_value="gho_gh_cli_token",
+    ):
+        resp = client.get("/api/providers/oauth", headers=HEADERS)
+
+    assert resp.status_code == 200, resp.text
+    providers = resp.json()["providers"]
+    copilot = next((p for p in providers if p["id"] == "copilot"), None)
+
+    assert copilot is not None, providers
+    assert copilot["name"] == "GitHub Copilot"
+    assert copilot["status"]["logged_in"] is True
+    assert copilot["status"]["source_label"] == "gh auth token"


### PR DESCRIPTION
## Bug Description

Dashboard provider logins did not surface GitHub Copilot at all, even when Hermes could already resolve a valid Copilot token via `gh auth token`.

Fixes #

## Root Cause

`/api/providers/oauth` only enumerated a small OAuth/external catalog and omitted the `copilot` provider entirely. Runtime auth supported Copilot through `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, and `gh auth token`, but the dashboard status API never exposed that provider, so the UI could not mark it connected.

## Fix

- add `copilot` to the dashboard provider catalog
- map Copilot dashboard status through `get_api_key_provider_status("copilot")`
- surface `source_label` from `key_source` so `gh auth token` shows correctly
- include a redacted token preview for the connected Copilot entry
- add a regression test for the `gh auth token` dashboard path

## How to Verify

1. Ensure `gh auth status` shows a valid GitHub login.
2. Open the Hermes dashboard keys/provider logins view.
3. Confirm GitHub Copilot appears and shows connected via `gh auth token`.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

Manual/API verification:
- `venv/bin/python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py -k copilot_when_gh_cli_token_exists -q`
- `venv/bin/python -m pytest tests/hermes_cli/test_web_oauth_dispatch.py tests/hermes_cli/test_api_key_providers.py -q`
- exercised `/api/providers/oauth` with patched `gh auth token` path and confirmed `copilot` now appears with `source_label: gh auth token`

## Risk Assessment

Low — change is isolated to dashboard provider enumeration/status shaping for Copilot and backed by targeted regression coverage.
