### PR TITLE
fix: reopen ended parent before marking as branched in /branch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6864,7 +6864,14 @@ class HermesCLI:
         # Save the current session's state before branching
         parent_session_id = self.session_id
 
-        # End the old session
+        # Reopen the parent if it was already ended (e.g. resumed from a
+        # previous CLI or gateway close), then end it with "branched" so
+        # list_sessions_rich's child filter (which requires parent
+        # end_reason = 'branched') doesn't silently hide the new branch.
+        try:
+            self._session_db.reopen_session(self.session_id)
+        except Exception:
+            pass
         try:
             self._session_db.end_session(self.session_id, "branched")
         except Exception:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2285,6 +2285,29 @@ class TestListSessionsRich:
         ids = [s["id"] for s in sessions]
         assert "branch" in ids, "Branch session should be visible in default list"
 
+    def test_branch_from_ended_parent_still_visible(self, db):
+        """Branch from an already-ended parent (e.g. resumed then /branch)
+        must be visible after the parent gets reopen+re-end('branched').
+        This is the /branch regression: parent ended with 'tui_close',
+        then _handle_branch_command calls reopen_session + end_session('branched')."""
+        db.create_session("parent", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET ended_at=?, end_reason='tui_close' WHERE id=?",
+            (100.0, "parent"),
+        )
+        db._conn.commit()
+        db.reopen_session("parent")
+        db.end_session("parent", "branched")
+        db.create_session("branch", "cli", parent_session_id="parent")
+        db.append_message("branch", "user", "fixing the cache bug")
+
+        sessions = db.list_sessions_rich()
+        ids = [s["id"] for s in sessions]
+        assert "branch" in ids, (
+            "Branch from an already-ended parent should be visible "
+            "after reopen+re-end('branched')"
+        )
+
     def test_subagent_session_still_hidden(self, db):
         """Sub-agent children (parent NOT ended with 'branched') remain hidden."""
         db.create_session("root", "cli")


### PR DESCRIPTION
## Summary

When `/branch` is called from a resumed session whose parent was already ended (e.g. via `tui_close` from a previous exit), `end_session("branched")` is a silent no-op because `ended_at IS NOT NULL`. The parent keeps its original `end_reason`, and `list_sessions_rich()` filters out the child since the filter requires `parent.end_reason = "branched"`.

## Root Cause

`_handle_branch_command()` in `cli.py`:

```python
try:
    self._session_db.end_session(self.session_id, "branched")  # no-op if already ended
except Exception:
    pass
```

Meanwhile `list_sessions_rich()` uses this filter (line 1224 of `hermes_state.py`):

```python
AND p.end_reason = 'branched'
```

When the parent already has `end_reason = "tui_close"` or `"tui_shutdown"`, the child is silently excluded from `hermes sessions list` even though it was correctly created and switched to.

## Fix

Call `reopen_session()` before `end_session("branched")` so the parent always gets the correct `end_reason`:

```python
try:
    self._session_db.reopen_session(self.session_id)
except Exception:
    pass
try:
    self._session_db.end_session(self.session_id, "branched")
except Exception:
    pass
```

## Testing

- `test_branch_from_ended_parent_still_visible` — new test proving a branch child whose parent was pre-ended with `tui_close` is visible in `list_sessions_rich()` after `reopen_session()` + `end_session("branched")`
- All existing visibility/filter tests still pass (branch, subagent, compression)
