### PR TITLE
fix(parser): handle list-form response field for kimi-k2 cloud (#28787)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -978,16 +978,65 @@ def extract_reasoning(agent, assistant_message) -> Optional[str]:
         Combined reasoning text, or None if no reasoning found
     """
     reasoning_parts = []
-    
+
+    def _coerce_reasoning(value):
+        """Normalize provider-supplied reasoning to a plain string.
+
+        Some models (e.g. kimi-k2.6:cloud via Ollama and direct cloud) return
+        the top-level ``reasoning`` / ``reasoning_content`` field as a list of
+        strings or a list of typed blocks instead of a single string. Joining
+        them here keeps the rest of the pipeline (``not in`` dedup checks,
+        ``str.join``, surrogate scrubbing, persistence) string-only and avoids
+        ``TypeError: unhashable type: 'list'`` downstream when these values
+        flow into hashing/dedup containers. Refs #28787.
+        """
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+        if isinstance(value, (list, tuple)):
+            parts = []
+            for item in value:
+                if isinstance(item, str):
+                    if item:
+                        parts.append(item)
+                elif isinstance(item, dict):
+                    text = (
+                        item.get("text")
+                        or item.get("thinking")
+                        or item.get("summary")
+                        or item.get("content")
+                        or ""
+                    )
+                    if isinstance(text, str) and text:
+                        parts.append(text)
+            return "\n\n".join(parts) if parts else None
+        if isinstance(value, dict):
+            text = (
+                value.get("text")
+                or value.get("thinking")
+                or value.get("summary")
+                or value.get("content")
+                or ""
+            )
+            return text if isinstance(text, str) and text else None
+        # Unknown shape — coerce to string defensively
+        try:
+            return str(value)
+        except Exception:
+            return None
+
     # Check direct reasoning field
-    if hasattr(assistant_message, 'reasoning') and assistant_message.reasoning:
-        reasoning_parts.append(assistant_message.reasoning)
-    
+    raw_reasoning = getattr(assistant_message, 'reasoning', None)
+    coerced_reasoning = _coerce_reasoning(raw_reasoning)
+    if coerced_reasoning:
+        reasoning_parts.append(coerced_reasoning)
+
     # Check reasoning_content field (alternative name used by some providers)
-    if hasattr(assistant_message, 'reasoning_content') and assistant_message.reasoning_content:
-        # Don't duplicate if same as reasoning
-        if assistant_message.reasoning_content not in reasoning_parts:
-            reasoning_parts.append(assistant_message.reasoning_content)
+    raw_reasoning_content = getattr(assistant_message, 'reasoning_content', None)
+    coerced_reasoning_content = _coerce_reasoning(raw_reasoning_content)
+    if coerced_reasoning_content and coerced_reasoning_content not in reasoning_parts:
+        reasoning_parts.append(coerced_reasoning_content)
     
     # Check reasoning_details array (OpenRouter unified format)
     # Format: [{"type": "reasoning.summary", "summary": "...", ...}, ...]

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -744,6 +744,45 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         model_extra = getattr(assistant_message, "model_extra", None) or {}
         if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
             raw_reasoning_content = model_extra["reasoning_content"]
+    # Normalize list/dict-form reasoning_content (e.g. kimi-k2.6:cloud returns
+    # a list of typed blocks) to a string so downstream surrogate scrubbing,
+    # dedup hashing, and JSON serialization don't hit
+    # ``TypeError: unhashable type: 'list'``. Refs #28787.
+    if raw_reasoning_content is not None and not isinstance(raw_reasoning_content, str):
+        # Inline coercion: list/dict shapes flatten to a single string.
+        def _flatten(value):
+            if isinstance(value, str):
+                return value
+            if isinstance(value, (list, tuple)):
+                parts = []
+                for item in value:
+                    if isinstance(item, str) and item:
+                        parts.append(item)
+                    elif isinstance(item, dict):
+                        text = (
+                            item.get("text")
+                            or item.get("thinking")
+                            or item.get("summary")
+                            or item.get("content")
+                            or ""
+                        )
+                        if isinstance(text, str) and text:
+                            parts.append(text)
+                return "\n\n".join(parts) if parts else None
+            if isinstance(value, dict):
+                text = (
+                    value.get("text")
+                    or value.get("thinking")
+                    or value.get("summary")
+                    or value.get("content")
+                    or ""
+                )
+                return text if isinstance(text, str) and text else None
+            try:
+                return str(value)
+            except Exception:
+                return None
+        raw_reasoning_content = _flatten(raw_reasoning_content)
     if raw_reasoning_content is not None:
         msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
     elif assistant_tool_calls and agent._needs_thinking_reasoning_pad():

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -446,6 +446,35 @@ class TestExtractReasoningFormats(unittest.TestCase):
         result = extract(None, msg)
         self.assertIn("async/await", result)
 
+    def test_kimi_k2_list_form_reasoning(self):
+        """kimi-k2.6:cloud returns reasoning as a list of strings — must not
+        raise ``TypeError: unhashable type: 'list'`` and must flatten to a
+        single string. Refs #28787."""
+        extract = self._get_extractor()
+        msg = SimpleNamespace(
+            reasoning=["The user wants me to say hello.", "I will greet them."],
+            reasoning_content=None,
+        )
+        result = extract(None, msg)
+        self.assertIsInstance(result, str)
+        self.assertIn("greet them", result)
+        self.assertIn("say hello", result)
+
+    def test_kimi_k2_list_of_typed_blocks_reasoning_content(self):
+        """Some cloud responses use list-of-dict typed blocks. Refs #28787."""
+        extract = self._get_extractor()
+        msg = SimpleNamespace(
+            reasoning=None,
+            reasoning_content=[
+                {"type": "thinking", "text": "Step 1: parse."},
+                {"type": "thinking", "thinking": "Step 2: answer."},
+            ],
+        )
+        result = extract(None, msg)
+        self.assertIsInstance(result, str)
+        self.assertIn("Step 1", result)
+        self.assertIn("Step 2", result)
+
     def test_no_reasoning_returns_none(self):
         extract = self._get_extractor()
         msg = SimpleNamespace(content="Hello!")


### PR DESCRIPTION
## Summary
Fixes #28787 — `TypeError: unhashable type: 'list'` on every `kimi-k2.6:cloud` call via Ollama and direct cloud.

kimi-k2.6:cloud returns the top-level `reasoning` / `reasoning_content` message field as a **list** (either of strings or of typed `{type:"thinking", text:...}` blocks) instead of a plain string. The existing reasoning extractor pushed the raw list onto `reasoning_parts`, then later `"\n\n".join(...)` and downstream dedup/hashing paths blew up with `TypeError: unhashable type: 'list'`.

## Changes
- `agent/agent_runtime_helpers.py::extract_reasoning` — added `_coerce_reasoning(value)` helper that flattens list/dict/typed-block shapes to a single string before dedup or join.
- `agent/chat_completion_helpers.py::build_assistant_message` — same flattening for `raw_reasoning_content` before it reaches `_sanitize_surrogates` (which requires `str`) and persistence.
- Strings continue to flow through unchanged — no behavior change for existing providers (DeepSeek, Moonshot, OpenRouter, etc.).

## Test plan
- [x] Added `test_kimi_k2_list_form_reasoning` — list-of-strings reasoning flattens to joined string.
- [x] Added `test_kimi_k2_list_of_typed_blocks_reasoning_content` — list of `{type:"thinking", text/thinking:...}` dicts flattens correctly.
- [ ] Manual: `kimi-k2.6:cloud` via Ollama local proxy no longer raises `TypeError: unhashable type: 'list'`.
- [ ] Existing reasoning tests (DeepSeek/Moonshot/OpenRouter string paths) still pass.