### PR TITLE
[codex] fix(tui): reap dashboard slash workers

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -74,6 +74,15 @@ class PtyBridge:
         self._proc = proc
         self._fd: int = proc.fd
         self._closed = False
+        self._pgid: Optional[int] = None
+        try:
+            pgid = os.getpgid(int(proc.pid))
+            # pty.fork/forkpty children should be in their own process group.
+            # Guard anyway: never signal the dashboard's own group.
+            if pgid != os.getpgrp():
+                self._pgid = pgid
+        except Exception:
+            self._pgid = None
 
     # -- lifecycle --------------------------------------------------------
 
@@ -212,20 +221,48 @@ class PtyBridge:
         self._closed = True
 
         # SIGHUP is the conventional "your terminal went away" signal.
-        # We escalate if the child ignores it.
+        # We signal the whole PTY child process group so grandchildren such
+        # as tui_gateway.slash_worker cannot survive a dashboard tab close.
         for sig in (signal.SIGHUP, signal.SIGTERM, signal.SIGKILL):  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
-            if not self._proc.isalive():
+            if not self._process_tree_alive():
                 break
-            try:
-                self._proc.kill(sig)
-            except Exception:
-                pass
+            self._signal_process_tree(sig)
             deadline = time.monotonic() + 0.5
-            while self._proc.isalive() and time.monotonic() < deadline:
+            while self._process_tree_alive() and time.monotonic() < deadline:
                 time.sleep(0.02)
 
         try:
             self._proc.close(force=True)
+        except Exception:
+            pass
+
+    def _process_tree_alive(self) -> bool:
+        if self._pgid is not None:
+            try:
+                os.killpg(self._pgid, 0)
+                return True
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                return True
+            except Exception:
+                pass
+        try:
+            return bool(self._proc.isalive())
+        except Exception:
+            return False
+
+    def _signal_process_tree(self, sig: signal.Signals) -> None:
+        if self._pgid is not None:
+            try:
+                os.killpg(self._pgid, sig)
+                return
+            except ProcessLookupError:
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill(sig)
         except Exception:
             pass
 

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import sys
 import time
 
@@ -144,6 +145,46 @@ class TestPtyBridgeClose:
                 reaped = True
                 break
         assert reaped, f"pid {pid} still running after close()"
