### PR TITLE
fix(kanban): clean up task_links when archiving a task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3835,6 +3835,15 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
+        # Sever parent→child links so children of the archived task are
+        # no longer blocked.  Without this, ``recompute_ready`` promotes
+        # children (archived ≈ done), but the children's workers may
+        # still try to access the archived parent's scratch workspace,
+        # which was already cleaned up on completion — causing crashes.
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ?",
+            (task_id,),
+        )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting


### PR DESCRIPTION
## Problem

When `archive_task()` archives a parent task, it does **not** remove `task_links` entries for that task. `recompute_ready()` treats archived parents as done (`archived ≈ done`), promoting child tasks to `ready`. The children's workers then try to access the archived parent's scratch workspace — which was already cleaned up on task completion — causing worker crashes.

## Case Study: 3-Task Kanban Pipeline Crash

In a real-world pipeline (T1 reviewer → T2 writer → T3 reviewer):

1. T2 (writer) completed its work → scratch workspace cleaned up by `_cleanup_workspace()` ✓
2. T2 was later archived → `task_links` **not cleaned up** ✗
3. `recompute_ready()` saw all parents as done/archived → promoted T3 to `ready`
4. T3 worker started, tried to access parent T2's workspace → **"File not found" → crash ×3**

Evidence from worker log:
```
Line 15: 工作区为空。需要找到父任务 t_c0227d60 的产出。
Line 55: read ...workspaces/t_c0227d60/... → File not found
Line 71: 父任务工作区已被 GC 清理
Line 91: 这是第三次尝试（前两次都崩溃了）
```

The fix was to manually `hermes kanban unlink` the stale parent link.

## Root Cause

In `hermes_cli/kanban_db.py`, `archive_task()` (line 3820) only updates the task status — it does NOT clean up `task_links`. Compare with `delete_archived_task()` (line 3846) which correctly deletes from `task_links`.

## Fix

Add `DELETE FROM task_links WHERE parent_id = ?` inside the `archive_task` write transaction. This severs the parent→child dependency so children no longer try to access the archived parent's resources.

```python
conn.execute(
    "DELETE FROM task_links WHERE parent_id = ?",
    (task_id,),
)
```

**Only `parent_id` is deleted**, not `child_id`. The archived task acting as a child of another task does not cause the same issue (the parent does not depend on the child's workspace).

## Previous PR #31265

This bug was previously identified and submitted as [PR #31265](https://github.com/NousResearch/hermes-agent/pull/31265) (fix(kanban): reject late-link after child start). That PR has been closed; this new PR provides a cleaner reproduction path and isolates the fix to the `archive_task` path only.

## Testing

All existing tests pass:
- 4 archive-specific tests ✓
- 165 core functionality tests ✓  
- 6 sticky block tests ✓

## Changes

- `hermes_cli/kanban_db.py`: +9 lines in `archive_task()`