### PR TITLE
feat(security): add secret provider core contracts

### DIFF
--- a/agent/secrets/__init__.py
+++ b/agent/secrets/__init__.py
@@ -1,0 +1,29 @@
+"""Native secret-provider core contracts.
+
+This package defines the small shared vocabulary for future Hermes secret
+storage backends. A SecretRef is only a locator; SecretRequestContext and
+SecretResolver decide whether a caller may resolve it.
+"""
+
+from .backends import EnvSecretProvider
+from .context import CallerBoundary, RuntimeMode, SecretRequestContext
+from .errors import SecretAccessDenied, SecretError, SecretRefError, SecretResolutionError
+from .providers import SecretProvider, SecretProviderStatus, SecretValue
+from .refs import SecretRef
+from .resolver import SecretResolver
+
+__all__ = [
+    "CallerBoundary",
+    "EnvSecretProvider",
+    "RuntimeMode",
+    "SecretAccessDenied",
+    "SecretError",
+    "SecretProvider",
+    "SecretProviderStatus",
+    "SecretRef",
+    "SecretRefError",
+    "SecretRequestContext",
+    "SecretResolutionError",
+    "SecretResolver",
+    "SecretValue",
+]

--- a/agent/secrets/backends/__init__.py
+++ b/agent/secrets/backends/__init__.py
@@ -1,0 +1,5 @@
+"""Secret provider backends."""
+
+from .env import EnvSecretProvider
+
+__all__ = ["EnvSecretProvider"]

--- a/agent/secrets/backends/env.py
+++ b/agent/secrets/backends/env.py
@@ -1,0 +1,38 @@
+"""Compatibility environment-variable secret provider.
+
+This backend is useful for tests and migration paths. It is not a native
+secret-storage backend; it simply adapts ``env:NAME`` references into the
+common SecretProvider contract.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ..context import SecretRequestContext
+from ..errors import SecretResolutionError
+from ..providers import SecretProviderStatus, SecretValue
+from ..refs import SecretRef
+
+
+class EnvSecretProvider:
+    """Resolve ``env:VARIABLE`` references from ``os.environ``."""
+
+    backend = "env"
+
+    def status(self) -> SecretProviderStatus:
+        return SecretProviderStatus.AVAILABLE
+
+    def resolve(self, ref: SecretRef, context: SecretRequestContext) -> SecretValue:
+        parsed = SecretRef.parse(ref)
+        if parsed.backend != self.backend:
+            raise SecretResolutionError(
+                f"EnvSecretProvider cannot resolve backend {parsed.backend!r}"
+            )
+
+        raw = os.environ.get(parsed.name, "")
+        if not raw:
+            raise SecretResolutionError(
+                f"Environment secret {parsed.name!r} is not set; failing closed"
+            )
+        return SecretValue(raw, source=parsed.display_safe)

--- a/agent/secrets/context.py
+++ b/agent/secrets/context.py
@@ -1,0 +1,59 @@
+"""Secret request policy context."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class CallerBoundary(str, Enum):
+    """Boundary of the code asking to resolve a secret."""
+
+    CORE = "core"
+    TOOL = "tool"
+    PLUGIN = "plugin"
+    SUBPROCESS = "subprocess"
+
+
+class RuntimeMode(str, Enum):
+    """Runtime surface where the request is being made."""
+
+    CLI = "cli"
+    GATEWAY = "gateway"
+    CRON = "cron"
+    TEST = "test"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class SecretRequestContext:
+    """Policy context for a secret-resolution request.
+
+    This is an application policy guard, not a cryptographic boundary. The
+    durable protection still comes from the backing secret provider.
+    """
+
+    provider: str
+    purpose: str
+    runtime_mode: RuntimeMode | str
+    profile: str
+    caller_boundary: CallerBoundary | str
+    local_unlock_allowed: bool = False
+    audit_label: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provider", (self.provider or "").strip())
+        object.__setattr__(self, "purpose", (self.purpose or "").strip())
+        object.__setattr__(self, "profile", (self.profile or "").strip() or "default")
+        object.__setattr__(
+            self,
+            "runtime_mode",
+            self.runtime_mode if isinstance(self.runtime_mode, RuntimeMode) else RuntimeMode(str(self.runtime_mode)),
+        )
+        object.__setattr__(
+            self,
+            "caller_boundary",
+            self.caller_boundary
+            if isinstance(self.caller_boundary, CallerBoundary)
+            else CallerBoundary(str(self.caller_boundary)),
+        )

