### PR TITLE
fix(tools): regex-fallback Matrix formatted_body when markdown lib missing

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1545,6 +1545,82 @@ class TestSendMatrixUrlEncoding:
         assert "!HLOQwxYGgFPMPJUSNR:matrix.org" not in put_url
 
 
+class TestSendMatrixFormattedBody:
+    """_send_matrix renders markdown to formatted_body in the cron delivery
+    path, with a regex fallback when the optional ``markdown`` library is
+    not installed (default Docker image case — issue #32486)."""
+
+    @staticmethod
+    def _build_session_mock():
+        mock_resp = MagicMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"event_id": "$evt"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=None)
+
+        mock_session = MagicMock()
+        mock_session.put = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        return mock_session
+
+    def test_markdown_lib_path_sets_formatted_body(self):
+        """When ``markdown`` is installed, the rendered HTML lands in
+        ``formatted_body`` and ``format`` is set to the Matrix custom-HTML
+        content type."""
+        pytest.importorskip("markdown")
+        from tools.send_message_tool import _send_matrix
+
+        mock_session = self._build_session_mock()
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(
+                _send_matrix(
+                    "tok",
+                    {"homeserver": "https://matrix.example.org"},
+                    "!room:matrix.org",
+                    "## Heading\n\n- bullet\n- bullet",
+                )
+            )
+
+        assert result["success"] is True
+        payload = mock_session.put.call_args.kwargs["json"]
+        assert payload["format"] == "org.matrix.custom.html"
+        # Element X compatibility: headings collapse to <strong>, not <h1-6>.
+        assert "<strong>Heading</strong>" in payload["formatted_body"]
+        assert "<h1>" not in payload["formatted_body"]
+        # List rendering survives.
+        assert "<li>bullet</li>" in payload["formatted_body"]
+
+    def test_fallback_path_sets_formatted_body_without_markdown_lib(self):
+        """When ``markdown`` is missing (default Docker image), the regex
+        fallback shared with ``MatrixAdapter`` still produces HTML — the
+        client no longer sees raw ``##`` / ``-`` / ``|...|`` source."""
+        from tools.send_message_tool import _send_matrix
+
+        mock_session = self._build_session_mock()
+        # Hide the markdown library to force the ImportError branch.
+        with patch.dict(sys.modules, {"markdown": None}):
+            with patch("aiohttp.ClientSession", return_value=mock_session):
+                result = asyncio.run(
+                    _send_matrix(
+                        "tok",
+                        {"homeserver": "https://matrix.example.org"},
+                        "!room:matrix.org",
+                        "## Heading\n\n- bullet\n- bullet",
+                    )
+                )
+
+        assert result["success"] is True
+        payload = mock_session.put.call_args.kwargs["json"]
+        assert payload["format"] == "org.matrix.custom.html"
+        # Element X compatibility carries through the fallback too.
+        assert "<strong>Heading</strong>" in payload["formatted_body"]
+        assert "<h1>" not in payload["formatted_body"]
+        # Raw markdown source must NOT survive into formatted_body.
+        assert "## Heading" not in payload["formatted_body"]
+        assert "<li>bullet</li>" in payload["formatted_body"]
+
+
 # ---------------------------------------------------------------------------
 # Tests for _derive_forum_thread_name
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1375,17 +1375,24 @@ async def _send_matrix(token, extra, chat_id, message):
         url = f"{homeserver}/_matrix/client/v3/rooms/{encoded_room}/send/m.room.message/{txn_id}"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
-        # Build message payload with optional HTML formatted_body.
+        # Build message payload with HTML formatted_body. Prefer the
+        # ``markdown`` library (ships with the ``[matrix]`` extra); fall
+        # back to the regex converter shared with the gateway adapter so
+        # cron deliveries still get formatted_body when the lib isn't
+        # installed. The official Docker image installs ``[all]`` +
+        # ``[messaging]`` only — neither pulls Markdown, so this branch
+        # is the default path inside the container.
         payload = {"msgtype": "m.text", "body": message}
         try:
             import markdown as _md
             html = _md.markdown(message, extensions=["fenced_code", "tables"])
-            # Convert h1-h6 to bold for Element X compatibility.
-            html = re.sub(r"<h[1-6]>(.*?)</h[1-6]>", r"<strong>\1</strong>", html)
-            payload["format"] = "org.matrix.custom.html"
-            payload["formatted_body"] = html
         except ImportError:
-            pass
+            from gateway.platforms.matrix import MatrixAdapter
+            html = MatrixAdapter._markdown_to_html_fallback(message)
+        # Convert h1-h6 to bold for Element X compatibility.
+        html = re.sub(r"<h[1-6]>(.*?)</h[1-6]>", r"<strong>\1</strong>", html)
+        payload["format"] = "org.matrix.custom.html"
+        payload["formatted_body"] = html
 
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
             async with session.put(url, headers=headers, json=payload) as resp:


