### PR TITLE
chore(gateway): drop plugin-migrated platforms from /update allowlist

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13822,11 +13822,15 @@ class GatewayRunner:
             return t("gateway.deny.denied_plural", count=count)
         return t("gateway.deny.denied_singular")
 
-    # Platforms where /update is allowed.  ACP, API server, and webhooks are
-    # programmatic interfaces that should not trigger system updates.
+    # Built-in messaging platforms where the ``/update`` command is allowed.
+    # ACP, API server, and webhooks are programmatic interfaces that should
+    # not trigger system updates.  Plugin-migrated platforms (discord,
+    # mattermost, teams, irc, line, …) are NOT listed here — they declare
+    # ``allow_update_command=True`` on their ``PlatformEntry`` and are
+    # honored via the registry fallback at ``_handle_update_command`` below.
     _UPDATE_ALLOWED_PLATFORMS = frozenset({
-        Platform.TELEGRAM, Platform.DISCORD, Platform.SLACK, Platform.WHATSAPP,
-        Platform.SIGNAL, Platform.MATTERMOST, Platform.MATRIX,
+        Platform.TELEGRAM, Platform.SLACK, Platform.WHATSAPP,
+        Platform.SIGNAL, Platform.MATRIX,
         Platform.HOMEASSISTANT, Platform.EMAIL, Platform.SMS, Platform.DINGTALK,
         Platform.FEISHU, Platform.WECOM, Platform.WECOM_CALLBACK, Platform.WEIXIN, Platform.BLUEBUBBLES, Platform.QQBOT, Platform.LOCAL,
     })

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -363,6 +363,127 @@ class TestHandleUpdateCommand:
 
 
 # ---------------------------------------------------------------------------
