### PR TITLE
fix: stabilize gateway recovery and kanban backups

### DIFF
--- a/gateway/approval_routing.py
+++ b/gateway/approval_routing.py
@@ -1,0 +1,134 @@
+"""Helpers for routing and wording gateway approval prompts."""
+
+from __future__ import annotations
+
+import html
+from typing import Any, Mapping
+
+
+def _as_dict(value: Any) -> dict:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _parse_target(target: str) -> tuple[str, str, str | None] | None:
+    """Parse `platform:chat_id[:thread_id]` approval target strings."""
+    raw = str(target or "").strip()
+    if not raw or ":" not in raw:
+        return None
+    platform, rest = raw.split(":", 1)
+    platform = platform.strip().lower()
+    rest = rest.strip()
+    if not platform or not rest:
+        return None
+
+    # Telegram supergroups are negative (`-100...`), so the final colon is
+    # safe to treat as the optional topic/thread separator.
+    chat_id, sep, thread_id = rest.rpartition(":")
+    if sep and chat_id:
+        return platform, chat_id.strip(), thread_id.strip() or None
+    return platform, rest, None
+
+
+def approval_target_for_adapter(
+    *,
+    adapter_name: str,
+    default_chat_id: str,
+    default_metadata: Mapping[str, Any] | None,
+    approvals_config: Mapping[str, Any] | None,
+) -> tuple[str, dict[str, Any] | None]:
+    """Return where an approval prompt should be sent for this adapter.
+
+    If `approvals.gateway_target` matches the current platform, route the
+    prompt there. Otherwise keep the original chat/thread untouched.
+    """
+    metadata = _as_dict(default_metadata)
+    cfg = _as_dict(approvals_config)
+    parsed = _parse_target(str(cfg.get("gateway_target") or cfg.get("target") or ""))
+    if not parsed:
+        return str(default_chat_id), (metadata or None)
+
+    target_platform, target_chat_id, target_thread_id = parsed
+    if target_platform != str(adapter_name or "").lower():
+        return str(default_chat_id), (metadata or None)
+
+    routed_metadata = dict(metadata)
+    # A prompt redirected to a central approvals topic should not reply to the
+    # original message id from another topic/chat; Telegram rejects that and it
+    # visually links the wrong conversation.
+    routed_metadata.pop("reply_to_message_id", None)
+    if target_thread_id:
+        routed_metadata["thread_id"] = target_thread_id
+    else:
+        routed_metadata.pop("thread_id", None)
+    return target_chat_id, (routed_metadata or None)
+
+
+def source_label_from_source(source: Any) -> str:
+    """Small human label for the project/session that requested approval."""
+    description = getattr(source, "description", "") or ""
+    if description:
+        return str(description)
+    chat_name = getattr(source, "chat_name", None)
+    chat_id = getattr(source, "chat_id", None)
+    thread_id = getattr(source, "thread_id", None)
+    label = str(chat_name or chat_id or "unknown session")
+    if thread_id:
+        label += f" / topic {thread_id}"
+    return label
+
+
+def format_approval_prompt(
+    *,
+    command: str,
+    description: str,
+    source_label: str = "",
+    language: str = "en",
+    html_mode: bool = False,
+) -> str:
+    """Format a plain-language approval prompt."""
+    cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+    reason = description or "dangerous command"
+    source = source_label or "current session"
+
+    if html_mode:
+        cmd = html.escape(cmd_preview)
+        reason_text = html.escape(reason)
+        source_text = html.escape(source)
+    else:
+        cmd = cmd_preview
+        reason_text = reason
+        source_text = source
+
+    if str(language or "").lower().startswith("lv"):
+        if html_mode:
+            return (
+                "⚠️ <b>Nepieciešams tavs apstiprinājums</b>\n\n"
+                f"<b>No kurienes:</b> {source_text}\n"
+                f"<b>Ko apstiprini:</b> šīs komandas palaišanu\n"
+                f"<pre>{cmd}</pre>\n"
+                f"<b>Kāpēc prasa:</b> {reason_text}\n\n"
+                "Ja saproti un gribi ļaut, spied pogu. Ja nē — Deny."
+            )
+        return (
+            "⚠️ **Nepieciešams tavs apstiprinājums**\n\n"
+            f"No kurienes: {source_text}\n"
+            "Ko apstiprini: šīs komandas palaišanu\n"
+            f"```\n{cmd}\n```\n"
+            f"Kāpēc prasa: {reason_text}\n\n"
+            "Ja saproti un gribi ļaut, spied /approve. Ja nē — /deny."
+        )
+
+    if html_mode:
+        return (
+            "⚠️ <b>Command Approval Required</b>\n\n"
+            f"<b>Source:</b> {source_text}\n"
+            f"<b>Approving:</b> run this command\n"
+            f"<pre>{cmd}</pre>\n\n"
+            f"<b>Reason:</b> {reason_text}"
+        )
+    return (
+        "⚠️ **Dangerous command requires approval:**\n"
+        f"Source: {source_text}\n"
+        f"```\n{cmd}\n```\n"
+        f"Reason: {reason_text}"
+    )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -105,7 +105,7 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 }
 
 
-MAX_COMMANDS_PER_SCOPE = 30
+MAX_COMMANDS_PER_SCOPE = 100
 
 
 def check_telegram_requirements() -> bool:
