### PR TITLE
feat(aci-2506): tool descriptions, gateway budgets, terminal auto-summary

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -32,7 +32,14 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 
 from agent.context_compressor import ContextCompressor
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import (
+    DEFAULT_MAX_TOOL_CALLS_PER_TURN,
+    DEFAULT_REPEAT_TOOL_THRESHOLD,
+    DEFAULT_USAGE_EVENTS_PATH,
+    IterationBudget,
+    coerce_optional_positive_float,
+    coerce_optional_positive_int,
+)
 from agent.memory_manager import StreamingContextScrubber
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -202,6 +209,10 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    max_tool_calls_per_turn: int | None = DEFAULT_MAX_TOOL_CALLS_PER_TURN,
+    repeat_tool_threshold: int = DEFAULT_REPEAT_TOOL_THRESHOLD,
+    cost_limit_per_turn: float | None = None,
+    usage_events_path: str | None = DEFAULT_USAGE_EVENTS_PATH,
 ):
     """
     Initialize the AI Agent.
@@ -255,6 +266,19 @@ def init_agent(
 
     agent.model = model
     agent.max_iterations = max_iterations
+    agent.max_tool_calls_per_turn = coerce_optional_positive_int(
+        max_tool_calls_per_turn,
+        DEFAULT_MAX_TOOL_CALLS_PER_TURN,
+    )
+    agent.repeat_tool_threshold = coerce_optional_positive_int(
+        repeat_tool_threshold,
+        DEFAULT_REPEAT_TOOL_THRESHOLD,
+    ) or DEFAULT_REPEAT_TOOL_THRESHOLD
+    agent.cost_limit_per_turn = coerce_optional_positive_float(
+        cost_limit_per_turn,
+        None,
+    )
+    agent.usage_events_path = usage_events_path or DEFAULT_USAGE_EVENTS_PATH
     # Shared iteration budget — parent creates, children inherit.
     # Consumed by every LLM turn across parent + all subagents.
     agent.iteration_budget = iteration_budget or IterationBudget(max_iterations)
@@ -339,6 +363,24 @@ def init_agent(
             agent.model = normalize_model_for_provider(agent.model, agent.provider)
     except Exception:
         pass
+
+    try:
+        from agent.model_policy import enforce_allowed_model, enforce_allowed_provider
+
+        agent.provider = enforce_allowed_provider(
+            agent.provider,
+            usage="main provider",
+        )
+        agent.model = enforce_allowed_model(
+            agent.model,
+            usage=f"main provider {agent.provider or 'unknown'}",
+        )
+    except Exception as exc:
+        from agent.model_policy import ForbiddenModelError
+
+        if isinstance(exc, ForbiddenModelError):
+            raise
+        logging.debug("Model policy check skipped during init: %s", exc)
 
     # GPT-5.x models usually require the Responses API path, but some
     # providers have exceptions (for example Copilot's gpt-5-mini still
@@ -806,7 +848,19 @@ def init_agent(
                         )
                         if _fb_client is not None:
                             agent.provider = _fb["provider"]
-                            agent.model = _fb_model or _fb["model"]
+                            from agent.model_policy import (
+                                enforce_allowed_model,
+                                enforce_allowed_provider,
+                            )
+
+                            agent.provider = enforce_allowed_provider(
+                                _fb["provider"],
+                                usage="fallback provider",
+                            )
+                            agent.model = enforce_allowed_model(
+                                _fb_model or _fb["model"],
+                                usage=f"fallback provider {_fb['provider']}",
+                            )
                             agent._fallback_activated = True
                             client_kwargs = {
                                 "api_key": _fb_client.api_key,
@@ -894,6 +948,12 @@ def init_agent(
         agent._fallback_chain = []
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
+    agent._runtime_monitor_primary_healthy = not agent._fallback_activated
+    agent._runtime_monitor_last_failure_reason = ""
+    agent._runtime_monitor_last_probe_error = ""
+    agent._runtime_monitor_next_probe_at = 0.0
+    agent._runtime_monitor_notify_sent_at = {}
+    agent._runtime_monitor_probe_thread = None
     # Legacy attribute kept for backward compat (tests, external callers)
     agent._fallback_model = agent._fallback_chain[0] if agent._fallback_chain else None
     if agent._fallback_chain and not agent.quiet_mode:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -32,7 +32,7 @@ from agent.auxiliary_client import set_runtime_main
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import IterationBudget, append_usage_event
 from agent.memory_manager import build_memory_context_block
 from agent.message_sanitization import (
     _repair_tool_call_arguments,
@@ -587,6 +587,13 @@ def run_conversation(
     # present are surfaced in an advisory footer so the model cannot
     # over-claim success while the file is actually unchanged on disk.
     agent._turn_failed_file_mutations: Dict[str, Dict[str, Any]] = {}
+    agent._turn_tool_call_count = 0
+    agent._turn_repeat_tool_warnings = 0
+    agent._turn_budget_hit = False
+    agent._turn_estimated_cost_usd = 0.0
+    agent._turn_cost_limit_exceeded = False
+    agent._turn_recent_tool_call_signatures = []
+    agent._turn_repeat_tool_warning_active = False
     
     # Record the execution thread so interrupt()/clear_interrupt() can
     # scope the tool-level interrupt signal to THIS agent's thread only.
@@ -1023,7 +1030,10 @@ def run_conversation(
                             force=True,
                         )
                         agent._emit_status(f"⏳ {_nous_msg}")
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(
+                            reason=FailoverReason.rate_limit,
+                            reason_detail=_nous_msg,
+                        ):
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False
@@ -1259,7 +1269,10 @@ def run_conversation(
                     # rather than retrying with extended backoff.
                     if agent._fallback_index < len(agent._fallback_chain):
                         agent._emit_status("⚠️ Empty/malformed response — switching to fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(
+                        reason=FailoverReason.format_error,
+                        reason_detail="empty/malformed response before provider error payload",
+                    ):
                         retry_count = 0
                         compression_attempts = 0
                         primary_recovery_attempted = False
@@ -1329,7 +1342,10 @@ def run_conversation(
                     if retry_count >= max_retries:
                         # Try fallback before giving up
                         agent._emit_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(
+                            reason=FailoverReason.format_error,
+                            reason_detail=", ".join(error_details)[:500],
+                        ):
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False
@@ -1650,7 +1666,21 @@ def run_conversation(
                         api_key=getattr(agent, "api_key", ""),
                     )
                     if cost_result.amount_usd is not None:
-                        agent.session_estimated_cost_usd += float(cost_result.amount_usd)
+                        _call_cost = float(cost_result.amount_usd)
+                        agent.session_estimated_cost_usd += _call_cost
+                        agent._turn_estimated_cost_usd += _call_cost
+                        if (
+                            agent.cost_limit_per_turn is not None
+                            and agent._turn_estimated_cost_usd > agent.cost_limit_per_turn
+                        ):
+                            agent._turn_cost_limit_exceeded = True
+                            agent._turn_budget_hit = True
+                            agent._budget_grace_call = True
+                            logger.warning(
+                                "cost_limit_per_turn=%.4f exceeded (%.4f)",
+                                agent.cost_limit_per_turn,
+                                agent._turn_estimated_cost_usd,
+                            )
                     agent.session_cost_status = cost_result.status
                     agent.session_cost_source = cost_result.source
 
@@ -2791,7 +2821,10 @@ def run_conversation(
                     # Try fallback before aborting — a different provider
                     # may not have the same issue (rate limit, auth, etc.)
                     agent._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(
+                        reason=classified.reason,
+                        reason_detail=classified.message or agent._summarize_api_error(api_error),
+                    ):
                         retry_count = 0
                         compression_attempts = 0
                         primary_recovery_attempted = False
@@ -2862,7 +2895,10 @@ def run_conversation(
                         continue
                     # Try fallback before giving up entirely
                     agent._emit_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if agent._try_activate_fallback(
+                        reason=classified.reason,
+                        reason_detail=classified.message or agent._summarize_api_error(api_error),
+                    ):
                         retry_count = 0
                         compression_attempts = 0
                         primary_recovery_attempted = False
@@ -3412,6 +3448,30 @@ def run_conversation(
                 messages.append(assistant_msg)
                 agent._emit_interim_assistant_message(assistant_msg)
 
+                if getattr(agent, "_turn_cost_limit_exceeded", False):
+                    from agent.tool_dispatch_helpers import make_tool_result_message
+
+                    limit = getattr(agent, "cost_limit_per_turn", None)
+                    spent = getattr(agent, "_turn_estimated_cost_usd", 0.0)
+                    for tc in assistant_message.tool_calls:
+                        messages.append(make_tool_result_message(
+                            tc.function.name,
+                            "[BUDGET] cost_limit_per_turn exceeded "
+                            f"({spent:.4f} USD"
+                            + (f" > {limit:.4f} USD" if limit is not None else "")
+                            + "). Tool execution skipped; give a final answer.",
+                            tc.id,
+                        ))
+                    messages.append({
+                        "role": "user",
+                        "content": (
+                            "[BUDGET] The per-turn cost limit has been exceeded. "
+                            "Stop calling tools and provide the best final answer from existing context."
+                        ),
+                    })
+                    _turn_exit_reason = "cost_limit_per_turn"
+                    continue
+
                 # Close any open streaming display (response box, reasoning
                 # box) before tool execution begins.  Intermediate turns may
                 # have streamed early content that opened the response box;
@@ -3715,7 +3775,10 @@ def run_conversation(
                             "⚠️ Model returning empty responses — "
                             "switching to fallback provider..."
                         )
-                        if agent._try_activate_fallback():
+                        if agent._try_activate_fallback(
+                            reason=FailoverReason.format_error,
+                            reason_detail="model returned repeated empty responses",
+                        ):
                             agent._empty_content_retries = 0
                             agent._emit_status(
                                 f"↻ Switched to fallback: {agent.model} "
@@ -4116,6 +4179,30 @@ def run_conversation(
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
+
+    append_usage_event(
+        {
+            "session_id": agent.session_id,
+            "platform": agent.platform,
+            "user_id": getattr(agent, "_user_id", None),
+            "chat_id": getattr(agent, "_chat_id", None),
+            "thread_id": getattr(agent, "_thread_id", None),
+            "turn_tool_calls": getattr(agent, "_turn_tool_call_count", 0),
+            "max_tool_calls_per_turn": getattr(agent, "max_tool_calls_per_turn", None),
+            "repeat_tool_warnings": getattr(agent, "_turn_repeat_tool_warnings", 0),
+            "input_tokens": agent.session_input_tokens,
+            "output_tokens": agent.session_output_tokens,
+            "prompt_tokens": agent.session_prompt_tokens,
+            "completion_tokens": agent.session_completion_tokens,
+            "estimated_cost_usd": getattr(agent, "_turn_estimated_cost_usd", 0.0),
+            "session_estimated_cost_usd": agent.session_estimated_cost_usd,
+            "model": agent.model,
+            "provider": agent.provider,
+            "budget_hit": getattr(agent, "_turn_budget_hit", False),
+            "turn_exit_reason": _turn_exit_reason,
+        },
+        path=getattr(agent, "usage_events_path", None),
+    )
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.

--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -1,4 +1,4 @@
-"""Per-agent iteration budget — thread-safe consume/refund counter.
+"""Per-agent iteration and per-turn budget helpers.
 
 Extracted from ``run_agent.py``.  Each ``AIAgent`` instance (parent or
 subagent) holds an :class:`IterationBudget`; the parent's cap comes from
@@ -11,7 +11,57 @@ subagent) holds an :class:`IterationBudget`; the parent's cap comes from
 
 from __future__ import annotations
 
+import json
+import logging
 import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_TOOL_CALLS_PER_TURN = 50
+DEFAULT_REPEAT_TOOL_THRESHOLD = 3
+DEFAULT_USAGE_EVENTS_PATH = "/Users/xbr/.agentic-stack/usage-events.jsonl"
+
+
+def coerce_optional_positive_int(value: Any, default: int | None) -> int | None:
+    """Return a positive int, or default when unset/invalid."""
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def coerce_optional_positive_float(value: Any, default: float | None = None) -> float | None:
+    """Return a positive float, or default when unset/invalid."""
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def append_usage_event(event: dict[str, Any], path: str | None = None) -> bool:
+    """Append one usage event to JSONL. Best-effort; never raises."""
+    target = path or DEFAULT_USAGE_EVENTS_PATH
+    try:
+        event = dict(event)
+        event.setdefault("ts", datetime.now(timezone.utc).isoformat())
+        out_path = Path(target).expanduser()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+        return True
+    except Exception as exc:  # pragma: no cover - logging-only failure path
+        logger.warning("Failed to append usage event to %s: %s", target, exc)
+        return False
 
 
 class IterationBudget:
@@ -59,4 +109,12 @@ class IterationBudget:
             return max(0, self.max_total - self._used)
 
 
-__all__ = ["IterationBudget"]
+__all__ = [
+    "IterationBudget",
+    "DEFAULT_MAX_TOOL_CALLS_PER_TURN",
+    "DEFAULT_REPEAT_TOOL_THRESHOLD",
+    "DEFAULT_USAGE_EVENTS_PATH",
+    "append_usage_event",
+    "coerce_optional_positive_float",
+    "coerce_optional_positive_int",
+]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -53,6 +53,13 @@ from typing import Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
+from agent.iteration_budget import (
+    DEFAULT_MAX_TOOL_CALLS_PER_TURN,
+    DEFAULT_REPEAT_TOOL_THRESHOLD,
+    DEFAULT_USAGE_EVENTS_PATH,
+    coerce_optional_positive_float,
+    coerce_optional_positive_int,
+)
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -98,6 +105,29 @@ _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
+
+
+def _resolve_loop_protection_config(user_config: dict | None) -> dict:
+    """Resolve gateway.loop_protection with backward-compatible defaults."""
+    gateway_cfg = (user_config or {}).get("gateway") if isinstance(user_config, dict) else None
+    loop_cfg = gateway_cfg.get("loop_protection") if isinstance(gateway_cfg, dict) else None
+    if not isinstance(loop_cfg, dict):
+        loop_cfg = {}
+    return {
+        "max_tool_calls_per_turn": coerce_optional_positive_int(
+            loop_cfg.get("max_tool_calls_per_turn"),
+            DEFAULT_MAX_TOOL_CALLS_PER_TURN,
+        ),
+        "repeat_tool_threshold": coerce_optional_positive_int(
+            loop_cfg.get("repeat_tool_threshold"),
+            DEFAULT_REPEAT_TOOL_THRESHOLD,
+        ) or DEFAULT_REPEAT_TOOL_THRESHOLD,
+        "cost_limit_per_turn": coerce_optional_positive_float(
+            loop_cfg.get("cost_limit_per_turn"),
+            None,
+        ),
+        "usage_events_path": loop_cfg.get("usage_events_path") or DEFAULT_USAGE_EVENTS_PATH,
+    }
 
 _GATEWAY_PROVIDER_POLICY_RE = re.compile(
     r"("  # raw provider policy/safety bodies are noisy and may be sensitive
@@ -11476,6 +11506,7 @@ class GatewayRunner:
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+            loop_protection = _resolve_loop_protection_config(user_config)
 
             pr = self._provider_routing
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
@@ -11529,6 +11560,7 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    **loop_protection,
                 )
                 try:
                     return agent.run_conversation(
@@ -16333,6 +16365,7 @@ class GatewayRunner:
                 )
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            loop_protection = _resolve_loop_protection_config(user_config)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -16394,6 +16427,7 @@ class GatewayRunner:
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    **loop_protection,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
@@ -16411,6 +16445,10 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            agent.max_tool_calls_per_turn = loop_protection["max_tool_calls_per_turn"]
+            agent.repeat_tool_threshold = loop_protection["repeat_tool_threshold"]
+            agent.cost_limit_per_turn = loop_protection["cost_limit_per_turn"]
+            agent.usage_events_path = loop_protection["usage_events_path"]
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/run_agent.py
+++ b/run_agent.py
@@ -81,7 +81,12 @@ from agent.process_bootstrap import (
     _get_proxy_from_env,
     _get_proxy_for_base_url,
 )
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import (
+    DEFAULT_MAX_TOOL_CALLS_PER_TURN,
+    DEFAULT_REPEAT_TOOL_THRESHOLD,
+    DEFAULT_USAGE_EVENTS_PATH,
+    IterationBudget,
+)
 
 
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -412,6 +417,10 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        max_tool_calls_per_turn: int | None = DEFAULT_MAX_TOOL_CALLS_PER_TURN,
+        repeat_tool_threshold: int = DEFAULT_REPEAT_TOOL_THRESHOLD,
+        cost_limit_per_turn: float | None = None,
+        usage_events_path: str | None = DEFAULT_USAGE_EVENTS_PATH,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -481,6 +490,10 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            max_tool_calls_per_turn=max_tool_calls_per_turn,
+            repeat_tool_threshold=repeat_tool_threshold,
+            cost_limit_per_turn=cost_limit_per_turn,
+            usage_events_path=usage_events_path,
         )
 
     def _get_session_db_for_recall(self):
@@ -3148,10 +3161,14 @@ class AIAgent:
         from agent.chat_completion_helpers import interruptible_streaming_api_call
         return interruptible_streaming_api_call(self, api_kwargs, on_first_delta=on_first_delta)
 
-    def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
+    def _try_activate_fallback(
+        self,
+        reason: "FailoverReason | None" = None,
+        reason_detail: str | None = None,
+    ) -> bool:
         """Forwarder — see ``agent.chat_completion_helpers.try_activate_fallback``."""
         from agent.chat_completion_helpers import try_activate_fallback
-        return try_activate_fallback(self, reason)
+        return try_activate_fallback(self, reason, reason_detail=reason_detail)
 
     # ── Per-turn primary restoration ─────────────────────────────────────
 
@@ -3961,6 +3978,68 @@ class AIAgent:
         self._set_tool_guardrail_halt(decision)
         return toolguard_synthetic_result(decision)
 
+    @staticmethod
+    def _tool_call_signature(tool_call) -> tuple[str, str]:
+        function = getattr(tool_call, "function", None)
+        return (
+            getattr(function, "name", "") or "",
+            getattr(function, "arguments", "") or "",
+        )
+
+    def _reserve_tool_calls_for_turn(self, tool_calls: list) -> tuple[list, list, list[str]]:
+        """Apply per-turn tool-call budget and detect repeated identical calls."""
+        max_calls = getattr(self, "max_tool_calls_per_turn", DEFAULT_MAX_TOOL_CALLS_PER_TURN)
+        recent = getattr(self, "_turn_recent_tool_call_signatures", None)
+        if recent is None:
+            recent = []
+            self._turn_recent_tool_call_signatures = recent
+        warnings: list[str] = []
+        allowed = []
+        skipped = []
+
+        for tc in tool_calls:
+            current_count = int(getattr(self, "_turn_tool_call_count", 0) or 0) + 1
+            self._turn_tool_call_count = current_count
+
+            signature = self._tool_call_signature(tc)
+            recent.append(signature)
+            threshold = max(1, int(getattr(self, "repeat_tool_threshold", DEFAULT_REPEAT_TOOL_THRESHOLD) or DEFAULT_REPEAT_TOOL_THRESHOLD))
+            if (
+                len(recent) >= threshold
+                and all(item == signature for item in recent[-threshold:])
+            ):
+                if not getattr(self, "_turn_repeat_tool_warning_active", False):
+                    self._turn_repeat_tool_warning_active = True
+                    self._turn_repeat_tool_warnings = int(getattr(self, "_turn_repeat_tool_warnings", 0) or 0) + 1
+                    tool_name = signature[0] or "unknown"
+                    msg = (
+                        f"[LOOP WARNING] You called '{tool_name}' {threshold}+ times "
+                        "consecutively with identical arguments. Confirm this is intentional "
+                        "or switch approach before calling it again."
+                    )
+                    warnings.append(msg)
+                    logger.warning("Loop warning: repeated identical tool call %s", tool_name)
+            elif len(recent) >= 2 and recent[-1] != recent[-2]:
+                self._turn_repeat_tool_warning_active = False
+
+            if max_calls is not None and current_count > int(max_calls):
+                skipped.append(tc)
+                self._turn_budget_hit = True
+                continue
+            allowed.append(tc)
+
+        if skipped:
+            logger.warning(
+                "max_tool_calls_per_turn=%s reached; skipped %d tool call(s)",
+                max_calls,
+                len(skipped),
+            )
+        return allowed, skipped, warnings
+
+    def _append_turn_budget_warnings(self, messages: list, warnings: list[str]) -> None:
+        for warning in warnings:
+            messages.append({"role": "user", "content": warning})
+
     def _execute_tool_calls(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
         """Execute tool calls from the assistant message and append results to messages.
 