--- a/agent/secrets/errors.py
+++ b/agent/secrets/errors.py
@@ -1,0 +1,17 @@
+"""Exceptions for Hermes secret-provider resolution."""
+
+
+class SecretError(RuntimeError):
+    """Base class for secret-provider errors."""
+
+
+class SecretRefError(ValueError, SecretError):
+    """Raised when a secret reference string is malformed."""
+
+
+class SecretResolutionError(SecretError):
+    """Raised when a secret cannot be resolved safely."""
+
+
+class SecretAccessDenied(SecretResolutionError):
+    """Raised when caller context is not authorized to resolve a secret."""

--- a/agent/secrets/providers.py
+++ b/agent/secrets/providers.py
@@ -1,0 +1,106 @@
+"""Secret provider contracts and redacted secret value wrapper."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from enum import Enum
+from typing import Any, Iterator, Mapping, Protocol, runtime_checkable
+
+try:
+    from agent.redact import redact_sensitive_text
+except Exception:  # pragma: no cover - redaction import must never break secrets
+    redact_sensitive_text = None  # type: ignore[assignment]
+
+
+class SecretProviderStatus(str, Enum):
+    """Coarse provider availability state."""
+
+    AVAILABLE = "available"
+    MISSING = "missing"
+    LOCKED = "locked"
+    UNAVAILABLE = "unavailable"
+
+
+class SecretValue:
+    """Runtime-only secret wrapper with redacted display behavior."""
+
+    __slots__ = ("_value", "source", "metadata")
+
+    def __init__(
+        self,
+        value: str,
+        *,
+        source: str = "",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._value = str(value)
+        self.source = source
+        self.metadata = dict(metadata or {})
+
+    def reveal(self) -> str:
+        """Explicitly reveal the raw value to trusted provider-client code."""
+        return self._value
+
+    @contextmanager
+    def reveal_temporarily(self) -> Iterator[str]:
+        """Context-manager reveal helper for call sites that prefer scoped use."""
+        yield self._value
+
+    def to_public_dict(self) -> dict[str, Any]:
+        """Return metadata safe for status/log output."""
+        return {
+            "redacted": True,
+            "source": self._redact_public(self.source),
+            "metadata": self._redact_public(self.metadata),
+        }
+
+    def _redact_public(self, value: Any) -> Any:
+        if isinstance(value, str):
+            return self._redact_public_text(value)
+        if isinstance(value, Mapping):
+            return {
+                self._redact_public_text(str(key)): self._redact_public(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self._redact_public(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._redact_public(item) for item in value)
+        if isinstance(value, set):
+            return sorted(self._redact_public(item) for item in value)
+        return value
+
+    def _redact_public_text(self, text: str) -> str:
+        redacted = text
+        if self._value and self._value in redacted:
+            redacted = redacted.replace(self._value, "<redacted>")
+        if redact_sensitive_text is not None:
+            redacted = redact_sensitive_text(redacted, force=True)
+        return redacted
+
+    def __bool__(self) -> bool:
+        return bool(self._value)
+
+    def __repr__(self) -> str:
+        source = f" source={self._redact_public_text(self.source)!r}" if self.source else ""
+        return f"<SecretValue redacted{source}>"
+
+    __str__ = __repr__
+
+
+@runtime_checkable
+class SecretProvider(Protocol):
+    """Backend contract for resolving SecretRefs."""
+
+    @property
+    def backend(self) -> str:
+        """Backend key this provider resolves, for example ``env``."""
+        ...
+
+    def status(self) -> SecretProviderStatus:
+        """Return current provider availability."""
+        ...
+
+    def resolve(self, ref, context) -> SecretValue:
+        """Resolve a SecretRef for an already-authorized request context."""
+        ...

--- a/agent/secrets/refs.py
+++ b/agent/secrets/refs.py
@@ -1,0 +1,230 @@
+"""Secret reference parsing.
+
+A SecretRef is a locator only. It identifies where a secret should be
+resolved from; it is not authorization to read that secret and must never
+contain the raw secret value itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from urllib.parse import parse_qsl, quote, urlencode, urlparse
+
+from .errors import SecretRefError
+
+try:
+    from agent.redact import redact_sensitive_text
+except Exception:  # pragma: no cover - secret-ref parsing must stay import-safe
+    redact_sensitive_text = None  # type: ignore[assignment]
+
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.@-]+$")
+_SAFE_QUERY_VALUE_RE = re.compile(r"^[A-Za-z0-9_.@-]{0,32}$")
+
+
+def _validate_path_segments(parts: tuple[str, ...], *, raw: str) -> None:
+    if not parts:
+        raise SecretRefError("Secret reference has no item path")
+    for part in parts:
+        if not part or part in {".", ".."} or not _SAFE_SEGMENT_RE.match(part):
+            raise SecretRefError("Secret reference contains invalid path segment")
+
+
+def _is_secret_like_query_key(key: str) -> bool:
+    normalized = key.lower().replace("-", "_")
+    secret_markers = (
+        "api_key",
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "authorization",
+        "password",
+        "passwd",
+        "secret",
+        "credential",
+        "key",
+        "jwt",
+        "signature",
+        "code",
+        "token",
+    )
+    return any(marker in normalized for marker in secret_markers)
+
+
+def _is_secret_like_query_value(value: str) -> bool:
+    if not _SAFE_QUERY_VALUE_RE.fullmatch(value):
+        return True
+    if redact_sensitive_text is not None and redact_sensitive_text(value, force=True) != value:
+        return True
+    return False
+
+
+def _normalize_path(parts: tuple[str, ...]) -> str:
+    return "/".join(quote(part, safe="._@-") for part in parts)
+
+
+def _provider_hint_from_name(name: str) -> str:
+    normalized = name.lower()
+    for suffix in ("_client_secret", "_access_token", "_refresh_token", "_api_key", "_token", "_secret"):
+        if normalized.endswith(suffix):
+            return normalized[: -len(suffix)].replace("_", "-")
+    return ""
+
+
+@dataclass(frozen=True)
+class SecretRef:
+    """Parsed secret locator.
+
+    ``backend`` names the storage mechanism (for example ``env``, ``systemd``,
+    or ``secret-service``). ``path`` identifies the item inside that backend.
+    """
+
+    scheme: str
+    backend: str
+    path: tuple[str, ...]
+    original: str
+    normalized: str
+    display_safe: str
+    _query_items: tuple[tuple[str, str], ...] = field(default_factory=tuple, repr=False)
+
+    @property
+    def query(self) -> dict[str, str]:
+        """Public, non-secret query metadata as a defensive copy."""
+        return dict(self._query_items)
+
+    @property
+    def name(self) -> str:
+        """Leaf item name inside the backend."""
+        return self.path[-1]
+
+    @classmethod
+    def parse(cls, raw: "str | SecretRef") -> "SecretRef":
+        """Parse a supported secret reference string.
+
+        Supported initial forms:
+        - ``env:OPENROUTER_API_KEY``
+        - ``systemd://openrouter_api_key``
+        - ``secret://secret-service/hermes/openrouter/api_key``
+        """
+        if isinstance(raw, SecretRef):
+            return raw
+        if not isinstance(raw, str) or not raw.strip():
+            raise SecretRefError("Secret reference must be a non-empty string")
+
+        text = raw.strip()
+        if text.startswith("env:"):
+            return cls._parse_env(text)
+
+        parsed = urlparse(text)
+        if parsed.scheme == "systemd":
+            return cls._parse_systemd(text, parsed)
+        if parsed.scheme == "secret":
+            return cls._parse_secret(text, parsed)
+
+        raise SecretRefError("Unsupported or malformed secret reference")
+
+    @classmethod
+    def _parse_env(cls, text: str) -> "SecretRef":
+        env_name = text[len("env:") :]
+        if not _ENV_NAME_RE.match(env_name):
+            raise SecretRefError("Invalid environment secret reference")
+        return cls(
+            scheme="env",
+            backend="env",
+            path=(env_name,),
+            original=text,
+            normalized=f"env:{env_name}",
+            display_safe=f"env:{env_name}",
+        )
+
+    @classmethod
+    def _parse_systemd(cls, text: str, parsed) -> "SecretRef":
+        if parsed.params or parsed.query or parsed.fragment:
+            raise SecretRefError("systemd secret references cannot include params/query/fragment")
+        if parsed.path not in {"", "/"}:
+            raise SecretRefError("systemd secret references must use systemd://<name>")
+        name = parsed.netloc
+        if not name or not _SAFE_SEGMENT_RE.match(name) or name in {".", ".."}:
+            raise SecretRefError("Invalid systemd credential name")
+        normalized = f"systemd://{quote(name, safe='._@-')}"
+        return cls(
+            scheme="systemd",
+            backend="systemd",
+            path=(name,),
+            original=text,
+            normalized=normalized,
+            display_safe=normalized,
+        )
+
+    @classmethod
+    def _parse_secret(cls, text: str, parsed) -> "SecretRef":
+        backend = parsed.netloc
+        if not backend or not _SAFE_SEGMENT_RE.match(backend):
+            raise SecretRefError("Secret reference has invalid backend")
+        if parsed.params or parsed.fragment:
+            raise SecretRefError("Secret references cannot include params or fragments")
+
+        parts = tuple(part for part in parsed.path.split("/") if part)
+        # Reject doubled slash or trailing slash instead of silently normalizing.
+        if parsed.path != "/" + "/".join(parts):
+            raise SecretRefError("Secret reference contains an empty path segment")
+        _validate_path_segments(parts, raw=text)
+
+        query_items = tuple(parse_qsl(parsed.query, keep_blank_values=True))
+        for key, value in query_items:
+            if (
+                _is_secret_like_query_key(key)
+                or _is_secret_like_query_value(key)
+                or _is_secret_like_query_value(value)
+            ):
+                raise SecretRefError("Secret reference query contains unsafe secret-like metadata")
+        query = urlencode(query_items)
+        normalized = f"secret://{backend}/{_normalize_path(parts)}"
+        if query:
+            normalized = f"{normalized}?{query}"
+        return cls(
+            scheme="secret",
+            backend=backend,
+            path=parts,
+            original=text,
+            normalized=normalized,
+            display_safe=normalized,
+            _query_items=query_items,
+        )
+
+    def to_public_dict(self) -> dict[str, object]:
+        """Return locator-only metadata safe for logs/status output."""
+        return {
+            "scheme": self.scheme,
+            "backend": self.backend,
+            "path": list(self.path),
+            "name": self.name,
+            "query": self.query,
+            "provider_hint": self.provider_hint,
+            "ref": self.display_safe,
+        }
+
+    @property
+    def provider_hint(self) -> str:
+        """Best-effort provider hint encoded in the locator, if obvious."""
+        if self.backend in {"env", "systemd"}:
+            return _provider_hint_from_name(self.name)
+        if self.scheme == "secret" and len(self.path) >= 2:
+            leaf = self.path[-1].lower()
+            if leaf in {
+                "api_key",
+                "apikey",
+                "token",
+                "access_token",
+                "refresh_token",
+                "client_secret",
+            }:
+                return self.path[-2].lower().replace("_", "-")
+        return ""
+
+    def __str__(self) -> str:
+        return self.display_safe
+
+    def __repr__(self) -> str:
+        return f"SecretRef({self.display_safe!r})"