+# Platform allowlist gate
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateCommandPlatformGate:
+    """Tests for the platform-allowlist gate at the top of
+    ``_handle_update_command``.  Built-in messaging platforms are listed in
+    ``_UPDATE_ALLOWED_PLATFORMS``; plugin-migrated platforms (discord,
+    mattermost, teams, …) are NOT in the frozenset and rely on the
+    registry's ``allow_update_command=True`` fallback.  Programmatic
+    interfaces (ACP, API server, webhooks) must be blocked.
+    """
+
+    @pytest.mark.asyncio
+    async def test_blocks_programmatic_interface(self, monkeypatch):
+        """``Platform.WEBHOOK`` is not a messaging platform and must be
+        blocked by the allowlist gate before any side effects fire."""
+        runner = _make_runner()
+        event = _make_event(platform=Platform.WEBHOOK)
+        # Stop _handle_update_command from progressing further if the gate
+        # somehow lets the event through — the assertion on the returned
+        # string is the real test.
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        # The exact rejection message comes from
+        # ``gateway.update.platform_not_messaging`` translation key.
+        assert "only available from messaging platforms" in result
+
+    @pytest.mark.asyncio
+    async def test_blocks_api_server_platform(self, monkeypatch):
+        """``Platform.API_SERVER`` (programmatic, not messaging) must be
+        blocked by the allowlist gate.
+        """
+        runner = _make_runner()
+        event = _make_event(platform=Platform.API_SERVER)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        assert "only available from messaging platforms" in result
+
+    @pytest.mark.asyncio
+    async def test_allows_plugin_platform_via_registry_fallback(self, monkeypatch):
+        """A plugin-migrated platform (DISCORD) is no longer in
+        ``_UPDATE_ALLOWED_PLATFORMS`` but must still pass the gate via
+        the registry's ``allow_update_command=True`` flag.
+
+        This test is the empirical guarantee that removing DISCORD from
+        the hardcoded frozenset does not regress the /update command for
+        Discord users.
+        """
+        from gateway.run import GatewayRunner
+
+        # Precondition: DISCORD is NOT in the hardcoded set anymore.
+        assert Platform.DISCORD not in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+        # Make sure the plugin registry is populated so the fallback fires.
+        from hermes_cli.plugins import PluginManager
+        PluginManager().discover_and_load(force=True)
+        from gateway.platform_registry import platform_registry
+        discord_entry = platform_registry.get("discord")
+        assert discord_entry is not None
+        assert discord_entry.allow_update_command is True
+
+        runner = _make_runner()
+        event = _make_event(platform=Platform.DISCORD)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        # The gate must NOT have rejected us — anything other than the
+        # ``platform_not_messaging`` rejection string is acceptable here.
+        # Later steps may legitimately return success ("Starting Hermes
+        # update…") or fail for environment reasons.
+        assert "only available from messaging platforms" not in result
+
+    @pytest.mark.asyncio
+    async def test_allows_mattermost_via_registry_fallback(self, monkeypatch):
+        """Same as DISCORD: MATTERMOST is now plugin-migrated and not in
+        the hardcoded frozenset; the registry must keep /update working.
+        """
+        from gateway.run import GatewayRunner
+
+        assert Platform.MATTERMOST not in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+        from hermes_cli.plugins import PluginManager
+        PluginManager().discover_and_load(force=True)
+        from gateway.platform_registry import platform_registry
+        mm_entry = platform_registry.get("mattermost")
+        assert mm_entry is not None
+        assert mm_entry.allow_update_command is True
+
+        runner = _make_runner()
+        event = _make_event(platform=Platform.MATTERMOST)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        assert "only available from messaging platforms" not in result
+
+    @pytest.mark.asyncio
+    async def test_allows_builtin_platform_in_allowlist(self, monkeypatch):
+        """``Platform.TELEGRAM`` is in the hardcoded allowlist — gate
+        must pass without consulting the registry.
+        """
+        from gateway.run import GatewayRunner
+
+        assert Platform.TELEGRAM in GatewayRunner._UPDATE_ALLOWED_PLATFORMS
+
+        runner = _make_runner()
+        event = _make_event(platform=Platform.TELEGRAM)
+        monkeypatch.setenv("HERMES_MANAGED", "")
+
+        result = await runner._handle_update_command(event)
+
+        assert "only available from messaging platforms" not in result
+
+
+# ---------------------------------------------------------------------------
 # _send_update_notification
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Drops `Platform.DISCORD` and `Platform.MATTERMOST` from the hardcoded `_UPDATE_ALLOWED_PLATFORMS` frozenset in `gateway/run.py`. Both platforms are bundled plugins now (PR #24356 migrated Discord, PR #31748 migrated Mattermost) and they declare `allow_update_command=True` on their `PlatformEntry`. The gate at `_handle_update_command` already falls back to the registry when a platform isn't in the frozenset:

```python
_allowed = self._UPDATE_ALLOWED_PLATFORMS
if platform not in _allowed:
    entry = platform_registry.get(platform.value)
    if not entry or not entry.allow_update_command:
        return t("gateway.update.platform_not_messaging")
```

Today both entries say "allowed" twice — once in the frozenset, once on the registry. Cleaning up the frozenset makes the registry flag actually do work for these platforms instead of being a redundant no-op.

## What's NOT touched

- The Home Assistant entry stays — PR #32500 migrates HA but isn't merged yet. Drop it in a follow-up after that lands.
- Other plugin-only platforms (`teams`, `irc`, `line`, `google_chat`, `ntfy`, `simplex`) were never in the frozenset to begin with — they've always relied on the registry fallback.
- Remaining built-ins (telegram, slack, whatsapp, signal, matrix, email, sms, dingtalk, feishu, wecom, weixin, bluebubbles, qqbot, local) stay in the frozenset; they're not plugin-migrated yet.

## Verification

```python
# All currently-migrated plugin platforms declare allow_update_command=True:
from hermes_cli.plugins import PluginManager
PluginManager().discover_and_load(force=True)
from gateway.platform_registry import platform_registry
for n in ['discord', 'mattermost', 'teams', 'irc', 'line', 'google_chat', 'ntfy', 'simplex']:
    e = platform_registry.get(n)
    print(n, e.allow_update_command)
# discord True / mattermost True / teams True / irc True / line True / google_chat True / ntfy True / simplex True
```

Empirical test from the worktree:

```python
# /update on Discord/Mattermost still works (passes the gate via registry fallback)
# /update on Webhook/API_Server still blocked (not messaging platforms)
```

## Tests

Added `TestUpdateCommandPlatformGate` to `tests/gateway/test_update_command.py` with five cases that pin down every branch of the allowlist gate. The gate previously had zero direct coverage:

- `test_blocks_programmatic_interface` — `Platform.WEBHOOK` must be blocked
- `test_blocks_api_server_platform` — `Platform.API_SERVER` must be blocked
- `test_allows_plugin_platform_via_registry_fallback` — `Platform.DISCORD` must pass via registry fallback (the regression test for this PR's change)
- `test_allows_mattermost_via_registry_fallback` — same for `Platform.MATTERMOST`
- `test_allows_builtin_platform_in_allowlist` — `Platform.TELEGRAM` must still pass directly via the frozenset

Each plugin-platform test asserts the precondition `Platform.X not in _UPDATE_ALLOWED_PLATFORMS` explicitly, so if anyone re-adds Discord/Mattermost to the frozenset in the future, the tests fail loudly.

All 74 `/update`-related tests pass (was 69 before, +5 new).

## Surfaced during

Self-review of PR #32500 (Home Assistant migration). The migration playbook calls out this redundancy as out-of-scope tech debt for the migration PR itself; this PR closes that follow-up for the platforms already migrated.
