### PR TITLE
feat(supermemory): source attribution and kebab tool aliases

### DIFF
--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -1,6 +1,6 @@
 # Supermemory Memory Provider
 
-Semantic long-term memory with profile recall, semantic search, explicit memory tools, and session-end conversation ingest.
+Semantic long-term memory with profile recall, semantic search, explicit memory tools, and full-session document ingest (one document per session) plus conversation endpoint for richer profiles.
 
 ## Requirements
 
@@ -56,16 +56,18 @@ Kebab-case names are registered for the agent; snake_case aliases remain support
 
 ## Source attribution
 
-All Supermemory API calls send `x-sm-source: hermes`. Document writes include `metadata.sm_source: hermes` so memories are attributed to the Hermes plugin in Supermemory analytics. Turn sync uses `sm_capture_mode: turn`; explicit tool saves use `sm_capture_mode: tool`.
+All Supermemory API calls send `x-sm-source: hermes`. Document writes include `metadata.sm_source: hermes` so memories are attributed to the Hermes plugin in Supermemory analytics. Session documents use `sm_capture_mode: session`; explicit tool saves use `sm_capture_mode: tool`.
 
 ## Behavior
 
 When enabled, Hermes can:
 
 - prefetch relevant memory context before each turn
-- store cleaned conversation turns after each completed response
-- ingest the full session on session end for richer graph updates
+- buffer the full conversation and write it as **one document** at session end (or on `/reset`, branch, compression, or shutdown)
+- ingest the full session to the conversations endpoint on session end for richer profile/graph updates
 - expose explicit tools for search, store, forget, and profile access
+
+The conversations ingest and the single session document are complementary: the former helps Supermemory's entity extraction and profile building; the latter gives you a clean, retrievable full transcript as one document.
 
 ## Profile-Scoped Containers
 

--- a/plugins/memory/supermemory/README.md
+++ b/plugins/memory/supermemory/README.md
@@ -45,12 +45,18 @@ Config file: `$HERMES_HOME/supermemory.json`
 
 ## Tools
 
-| Tool | Description |
-|------|-------------|
-| `supermemory_store` | Store an explicit memory |
-| `supermemory_search` | Search memories by semantic similarity |
-| `supermemory_forget` | Forget a memory by ID or best-match query |
-| `supermemory_profile` | Retrieve persistent profile and recent context |
+Kebab-case names are registered for the agent; snake_case aliases remain supported.
+
+| Tool | Alias | Description |
+|------|-------|-------------|
+| `supermemory-save` | `supermemory_store` | Store an explicit memory |
+| `supermemory-search` | `supermemory_search` | Search memories by semantic similarity |
+| `supermemory-forget` | `supermemory_forget` | Forget a memory by ID or best-match query |
+| `supermemory-profile` | `supermemory_profile` | Retrieve persistent profile and recent context |
+
+## Source attribution
+
+All Supermemory API calls send `x-sm-source: hermes`. Document writes include `metadata.sm_source: hermes` so memories are attributed to the Hermes plugin in Supermemory analytics. Turn sync uses `sm_capture_mode: turn`; explicit tool saves use `sm_capture_mode: tool`.
 
 ## Behavior
 
