### PR TITLE
fix: guard json.loads on network input and add subprocess timeouts

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -318,7 +318,10 @@ async def _default_url_fetcher(url: str) -> str:
     from tools.web_tools import web_extract_tool
 
     raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
-    payload = json.loads(raw)
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return ""
     docs = payload.get("data", {}).get("documents", [])
     if not docs:
         return ""

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -344,6 +344,7 @@ def _ensure_sdk_installed() -> bool:
         [sys.executable, "-m", "pip", "install", "honcho-ai>=2.0.1"],
         capture_output=True,
         text=True,
+        timeout=300,
     )
     if result.returncode == 0:
         print("  Installed.\n")

--- a/skills/creative/excalidraw/scripts/upload.py
+++ b/skills/creative/excalidraw/scripts/upload.py
@@ -89,7 +89,10 @@ def upload(excalidraw_json: str) -> str:
     with urllib.request.urlopen(req, timeout=30) as resp:
         if resp.status != 200:
             raise RuntimeError(f"Upload failed with HTTP {resp.status}")
-        result = json.loads(resp.read().decode("utf-8"))
+        try:
+            result = json.loads(resp.read().decode("utf-8"))
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise RuntimeError(f"Upload returned non-JSON response: {exc}") from exc
 
     file_id = result.get("id")
     if not file_id:

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -110,6 +110,7 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
         capture_output=True,
         text=True,
         env=_gws_env(),
+        timeout=120,
     )
     if result.returncode != 0:
         err = result.stderr.strip() or result.stdout.strip() or "Unknown gws error"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1163,7 +1163,7 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
     command = [ffmpeg, "-y", "-i", file_path, converted_path]
 
     try:
-        subprocess.run(command, check=True, capture_output=True, text=True)
+        subprocess.run(command, check=True, capture_output=True, text=True, timeout=300)
         return converted_path, None
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)
@@ -1206,9 +1206,9 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
             use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
             if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+                subprocess.run(command, shell=True, check=True, capture_output=True, text=True, timeout=300)
             else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True, timeout=300)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))


### PR DESCRIPTION
## Summary

Two categories of robustness fixes: guarding `json.loads()` on network input, and adding timeouts to `subprocess.run()` calls.

### 1. json.loads() without try/except (2 locations)

| File | Issue |
|------|-------|
| `agent/context_references.py:321` | `web_extract_tool` response parsed without catching `JSONDecodeError`. A non-JSON response (HTML error page) crashes the URL fetcher. |
| `skills/creative/excalidraw/scripts/upload.py:92` | HTTP upload response parsed without error handling. |

### 2. subprocess.run() without timeout (4 locations)

| File | Issue | Timeout Added |
|------|-------|---------------|
| `tools/transcription_tools.py:1166` | ffmpeg audio conversion | 300s |
| `tools/transcription_tools.py:1209` | STT command with `shell=True` | 300s |
| `tools/transcription_tools.py:1211` | STT command (list mode) | 300s |
| `plugins/memory/honcho/cli.py:343` | `pip install honcho-ai` | 300s |
| `skills/productivity/google-workspace/scripts/google_api.py:108` | gws CLI call | 120s |

### Impact

- **json.loads**: A proxy returning HTML (rate limit, auth error) instead of JSON currently crashes with an unhandled `JSONDecodeError` — no user-friendly error message.
- **subprocess**: Corrupt audio input, network hangs, or stuck child processes currently block the agent indefinitely. The `shell=True` + no timeout case in transcription_tools.py is especially risky since user-provided env var commands could hang.

### Test Plan

- [x] All 5 modified files pass `py_compile`
