### PR TITLE
feat(weixin): add SendGate state machine, poll watchdog, wxbot directory

### DIFF
--- a/gateway/platforms/wxbot/__init__.py
+++ b/gateway/platforms/wxbot/__init__.py
@@ -1,0 +1,25 @@
+"""
+WeChat / iLink Bot platform package.
+
+Re-exports the main adapter symbols from ``adapter.py`` (the original
+``weixin.py``) so that all existing import paths remain unchanged::
+
+    from gateway.platforms.wxbot import WeixinAdapter       # new — works
+    from gateway.platforms.weixin import WeixinAdapter      # old — works (shim)
+"""
+
+from .adapter import (  # noqa: F401
+    WeixinAdapter,
+    check_weixin_requirements,
+    send_weixin_direct,
+    qr_login,
+    ContextTokenStore,
+)
+
+__all__ = [
+    "WeixinAdapter",
+    "check_weixin_requirements",
+    "send_weixin_direct",
+    "qr_login",
+    "ContextTokenStore",
+]

--- a/gateway/platforms/wxbot/adapter.py
+++ b/gateway/platforms/wxbot/adapter.py
@@ -66,6 +66,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_image_from_bytes,
 )
+from gateway.platforms.wxbot.send_gate import SendGate
 from hermes_constants import get_hermes_home
 from utils import atomic_json_write
 
@@ -1192,6 +1193,8 @@ class WeixinAdapter(BasePlatformAdapter):
         self._poll_session: Optional[aiohttp.ClientSession] = None
         self._send_session: Optional[aiohttp.ClientSession] = None
         self._poll_task: Optional[asyncio.Task] = None
+        self._poll_guardian_task: Optional[asyncio.Task] = None
+        self._send_gate = SendGate()
         self._dedup = MessageDeduplicator(ttl_seconds=MESSAGE_DEDUP_TTL_SECONDS)
 
         self._account_id = str(extra.get("account_id") or os.getenv("WEIXIN_ACCOUNT_ID", "")).strip()
@@ -1274,6 +1277,9 @@ class WeixinAdapter(BasePlatformAdapter):
         self._send_session = aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector(), timeout=_no_aiohttp_timeout)
         self._token_store.restore(self._account_id)
         self._poll_task = asyncio.create_task(self._poll_loop(), name="weixin-poll")
+        self._poll_guardian_task = asyncio.create_task(
+            self._poll_guardian(), name="weixin-poll-guardian"
+        )
         self._mark_connected()
         _LIVE_ADAPTERS[self._token] = self
         logger.info("[%s] Connected account=%s base=%s", self.name, _safe_id(self._account_id), self._base_url)
@@ -1293,6 +1299,16 @@ class WeixinAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         _LIVE_ADAPTERS.pop(self._token, None)
         self._running = False
+
+        # Cancel the guardian first so it doesn't race with poll_task shutdown
+        if self._poll_guardian_task and not self._poll_guardian_task.done():
+            self._poll_guardian_task.cancel()
+            try:
+                await self._poll_guardian_task
+            except asyncio.CancelledError:
+                pass
+        self._poll_guardian_task = None
+
         if self._poll_task and not self._poll_task.done():
             self._poll_task.cancel()
             try:
@@ -1370,6 +1386,40 @@ class WeixinAdapter(BasePlatformAdapter):
                 if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
                     consecutive_failures = 0
 
+    async def _poll_guardian(self) -> None:
+        """Monitor _poll_task and restart it if it finishes unexpectedly.
+
+        The guardian runs as long as ``self._running`` is True.  When
+        ``_poll_task`` completes with a ``CancelledError`` it means a
+        planned shutdown (via ``disconnect()``), so the guardian exits.
+        Any other completion (unhandled exception, infinite-loop exit) is
+        treated as unexpected — the guardian recreates ``_poll_task`` and
+        the ``_poll_session`` if needed, then loops back to watch again.
+        """
+        while self._running:
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                return  # Planned disconnect — guardian exits
+
+            if not self._running:
+                return  # Already stopped during restart — race guard
+
+            logger.warning(
+                "[%s] _poll_task terminated unexpectedly; restarting...",
+                self.name,
+            )
+
+            # Recreate poll session if it was closed
+            if self._poll_session is None or self._poll_session.closed:
+                self._poll_session = aiohttp.ClientSession(
+                    trust_env=True, connector=_make_ssl_connector()
+                )
+
+            self._poll_task = asyncio.create_task(
+                self._poll_loop(), name="weixin-poll"
+            )
+
     async def _process_message_safe(self, message: Dict[str, Any]) -> None:
         try:
             await self._process_message(message)
