### PR TITLE
fix(gateway): deliver native-Opus TTS replies as Telegram voice notes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3615,9 +3615,21 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
-                            )
+                            # The gateway runner clears HERMES_SESSION_PLATFORM
+                            # (to "") before this auto-TTS step runs, so re-set
+                            # it for the duration of the TTS call. Without this
+                            # the TTS tool sees platform="" and falls back to
+                            # a .mp3 output path; downstream send_voice then
+                            # routes through sendAudio (audio-file card) on
+                            # Telegram instead of sendVoice (waveform bubble).
+                            from gateway.session_context import _SESSION_PLATFORM
+                            _platform_token = _SESSION_PLATFORM.set(self.platform.value)
+                            try:
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_text
+                                )
+                            finally:
+                                _SESSION_PLATFORM.reset(_platform_token)
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11369,17 +11369,37 @@ class GatewayRunner:
         audio_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import (
+                text_to_speech_tool,
+                _strip_markdown_for_tts,
+                _load_tts_config,
+                _get_provider,
+            )
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
                 return
 
-            # Use .mp3 extension so edge-tts conversion to opus works correctly.
-            # The TTS tool may convert to .ogg — use file_path from result.
+            # Pick the temp extension based on the configured provider so the
+            # TTS tool emits the right format directly. Providers in the
+            # native-Opus set ({openai, elevenlabs, mistral, gemini, inworld})
+            # honor the supplied path's extension; handing them ".mp3" makes
+            # them produce MP3 bytes, which then routes to sendAudio (audio-
+            # file card) instead of sendVoice (waveform bubble) on Telegram.
+            # Other providers (edge, neutts, etc.) still need .mp3 / .wav and
+            # get converted to .opus downstream by _convert_to_opus.
+            try:
+                _active_provider = _get_provider(_load_tts_config())
+            except Exception:
+                _active_provider = ""
+            _voice_reply_ext = (
+                ".ogg"
+                if _active_provider in {"openai", "elevenlabs", "mistral", "gemini", "inworld"}
+                else ".mp3"
+            )
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
+                f"tts_reply_{_uuid.uuid4().hex[:12]}{_voice_reply_ext}",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 

--- a/tests/gateway/test_send_voice_reply_native_opus_ext.py
+++ b/tests/gateway/test_send_voice_reply_native_opus_ext.py
@@ -1,0 +1,125 @@
+"""Regression test: ``GatewayRunner._send_voice_reply`` must pick an
+extension that matches the configured TTS provider's native output.
+
+Providers in the native-Opus set ({openai, elevenlabs, mistral, gemini,
+inworld}) honor the supplied output path's extension. Passing ``.mp3`` (the
+old hardcoded value) makes them produce MP3 bytes, which downstream
+``adapter.send_voice`` then routes through Telegram's ``sendAudio`` (audio-
+file card) instead of ``sendVoice`` (waveform bubble). Picking ``.ogg``
+for those providers restores native voice-note rendering.
+
+Other providers (edge, neutts, etc.) still need ``.mp3`` / ``.wav`` and get
+converted to ``.opus`` downstream by ``_convert_to_opus``.
+"""
+
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_event():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="208214988",
+        user_id="208214988",
+        chat_type="dm",
+    )
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+
+def _runner_with_adapter(send_voice_mock):
+    runner = object.__new__(GatewayRunner)
+    adapter = SimpleNamespace(
+        send_voice=send_voice_mock,
+        is_in_voice_channel=lambda *_a, **_k: False,
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner
+
+
+def _patch_tts_to_capture_path(monkeypatch, recorder: list):
+    """Patch the TTS tool to record the output_path it was handed."""
+
+    def _fake_text_to_speech_tool(*, text, output_path, **_kwargs):
+        recorder.append(output_path)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as fh:
+            fh.write(b"\x00" * 32)
+        return json.dumps({"success": True, "file_path": output_path})
+
+    monkeypatch.setattr(
+        "tools.tts_tool.text_to_speech_tool",
+        _fake_text_to_speech_tool,
+    )
+    monkeypatch.setattr(
+        "tools.tts_tool._strip_markdown_for_tts",
+        lambda text: text,
+    )
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["openai", "elevenlabs", "mistral", "gemini", "inworld"],
+)
+@pytest.mark.asyncio
+async def test_voice_reply_picks_ogg_for_native_opus_providers(
+    monkeypatch, tmp_path, provider
+):
+    """Native-Opus providers must receive a ``.ogg`` output path so the
+    Telegram adapter routes the file through ``sendVoice`` (waveform bubble)
+    instead of ``sendAudio`` (audio-file card)."""
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {"provider": provider})
+    monkeypatch.setattr("tools.tts_tool._get_provider", lambda _cfg: provider)
+    paths: list = []
+    _patch_tts_to_capture_path(monkeypatch, paths)
+
+    send_voice = AsyncMock()
+    runner = _runner_with_adapter(send_voice)
+    event = _make_event()
+
+    await runner._send_voice_reply(event, "Hello there.")
+
+    assert len(paths) == 1, "TTS tool should have been called exactly once"
+    assert paths[0].endswith(".ogg"), (
+        f"Expected .ogg path for native-Opus provider {provider!r}, got {paths[0]!r}"
+    )
+
+
+@pytest.mark.parametrize("provider", ["edge", "neutts", "kittentts", "piper", "xai"])
+@pytest.mark.asyncio
+async def test_voice_reply_keeps_mp3_for_non_native_opus_providers(
+    monkeypatch, tmp_path, provider
+):
+    """Non-native-Opus providers still get ``.mp3`` so the existing
+    ``_convert_to_opus`` step (Edge TTS et al.) keeps working."""
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {"provider": provider})
+    monkeypatch.setattr("tools.tts_tool._get_provider", lambda _cfg: provider)
+    paths: list = []
+    _patch_tts_to_capture_path(monkeypatch, paths)
+
+    send_voice = AsyncMock()
+    runner = _runner_with_adapter(send_voice)
+    event = _make_event()
+
+    await runner._send_voice_reply(event, "Hello there.")
+
+    assert len(paths) == 1
+    assert paths[0].endswith(".mp3"), (
+        f"Expected .mp3 path for non-native-Opus provider {provider!r}, got {paths[0]!r}"
+    )


