### PR TITLE
fix(curator-backup): reject non-file tar members in rollback pre-check

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -605,12 +605,20 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
         with tarfile.open(archive, "r:gz") as tf:
             # Python 3.12+ supports filter='data' for safer extraction.
             # Fall back to the unfiltered call for older interpreters but
-            # still reject absolute paths and .. components defensively.
+            # still reject unsafe members defensively.  filter='data' is only
+            # available on 3.12+ and on 3.11.4+ (PEP 706 backport) — earlier
+            # 3.11 patch releases hit the fallback unconditionally, so the
+            # pre-check has to refuse anything that isn't a plain file or
+            # directory.  Mirrors hermes_cli/profiles._safe_extract_profile_archive.
             for member in tf.getmembers():
                 name = member.name
                 if name.startswith("/") or ".." in Path(name).parts:
                     raise tarfile.TarError(
                         f"refusing to extract unsafe path: {name!r}"
+                    )
+                if not (member.isfile() or member.isdir()):
+                    raise tarfile.TarError(
+                        f"refusing to extract unsupported tar member type: {name!r}"
                     )
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -259,6 +259,70 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
 
 
+def test_rollback_rejects_symlink_member(backup_env, monkeypatch, tmp_path):
+    """Tarballs with symlink/hardlink/device members must be refused at the
+    pre-check stage, not relying on ``filter='data'`` which is unavailable on
+    Python 3.11.0–3.11.3 (PEP 706 was only backported in 3.11.4).
+
+    Without a pre-check on the member type, the fallback
+    ``tf.extractall(str(skills))`` call materialises an attacker-supplied
+    symlink via ``os.symlink(linkname, targetpath)``.  A snapshot tarball
+    placed in ``.curator_backups/`` (e.g. by a malicious skill, a
+    co-tenant with write access, or a user tricked into importing a
+    third-party 'snapshot') can then plant ``skills/leak → /etc/passwd``,
+    leaking the target's content to the agent on the next skill_view.
+    """
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    cb.snapshot_skills(reason="legit")
+
+    # Plant a victim file outside the skills tree.  After a successful
+    # exploit, this file's contents become readable from inside skills/.
+    victim = tmp_path / "secret"
+    victim.write_text("CONFIDENTIAL", encoding="utf-8")
+
+    # Replace the legit snapshot tarball with one whose only member is a
+    # symlink pointing at the victim.  The member name itself is safe
+    # ("leak", no "/" prefix, no ".."), so only a type-aware pre-check
+    # can stop it.
+    rows = cb.list_backups()
+    snap_dir = Path(rows[0]["path"])
+    mal = snap_dir / "skills.tar.gz"
+    mal.unlink()
+    with tarfile.open(mal, "w:gz") as tf:
+        info = tarfile.TarInfo(name="leak")
+        info.type = tarfile.SYMTYPE
+        info.linkname = str(victim)
+        tf.addfile(info)
+
+    # Force the legacy fallback branch (``filter`` kwarg unavailable) so we
+    # exercise the same code path Python 3.11.0–3.11.3 hits unconditionally.
+    real_extractall = tarfile.TarFile.extractall
+
+    def no_filter_extractall(self, *args, **kwargs):
+        if "filter" in kwargs:
+            raise TypeError(
+                "extractall() got an unexpected keyword argument 'filter'"
+            )
+        return real_extractall(self, *args, **kwargs)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractall", no_filter_extractall)
+
+    ok, msg, _ = cb.rollback()
+    assert not ok, f"rollback should refuse a symlink member, got msg={msg!r}"
+
+    # The symlink must never have materialised under skills/, and the
+    # victim's contents must not be reachable from inside skills/.
+    leak = skills / "leak"
+    assert not leak.is_symlink(), (
+        f"symlink should be rejected before extract; resolved to "
+        f"{leak.resolve() if leak.exists() else '<missing>'}"
+    )
+    if leak.exists():
+        assert leak.read_text(encoding="utf-8") != "CONFIDENTIAL"
+
+
 # ---------------------------------------------------------------------------
 # Integration with run_curator_review
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The rollback path in `agent/curator_backup.py` uses
`tf.extractall(..., filter="data")` when available, with an explicit
`except TypeError` fallback to plain `tf.extractall(...)` on older
interpreters. The pre-check above the call refused tar members whose
*name* was absolute or contained `..`, but not members whose *type* was
unsafe — so a tar entry like:

```
TarInfo(name="leak", type=SYMTYPE, linkname="/etc/passwd")
```

…slipped through the pre-check.

`filter="data"` itself rejects this on Python 3.12+ and on 3.11.4+ (PEP
706 was backported there), but `pyproject.toml` declares `python>=3.11`
and the `except TypeError` branch is reachable on 3.11.0–3.11.3 where
the `filter` kwarg is unknown. On those interpreters the fallback
materialises the symlink via `os.symlink(linkname, targetpath)`, and
the agent reads the link target's content on the next `skill_view`.

A malicious tarball under \`~/.hermes/skills/.curator_backups/\` (e.g. a
co-tenant on a shared host with write access to the home, a user
tricked into importing a third-party 'snapshot', or a write-anywhere
primitive surfaced by another skill) is enough to plant
\`skills/leak → /etc/passwd\` or \`~/.ssh/id_rsa\` ahead of the next
\`hermes curator rollback\`.

## Fix

Extend the existing pre-check loop with a member-type whitelist —
refuse anything that isn't \`isfile()\` or \`isdir()\`. This mirrors
\`hermes_cli/profiles._safe_extract_profile_archive\`, which already
applies the same gate for profile imports. Same shape as c26af4681
('reject symlinks in skill bundles before install'), one code path
over.

## Test plan

- [x] New \`test_rollback_rejects_symlink_member\` forces the legacy
  fallback (monkeypatches \`tarfile.TarFile.extractall\` to raise
  \`TypeError\` on \`filter='data'\`), plants a victim file outside the
  skills tree, and asserts the symlink is never materialised. Without
  the patch the assertion \`not leak.is_symlink()\` fails.
- [x] \`pytest tests/agent/test_curator_backup.py\` — 26 passed.
- [x] \`pytest tests/agent/test_curator*.py\` — 105 passed (no
  regressions in sibling curator suites).
- [x] \`ruff check agent/curator_backup.py tests/agent/test_curator_backup.py\` — clean.