### PR TITLE
fix: remove logging.basicConfig() from library __init__ methods

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -198,12 +198,6 @@ class MiniSWERunner:
         self.image = image
         self.cwd = cwd
         
-        # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary

Removes `logging.basicConfig()` from two library class `__init__` methods that hijack the root logger configuration.

### Bug Pattern

`logging.basicConfig()` configures the **root logger** — affecting all loggers in the process. When called inside library class `__init__` methods, it overrides the host application's logging setup (format, level, handlers).

```python
# BEFORE (bug): hijacks root logger when class is instantiated
class TrajectoryCompressor:
    def __init__(self):
        logging.basicConfig(level=logging.INFO, format='...')
        self.logger = logging.getLogger(__name__)

# AFTER (safe): only creates a child logger, root config untouched
class TrajectoryCompressor:
    def __init__(self):
        self.logger = logging.getLogger(__name__)
```

### Files Fixed

| File | Class | Line |
|------|-------|------|
| `trajectory_compressor.py` | `TrajectoryCompressor.__init__` | 355 |
| `mini_swe_runner.py` | `MiniSWERunner.__init__` | 202 |

### Why This Matters

- `basicConfig()` is a no-op **after** the first call — but if these classes are instantiated **before** the main app configures logging, they steal the root logger config
- The entry point (`cli.py`, `gateway/run.py`) is responsible for root logger configuration
- `getLogger(__name__)` is always safe in library code

### Test Plan

- [x] Both files pass `py_compile`
- [ ] Verify agent startup logging format is unchanged
