### PR TITLE
[codex] fix(tui): guard against OpenTUI native runtime

### DIFF
--- a/ui-tui/scripts/build.mjs
+++ b/ui-tui/scripts/build.mjs
@@ -54,8 +54,19 @@ await build({
 // always invokes this file as `node dist/entry.js` anyway, so the shebang is
 // redundant — strip it.
 const body = readFileSync(out, 'utf8')
-if (body.startsWith('#!')) {
-  writeFileSync(out, body.slice(body.indexOf('\n') + 1))
+const bundled = body.startsWith('#!') ? body.slice(body.indexOf('\n') + 1) : body
+
+// Guard release bundles against reintroducing OpenTUI's native extractor,
+// which leaked hidden libopentui.so copies into /tmp on Linux (#32283).
+const forbiddenNativeMarkers = ['@opentui/', 'libopentui', 'opentui']
+for (const marker of forbiddenNativeMarkers) {
+  if (bundled.toLowerCase().includes(marker)) {
+    throw new Error(`TUI bundle contains forbidden native runtime marker ${JSON.stringify(marker)}`)
+  }
+}
+
+if (bundled !== body) {
+  writeFileSync(out, bundled)
 }
 
 console.log(`built ${out}`)

--- a/ui-tui/src/__tests__/nativeRuntimeDeps.test.ts
+++ b/ui-tui/src/__tests__/nativeRuntimeDeps.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { extname, join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const ROOT = fileURLToPath(new URL('../..', import.meta.url))
+const SOURCE_EXTENSIONS = new Set(['.js', '.json', '.mjs', '.ts', '.tsx'])
+const SKIP_DIRS = new Set(['__tests__', 'dist', 'node_modules'])
+const FORBIDDEN_MARKERS = ['@opentui/', 'libopentui', 'opentui']
+
+function collectFiles(target: string): string[] {
+  if (!existsSync(target)) {
+    return []
+  }
+
+  const stat = statSync(target)
+  if (stat.isFile()) {
+    return SOURCE_EXTENSIONS.has(extname(target)) ? [target] : []
+  }
+
+  if (!stat.isDirectory()) {
+    return []
+  }
+
+  return readdirSync(target, { withFileTypes: true }).flatMap(entry => {
+    if (entry.isDirectory() && SKIP_DIRS.has(entry.name)) {
+      return []
+    }
+
+    return collectFiles(join(target, entry.name))
+  })
+}
+
+describe('native TUI runtime dependencies', () => {
+  it('does not reintroduce the OpenTUI native shared-object runtime', () => {
+    const targets = [
+      'package.json',
+      'package-lock.json',
+      'packages/hermes-ink/package.json',
+      'packages/hermes-ink/package-lock.json',
+      'packages/hermes-ink/src',
+      'src'
+    ]
+
+    const matches = targets
+      .flatMap(target => collectFiles(join(ROOT, target)))
+      .flatMap(file => {
+        const text = readFileSync(file, 'utf8').toLowerCase()
+
+        return FORBIDDEN_MARKERS.filter(marker => text.includes(marker)).map(marker => ({
+          marker,
+          path: relative(ROOT, file)
+        }))
+      })
+
+    expect(matches).toEqual([])
+  })
+})


### PR DESCRIPTION
> **Upstream value:** Adds a build-time + test guard so the OpenTUI native runtime (which leaked `libopentui.so` into `/tmp`, #32283) cannot silently re-enter the bundle — zero behavior change, pure regression protection.

## Summary

- Fail the TUI release bundle if OpenTUI/native shared-object markers are present.
- Add a Vitest regression scan over TUI lockfiles and runtime source so `@opentui` / `libopentui` cannot silently re-enter the runtime path.

## Why

Issue #32283 reports Linux TUI sessions leaking hidden `/tmp/.*.so` files matching `libopentui.so`. Current `origin/main` no longer references OpenTUI in source or lockfiles, but the release build did not have an explicit guard against reintroducing that native extractor.

Refs #32283.

## Validation

- `npm ci`
- `npm run build`
- `npm test -- nativeRuntimeDeps`
- `npm test -- nativeRuntimeDeps terminalSetup`
- `npm run build --prefix packages/hermes-ink`
- Linux runtime smoke in `node:20-alpine` with TTY and isolated `TMPDIR=/tmp/hermes-tui-repro`: `before_so_count=0`, TUI rendered until timeout/SIGTERM (`node_exit=143`), `after_so_count=0`, `after_all_tmp_files=0`.
- `git diff --check`

Notes:
- `npm run type-check` currently fails on existing unrelated errors in `packages/hermes-ink/src/utils/execFileNoThrow.ts` and `src/app/useMainApp.ts`.
- Full `npm test` still has unrelated failures unless `@hermes/ink` is prebuilt, and `packages/hermes-ink/src/ink/ink-resize.test.ts` fails an existing clear-screen sequence assertion on this checkout.