### PR DESCRIPTION
## Summary

Auto-TTS replies from Inworld (and any other native-Opus provider — OpenAI, ElevenLabs, Mistral, Gemini) currently arrive in Telegram as audio-file cards (with title + play button) instead of native voice notes (waveform bubble). Two separate but related bugs cause this:

1. **`gateway/platforms/base.py` auto-TTS path** — the gateway runner sets `HERMES_SESSION_PLATFORM=telegram` while the agent runs and then `clear_session_vars` resets it to `""` (intentional — to distinguish "explicitly cleared" from "never set"). The base adapter's auto-TTS step at `_process_message_background` runs *after* that clear, so `text_to_speech_tool` sees `platform=""` → `want_opus=False` → falls through to the `.mp3` branch.

2. **`gateway/run.py` `_send_voice_reply`** — independently, this helper hardcodes the temp path extension to `.mp3` with a comment claiming "the TTS tool may convert to .ogg." That's true for Edge/NeuTTS/Piper (they're MP3/WAV-native and get `_convert_to_opus`'d), but for native-Opus providers the TTS tool *honors the supplied extension* — so it produces MP3 bytes too. This also affects `voice_mode=all` text-input → voice-reply flows.

In both cases, `adapter.send_voice` then sees a `.mp3` file and routes it through Telegram's `sendAudio` (audio-file card UI) instead of `sendVoice` (waveform bubble).

## Changes

- **`gateway/platforms/base.py`**: set `HERMES_SESSION_PLATFORM` via the contextvar (token-scoped, restored in `finally`) around the auto-TTS call so the TTS tool sees the live platform.
- **`gateway/run.py`**: pick the temp extension based on the configured provider — `.ogg` for `{openai, elevenlabs, mistral, gemini, inworld}`, `.mp3` for everything else (preserving the existing `_convert_to_opus` path for Edge TTS et al.).
- **`tests/gateway/test_send_voice_reply_native_opus_ext.py`**: parametrized over all five native-Opus providers and five non-native providers, asserting the right extension is handed to the TTS tool.

## Reproduction (pre-fix)

1. Set `tts.provider: inworld` (or `openai`, `elevenlabs`, `mistral`, `gemini`) in `~/.hermes/config.yaml`.
2. Enable voice mode on a Telegram chat: `/voice on`.
3. Send Nellie a voice note.
4. Observe the reply renders as an audio-file card, not a waveform voice note. Confirm via `journalctl -u hermes-gateway` — the `TTS audio saved:` line will show `provider=inworld, want_opus=False`, file ending in `.mp3`.

## Test plan

- [x] `pytest tests/gateway/test_send_voice_reply_native_opus_ext.py` — 10 new tests pass
- [x] `pytest tests/gateway/test_send_voice_reply_notify.py` — existing notify-flag regressions still pass
- [x] `pytest tests/tools/test_tts_opus_routing.py` — opus-routing tests still pass
- [x] Manual: switch `tts.provider: inworld` (model `inworld-tts-2`, voice `Selene`, `delivery_mode: BALANCED`), `/voice on`, send a Telegram voice note → reply now renders as the native waveform bubble with no extra latency from Opus conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)