@@ -1441,6 +1491,16 @@ class WeixinAdapter(BasePlatformAdapter):
             timestamp=datetime.now(),
         )
         logger.info("[%s] inbound from=%s type=%s media=%d", self.name, _safe_id(sender_id), source.chat_type, len(media_paths))
+        self._send_gate.on_user_message()
+
+        # WeChat heartbeat: bare "==" (half-width) or "＝＝" (full-width) resets
+        # the SendGate rate-limit state without forwarding to the session.
+        # This lets the user send a quick ping to unstick the gate after a
+        # RATE_LIMITED timeout without triggering any AI response.
+        if text and text.strip() in ("==", "＝＝"):
+            logger.info("[%s] Heartbeat ping from=%s — gate reset, session not invoked", self.name, _safe_id(sender_id))
+            return
+
         await self.handle_message(event)
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
@@ -1619,28 +1679,22 @@ class WeixinAdapter(BasePlatformAdapter):
                                 self.name, _safe_id(chat_id),
                             )
                             continue
-                        # Rate limit (-2) — backoff and retry
+                        # Rate limit (-2) — log error and abort, no retry
                         is_rate_limited = (
                             ret == RATE_LIMIT_ERRCODE
                             or errcode == RATE_LIMIT_ERRCODE
                         )
                         if is_rate_limited:
                             errmsg = resp.get("errmsg") or resp.get("msg") or "rate limited"
-                            # Record the error so we raise a descriptive
-                            # RuntimeError (instead of AssertionError) if the
-                            # loop exhausts with the server still rate-limiting.
+                            logger.error(
+                                "[%s] rate limited for %s; aborting send (no retry): "
+                                "ret=%s errcode=%s errmsg=%s",
+                                self.name, _safe_id(chat_id), ret, errcode, errmsg,
+                            )
                             last_error = RuntimeError(
                                 f"iLink sendmessage rate limited: ret={ret} errcode={errcode} errmsg={errmsg}"
                             )
-                            if attempt >= self._send_chunk_retries:
-                                break
-                            wait = self._send_chunk_retry_delay_seconds * 3  # 3x backoff for rate limit
-                            logger.warning(
-                                "[%s] rate limited for %s; backing off %.1fs before retry",
-                                self.name, _safe_id(chat_id), wait,
-                            )
-                            await asyncio.sleep(wait)
-                            continue
+                            break
                         errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
                         raise RuntimeError(
                             f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg}"
@@ -1674,6 +1728,16 @@ class WeixinAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
+
+        # iLink send gate — reject if rate-limited
+        allowed, gate_err = self._send_gate.try_acquire()
+        if not allowed:
+            logger.error(
+                "[%s] send blocked by gate: %s",
+                self.name, gate_err,
+            )
+            return SendResult(success=False, error=gate_err or "rate limited")
+
         context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
 
@@ -1727,6 +1791,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 last_message_id = client_id
                 if idx < len(chunks) - 1 and self._send_chunk_delay_seconds > 0:
                     await asyncio.sleep(self._send_chunk_delay_seconds)
+            self._send_gate.on_send_done()
             return SendResult(success=True, message_id=last_message_id)
         except Exception as exc:
             logger.error("[%s] send failed to=%s: %s", self.name, _safe_id(chat_id), exc)