--- a/agent/secrets/resolver.py
+++ b/agent/secrets/resolver.py
@@ -1,0 +1,90 @@
+"""Secret resolver registry and deny-by-default policy gate."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .context import CallerBoundary, SecretRequestContext
+from .errors import SecretAccessDenied, SecretResolutionError
+from .providers import SecretProvider, SecretProviderStatus, SecretValue
+from .refs import SecretRef
+
+_ALLOWED_CALLER_BOUNDARIES = frozenset({CallerBoundary.CORE})
+_ALLOWED_PURPOSES = frozenset({
+    "provider_api_key",
+    "provider_access_token",
+    "provider_refresh_token",
+    "credential_pool_seed",
+    "secret_status_check",
+    "test",
+})
+
+
+def _normalize_provider(value: str) -> str:
+    return value.strip().lower().replace("_", "-")
+
+
+class SecretResolver:
+    """Route allowed secret-resolution requests to registered providers."""
+
+    def __init__(self, providers: Iterable[SecretProvider] | None = None) -> None:
+        self._providers: dict[str, SecretProvider] = {}
+        for provider in providers or ():
+            self.register(provider)
+
+    def register(self, provider: SecretProvider) -> None:
+        backend = getattr(provider, "backend", "")
+        if not isinstance(backend, str) or not backend.strip():
+            raise SecretResolutionError("Secret provider must declare a non-empty backend")
+        self._providers[backend.strip()] = provider
+
+    def resolve(self, ref: str | SecretRef, context: SecretRequestContext) -> SecretValue:
+        parsed = SecretRef.parse(ref)
+        self._authorize(parsed, context)
+
+        provider = self._providers.get(parsed.backend)
+        if provider is None:
+            raise SecretResolutionError(
+                f"No secret provider registered for backend {parsed.backend!r}"
+            )
+
+        status = provider.status()
+        if not isinstance(status, SecretProviderStatus):
+            raise SecretResolutionError(
+                f"Secret provider {parsed.backend!r} returned invalid status; failing closed"
+            )
+        if status != SecretProviderStatus.AVAILABLE:
+            raise SecretResolutionError(
+                f"Secret provider {parsed.backend!r} is {status.value}; failing closed"
+            )
+
+        value = provider.resolve(parsed, context)
+        if not isinstance(value, SecretValue):
+            raise SecretResolutionError(
+                f"Secret provider {parsed.backend!r} returned an invalid value"
+            )
+        return value
+
+    def _authorize(self, ref: SecretRef, context: SecretRequestContext) -> None:
+        boundary_value = getattr(context.caller_boundary, "value", str(context.caller_boundary))
+        if context.caller_boundary not in _ALLOWED_CALLER_BOUNDARIES:
+            raise SecretAccessDenied(
+                "Secret resolution denied for caller boundary "
+                f"{boundary_value!r}; secret refs are locators, not authorization"
+            )
+        if not context.provider:
+            raise SecretAccessDenied("Secret resolution requires a provider in request context")
+        if not context.purpose:
+            raise SecretAccessDenied("Secret resolution requires a purpose in request context")
+        if context.purpose not in _ALLOWED_PURPOSES:
+            raise SecretAccessDenied(
+                f"Secret resolution denied for purpose {context.purpose!r}"
+            )
+
+        requested_provider = _normalize_provider(context.provider)
+        ref_provider = _normalize_provider(ref.provider_hint)
+        if ref_provider and requested_provider != ref_provider:
+            raise SecretAccessDenied(
+                "Secret resolution denied because request context provider "
+                "does not match the secret reference provider hint"
+            )

--- a/tests/agent/test_secret_refs.py
+++ b/tests/agent/test_secret_refs.py
@@ -1,0 +1,119 @@
+"""Tests for SecretRef parsing and display-safe behavior."""
+
+import json
+
+import pytest
+
+from agent.secrets import SecretRef, SecretRefError
+
+
+def test_parse_secret_service_uri_preserves_locator_parts_without_secret_value():
+    ref = SecretRef.parse("secret://secret-service/hermes/openrouter/api_key?label=primary")
+
+    assert ref.scheme == "secret"
+    assert ref.backend == "secret-service"
+    assert ref.path == ("hermes", "openrouter", "api_key")
+    assert ref.name == "api_key"
+    assert ref.query == {"label": "primary"}
+    assert ref.original == "secret://secret-service/hermes/openrouter/api_key?label=primary"
+    assert ref.normalized == "secret://secret-service/hermes/openrouter/api_key?label=primary"
+    assert ref.display_safe == "secret://secret-service/hermes/openrouter/api_key?label=primary"
+
+
+def test_parse_systemd_uri_uses_systemd_backend_and_single_name():
+    ref = SecretRef.parse("systemd://openrouter_api_key")
+
+    assert ref.scheme == "systemd"
+    assert ref.backend == "systemd"
+    assert ref.path == ("openrouter_api_key",)
+    assert ref.name == "openrouter_api_key"
+    assert ref.query == {}
+    assert ref.normalized == "systemd://openrouter_api_key"
+
+
+def test_parse_env_reference_uses_env_backend_without_reading_environment():
+    ref = SecretRef.parse("env:OPENROUTER_API_KEY")
+
+    assert ref.scheme == "env"
+    assert ref.backend == "env"
+    assert ref.path == ("OPENROUTER_API_KEY",)
+    assert ref.name == "OPENROUTER_API_KEY"
+    assert ref.query == {}
+    assert ref.normalized == "env:OPENROUTER_API_KEY"
+    assert "sk-" not in ref.display_safe
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "not-a-secret-ref",
+        "env:",
+        "env:OPEN ROUTER KEY",
+        "systemd://",
+        "secret://",
+        "secret://secret-service",
+        "secret://secret-service/../api_key",
+        "secret://secret-service/hermes//api_key",
+    ],
+)
+def test_malformed_refs_fail_closed(raw):
+    with pytest.raises(SecretRefError):
+        SecretRef.parse(raw)
+
+
+def test_secret_ref_json_serialization_is_locator_only():
+    ref = SecretRef.parse("secret://secret-service/hermes/openrouter/api_key")
+
+    encoded = json.dumps(ref.to_public_dict(), sort_keys=True)
+
+    assert "secret-service" in encoded
+    assert "openrouter" in encoded
+    assert "api_key" in encoded
+    assert "sk-" not in encoded
+    assert "access_token" not in encoded
+
+
+def test_secret_ref_errors_do_not_echo_raw_secret_like_input():
+    sentinel = "S3NTINEL_DO_NOT_PERSIST_ref_parse_error"
+
+    with pytest.raises(SecretRefError) as excinfo:
+        SecretRef.parse(sentinel)
+    assert sentinel not in str(excinfo.value)
+
+    with pytest.raises(SecretRefError) as excinfo:
+        SecretRef.parse(f"env:BAD VALUE {sentinel}")
+    assert sentinel not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "?access_token={sentinel}",
+        "?key={sentinel}",
+        "?jwt={sentinel}",
+        "?signature={sentinel}",
+        "?label={sentinel}",
+        "?{sentinel}=primary",
+    ],
+)
+def test_secret_ref_rejects_secret_like_query_metadata_without_leaking_value(suffix):
+    sentinel = "S3NTINEL_DO_NOT_PERSIST_query_value"
+
+    with pytest.raises(SecretRefError) as excinfo:
+        SecretRef.parse(
+            "secret://secret-service/hermes/openrouter/api_key"
+            + suffix.format(sentinel=sentinel)
+        )
+
+    assert sentinel not in str(excinfo.value)
+
+
+def test_secret_ref_repr_is_display_safe():
+    ref = SecretRef.parse("secret://secret-service/hermes/openrouter/api_key?label=primary")
+
+    rendered = repr(ref)
+
+    assert "original=" not in rendered
+    assert "_query_items" not in rendered
+    assert "secret://secret-service/hermes/openrouter/api_key?label=primary" in rendered

--- a/tests/agent/test_secret_resolver.py
+++ b/tests/agent/test_secret_resolver.py
@@ -1,0 +1,182 @@
+"""Tests for SecretResolver policy gates and SecretValue redaction."""
+
+import json
+
+import pytest
+
+from agent.secrets import (
+    CallerBoundary,
+    EnvSecretProvider,
+    RuntimeMode,
+    SecretAccessDenied,
+    SecretProviderStatus,
+    SecretRequestContext,
+    SecretResolver,
+    SecretResolutionError,
+    SecretValue,
+)
+
+SENTINEL = "S3NTINEL_DO_NOT_PERSIST_secret_provider_core"
+
+
+def first_party_context(**overrides):
+    data = {
+        "provider": "openrouter",
+        "purpose": "provider_api_key",
+        "runtime_mode": RuntimeMode.CLI,
+        "profile": "default",
+        "caller_boundary": CallerBoundary.CORE,
+        "local_unlock_allowed": False,
+        "audit_label": "test-openrouter",
+    }
+    data.update(overrides)
+    return SecretRequestContext(**data)
+
+
+def test_secret_value_requires_explicit_reveal_and_redacts_common_string_paths():
+    value = SecretValue(SENTINEL, source="env:OPENROUTER_API_KEY")
+
+    assert value.reveal() == SENTINEL
+    with value.reveal_temporarily() as revealed:
+        assert revealed == SENTINEL
+
+    rendered = [str(value), repr(value), f"{value}", json.dumps({"secret": value}, default=str)]
+    for text in rendered:
+        assert SENTINEL not in text
+        assert "<redacted" in text or "SecretValue" in text
+
+    public = value.to_public_dict()
+    assert SENTINEL not in json.dumps(public, sort_keys=True)
+    assert public["redacted"] is True
+    assert public["source"] == "env:OPENROUTER_API_KEY"
+
+
+def test_secret_value_redacts_source_and_metadata_if_provider_supplies_secret_material():
+    value = SecretValue(
+        SENTINEL,
+        source=SENTINEL,
+        metadata={"raw": SENTINEL, "nested": ["prefix", SENTINEL]},
+    )
+
+    rendered = [
+        str(value),
+        repr(value),
+        json.dumps({"secret": value}, default=str),
+        json.dumps(value.to_public_dict(), sort_keys=True),
+    ]
+
+    for text in rendered:
+        assert SENTINEL not in text
+
+
+def test_env_provider_resolves_registered_env_ref_for_core_context(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", SENTINEL)
+    resolver = SecretResolver()
+    resolver.register(EnvSecretProvider())
+
+    value = resolver.resolve("env:OPENROUTER_API_KEY", first_party_context())
+
+    assert isinstance(value, SecretValue)
+    assert value.reveal() == SENTINEL
+    assert SENTINEL not in repr(value)
+
+
+def test_resolver_denies_tool_plugin_and_subprocess_boundaries_by_default(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", SENTINEL)
+    resolver = SecretResolver([EnvSecretProvider()])
+
+    for boundary in (CallerBoundary.TOOL, CallerBoundary.PLUGIN, CallerBoundary.SUBPROCESS):
+        with pytest.raises(SecretAccessDenied):
+            resolver.resolve(
+                "env:OPENROUTER_API_KEY",
+                first_party_context(caller_boundary=boundary),
+            )
+
+
+def test_resolver_denies_wrong_provider_or_purpose_even_for_core_boundary(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", SENTINEL)
+    resolver = SecretResolver([EnvSecretProvider()])
+
+    with pytest.raises(SecretAccessDenied):
+        resolver.resolve(
+            "env:OPENROUTER_API_KEY",
+            first_party_context(provider="anthropic"),
+        )
+
+    with pytest.raises(SecretAccessDenied):
+        resolver.resolve(
+            "env:OPENROUTER_API_KEY",
+            first_party_context(purpose="debug_dump"),
+        )
+
+
+def test_resolver_denies_wrong_provider_for_refresh_token_secret_refs():
+    class DummySecretServiceProvider:
+        backend = "secret-service"
+
+        def status(self):
+            return SecretProviderStatus.AVAILABLE
+
+        def resolve(self, ref, context):
+            return SecretValue(SENTINEL, source=ref.display_safe)
+
+    resolver = SecretResolver([DummySecretServiceProvider()])
+
+    with pytest.raises(SecretAccessDenied):
+        resolver.resolve(
+            "secret://secret-service/hermes/openrouter/refresh_token",
+            first_party_context(
+                provider="anthropic",
+                purpose="provider_refresh_token",
+            ),
+        )
+
+
+def test_resolver_fails_closed_for_missing_backend():
+    resolver = SecretResolver()
+
+    with pytest.raises(SecretResolutionError) as excinfo:
+        resolver.resolve("secret://secret-service/hermes/openrouter/api_key", first_party_context())
+
+    assert "No secret provider registered" in str(excinfo.value)
+
+
+def test_env_provider_missing_value_fails_closed_without_plaintext_fallback(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    resolver = SecretResolver([EnvSecretProvider()])
+
+    with pytest.raises(SecretResolutionError) as excinfo:
+        resolver.resolve("env:OPENROUTER_API_KEY", first_party_context())
+
+    assert "OPENROUTER_API_KEY" in str(excinfo.value)
+    assert SENTINEL not in str(excinfo.value)
+
+
+def test_resolver_fails_closed_when_provider_status_not_available(monkeypatch):
+    class LockedProvider(EnvSecretProvider):
+        def status(self):
+            return SecretProviderStatus.LOCKED
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", SENTINEL)
+    resolver = SecretResolver([LockedProvider()])
+
+    with pytest.raises(SecretResolutionError) as excinfo:
+        resolver.resolve("env:OPENROUTER_API_KEY", first_party_context())
+
+    assert "locked" in str(excinfo.value).lower()
+    assert SENTINEL not in str(excinfo.value)
+
+
+def test_resolver_fails_closed_for_invalid_provider_status(monkeypatch):
+    class BadStatusProvider(EnvSecretProvider):
+        def status(self):  # type: ignore[override]
+            return "surprising"
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", SENTINEL)
+    resolver = SecretResolver([BadStatusProvider()])
+
+    with pytest.raises(SecretResolutionError) as excinfo:
+        resolver.resolve("env:OPENROUTER_API_KEY", first_party_context())
+
+    assert "invalid status" in str(excinfo.value).lower()
+    assert SENTINEL not in str(excinfo.value)


### PR DESCRIPTION
## What does this PR do?

Adds the core secret-provider contract layer for Hermes' native secret-storage work. This PR intentionally stops at the contract/resolver layer so future provider migrations can build on a small, test-covered API without changing runtime provider clients yet.

It adds:

- `SecretRef`: locator-only parsing for `env:`, `systemd://`, and `secret://` references.
- `SecretRequestContext`: caller/provider/purpose/runtime policy context.
- `SecretProvider` and `SecretProviderStatus`: backend contract and availability state.
- `SecretValue`: runtime-only plaintext wrapper with explicit `reveal()` / `reveal_temporarily()` and redacted public display.
- `SecretResolver`: deny-by-default resolution gate for caller boundary, purpose, provider hints, provider status, and provider return type.
- `EnvSecretProvider`: compatibility backend for `env:` references during migration.

The implementation is defensive around secret exposure: malformed refs do not echo raw input, `SecretRef` query metadata rejects suspicious keys/values, `SecretValue` redacts source/metadata if a provider accidentally includes secret material, and non-core caller boundaries fail closed.

## Related Issue

No issue number. This is PR2 in the native secret-storage implementation sequence.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent/secrets/` package:
  - `agent/secrets/refs.py`
  - `agent/secrets/context.py`
  - `agent/secrets/providers.py`
  - `agent/secrets/resolver.py`
  - `agent/secrets/errors.py`
  - `agent/secrets/backends/env.py`
- Exported the public core symbols from `agent/secrets/__init__.py`.
- Added tests covering:
  - `SecretRef` parsing and malformed-ref fail-closed behavior.
  - Display-safe `SecretRef` repr/public serialization.
  - Secret-like query key/value rejection.
  - `SecretValue` explicit reveal and redaction paths.
  - Resolver deny-by-default behavior for tools/plugins/subprocesses.
  - Wrong provider/purpose denial.
  - Missing provider/backend/value failure behavior.
  - Invalid provider status and invalid provider return type failure behavior.

## How to Test

Focused verification passed locally:

1. `python -m pytest tests/agent/test_secret_refs.py tests/agent/test_secret_resolver.py -o addopts= -q`
   - `31 passed`
2. `python -m pytest tests/agent/test_credential_pool.py -o addopts= -q`
   - `67 passed`
3. `python -m pytest tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py -o addopts= -q`
   - `35 passed`
   - Existing warnings from `tools/environments/base.py` background drain threads were observed.
4. `python -m compileall -q agent/secrets tests/agent/test_secret_refs.py tests/agent/test_secret_resolver.py`
   - passed
5. `git diff --check HEAD~1..HEAD`
   - passed

Full-suite note:

- I also ran the contribution guide's recommended `scripts/run_tests.sh`.
- Result: `26038` tests passed, `3` failed.
- The failures were in plugin-discovery tests and came from a locally installed pip/entry-point plugin named `rtk-rewrite` being discovered as a non-bundled plugin:
  - `tests/hermes_cli/test_plugin_scanner_recursion.py::TestCategoryNamespaceRecursion::test_depth_cap_two`
  - `tests/hermes_cli/test_plugins.py::TestPluginDiscovery::test_discover_is_idempotent`
  - `tests/hermes_cli/test_plugins.py::TestPluginDiscovery::test_discover_skips_dir_without_manifest`
- These failures are unrelated to this PR's `agent/secrets` changes; the focused suites above pass.

Tested on:

- Linux `7.0.9-arch1-1` x86_64

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Full runner attempted via `scripts/run_tests.sh`; 3 unrelated plugin-discovery failures from local `rtk-rewrite` entry-point contamination are documented above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - N/A: no user-facing behavior or CLI/config surface changed in this contract-only PR.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - N/A: no config keys added or changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - N/A: no contributor workflow changed.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - Pure Python/stdlib path/query parsing and environment access; no shell/process/path-management behavior added.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  - N/A: no tool schemas or tool behavior changed.

## Screenshots / Logs

Not applicable; this is a core contract/test PR with no UI changes.
