### PR TITLE
fix(tools): forward thread_ts to chat.postMessage so 3-segment Slack targets thread

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -590,7 +590,98 @@ class TestSendToPlatformChunking:
             "***",
             "C123",
             "*hello* from <https://example.com|Hermes>",
+            thread_id=None,
         )
+
+    def test_slack_thread_id_forwarded_to_send_slack(self, monkeypatch):
+        """3-segment Slack targets must reach _send_slack with thread_id set
+        so chat.postMessage receives thread_ts and the message threads."""
+        _ensure_slack_mock(monkeypatch)
+        import gateway.platforms.slack as slack_mod
+
+        monkeypatch.setattr(slack_mod, "SLACK_AVAILABLE", True)
+        send = AsyncMock(return_value={"success": True, "message_id": "1"})
+
+        with patch("tools.send_message_tool._send_slack", send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.SLACK,
+                    SimpleNamespace(enabled=True, token="***", extra={}),
+                    "C123",
+                    "hello in thread",
+                    thread_id="1779330010.215119",
+                )
+            )
+
+        assert result["success"] is True
+        send.assert_awaited_once_with(
+            "***",
+            "C123",
+            "hello in thread",
+            thread_id="1779330010.215119",
+        )
+
+    def test_slack_send_slack_includes_thread_ts_in_payload(self, monkeypatch):
+        """_send_slack must put thread_ts on the chat.postMessage payload
+        when thread_id is provided."""
+        from tools.send_message_tool import _send_slack
+
+        captured = {}
+
+        class _FakeResp:
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def json(self): return {"ok": True, "ts": "9999.0001"}
+
+        class _FakeSession:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            def post(self, url, headers=None, json=None, **kw):
+                captured["url"] = url
+                captured["payload"] = json
+                return _FakeResp()
+
+        import aiohttp
+        monkeypatch.setattr(aiohttp, "ClientSession", _FakeSession)
+
+        result = asyncio.run(
+            _send_slack("xoxb-token", "C123", "hi", thread_id="1779330010.215119")
+        )
+
+        assert result["success"] is True
+        assert captured["url"] == "https://slack.com/api/chat.postMessage"
+        assert captured["payload"]["channel"] == "C123"
+        assert captured["payload"]["text"] == "hi"
+        assert captured["payload"]["thread_ts"] == "1779330010.215119"
+
+    def test_slack_send_slack_omits_thread_ts_when_no_thread_id(self, monkeypatch):
+        """Without thread_id, _send_slack must not put a thread_ts key on the
+        payload (so the message lands at the channel root as intended)."""
+        from tools.send_message_tool import _send_slack
+
+        captured = {}
+
+        class _FakeResp:
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def json(self): return {"ok": True, "ts": "9999.0001"}
+
+        class _FakeSession:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            def post(self, url, headers=None, json=None, **kw):
+                captured["payload"] = json
+                return _FakeResp()
+
+        import aiohttp
+        monkeypatch.setattr(aiohttp, "ClientSession", _FakeSession)
+
+        result = asyncio.run(_send_slack("xoxb-token", "C123", "hi"))
+
+        assert result["success"] is True
+        assert "thread_ts" not in captured["payload"]
 
     def test_slack_bold_italic_formatted_before_send(self, monkeypatch):
         """Bold+italic ***text*** survives tool-layer formatting."""

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -752,7 +752,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     last_result = None
     for chunk in chunks:
         if platform == Platform.SLACK:
-            result = await _send_slack(pconfig.token, chat_id, chunk)
+            result = await _send_slack(pconfig.token, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WHATSAPP:
             result = await _send_whatsapp(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SIGNAL:
@@ -1036,8 +1036,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         return _error(f"Telegram send failed: {e}")
 
 
-async def _send_slack(token, chat_id, message):
-    """Send via Slack Web API."""
+async def _send_slack(token, chat_id, message, thread_id=None):
+    """Send via Slack Web API.
+
+    When ``thread_id`` is provided it is forwarded as ``thread_ts`` so the
+    message threads under the given parent. Without this, 3-segment targets
+    like ``slack:<channel>:<thread_ts>`` silently degrade to channel-root
+    posts.
+    """
     try:
         import aiohttp
     except ImportError:
@@ -1050,6 +1056,8 @@ async def _send_slack(token, chat_id, message):
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+            if thread_id:
+                payload["thread_ts"] = str(thread_id)
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
## What does this PR do?

`send_message(target="slack:<channel>:<thread_ts>")` was silently posting to the channel root instead of threading under the given parent. The 3-segment Slack target syntax existed and was parsed, but the `thread_ts` was dropped on the way to `chat.postMessage`.

Two consecutive layers were responsible:

1. In `_send_to_platform` (tools/send_message_tool.py), the Slack branch did not forward `thread_id` to `_send_slack`. Every other platform branch (Telegram, Discord, Matrix, Feishu, Signal, Yuanbao) does.
2. `_send_slack` itself did not include `thread_ts` on the `chat.postMessage` payload at all.

Net effect: any caller passing `slack:<channel>:<thread_ts>` got the parsing-side validation to pass but the message still landed at the channel root. This surfaced as multi-bot conversation chains "splitting" across multiple threads in environments that rely on `send_message` to keep replies inside the originating thread.

## Related Issue

N/A — discovered while debugging cross-bot Slack threading in a self-hosted gateway deployment.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py`:
  - `_send_to_platform` Slack branch now forwards `thread_id` to `_send_slack`.
  - `_send_slack` gains a `thread_id` parameter and, when set, includes `thread_ts` on the `chat.postMessage` payload.
- `tests/tools/test_send_message_tool.py`:
  - New: `test_slack_thread_id_forwarded_to_send_slack`
  - New: `test_slack_send_slack_includes_thread_ts_in_payload`
  - New: `test_slack_send_slack_omits_thread_ts_when_no_thread_id`
  - Updated: `test_slack_messages_are_formatted_before_send` to assert the new `thread_id=None` keyword argument.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_send_message_tool.py
```

All 124 tests pass locally (4.8s on macOS 15.x).

Manual repro of the original bug (pre-fix):
```python
# Before: posts to channel root regardless of the :thread_ts suffix
send_message(action="send",
             target="slack:C0B4N9Z121E:1779330010.215119",
             message="reply inside the thread")
# After: actually threads under 1779330010.215119
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/tools/test_send_message_tool.py` and all 124 tests pass
- [x] I've added tests for my changes (3 new + 1 updated)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — `_send_slack` docstring now documents the new parameter
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (network call only, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no schema change, behavior now matches the existing `SEND_MESSAGE_SCHEMA` description that already documents 3-segment targets)