### PR DESCRIPTION
## What does this PR do?

`_send_matrix()` in `tools/send_message_tool.py` (the cron / `send_message`-tool path to Matrix) imports the optional `markdown` library and silently degrades to plain text when it isn't installed. The official Docker image installs `[all]` + `[messaging]` only, neither of which pulls `Markdown` — so out-of-the-box cron deliveries render in Element as raw `##`, `**`, `|...|` despite [PR #5271](https://github.com/NousResearch/hermes-agent/pull/5271).

`MatrixAdapter._markdown_to_html_fallback()` already exists in `gateway/platforms/matrix.py` as a comprehensive regex converter (fenced code, inline code, headers, bold, italic, strikethrough, links, blockquotes, lists, hr) — it's a `@staticmethod` that depends only on `re` and `html.escape`, safe to import without `mautrix` installed.

Mirror `MatrixAdapter._markdown_to_html()`'s precedence in `_send_matrix()`: `markdown` library when available, regex fallback otherwise. The Element X heading→bold post-processing already runs after both branches.

> Mirrors `MatrixAdapter._markdown_to_html` precedence: `markdown` lib > `_markdown_to_html_fallback` regex converter. Element X `<h*>` → `<strong>` rewrite applies to both branches.

## Related Issue

Fixes #32486

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py` — when `import markdown` fails inside `_send_matrix()`, fall back to `MatrixAdapter._markdown_to_html_fallback()` instead of silently dropping `formatted_body`. The Element X `<h*>` → `<strong>` post-processing is hoisted out of the success-only branch so it applies to both paths.
- `tests/tools/test_send_message_tool.py` — new `TestSendMatrixFormattedBody` class with two cases: (1) markdown lib path produces `<strong>Heading</strong>` + `<li>bullet</li>` in `formatted_body`; (2) lib-missing path (`patch.dict(sys.modules, {"markdown": None})`) still produces `<strong>Heading</strong>` + `<li>bullet</li>`, with no raw `## Heading` surviving into `formatted_body`.

## How to Test

1. Reproduction (without this PR): in a venv that lacks `markdown`, call `_send_matrix(token, extra, room_id, "## H\n\n- a\n- b")` and observe the captured `aiohttp` PUT payload — `formatted_body` and `format` are absent; Element renders raw markdown.
2. Focused tests:

   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio --with pytest-timeout \
     --with 'python-telegram-bot[webhooks]==22.6' --with 'discord.py[voice]==2.7.1' \
     --with 'aiohttp==3.13.3' --with 'markdown==3.10.2' \
     python3 -m pytest tests/tools/test_send_message_tool.py::TestSendMatrixFormattedBody -v
   ```

3. Regression sweep:

   ```
   uv run [...same plugins...] python3 -m pytest tests/tools/test_send_message_tool.py -v
   uv run [...same plugins with mautrix==0.21.0...] python3 -m pytest tests/gateway/test_matrix.py -k markdown -v
   ```

   123 tests in `test_send_message_tool.py` pass; 29 markdown tests in `test_matrix.py` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (inline docstring updated to describe the fallback)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change; only payload shape)

## Screenshots / Logs

Before (no markdown lib in venv):

```
PUT .../send/m.room.message/...
{"msgtype": "m.text", "body": "## Heading\n\n- a\n- b"}
```

After (no markdown lib in venv):

```
PUT .../send/m.room.message/...
{
  "msgtype": "m.text",
  "body": "## Heading\n\n- a\n- b",
  "format": "org.matrix.custom.html",
  "formatted_body": "<strong>Heading</strong>...<ul><li>a</li><li>b</li></ul>..."
}
```

## Related / Positioning

The reporter listed three options in #32486 — (1) ship `markdown` in the Docker image, (2) make `markdown` a hard dependency, (3) align the cron-path fallback with the interactive path's regex `_markdown_to_html_fallback`. This PR is option (3): smallest blast-radius change (no `pyproject.toml` / `Dockerfile` / `uv.lock` churn, no transitive-dep movement) and removes the asymmetry between the two Matrix HTML emitters at the same time. Options (1) and (2) remain viable as follow-ups if the maintainers prefer a dep-level fix; this PR doesn't block either.

[PR #20259](https://github.com/NousResearch/hermes-agent/pull/20259) (DanAsBjorn) proposes routing all Matrix text sends through the adapter — a wider scope that has been idle 21 days. If it lands, `_send_matrix` is removed wholesale and this fallback goes with it; the two PRs don't conflict.

> Audited siblings: the only other `import markdown as _md` site in the repo is `MatrixAdapter._markdown_to_html` in `gateway/platforms/matrix.py`, which already has the regex fallback this PR copies. No widening needed.
