### PR TITLE
fix(db): preserve message timestamps across fork/compress/branch (#28841)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6897,6 +6897,7 @@ class HermesCLI:
                     tool_calls=msg.get("tool_calls"),
                     tool_call_id=msg.get("tool_call_id"),
                     reasoning=msg.get("reasoning"),
+                    timestamp=msg.get("timestamp"),
                 )
             except Exception:
                 pass  # Best-effort copy

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -160,6 +160,7 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
             session_id=session_id,
             role=message.get("role", "assistant"),
             content=message.get("content"),
+            timestamp=message.get("timestamp"),
         )
     except Exception as e:
         logger.debug("Mirror SQLite write failed: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13025,6 +13025,7 @@ class GatewayRunner:
                     reasoning_details=msg.get("reasoning_details"),
                     codex_reasoning_items=msg.get("codex_reasoning_items"),
                     codex_message_items=msg.get("codex_message_items"),
+                    timestamp=msg.get("timestamp"),
                 )
             except Exception:
                 pass  # Best-effort copy

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1278,6 +1278,7 @@ class SessionStore:
                         message.get("platform_message_id") or message.get("message_id")
                     ),
                     observed=bool(message.get("observed")),
+                    timestamp=message.get("timestamp"),
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1462,6 +1462,7 @@ class SessionDB:
         codex_message_items: Any = None,
         platform_message_id: str = None,
         observed: bool = False,
+        timestamp: float = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -1498,6 +1499,8 @@ class SessionDB:
         if tool_calls is not None:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
+        ts_value = timestamp if timestamp is not None else time.time()
+
         def _do(conn):
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
@@ -1512,7 +1515,7 @@ class SessionDB:
                     tool_call_id,
                     tool_calls_json,
                     tool_name,
-                    time.time(),
+                    ts_value,
                     token_count,
                     finish_reason,
                     reasoning,
@@ -1589,6 +1592,15 @@ class SessionDB:
                     msg.get("platform_message_id") or msg.get("message_id")
                 )
 
