### PR TITLE
fix: add latest error messages panel API for dashboard

### DIFF
--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -388,3 +388,58 @@ def list_logs() -> None:
 
     if not found:
         print("  (no log files yet — run 'hermes chat' to generate logs)")
+
+
+def get_latest_errors(num_errors: int = 50) -> list[dict]:
+    """Read latest error messages from logs and profiles/coder logs.
+
+    Searches errors.log, agent.log, and ~/.hermes/profiles/coder/logs/ for
+    ERROR or CRITICAL level entries. Returns a compact list including
+    timestamp, file path, and error message.
+
+    Returns a list of dicts with keys: timestamp, file, message
+    """
+    errors: list[dict] = []
+    hermes_home = get_hermes_home()
+
+    # Collect log paths to scan
+    log_dir = hermes_home / "logs"
+    coder_logs_dir = hermes_home / "profiles" / "coder" / "logs"
+
+    paths_to_scan: list[tuple[str, Path]] = []
+
+    if log_dir.exists():
+        for log_file in ["errors.log", "gateway.log", "agent.log"]:
+            p = log_dir / log_file
+            if p.exists():
+                paths_to_scan.append((str(p), p))
+
+    if coder_logs_dir.exists():
+        for p in coder_logs_dir.glob("*.log"):
+            if p.exists():
+                paths_to_scan.append((str(p), p))
+
+    for display_path, log_path in paths_to_scan:
+        try:
+            raw_lines = _read_last_n_lines(log_path, 1000)
+            for line in raw_lines:
+                level = _extract_level(line)
+                if level in ("ERROR", "CRITICAL"):
+                    ts = _parse_line_timestamp(line)
+                    timestamp = ts.strftime("%Y-%m-%d %H:%M:%S") if ts else ""
+                    # Truncate message for compact display
+                    msg = line.strip()
+                    if len(msg) > 200:
+                        msg = msg[:200] + "..."
+                    errors.append({
+                        "timestamp": timestamp,
+                        "file": display_path,
+                        "message": msg,
+                    })
+        except Exception:
+            continue
+
+    # Sort by timestamp descending (most recent first), limit to num_errors
+    errors.sort(key=lambda x: x["timestamp"] or "", reverse=True)
+    return errors[:num_errors]
+

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2571,6 +2571,25 @@ async def get_logs(
     return {"file": file, "lines": result}
 
 
+@app.get("/api/logs/errors")
+async def get_latest_errors_endpoint(num: int = 50):
+    """Return latest error messages from logs and profiles/coder logs.
+
+    Searches errors.log, agent.log, gateway.log, and
+    ~/.hermes/profiles/coder/logs/ for ERROR or CRITICAL level entries.
+    Returns a compact list including timestamp, file path, and error message.
+    """
+    from hermes_cli.logs import get_latest_errors
+
+    try:
+        errors = get_latest_errors(num_errors=min(num, 200))
+        return {"errors": errors}
+    except Exception as e:
+        _log.exception("GET /api/logs/errors failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+
 # ---------------------------------------------------------------------------
 # Cron job management endpoints
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_logs.py
+++ b/tests/hermes_cli/test_logs.py
@@ -253,3 +253,109 @@ class TestLogFiles:
         assert "agent" in LOG_FILES
         assert "errors" in LOG_FILES
         assert "gateway" in LOG_FILES
+
+
+# ---------------------------------------------------------------------------
+# Latest errors function
+# ---------------------------------------------------------------------------
+
+class TestGetLatestErrors:
+    def test_extracts_error_lines(self, tmp_path, monkeypatch):
+        # Create test log files
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        (log_dir / "errors.log").write_text(
+            "2026-01-01 10:00:00 ERROR test.module: first error\n"
+            "2026-01-01 10:01:00 INFO test.module: normal msg\n"
+            "2026-01-01 10:02:00 ERROR test.module: second error\n"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.logs.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.logs import get_latest_errors
+        errors = get_latest_errors(num_errors=10)
+
+        assert len(errors) == 2
+        assert all(e["level"] in ("ERROR", "CRITICAL") for e in errors)
+        assert "first error" in errors[0]["message"]
+        assert "second error" in errors[1]["message"]
+
+    def test_includes_timestamp_and_file(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        log_file = log_dir / "gateway.log"
+        log_file.write_text("2026-01-01 12:00:00 CRITICAL test: critical failure\n")
+        monkeypatch.setattr(
+            "hermes_cli.logs.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.logs import get_latest_errors
+        errors = get_latest_errors()
+
+        assert len(errors) == 1
+        assert errors[0]["timestamp"] == "2026-01-01 12:00:00"
+        assert "gateway.log" in errors[0]["file"]
+        assert "critical failure" in errors[0]["message"]
+
+    def test_includes_coder_logs(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        coder_logs = tmp_path / "profiles" / "coder" / "logs"
+        log_dir.mkdir()
+        coder_logs.mkdir(parents=True)
+        (log_dir / "agent.log").write_text(
+            "2026-01-01 10:00:00 ERROR agent: agent error\n"
+        )
+        (coder_logs / "coder.log").write_text(
+            "2026-01-01 10:01:00 ERROR coder: coder error\n"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.logs.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.logs import get_latest_errors
+        errors = get_latest_errors()
+
+        assert len(errors) == 2
+        files = [e["file"] for e in errors]
+        assert any("agent.log" in f for f in files)
+        assert any("coder.log" in f for f in files)
+
+    def test_respects_num_errors_limit(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        lines = [
+            f"2026-01-01 10:0{i}:00 ERROR test: error {i}\n"
+            for i in range(10)
+        ]
+        (log_dir / "errors.log").write_text("".join(lines))
+        monkeypatch.setattr(
+            "hermes_cli.logs.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.logs import get_latest_errors
+        errors = get_latest_errors(num_errors=3)
+
+        assert len(errors) == 3
+
+    def test_handles_missing_directories(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.logs.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.logs import get_latest_errors
+        errors = get_latest_errors()
+
+        assert errors == []
+
+    def test_truncates_long_messages(self, tmp_path, monkeypatch):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        long_msg = "x" * 500
+        (log_dir / "errors.log").write_text(
+            f"2026-01-01 10:00:00 ERROR test: {long_msg}\n"
+        )
+        monkeypatch.setattr(
+            "hermes_cli.logs.get_hermes_home", lambda: tmp_path)
+
+        from hermes_cli.logs import get_latest_errors
+        errors = get_latest_errors()
+
+        assert len(errors) == 1
+        assert len(errors[0]["message"]) <= 200
+        assert errors[0]["message"].endswith("...")


### PR DESCRIPTION
## Summary

- Add `get_latest_errors()` function in `hermes_cli/logs.py` to extract ERROR and CRITICAL level entries from log files
- Add `/api/logs/errors` endpoint in `hermes_cli/web_server.py` to serve error entries to the dashboard
- Add comprehensive tests for the new functionality

## Changes

### hermes_cli/logs.py

- New function `get_latest_errors(num_errors: int = 50)` that:
  - Scans `~/.hermes/logs/` for errors.log, gateway.log, agent.log
  - Scans `~/.hermes/profiles/coder/logs/` for coder log files
  - Extracts ERROR and CRITICAL level entries
  - Returns compact entries with timestamp, file path, and message (truncated to 200 chars)
  - Sorts by timestamp descending (most recent first)

### hermes_cli/web_server.py

- New endpoint `GET /api/logs/errors?num=50` that:
  - Calls `get_latest_errors()` with the requested limit
  - Returns `{"errors": [...]}` with max 200 entries

### tests/hermes_cli/test_logs.py

- Added `TestGetLatestErrors` test class with 6 test cases covering:
  - Error line extraction
  - Timestamp and file path inclusion
  - Coder logs directory support
  - Limit enforcement
  - Missing directory handling
  - Long message truncation

## Test plan

- [ ] Run `python -m pytest tests/hermes_cli/test_logs.py::TestGetLatestErrors -v` to verify new tests pass
- [ ] Test `/api/logs/errors` endpoint with `curl http://localhost:9119/api/logs/errors`
- [ ] Verify error entries display correctly in dashboard

Closes #32389
