### PR TITLE
chore: preserve local gateway UX and telegram DM recovery tweaks

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import html as _html
 import re
+import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
@@ -427,6 +428,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None
         self._polling_conflict_count: int = 0
+        self._polling_last_conflict_at: float = 0.0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
         # After sustained reconnect storms the PTB httpx pool can return
@@ -1482,8 +1484,6 @@ class TelegramAdapter(BasePlatformAdapter):
                         await asyncio.sleep(wait)
                     else:
                         raise
-            await self._app.start()
-
             # Decide between webhook and polling mode
             webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
 
@@ -1560,6 +1560,10 @@ class TelegramAdapter(BasePlatformAdapter):
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )
+
+            # Match python-telegram-bot's run_polling/run_webhook lifecycle:
+            # initialize -> updater.start_* -> application.start.
+            await self._app.start()
             
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
@@ -1826,6 +1830,18 @@ class TelegramAdapter(BasePlatformAdapter):
                                 thread_kwargs = {"message_thread_id": None}
                                 continue
                             err_lower = str(send_err).lower()
+                            if "chat not found" in err_lower:
+                                logger.warning(
+                                    "[%s] Telegram chat %s is no longer reachable; "
+                                    "dropping non-retryable send instead of blocking delivery retries",
+                                    self.name,
+                                    chat_id,
+                                )
+                                return SendResult(
+                                    success=False,
+                                    error="Chat not found",
+                                    retryable=False,
+                                )
                             if "message to be replied not found" in err_lower and reply_to_id is not None:
                                 # Original message was deleted before we
                                 # could reply. For private-topic fallback
@@ -5484,6 +5500,88 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, cache_key, thread_id,
             )
 
+    def _remember_dm_chat(self, chat_id: str, user_name: Optional[str]) -> None:
+        """Persist the latest reachable Telegram DM as home/approved chat.
+
+        Bot tokens are sometimes rotated during recovery. A chat id that was
+        valid for the previous token can become unreachable for the new bot
+        until the user messages it again. When a real incoming DM arrives, make
+        that source of truth durable so startup notifications, cron origin
+        delivery, and channel-directory rebuilds stop using a stale target.
+        """
+        if not chat_id:
+            return
+        try:
+            from hermes_constants import get_hermes_home
+            import yaml as _yaml
+
+            home = get_hermes_home()
+            config_path = home / "config.yaml"
+            changed = False
+
+            if config_path.exists():
+                with open(config_path, "r", encoding="utf-8") as f:
+                    config = _yaml.safe_load(f) or {}
+                if str(config.get("TELEGRAM_HOME_CHANNEL") or "") != str(chat_id):
+                    config["TELEGRAM_HOME_CHANNEL"] = str(chat_id)
+                    changed = True
+                    fd, tmp_path = tempfile.mkstemp(
+                        dir=str(config_path.parent),
+                        suffix=".tmp",
+                        prefix=".config_",
+                    )
+                    try:
+                        with os.fdopen(fd, "w", encoding="utf-8") as f:
+                            _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                            f.flush()
+                            os.fsync(f.fileno())
+                        atomic_replace(tmp_path, config_path)
+                    except BaseException:
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            pass
+                        raise
+
+            pairing_dir = home / "platforms" / "pairing"
+            approved_path = pairing_dir / "telegram-approved.json"
+            pairing_dir.mkdir(parents=True, exist_ok=True)
+            approved = {}
+            if approved_path.exists():
+                try:
+                    approved = json.loads(approved_path.read_text(encoding="utf-8") or "{}")
+                except Exception:
+                    approved = {}
+            if str(chat_id) not in approved:
+                approved[str(chat_id)] = {
+                    "user_name": user_name or str(chat_id),
+                    "approved_at": time.time(),
+                }
+                fd, tmp_path = tempfile.mkstemp(
+                    dir=str(approved_path.parent),
+                    suffix=".tmp",
+                    prefix=".telegram-approved_",
+                )
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as f:
+                        json.dump(approved, f, ensure_ascii=False, indent=2)
+                        f.write("\n")
+                        f.flush()
+                        os.fsync(f.fileno())
+                    atomic_replace(tmp_path, approved_path)
+                    changed = True
+                except BaseException:
+                    try:
+                        os.unlink(tmp_path)
+                    except OSError:
+                        pass
+                    raise
+
+            if changed:
+                logger.info("[%s] Remembered reachable Telegram DM chat %s", self.name, chat_id)
+        except Exception as e:
+            logger.debug("[%s] Failed to remember Telegram DM chat %s: %s", self.name, chat_id, e, exc_info=True)
+
     def _build_message_event(
         self,
         message: Message,
@@ -5586,6 +5684,8 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
             message_id=str(message.message_id),
         )
+        if chat_type == "dm":
+            self._remember_dm_chat(str(chat.id), source.user_name)
         
         # Extract reply context if this message is a reply.
         # Prefer Telegram's native partial quote (message.quote, TextQuote)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1243,8 +1243,8 @@ _INTERRUPT_REASON_STOP = "Stop requested"
 _INTERRUPT_REASON_RESET = "Session reset requested"
 _INTERRUPT_REASON_TIMEOUT = "Execution timed out (inactivity)"
 _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
-_INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
-_INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
+_INTERRUPT_REASON_GATEWAY_SHUTDOWN = "网关正在关闭"
+_INTERRUPT_REASON_GATEWAY_RESTART = "网关正在重启"
 
 _CONTROL_INTERRUPT_MESSAGES = frozenset(
     {
@@ -3364,14 +3364,14 @@ class GatewayRunner:
         """
         active = self._snapshot_running_agents()
 
-        action = "restarting" if self._restart_requested else "shutting down"
+        action = "重启" if self._restart_requested else "关闭"
         hint = (
-            "Your current task will be interrupted. "
-            "Send any message after restart and I'll try to resume where you left off."
+            "你当前的任务会被中断。"
+            "重启后再发一条消息，我会尽量从中断处继续。"
             if self._restart_requested
-            else "Your current task will be interrupted."
+            else "你当前的任务会被中断。"
         )
-        msg = f"⚠️ Gateway {action} — {hint}"
+        msg = f"⚠️ 网关正在{action}——{hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -6774,9 +6774,9 @@ class GatewayRunner:
                     if adapter:
                         await adapter.send(
                             source.chat_id,
-                            f"Hi~ I don't recognize you yet!\n\n"
-                            f"Here's your pairing code: `{code}`\n\n"
-                            f"Ask the bot owner to run:\n"
+                            f"你好，我暂时还未识别你的身份。\n\n"
+                            f"这是你的配对码：`{code}`\n\n"
+                            f"请让机器人管理员执行：\n"
                             f"`hermes pairing approve {platform_name} {code}`"
                         )
                 else:
@@ -6784,8 +6784,7 @@ class GatewayRunner:
                     if adapter:
                         await adapter.send(
                             source.chat_id,
-                            "Too many pairing requests right now~ "
-                            "Please try again later!"
+                            "当前配对请求过多，请稍后再试。"
                         )
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -121,7 +121,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration",
-               aliases=("provider",), args_hint="[model] [--provider name] [--global]"),
+               aliases=("provider", "models"), args_hint="[model] [--provider name] [--global]"),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),


### PR DESCRIPTION
## Summary\n- preserve localized gateway interruption/pairing messages\n- keep telegram DM reachability persistence and polling lifecycle/order fixes\n- keep local alias for `/models` command\n\n## Notes\n- this PR carries local operational tweaks after syncing to latest upstream\n- upgraded local environment and resolved autostash conflict before extracting this patch