+                # Preserve the message's original timestamp when present so
+                # fork/compress/branch rewrites don't clobber wall-clock times
+                # with the rewrite moment. Fall back to a monotonically
+                # increasing now_ts for messages that lack one.
+                msg_ts = msg.get("timestamp")
+                if msg_ts is None:
+                    msg_ts = now_ts
+                    now_ts += 1e-6
+
                 conn.execute(
                     """INSERT INTO messages (session_id, role, content, tool_call_id,
                        tool_calls, tool_name, timestamp, token_count, finish_reason,
@@ -1602,7 +1614,7 @@ class SessionDB:
                         msg.get("tool_call_id"),
                         tool_calls_json,
                         msg.get("tool_name"),
-                        now_ts,
+                        msg_ts,
                         msg.get("token_count"),
                         msg.get("finish_reason"),
                         msg.get("reasoning") if role == "assistant" else None,
@@ -1619,7 +1631,6 @@ class SessionDB:
                     total_tool_calls += (
                         len(tool_calls) if isinstance(tool_calls, list) else 1
                     )
-                now_ts += 1e-6
 
             conn.execute(
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1354,6 +1354,7 @@ class AIAgent:
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    timestamp=msg.get("timestamp"),
                 )
             self._last_flushed_db_idx = len(messages)
         except Exception as e:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3021,3 +3021,116 @@ class TestFTS5ToolCallMigration:
         finally:
             session_db.close()
 
+
+
+# =========================================================================
+# Issue #28841 — explicit message timestamps preserved across fork/compress
+# =========================================================================
+
+class TestMessageTimestampPreservation:
+    """Regression coverage for #28841.
+
+    ``messages.timestamp`` used to be unconditionally ``time.time()`` at
+    INSERT, so /branch, /compress, /retry and /undo silently rewrote
+    wall-clock times to the rewrite moment. ``append_message`` now accepts
+    an explicit ``timestamp`` and ``replace_messages`` reads
+    ``msg['timestamp']`` per row.
+    """
+
+    def _new_session(self, db, sid="s_ts"):
+        db.create_session(session_id=sid, source="cli", model="m")
+        return sid
+
+    def test_append_message_uses_explicit_timestamp(self, db):
+        sid = self._new_session(db)
+        ts = 1_600_000_000.0
+        db.append_message(sid, role="user", content="hi", timestamp=ts)
+        msgs = db.get_messages(sid)
+        assert msgs[0]["timestamp"] == ts
+
+    def test_append_message_defaults_to_now_when_omitted(self, db):
+        sid = self._new_session(db)
+        before = time.time()
+        db.append_message(sid, role="user", content="hi")
+        after = time.time()
+        ts = db.get_messages(sid)[0]["timestamp"]
+        assert before <= ts <= after
+
+    def test_append_message_accepts_zero_timestamp(self, db):
+        # 0.0 is a legal epoch — must not fall back to now.
+        sid = self._new_session(db)
+        db.append_message(sid, role="user", content="x", timestamp=0.0)
+        assert db.get_messages(sid)[0]["timestamp"] == 0.0
+
+    def test_replace_messages_preserves_explicit_timestamps(self, db):
+        sid = self._new_session(db)
+        # Seed with three messages whose original timestamps span an hour.
+        for i, ts in enumerate([1000.0, 1500.0, 3600.0]):
+            db.append_message(sid, role="user", content=f"m{i}", timestamp=ts)
+        loaded = db.get_messages(sid)
+        # Round-trip back through replace_messages (simulates /compress).
+        db.replace_messages(sid, loaded)
+        rewritten = db.get_messages(sid)
+        assert [m["timestamp"] for m in rewritten] == [1000.0, 1500.0, 3600.0]
+
+    def test_replace_messages_falls_back_when_timestamp_missing(self, db):
+        sid = self._new_session(db)
+        before = time.time()
+        db.replace_messages(
+            sid,
+            [
+                {"role": "user", "content": "a"},
+                {"role": "assistant", "content": "b"},
+            ],
+        )
+        after = time.time()
+        ts = [m["timestamp"] for m in db.get_messages(sid)]
+        assert all(before <= t <= after + 1 for t in ts)
+        # Distinct values so ORDER BY id still matches insertion order.
+        assert ts[0] != ts[1]
+
+    def test_replace_messages_mixed_explicit_and_missing(self, db):
+        sid = self._new_session(db)
+        before = time.time()
+        db.replace_messages(
+            sid,
+            [
+                {"role": "user", "content": "old", "timestamp": 500.0},
+                {"role": "assistant", "content": "new"},  # no timestamp
+                {"role": "user", "content": "older", "timestamp": 100.0},
+            ],
+        )
+        after = time.time()
+        out = db.get_messages(sid)
+        assert out[0]["timestamp"] == 500.0
+        assert before <= out[1]["timestamp"] <= after + 1
+        assert out[2]["timestamp"] == 100.0
+
+    def test_fork_chain_preserves_original_timestamps(self, db):
+        """Simulate /branch: copy messages from parent to child via
+        append_message, forwarding the original timestamps."""
+        parent = self._new_session(db, sid="parent")
+        for i, ts in enumerate([10.0, 20.0, 30.0]):
+            db.append_message(parent, role="user", content=f"m{i}", timestamp=ts)
+
+        child = "child"
+        db.create_session(session_id=child, source="cli", model="m")
+        for msg in db.get_messages(parent):
+            db.append_message(
+                child,
+                role=msg["role"],
+                content=msg["content"],
+                timestamp=msg.get("timestamp"),
+            )
+
+        assert [m["timestamp"] for m in db.get_messages(child)] == [10.0, 20.0, 30.0]
+
+    def test_repeated_compress_does_not_drift_timestamps(self, db):
+        sid = self._new_session(db)
+        originals = [100.0, 200.0, 300.0]
+        for i, ts in enumerate(originals):
+            db.append_message(sid, role="user", content=f"m{i}", timestamp=ts)
+        # Round-trip three times — used to drift to the latest time.time().
+        for _ in range(3):
+            db.replace_messages(sid, db.get_messages(sid))
+        assert [m["timestamp"] for m in db.get_messages(sid)] == originals

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2838,6 +2838,7 @@ def _(rid, params: dict) -> dict:
                 session_id=new_key,
                 role=msg.get("role", "user"),
                 content=msg.get("content"),
+                timestamp=msg.get("timestamp"),
             )
         db.set_session_title(new_key, title)
     except Exception as e:


### PR DESCRIPTION
Fixes #28841.

## Summary
- `SessionDB.append_message` now accepts an optional `timestamp: float`. When omitted it falls back to `time.time()` (existing behavior).
- `SessionDB.replace_messages` reads `msg["timestamp"]` per row and only synthesizes a monotonically-increasing `now_ts` for messages that lack one. This stops `/compress`, `/retry` and `/undo` from rewriting wall-clock times to the rewrite moment.
- Six call sites that copy/replay messages (`run_agent.py`, `cli.py`, `gateway/run.py`, `gateway/session.py`, `gateway/mirror.py`, `tui_gateway/server.py`) now forward `msg.get("timestamp")` so `/branch` and mirror writes preserve origin times.

## Tests
Added `TestMessageTimestampPreservation` in `tests/test_hermes_state.py` (8 tests): explicit timestamp, default-now fallback, `0.0` epoch is honored, `replace_messages` round-trip preserves, fallback assigns distinct increasing times, mixed explicit/missing, fork-chain preservation, and repeated-compress no-drift.

## Test plan
- [ ] `pytest tests/test_hermes_state.py::TestMessageTimestampPreservation`
- [ ] Manual: start a conversation, `/compress`, query `SELECT timestamp FROM messages` — original times retained.
- [ ] Manual: `/branch` — child session keeps parent timestamps.