### PR TITLE
fix(mattermost): declare proxy env in plugin manifest

### DIFF
--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,3 +47,7 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
+  - name: MATTERMOST_PROXY
+    description: "HTTP(S) proxy URL for outbound Mattermost API calls (cron / standalone delivery)."
+    prompt: "Mattermost proxy URL"
+    password: false

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -2,8 +2,11 @@
 import json
 import os
 import time
+from pathlib import Path
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
+
+import yaml
 
 from gateway.config import Platform, PlatformConfig
 
@@ -63,6 +66,26 @@ class TestMattermostConfigLoading:
 
         assert Platform.MATTERMOST in config.platforms
         assert config.platforms[Platform.MATTERMOST].extra.get("url") == ""
+
+    def test_plugin_manifest_declares_proxy_optional_env(self):
+        """Setup/plugin inspection should surface the supported proxy env var."""
+        manifest_path = (
+            Path(__file__).resolve().parents[2]
+            / "plugins"
+            / "platforms"
+            / "mattermost"
+            / "plugin.yaml"
+        )
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+
+        optional_env = {
+            entry["name"]: entry for entry in manifest.get("optional_env", [])
+        }
+        proxy_env = optional_env["MATTERMOST_PROXY"]
+
+        assert "proxy" in proxy_env["description"].lower()
+        assert proxy_env["prompt"] == "Mattermost proxy URL"
+        assert proxy_env["password"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Declare `MATTERMOST_PROXY` in the bundled Mattermost plugin manifest so setup/plugin inspection surfaces the already-supported standalone proxy env var.
- Refs #30920 (follow-up 2 only).

## Why
- #30920 notes that `_standalone_send` already reads `MATTERMOST_PROXY`, but `plugin.yaml` did not list it under `optional_env`, making the supported knob undiscoverable in setup/plugin inspection surfaces.

## Changes
- `plugins/platforms/mattermost/plugin.yaml`: add the optional `MATTERMOST_PROXY` env var metadata.
- `tests/gateway/test_mattermost.py`: add regression coverage that the manifest exposes the proxy env var with non-secret prompt metadata.

## Validation
- `python -m pytest tests/gateway/test_mattermost.py::TestMattermostConfigLoading::test_plugin_manifest_declares_proxy_optional_env -o 'addopts=' -q`
- `python -m pytest tests/gateway/test_mattermost.py::TestMattermostConfigLoading -o 'addopts=' -q`

## Scope
- In scope: manifest discoverability for the standalone/cron Mattermost proxy env var.
- Out of scope: batching Mattermost file uploads and threading `MATTERMOST_PROXY` through the live adapter session/request path; those remain separate follow-ups in #30920.