@@ -3969,19 +4048,37 @@ class AIAgent:
         file reads/writes may do so only when their target paths do not overlap.
         """
         tool_calls = assistant_message.tool_calls
+        allowed_calls, skipped_calls, warnings = self._reserve_tool_calls_for_turn(tool_calls)
+        assistant_message.tool_calls = allowed_calls
 
         # Allow _vprint during tool execution even with stream consumers
         self._executing_tools = True
         try:
-            if not _should_parallelize_tool_batch(tool_calls):
-                return self._execute_tool_calls_sequential(
-                    assistant_message, messages, effective_task_id, api_call_count
-                )
-
-            return self._execute_tool_calls_concurrent(
-                assistant_message, messages, effective_task_id, api_call_count
-            )
+            if allowed_calls:
+                if not _should_parallelize_tool_batch(allowed_calls):
+                    self._execute_tool_calls_sequential(
+                        assistant_message, messages, effective_task_id, api_call_count
+                    )
+                else:
+                    self._execute_tool_calls_concurrent(
+                        assistant_message, messages, effective_task_id, api_call_count
+                    )
+            if skipped_calls:
+                from agent.tool_dispatch_helpers import make_tool_result_message
+                max_calls = getattr(self, "max_tool_calls_per_turn", DEFAULT_MAX_TOOL_CALLS_PER_TURN)
+                for tc in skipped_calls:
+                    name = getattr(getattr(tc, "function", None), "name", "") or "unknown"
+                    messages.append(make_tool_result_message(
+                        name,
+                        f"[BUDGET] Tool call limit ({max_calls}) reached for this turn. "
+                        "This tool call was skipped; stop calling tools and give a final answer.",
+                        tc.id,
+                    ))
+                self._budget_grace_call = True
+            if warnings:
+                self._append_turn_budget_warnings(messages, warnings)
         finally:
+            assistant_message.tool_calls = tool_calls
             self._executing_tools = False
 
     def _dispatch_delegate_task(self, function_args: dict) -> str:

--- a/tests/agent/test_turn_loop_protection.py
+++ b/tests/agent/test_turn_loop_protection.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+def _tool_call(name="terminal", arguments="{}", tool_id="tc"):
+    return SimpleNamespace(
+        id=tool_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _agent(max_calls=2, repeat_threshold=3):
+    agent = AIAgent.__new__(AIAgent)
+    agent.max_tool_calls_per_turn = max_calls
+    agent.repeat_tool_threshold = repeat_threshold
+    agent._turn_tool_call_count = 0
+    agent._turn_repeat_tool_warnings = 0
+    agent._turn_budget_hit = False
+    agent._turn_recent_tool_call_signatures = []
+    agent._turn_repeat_tool_warning_active = False
+    return agent
+
+
+def test_reserve_tool_calls_enforces_per_turn_limit():
+    agent = _agent(max_calls=2)
+
+    allowed, skipped, warnings = agent._reserve_tool_calls_for_turn([
+        _tool_call(tool_id="1"),
+        _tool_call(tool_id="2"),
+        _tool_call(tool_id="3"),
+    ])
+
+    assert [tc.id for tc in allowed] == ["1", "2"]
+    assert [tc.id for tc in skipped] == ["3"]
+    assert agent._turn_tool_call_count == 3
+    assert agent._turn_budget_hit is True
+    assert len(warnings) == 1
+
+
+def test_repeat_warning_resets_when_tool_signature_changes():
+    agent = _agent(max_calls=10, repeat_threshold=3)
+
+    _, _, first_warnings = agent._reserve_tool_calls_for_turn([
+        _tool_call("terminal", "{}", "1"),
+        _tool_call("terminal", "{}", "2"),
+        _tool_call("terminal", "{}", "3"),
+    ])
+    _, _, second_warnings = agent._reserve_tool_calls_for_turn([
+        _tool_call("read_file", '{"path":"a"}', "4"),
+        _tool_call("terminal", "{}", "5"),
+        _tool_call("terminal", "{}", "6"),
+        _tool_call("terminal", "{}", "7"),
+    ])
+
+    assert len(first_warnings) == 1
+    assert len(second_warnings) == 1
+    assert agent._turn_repeat_tool_warnings == 2

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -64,6 +64,39 @@ class TestGeneratePreview:
         assert preview == text
         assert has_more is False
 
+    def test_terminal_large_output_gets_head_tail_error_summary(self):
+        text = "\n".join(
+            [f"head {i}" for i in range(400)]
+            + ["ERROR build failed"]
+            + [f"tail {i}" for i in range(400)]
+        )
+        preview, has_more = generate_preview(
+            text,
+            tool_name="terminal",
+            file_path="/tmp/hermes-results/tc_123.txt",
+        )
+
+        assert has_more is True
+        assert "[TERMINAL OUTPUT SUMMARY" in preview
+        assert "=== HEAD" in preview
+        assert "=== TAIL" in preview
+        assert "=== ERRORS/WARNINGS" in preview
+        assert "ERROR build failed" in preview
+        assert "Full output: /tmp/hermes-results/tc_123.txt" in preview
+
+    def test_non_terminal_large_output_keeps_legacy_preview(self):
+        text = "x" * 6000
+        preview, has_more = generate_preview(
+            text,
+            max_chars=2000,
+            tool_name="read_file",
+            file_path="/tmp/hermes-results/tc_123.txt",
+        )
+
+        assert has_more is True
+        assert preview == "x" * 2000
+        assert "TERMINAL OUTPUT SUMMARY" not in preview
+
 
 # ── _heredoc_marker ───────────────────────────────────────────────────
 
@@ -219,6 +252,24 @@ class TestMaybePersistToolResult:
         )
         assert result == content
 
+    def test_terminal_output_over_summary_threshold_is_persisted(self):
+        env = MagicMock()
+        env.get_temp_dir.return_value = "/tmp"
+        env.execute.return_value = {"output": "", "returncode": 0}
+        content = "\n".join([f"line {i}" for i in range(800)] + ["ERROR bad"])
+
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_terminal",
+            env=env,
+        )
+
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "TERMINAL OUTPUT SUMMARY" in result
+        assert "Full output saved to: /tmp/hermes-results/tc_terminal.txt" in result
+        assert "ERROR bad" in result
+
     def test_above_threshold_with_env_persists(self):
         env = MagicMock()
         env.execute.return_value = {"output": "", "returncode": 0}
@@ -232,7 +283,8 @@ class TestMaybePersistToolResult:
         )
         assert PERSISTED_OUTPUT_TAG in result
         assert "tc_456.txt" in result
-        assert len(result) < len(content)
+        assert "TERMINAL OUTPUT SUMMARY" in result
+        assert "/hermes-results/" in result
         env.execute.assert_called_once()
 
     def test_persists_full_content_as_is(self):
@@ -265,7 +317,7 @@ class TestMaybePersistToolResult:
         )
         assert PERSISTED_OUTPUT_TAG not in result
         assert "Truncated" in result
-        assert len(result) < len(content)
+        assert "TERMINAL OUTPUT SUMMARY" in result
 
     def test_env_write_failure_falls_back_to_truncation(self):
         env = MagicMock()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1033,7 +1033,7 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Use when: \"show me the file\", \"what's in X.py\", \"open config.yaml\", \"display the contents of\", \"read log file\", \"что в файле\", \"покажи содержимое\". Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1047,7 +1047,7 @@ READ_FILE_SCHEMA = {
 
 WRITE_FILE_SCHEMA = {
     "name": "write_file",
-    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out).",
+    "description": "Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Use when: \"create a new file\", \"save this content to\", \"write to file X\", \"create script Y\". NOTE: OVERWRITES entire file — use patch() for targeted edits to existing files. Creates parent directories automatically. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by this write are surfaced (pre-existing errors are filtered out).",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1062,6 +1062,9 @@ PATCH_SCHEMA = {
     "name": "patch",
     "description": (
         "Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. "
+        "Use when: \"change line X in file Y\", \"replace function Z\", "
+        "\"update this config value\", \"fix this bug in\", "
+        "\"edit only this part of the file\". Safer than write_file for existing files. "
         "Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. "
         "Returns a unified diff. Auto-runs syntax checks after editing.\n\n"
         "REPLACE MODE (mode='replace', default): find a unique string and replace it. "
@@ -1106,7 +1109,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Use when: \"find where X is defined\", \"search for all .py files\", \"grep for pattern Y\", \"list files in directory\", \"where is function Z called\", \"найди все файлы с X\". Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -622,6 +622,10 @@ MEMORY_SCHEMA = {
         "Save durable information to persistent memory that survives across sessions. "
         "Memory is injected into future turns, so keep it compact and focused on facts "
         "that will still matter later.\n\n"
+        "Use when: \"remember that\", \"don't forget\", \"my preference is\", "
+        "\"save this for later\", \"I always use X\", \"запомни\", \"сохрани это\". "
+        "Proactively trigger when user corrects you, shares preference, or says "
+        "\"next time do X\".\n\n"
         "WHEN TO SAVE (do this proactively, don't wait to be asked):\n"
         "- User corrects you or says 'remember this' / 'don't do that again'\n"
         "- User shares a preference, habit, or personal detail (name, role, timezone, coding style)\n"
@@ -684,7 +688,6 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -119,6 +119,9 @@ SEND_MESSAGE_SCHEMA = {
     "name": "send_message",
     "description": (
         "Send a message to a connected messaging platform, or list available targets.\n\n"
+        "Use when: \"message/notify/tell [someone/channel]\", \"post to telegram\", "
+        "\"send this to topic X\", \"отправь в топик\", \"уведоми Михаила\", "
+        "\"post a summary to\".\n\n"
         "IMPORTANT: When the user asks to send to a specific channel or person "
         "(not just a bare platform name), call send_message(action='list') FIRST to see "
         "available targets, then send to the correct one.\n"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -896,6 +896,8 @@ import sys
 # Tool description for LLM
 TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem usually persists between calls.
 
+Trigger phrases: "run this command", "execute X", "check if process Y is running", "install package", "start/stop service", "git status/commit/push", "build the project", "run tests", "what's the disk space", "check port 8080".
+
 Do NOT use cat/head/tail to read files — use read_file instead.
 Do NOT use grep/rg/find to search — use search_files instead.
 Do NOT use ls to list directories — use search_files(target='files') instead.

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -39,6 +39,10 @@ from typing import Any, Dict
 DEFAULT_MAX_BYTES = 50_000       # terminal_tool.MAX_OUTPUT_CHARS
 DEFAULT_MAX_LINES = 2000         # file_operations.MAX_LINES
 DEFAULT_MAX_LINE_LENGTH = 2000   # file_operations.MAX_LINE_LENGTH
+DEFAULT_TERMINAL_SUMMARY_THRESHOLD = 5_000
+DEFAULT_TERMINAL_SUMMARY_HEAD_LINES = 50
+DEFAULT_TERMINAL_SUMMARY_TAIL_LINES = 50
+DEFAULT_TERMINAL_SUMMARY_MAX_ERROR_LINES = 50
 
 
 def _coerce_positive_int(value: Any, default: int) -> int:
@@ -74,6 +78,22 @@ def get_tool_output_limits() -> Dict[str, int]:
         "max_line_length": _coerce_positive_int(
             section.get("max_line_length"), DEFAULT_MAX_LINE_LENGTH
         ),
+        "terminal_summary_threshold": _coerce_positive_int(
+            section.get("terminal_summary_threshold"),
+            DEFAULT_TERMINAL_SUMMARY_THRESHOLD,
+        ),
+        "terminal_summary_head_lines": _coerce_positive_int(
+            section.get("terminal_summary_head_lines"),
+            DEFAULT_TERMINAL_SUMMARY_HEAD_LINES,
+        ),
+        "terminal_summary_tail_lines": _coerce_positive_int(
+            section.get("terminal_summary_tail_lines"),
+            DEFAULT_TERMINAL_SUMMARY_TAIL_LINES,
+        ),
+        "terminal_summary_max_error_lines": _coerce_positive_int(
+            section.get("terminal_summary_max_error_lines"),
+            DEFAULT_TERMINAL_SUMMARY_MAX_ERROR_LINES,
+        ),
     }
 
 
@@ -90,3 +110,14 @@ def get_max_lines() -> int:
 def get_max_line_length() -> int:
     """Shortcut for file-ops callers that only need the per-line cap."""
     return get_tool_output_limits()["max_line_length"]
+
+
+def get_terminal_summary_config() -> Dict[str, int]:
+    """Return smart-summary settings for large terminal output."""
+    limits = get_tool_output_limits()
+    return {
+        "threshold": limits["terminal_summary_threshold"],
+        "head_lines": limits["terminal_summary_head_lines"],
+        "tail_lines": limits["terminal_summary_tail_lines"],
+        "max_error_lines": limits["terminal_summary_max_error_lines"],
+    }

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -24,6 +24,7 @@ Defense against context-window overflow operates at three levels:
 
 import logging
 import os
+import re
 import shlex
 import uuid
 
@@ -39,6 +40,11 @@ PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
 STORAGE_DIR = "/tmp/hermes-results"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+TERMINAL_TOOL_NAME = "terminal"
+TERMINAL_ERROR_PATTERN = re.compile(
+    r"\b(ERROR|WARN|WARNING|FATAL|Exception|Traceback|error:|failed|FAILED|AssertionError)\b",
+    re.IGNORECASE,
+)
 
 
 def _resolve_storage_dir(env) -> str:
@@ -57,8 +63,88 @@ def _resolve_storage_dir(env) -> str:
     return STORAGE_DIR
 
 
-def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
+def _smart_terminal_summary(
+    content: str,
+    *,
+    file_path: str | None = None,
+    head_lines: int = 50,
+    tail_lines: int = 50,
+    max_error_lines: int = 50,
+) -> str:
+    """Build head/tail/error summary for large terminal output."""
+    lines = content.splitlines(keepends=True)
+    total_lines = len(lines)
+    total_chars = len(content)
+    head = lines[:head_lines]
+    tail = lines[-tail_lines:] if total_lines > head_lines else []
+
+    seen = set()
+    error_lines = []
+    for line in lines:
+        if not TERMINAL_ERROR_PATTERN.search(line):
+            continue
+        key = line.strip()
+        if key in seen:
+            continue
+        seen.add(key)
+        error_lines.append(line)
+        if len(error_lines) >= max_error_lines:
+            break
+
+    location = f" — full output saved to {file_path}" if file_path else ""
+    parts = [
+        f"[TERMINAL OUTPUT SUMMARY — {total_lines} lines, {total_chars} chars{location}]\n\n"
+    ]
+    if head:
+        parts.append(f"=== HEAD ({min(head_lines, total_lines)} lines) ===\n")
+        parts.extend(head)
+        parts.append("\n")
+    if total_lines > head_lines + tail_lines:
+        parts.append(f"... [{total_lines - head_lines - tail_lines} lines omitted — see full file] ...\n\n")
+    if tail and total_lines > head_lines:
+        parts.append(f"=== TAIL ({min(tail_lines, total_lines)} lines) ===\n")
+        parts.extend(tail)
+        parts.append("\n")
+    if error_lines:
+        parts.append(f"=== ERRORS/WARNINGS ({len(error_lines)} unique matches) ===\n")
+        parts.extend(error_lines)
+        parts.append("\n")
+    elif total_lines > head_lines:
+        parts.append("=== ERRORS/WARNINGS: none found ===\n")
+    if file_path:
+        parts.append(f"Full output: {file_path}\n")
+    return "".join(parts)
+
+
+def generate_preview(
+    content: str,
+    max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS,
+    tool_name: str | None = None,
+    file_path: str | None = None,
+) -> tuple[str, bool]:
     """Truncate at last newline within max_chars. Returns (preview, has_more)."""
+    if tool_name == TERMINAL_TOOL_NAME:
+        try:
+            from tools.tool_output_limits import get_terminal_summary_config
+            summary_cfg = get_terminal_summary_config()
+        except Exception:
+            summary_cfg = {
+                "threshold": 5_000,
+                "head_lines": 50,
+                "tail_lines": 50,
+                "max_error_lines": 50,
+            }
+        if len(content) > summary_cfg["threshold"]:
+            return (
+                _smart_terminal_summary(
+                    content,
+                    file_path=file_path,
+                    head_lines=summary_cfg["head_lines"],
+                    tail_lines=summary_cfg["tail_lines"],
+                    max_error_lines=summary_cfg["max_error_lines"],
+                ),
+                True,
+            )
     if len(content) <= max_chars:
         return content, False
     truncated = content[:max_chars]
@@ -111,7 +197,10 @@ def _build_persisted_message(
     msg += f"This tool result was too large ({original_size:,} characters, {size_str}).\n"
     msg += f"Full output saved to: {file_path}\n"
     msg += "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
-    msg += f"Preview (first {len(preview)} chars):\n"
+    if preview.startswith("[TERMINAL OUTPUT SUMMARY"):
+        msg += "Preview:\n"
+    else:
+        msg += f"Preview (first {len(preview)} chars):\n"
     msg += preview
     if has_more:
         msg += "\n..."
@@ -146,6 +235,14 @@ def maybe_persist_tool_result(
     """
     effective_threshold = threshold if threshold is not None else config.resolve_threshold(tool_name)
 