--- a/gateway/platforms/wxbot/send_gate.py
+++ b/gateway/platforms/wxbot/send_gate.py
@@ -1,0 +1,181 @@
+"""
+Thread-safe send gate for iLink Bot sendmessage API.
+
+Controls the rate at which outbound messages are sent to the iLink API,
+preventing "one-way burst" behavior that triggers ret=-2 rate limiting.
+
+State machine:
+
+```
+                    ┌────────────────────────────────────────┐
+                    │                                        │
+                    ▼                                        │
+            ┌────────────┐   NOTIFY rmn<0 ┌──────────────┐  │
+  ┌────────→│  NOTIFY    │───────────────→│ RATE_LIMITED  │──┘
+  │         │  (rmn=N)  │                └──────┬───────┘
+  │         └─────┬──────┘                       │
+  │               │                              │
+  │               │ receive msg          receive msg (→ INTERACTIVE)
+  │               ▼                              ▼
+  │         ┌──────────────┐              ┌──────────────┐
+  │         │ INTERACTIVE  │◄─────────────│ RATE_LIMITED  │
+  │         └──────┬───────┘              │  + 50min exp │
+  │                │                      └──────────────┘
+  │                │ send → NOTIFY(rmn=5)
+  └────────────────┘
+
+NOTIFY mode: one-way send budget (5 messages). After each send, decrement
+  the budget. When budget is exhausted → RATE_LIMITED. Resets to 5 whenever
+  the mode transitions TO NOTIFY (from INTERACTIVE or RATE_LIMITED).
+
+Usage:
+    gate = SendGate()
+    gate.on_user_message()          # inbound → INTERACTIVE
+    ok, err = gate.try_acquire()    # request send permission
+    if ok:
+        ...  # do the send
+        gate.on_send_done()         # after successful send
+    else:
+        ...  # log and abort
+"""
+
+import os
+import threading
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Optional, Tuple
+
+
+class SendMode(Enum):
+    """Current send-gate mode."""
+    NOTIFY = 0        # Notify mode: N sends budget, exhaust → RATE_LIMITED
+    INTERACTIVE = 1   # Interactive mode: user-engaged, allows send, resets to NOTIFY
+    RATE_LIMITED = 2  # Rate-limited mode: locked for a 50-minute window
+
+
+# Maximum window for one-way burst lockout (seconds).
+# Empirical value from two rate-limit events:
+#   May 15: 47 min (03:28→04:15),  May 17: ~52 min (22:08→23:00)
+RATE_LIMIT_WINDOW_SECONDS = 3000  # 50 minutes
+
+# Sends allowed in NOTIFY mode before entering RATE_LIMITED.
+# Can be overridden via WEIXIN_NOTIFY_SEND_LIMIT env var.
+# Observed: OpenAI's openclaw uses 10; we default to 9 for a conservative buffer.
+NOTIFY_SEND_LIMIT = int(os.getenv("WEIXIN_NOTIFY_SEND_LIMIT", "9"))
+
+
+class SendGate:
+    """Thread-safe gate controlling iLink sendmessage permissions.
+
+    All public methods are safe to call from any thread without additional
+    locking by the caller.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._mode = SendMode.NOTIFY
+        self._rate_limit_start: Optional[datetime] = None
+        self._user_msg_counter = 0     # incremented on each on_user_message()
+        self._acquire_msg_counter = 0  # snapshot taken at try_acquire()
+        self._notify_remaining = NOTIFY_SEND_LIMIT
+
+    # ── public API ──────────────────────────────────────────────────────
+
+    def on_user_message(self) -> None:
+        """Report an inbound user message.
+
+        Transitions to *INTERACTIVE* from NOTIFY/RATE_LIMITED — user
+        input reopens the gate for interactive replies.
+        """
+        with self._lock:
+            self._mode = SendMode.INTERACTIVE
+            self._user_msg_counter += 1
+
+    def try_acquire(self) -> Tuple[bool, Optional[str]]:
+        """Try to obtain permission for one outbound send.
+
+        Returns:
+            (True, None)          — send is allowed.
+            (False, error_msg)   — send is blocked.
+        """
+        with self._lock:
+            now = datetime.now()
+
+            if self._mode == SendMode.INTERACTIVE:
+                self._acquire_msg_counter = self._user_msg_counter
+                return (True, None)
+
+            if self._mode == SendMode.NOTIFY:
+                self._acquire_msg_counter = self._user_msg_counter
+                return (True, None)
+
+            # ── RATE_LIMITED mode ───────────────────────────────────
+            if self._rate_limit_start is None:
+                # Safety fallback — timestamp missing, allow.
+                self._acquire_msg_counter = self._user_msg_counter
+                return (True, None)
+
+            elapsed = (now - self._rate_limit_start).total_seconds()
+            if elapsed >= RATE_LIMIT_WINDOW_SECONDS:
+                # Window has elapsed — allow one more send.
+                self._acquire_msg_counter = self._user_msg_counter
+                return (True, None)
+
+            remaining = int(RATE_LIMIT_WINDOW_SECONDS - elapsed)
+            return (False, f"iLink rate limited: ~{remaining}s remaining until next send")
+
+    def on_send_done(self) -> None:
+        """Confirm one send completed successfully.
+
+        Advances the state machine — call **after** the API call returns
+        without error.
+
+        If a new user message arrived while this send was in flight, the
+        gate stays put — the new interactive session owns the state now.
+        """
+        with self._lock:
+            now = datetime.now()
+
+            # Stale-send guard: if a new user message arrived after
+            # try_acquire(), don't advance the state machine.  The new
+            # interactive session owns the gate.
+            if self._acquire_msg_counter != self._user_msg_counter:
+                return
+
+            if self._mode == SendMode.INTERACTIVE:
+                # INTERACTIVE → NOTIFY  (reset budget to 5)
+                self._mode = SendMode.NOTIFY
+                self._notify_remaining = NOTIFY_SEND_LIMIT
+
+            elif self._mode == SendMode.NOTIFY:
+                # Decrement budget; exhaust → RATE_LIMITED
+                self._notify_remaining -= 1
+                if self._notify_remaining <= 0:
+                    self._mode = SendMode.RATE_LIMITED
+                    self._rate_limit_start = now
+
+            elif self._mode == SendMode.RATE_LIMITED:
+                # RATE_LIMITED (50 min expired) → stay RATE_LIMITED,
+                # reset the window clock.
+                self._rate_limit_start = now
+
+    # ── introspection (for logging / debugging) ─────────────────────────
+
+    @property
+    def mode(self) -> SendMode:
+        with self._lock:
+            return self._mode
+
+    def remaining_lockout_seconds(self) -> float:
+        """Seconds until the rate-limit window expires (0 if not locked)."""
+        with self._lock:
+            if self._mode != SendMode.RATE_LIMITED or self._rate_limit_start is None:
+                return 0.0
+            elapsed = (datetime.now() - self._rate_limit_start).total_seconds()
+            return max(0.0, RATE_LIMIT_WINDOW_SECONDS - elapsed)
+
+    @property
+    def notify_remaining(self) -> int:
+        """Remaining sends in NOTIFY mode before entering RATE_LIMITED."""
+        with self._lock:
+            return self._notify_remaining

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6306,7 +6306,7 @@ class GatewayRunner:
             return WeComAdapter(config)
 
         elif platform == Platform.WEIXIN:
-            from gateway.platforms.weixin import WeixinAdapter, check_weixin_requirements
+            from gateway.platforms.wxbot import WeixinAdapter, check_weixin_requirements
             if not check_weixin_requirements():
                 logger.warning("Weixin: aiohttp/cryptography not installed")
                 return None

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4229,7 +4229,7 @@ def _setup_weixin():
             return
 
     try:
-        from gateway.platforms.weixin import check_weixin_requirements, qr_login
+        from gateway.platforms.wxbot import check_weixin_requirements, qr_login
     except Exception as exc:
         print_error(f"  Weixin adapter import failed: {exc}")
         print_info("  Install gateway dependencies first, then retry.")

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -12,8 +12,8 @@ import pytest
 from gateway.config import PlatformConfig
 from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_overrides
 from gateway.platforms.base import SendResult
-from gateway.platforms import weixin
-from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter
+from gateway.platforms.wxbot import adapter as weixin
+from gateway.platforms.wxbot import ContextTokenStore, WeixinAdapter
 from tools.send_message_tool import _parse_target_ref, _send_to_platform
 
 
@@ -312,10 +312,10 @@ class TestWeixinQrLogin:
         }
         pending = {"status": "wait"}
 
-        with patch("gateway.platforms.weixin._api_get", new_callable=AsyncMock) as api_get_mock, \
-             patch("gateway.platforms.weixin.time") as mock_time, \
-             patch("gateway.platforms.weixin.AIOHTTP_AVAILABLE", True), \
-             patch("gateway.platforms.weixin.aiohttp.ClientSession", create=True) as session_cls, \
+        with patch("gateway.platforms.wxbot.adapter._api_get", new_callable=AsyncMock) as api_get_mock, \
+             patch("gateway.platforms.wxbot.adapter.time") as mock_time, \
+             patch("gateway.platforms.wxbot.adapter.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.platforms.wxbot.adapter.aiohttp.ClientSession", create=True) as session_cls, \
              patch("builtins.print"):
             api_get_mock.side_effect = [first_qr, pending]
             mock_time.monotonic.side_effect = [1000, 1000.2, 1001.1]
@@ -372,8 +372,8 @@ class TestWeixinChunkDelivery:
         adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
         return adapter
 
-    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
-    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    @patch("gateway.platforms.wxbot.adapter.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.wxbot.adapter._send_message", new_callable=AsyncMock)
     def test_send_waits_between_multiple_chunks(self, send_message_mock, sleep_mock):
         adapter = self._connected_adapter()
         adapter.MAX_MESSAGE_LENGTH = 12
@@ -385,8 +385,8 @@ class TestWeixinChunkDelivery:
         assert send_message_mock.await_count == 3
         assert sleep_mock.await_count == 2
 
-    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
-    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    @patch("gateway.platforms.wxbot.adapter.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.wxbot.adapter._send_message", new_callable=AsyncMock)
     def test_send_retries_failed_chunk_before_continuing(self, send_message_mock, sleep_mock):
         adapter = self._connected_adapter()
         adapter.MAX_MESSAGE_LENGTH = 12
@@ -502,10 +502,10 @@ class TestWeixinOutboundMedia:
         aes_key = bytes(range(16))
         expected_aes_key = base64.b64encode(aes_key.hex().encode("ascii")).decode("ascii")
 
-        with patch("gateway.platforms.weixin._get_upload_url", new=AsyncMock(return_value={"upload_full_url": "https://upload.example.com/media"})), \
-             patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock) as api_post_mock, \
-             patch("gateway.platforms.weixin.secrets.token_hex", return_value="filekey-123"), \
-             patch("gateway.platforms.weixin.secrets.token_bytes", return_value=aes_key):
+        with patch("gateway.platforms.wxbot.adapter._get_upload_url", new=AsyncMock(return_value={"upload_full_url": "https://upload.example.com/media"})), \
+             patch("gateway.platforms.wxbot.adapter._api_post", new_callable=AsyncMock) as api_post_mock, \
+             patch("gateway.platforms.wxbot.adapter.secrets.token_hex", return_value="filekey-123"), \
+             patch("gateway.platforms.wxbot.adapter.secrets.token_bytes", return_value=aes_key):
             message_id = asyncio.run(adapter._send_file("wxid_test123", str(image_path), ""))
 
         assert message_id.startswith("hermes-weixin-")
@@ -583,7 +583,7 @@ class TestWeixinBlankMessagePrevention:
         )
         assert adapter._split_text("") == []
 
-    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    @patch("gateway.platforms.wxbot.adapter._send_message", new_callable=AsyncMock)
     def test_send_empty_content_does_not_call_send_message(self, send_message_mock):
         adapter = _make_adapter()
         adapter._session = object()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1544,7 +1544,7 @@ async def _send_wecom(extra, chat_id, message):
 async def _send_weixin(pconfig, chat_id, message, media_files=None):
     """Send via Weixin iLink using the native adapter helper."""
     try:
-        from gateway.platforms.weixin import check_weixin_requirements, send_weixin_direct
+        from gateway.platforms.wxbot import check_weixin_requirements, send_weixin_direct
         if not check_weixin_requirements():
             return {"error": "Weixin requirements not met. Need aiohttp + cryptography."}
     except ImportError:


### PR DESCRIPTION
The iLink WeChat adapter had two systemic problems:

1. Poll loop silently dying — _poll_loop could crash from CancelledError with no automatic recovery, leaving the adapter registered in _LIVE_ADAPTERS but dead. Added _poll_guardian watchdog that detects task termination and restarts it immediately.

2. One-way burst rate limiting — iLink locks the account for ~50 minutes (ret=-2) when the bot sends multiple messages without user input. Added SendGate, a 3-state (NOTIFY/INTERACTIVE/RATE_LIMITED) state machine to control outbound send permission:
   - NOTIFY: N-message budget (9 by default, configurable via WEIXIN_NOTIFY_SEND_LIMIT). One-way burst is capped; exhaust triggers RATE_LIMITED.
   - INTERACTIVE: triggered by inbound user message, allows sends, resets to NOTIFY after each reply.
   - stale-send guard: if a new user message arrives while a send is in-flight, the gate stays in INTERACTIVE — prevents cross-turn state machine hijack.
   - WeChat heartbeat: bare "==" resets the gate from RATE_LIMITED back to INTERACTIVE without invoking the AI session, letting the user quickly unstick the gate after a timeout.

3. Directory reorganization: moved weixin.py → wxbot/adapter.py and send_gate.py → wxbot/send_gate.py, following the qqbot/ subdirectory pattern. Old import paths updated in run.py, hermes_cli/gateway.py, tools/send_message_tool.py, and tests.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

