### PR TITLE
fix(matrix): warn-and-skip on missing local file instead of leaking to main room

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1420,9 +1420,14 @@ class MatrixAdapter(BasePlatformAdapter):
         """Read a local file and upload it."""
         p = Path(file_path).expanduser()
         if not p.exists():
-            return await self.send(
-                room_id, f"{caption or ''}\n(file not found: {file_path})", reply_to
+            # Mirrors the mattermost pattern landed in #28350: surfacing the
+            # error via self.send() bypasses thread routing (metadata is not
+            # threaded through) and posts a confusing user-visible reply to the
+            # main room. The agent has already moved on, so just log and skip.
+            logger.warning(
+                "Matrix: local file not found, skipping: %s", file_path
             )
+            return SendResult(success=True, message_id=None)
 
         fname = file_name or p.name
         ct = mimetypes.guess_type(fname)[0] or "application/octet-stream"

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1364,6 +1364,39 @@ class TestMatrixUploadAndSend:
         assert "file" in sent
         assert sent["file"]["url"] == "mxc://example.org/enc"
 
+    @pytest.mark.asyncio
+    async def test_send_local_file_missing_does_not_post_to_main_room(self, tmp_path, caplog):
+        """Missing local file should warn-and-skip, not post user-visible text.
+
+        Regression for #32503: ``_send_local_file`` previously called
+        ``self.send(room_id, "(file not found: ...)", reply_to)`` without
+        propagating ``metadata`` (containing ``thread_id``), so the error
+        leaked into the main room. Mirror the mattermost #28350 fix: warn
+        and return ``SendResult(success=True, message_id=None)`` so the
+        agent's already-completed turn isn't dragged back to a delivery
+        failure that retries pointlessly.
+        """
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter.send = AsyncMock()  # must not be called
+
+        missing = tmp_path / "definitely-not-here.png"
+
+        with caplog.at_level("WARNING"):
+            result = await adapter._send_local_file(
+                "!room:example.org",
+                str(missing),
+                "m.image",
+                caption="hi",
+                reply_to="$thread-root",
+                metadata={"thread_id": "$thread-root"},
+            )
+
+        assert result.success is True
+        assert result.message_id is None
+        adapter.send.assert_not_called()
+        assert any(str(missing) in rec.getMessage() for rec in caplog.records)
+
 
 class TestMatrixEncryptedSendFallback:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

`gateway/platforms/matrix.py::_send_local_file` previously surfaced `(file not found: ...)` by calling `self.send(room_id, f"...", reply_to)` without propagating `metadata` — which carries `thread_id` for threaded sends. The user-visible error therefore landed in the **main room** even when the original MEDIA send was thread-targeted, on top of being a confusing reply for a problem the agent has already moved past.

This mirrors the mattermost adapter pattern landed in #28350 (`fix(gateway): tighten MEDIA extraction regex + silent skip on file-not-found`): replace the user-visible error with a `logger.warning(...)` and return `SendResult(success=True, message_id=None)`. The agent's turn is already complete by the time the missing file is detected, so treating it as a silent skip avoids both the wrong-room leak and pointless delivery retries.

> Mirrors the mattermost `_send_local_file` pattern from #28350 (`logger.warning` + `SendResult(success=True, message_id=None)`).

## Related Issue

Fixes #32503

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/matrix.py` — in `_send_local_file`, replace the `self.send(room_id, "(file not found: ...)", reply_to)` fallback (which dropped `metadata.thread_id` and posted to the wrong room) with `logger.warning(...)` + `SendResult(success=True, message_id=None)`. Brief comment cites #28350 so the maintainer-blessed prior is obvious next to the change.
- `tests/gateway/test_matrix.py` — add `test_send_local_file_missing_does_not_post_to_main_room` under `TestMatrixUploadAndSend`. Mocks `adapter.send` so the regression assert is strict (must not be called), asserts the return is `success=True, message_id=None`, and confirms the warning records the missing path.

## How to Test

1. Send a Matrix MEDIA message in a thread where the file does not exist. Verify no message is posted to the main room; the gateway logs a warning instead.
2. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_matrix.py::TestMatrixUploadAndSend -v`
3. Expected: 3 passed (2 existing + the new missing-file regression).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config surface)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure error-handling change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- #28350 (merged) — mattermost equivalent of this fix; we adopt the same `logger.warning` + `SendResult(success=True, message_id=None)` shape so the platform adapters stay consistent.
- Audited siblings: the other gateway platforms with file-not-found paths (`slack`, `feishu`, `signal`, `line`, `qqbot`, `wecom`) return `SendResult(success=False, error=...)` or raise `FileNotFoundError` — they do **not** call `self.send(...)` and therefore do **not** leak to the wrong room. No widening needed. Matrix was the lone holdout against the mattermost-canonical pattern after #28350.