+
+    @pytest.mark.live_system_guard_bypass
+    def test_close_terminates_child_process_group(self):
+        """PTY teardown must reap descendants, not only the root process."""
+        script = (
+            "import os, signal, subprocess, sys; "
+            "signal.signal(signal.SIGHUP, signal.SIG_IGN); "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "code = 'import signal, time; "
+            "signal.signal(signal.SIGHUP, signal.SIG_IGN); "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "time.sleep(30)'; "
+            "p = subprocess.Popen([sys.executable, '-c', code]); "
+            "print(p.pid, flush=True); "
+            "p.wait()"
+        )
+        bridge = PtyBridge.spawn([sys.executable, "-c", script])
+        child_pid = None
+        try:
+            output = _read_until(bridge, b"\n")
+            child_pid = int(output.decode(errors="ignore").strip().splitlines()[0])
+            bridge.close()
+
+            deadline = time.monotonic() + 3.0
+            reaped = False
+            while time.monotonic() < deadline:
+                try:
+                    os.kill(child_pid, 0)
+                    time.sleep(0.05)
+                except ProcessLookupError:
+                    reaped = True
+                    break
+            assert reaped, f"grandchild pid {child_pid} still running after close()"
+        finally:
+            bridge.close()
+            if child_pid is not None:
+                try:
+                    os.kill(child_pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
 
 
 @skip_on_windows

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import subprocess
 import sys
 import threading
 import time
@@ -121,6 +122,66 @@ def test_write_json_unrelated_value_error_re_raises(server):
     server._real_stdout = _BadValue()
     with pytest.raises(ValueError, match="something else entirely"):
         server.write_json({"x": 1})
+
+
+def test_slash_worker_close_waits_after_kill(server):
+    """A timed-out slash worker should be SIGKILLed and reaped."""
+    worker = server._SlashWorker.__new__(server._SlashWorker)
+
+    class _FakeProc:
+        def __init__(self):
+            self.terminated = False
+            self.killed = False
+            self.wait_calls = 0
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            self.wait_calls += 1
+            if self.wait_calls == 1:
+                raise subprocess.TimeoutExpired("slash_worker", timeout)
+            return 0
+
+        def kill(self):
+            self.killed = True
+
+    proc = _FakeProc()
+    worker.proc = proc
+
+    worker.close()
+
+    assert proc.terminated is True
+    assert proc.killed is True
+    assert proc.wait_calls == 2
+
+
+def test_slash_worker_child_installs_linux_parent_death_signal(monkeypatch):
+    """The worker process should terminate if its gateway parent disappears."""
+    from tui_gateway import slash_worker
+
+    calls = []
+
+    class _FakeLibc:
+        def prctl(self, *args):
+            calls.append(args)
+            return 0
+
+    fake_ctypes = types.SimpleNamespace(
+        CDLL=lambda *args, **kwargs: _FakeLibc()
+    )
+
+    monkeypatch.setitem(sys.modules, "ctypes", fake_ctypes)
+    monkeypatch.setattr(slash_worker.sys, "platform", "linux")
+    monkeypatch.setattr(slash_worker.os, "getppid", lambda: 12345)
+
+    slash_worker._install_parent_death_signal()
+
+    assert calls
+    assert calls[0][0] == 1  # PR_SET_PDEATHSIG
 
 
 def test_write_json_non_serializable_payload_re_raises(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -255,13 +255,31 @@ class _SlashWorker:
     def close(self):
         try:
             if self.proc.poll() is None:
-                self.proc.terminate()
-                self.proc.wait(timeout=1)
-        except Exception:
-            try:
-                self.proc.kill()
-            except Exception:
-                pass
+                try:
+                    self.proc.terminate()
+                    self.proc.wait(timeout=1)
+                    return
+                except subprocess.TimeoutExpired:
+                    pass
+                except Exception:
+                    pass
+            if self.proc.poll() is None:
+                try:
+                    self.proc.kill()
+                except Exception:
+                    pass
+                try:
+                    self.proc.wait(timeout=1)
+                except Exception:
+                    pass
+        finally:
+            for stream_name in ("stdin", "stdout", "stderr"):
+                stream = getattr(self.proc, stream_name, None)
+                try:
+                    if stream is not None:
+                        stream.close()
+                except Exception:
+                    pass
 
 
 def _load_busy_input_mode() -> str:

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -15,6 +15,29 @@ from cli import HermesCLI
 from rich.console import Console
 
 
+def _install_parent_death_signal() -> None:
+    """On Linux, terminate this worker when its gateway parent exits.
+
+    The dashboard PTY path can kill the TUI/gateway process abruptly when a
+    browser tab or proxy drops the websocket. Installing this in the child
+    process avoids using ``preexec_fn`` from the multithreaded gateway parent.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        import ctypes
+        import signal
+
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        PR_SET_PDEATHSIG = 1
+        libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0)
+        # Close the race where the parent exited before prctl was installed.
+        if os.getppid() == 1:
+            os._exit(0)
+    except Exception:
+        pass
+
+
 def _run(cli: HermesCLI, command: str) -> str:
     cmd = (command or "").strip()
     if not cmd:
@@ -44,6 +67,8 @@ def _run(cli: HermesCLI, command: str) -> str:
 
 
 def main():
+    _install_parent_death_signal()
+
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("--session-key", required=True)
     p.add_argument("--model", default="")


### PR DESCRIPTION
## Summary

Fixes #32377 by tightening dashboard PTY teardown so `tui_gateway.slash_worker` descendants do not survive repeated `/api/pty` disconnects.

## Root Cause

The dashboard PTY close path signalled only the PTY root process. If that process exited while descendants such as the TUI gateway's slash worker were still alive, the worker could become orphaned and accumulate under the dashboard service cgroup. Separately, `_SlashWorker.close()` did not wait after SIGKILL, and the worker process had no Linux parent-death guard for abrupt gateway exits.

## Changes

- Track the PTY child process group in `PtyBridge` and send SIGHUP -> SIGTERM -> SIGKILL to that group during close.
- Add Linux `PR_SET_PDEATHSIG` setup in `tui_gateway.slash_worker` itself, avoiding `preexec_fn` from the multithreaded gateway parent.
- Make `_SlashWorker.close()` wait after SIGKILL and close stdio pipes in all exit paths.
- Add regression tests for PTY grandchild cleanup, slash worker parent-death signal installation, and SIGKILL wait/reap behavior.

## Validation

- `pytest tests/hermes_cli/test_pty_bridge.py::TestPtyBridgeClose::test_close_terminates_child_process_group -q`
- `pytest tests/tui_gateway/test_protocol.py::test_slash_worker_child_installs_linux_parent_death_signal tests/tui_gateway/test_protocol.py::test_slash_worker_close_waits_after_kill -q`
- `pytest tests/hermes_cli/test_pty_bridge.py tests/hermes_cli/test_web_server.py::TestPtyWebSocket -q`
- `pytest tests/tui_gateway/test_protocol.py -q`
- `pytest tests/test_tui_gateway_server.py::test_session_create_close_race_does_not_orphan_worker tests/test_tui_gateway_server.py::test_session_create_no_race_keeps_worker_alive -q`
- `python -m py_compile hermes_cli/pty_bridge.py tui_gateway/server.py tui_gateway/slash_worker.py`
- `git diff --check`

Note: `pytest tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint -q` fails in this checkout independently of these changes; the assertion expects a browser-launch hint that the current local environment/code path does not emit.