### PR TITLE
fix(gateway): catch KanbanDbCorruptError in kanban dispatcher corrupt-board path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5418,6 +5418,8 @@ class GatewayRunner:
             return (resolved, stat.st_mtime_ns, stat.st_size)
 
         def _is_corrupt_board_db_error(exc: Exception) -> bool:
+            if isinstance(exc, _kb.KanbanDbCorruptError):
+                return True
             if not isinstance(exc, sqlite3.DatabaseError):
                 return False
             msg = str(exc).lower()
@@ -5462,15 +5464,15 @@ class GatewayRunner:
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
                 )
-            except sqlite3.DatabaseError as exc:
+            except (sqlite3.DatabaseError, _kb.KanbanDbCorruptError) as exc:
                 if _is_corrupt_board_db_error(exc):
                     disabled_corrupt_boards[slug] = fingerprint
                     logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; disabling dispatch for this board "
-                        "until the file changes or the gateway restarts. Move "
-                        "or restore the file, then run `hermes kanban init` if "
-                        "you need a fresh board.",
+                        "kanban dispatcher: board %s database %s is corrupt or "
+                        "not a valid SQLite database; disabling dispatch for "
+                        "this board until the file changes or the gateway "
+                        "restarts. Move or restore the file, then run "
+                        "`hermes kanban init` if you need a fresh board.",
                         slug,
                         fingerprint[0],
                     )

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3670,7 +3670,7 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
         )
 
     messages = [record.getMessage() for record in caplog.records]
-    assert sum("not a valid SQLite database" in msg for msg in messages) == 1
+    assert sum("corrupt or" in msg for msg in messages) == 1
     assert not any("tick failed on board" in msg for msg in messages)
     assert not any(record.exc_info for record in caplog.records)
     # First tick connect (dispatch) + two probes per `_has_ready_work` call
@@ -3679,6 +3679,87 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     # disabled, but the ready/review probes still each connect. PR f55d94a1e
     # added the review-column probe alongside the existing ready-column
     # probe, bumping this from 3 → 5.
+    assert calls["connect"] == 5
+
+
+def test_gateway_dispatcher_disables_btree_corrupt_board_without_traceback(
+    monkeypatch, tmp_path, caplog
+):
+    """KanbanDbCorruptError (B-tree corruption) disables the board just like
+    sqlite3.DatabaseError — the board must not re-enter the generic handler
+    and must not be retried each tick."""
+    import asyncio
+    import logging
+
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    corrupt_db = tmp_path / "kanban.db"
+    # Write a valid SQLite header so _validate_sqlite_header passes, but
+    # content is otherwise garbage so integrity_check would fail.
+    corrupt_db.write_bytes(b"SQLite format 3\x00" + b"\x00" * 84)
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
+
+    calls = {"connect": 0, "to_thread": 0}
+
+    def _connect(*args, **kwargs):
+        calls["connect"] += 1
+        raise _kb.KanbanDbCorruptError(
+            corrupt_db,
+            None,
+            "integrity_check returned '*** in database main ***\nTree 9 page 9 cell 0: invalid page number 162'",
+        )
+
+    async def _to_thread(fn, *args, **kwargs):
+        calls["to_thread"] += 1
+        result = fn(*args, **kwargs)
+        if calls["to_thread"] >= 4:
+            runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.ERROR, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum("corrupt or" in msg for msg in messages) == 1
+    assert not any("tick failed on board" in msg for msg in messages)
+    assert not any(record.exc_info for record in caplog.records)
     assert calls["connect"] == 5
 
 


### PR DESCRIPTION
## What changed and why

The existing fix for #26479 (PR #26490) only catches `sqlite3.DatabaseError` in `_tick_once_for_board`. When SQLite can open the file but `PRAGMA integrity_check` finds corrupt B-tree pages, `kanban_db.py` raises `KanbanDbCorruptError` — a `RuntimeError` subclass, **not** a `sqlite3.DatabaseError`. This means:

- `KanbanDbCorruptError` fell through to the generic `except Exception:` handler
- The board was never added to `disabled_corrupt_boards`
- Every tick (~60 s): re-runs integrity_check, calls `_backup_corrupt_db()` → `shutil.copy2()`, raising again
- Result: ~100+ `.bak` copies per day and a full traceback in `agent.log` every minute, with no automatic recovery

Two targeted changes in `gateway/run.py`:
1. `_is_corrupt_board_db_error`: add an early `isinstance(exc, _kb.KanbanDbCorruptError) → True` check
2. `_tick_once_for_board` except clause: `except sqlite3.DatabaseError` → `except (sqlite3.DatabaseError, _kb.KanbanDbCorruptError)` so the disable path is reachable for B-tree corruption

Log message updated from "not a valid SQLite database" to "corrupt or not a valid SQLite database" since B-tree corruption is a valid SQLite file with internal integrity failures.

Per the reporter's analysis on 2026-05-26 (magnus919, comment on #26479).

## How to test

```bash
pytest tests/hermes_cli/test_kanban_core_functionality.py -q -x --timeout=60 -k "corrupt"
```

Expect 2 tests to pass:
- `test_gateway_dispatcher_disables_corrupt_board_without_traceback` (existing, for `sqlite3.DatabaseError`)
- `test_gateway_dispatcher_disables_btree_corrupt_board_without_traceback` (new, for `KanbanDbCorruptError`)

Both tests verify: exactly one actionable error log, no "tick failed" logs, no tracebacks, and the connect-call count matches the expected fingerprint-disable behaviour.

## What platforms tested on

- macOS (Darwin 24.6.0)

Fixes #26479

<!-- autocontrib:worker-id=issue-followup-64443b6f kind=pr-open -->