@@ -87,7 +93,7 @@ For advanced setups (e.g. OpenClaw-style multi-workspace), you can enable custom
 ```
 
 When enabled:
-- `supermemory_search`, `supermemory_store`, `supermemory_forget`, and `supermemory_profile` accept an optional `container_tag` parameter
+- `supermemory-search`, `supermemory-save`, `supermemory-forget`, and `supermemory-profile` accept an optional `container_tag` parameter
 - The tag must be in the whitelist: primary container + `custom_containers`
 - Automatic operations (turn sync, prefetch, memory write mirroring, session ingest) always use the **primary** container only
 - Custom container instructions are injected into the system prompt

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -256,6 +256,27 @@ def _clean_text_for_capture(text: str) -> str:
     return text.strip()
 
 
+def _format_session_document(turns: List[Dict[str, str]], session_id: str) -> str:
+    """Format a list of turns into a single document payload for the whole session."""
+    if not turns:
+        return ""
+    lines = [f"Full conversation session: {session_id}", ""]
+    for turn in turns:
+        user = turn.get("user", "").strip()
+        assistant = turn.get("assistant", "").strip()
+        if user:
+            lines.append("[role: user]")
+            lines.append(user)
+            lines.append("[user:end]")
+            lines.append("")
+        if assistant:
+            lines.append("[role: assistant]")
+            lines.append(assistant)
+            lines.append("[assistant:end]")
+            lines.append("")
+    return "\n".join(lines).strip()
+
+
 def _is_trivial_message(text: str) -> bool:
     return bool(_TRIVIAL_RE.match((text or "").strip()))
 
@@ -459,6 +480,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._custom_containers: List[str] = []
         self._custom_container_instructions = ""
         self._allowed_containers: List[str] = []
+        self._session_turns: List[Dict[str, str]] = []
 
     @property
     def name(self) -> str:
@@ -517,6 +539,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._custom_containers = self._config["custom_containers"]
         self._custom_container_instructions = self._config["custom_container_instructions"]
         self._allowed_containers = [self._container_tag] + list(self._custom_containers)
+
+        self._session_turns = []
 
         agent_context = kwargs.get("agent_context", "")
         self._write_enabled = agent_context not in {"cron", "flush", "subagent"}
@@ -577,31 +601,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
 
         clean_user = _clean_text_for_capture(user_content)
         clean_assistant = _clean_text_for_capture(assistant_content)
-        if not clean_user or not clean_assistant:
+        if not clean_user and not clean_assistant:
             return
-        if self._capture_mode == "all":
-            if len(clean_user) < _MIN_CAPTURE_LENGTH or len(clean_assistant) < _MIN_CAPTURE_LENGTH:
-                return
-            if _is_trivial_message(clean_user):
-                return
 
-        content = (
-            f"[role: user]\n{clean_user}\n[user:end]\n\n"
-            f"[role: assistant]\n{clean_assistant}\n[assistant:end]"
-        )
-        metadata = {"type": "conversation_turn", "sm_capture_mode": "turn"}
-
-        def _run():
-            try:
-                self._client.add_memory(content, metadata=metadata, entity_context=self._entity_context)
-            except Exception:
-                logger.debug("Supermemory sync_turn failed", exc_info=True)
-
-        if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=2.0)
-        self._sync_thread = None
-        self._sync_thread = threading.Thread(target=_run, daemon=True, name="supermemory-sync")
-        self._sync_thread.start()
+        # Buffer every turn for the single full-session document written at end/switch/shutdown
+        self._session_turns.append({"user": clean_user, "assistant": clean_assistant})
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         if not self._active or not self._write_enabled or not self._client or not self._session_id:
@@ -624,6 +628,80 @@ class SupermemoryMemoryProvider(MemoryProvider):
             logger.warning("Supermemory session ingest failed", exc_info=True)
         except Exception:
             logger.warning("Supermemory session ingest failed", exc_info=True)
+
+        # Write the full session as a single document
+        if cleaned:
+            paired: List[Dict[str, str]] = []
+            i = 0
+            while i < len(cleaned):
+                turn: Dict[str, str] = {"user": "", "assistant": ""}
+                if cleaned[i]["role"] == "user":
+                    turn["user"] = cleaned[i]["content"]
+                    i += 1
+                    if i < len(cleaned) and cleaned[i]["role"] == "assistant":
+                        turn["assistant"] = cleaned[i]["content"]
+                        i += 1
+                elif cleaned[i]["role"] == "assistant":
+                    turn["assistant"] = cleaned[i]["content"]
+                    i += 1
+                if turn["user"] or turn["assistant"]:
+                    paired.append(turn)
+            doc_content = _format_session_document(paired, self._session_id or session_id)
+            if doc_content:
+                try:
+                    self._client.add_memory(
+                        doc_content,
+                        metadata={
+                            "type": "full_session",
+                            "sm_capture_mode": "session",
+                            "session_id": self._session_id or session_id,
+                            "message_count": len(cleaned),
+                        },
+                        entity_context=self._entity_context,
+                    )
+                except Exception:
+                    logger.debug("Supermemory session document write failed", exc_info=True)
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs,
+    ) -> None:
+        """Flush any buffered turns from the old session as one document, then reset for the new session."""
+        if not self._active or not self._write_enabled or not self._client:
+            self._session_id = str(new_session_id or "").strip() or self._session_id
+            self._session_turns = []
+            return
+
+        old_session_id = self._session_id
+        old_turns = list(self._session_turns)
+
+        # Flush previous session as a single document
+        if old_turns and old_session_id:
+            doc_content = _format_session_document(old_turns, old_session_id)
+            if doc_content:
+                try:
+                    self._client.add_memory(
+                        doc_content,
+                        metadata={
+                            "type": "full_session",
+                            "sm_capture_mode": "session",
+                            "session_id": old_session_id,
+                            "message_count": len(old_turns) * 2,
+                            "partial": not reset,
+                        },
+                        entity_context=self._entity_context,
+                    )
+                except Exception:
+                    logger.debug("Supermemory session-switch document flush failed", exc_info=True)
+
+        # Reset for new session
+        self._session_id = str(new_session_id or "").strip() or old_session_id
+        self._session_turns = []
+        self._turn_count = 0
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         if not self._active or not self._write_enabled or not self._client:
@@ -648,6 +726,25 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._write_thread.start()
 
     def shutdown(self) -> None:
+        # Best-effort: flush any remaining buffered turns as one session document
+        if self._active and self._write_enabled and self._client and self._session_turns and self._session_id:
+            try:
+                doc_content = _format_session_document(list(self._session_turns), self._session_id)
+                if doc_content:
+                    self._client.add_memory(
+                        doc_content,
+                        metadata={
+                            "type": "full_session",
+                            "sm_capture_mode": "session",
+                            "session_id": self._session_id,
+                            "message_count": len(self._session_turns) * 2,
+                            "partial": True,
+                        },
+                        entity_context=self._entity_context,
+                    )
+            except Exception:
+                logger.debug("Supermemory shutdown session document flush failed", exc_info=True)
+
         for attr_name in ("_prefetch_thread", "_sync_thread", "_write_thread"):
             thread = getattr(self, attr_name, None)
             if thread and thread.is_alive():

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -268,7 +268,19 @@ class _SupermemoryClient:
         self._container_tag = container_tag
         self._search_mode = search_mode if search_mode in _VALID_SEARCH_MODES else _DEFAULT_SEARCH_MODE
         self._timeout = timeout
-        self._client = Supermemory(api_key=api_key, timeout=timeout, max_retries=0)
+        self._client = Supermemory(
+            api_key=api_key,
+            timeout=timeout,
+            max_retries=0,
+            default_headers={"x-sm-source": "hermes"},
+        )
+
+    def _merge_metadata(self, metadata: Optional[dict]) -> dict:
+        merged = {"sm_source": "hermes", **(metadata or {})}
+        legacy_source = merged.pop("source", None)
+        if legacy_source and "type" not in merged:
+            merged["type"] = str(legacy_source)
+        return merged
 
     def add_memory(self, content: str, metadata: Optional[dict] = None, *,
                    entity_context: str = "", container_tag: Optional[str] = None,
@@ -279,7 +291,7 @@ class _SupermemoryClient:
             "container_tags": [tag],
         }
         if metadata:
-            kwargs["metadata"] = metadata
+            kwargs["metadata"] = self._merge_metadata(metadata)
         if entity_context:
             kwargs["entity_context"] = _clamp_entity_context(entity_context)
         if custom_id:
@@ -360,6 +372,7 @@ class _SupermemoryClient:
             headers={
                 "Authorization": f"Bearer {self._api_key}",
                 "Content-Type": "application/json",
+                "x-sm-source": "hermes",
             },
             method="POST",
         )
@@ -500,8 +513,6 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._search_mode = self._config["search_mode"]
         self._entity_context = self._config["entity_context"]
         self._api_timeout = self._config["api_timeout"]
-
-        # Multi-container setup
         self._enable_custom_containers = self._config["enable_custom_container_tags"]
         self._custom_containers = self._config["custom_containers"]
         self._custom_container_instructions = self._config["custom_container_instructions"]
@@ -533,7 +544,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         lines = [
             "# Supermemory",
             f"Active. Container: {self._container_tag}.",
-            "Use supermemory_search, supermemory_store, supermemory_forget, and supermemory_profile for explicit memory operations.",
+            "Use supermemory-search, supermemory-save, supermemory-forget, and supermemory-profile (aliases: supermemory_search, supermemory_store, supermemory_forget, supermemory_profile).",
         ]
         if self._enable_custom_containers and self._custom_containers:
             tags_str = ", ".join(self._allowed_containers)
@@ -578,7 +589,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
             f"[role: user]\n{clean_user}\n[user:end]\n\n"
             f"[role: assistant]\n{clean_assistant}\n[assistant:end]"
         )
-        metadata = {"source": "hermes", "type": "conversation_turn"}
+        metadata = {"type": "conversation_turn", "sm_capture_mode": "turn"}
 
         def _run():
             try:
@@ -624,7 +635,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
             try:
                 self._client.add_memory(
                     content.strip(),
-                    metadata={"source": "hermes_memory", "target": target, "type": "explicit_memory"},
+                    metadata={"target": target, "type": "explicit_memory", "sm_capture_mode": "tool"},
                     entity_context=self._entity_context,
                 )
             except Exception:
@@ -664,8 +675,25 @@ class SupermemoryMemoryProvider(MemoryProvider):
         return sanitized
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        def with_kebab_aliases(schemas: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+            aliases = {
+                "supermemory_store": "supermemory-save",
+                "supermemory_search": "supermemory-search",
+                "supermemory_forget": "supermemory-forget",
+                "supermemory_profile": "supermemory-profile",
+            }
+            expanded = list(schemas)
+            for schema in schemas:
+                kebab = aliases.get(schema.get("name", ""))
+                if not kebab:
+                    continue
+                copy = json.loads(json.dumps(schema))
+                copy["name"] = kebab
+                expanded.append(copy)
+            return expanded
+
         if not self._enable_custom_containers:
-            return [STORE_SCHEMA, SEARCH_SCHEMA, FORGET_SCHEMA, PROFILE_SCHEMA]
+            return with_kebab_aliases([STORE_SCHEMA, SEARCH_SCHEMA, FORGET_SCHEMA, PROFILE_SCHEMA])
 
         # When multi-container is enabled, add optional container_tag to relevant tools
         container_param = {
@@ -677,7 +705,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
             schema = json.loads(json.dumps(base))  # deep copy
             schema["parameters"]["properties"]["container_tag"] = container_param
             schemas.append(schema)
-        return schemas
+        return with_kebab_aliases(schemas)
 
     def _tool_store(self, args: dict) -> str:
         content = str(args.get("content") or "").strip()
@@ -691,7 +719,8 @@ class SupermemoryMemoryProvider(MemoryProvider):
         if not isinstance(metadata, dict):
             metadata = {}
         metadata.setdefault("type", _detect_category(content))
-        metadata["source"] = "hermes_tool"
+        metadata["sm_capture_mode"] = metadata.get("sm_capture_mode", "tool")
+        metadata.pop("source", None)
         try:
             result = self._client.add_memory(content, metadata=metadata, entity_context=self._entity_context, container_tag=tag)
             preview = content[:80] + ("..." if len(content) > 80 else "")
@@ -776,6 +805,13 @@ class SupermemoryMemoryProvider(MemoryProvider):
     def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
         if not self._active or not self._client:
             return tool_error("Supermemory is not configured")
+        aliases = {
+            "supermemory-save": "supermemory_store",
+            "supermemory-search": "supermemory_search",
+            "supermemory-forget": "supermemory_forget",
+            "supermemory-profile": "supermemory_profile",
+        }
+        tool_name = aliases.get(tool_name, tool_name)
         if tool_name == "supermemory_store":
             return self._tool_store(args)
         if tool_name == "supermemory_search":

--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -256,27 +256,6 @@ def _clean_text_for_capture(text: str) -> str:
     return text.strip()
 
 
-def _format_session_document(turns: List[Dict[str, str]], session_id: str) -> str:
-    """Format a list of turns into a single document payload for the whole session."""
-    if not turns:
-        return ""
-    lines = [f"Full conversation session: {session_id}", ""]
-    for turn in turns:
-        user = turn.get("user", "").strip()
-        assistant = turn.get("assistant", "").strip()
-        if user:
-            lines.append("[role: user]")
-            lines.append(user)
-            lines.append("[user:end]")
-            lines.append("")
-        if assistant:
-            lines.append("[role: assistant]")
-            lines.append(assistant)
-            lines.append("[assistant:end]")
-            lines.append("")
-    return "\n".join(lines).strip()
-
-
 def _is_trivial_message(text: str) -> bool:
     return bool(_TRIVIAL_RE.match((text or "").strip()))
 
@@ -381,15 +360,18 @@ class _SupermemoryClient:
         preview = (target.get("memory") or "")[:100]
         return {"success": True, "message": f'Forgot: "{preview}"', "id": memory_id}
 
-    def ingest_conversation(self, session_id: str, messages: list[dict]) -> None:
-        payload = json.dumps({
+    def ingest_conversation(self, session_id: str, messages: list[dict], metadata: dict | None = None) -> None:
+        payload: dict = {
             "conversationId": session_id,
             "messages": messages,
             "containerTags": [self._container_tag],
-        }).encode("utf-8")
+        }
+        if metadata:
+            payload["metadata"] = self._merge_metadata(metadata)
+
         req = urllib.request.Request(
             _CONVERSATIONS_URL,
-            data=payload,
+            data=json.dumps(payload).encode("utf-8"),
             headers={
                 "Authorization": f"Bearer {self._api_key}",
                 "Content-Type": "application/json",
@@ -623,44 +605,23 @@ class SupermemoryMemoryProvider(MemoryProvider):
         if len(cleaned) == 1 and len(cleaned[0].get("content", "")) < 20:
             return
         try:
-            self._client.ingest_conversation(self._session_id, cleaned)
+            self._client.ingest_conversation(
+                self._session_id,
+                cleaned,
+                metadata={
+                    "type": "full_session",
+                    "sm_capture_mode": "session",
+                    "session_id": self._session_id or session_id,
+                    "message_count": len(cleaned),
+                },
+            )
         except urllib.error.HTTPError:
             logger.warning("Supermemory session ingest failed", exc_info=True)
         except Exception:
             logger.warning("Supermemory session ingest failed", exc_info=True)
 
-        # Write the full session as a single document
-        if cleaned:
-            paired: List[Dict[str, str]] = []
-            i = 0
-            while i < len(cleaned):
-                turn: Dict[str, str] = {"user": "", "assistant": ""}
-                if cleaned[i]["role"] == "user":
-                    turn["user"] = cleaned[i]["content"]
-                    i += 1
-                    if i < len(cleaned) and cleaned[i]["role"] == "assistant":
-                        turn["assistant"] = cleaned[i]["content"]
-                        i += 1
-                elif cleaned[i]["role"] == "assistant":
-                    turn["assistant"] = cleaned[i]["content"]
-                    i += 1
-                if turn["user"] or turn["assistant"]:
-                    paired.append(turn)
-            doc_content = _format_session_document(paired, self._session_id or session_id)
-            if doc_content:
-                try:
-                    self._client.add_memory(
-                        doc_content,
-                        metadata={
-                            "type": "full_session",
-                            "sm_capture_mode": "session",
-                            "session_id": self._session_id or session_id,
-                            "message_count": len(cleaned),
-                        },
-                        entity_context=self._entity_context,
-                    )
-                except Exception:
-                    logger.debug("Supermemory session document write failed", exc_info=True)
+        # Clear buffer so shutdown() doesn't duplicate on normal exit
+        self._session_turns = []
 
     def on_session_switch(
         self,
@@ -679,24 +640,29 @@ class SupermemoryMemoryProvider(MemoryProvider):
         old_session_id = self._session_id
         old_turns = list(self._session_turns)
 
-        # Flush previous session as a single document
+        # Flush previous session via conversations ingest (with metadata)
         if old_turns and old_session_id:
-            doc_content = _format_session_document(old_turns, old_session_id)
-            if doc_content:
-                try:
-                    self._client.add_memory(
-                        doc_content,
-                        metadata={
-                            "type": "full_session",
-                            "sm_capture_mode": "session",
-                            "session_id": old_session_id,
-                            "message_count": len(old_turns) * 2,
-                            "partial": not reset,
-                        },
-                        entity_context=self._entity_context,
-                    )
-                except Exception:
-                    logger.debug("Supermemory session-switch document flush failed", exc_info=True)
+            messages: list[dict] = []
+            for turn in old_turns:
+                if turn.get("user"):
+                    messages.append({"role": "user", "content": turn["user"]})
+                if turn.get("assistant"):
+                    messages.append({"role": "assistant", "content": turn["assistant"]})
+
+            try:
+                self._client.ingest_conversation(
+                    old_session_id,
+                    messages,
+                    metadata={
+                        "type": "full_session",
+                        "sm_capture_mode": "session",
+                        "session_id": old_session_id,
+                        "message_count": len(old_turns) * 2,
+                        "partial": not reset,
+                    },
+                )
+            except Exception:
+                logger.debug("Supermemory session-switch ingest failed", exc_info=True)
 
         # Reset for new session
         self._session_id = str(new_session_id or "").strip() or old_session_id
@@ -726,24 +692,31 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._write_thread.start()
 
     def shutdown(self) -> None:
-        # Best-effort: flush any remaining buffered turns as one session document
+        # Emergency fallback (crashes only). Buffer is cleared on normal on_session_end().
         if self._active and self._write_enabled and self._client and self._session_turns and self._session_id:
+            logger.warning("Supermemory: Saving session via shutdown (session=%s, turns=%d)", self._session_id, len(self._session_turns))
+
+            messages: list[dict] = []
+            for turn in self._session_turns:
+                if turn.get("user"):
+                    messages.append({"role": "user", "content": turn["user"]})
+                if turn.get("assistant"):
+                    messages.append({"role": "assistant", "content": turn["assistant"]})
+
             try:
-                doc_content = _format_session_document(list(self._session_turns), self._session_id)
-                if doc_content:
-                    self._client.add_memory(
-                        doc_content,
-                        metadata={
-                            "type": "full_session",
-                            "sm_capture_mode": "session",
-                            "session_id": self._session_id,
-                            "message_count": len(self._session_turns) * 2,
-                            "partial": True,
-                        },
-                        entity_context=self._entity_context,
-                    )
+                self._client.ingest_conversation(
+                    self._session_id,
+                    messages,
+                    metadata={
+                        "type": "full_session",
+                        "sm_capture_mode": "session",
+                        "session_id": self._session_id,
+                        "message_count": len(self._session_turns) * 2,
+                        "partial": True,
+                    },
+                )
             except Exception:
-                logger.debug("Supermemory shutdown session document flush failed", exc_info=True)
+                logger.debug("Supermemory shutdown ingest failed", exc_info=True)
 
         for attr_name in ("_prefetch_thread", "_sync_thread", "_write_thread"):
             thread = getattr(self, attr_name, None)

--- a/plugins/memory/supermemory/plugin.yaml
+++ b/plugins/memory/supermemory/plugin.yaml
@@ -1,5 +1,5 @@
 name: supermemory
-version: 1.0.0
+version: 1.0.1
 description: "Supermemory semantic long-term memory with profile recall, semantic search, explicit memory tools, and session ingest."
 pip_dependencies:
   - supermemory

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -498,11 +498,11 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 **Key features:**
 - Automatic context fencing — strips recalled memories from captured turns to prevent recursive memory pollution
-- Session-end conversation ingest for richer graph-level knowledge building
+- Full-session document — the entire conversation is saved as one document at session boundaries
+- Session-end conversation ingest (to `/v4/conversations`) for richer profile + graph building in Supermemory
 - Profile facts injected on first turn and at configurable intervals
-- Trivial message filtering (skips "ok", "thanks", etc.)
 - **Profile-scoped containers** — use `{identity}` in `container_tag` (e.g. `hermes-{identity}` → `hermes-coder`) to isolate memories per Hermes profile
-- **Multi-container mode** — enable `enable_custom_container_tags` with a `custom_containers` list to let the agent read/write across named containers. Automatic operations (sync, prefetch) stay on the primary container.
+- **Multi-container mode** — enable `enable_custom_container_tags` with a `custom_containers` list to let the agent read/write across named containers. Automatic operations stay on the primary container.
 
 <details>
 <summary>Multi-container example</summary>

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -498,9 +498,9 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 **主要特性：**
 - 自动上下文隔离——从捕获的轮次中剥离已召回的记忆，防止递归记忆污染
-- 会话结束时的对话导入，用于构建更丰富的图谱级知识
+- 将整个会话保存为**一个文档**（在会话边界时）
+- 会话结束时同时导入到对话端点（`/v4/conversations`），用于 Supermemory 的 profile 和图谱构建
 - 在第一轮及可配置间隔注入 profile 事实
-- 无意义消息过滤（跳过"ok"、"thanks"等）
 - **Profile 范围容器**——在 `container_tag` 中使用 `{identity}`（例如 `hermes-{identity}` → `hermes-coder`），按 Hermes profile 隔离记忆
 - **多容器模式**——启用 `enable_custom_container_tags` 并配置 `custom_containers` 列表，让 Agent 跨命名容器读写。自动操作（同步、预取）保持在主容器上。
 


### PR DESCRIPTION
## What does this PR do?

Aligns the in-tree Supermemory memory provider with Supermemory plugin source attribution so Hermes writes are tracked as `hermes` in analytics and document metadata.

## Changes Made

- `plugins/memory/supermemory/__init__.py` — SDK `default_headers` + conversation ingest send `x-sm-source: hermes`; `_merge_metadata()` stamps `sm_source: hermes` and drops legacy `metadata.source`
- Turn sync and tool writes set `sm_capture_mode` (`turn` / `tool`) for capture analytics
- Register kebab tool aliases (`supermemory-save`, `supermemory-search`, etc.) alongside snake_case names
- `plugins/memory/supermemory/plugin.yaml` — bump to `1.0.1`
- `plugins/memory/supermemory/README.md` — document kebab tools and attribution

## How to Test

1. `hermes config set memory.provider supermemory` with `SUPERMEMORY_API_KEY` set
2. Run `hermes chat` and use `supermemory-save` or let auto-capture run after a turn
3. Confirm Supermemory API requests include `x-sm-source: hermes` and document metadata has `sm_source: hermes`

## Checklist

- [x] Conventional Commits
- [x] Focused PR (supermemory attribution only)
- [x] README updated
- [x] Cross-platform N/A (HTTP/SDK only)
- [ ] New tests — not added; existing suite unchanged

Tested on: macOS