+    if tool_name == TERMINAL_TOOL_NAME and effective_threshold != float("inf"):
+        try:
+            from tools.tool_output_limits import get_terminal_summary_config
+            terminal_threshold = get_terminal_summary_config()["threshold"]
+        except Exception:
+            terminal_threshold = 5_000
+        effective_threshold = min(int(effective_threshold), terminal_threshold)
+
     if effective_threshold == float("inf"):
         return content
 
@@ -154,7 +251,12 @@ def maybe_persist_tool_result(
 
     storage_dir = _resolve_storage_dir(env)
     remote_path = f"{storage_dir}/{tool_use_id}.txt"
-    preview, has_more = generate_preview(content, max_chars=config.preview_size)
+    preview, has_more = generate_preview(
+        content,
+        max_chars=config.preview_size,
+        tool_name=tool_name,
+        file_path=remote_path,
+    )
 
     if env is not None:
         try:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1500,7 +1500,7 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": "Search the web for information. Use when: \"search the web for\", \"look up X\", \"what is Y\", \"find documentation for Z\", \"latest news about\", \"поищи в интернете\", \"найди информацию о\". Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1522,7 +1522,7 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
+    "description": "Extract content from web page URLs. Use when: \"open this URL\", \"read this article\", \"extract content from\", \"what does this page say\", \"summarize this link\", \"прочитай по ссылке\". Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## ACI Sprint 2506

### Changes

**1. Tool Description Audit**
Added `Use when:` / `Trigger phrases:` sections to 9 core tools (terminal, file_tools, web_tools, memory, send_message, session_search). Natural-language examples in both English and Russian. No logic changes — descriptions only.

**2. Gateway Loop Protection**
- `max_tool_calls_per_turn=50` — per-turn counter in `run_conversation()`
- Repeat-tool detection: 3+ identical consecutive tool calls → warning injected into context
- Optional `cost_limit_per_turn` hook
- Usage JSONL: `~/.agentic-stack/usage-events.jsonl`
- Config section: `gateway.loop_protection`
- `max_iterations=90` untouched

**3. Terminal Output Auto-Summary**
- Threshold: 5k chars
- Format: HEAD(50 lines) + TAIL(50 lines) + grep(ERROR|WARN|FATAL|Exception)
- Full output saved to `/tmp/hermes-results/*.txt`, path returned in context
- Other tools use legacy preview path (backward compat)

### Tests
54/54 passing (includes new `test_turn_loop_protection.py`)