### PR TITLE
fix(vision): native image payloads for local OpenAI-compatible endpoints (#29066)

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -186,6 +186,66 @@ def _lookup_supports_vision(
     return bool(caps.supports_vision)
 
 
+# Hosts that identify an OpenAI-compatible local inference endpoint
+# (LM Studio, llama.cpp server, Ollama in OpenAI-compat mode, vLLM, etc.).
+# Local endpoints don't appear in models.dev, so capability lookup returns
+# None for them. When a user has wired the agent to a local vision-capable
+# model (e.g. qwen2.5-vl via LM Studio, #29066), defaulting to the text
+# pipeline silently bypasses their model entirely — vision_analyze runs on
+# a different backend or fails outright. Treating unknown-caps + local-host
+# as "native" sends pixels to the model the user actually configured.
+_LOCAL_HOST_TOKENS = (
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "::1",
+    "host.docker.internal",
+)
+
+
+def _is_local_openai_compatible(
+    provider: str,
+    cfg: Optional[Dict[str, Any]],
+) -> bool:
+    """True when the active provider points at a local OpenAI-compatible host.
+
+    Checks the active model's ``base_url`` (top-level ``model.base_url`` or
+    ``providers.<provider>.base_url``). Returns False if no base_url is set
+    or the host doesn't match a known loopback token.
+    """
+    if not isinstance(cfg, dict):
+        return False
+
+    candidates: List[str] = []
+
+    model_cfg = cfg.get("model")
+    if isinstance(model_cfg, dict):
+        bu = model_cfg.get("base_url")
+        if isinstance(bu, str) and bu.strip():
+            candidates.append(bu.strip())
+
+    providers_cfg = cfg.get("providers")
+    if isinstance(providers_cfg, dict):
+        # Try the resolved provider id and the user-declared one (named
+        # custom providers get rewritten to "custom" at runtime).
+        config_provider = ""
+        if isinstance(model_cfg, dict):
+            config_provider = str(model_cfg.get("provider") or "").strip()
+        for p in dict.fromkeys(filter(None, (provider, config_provider))):
+            entry = providers_cfg.get(p)
+            if isinstance(entry, dict):
+                bu = entry.get("base_url")
+                if isinstance(bu, str) and bu.strip():
+                    candidates.append(bu.strip())
+
+    for raw in candidates:
+        lowered = raw.lower()
+        for token in _LOCAL_HOST_TOKENS:
+            if token in lowered:
+                return True
+    return False
+
+
 def decide_image_input_mode(
     provider: str,
     model: str,
@@ -215,6 +275,13 @@ def decide_image_input_mode(
 
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
+        return "native"
+    # When caps are unknown (None) and the active provider is a local
+    # OpenAI-compatible endpoint (LM Studio etc., #29066), default to native
+    # so a user-configured local vision model actually receives pixels
+    # instead of having them silently routed through vision_analyze.
+    # An explicit supports_vision: false override is still honoured above.
+    if supports is None and _is_local_openai_compatible(provider, cfg):
         return "native"
     return "text"
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -97,6 +97,35 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=None):
             assert decide_image_input_mode("openrouter", "brand-new-slug", {}) == "text"
 
+    def test_auto_unknown_caps_local_endpoint_defaults_native(self):
+        """#29066: LM Studio / local OpenAI-compatible host gets native pixels
+        when caps lookup is None (model not in models.dev)."""
+        cfg = {"model": {"base_url": "http://localhost:1234/v1"}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert decide_image_input_mode("custom", "qwen/qwen2.5-vl-7b", cfg) == "native"
+
+    def test_auto_unknown_caps_local_via_provider_base_url(self):
+        cfg = {
+            "model": {"provider": "lmstudio"},
+            "providers": {"lmstudio": {"base_url": "http://127.0.0.1:55888/v1"}},
+        }
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert decide_image_input_mode("custom", "qwen/qwen3.5-9b", cfg) == "native"
+
+    def test_auto_unknown_caps_remote_endpoint_still_text(self):
+        """Unknown model on a non-local endpoint must NOT auto-promote to native."""
+        cfg = {"model": {"base_url": "https://api.example.com/v1"}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=None):
+            assert decide_image_input_mode("custom", "some-unknown", cfg) == "text"
+
+    def test_auto_local_endpoint_explicit_false_override_still_text(self):
+        """A user-declared supports_vision:false beats the local-host default."""
+        cfg = {
+            "model": {"base_url": "http://localhost:1234/v1", "supports_vision": False},
+        }
+        # _lookup returns False via the override path, so we don't reach the local check.
+        assert decide_image_input_mode("custom", "tinyllama", cfg) == "text"
+
     def test_auto_respects_aux_vision_override_even_for_vision_model(self):
         """If the user configured a dedicated vision backend, don't bypass it."""
         cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}


### PR DESCRIPTION
## Summary
- Closes #29066. In `decide_image_input_mode` auto path, when models.dev caps lookup returns `None` (typical for LM Studio / llama.cpp / Ollama-compat / vLLM), the agent fell through to `text` mode and silently re-routed user images through `vision_analyze` — so a local vision model never received pixels.
- Detect loopback `base_url` (`model.base_url` or `providers.<p>.base_url` containing `localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `host.docker.internal`) and default unknown-caps + local-host to `native`, so images are attached as OpenAI-style `{"type":"image_url","image_url":{"url":"data:image/...;base64,..."}}` parts that LM Studio expects.
- An explicit `supports_vision: false` override still wins; explicit `image_input_mode: text` still wins.

## Test plan
- [x] `pytest tests/agent/test_image_routing.py` -> 61 passed
- [x] Added 4 cases: localhost via `model.base_url`, 127.0.0.1 via `providers.<p>.base_url`, remote https endpoint stays `text`, explicit `supports_vision:false` still beats local default.

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>