### PR TITLE
fix(gateway): emit session:end from idle-expiry and auto-reset paths (#28746)

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -9,7 +9,10 @@ Hooks are discovered from ~/.hermes/hooks/ directories, each containing:
 Events:
   - gateway:startup     -- Gateway process starts
   - session:start       -- New session created (first message of a new session)
-  - session:end         -- Session ends (user ran /new or /reset)
+  - session:end         -- Session ends (manual /new or /reset, idle expiry,
+                           or auto-reset).  Payload includes a ``reason``
+                           field: ``manual_reset`` | ``idle_expiry`` |
+                           ``auto_reset``.
   - session:reset       -- Session reset completed (new session entry created)
   - agent:start         -- Agent begins processing a message
   - agent:step          -- Each turn in the tool-calling loop

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4683,6 +4683,26 @@ class GatewayRunner:
                         with self.session_store._lock:
                             entry.expiry_finalized = True
                             self.session_store._save()
+                        # Emit gateway-level session:end hook so external
+                        # observers see idle-expiry closes (symmetric with
+                        # session:start).  Wrapped in try/except so a
+                        # misbehaving subscriber can't break the watcher.
+                        # See #28746.
+                        try:
+                            _parts2 = key.split(":")
+                            _platform2 = _parts2[2] if len(_parts2) > 2 else ""
+                            await self.hooks.emit("session:end", {
+                                "platform": _platform2,
+                                "user_id": getattr(entry.origin, "user_id", "") if entry.origin else "",
+                                "session_id": entry.session_id,
+                                "session_key": key,
+                                "reason": "idle_expiry",
+                            })
+                        except Exception:
+                            logger.debug(
+                                "session:end emit failed on idle expiry for %s",
+                                entry.session_id, exc_info=True,
+                            )
                         logger.debug(
                             "Session expiry finalized for %s",
                             entry.session_id,
@@ -8180,6 +8200,26 @@ class GatewayRunner:
         if getattr(session_entry, "is_fresh_reset", False):
             session_entry.is_fresh_reset = False
         if _is_new_session:
+            # If this new session replaced a prior one via auto-reset, emit
+            # session:end for the OLD session_id first so subscribers see a
+            # symmetric close before the new session:start.  See #28746.
+            _prior_sid = getattr(session_entry, "auto_reset_prior_session_id", None)
+            if _prior_sid:
+                try:
+                    await self.hooks.emit("session:end", {
+                        "platform": source.platform.value if source.platform else "",
+                        "user_id": source.user_id,
+                        "session_id": _prior_sid,
+                        "session_key": session_key,
+                        "reason": "auto_reset",
+                    })
+                except Exception:
+                    logger.debug(
+                        "session:end emit failed on auto_reset for %s",
+                        _prior_sid, exc_info=True,
+                    )
+                # Clear so a retry of the same turn won't re-emit.
+                session_entry.auto_reset_prior_session_id = None
             await self.hooks.emit("session:start", {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
@@ -9340,7 +9380,9 @@ class GatewayRunner:
         await self.hooks.emit("session:end", {
             "platform": source.platform.value if source.platform else "",
             "user_id": source.user_id,
+            "session_id": old_entry.session_id if old_entry else None,
             "session_key": session_key,
+            "reason": "manual_reset",
         })
 
         # Emit session:reset hook

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -459,6 +459,12 @@ class SessionEntry:
     auto_reset_reason: Optional[str] = None  # "idle" or "daily"
     reset_had_activity: bool = False  # whether the expired session had any messages
 
+    # Transient: when the prior session was closed by the auto-reset branch in
+    # ``get_or_create_session``, this holds its ``session_id`` so the next
+    # caller (``_handle_message_with_agent``) can emit a ``session:end`` hook
+    # event for it.  Not persisted — consumed once and cleared.  See #28746.
+    auto_reset_prior_session_id: Optional[str] = None
+
     # Set by reset_session() when the user explicitly sends /new or /reset.
     # Consumed once by _handle_message_with_agent to trigger topic/channel
     # skill re-injection on the first message of the new session.  We can't
@@ -929,6 +935,9 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                auto_reset_prior_session_id=(
+                    db_end_session_id if was_auto_reset else None
+                ),
             )
 
             self._entries[session_key] = entry

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -280,3 +280,69 @@ class TestSessionEntryAutoResetRoundtrip:
         assert reloaded.was_auto_reset is False
         assert reloaded.auto_reset_reason is None
         assert reloaded.reset_had_activity is False
+
+
+# ---------------------------------------------------------------------------
+# Auto-reset plumbs prior session_id for session:end emission (#28746)
+# ---------------------------------------------------------------------------
+
+class TestAutoResetPriorSessionId:
+    def test_prior_session_id_captured_on_auto_reset(self, tmp_path):
+        """When the auto-reset branch closes a stale session and creates a
+        new one for the same session_key, the new entry must carry the OLD
+        session_id in ``auto_reset_prior_session_id`` so the message handler
+        can emit ``session:end`` for it."""
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry1 = store.get_or_create_session(source)
+        old_sid = entry1.session_id
+        assert entry1.auto_reset_prior_session_id is None
+
+        # Age past idle threshold so the next call triggers auto-reset
+        entry1.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        entry2 = store.get_or_create_session(source)
+        assert entry2.was_auto_reset is True
+        assert entry2.session_id != old_sid
+        assert entry2.auto_reset_prior_session_id == old_sid
+
+    def test_prior_session_id_none_on_fresh_session(self, tmp_path):
+        """A first-time-created session (no prior entry) must have
+        ``auto_reset_prior_session_id is None``."""
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=30),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry = store.get_or_create_session(source)
+        assert entry.was_auto_reset is False
+        assert entry.auto_reset_prior_session_id is None
+
+    def test_prior_session_id_not_persisted(self, tmp_path):
+        """The transient field must not survive a reload of sessions.json."""
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry1 = store.get_or_create_session(source)
+        entry1.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+        entry2 = store.get_or_create_session(source)
+        assert entry2.auto_reset_prior_session_id is not None
+
+        # Reload from disk — transient field should not persist
+        store._loaded = False
+        store._entries.clear()
+        store._ensure_loaded()
+        reloaded = store._entries.get(entry2.session_key)
+        assert reloaded is not None
+        assert reloaded.session_id == entry2.session_id
+        assert reloaded.auto_reset_prior_session_id is None


### PR DESCRIPTION
## Summary
- Idle-expiry watcher and auto-reset previously closed sessions without emitting the gateway-level `session:end` hook, breaking external observers (orphan `running` rows downstream).
- Expiry watcher now emits `session:end` with `reason="idle_expiry"` after `expiry_finalized` is set.
- `get_or_create_session` plumbs the closed prior `session_id` via a transient `auto_reset_prior_session_id` field on the new `SessionEntry`; `_handle_message_with_agent` consumes it and emits `session:end` with `reason="auto_reset"` before the new `session:start`.
- Existing `/new` `/reset` emit site gains `reason="manual_reset"` and the closed `session_id` for symmetry; docstring in `gateway/hooks.py` updated.

Fixes #28746.

## Test plan
- [x] `pytest tests/gateway/test_session_reset_notify.py` (19 passed; 3 new tests for prior-session-id plumbing + non-persistence)
- [ ] Manual: install a `session:start` / `session:end` hook, observe end-event fires on idle expiry (path A) and on auto-reset on the next turn (path B).

Generated with Claude Code.