@@ -962,6 +962,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
+            # start_polling() has successfully re-established polling, so do not
+            # keep outbound replies blocked for the full deferred heartbeat
+            # window. The heartbeat below still catches a wedged poller and
+            # re-enters the reconnect ladder if the pool is actually broken.
+            self._send_path_degraded = False
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx
@@ -2582,6 +2587,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        prompt_text: Optional[str] = None,
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
 
@@ -2593,7 +2599,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
-            text = (
+            text = prompt_text or (
                 f"⚠️ <b>Command Approval Required</b>\n\n"
                 f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
                 f"Reason: {_html.escape(description)}"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -53,6 +53,11 @@ from typing import Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
+from gateway.approval_routing import (
+    approval_target_for_adapter,
+    format_approval_prompt,
+    source_label_from_source,
+)
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -1441,6 +1446,38 @@ def _load_gateway_runtime_config() -> dict:
 
     expanded = _expand_env_vars(cfg)
     return expanded if isinstance(expanded, dict) else {}
+
+
+def _gateway_approval_delivery_context(
+    *,
+    source: Any,
+    default_chat_id: str,
+    default_metadata: Dict[str, Any] | None,
+    command: str,
+    description: str,
+    html_mode: bool = False,
+) -> tuple[str, Dict[str, Any] | None, str]:
+    """Resolve chat/thread + prompt text for a gateway approval request."""
+    cfg = _load_gateway_runtime_config()
+    approvals_config = cfg_get(cfg, "approvals", default={}) or {}
+    source_platform = getattr(source, "platform", "")
+    adapter_name = getattr(source_platform, "value", str(source_platform)).lower()
+    if adapter_name == "local":
+        adapter_name = "cli"
+    chat_id, metadata = approval_target_for_adapter(
+        adapter_name=adapter_name,
+        default_chat_id=default_chat_id,
+        default_metadata=default_metadata,
+        approvals_config=approvals_config,
+    )
+    prompt = format_approval_prompt(
+        command=command,
+        description=description,
+        source_label=source_label_from_source(source),
+        language=str(approvals_config.get("prompt_language") or "en"),
+        html_mode=html_mode,
+    )
+    return chat_id, metadata, prompt
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:
@@ -16857,20 +16894,43 @@ class GatewayRunner:
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                _approval_chat_id, _approval_metadata, _approval_prompt_html = _gateway_approval_delivery_context(
+                    source=source,
+                    default_chat_id=_status_chat_id,
+                    default_metadata=_status_thread_metadata,
+                    command=cmd,
+                    description=desc,
+                    html_mode=True,
+                )
+                _, _, _approval_prompt_text = _gateway_approval_delivery_context(
+                    source=source,
+                    default_chat_id=_status_chat_id,
+                    default_metadata=_status_thread_metadata,
+                    command=cmd,
+                    description=desc,
+                    html_mode=False,
+                )
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
                 # false positives from MagicMock auto-attribute creation in tests.
                 if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
                     try:
+                        _approval_kwargs = dict(
+                            chat_id=_approval_chat_id,
+                            command=cmd,
+                            session_key=_approval_session_key,
+                            description=desc,
+                            metadata=_approval_metadata,
+                        )
+                        try:
+                            _approval_sig = inspect.signature(type(_status_adapter).send_exec_approval)
+                            if "prompt_text" in _approval_sig.parameters:
+                                _approval_kwargs["prompt_text"] = _approval_prompt_html
+                        except (TypeError, ValueError):
+                            pass
                         _approval_fut = safe_schedule_threadsafe(
-                            _status_adapter.send_exec_approval(
-                                chat_id=_status_chat_id,
-                                command=cmd,
-                                session_key=_approval_session_key,
-                                description=desc,
-                                metadata=_status_thread_metadata,
-                            ),
+                            _status_adapter.send_exec_approval(**_approval_kwargs),
                             _loop_for_step,
                             logger=logger,
                             log_message="send_exec_approval scheduling error",
@@ -16890,20 +16950,12 @@ class GatewayRunner:
                         )
 
                 # Fallback: plain text approval prompt
-                cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
-                msg = (
-                    f"⚠️ **Dangerous command requires approval:**\n"
-                    f"```\n{cmd_preview}\n```\n"
-                    f"Reason: {desc}\n\n"
-                    f"Reply `/approve` to execute, `/approve session` to approve this pattern "
-                    f"for the session, `/approve always` to approve permanently, or `/deny` to cancel."
-                )
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(
                         _status_adapter.send(
-                            _status_chat_id,
-                            msg,
-                            metadata=_status_thread_metadata,
+                            _approval_chat_id,
+                            _approval_prompt_text,
+                            metadata=_approval_metadata,
                         ),
                         _loop_for_step,
                         logger=logger,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1050,6 +1050,30 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     # anyway so static analyzers can see the containment guarantee.
     if candidate.parent != parent:
         return None
+    # Backup cap @5: prune oldest .corrupt.*.bak before adding new one.
+    # Without this a cascade bug can flood the board dir (93+ files seen 2026-05-26).
+    # Patched locally — see ~/.hermes/scripts/reapply-cascade-patch.sh
+    _BACKUP_CAP = 5
+    try:
+        existing = sorted(
+            parent.glob(f"{base_name}.corrupt.*.bak"),
+            key=lambda p: p.stat().st_mtime,
+        )
+        excess = len(existing) - (_BACKUP_CAP - 1)
+        if excess > 0:
+            for old in existing[:excess]:
+                if old.parent != parent:
+                    continue
+                for suffix in ("", "-wal", "-shm"):
+                    sibling = parent / (old.name + suffix)
+                    if sibling.parent != parent or not sibling.exists():
+                        continue
+                    try:
+                        sibling.unlink()
+                    except OSError:
+                        pass
+    except OSError:
+        pass
     counter = 0
     while candidate.exists():
         counter += 1

--- a/tests/gateway/test_approval_routing.py
+++ b/tests/gateway/test_approval_routing.py
@@ -1,0 +1,82 @@
+from types import SimpleNamespace
+
+from gateway.approval_routing import approval_target_for_adapter, format_approval_prompt
+from gateway.platforms.base import Platform
+from gateway.run import _gateway_approval_delivery_context
+
+
+def test_approval_target_for_adapter_routes_telegram_to_configured_topic():
+    chat_id, metadata = approval_target_for_adapter(
+        adapter_name="telegram",
+        default_chat_id="615821439",
+        default_metadata={"thread_id": "1", "reply_to_message_id": 99},
+        approvals_config={"gateway_target": "telegram:-1003812316571:126"},
+    )
+
+    assert chat_id == "-1003812316571"
+    assert metadata["thread_id"] == "126"
+    assert "reply_to_message_id" not in metadata
+
+
+def test_approval_target_for_adapter_ignores_other_platforms():
+    chat_id, metadata = approval_target_for_adapter(
+        adapter_name="discord",
+        default_chat_id="orig-channel",
+        default_metadata={"thread_id": "source-thread"},
+        approvals_config={"gateway_target": "telegram:-1003812316571:126"},
+    )
+
+    assert chat_id == "orig-channel"
+    assert metadata == {"thread_id": "source-thread"}
+
+
+def test_gateway_approval_delivery_context_uses_runtime_config_for_routing_and_lv_prompt(monkeypatch):
+    monkeypatch.setattr(
+        "gateway.run._load_gateway_runtime_config",
+        lambda: {
+            "approvals": {
+                "gateway_target": "telegram:-1003812316571:126",
+                "prompt_language": "lv",
+            }
+        },
+    )
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="-100source",
+        thread_id="180",
+        chat_name="Life_OS_Hermes",
+        description="Life_OS_Hermes / topic 180",
+    )
+
+    chat_id, metadata, prompt = _gateway_approval_delivery_context(
+        source=source,
+        default_chat_id="-100source",
+        default_metadata={"thread_id": "180", "reply_to_message_id": 99},
+        command="rm -rf /tmp/demo",
+        description="recursive delete",
+        html_mode=True,
+    )
+
+    assert chat_id == "-1003812316571"
+    assert metadata is not None
+    assert metadata["thread_id"] == "126"
+    assert "reply_to_message_id" not in metadata
+    assert "Nepieciešams tavs apstiprinājums" in prompt
+    assert "Life_OS_Hermes / topic 180" in prompt
+    assert "rm -rf /tmp/demo" in prompt
+
+
+def test_format_approval_prompt_lv_simple_language_has_project_and_action():
+    text = format_approval_prompt(
+        command="rm -rf /tmp/demo",
+        description="recursive delete",
+        source_label="Life_OS_Hermes / topic 126",
+        language="lv",
+    )
+
+    assert "Nepieciešams tavs apstiprinājums" in text
+    assert "No kurienes" in text
+    assert "Life_OS_Hermes / topic 126" in text
+    assert "Ko apstiprini" in text
+    assert "rm -rf /tmp/demo" in text
+    assert "recursive delete" in text

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -66,9 +66,10 @@ async def test_send_short_circuits_when_path_degraded():
 
 
 @pytest.mark.asyncio
-async def test_reconnect_storm_sets_and_heartbeat_clears_flag(monkeypatch):
-    """_handle_polling_network_error sets the flag; a successful heartbeat
-    probe in _verify_polling_after_reconnect clears it."""
+async def test_reconnect_storm_sets_and_successful_reconnect_clears_flag(monkeypatch):
+    """_handle_polling_network_error gates sends during the reconnect delay,
+    then unblocks sends as soon as start_polling succeeds. A later heartbeat
+    still verifies the path and can re-enter reconnect if the pool is wedged."""
     adapter = _make_adapter()
     adapter._app = MagicMock()
     adapter._app.updater = MagicMock()
@@ -82,8 +83,12 @@ async def test_reconnect_storm_sets_and_heartbeat_clears_flag(monkeypatch):
         "gateway.platforms.telegram.Update", MagicMock(ALL_TYPES=[])
     )
 
-    await adapter._handle_polling_network_error(OSError("Bad Gateway"))
-    assert adapter._send_path_degraded is True
+    async def assert_flag_during_delay(*_args, **_kwargs):
+        assert adapter._send_path_degraded is True
+
+    with patch("gateway.platforms.telegram.asyncio.sleep", side_effect=assert_flag_during_delay):
+        await adapter._handle_polling_network_error(OSError("Bad Gateway"))
+    assert adapter._send_path_degraded is False
 
     with patch("gateway.platforms.telegram.asyncio.sleep", new_callable=AsyncMock):
         await adapter._verify_polling_after_reconnect()


### PR DESCRIPTION
## Summary
- caps Kanban corrupt DB backup cascades so recovery cannot flood the board directory
- restores gateway approval routing helpers after upstream drift
- keeps Telegram send-path recovery behavior covered by regression tests

## Test Plan
- uv run --with pytest --with pytest-asyncio --with pytest-xdist python -m pytest tests/gateway/test_approval_routing.py tests/gateway/test_telegram_send_path_health.py tests/gateway/test_delivery.py tests/gateway/test_dm_topics.py tests/hermes_cli/test_kanban_db.py -q -o 'addopts='
