### PR TITLE
feat: add Visibility OS kanban board

### DIFF
--- a/docs/plans/2026-05-25-hermes-visibility-os.md
+++ b/docs/plans/2026-05-25-hermes-visibility-os.md
@@ -1,0 +1,1065 @@
+# Hermes Visibility OS Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task. Do not execute external/public write actions without explicit human approval through the Action Queue.
+
+**Goal:** Build Hermes Visibility OS: a Hermes-native plugin and dashboard extension that finds real engineering opportunities, prepares evidence-backed artifacts, and queues all reputation-sensitive write actions for human approval.
+
+**Architecture:** Implement as a Hermes dashboard plugin plus core Python modules under `plugins/visibility_os/`. Use profile-aware SQLite for MVP persistence. The dashboard exposes a news-feed/action-queue UI; backend routes live under `/api/plugins/visibility-os/...`; scheduled work uses Hermes cron. External writes are deny-by-default and can only happen through approved action items with audit logging.
+
+**Tech Stack:** Python, FastAPI `APIRouter`, SQLite, Pydantic, Hermes dashboard plugin system, React/Vite dashboard frontend, Hermes cron, `gh` CLI for GitHub MVP.
+
+---
+
+## Non-Negotiable Product Rules
+
+1. **SQLite first.** Use profile-aware SQLite via `get_hermes_home()`; do not introduce Postgres in MVP.
+2. **Read freely, write through approval.** Scanners may read GitHub/Slack/Linear/docs/CI, but all external write-actions must be queued.
+3. **No unapproved reputation-sensitive actions.** Slack posts, GitHub comments, PR creation, branch pushes, docs publication, deployments, incident updates, and ticket changes require human approval.
+4. **Hard-block high-risk actions.** Merge PR, production deploy, delete branch, mute alert, permission change, close customer ticket, and executive-channel message are manual-only unless a future explicit override flow is added.
+5. **No fake impact.** Completion claims require evidence and executed/shipped status.
+6. **Audit everything.** Every approval transition and execution attempt writes an audit-log row.
+
+---
+
+## Data Model Overview
+
+SQLite database path:
+
+```python
+get_hermes_home() / "visibility_os.db"
+```
+
+Initial tables:
+
+- `schema_migrations`
+- `opportunities`
+- `action_queue`
+- `audit_log`
+- `daily_summaries`
+- `weekly_summaries`
+- `scan_runs`
+- `connector_state`
+
+JSON fields are stored as encoded `TEXT` in SQLite.
+
+---
+
+## Task 1: Create plugin skeleton
+
+**Objective:** Add the minimal plugin structure so Hermes can discover Visibility OS.
+
+**Files:**
+- Create: `plugins/visibility_os/plugin.yaml`
+- Create: `plugins/visibility_os/__init__.py`
+- Create: `plugins/visibility_os/core/__init__.py`
+- Create: `plugins/visibility_os/dashboard/plugin_api.py`
+- Create: `tests/plugins/visibility_os/test_plugin_api.py`
+
+**Step 1: Create plugin manifest**
+
+Create `plugins/visibility_os/plugin.yaml`:
+
+```yaml
+name: visibility-os
+display_name: Hermes Visibility OS
+description: Evidence-backed engineering impact feed and human approval queue.
+version: 0.1.0
+kind: dashboard
+sidebar:
+  label: Visibility OS
+  path: /plugins/visibility-os
+api: plugin_api.py
+```
+
+**Step 2: Create minimal API router**
+
+Create `plugins/visibility_os/dashboard/plugin_api.py`:
+
+```python
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health() -> dict[str, str]:
+    return {"ok": "true", "plugin": "visibility-os"}
+```
+
+**Step 3: Add test**
+
+Create `tests/plugins/visibility_os/test_plugin_api.py`:
+
+```python
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+
+from plugins.visibility_os.dashboard.plugin_api import router
+
+
+def test_visibility_os_health_endpoint():
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+
+    res = client.get("/api/plugins/visibility-os/health")
+
+    assert res.status_code == 200
+    assert res.json() == {"ok": "true", "plugin": "visibility-os"}
+```
+
+**Step 4: Run test**
+
+Run:
+
+```bash
+python -m pytest tests/plugins/visibility_os/test_plugin_api.py -q -o 'addopts='
+```
+
+Expected: `1 passed`.
+
+**Step 5: Commit**
+
+```bash
+git add plugins/visibility_os tests/plugins/visibility_os
+git commit -m "feat: add visibility os plugin skeleton"
+```
+
+---
+
+## Task 2: Add profile-aware SQLite database layer
+
+**Objective:** Create an idempotent SQLite initialization layer.
+
+**Files:**
+- Create: `plugins/visibility_os/core/db.py`
+- Create: `tests/plugins/visibility_os/test_db.py`
+
+**Step 1: Write failing tests**
+
+Create `tests/plugins/visibility_os/test_db.py`:
+
+```python
+import sqlite3
+
+from plugins.visibility_os.core import db
+
+
+def test_init_db_creates_required_tables(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "get_db_path", lambda: tmp_path / "visibility_os.db")
+
+    db.init_db()
+
+    conn = sqlite3.connect(tmp_path / "visibility_os.db")
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    names = {row[0] for row in rows}
+
+    assert "schema_migrations" in names
+    assert "opportunities" in names
+    assert "action_queue" in names
+    assert "audit_log" in names
+    assert "daily_summaries" in names
+    assert "weekly_summaries" in names
+    assert "scan_runs" in names
+    assert "connector_state" in names
+
+
+def test_init_db_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, "get_db_path", lambda: tmp_path / "visibility_os.db")
+
+    db.init_db()
+    db.init_db()
+
+    conn = sqlite3.connect(tmp_path / "visibility_os.db")
+    row = conn.execute("SELECT COUNT(*) FROM schema_migrations").fetchone()
+    assert row[0] >= 1
+```
+
+**Step 2: Implement database module**
+
+Create `plugins/visibility_os/core/db.py`:
+
+```python
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterator
+from contextlib import contextmanager
+
+from hermes_constants import get_hermes_home
+
+DB_FILENAME = "visibility_os.db"
+SCHEMA_VERSION = 1
+
+
+def get_db_path() -> Path:
+    return Path(get_hermes_home()) / DB_FILENAME
+
+
+@contextmanager
+def connect() -> Iterator[sqlite3.Connection]:
+    path = get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    with connect() as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS opportunities (
+                id TEXT PRIMARY KEY,
+                source_system TEXT NOT NULL,
+                source_url TEXT,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL,
+                category TEXT,
+                impact_score INTEGER NOT NULL,
+                visibility_score INTEGER NOT NULL,
+                effort_score INTEGER NOT NULL,
+                safety_score INTEGER NOT NULL,
+                risk_penalty INTEGER NOT NULL DEFAULT 0,
+                priority_score INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open',
+                metadata TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS action_queue (
+                id TEXT PRIMARY KEY,
+                opportunity_id TEXT REFERENCES opportunities(id),
+                proposed_by_agent TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                target_system TEXT NOT NULL,
+                target_location TEXT NOT NULL,
+                title TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                proposed_payload TEXT NOT NULL,
+                final_payload TEXT,
+                evidence_links TEXT NOT NULL DEFAULT '[]',
+                risk_level TEXT NOT NULL,
+                impact_score INTEGER,
+                visibility_score INTEGER,
+                effort_score INTEGER,
+                approval_required INTEGER NOT NULL DEFAULT 1,
+                approval_reason TEXT,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                approved_at TEXT,
+                executed_at TEXT,
+                approved_by TEXT,
+                execution_result TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id TEXT PRIMARY KEY,
+                action_id TEXT REFERENCES action_queue(id),
+                event_type TEXT NOT NULL,
+                actor TEXT NOT NULL,
+                before_state TEXT,
+                after_state TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS daily_summaries (
+                id TEXT PRIMARY KEY,
+                date TEXT NOT NULL,
+                summary_payload TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS weekly_summaries (
+                id TEXT PRIMARY KEY,
+                week_start TEXT NOT NULL,
+                week_end TEXT NOT NULL,
+                summary_payload TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE TABLE IF NOT EXISTS scan_runs (
+                id TEXT PRIMARY KEY,
+                scanner_name TEXT NOT NULL,
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL DEFAULT (datetime('now')),
+                finished_at TEXT,
+                result_payload TEXT NOT NULL DEFAULT '{}'
+            );
+
+            CREATE TABLE IF NOT EXISTS connector_state (
+                connector_name TEXT PRIMARY KEY,
+                state_payload TEXT NOT NULL DEFAULT '{}',
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            """
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)",
+            (SCHEMA_VERSION,),
+        )
+```
+
+**Step 3: Run test**
+
+```bash
+python -m pytest tests/plugins/visibility_os/test_db.py -q -o 'addopts='
+```
+
+Expected: `2 passed`.
+
+**Step 4: Commit**
+
+```bash
+git add plugins/visibility_os/core/db.py tests/plugins/visibility_os/test_db.py
+git commit -m "feat: add visibility os sqlite store"
+```
+
+---
+
+## Task 3: Implement scoring engine
+
+**Objective:** Implement deterministic priority scoring from the JSON spec.
+
+**Files:**
+- Create: `plugins/visibility_os/core/scoring.py`
+- Create: `tests/plugins/visibility_os/test_scoring.py`
+
+**Step 1: Write tests**
+
+Create `tests/plugins/visibility_os/test_scoring.py`:
+
+```python
+from plugins.visibility_os.core.scoring import score_opportunity
+
+
+def test_score_opportunity_uses_visibility_formula():
+    result = score_opportunity(
+        impact=4,
+        visibility=5,
+        effort=4,
+        safety=5,
+        risk_penalty=0,
+    )
+
+    assert result.priority_score == 31
+
+
+def test_risk_penalty_reduces_priority():
+    safe = score_opportunity(impact=4, visibility=5, effort=4, safety=5, risk_penalty=0)
+    risky = score_opportunity(impact=4, visibility=5, effort=4, safety=5, risk_penalty=10)
+
+    assert risky.priority_score == safe.priority_score - 10
+
+
+def test_scores_are_clamped():
+    result = score_opportunity(
+        impact=99,
+        visibility=-1,
+        effort=99,
+        safety=-1,
+        risk_penalty=99,
+    )
+
+    assert result.impact == 5
+    assert result.visibility == 0
+    assert result.effort == 5
+    assert result.safety == 1
+    assert result.risk_penalty == 10
+```
+
+**Step 2: Implement scoring**
+
+Create `plugins/visibility_os/core/scoring.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScoreResult:
+    impact: int
+    visibility: int
+    effort: int
+    safety: int
+    risk_penalty: int
+    priority_score: int
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, int(value)))
+
+
+def score_opportunity(
+    *,
+    impact: int,
+    visibility: int,
+    effort: int,
+    safety: int,
+    risk_penalty: int,
+) -> ScoreResult:
+    impact = _clamp(impact, 0, 5)
+    visibility = _clamp(visibility, 0, 5)
+    effort = _clamp(effort, 1, 5)
+    safety = _clamp(safety, 1, 5)
+    risk_penalty = _clamp(risk_penalty, 0, 10)
+    priority_score = (impact * 3) + (visibility * 2) + effort + safety - risk_penalty
+    return ScoreResult(
+        impact=impact,
+        visibility=visibility,
+        effort=effort,
+        safety=safety,
+        risk_penalty=risk_penalty,
+        priority_score=priority_score,
+    )
+```
+
+**Step 3: Run tests**
+
+```bash
+python -m pytest tests/plugins/visibility_os/test_scoring.py -q -o 'addopts='
+```
+
+Expected: `3 passed`.
+
+**Step 4: Commit**
+
+```bash
+git add plugins/visibility_os/core/scoring.py tests/plugins/visibility_os/test_scoring.py
+git commit -m "feat: add visibility scoring engine"
+```
+
+---
+
+## Task 4: Implement action queue state machine
+
+**Objective:** Create, list, approve, edit, reject, and guard execution of queued actions.
+
+**Files:**
+- Create: `plugins/visibility_os/core/actions.py`
+- Create: `plugins/visibility_os/core/audit.py`
+- Create: `plugins/visibility_os/core/policies.py`
+- Create: `tests/plugins/visibility_os/test_action_queue.py`
+
+**Step 1: Define policy constants**
+
+Create `plugins/visibility_os/core/policies.py`:
+
+```python
+WRITE_ACTIONS_REQUIRE_APPROVAL = {
+    "slack_message",
+    "slack_thread_reply",
+    "github_issue_comment",
+    "github_pr_comment",
+    "github_pr_creation",
+    "github_pr_merge",
+    "github_branch_push",
+    "jira_ticket_update",
+    "jira_ticket_creation",
+    "docs_publication",
+    "incident_update",
+    "release_note",
+    "deployment",
+    "production_config_change",
+}
+
+HARD_BLOCKED_ACTIONS = {
+    "merge_pull_request",
+    "production_deploy",
+    "delete_branch",
+    "close_customer_ticket",
+    "mute_alert",
+    "change_permissions",
+    "send_message_to_executive_channel",
+}
+
+VALID_STATUSES = {
+    "drafted",
+    "queued",
+    "needs_review",
+    "approved",
+    "rejected",
+    "edited_by_human",
+    "executed",
+    "failed",
+    "cancelled",
+    "expired",
+}
+
+VALID_TRANSITIONS = {
+    "drafted": {"queued", "cancelled"},
+    "queued": {"approved", "rejected", "needs_review", "edited_by_human", "cancelled", "expired"},
+    "needs_review": {"queued", "rejected", "cancelled"},
+    "edited_by_human": {"approved", "queued", "rejected", "cancelled"},
+    "approved": {"executed", "failed", "cancelled"},
+    "rejected": set(),
+    "executed": set(),
+    "failed": set(),
+    "cancelled": set(),
+    "expired": set(),
+}
+```
+
+**Step 2: Implement audit helper**
+
+Create `plugins/visibility_os/core/audit.py`:
+
+```python
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from .db import connect
+
+
+def record_event(
+    *,
+    action_id: str | None,
+    event_type: str,
+    actor: str,
+    before_state: dict[str, Any] | None = None,
+    after_state: dict[str, Any] | None = None,
+) -> str:
+    event_id = f"audit_{uuid.uuid4().hex}"
+    with connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO audit_log(id, action_id, event_type, actor, before_state, after_state)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                action_id,
+                event_type,
+                actor,
+                json.dumps(before_state) if before_state is not None else None,
+                json.dumps(after_state) if after_state is not None else None,
+            ),
+        )
+    return event_id
+```
+
+**Step 3: Implement action service**
+
+Create `plugins/visibility_os/core/actions.py` with functions:
+
+```python
+create_action(...)
+get_action(action_id)
+list_actions(status=None)
+transition_action(action_id, to_status, actor, reason=None)
+approve_action(action_id, actor)
+edit_action(action_id, actor, final_payload)
+reject_action(action_id, actor, reason)
+execute_action_guard(action_id)
+```
+
+Required behavior:
+
+- Call `init_db()` before database operations.
+- Use IDs like `act_<uuidhex>`.
+- Store `proposed_payload`, `final_payload`, `evidence_links`, and `execution_result` as JSON text.
+- Reject invalid status transitions.
+- `execute_action_guard()` raises if status is not `approved`.
+- `execute_action_guard()` raises if action type is hard-blocked.
+- Every mutation records an audit event.
+
+**Step 4: Tests**
+
+Create tests for:
+
+- creating an action defaults to `queued`
+- approving queued action changes status to `approved`
+- rejecting queued action changes status to `rejected`
+- invalid transition raises
+- execute guard rejects non-approved action
+- execute guard rejects hard-blocked action
+- audit rows are written
+
+**Step 5: Run tests**
+
+```bash
+python -m pytest tests/plugins/visibility_os/test_action_queue.py -q -o 'addopts='
+```
+
+**Step 6: Commit**
+
+```bash
+git add plugins/visibility_os/core/actions.py plugins/visibility_os/core/audit.py plugins/visibility_os/core/policies.py tests/plugins/visibility_os/test_action_queue.py
+git commit -m "feat: add visibility action queue"
+```
+
+---
+
+## Task 5: Add feed and action queue API routes
+
+**Objective:** Expose the action queue through dashboard plugin API routes.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/plugin_api.py`
+- Create: `tests/plugins/visibility_os/test_visibility_api.py`
+
+**Routes:**
+
+```text
+GET  /feed
+GET  /actions
+GET  /actions/{action_id}
+POST /actions/{action_id}/approve
+POST /actions/{action_id}/edit
+POST /actions/{action_id}/reject
+POST /actions/{action_id}/execute
+GET  /audit-log
+```
+
+**API behavior:**
+
+- `/feed` returns mixed cards: queued actions, opportunities, summaries, risk warnings.
+- `/actions` supports optional `status` query.
+- `/approve` changes status only unless body has `execute_immediately: true`.
+- `/edit` stores final payload and moves to `edited_by_human`.
+- `/reject` requires a reason.
+- `/execute` calls guard only in this task; actual external execution comes later.
+
+**Step: Run tests**
+
+```bash
+python -m pytest tests/plugins/visibility_os/test_visibility_api.py -q -o 'addopts='
+```
+
+**Commit:**
+
+```bash
+git add plugins/visibility_os/dashboard/plugin_api.py tests/plugins/visibility_os/test_visibility_api.py
+git commit -m "feat: expose visibility action queue api"
+```
+
+---
+
+## Task 6: Add language guard
+
+**Objective:** Prevent overclaiming and misleading updates.
+
+**Files:**
+- Create: `plugins/visibility_os/core/language_guard.py`
+- Create: `tests/plugins/visibility_os/test_language_guard.py`
+
+**Blocked terms when status is not executed:**
+
+```text
+fixed
+shipped
+resolved
+completed
+deployed
+```
+
+**Allowed unfinished-work language:**
+
+```text
+I am investigating
+I found a likely cause
+I opened a draft
+I am testing a fix
+I proposed a follow-up
+```
+
+**Tests:**
+
+- non-executed action with “Fixed” fails
+- executed action with “Fixed” passes if evidence exists
+- team-channel post without evidence fails
+- progress update with “likely cause” passes
+
+**Commit:**
+
+```bash
+git add plugins/visibility_os/core/language_guard.py tests/plugins/visibility_os/test_language_guard.py
+git commit -m "feat: add visibility language guard"
+```
+
+---
+
+## Task 7: Add evidence package builder
+
+**Objective:** Standardize the evidence required for PRs, comments, Slack updates, and weekly summaries.
+
+**Files:**
+- Create: `plugins/visibility_os/core/evidence.py`
+- Create: `tests/plugins/visibility_os/test_evidence.py`
+
+**Evidence fields:**
+
+```text
+problem_statement
+affected_users_or_systems
+root_cause
+fix_summary
+before_after_behaviour
+tests_run
+logs_or_screenshots
+risk_assessment
+follow_up_tasks
+```
+
+**Required for completion updates:**
+
+- PR URL or issue URL
+- test result or explanation
+- clear actual status
+
+**Commit:**
+
+```bash
+git add plugins/visibility_os/core/evidence.py tests/plugins/visibility_os/test_evidence.py
+git commit -m "feat: add visibility evidence packages"
+```
+
+---
+
+## Task 8: Implement communications drafter
+
+**Objective:** Generate concise, factual message drafts that always become queued actions.
+
+**Files:**
+- Create: `plugins/visibility_os/core/communications.py`
+- Create: `tests/plugins/visibility_os/test_communications.py`
+
+**Formats:**
+
+Progress update:
+
+```text
+Problem → current diagnosis → action underway → expected next step
+```
+
+Completion update:
+
+```text
+Problem → fix → evidence → impact → follow-up
+```
+
+Weekly update:
+
+```text
+Outcomes shipped → systems improved → blockers removed → next risks
+```
+
+**Behavior:**
+
+- Run language guard before queueing.
+- Require evidence links for team-visible messages.
+- Create `slack_message`, `github_issue_comment`, or `weekly_update_draft` action items.
+
+**Commit:**
+
+```bash
+git add plugins/visibility_os/core/communications.py tests/plugins/visibility_os/test_communications.py
+git commit -m "feat: draft evidence-backed visibility updates"
+```
+
+---
+
+## Task 9: Implement GitHub read-only scanner
+
+**Objective:** Find initial opportunities from GitHub without writing anything.
+
+**Files:**
+- Create: `plugins/visibility_os/core/connectors/__init__.py`
+- Create: `plugins/visibility_os/core/connectors/github.py`
+- Create: `plugins/visibility_os/core/scanner.py`
+- Create: `tests/plugins/visibility_os/test_github_scanner.py`
+
+**Use `gh` CLI:**
+
+```bash
+gh issue list --json number,title,url,labels,updatedAt,assignees
+
+gh pr list --json number,title,url,updatedAt,reviewDecision,statusCheckRollup
+
+gh run list --json databaseId,status,conclusion,displayTitle,workflowName,url,createdAt
+```
+
+**MVP opportunity categories:**
+
+- flaky tests / CI failures
+- stale PRs
+- issues labelled bug/test/docs
+- PRs awaiting review
+- docs/runbook gaps inferred from labels/title
+
+**Scanner output:** normalized opportunity rows with score and suggested artifacts.
+
+**Tests:** mock `subprocess.run` output from `gh`.
+
+**Commit:**
+
+```bash
+git add plugins/visibility_os/core/connectors plugins/visibility_os/core/scanner.py tests/plugins/visibility_os/test_github_scanner.py
+git commit -m "feat: scan github visibility opportunities"
+```
+
+---
+
+## Task 10: Implement impact picker
+
+**Objective:** Create a daily plan from ranked opportunities.
+
+**Files:**
+- Create: `plugins/visibility_os/core/impact_picker.py`
+- Create: `tests/plugins/visibility_os/test_impact_picker.py`
+
+**Rules:**
+
+- Pick 1 main task.
+- Pick 2 side quests.
+- Pick 1 communication artifact.
+- Avoid high-risk/unbounded/private/no-artifact work.
+
+**Output:** daily feed card stored in `daily_summaries`.
+
+**Commit:**
+
+```bash
+git add plugins/visibility_os/core/impact_picker.py tests/plugins/visibility_os/test_impact_picker.py
+git commit -m "feat: select daily visibility plan"
+```
+
+---
+
+## Task 11: Add dashboard UI page
+
+**Objective:** Add a news-feed interface to review opportunities and action items.
+
+**Files:**
+- Create: `web/src/pages/VisibilityOSPage.tsx`
+- Create: `web/src/components/visibility/ActionCard.tsx`
+- Create: `web/src/components/visibility/ApprovalControls.tsx`
+- Create: `web/src/components/visibility/EvidenceLinks.tsx`
+- Create: `web/src/components/visibility/FeedFilters.tsx`
+- Create: `web/src/components/visibility/ScoreBadges.tsx`
+- Modify: routing/sidebar registration files after inspecting current dashboard route pattern.
+- Modify: `web/src/lib/api.ts` to add Visibility OS API client functions.
+
+**UI card fields:**
+
+- title
+- agent name
+- target system
+- target location
+- proposed action
+- generated text/diff
+- risk level
+- impact score
+- visibility score
+- evidence links
+- approval buttons
+- audit history
+
+**Controls:**
+
+- Approve & Execute
+- Edit & Execute
+- Reject
+- Ask Hermes to Revise
+- Save for Later
+- Mark Done Manually
+
+**Verification:**
+
+```bash
+cd web
+npm run build
+```
+
+**Commit:**
+
+```bash
+git add web/src/pages/VisibilityOSPage.tsx web/src/components/visibility web/src/lib/api.ts
+git commit -m "feat: add visibility os dashboard feed"
+```
+
+---
+
+## Task 12: Add safe executors
+
+**Objective:** Execute approved low-risk actions only.
+
+**Files:**
+- Create: `plugins/visibility_os/core/executors/__init__.py`
+- Create: `plugins/visibility_os/core/executors/base.py`
+- Create: `plugins/visibility_os/core/executors/github.py`
+- Create: `plugins/visibility_os/core/executors/slack.py`
+- Create: `tests/plugins/visibility_os/test_executors.py`
+
+**First supported actions:**
+
+- `github_issue_comment`
+- `github_pr_comment`
+- `slack_message`
+
+**Do not implement in MVP:**
+
+- merge PR
+- production deploy
+- mute alert
+- permission change
+- delete branch
+
+**Pre-execution checks:**
+
+- target system is valid
+- user permissions are available
+- status is `approved`
+- final/reviewed payload exists or proposed payload is explicitly accepted
+- no forbidden claims
+- no obvious sensitive data leak
+- evidence links exist when required
+- audit log is written before and after execution
+
+**Commit:**
+
+```bash
+git add plugins/visibility_os/core/executors tests/plugins/visibility_os/test_executors.py
+git commit -m "feat: execute approved visibility actions"
+```
+
+---
+
+## Task 13: Add scheduled jobs
+
+**Objective:** Wire Visibility OS into Hermes cron without bypassing approval.
+
+**Jobs:**
+
+```text
+Europe/London 08:30 scan_opportunities
+Europe/London 09:00 generate_daily_plan
+Europe/London 11:30 draft_progress_update
+Europe/London 14:30 check_pr_and_ci_status
+Europe/London 17:30 draft_end_of_day_summary
+Europe/London Friday 16:00 generate_weekly_impact_summary
+Europe/London Friday 16:30 generate_next_week_opportunity_backlog
+```
+
+**Implementation options:**
+
+1. Add CLI entrypoints under `hermes_cli` for plugin operations, then cron calls those.
+2. Add lightweight scripts under `plugins/visibility_os/scripts/` that invoke core functions.
+3. Use Hermes cron prompts that instruct the agent to call Visibility OS routes/core code.
+
+Preferred MVP: **scripts calling core functions**, because they are deterministic and do not rely on an LLM for simple scans.
+
+**Acceptance criteria:**
+
+- Scheduled jobs create feed cards/action items only.
+- Scheduled jobs never execute external writes.
+- The configured human approver receives a notification only when review items are waiting.
+
+---
+
+## Task 14: End-to-end safety tests
+
+**Objective:** Prove the approval boundary cannot be bypassed.
+
+**Files:**
+- Create: `tests/plugins/visibility_os/test_safety_e2e.py`
+
+**Test cases:**
+
+1. Unapproved Slack action cannot execute.
+2. Approved Slack action executes exactly final payload.
+3. Draft claiming “Fixed” without executed status is rejected.
+4. GitHub comment requires evidence link.
+5. Hard-blocked deploy action cannot execute even if approved.
+6. Every failed execution attempt has an audit event.
+
+**Commit:**
+
+```bash
+git add tests/plugins/visibility_os/test_safety_e2e.py
+git commit -m "test: enforce visibility os approval boundary"
+```
+
+---
+
+## MVP Completion Criteria
+
+MVP is complete when:
+
+- Dashboard shows Visibility OS feed.
+- SQLite action queue persists proposed actions.
+- User can approve/edit/reject actions.
+- Audit log records every state transition.
+- GitHub scanner can produce scored opportunities.
+- Communications drafter queues factual updates.
+- No external write occurs unless action status is `approved`.
+- Hard-blocked actions cannot execute through the agent.
+- Tests pass for database, scoring, actions, API, language guard, and safety E2E.
+
+---
+
+## Verification Commands
+
+Run focused tests:
+
+```bash
+python -m pytest tests/plugins/visibility_os -q -o 'addopts='
+```
+
+Run dashboard build:
+
+```bash
+cd web
+npm run build
+```
+
+Run broader relevant tests:
+
+```bash
+python -m pytest tests/plugins tests/hermes_cli -q -o 'addopts='
+```
+
+---
+
+## Recommended Implementation Order
+
+1. Plugin skeleton
+2. SQLite database
+3. Scoring engine
+4. Action queue state machine
+5. API routes
+6. Language guard
+7. Evidence builder
+8. Communications drafter
+9. GitHub scanner
+10. Impact picker
+11. Dashboard UI
+12. Safe executors
+13. Cron jobs
+14. End-to-end safety tests
+
+The Action Queue must be implemented before any executor. The dashboard approval experience should exist before any external write integration is enabled.

--- a/docs/plans/2026-05-26-visibility-os-workstream-visibility.md
+++ b/docs/plans/2026-05-26-visibility-os-workstream-visibility.md
@@ -1,0 +1,552 @@
+# Visibility OS Workstream Visibility Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Make Visibility OS clearly show what agentic opportunities exist, what workstreams agents are currently working on, what they have already worked on, where each workstream is in the lane lifecycle, and what code or review changes the agent proposes before any external GitHub side effect.
+
+**Architecture:** Add a first-class `workstreams` model that ties together an opportunity, its lane action, agent session/run metadata, progress events, produced artifacts, reviews, proposed PRs, and final GitHub side effects. Keep `action_queue` as the approval/execution state machine, but stop using it as the only user-visible progress surface. Add API endpoints that return workstream timelines and artifact summaries, then upgrade the dashboard from a feed of cards into a workbench with Kanban/status views, live-ish progress, and human-friendly diff/review visualisations.
+
+**Tech Stack:** Python/FastAPI plugin backend, SQLite profile-scoped storage, existing `actions`, `audit_log`, `opportunities`, `executors/hermes.py`, GitHub CLI integration, dashboard `dist/index.js` React bundle using Hermes plugin SDK.
+
+---
+
+## Product principles
+
+- One opportunity equals one trackable workstream once an agent starts acting on it.
+- The dashboard must answer four questions at a glance:
+  1. What is available for agents to work on?
+  2. What is currently being worked on?
+  3. What has the agent already done?
+  4. What does Barney need to approve, reject, or inspect?
+- Internal agent steps should be visible without requiring extra user clicks.
+- External side effects remain separately approved: push branch, post review/comment, merge, deploy.
+- Proposed changes should be understandable without opening a terminal.
+- PR review/audit output should feel like a review workspace, not raw JSON.
+
+---
+
+## Target lifecycle model
+
+Use these workstream stages consistently in backend and UI:
+
+1. `opportunity_open`
+   - Opportunity exists, no agent lane has started.
+2. `queued`
+   - A lane action has been created but not started.
+3. `agent_starting`
+   - Hermes process/session is launching.
+4. `gathering_context`
+   - Agent is reading issue/PR/CI evidence and repo context.
+5. `editing`
+   - Agent is making local code/docs/test changes.
+6. `verifying`
+   - Agent is running tests/checks.
+7. `self_auditing`
+   - Agent is reviewing its own diff.
+8. `independent_reviewing`
+   - Fresh session review is running with no fix context.
+9. `ready_for_push`
+   - Proposed PR branch passed gates and waits for Barney's push approval.
+10. `push_queued`
+    - Push action exists but is not executed yet.
+11. `pushed`
+    - Branch/PR has been pushed/opened.
+12. `review_ready`
+    - PR audit/review findings are ready for Barney.
+13. `comment_queued`
+    - Review/comment action exists but is not posted yet.
+14. `completed`
+    - Workstream reached its intended terminal state.
+15. `failed`
+    - Lane failed with useful evidence and retry guidance.
+16. `cancelled`
+    - Human or system cancelled it.
+
+---
+
+## Data model tasks
+
+### Task 1: Add workstream tables
+
+**Objective:** Persist agentic work as first-class trackable workstreams instead of inferring everything from actions.
+
+**Files:**
+- Modify: `plugins/visibility_os/core/db.py`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Schema additions:**
+
+```sql
+CREATE TABLE IF NOT EXISTS workstreams (
+    id TEXT PRIMARY KEY,
+    opportunity_id TEXT REFERENCES opportunities(id),
+    root_action_id TEXT REFERENCES action_queue(id),
+    lane_kind TEXT NOT NULL,
+    title TEXT NOT NULL,
+    repo TEXT,
+    source_url TEXT,
+    stage TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    completed_at TEXT,
+    agent_session_id TEXT,
+    summary TEXT NOT NULL DEFAULT '',
+    current_step TEXT NOT NULL DEFAULT '',
+    progress_percent INTEGER NOT NULL DEFAULT 0,
+    result_payload TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_visibility_workstreams_status ON workstreams(status);
+CREATE INDEX IF NOT EXISTS idx_visibility_workstreams_opportunity ON workstreams(opportunity_id);
+
+CREATE TABLE IF NOT EXISTS workstream_events (
+    id TEXT PRIMARY KEY,
+    workstream_id TEXT NOT NULL REFERENCES workstreams(id),
+    event_type TEXT NOT NULL,
+    stage TEXT,
+    actor TEXT NOT NULL,
+    message TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_visibility_workstream_events_ws ON workstream_events(workstream_id, created_at);
+
+CREATE TABLE IF NOT EXISTS workstream_artifacts (
+    id TEXT PRIMARY KEY,
+    workstream_id TEXT NOT NULL REFERENCES workstreams(id),
+    artifact_type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    summary TEXT NOT NULL DEFAULT '',
+    payload TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_visibility_workstream_artifacts_ws ON workstream_artifacts(workstream_id, artifact_type);
+```
+
+**Test:** Assert the new tables and indexes are created by `db.init_db()`.
+
+---
+
+### Task 2: Add workstream core module
+
+**Objective:** Provide a small API for creating workstreams, moving stages, recording events, and attaching artifacts.
+
+**Files:**
+- Create: `plugins/visibility_os/core/workstreams.py`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Required functions:**
+
+```python
+def create_workstream(*, opportunity_id: str | None, root_action_id: str | None, lane_kind: str, title: str, repo: str | None = None, source_url: str | None = None, actor: str = "visibility_os") -> dict[str, Any]: ...
+
+def get_workstream(workstream_id: str) -> dict[str, Any]: ...
+
+def list_workstreams(*, status: str | None = None, limit: int = 100) -> list[dict[str, Any]]: ...
+
+def update_stage(workstream_id: str, *, stage: str, status: str | None = None, current_step: str = "", progress_percent: int | None = None, actor: str = "system", payload: dict[str, Any] | None = None) -> dict[str, Any]: ...
+
+def record_workstream_event(workstream_id: str, *, event_type: str, message: str, actor: str = "system", stage: str | None = None, payload: dict[str, Any] | None = None) -> dict[str, Any]: ...
+
+def add_workstream_artifact(workstream_id: str, *, artifact_type: str, title: str, summary: str = "", payload: dict[str, Any] | None = None) -> dict[str, Any]: ...
+```
+
+**Test:** Create a workstream, transition through two stages, add an artifact, and assert `get_workstream()` returns events and artifacts ordered chronologically.
+
+---
+
+### Task 3: Connect lane actions to workstreams
+
+**Objective:** Starting any agentic lane should create or reuse a workstream linked to the opportunity and action.
+
+**Files:**
+- Modify: `plugins/visibility_os/core/opportunity_actions.py`
+- Modify: `plugins/visibility_os/core/actions.py` if needed
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Implementation notes:**
+
+- For `ci_fix_lane`, `github_issue_fix_lane`, `pr_ci_fix_lane`, `wip_handoff_lane`, and `github_pr_review_lane`, create a workstream when the action is drafted.
+- Include `workstream_id` in the action `proposed_payload`.
+- If the same open opportunity already has an active workstream for the same lane, reuse it or return a clear conflict instead of silently creating duplicates.
+- Workstream title should be human-readable, e.g. `Fix bug: Negative add support` or `Review PR #123: Improve vault accounting`.
+
+**Test:** Draft a fix issue lane and assert one workstream exists, linked to the action and opportunity.
+
+---
+
+## Agent progress tracking tasks
+
+### Task 4: Emit progress events from Hermes lane executor
+
+**Objective:** The dashboard should show where the agent is while the lane runs.
+
+**Files:**
+- Modify: `plugins/visibility_os/core/executors/hermes.py`
+- Modify: `plugins/visibility_os/core/workstreams.py`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Implementation notes:**
+
+- Before launching Hermes: `agent_starting`.
+- After prompt/context is prepared: `gathering_context`.
+- Before applying/expecting local changes: `editing`.
+- Before verification parsing: `verifying`.
+- Before self-audit parsing: `self_auditing`.
+- Before fresh session review: `independent_reviewing`.
+- If review passes and push action is queued: `ready_for_push`.
+- If review fails: `failed` with blockers surfaced.
+
+Because the current Hermes subprocess output may not provide structured streaming events, start with coarse deterministic events around known executor milestones. Do not fake fine-grained progress.
+
+**Test:** Mock Hermes execution and assert stage events are recorded in the expected order for a successful lane and a failed review lane.
+
+---
+
+### Task 5: Store agent artifacts as structured workstream artifacts
+
+**Objective:** Proposed PRs and reviews should be durable and inspectable from the workstream, not buried in raw action payloads.
+
+**Files:**
+- Modify: `plugins/visibility_os/core/executors/hermes.py`
+- Modify: `plugins/visibility_os/core/executors/github.py`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Artifacts to capture:**
+
+- `proposed_pr`
+  - branch
+  - commit message
+  - PR title/body
+  - changed files
+  - verification evidence
+  - self audit
+  - independent review
+- `diff_summary`
+  - files changed
+  - additions/deletions if available
+  - human summary by file
+- `review_findings`
+  - severity counts
+  - findings by file/line
+  - copyable comments
+- `github_result`
+  - pushed branch URL
+  - PR URL
+  - posted comment URL
+
+**Test:** Successful branch prep creates `proposed_pr` and `diff_summary`; successful push adds `github_result` and moves stage to `pushed` or `completed`.
+
+---
+
+## API tasks
+
+### Task 6: Add workstream API endpoints
+
+**Objective:** The dashboard can fetch current, historical, and detailed workstream state directly.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/plugin_api.py`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Endpoints:**
+
+```text
+GET /api/plugins/visibility-os/workstreams
+GET /api/plugins/visibility-os/workstreams?status=active
+GET /api/plugins/visibility-os/workstreams/{workstream_id}
+GET /api/plugins/visibility-os/opportunities/{opportunity_id}/workstreams
+```
+
+**Response shape for list endpoint:**
+
+```json
+{
+  "workstreams": [
+    {
+      "id": "ws_...",
+      "title": "Fix bug: negative add support",
+      "lane_kind": "github_issue_fix_lane",
+      "stage": "independent_reviewing",
+      "status": "active",
+      "current_step": "Fresh review agent is checking the local diff",
+      "progress_percent": 70,
+      "repo": "org/repo",
+      "source_url": "https://github.com/org/repo/issues/2",
+      "updated_at": "...",
+      "pending_human_action": null
+    }
+  ]
+}
+```
+
+**Test:** List endpoint returns active and completed workstreams with summary fields; detail endpoint returns events and artifacts.
+
+---
+
+### Task 7: Upgrade feed to include workstream rollups
+
+**Objective:** Existing feed cards should show whether an opportunity is untouched, active, done, or waiting on Barney.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/plugin_api.py`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Feed additions:**
+
+- `workstream_status`
+- `workstream_stage`
+- `workstream_id`
+- `agent_has_worked_on_this`
+- `last_agent_activity_at`
+- `pending_human_action`
+
+**Test:** Feed item for an opportunity with active workstream includes these fields.
+
+---
+
+## Dashboard UX tasks
+
+### Task 8: Add Overview sections
+
+**Objective:** Make the landing dashboard immediately show queue and progress.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/dist/index.js`
+
+**Sections:**
+
+1. **Needs decision**
+   - Push branch
+   - Post review/comment
+   - Failed lane needing retry or discard
+2. **Agent working now**
+   - Active workstreams with stage pill and progress bar
+3. **Open opportunities**
+   - Unstarted opportunities
+4. **Completed recently**
+   - Pushed PRs, posted reviews, closed/resolved opportunities
+
+**No backend test required**, but add API-level tests already covered above.
+
+---
+
+### Task 9: Add Workstream detail drawer/page
+
+**Objective:** Clicking a workstream should show a readable timeline and artifacts.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/dist/index.js`
+
+**UI content:**
+
+- Header: title, repo, source link, lane kind, current stage.
+- Progress stepper with lifecycle stages.
+- Timeline of events:
+  - queued
+  - agent started
+  - context gathered
+  - files changed
+  - tests run
+  - self-audit complete
+  - independent review complete
+  - push/comment queued
+  - pushed/commented/completed
+- Artifact tabs:
+  - Summary
+  - Changes
+  - Verification
+  - Self-audit
+  - Independent review
+  - Raw JSON fallback
+
+---
+
+### Task 10: Improve Proposed PR visualisation
+
+**Objective:** Proposed code changes should be inspectable without reading raw JSON or opening GitHub first.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/dist/index.js`
+- Optional backend support: `plugins/visibility_os/core/executors/hermes.py`
+
+**UI content for `proposed_pr` artifact:**
+
+- Branch name and commit message.
+- PR title/body preview.
+- Changed file list grouped by type:
+  - code
+  - tests
+  - docs
+  - config/CI
+- Per-file summaries from agent output where available.
+- Verification commands with pass/fail badge.
+- Self-audit summary:
+  - status
+  - issues found
+  - fixes applied
+- Independent review summary:
+  - status
+  - blockers
+  - non-blocking findings
+- Clear call to action:
+  - **Push branch** if safe and queued
+  - **Reject/discard** if not wanted
+  - **Retry with note** as a later enhancement
+
+---
+
+### Task 11: Add human-friendly diff artifact
+
+**Objective:** Show meaningful code change previews even before a PR exists on GitHub.
+
+**Files:**
+- Modify: `plugins/visibility_os/core/executors/hermes.py`
+- Modify: `plugins/visibility_os/dashboard/dist/index.js`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Backend approach:**
+
+- After the agent prepares the branch, run a local git diff summary for the branch vs base.
+- Store a safe summarized artifact:
+  - file path
+  - change type
+  - additions/deletions if available
+  - first N changed hunks, capped to avoid huge payloads
+- Do not store secrets or huge diffs blindly. Cap by file and total payload size.
+
+**UI approach:**
+
+- File tree on left or stacked file cards.
+- Each file card shows:
+  - path
+  - additions/deletions
+  - agent explanation
+  - expandable diff hunk preview
+- Link to local branch metadata and GitHub PR once pushed.
+
+**Test:** Mock diff collection and assert artifact is capped and attached to the workstream.
+
+---
+
+### Task 12: Upgrade PR audit/review visualisation
+
+**Objective:** Reviews should be actionable and skimmable.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/dist/index.js`
+- Possibly modify: `plugins/visibility_os/core/pr_audit.py`
+- Test: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**UI content:**
+
+- Summary counts: blockers, warnings, suggestions.
+- Group findings by file.
+- Each finding card:
+  - severity
+  - file and line
+  - short casual explanation
+  - technical detail expandable
+  - suggested fix
+  - copyable GitHub comment
+  - mark checked / needs follow-up local UI status
+- Separate deterministic findings from agentic findings.
+- Show final recommended decision:
+  - approve
+  - request changes
+  - comment only
+  - no action
+
+**Test:** Ensure review artifact payload supports severity counts and grouped findings.
+
+---
+
+## History and filters tasks
+
+### Task 13: Add filters and tabs
+
+**Objective:** Barney can quickly answer what agents are doing or have done.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/dist/index.js`
+
+**Filters:**
+
+- Status: active, waiting on me, completed, failed, unstarted.
+- Lane: Fix Docs, Fix Bug, Deflake, Fix CI, Fix PR CI, Review PR, Handoff.
+- Repo.
+- Time: today, 7 days, all.
+- Outcome: PR opened, review posted, failed, rejected.
+
+---
+
+### Task 14: Add opportunity history trail
+
+**Objective:** Each opportunity card should show if the agent has previously worked on it.
+
+**Files:**
+- Modify: `plugins/visibility_os/dashboard/dist/index.js`
+- Backend covered by Task 7.
+
+**UI content:**
+
+- `Not started`
+- `Agent working: independent review`
+- `Waiting for you: Push branch`
+- `Worked on: PR #10 opened`
+- `Failed: independent review found blocker`
+
+---
+
+## Verification tasks
+
+### Task 15: Add regression tests for workstream tracking
+
+**Objective:** Prevent future regressions where agent work becomes invisible again.
+
+**Files:**
+- Modify: `tests/plugins/visibility_os/test_visibility_os_core.py`
+
+**Test cases:**
+
+- Starting a fix lane creates a workstream.
+- Duplicate clicks do not create duplicate active workstreams for the same opportunity/lane.
+- Hermes executor records stage transitions.
+- Successful fix lane attaches proposed PR, diff summary, self-audit, and independent review artifacts.
+- Failed independent review leaves workstream failed and no push action queued.
+- Pushing branch attaches GitHub result and marks workstream completed/pushed.
+- Review PR lane attaches review findings and queues comment action.
+- Feed returns workstream rollups.
+
+---
+
+### Task 16: Manual lab verification
+
+**Objective:** Prove the UX with the existing `visibility-os-flow-lab` repo.
+
+**Manual checks:**
+
+- Start Fix Docs and see workstream move from queued to ready for push.
+- Start Fix PR CI and see self-audit plus independent review in the workstream detail.
+- Push branch and see PR URL attached to the same workstream.
+- Run Review PR and see findings grouped by file with copyable comments.
+- Confirm the LAN dashboard view shows the same information Barney uses, not just localhost.
+
+---
+
+## MVP cut
+
+If implementing in phases, ship in this order:
+
+1. Workstream tables/module/API.
+2. Coarse stage events from lane executor.
+3. Dashboard sections: Needs decision, Agent working now, Open opportunities, Completed recently.
+4. Proposed PR artifact view.
+5. PR review artifact view.
+6. Local diff preview.
+7. Filters and history polish.
+
+This gives immediate visibility first, then richer code/review visualisation.

--- a/plugins/visibility_os/.env.example
+++ b/plugins/visibility_os/.env.example
@@ -1,0 +1,24 @@
+# Visibility OS configuration
+# Copy these values into your Hermes profile .env file, usually ~/.hermes/.env.
+
+# Human-readable organisation/company name used in agent prompts and UI copy.
+VISIBILITY_OS_COMPANY_NAME="Acme Robotics"
+
+# Comma-separated GitHub org owners Visibility OS is allowed to inspect or modify.
+# Safety gate: Fix CI and GitHub executors reject repos outside these orgs.
+VISIBILITY_OS_GITHUB_ORGS="acme-inc,acme-labs"
+
+# Comma-separated repositories to scan when using Scan GitHub Repos.
+# If omitted, Visibility OS can fall back to repos stored in connector_state.
+VISIBILITY_OS_GITHUB_REPOS="acme-inc/api,acme-inc/web,acme-labs/infrastructure"
+
+# Default Slack channel for drafted team updates. Use a channel name or ID.
+VISIBILITY_OS_DEFAULT_SLACK_CHANNEL="#team-updates"
+
+# Required only when executing Slack post actions. Leave blank if you do not use Slack actions.
+SLACK_BOT_TOKEN=replace_with_your_slack_bot_token
+
+# GitHub access is provided by gh CLI auth.
+# Run: gh auth login
+# Recommended scopes for private repos/actions/issues/PRs:
+# gh auth refresh -h github.com -s repo -s read:org -s workflow

--- a/plugins/visibility_os/README.md
+++ b/plugins/visibility_os/README.md
@@ -1,0 +1,50 @@
+# Visibility OS
+
+Visibility OS is a Hermes dashboard plugin for engineering-lead visibility:
+
+- scans configured GitHub repositories for actionable issues, PRs, and failing CI
+- correlates CI failures with PR state before proposing work
+- drafts Slack or GitHub updates behind a human approval queue
+- runs a one-click **Fix CI** lane that prepares a local branch, self-audits, launches an independent fresh-session review, then queues a separate **Push branch** decision
+- runs the same one-click **Fix Issue** lane for GitHub issues
+
+## Configuration
+
+Copy `plugins/visibility_os/.env.example` into your Hermes profile `.env` file, usually:
+
+```bash
+cp plugins/visibility_os/.env.example ~/.hermes/.env
+```
+
+Then edit these values for your organisation:
+
+- `VISIBILITY_OS_COMPANY_NAME`: label used in agent prompts, for example `Acme Robotics`
+- `VISIBILITY_OS_GITHUB_ORGS`: comma-separated GitHub org owners that Visibility OS may inspect or modify
+- `VISIBILITY_OS_GITHUB_REPOS`: comma-separated `owner/repo` list scanned by **Scan GitHub Repos**
+- `VISIBILITY_OS_DEFAULT_SLACK_CHANNEL`: default Slack destination for drafted updates
+- `SLACK_BOT_TOKEN`: required only when executing Slack message actions
+
+GitHub access uses the local `gh` CLI session:
+
+```bash
+gh auth login
+gh auth refresh -h github.com -s repo -s read:org -s workflow
+```
+
+## Safety model
+
+Visibility OS is intentionally scoped by environment configuration:
+
+- GitHub actions and Fix CI lanes reject repositories outside `VISIBILITY_OS_GITHUB_ORGS`.
+- If `VISIBILITY_OS_GITHUB_REPOS` is set, scans and actions are restricted to that explicit repo list.
+- The Fix CI and Fix Issue lanes prepare local branches only. They do not push, open PRs, merge, or deploy.
+- A separate fresh Hermes session reviews the prepared branch before any push action is queued.
+- Pushing the branch and creating the PR remains a separate explicit human action.
+
+## Running locally
+
+```bash
+hermes dashboard --host 0.0.0.0 --port 9119 --no-open --skip-build --insecure
+```
+
+Then open the Hermes dashboard and choose **Visibility OS**.

--- a/plugins/visibility_os/__init__.py
+++ b/plugins/visibility_os/__init__.py
@@ -1,0 +1,1 @@
+"""Hermes Visibility OS plugin."""

--- a/plugins/visibility_os/core/__init__.py
+++ b/plugins/visibility_os/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core services for Hermes Visibility OS."""

--- a/plugins/visibility_os/core/actions.py
+++ b/plugins/visibility_os/core/actions.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from . import db
+from .audit import record_event
+from .policies import HARD_BLOCKED_ACTIONS, ActionPolicyError, VALID_STATUSES, validate_transition
+
+
+def _json(v: Any) -> str:
+    return json.dumps(v, sort_keys=True)
+
+
+def _decode(v: str | None, default: Any = None) -> Any:
+    if v is None:
+        return default
+    try:
+        return json.loads(v)
+    except Exception:
+        return default
+
+
+def _row_to_action(row) -> dict[str, Any]:
+    d = dict(row)
+    d["approval_required"] = bool(d.get("approval_required"))
+    d["proposed_payload"] = _decode(d.get("proposed_payload"), {})
+    d["final_payload"] = _decode(d.get("final_payload"), None)
+    d["evidence_links"] = _decode(d.get("evidence_links"), [])
+    d["execution_result"] = _decode(d.get("execution_result"), None)
+    return d
+
+
+def create_action(*, proposed_by_agent: str, action_type: str, target_system: str, target_location: str, title: str, summary: str, proposed_payload: dict[str, Any], evidence_links: list[dict[str, Any]] | None = None, risk_level: str = "low", opportunity_id: str | None = None, impact_score: int | None = None, visibility_score: int | None = None, effort_score: int | None = None, approval_reason: str | None = None, status: str = "queued") -> dict[str, Any]:
+    if status not in VALID_STATUSES:
+        raise ActionPolicyError(f"Unknown initial action status {status!r}")
+    if status not in {"drafted", "queued", "needs_review"}:
+        raise ActionPolicyError("Actions cannot be created directly in approved/executed terminal states; use the approval state machine")
+    db.init_db()
+    action_id = f"act_{uuid.uuid4().hex}"
+    evidence_links = evidence_links or []
+    approval_reason = approval_reason or "External or reputation-sensitive write action"
+    with db.connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO action_queue(id, opportunity_id, proposed_by_agent, action_type, target_system, target_location, title, summary, proposed_payload, evidence_links, risk_level, impact_score, visibility_score, effort_score, approval_required, approval_reason, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+            """,
+            (action_id, opportunity_id, proposed_by_agent, action_type, target_system, target_location, title, summary, _json(proposed_payload), _json(evidence_links), risk_level, impact_score, visibility_score, effort_score, approval_reason, status),
+        )
+    action = get_action(action_id)
+    record_event(action_id=action_id, event_type="created", actor=proposed_by_agent, after_state=action)
+    return action
+
+
+def get_action(action_id: str) -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        row = conn.execute("SELECT * FROM action_queue WHERE id = ?", (action_id,)).fetchone()
+    if not row:
+        raise KeyError(f"Action not found: {action_id}")
+    return _row_to_action(row)
+
+
+def list_actions(status: str | None = None) -> list[dict[str, Any]]:
+    db.init_db()
+    with db.connect() as conn:
+        if status:
+            rows = conn.execute("SELECT * FROM action_queue WHERE status = ? ORDER BY created_at DESC", (status,)).fetchall()
+        else:
+            rows = conn.execute("SELECT * FROM action_queue ORDER BY created_at DESC").fetchall()
+    return [_row_to_action(r) for r in rows]
+
+
+def transition_action(action_id: str, to_status: str, *, actor: str, event_type: str | None = None, updates: dict[str, Any] | None = None) -> dict[str, Any]:
+    before = get_action(action_id)
+    validate_transition(before["status"], to_status)
+    updates = dict(updates or {})
+    updates["status"] = to_status
+    assignments = []
+    values = []
+    for key, value in updates.items():
+        assignments.append(f"{key} = ?")
+        if key in {"final_payload", "execution_result"}:
+            values.append(_json(value))
+        else:
+            values.append(value)
+    values.append(action_id)
+    with db.connect() as conn:
+        conn.execute(f"UPDATE action_queue SET {', '.join(assignments)} WHERE id = ?", tuple(values))
+    after = get_action(action_id)
+    record_event(action_id=action_id, event_type=event_type or to_status, actor=actor, before_state=before, after_state=after)
+    return after
+
+
+def approve_action(action_id: str, *, actor: str = "human") -> dict[str, Any]:
+    return transition_action(action_id, "approved", actor=actor, event_type="approved", updates={"approved_by": actor, "approved_at": _now_sql()})
+
+
+def edit_action(action_id: str, *, final_payload: dict[str, Any], actor: str = "human") -> dict[str, Any]:
+    return transition_action(action_id, "edited_by_human", actor=actor, event_type="edited_by_human", updates={"final_payload": final_payload})
+
+
+def reject_action(action_id: str, *, reason: str, actor: str = "human") -> dict[str, Any]:
+    return transition_action(action_id, "rejected", actor=actor, event_type="rejected", updates={"execution_result": {"reason": reason}})
+
+
+def mark_executed(action_id: str, *, actor: str, execution_result: dict[str, Any]) -> dict[str, Any]:
+    return transition_action(action_id, "executed", actor=actor, event_type="executed", updates={"executed_at": _now_sql(), "execution_result": execution_result})
+
+
+def mark_failed(action_id: str, *, actor: str, error: str) -> dict[str, Any]:
+    return transition_action(action_id, "failed", actor=actor, event_type="failed", updates={"execution_result": {"error": error}})
+
+
+def save_for_later(action_id: str, *, actor: str = "human") -> dict[str, Any]:
+    before = get_action(action_id)
+    record_event(action_id=action_id, event_type="saved_for_later", actor=actor, before_state=before, after_state=before)
+    return before
+
+
+def execute_action_guard(action_id: str) -> dict[str, Any]:
+    action = get_action(action_id)
+    if action["status"] != "approved":
+        record_event(action_id=action_id, event_type="execution_blocked", actor="system", before_state=action, after_state={"reason": "not approved"})
+        raise ActionPolicyError("Action must be approved before execution")
+    if action["action_type"] in HARD_BLOCKED_ACTIONS:
+        record_event(action_id=action_id, event_type="execution_blocked", actor="system", before_state=action, after_state={"reason": "hard blocked"})
+        raise ActionPolicyError(f"Action type {action['action_type']} is hard-blocked and must be done manually")
+    return action
+
+
+def list_audit_log(action_id: str | None = None) -> list[dict[str, Any]]:
+    db.init_db()
+    with db.connect() as conn:
+        if action_id:
+            rows = conn.execute("SELECT * FROM audit_log WHERE action_id = ? ORDER BY rowid", (action_id,)).fetchall()
+        else:
+            rows = conn.execute("SELECT * FROM audit_log ORDER BY rowid DESC").fetchall()
+    out = []
+    for row in rows:
+        d = dict(row)
+        d["before_state"] = _decode(d.get("before_state"), None)
+        d["after_state"] = _decode(d.get("after_state"), None)
+        out.append(d)
+    return out
+
+
+def _now_sql() -> str:
+    # Keep timestamps SQLite-compatible and deterministic enough for tests.
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/plugins/visibility_os/core/audit.py
+++ b/plugins/visibility_os/core/audit.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from . import db
+
+
+def record_event(*, action_id: str | None, event_type: str, actor: str, before_state: dict[str, Any] | None = None, after_state: dict[str, Any] | None = None) -> str:
+    db.init_db()
+    event_id = f"audit_{uuid.uuid4().hex}"
+    with db.connect() as conn:
+        conn.execute(
+            "INSERT INTO audit_log(id, action_id, event_type, actor, before_state, after_state) VALUES (?, ?, ?, ?, ?, ?)",
+            (event_id, action_id, event_type, actor, json.dumps(before_state, sort_keys=True) if before_state is not None else None, json.dumps(after_state, sort_keys=True) if after_state is not None else None),
+        )
+    return event_id

--- a/plugins/visibility_os/core/board.py
+++ b/plugins/visibility_os/core/board.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import db
+
+VALID_BOARD_STATES = {"todo", "in_progress", "in_review", "done", "archived"}
+
+
+def set_board_state(*, item_kind: str, item_id: str, board_state: str, actor: str = "human") -> dict[str, Any]:
+    if item_kind not in {"opportunity", "action"}:
+        raise ValueError(f"Unsupported board item kind {item_kind!r}")
+    if board_state not in VALID_BOARD_STATES:
+        raise ValueError(f"Unsupported board state {board_state!r}")
+    db.init_db()
+    with db.connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO board_item_states(item_kind, item_id, board_state, actor, updated_at)
+            VALUES (?, ?, ?, ?, datetime('now'))
+            ON CONFLICT(item_kind, item_id) DO UPDATE SET
+              board_state=excluded.board_state,
+              actor=excluded.actor,
+              updated_at=datetime('now')
+            """,
+            (item_kind, item_id, board_state, actor),
+        )
+        row = conn.execute(
+            "SELECT item_kind, item_id, board_state, actor, updated_at FROM board_item_states WHERE item_kind = ? AND item_id = ?",
+            (item_kind, item_id),
+        ).fetchone()
+    return dict(row)
+
+
+def get_board_states() -> dict[tuple[str, str], dict[str, Any]]:
+    db.init_db()
+    with db.connect() as conn:
+        rows = conn.execute("SELECT item_kind, item_id, board_state, actor, updated_at FROM board_item_states").fetchall()
+    return {(row["item_kind"], row["item_id"]): dict(row) for row in rows}

--- a/plugins/visibility_os/core/communications.py
+++ b/plugins/visibility_os/core/communications.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .actions import create_action
+from .language_guard import validate_message
+
+
+def draft_progress_update(*, problem: str, diagnosis: str, action_underway: str, next_step: str, target_location: str, evidence_links: list[dict[str, Any]], target_system: str = "slack") -> dict[str, Any]:
+    text = (
+        f"Problem: {problem}\n"
+        f"Diagnosis: {diagnosis}\n"
+        f"Action underway: {action_underway}\n"
+        f"Next step: {next_step}"
+    )
+    validate_message(text, status="queued", evidence_links=evidence_links, team_visible=True)
+    return create_action(
+        proposed_by_agent="communications_agent",
+        action_type="slack_message" if target_system == "slack" else "github_issue_comment",
+        target_system=target_system,
+        target_location=target_location,
+        title=f"Progress update: {problem[:80]}",
+        summary="Draft factual progress update with evidence links.",
+        proposed_payload={"text" if target_system == "slack" else "body": text},
+        evidence_links=evidence_links,
+        risk_level="medium" if target_system == "slack" else "low",
+        impact_score=3,
+        visibility_score=4,
+        effort_score=5,
+    )
+
+
+def draft_completion_update(*, problem: str, fix: str, evidence: str, impact: str, follow_up: str, target_location: str, evidence_links: list[dict[str, Any]], target_system: str = "slack") -> dict[str, Any]:
+    text = f"Problem: {problem}\nFix: {fix}\nEvidence: {evidence}\nImpact: {impact}\nFollow-up: {follow_up}"
+    validate_message(text, status="executed", evidence_links=evidence_links, team_visible=True)
+    return create_action(
+        proposed_by_agent="communications_agent",
+        action_type="slack_message" if target_system == "slack" else "github_issue_comment",
+        target_system=target_system,
+        target_location=target_location,
+        title=f"Completion update: {problem[:80]}",
+        summary="Draft completion update with evidence links.",
+        proposed_payload={"text" if target_system == "slack" else "body": text},
+        evidence_links=evidence_links,
+        risk_level="medium",
+        impact_score=4,
+        visibility_score=5,
+        effort_score=5,
+    )
+
+
+def draft_weekly_update(*, text: str, target_location: str, evidence_links: list[dict[str, Any]]) -> dict[str, Any]:
+    validate_message(text, status="queued", evidence_links=evidence_links, team_visible=True)
+    return create_action(
+        proposed_by_agent="communications_agent",
+        action_type="weekly_update_draft",
+        target_system="slack",
+        target_location=target_location,
+        title="Draft weekly engineering impact summary",
+        summary="Weekly summary based on evidence-backed actions.",
+        proposed_payload={"text": text},
+        evidence_links=evidence_links,
+        risk_level="medium",
+        impact_score=3,
+        visibility_score=5,
+        effort_score=5,
+    )

--- a/plugins/visibility_os/core/config.py
+++ b/plugins/visibility_os/core/config.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+
+_ENV_CACHE: dict[str, str] | None = None
+
+
+def _parse_env_file(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        return values
+    for raw in path.read_text(errors="ignore").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def env_value(name: str, default: str = "") -> str:
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    global _ENV_CACHE
+    if _ENV_CACHE is None:
+        _ENV_CACHE = _parse_env_file(Path(get_hermes_home()) / ".env")
+    return _ENV_CACHE.get(name, default)
+
+
+def _csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+@dataclass(frozen=True)
+class VisibilityConfig:
+    company_name: str
+    github_orgs: set[str]
+    github_repos: list[str]
+    default_slack_channel: str
+
+    def github_repo_allowed(self, repo: str | None) -> bool:
+        if not repo or "/" not in repo:
+            return False
+        owner = repo.split("/", 1)[0]
+        if self.github_repos and repo not in self.github_repos:
+            return False
+        return owner in self.github_orgs
+
+    @property
+    def github_scope_label(self) -> str:
+        if self.github_orgs:
+            return ", ".join(sorted(self.github_orgs))
+        return "configured GitHub organisations"
+
+
+def get_visibility_config() -> VisibilityConfig:
+    orgs = set(_csv(env_value("VISIBILITY_OS_GITHUB_ORGS") or env_value("VISIBILITY_OS_GITHUB_ORG_ALLOWLIST")))
+    return VisibilityConfig(
+        company_name=env_value("VISIBILITY_OS_COMPANY_NAME", "your organisation") or "your organisation",
+        github_orgs=orgs,
+        github_repos=_csv(env_value("VISIBILITY_OS_GITHUB_REPOS")),
+        default_slack_channel=env_value("VISIBILITY_OS_DEFAULT_SLACK_CHANNEL", ""),
+    )

--- a/plugins/visibility_os/core/connectors/__init__.py
+++ b/plugins/visibility_os/core/connectors/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only connectors for Visibility OS scanners."""

--- a/plugins/visibility_os/core/connectors/github.py
+++ b/plugins/visibility_os/core/connectors/github.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class GitHubConnector:
+    repo: str | None = None
+    timeout: int = 30
+
+    def _run_json(self, args: list[str]) -> list[dict[str, Any]]:
+        if self.repo and "--repo" not in args:
+            args = [*args, "--repo", self.repo]
+        res = subprocess.run(args, capture_output=True, text=True, timeout=self.timeout, check=False)
+        if res.returncode != 0:
+            raise RuntimeError(f"gh command failed: {' '.join(args)}\n{res.stderr}")
+        data = json.loads(res.stdout or "[]")
+        return data if isinstance(data, list) else [data]
+
+    def issues(self) -> list[dict[str, Any]]:
+        return self._run_json(["gh", "issue", "list", "--json", "number,title,url,labels,updatedAt,assignees"])
+
+    def prs(self) -> list[dict[str, Any]]:
+        try:
+            return self._run_json(["gh", "pr", "list", "--json", "number,title,url,updatedAt,reviewDecision,isDraft,author,statusCheckRollup"])
+        except RuntimeError as exc:
+            # Some fine-grained tokens can list PRs but cannot read nested
+            # status-check rollups. Fall back to the useful metadata rather
+            # than losing every open-PR opportunity for that repo.
+            if "statusCheckRollup" not in str(exc):
+                raise
+            return self._run_json(["gh", "pr", "list", "--json", "number,title,url,updatedAt,reviewDecision,isDraft,author"])
+
+    def runs(self) -> list[dict[str, Any]]:
+        return self._run_json(["gh", "run", "list", "--json", "databaseId,status,conclusion,displayTitle,workflowName,url,createdAt,headBranch,headSha,event"])
+
+    def prs_for_branch(self, branch: str) -> list[dict[str, Any]]:
+        return self._run_json([
+            "gh", "pr", "list",
+            "--head", branch,
+            "--state", "all",
+            "--json", "number,title,state,url,headRefName,headRefOid,baseRefName,mergedAt,statusCheckRollup",
+        ])

--- a/plugins/visibility_os/core/db.py
+++ b/plugins/visibility_os/core/db.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from hermes_constants import get_hermes_home
+
+DB_FILENAME = "visibility_os.db"
+SCHEMA_VERSION = 2
+
+
+def get_db_path() -> Path:
+    return Path(get_hermes_home()) / DB_FILENAME
+
+
+@contextmanager
+def connect() -> Iterator[sqlite3.Connection]:
+    path = get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    with connect() as conn:
+        conn.executescript("""
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS opportunities (
+            id TEXT PRIMARY KEY,
+            source_system TEXT NOT NULL,
+            source_url TEXT,
+            title TEXT NOT NULL,
+            description TEXT NOT NULL,
+            category TEXT,
+            impact_score INTEGER NOT NULL,
+            visibility_score INTEGER NOT NULL,
+            effort_score INTEGER NOT NULL,
+            safety_score INTEGER NOT NULL,
+            risk_penalty INTEGER NOT NULL DEFAULT 0,
+            priority_score INTEGER NOT NULL,
+            status TEXT NOT NULL DEFAULT 'open',
+            suggested_artifacts TEXT NOT NULL DEFAULT '[]',
+            metadata TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_visibility_opportunity_source
+            ON opportunities(source_system, source_url, category);
+
+        CREATE TABLE IF NOT EXISTS action_queue (
+            id TEXT PRIMARY KEY,
+            opportunity_id TEXT REFERENCES opportunities(id),
+            proposed_by_agent TEXT NOT NULL,
+            action_type TEXT NOT NULL,
+            target_system TEXT NOT NULL,
+            target_location TEXT NOT NULL,
+            title TEXT NOT NULL,
+            summary TEXT NOT NULL,
+            proposed_payload TEXT NOT NULL,
+            final_payload TEXT,
+            evidence_links TEXT NOT NULL DEFAULT '[]',
+            risk_level TEXT NOT NULL,
+            impact_score INTEGER,
+            visibility_score INTEGER,
+            effort_score INTEGER,
+            approval_required INTEGER NOT NULL DEFAULT 1,
+            approval_reason TEXT,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            approved_at TEXT,
+            executed_at TEXT,
+            approved_by TEXT,
+            execution_result TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_visibility_action_status ON action_queue(status);
+
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id TEXT PRIMARY KEY,
+            action_id TEXT REFERENCES action_queue(id),
+            event_type TEXT NOT NULL,
+            actor TEXT NOT NULL,
+            before_state TEXT,
+            after_state TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_visibility_audit_action ON audit_log(action_id);
+
+        CREATE TABLE IF NOT EXISTS daily_summaries (
+            id TEXT PRIMARY KEY,
+            date TEXT NOT NULL,
+            summary_payload TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS weekly_summaries (
+            id TEXT PRIMARY KEY,
+            week_start TEXT NOT NULL,
+            week_end TEXT NOT NULL,
+            summary_payload TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS scan_runs (
+            id TEXT PRIMARY KEY,
+            scanner_name TEXT NOT NULL,
+            status TEXT NOT NULL,
+            started_at TEXT NOT NULL DEFAULT (datetime('now')),
+            finished_at TEXT,
+            result_payload TEXT NOT NULL DEFAULT '{}'
+        );
+
+        CREATE TABLE IF NOT EXISTS connector_state (
+            connector_name TEXT PRIMARY KEY,
+            state_payload TEXT NOT NULL DEFAULT '{}',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE IF NOT EXISTS workstreams (
+            id TEXT PRIMARY KEY,
+            opportunity_id TEXT REFERENCES opportunities(id),
+            root_action_id TEXT REFERENCES action_queue(id),
+            lane_kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            repo TEXT,
+            source_url TEXT,
+            stage TEXT NOT NULL,
+            status TEXT NOT NULL,
+            started_at TEXT,
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            completed_at TEXT,
+            agent_session_id TEXT,
+            summary TEXT NOT NULL DEFAULT '',
+            current_step TEXT NOT NULL DEFAULT '',
+            progress_percent INTEGER NOT NULL DEFAULT 0,
+            result_payload TEXT NOT NULL DEFAULT '{}'
+        );
+        CREATE INDEX IF NOT EXISTS idx_visibility_workstreams_status ON workstreams(status);
+        CREATE INDEX IF NOT EXISTS idx_visibility_workstreams_opportunity ON workstreams(opportunity_id);
+        CREATE INDEX IF NOT EXISTS idx_visibility_workstreams_root_action ON workstreams(root_action_id);
+
+        CREATE TABLE IF NOT EXISTS workstream_events (
+            id TEXT PRIMARY KEY,
+            workstream_id TEXT NOT NULL REFERENCES workstreams(id),
+            event_type TEXT NOT NULL,
+            stage TEXT,
+            actor TEXT NOT NULL,
+            message TEXT NOT NULL,
+            payload TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_visibility_workstream_events_ws ON workstream_events(workstream_id, created_at);
+
+        CREATE TABLE IF NOT EXISTS workstream_artifacts (
+            id TEXT PRIMARY KEY,
+            workstream_id TEXT NOT NULL REFERENCES workstreams(id),
+            artifact_type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            summary TEXT NOT NULL DEFAULT '',
+            payload TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE INDEX IF NOT EXISTS idx_visibility_workstream_artifacts_ws ON workstream_artifacts(workstream_id, artifact_type);
+
+        CREATE TABLE IF NOT EXISTS board_item_states (
+            item_kind TEXT NOT NULL,
+            item_id TEXT NOT NULL,
+            board_state TEXT NOT NULL,
+            actor TEXT NOT NULL DEFAULT 'human',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY(item_kind, item_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_visibility_board_state ON board_item_states(board_state);
+        """)
+        conn.execute("INSERT OR IGNORE INTO schema_migrations(version) VALUES (?)", (SCHEMA_VERSION,))

--- a/plugins/visibility_os/core/evidence.py
+++ b/plugins/visibility_os/core/evidence.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+class EvidenceError(ValueError):
+    """Raised when evidence is insufficient for a claim."""
+
+@dataclass
+class EvidencePackage:
+    problem_statement: str
+    affected_users_or_systems: str | None = None
+    root_cause: str | None = None
+    fix_summary: str | None = None
+    before_after_behaviour: str | None = None
+    tests_run: str | None = None
+    logs_or_screenshots: list[str] = field(default_factory=list)
+    risk_assessment: str | None = None
+    follow_up_tasks: list[str] = field(default_factory=list)
+    evidence_links: list[dict[str, Any]] = field(default_factory=list)
+    actual_status: str = "drafted"
+
+    def validate_for_completion(self) -> bool:
+        if self.actual_status not in {"executed", "merged", "shipped", "completed"}:
+            raise EvidenceError("Completion update requires executed/merged/shipped status")
+        if not self.evidence_links:
+            raise EvidenceError("Completion update requires PR/issue/evidence link")
+        if not self.tests_run:
+            raise EvidenceError("Completion update requires tests run or explanation")
+        return True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "problem_statement": self.problem_statement,
+            "affected_users_or_systems": self.affected_users_or_systems,
+            "root_cause": self.root_cause,
+            "fix_summary": self.fix_summary,
+            "before_after_behaviour": self.before_after_behaviour,
+            "tests_run": self.tests_run,
+            "logs_or_screenshots": self.logs_or_screenshots,
+            "risk_assessment": self.risk_assessment,
+            "follow_up_tasks": self.follow_up_tasks,
+            "evidence_links": self.evidence_links,
+            "actual_status": self.actual_status,
+        }

--- a/plugins/visibility_os/core/executors/__init__.py
+++ b/plugins/visibility_os/core/executors/__init__.py
@@ -1,0 +1,3 @@
+from .base import execute_approved_action
+
+__all__ = ["execute_approved_action"]

--- a/plugins/visibility_os/core/executors/base.py
+++ b/plugins/visibility_os/core/executors/base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..actions import execute_action_guard, mark_executed, mark_failed
+from ..audit import record_event
+from ..language_guard import validate_message
+from .github import execute_github_action
+from .hermes import execute_hermes_action
+from .slack import execute_slack_action
+
+
+def execute_approved_action(action_id: str, *, actor: str = "human") -> dict[str, Any]:
+    action = execute_action_guard(action_id)
+    record_event(action_id=action_id, event_type="execution_attempt_started", actor=actor, before_state=action, after_state={"target_system": action["target_system"], "action_type": action["action_type"]})
+    try:
+        payload = action.get("final_payload") or action.get("proposed_payload") or {}
+        text = payload.get("text") or payload.get("body") or ""
+        if text:
+            validate_message(text, status=action["status"], evidence_links=action.get("evidence_links") or [], team_visible=action["target_system"] in {"slack", "github"})
+        if action["target_system"] == "github":
+            result = execute_github_action(action, payload)
+        elif action["target_system"] == "slack":
+            result = execute_slack_action(action, payload)
+        elif action["target_system"] == "hermes":
+            result = execute_hermes_action(action, payload)
+        else:
+            raise RuntimeError(f"No executor for target system {action['target_system']}")
+        return mark_executed(action_id, actor=actor, execution_result=result)
+    except Exception as exc:
+        mark_failed(action_id, actor="system", error=str(exc))
+        raise

--- a/plugins/visibility_os/core/executors/github.py
+++ b/plugins/visibility_os/core/executors/github.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from plugins.visibility_os.core.config import get_visibility_config
+from plugins.visibility_os.core.workstreams import add_workstream_artifact, update_stage
+
+
+def _ensure_allowed_repo(repo: str | None) -> None:
+    cfg = get_visibility_config()
+    if not cfg.github_repo_allowed(repo):
+        raise RuntimeError(f"Visibility OS GitHub actions are restricted to configured repositories: {cfg.github_scope_label}")
+
+
+def _parse_github_target(target: str, kind: str) -> tuple[str, str | None]:
+    """Return (number, repo) from either org/repo/issues/123 or GitHub URL."""
+    target = target.rstrip("/")
+    parts = target.split("/")
+    number = parts[-1]
+    repo = None
+    if target.startswith("https://github.com/") and len(parts) >= 7:
+        repo = f"{parts[3]}/{parts[4]}"
+    elif len(parts) >= 4 and parts[-2] in {"issues", "pull"}:
+        repo = f"{parts[0]}/{parts[1]}"
+    if not number.isdigit():
+        raise RuntimeError(f"Could not parse GitHub {kind} number from target_location={target!r}")
+    return number, repo
+
+
+def _execute_push_branch(payload: dict[str, Any]) -> dict[str, Any]:
+    repo = payload.get("repo")
+    _ensure_allowed_repo(repo)
+    branch = payload.get("branch")
+    if not branch:
+        raise RuntimeError("github_push_branch requires branch")
+    workdir = payload.get("workdir")
+    if not workdir:
+        raise RuntimeError("github_push_branch requires workdir containing the prepared local branch")
+    if not Path(workdir).exists():
+        raise RuntimeError(f"Prepared branch workdir does not exist: {workdir}")
+    push = subprocess.run(["git", "push", "-u", "origin", str(branch)], capture_output=True, text=True, timeout=300, check=False, cwd=workdir)
+    if push.returncode != 0:
+        raise RuntimeError(push.stderr or push.stdout or "git push failed")
+    pr = subprocess.run([
+        "gh", "pr", "create",
+        "--repo", str(repo),
+        "--head", str(branch),
+        "--base", str(payload.get("base_branch") or "main"),
+        "--title", str(payload.get("pr_title") or payload.get("commit_message") or branch),
+        "--body", str(payload.get("pr_body") or "Prepared by Visibility OS Fix CI lane."),
+    ], capture_output=True, text=True, timeout=120, check=False, cwd=workdir)
+    if pr.returncode != 0:
+        raise RuntimeError(pr.stderr or pr.stdout or "gh pr create failed")
+    result = {
+        "ok": True,
+        "repo": repo,
+        "branch": branch,
+        "pr_url": pr.stdout.strip(),
+        "push_stdout": push.stdout.strip(),
+        "push_stderr": push.stderr.strip(),
+        "command": ["git", "push", "..."],
+    }
+    workstream_id = payload.get("workstream_id")
+    if workstream_id:
+        add_workstream_artifact(
+            workstream_id,
+            artifact_type="github_result",
+            title="GitHub PR opened",
+            summary=f"Pushed {branch} and opened {result['pr_url']}",
+            payload=result,
+        )
+        update_stage(workstream_id, stage="pushed", status="completed", current_step="Branch pushed and PR opened", progress_percent=100, actor="github", payload=result)
+    return result
+
+
+def execute_github_action(action: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    if action["action_type"] == "github_push_branch":
+        return _execute_push_branch(payload)
+    body = payload.get("body") or payload.get("text")
+    if not body:
+        raise RuntimeError("GitHub action requires body/text payload")
+    target = action["target_location"]
+    if action["action_type"] == "github_issue_comment":
+        issue, repo = _parse_github_target(target, "issue")
+        _ensure_allowed_repo(repo)
+        cmd = ["gh", "issue", "comment", issue, "--body", body]
+        if repo:
+            cmd += ["--repo", repo]
+    elif action["action_type"] == "github_pr_comment":
+        pr, repo = _parse_github_target(target, "pull request")
+        _ensure_allowed_repo(repo)
+        cmd = ["gh", "pr", "comment", pr, "--body", body]
+        if repo:
+            cmd += ["--repo", repo]
+    else:
+        raise RuntimeError(f"Unsupported GitHub action type {action['action_type']}")
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=False)
+    if res.returncode != 0:
+        raise RuntimeError(res.stderr or res.stdout or "gh command failed")
+    return {"ok": True, "stdout": res.stdout.strip(), "command": cmd[:4] + ["..."]}

--- a/plugins/visibility_os/core/executors/hermes.py
+++ b/plugins/visibility_os/core/executors/hermes.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from ..actions import create_action
+from ..config import get_visibility_config
+from ..workstreams import add_workstream_artifact, update_stage
+
+
+def _ensure_allowed_repo(repo: str | None) -> None:
+    cfg = get_visibility_config()
+    if not cfg.github_repo_allowed(repo):
+        raise RuntimeError(f"Visibility OS Hermes lanes are restricted to configured repositories: {cfg.github_scope_label}")
+
+
+def _command_with_prompt(command: list[Any], prompt: str, *, source: str = "visibility-os-ci-fix") -> list[str]:
+    if not command:
+        return [
+            "hermes",
+            "chat",
+            "--query",
+            prompt,
+            "--quiet",
+            "--source",
+            source,
+            "--toolsets",
+            "terminal,file",
+        ]
+    return [prompt if str(part) == "__PROMPT__" else str(part) for part in command]
+
+
+def _parse_json_object(text: str, error_message: str) -> dict[str, Any]:
+    text = (text or "").strip()
+    if not text:
+        raise RuntimeError(error_message)
+    candidates: list[dict[str, Any]] = []
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+    except Exception:
+        pass
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"\{", text):
+        try:
+            parsed, _ = decoder.raw_decode(text[match.start():])
+        except Exception:
+            continue
+        if isinstance(parsed, dict):
+            candidates.append(parsed)
+    if not candidates:
+        raise RuntimeError(error_message)
+    return candidates[-1]
+
+
+def _parse_prepared_fix(stdout: str) -> dict[str, Any]:
+    parsed = _parse_json_object(stdout, "Hermes Fix CI lane must return JSON describing the prepared branch")
+    if not isinstance(parsed, dict):
+        raise RuntimeError("Hermes Fix CI lane JSON must be an object")
+    missing = [key for key in ("branch", "commit_message", "pr_title", "pr_body", "self_audit") if not parsed.get(key)]
+    if missing:
+        raise RuntimeError(f"Prepared Fix CI payload missing required field(s): {', '.join(missing)}")
+    self_audit = parsed.get("self_audit")
+    if not isinstance(self_audit, dict) or not self_audit.get("audit_status"):
+        raise RuntimeError("Prepared Fix CI payload requires self_audit.audit_status from the second-pass review")
+    if parsed.get("ready_to_push") is False:
+        raise RuntimeError("Hermes Fix CI lane did not mark the prepared branch ready to push")
+    return parsed
+
+
+def _parse_independent_review(stdout: str) -> dict[str, Any]:
+    parsed = _parse_json_object(stdout, "Independent Fix CI review must return JSON")
+    if not isinstance(parsed, dict) or not parsed.get("review_status"):
+        raise RuntimeError("Independent Fix CI review requires review_status")
+    status = str(parsed.get("review_status")).lower()
+    if status not in {"passed", "approved", "no_blockers"}:
+        raise RuntimeError(f"Independent Fix CI review did not pass: {parsed.get('review_status')}")
+    return parsed
+
+
+def _build_independent_review_prompt(repo: str, prepared: dict[str, Any], *, lane_label: str = "CI fix", issue_number: int | None = None) -> str:
+    context = [f"Repository: {repo}"]
+    if issue_number is not None:
+        context.append(f"Issue: #{issue_number}")
+    return "\n".join([
+        f"You are a fresh session independent reviewer for a prepared {lane_label}.",
+        "You were not involved in the fix. Do not assume the fix is correct.",
+        "Review only the current local repository state, branch, commit/diff, proposed PR text, and verification evidence.",
+        "Do not use or rely on the original fixing prompt or the fixing agent's reasoning.",
+        "Look for regressions, unintended scope creep, security issues, missing tests, brittle logic, and PR description inaccuracies.",
+        "Do not push, merge, deploy, rotate secrets, or touch production infrastructure.",
+        *context,
+        f"Prepared branch: {prepared.get('branch')}",
+        f"Commit: {prepared.get('commit_sha') or 'unknown'}",
+        f"Commit message: {prepared.get('commit_message')}",
+        f"PR title: {prepared.get('pr_title')}",
+        "Changed files: " + json.dumps(prepared.get("changed_files") or []),
+        "Verification evidence: " + json.dumps(prepared.get("verification") or []),
+        "PR body:",
+        str(prepared.get("pr_body") or ""),
+        "Return JSON only with: review_status, findings, fixes_required, notes.",
+        "Use review_status='passed' only if there are no blockers to pushing this prepared branch for PR creation.",
+    ])
+
+
+def _stage(workstream_id: str | None, stage: str, current_step: str, progress: int, *, actor: str = "visibility_os", payload: dict[str, Any] | None = None) -> None:
+    if not workstream_id:
+        return
+    update_stage(workstream_id, stage=stage, current_step=current_step, progress_percent=progress, actor=actor, payload=payload or {})
+
+
+def _artifact(workstream_id: str | None, artifact_type: str, title: str, *, summary: str = "", payload: dict[str, Any] | None = None) -> None:
+    if not workstream_id:
+        return
+    add_workstream_artifact(workstream_id, artifact_type=artifact_type, title=title, summary=summary, payload=payload or {})
+
+
+def execute_hermes_action(action: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    action_type = action["action_type"]
+    lane = payload.get("lane")
+    if action_type == "ci_fix_lane":
+        expected_lane = "fix_ci"
+        source = "visibility-os-ci-review"
+        lane_label = "CI fix"
+        default_workspace = "ci-fix-workspaces"
+        push_title = "Push prepared CI fix branch"
+        if payload.get("should_create_fix_branch") is False:
+            raise RuntimeError("Refusing to execute Fix CI lane because diagnosis marked it non-actionable")
+    elif action_type == "github_issue_fix_lane":
+        expected_lane = "fix_github_issue"
+        source = "visibility-os-issue-review"
+        lane_label = "GitHub issue fix"
+        default_workspace = "issue-fix-workspaces"
+        push_title = "Push prepared issue fix branch"
+    else:
+        raise RuntimeError(f"Unsupported Hermes action type {action_type}")
+    if lane != expected_lane:
+        raise RuntimeError(f"Hermes action payload must declare lane='{expected_lane}'")
+    repo = payload.get("repo")
+    workstream_id = payload.get("workstream_id")
+    _stage(workstream_id, "agent_starting", f"Starting {lane_label} agent", 10, payload={"action_id": action.get("id")})
+    _ensure_allowed_repo(repo)
+    prompt = payload.get("prompt")
+    if not prompt:
+        raise RuntimeError(f"{lane_label} lane requires a prompt")
+    workdir = payload.get("workdir") or str(Path.home() / ".hermes" / "visibility-os" / default_workspace / str(repo).replace("/", "__"))
+    Path(workdir).mkdir(parents=True, exist_ok=True)
+    _stage(workstream_id, "gathering_context", "Prepared repo context and agent prompt", 20, payload={"workdir": workdir, "repo": repo})
+    cmd = _command_with_prompt(payload.get("command") or [], str(prompt), source="visibility-os-issue-fix" if action_type == "github_issue_fix_lane" else "visibility-os-ci-fix")
+    _stage(workstream_id, "editing", f"Agent is preparing a local {lane_label} branch", 35, payload={"command": cmd[:3] + ["..."]})
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=int(payload.get("timeout_seconds") or 3600), check=False, cwd=workdir)
+    if res.returncode != 0:
+        _stage(workstream_id, "failed", res.stderr.strip() or res.stdout.strip() or f"Hermes {lane_label} lane failed", 100, payload={"stdout": res.stdout.strip(), "stderr": res.stderr.strip()})
+        raise RuntimeError(res.stderr.strip() or res.stdout.strip() or f"Hermes {lane_label} lane failed")
+    _stage(workstream_id, "verifying", "Agent returned prepared branch and verification evidence", 55)
+    prepared = _parse_prepared_fix(res.stdout)
+    _stage(workstream_id, "self_auditing", "Self-audit completed inside fixing session", 65, payload={"self_audit": prepared.get("self_audit") or {}})
+    review_prompt = _build_independent_review_prompt(str(repo), prepared, lane_label=lane_label, issue_number=payload.get("issue_number"))
+    review_cmd = _command_with_prompt(payload.get("review_command") or [], review_prompt, source=source)
+    _stage(workstream_id, "independent_reviewing", "Fresh independent review session is checking the prepared branch", 75, payload={"command": review_cmd[:3] + ["..."]})
+    review_res = subprocess.run(review_cmd, capture_output=True, text=True, timeout=int(payload.get("review_timeout_seconds") or 1800), check=False, cwd=workdir)
+    if review_res.returncode != 0:
+        _stage(workstream_id, "failed", review_res.stderr.strip() or review_res.stdout.strip() or f"Independent {lane_label} review failed", 100, payload={"stdout": review_res.stdout.strip(), "stderr": review_res.stderr.strip()})
+        raise RuntimeError(review_res.stderr.strip() or review_res.stdout.strip() or f"Independent {lane_label} review failed")
+    independent_review = _parse_independent_review(review_res.stdout)
+    push_payload = {
+        "repo": repo,
+        "branch": prepared["branch"],
+        "base_branch": (payload.get("pr_context") or {}).get("base_branch") or prepared.get("base_branch") or "main",
+        "workdir": workdir,
+        "commit_sha": prepared.get("commit_sha"),
+        "commit_message": prepared.get("commit_message"),
+        "pr_title": prepared.get("pr_title") or prepared.get("commit_message"),
+        "pr_body": prepared.get("pr_body"),
+        "verification": prepared.get("verification") or [],
+        "changed_files": prepared.get("changed_files") or [],
+        "self_audit": prepared.get("self_audit") or {},
+        "independent_review": independent_review,
+        "source_run_id": payload.get("run_id"),
+        "source_run_url": payload.get("run_url"),
+        "issue_number": payload.get("issue_number"),
+        "issue_url": payload.get("issue_url"),
+        "workstream_id": workstream_id,
+    }
+    _artifact(
+        workstream_id,
+        "proposed_pr",
+        prepared.get("pr_title") or prepared.get("commit_message") or "Proposed PR",
+        summary=f"Prepared branch {prepared.get('branch')} with {len(prepared.get('changed_files') or [])} changed file(s).",
+        payload=push_payload,
+    )
+    _artifact(
+        workstream_id,
+        "diff_summary",
+        "Changed files",
+        summary="Agent-reported changed files for the prepared local branch.",
+        payload={
+            "branch": prepared.get("branch"),
+            "files": [{"path": path} for path in (prepared.get("changed_files") or [])],
+            "changed_files": prepared.get("changed_files") or [],
+        },
+    )
+    push_action = create_action(
+        proposed_by_agent="visibility_os",
+        action_type="github_push_branch",
+        target_system="github",
+        target_location=f"{repo}#{prepared['branch']}",
+        title=f"{push_title}: {prepared['branch']}",
+        summary=f"Review and optionally push local branch {prepared['branch']} and create a PR for {repo}.",
+        proposed_payload=push_payload,
+        evidence_links=action.get("evidence_links") or [],
+        risk_level="high",
+        opportunity_id=action.get("opportunity_id"),
+        impact_score=action.get("impact_score"),
+        visibility_score=action.get("visibility_score"),
+        effort_score=action.get("effort_score"),
+        approval_reason="Pushes a prepared local branch and creates a GitHub PR, so a human approver must explicitly choose Push branch.",
+    )
+    _stage(workstream_id, "ready_for_push", "Prepared PR passed independent review and is waiting for Push branch approval", 90, payload={"push_action_id": push_action["id"]})
+    return {
+        "ok": True,
+        "lane": lane,
+        "mode": "prepared_local_branch_only",
+        "repo": repo,
+        "run_id": payload.get("run_id"),
+        "issue_number": payload.get("issue_number"),
+        "issue_url": payload.get("issue_url"),
+        "prepared_branch": prepared["branch"],
+        "commit_sha": prepared.get("commit_sha"),
+        "commit_message": prepared.get("commit_message"),
+        "pr_title": prepared.get("pr_title"),
+        "pr_body": prepared.get("pr_body"),
+        "verification": prepared.get("verification") or [],
+        "changed_files": prepared.get("changed_files") or [],
+        "self_audit": prepared.get("self_audit") or {},
+        "independent_review": independent_review,
+        "push_action_id": push_action["id"],
+        "stdout": res.stdout.strip(),
+        "stderr": res.stderr.strip(),
+        "command": cmd[:3] + ["..."],
+        "workdir": workdir,
+    }

--- a/plugins/visibility_os/core/executors/slack.py
+++ b/plugins/visibility_os/core/executors/slack.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+def _load_env_token(name: str) -> str | None:
+    token = os.getenv(name)
+    if token:
+        return token
+    env_path = Path(get_hermes_home()) / ".env"
+    if not env_path.exists():
+        return None
+    for line in env_path.read_text(errors="ignore").splitlines():
+        if line.startswith(name + "="):
+            return line.split("=", 1)[1].strip().strip('"').strip("'") or None
+    return None
+
+
+def execute_slack_action(action: dict[str, Any], payload: dict[str, Any]) -> dict[str, Any]:
+    if action.get("action_type") != "slack_message":
+        raise RuntimeError(f"Unsupported Slack action type {action.get('action_type')}")
+    text = payload.get("text") or payload.get("body")
+    if not text:
+        raise RuntimeError("Slack action requires text payload")
+    token = _load_env_token("SLACK_BOT_TOKEN")
+    if not token:
+        raise RuntimeError("SLACK_BOT_TOKEN is not configured")
+    body = json.dumps({"channel": action["target_location"], "text": text}).encode()
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=body,
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read().decode())
+    if not data.get("ok"):
+        raise RuntimeError(data.get("error") or "Slack API error")
+    return {"ok": True, "ts": data.get("ts"), "channel": data.get("channel")}

--- a/plugins/visibility_os/core/impact_picker.py
+++ b/plugins/visibility_os/core/impact_picker.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import date
+from typing import Any
+
+from . import db
+from .opportunities import list_opportunities
+
+
+def generate_daily_plan() -> dict[str, Any]:
+    opportunities = [o for o in list_opportunities(limit=50) if o.get("risk_penalty", 0) < 8]
+    main = opportunities[0] if opportunities else None
+    side = opportunities[1:3]
+    comm = next((o for o in opportunities if o.get("visibility_score", 0) >= 4), main)
+    plan = {
+        "main_task": main,
+        "side_quests": side,
+        "communication_artifact": comm,
+        "rationale": "Selected by priority score while excluding high reputation-risk work.",
+    }
+    db.init_db()
+    with db.connect() as conn:
+        conn.execute("INSERT INTO daily_summaries(id, date, summary_payload) VALUES (?, ?, ?)", (f"daily_{uuid.uuid4().hex}", date.today().isoformat(), json.dumps(plan, sort_keys=True)))
+    return plan

--- a/plugins/visibility_os/core/language_guard.py
+++ b/plugins/visibility_os/core/language_guard.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+class LanguageGuardError(ValueError):
+    """Raised when proposed communication overclaims or lacks evidence."""
+
+BLOCKED_WHEN_NOT_EXECUTED = {"fixed", "shipped", "resolved", "completed", "deployed"}
+
+
+def validate_message(text: str, *, status: str, evidence_links: list[dict[str, Any]] | None = None, team_visible: bool = False) -> bool:
+    evidence_links = evidence_links or []
+    lower = text.lower()
+    if status != "executed":
+        for term in BLOCKED_WHEN_NOT_EXECUTED:
+            if re.search(rf"\b{re.escape(term)}\b", lower):
+                raise LanguageGuardError(f"Message claims '{term}' before work is executed")
+    if team_visible and not evidence_links:
+        raise LanguageGuardError("Team-visible messages require evidence links")
+    if status == "executed" and any(re.search(rf"\b{re.escape(t)}\b", lower) for t in BLOCKED_WHEN_NOT_EXECUTED) and not evidence_links:
+        raise LanguageGuardError("Completion claims require evidence links")
+    return True

--- a/plugins/visibility_os/core/opportunities.py
+++ b/plugins/visibility_os/core/opportunities.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from . import db
+
+
+def _decode(v: str | None, default: Any) -> Any:
+    if not v:
+        return default
+    try:
+        return json.loads(v)
+    except Exception:
+        return default
+
+
+def row_to_opportunity(row) -> dict[str, Any]:
+    d = dict(row)
+    d["suggested_artifacts"] = _decode(d.get("suggested_artifacts"), [])
+    d["metadata"] = _decode(d.get("metadata"), {})
+    return d
+
+
+def upsert_opportunity(*, source_system: str, source_url: str | None, title: str, description: str, category: str, impact_score: int, visibility_score: int, effort_score: int, safety_score: int, risk_penalty: int, priority_score: int, suggested_artifacts: list[str] | None = None, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+    db.init_db()
+    oid = f"opp_{uuid.uuid4().hex}"
+    suggested_artifacts = suggested_artifacts or []
+    metadata = metadata or {}
+    with db.connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO opportunities(id, source_system, source_url, title, description, category, impact_score, visibility_score, effort_score, safety_score, risk_penalty, priority_score, suggested_artifacts, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_system, source_url, category) DO UPDATE SET
+              title=excluded.title, description=excluded.description, impact_score=excluded.impact_score,
+              visibility_score=excluded.visibility_score, effort_score=excluded.effort_score, safety_score=excluded.safety_score,
+              risk_penalty=excluded.risk_penalty, priority_score=excluded.priority_score,
+              suggested_artifacts=excluded.suggested_artifacts, metadata=excluded.metadata,
+              updated_at=datetime('now')
+            """,
+            (oid, source_system, source_url, title, description, category, impact_score, visibility_score, effort_score, safety_score, risk_penalty, priority_score, json.dumps(suggested_artifacts), json.dumps(metadata, sort_keys=True)),
+        )
+        row = conn.execute("SELECT * FROM opportunities WHERE source_system = ? AND source_url IS ? AND category = ?", (source_system, source_url, category)).fetchone()
+    return row_to_opportunity(row)
+
+
+def get_opportunity(opportunity_id: str) -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        row = conn.execute("SELECT * FROM opportunities WHERE id = ?", (opportunity_id,)).fetchone()
+    if not row:
+        raise KeyError(f"Opportunity not found: {opportunity_id}")
+    return row_to_opportunity(row)
+
+
+def mark_opportunity_resolved_by_source(source_system: str, source_url: str | None, category: str, *, reason: str) -> dict[str, Any] | None:
+    if not source_url:
+        return None
+    db.init_db()
+    with db.connect() as conn:
+        row = conn.execute("SELECT * FROM opportunities WHERE source_system = ? AND source_url IS ? AND category = ?", (source_system, source_url, category)).fetchone()
+        if not row:
+            return None
+        metadata = row_to_opportunity(row).get("metadata") or {}
+        metadata["resolved_reason"] = reason
+        conn.execute(
+            "UPDATE opportunities SET status = ?, metadata = ?, updated_at = datetime('now') WHERE id = ?",
+            ("resolved", json.dumps(metadata, sort_keys=True), row["id"]),
+        )
+        updated = conn.execute("SELECT * FROM opportunities WHERE id = ?", (row["id"],)).fetchone()
+    return row_to_opportunity(updated)
+
+
+def list_opportunities(status: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    db.init_db()
+    with db.connect() as conn:
+        if status:
+            rows = conn.execute("SELECT * FROM opportunities WHERE status = ? ORDER BY priority_score DESC, updated_at DESC LIMIT ?", (status, limit)).fetchall()
+        else:
+            rows = conn.execute("SELECT * FROM opportunities ORDER BY priority_score DESC, updated_at DESC LIMIT ?", (limit,)).fetchall()
+    return [row_to_opportunity(r) for r in rows]

--- a/plugins/visibility_os/core/opportunity_actions.py
+++ b/plugins/visibility_os/core/opportunity_actions.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from typing import Any
+
+from .actions import create_action
+from .communications import draft_completion_update, draft_progress_update
+from .config import get_visibility_config
+from .language_guard import validate_message
+from .opportunities import get_opportunity
+from .workstreams import bind_root_action, create_workstream
+
+
+def _team_channel_default() -> str:
+    return get_visibility_config().default_slack_channel or "#team-updates"
+
+
+def _source_repo(source_url: str | None) -> str | None:
+    if not source_url:
+        return None
+    match = re.search(r"github\.com/([^/]+/[^/]+)/", source_url)
+    return match.group(1) if match else None
+
+
+def _github_actions_ref(source_url: str | None) -> tuple[str, str] | None:
+    match = re.search(r"github\.com/([^/]+/[^/]+)/actions/runs/(\d+)", source_url or "")
+    if not match:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _github_issue_ref(source_url: str | None) -> tuple[str, int] | None:
+    match = re.search(r"github\.com/([^/]+/[^/]+)/issues/(\d+)", source_url or "")
+    if not match:
+        return None
+    return match.group(1), int(match.group(2))
+
+
+def _gh(args: list[str], *, timeout: int = 120) -> str:
+    result = subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"Command failed: {' '.join(args)}")
+    return result.stdout
+
+
+def _evidence_links(opportunity: dict[str, Any]) -> list[dict[str, Any]]:
+    links = []
+    if opportunity.get("source_url"):
+        links.append({"type": opportunity.get("source_system") or "source", "url": opportunity["source_url"], "label": opportunity.get("title")})
+    for key in ("url", "html_url"):
+        url = (opportunity.get("metadata") or {}).get(key)
+        if url and all(item.get("url") != url for item in links):
+            links.append({"type": "metadata", "url": url})
+    return links
+
+
+def _score_explanation(opportunity: dict[str, Any]) -> str:
+    return (
+        "priority_score = impact_score*3 + visibility_score*2 + effort_score + safety_score - risk_penalty "
+        f"= {opportunity.get('impact_score')}*3 + {opportunity.get('visibility_score')}*2 + "
+        f"{opportunity.get('effort_score')} + {opportunity.get('safety_score')} - {opportunity.get('risk_penalty')} "
+        f"= {opportunity.get('priority_score')}"
+    )
+
+
+def _recommended_actions(opportunity: dict[str, Any]) -> list[dict[str, Any]]:
+    source_url = opportunity.get("source_url") or ""
+    category = opportunity.get("category") or ""
+    actions: list[dict[str, Any]] = []
+    if _github_actions_ref(source_url):
+        actions.append({
+            "action_kind": "github_actions_diagnosis",
+            "label": "Diagnose CI",
+            "risk_level": "low",
+            "reason": "Fetch failed GitHub Actions metadata/logs and queue a read-only diagnosis with likely next steps.",
+        })
+        actions.append({
+            "action_kind": "ci_fix_lane",
+            "label": "Start Fix CI lane",
+            "risk_level": "high",
+            "reason": "If diagnosis proves the failure is actionable, queue an approval-gated Hermes repair lane to prepare a local fix branch, commit, PR title/body, and verification evidence for human review before any push.",
+        })
+    if "/pull/" in source_url or category in {"pr_review_acceleration", "stale_wip_handoff"}:
+        actions.append({
+            "action_kind": "github_pr_comment",
+            "label": "Draft PR coordination comment",
+            "risk_level": "low",
+            "reason": "Post a factual coordination/handoff note on the PR. This is not a code review.",
+        })
+    elif _github_issue_ref(source_url):
+        actions.append({
+            "action_kind": "github_issue_fix_lane",
+            "label": "Fix issue",
+            "risk_level": "high",
+            "reason": "Run a one-click Hermes issue repair lane that prepares a local fix branch, self-audits, runs an independent fresh-session review, then queues a separate Push branch decision.",
+        })
+        actions.append({
+            "action_kind": "github_issue_comment",
+            "label": "Draft GitHub issue comment",
+            "risk_level": "low",
+            "reason": "Add a factual investigation/status note to the issue.",
+        })
+    actions.append({
+        "action_kind": "slack_update",
+        "label": "Draft Slack update",
+        "risk_level": "medium",
+        "reason": "Summarize the opportunity for the team without claiming completion.",
+    })
+    return actions
+
+
+def build_opportunity_detail(opportunity_id: str) -> dict[str, Any]:
+    opportunity = get_opportunity(opportunity_id)
+    detail = dict(opportunity)
+    detail["source_repo"] = _source_repo(opportunity.get("source_url"))
+    detail["evidence_links"] = _evidence_links(opportunity)
+    detail["score_explanation"] = _score_explanation(opportunity)
+    detail["recommended_actions"] = _recommended_actions(opportunity)
+    detail["why_it_matters"] = (
+        f"{opportunity.get('category', 'opportunity').replace('_', ' ').title()} with priority score "
+        f"{opportunity.get('priority_score')}. {opportunity.get('description') or ''}"
+    ).strip()
+    detail["suggested_next_step"] = detail["recommended_actions"][0]["label"] if detail["recommended_actions"] else "Review manually"
+    return detail
+
+
+def _body_for(opportunity: dict[str, Any], *, action_kind: str) -> str:
+    url = opportunity.get("source_url") or ""
+    title = opportunity.get("title") or "this item"
+    description = opportunity.get("description") or "This looks like a visible unblock opportunity."
+    if action_kind == "slack_update":
+        return (
+            f"I found a visible review/unblock opportunity: {title}\n"
+            f"Evidence: {url}\n"
+            f"Why it matters: {description}\n"
+            "Current status: I have identified the opportunity and queued this for review.\n"
+            "Next step: review the linked item and decide whether to accelerate, hand off, or close it out."
+        )
+    return (
+        f"Coordination note: this PR looks like a visible review/unblock opportunity: {title}\n\n"
+        f"Evidence: {url}\n\n"
+        f"Why it matters: {description}\n\n"
+        "Suggested next step: confirm whether this is ready for review, needs a handoff, or should be closed. "
+        "I have not performed a code review in this comment."
+    )
+
+
+def _pr_context_for_run(repo: str, view: dict[str, Any]) -> dict[str, Any] | None:
+    branch = view.get("headBranch")
+    if not branch:
+        return None
+    try:
+        raw = _gh([
+            "gh", "pr", "list",
+            "--repo", repo,
+            "--head", str(branch),
+            "--state", "all",
+            "--json", "number,title,state,url,headRefName,headRefOid,baseRefName,mergedAt,statusCheckRollup",
+        ], timeout=90)
+        prs = json.loads(raw or "[]")
+    except Exception:
+        return None
+    if not isinstance(prs, list) or not prs:
+        return None
+    pr = next((p for p in prs if isinstance(p, dict) and p.get("headRefName") == branch), prs[0])
+    checks = [c for c in pr.get("statusCheckRollup") or [] if isinstance(c, dict)]
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "state": pr.get("state"),
+        "url": pr.get("url"),
+        "branch": pr.get("headRefName") or branch,
+        "head_sha": pr.get("headRefOid"),
+        "base_branch": pr.get("baseRefName"),
+        "merged_at": pr.get("mergedAt"),
+        "has_successful_later_check": any(str(c.get("conclusion") or "").upper() == "SUCCESS" for c in checks),
+        "status_checks": checks,
+    }
+
+
+def _resolution_status(pr_context: dict[str, Any] | None) -> tuple[str, bool, list[str], str | None]:
+    if not pr_context:
+        return "unknown", True, [
+            "Open the failing job and confirm the first real error above.",
+            "Reproduce the failing command locally or in the relevant repo checkout.",
+            "If the cause is clear, create a focused fix with before/after CI evidence.",
+        ], None
+    if str(pr_context.get("state") or "").upper() == "MERGED":
+        return "resolved_merged", False, [
+            "No new fix branch recommended, the linked PR has already been merged.",
+            "Confirm the opportunity can be closed as stale/resolved.",
+        ], f"This run belongs to PR #{pr_context.get('number')} on branch {pr_context.get('branch')}, which has already been merged. Treat this failed run as stale unless newer evidence says otherwise."
+    if pr_context.get("has_successful_later_check"):
+        return "resolved_newer_ci_passed", False, [
+            "No new fix branch recommended, a later check on the linked PR passed.",
+            "Confirm the opportunity can be closed as stale/resolved.",
+        ], f"This run belongs to PR #{pr_context.get('number')} and a later status check on that PR passed. Treat this failed run as stale."
+    return "actionable", True, [
+        "Open the linked PR/branch and confirm the first real error above.",
+        "Reproduce the failing command locally or in the relevant repo checkout.",
+        "Create a focused fix branch only if the PR is still open and the latest CI is still failing.",
+    ], f"This run correlates to PR #{pr_context.get('number')} on branch {pr_context.get('branch')}. The PR does not appear merged or resolved by a later successful check."
+
+
+def _diagnose_github_actions(opportunity: dict[str, Any]) -> dict[str, Any]:
+    ref = _github_actions_ref(opportunity.get("source_url"))
+    if not ref:
+        raise ValueError("Opportunity is not a GitHub Actions run URL")
+    repo, run_id = ref
+    raw_view = _gh([
+        "gh", "run", "view", run_id, "--repo", repo,
+        "--json", "name,displayTitle,conclusion,status,event,headBranch,headSha,jobs,url",
+    ], timeout=90)
+    try:
+        view = json.loads(raw_view or "{}")
+    except Exception:
+        view = {}
+    try:
+        failed_log = _gh(["gh", "run", "view", run_id, "--repo", repo, "--log-failed"], timeout=180)
+    except Exception as exc:
+        failed_log = f"Could not fetch failed logs: {exc}"
+    jobs = [j for j in (view.get("jobs") or []) if isinstance(j, dict)]
+    failed_jobs = [str(j.get("name") or "unnamed job") for j in jobs if str(j.get("conclusion") or "").lower() == "failure"]
+    failed_steps = []
+    for job in jobs:
+        for step in job.get("steps") or []:
+            if isinstance(step, dict) and str(step.get("conclusion") or "").lower() == "failure":
+                failed_steps.append(f"{job.get('name') or 'job'} / {step.get('name') or 'step'}")
+    important_lines = _important_log_lines(failed_log)
+    likely_cause = important_lines[0] if important_lines else "The run failed, but the failed log output did not include an obvious error line. Open the run logs and inspect the failed job manually."
+    pr_context = _pr_context_for_run(repo, view)
+    resolution_status, should_create_fix_branch, next_steps, stale_note = _resolution_status(pr_context)
+    body = "\n".join([
+        f"CI diagnosis for {opportunity.get('title') or 'GitHub Actions run'}",
+        f"Run: {opportunity.get('source_url')}",
+        f"Repository: {repo}",
+        f"Branch: {view.get('headBranch') or 'unknown'}",
+        f"Commit: {view.get('headSha') or 'unknown'}",
+        f"PR: #{pr_context.get('number')} {pr_context.get('state')} {pr_context.get('url')}" if pr_context else "PR: not found for run branch",
+        f"Status: {view.get('status') or 'unknown'} / {view.get('conclusion') or 'unknown'}",
+        f"Resolution status: {resolution_status}",
+        f"Should create fix branch: {'yes' if should_create_fix_branch else 'no'}",
+        f"Failed jobs: {', '.join(failed_jobs) if failed_jobs else 'not identified from metadata'}",
+        f"Failed steps: {', '.join(failed_steps) if failed_steps else 'not identified from metadata'}",
+        "",
+        "Likely cause:",
+        likely_cause,
+        "",
+        "Actionability:",
+        stale_note or "No stale/resolved PR evidence found, this may still need investigation.",
+        "",
+        "Relevant log lines:",
+        *(f"- {line}" for line in important_lines[:8]),
+        "",
+        "Recommended next steps:",
+        *(f"{idx}. {step}" for idx, step in enumerate(next_steps, 1)),
+    ]).strip()
+    return {
+        "body": body,
+        "repo": repo,
+        "run_id": run_id,
+        "run_url": opportunity.get("source_url"),
+        "diagnosis": {
+            "likely_cause": likely_cause,
+            "failed_jobs": failed_jobs,
+            "failed_steps": failed_steps,
+            "important_log_lines": important_lines[:20],
+            "metadata": view,
+        },
+        "pr_context": pr_context,
+        "resolution_status": resolution_status,
+        "should_create_fix_branch": should_create_fix_branch,
+        "next_steps": next_steps,
+    }
+
+
+def _build_ci_fix_lane_payload(opportunity: dict[str, Any]) -> dict[str, Any]:
+    diagnosis = _diagnose_github_actions(opportunity)
+    if not diagnosis.get("should_create_fix_branch"):
+        raise ValueError(
+            f"CI run is not actionable for fix lane: {diagnosis.get('resolution_status')}. "
+            "Use the diagnosis output to close or save the stale opportunity instead."
+        )
+    repo = diagnosis["repo"]
+    run_id = diagnosis["run_id"]
+    pr_context = diagnosis.get("pr_context") or {}
+    branch = pr_context.get("branch") or diagnosis.get("diagnosis", {}).get("metadata", {}).get("headBranch") or "unknown"
+    cfg = get_visibility_config()
+    prompt = "\n".join([
+        f"You are running the Visibility OS automated Fix CI lane for {cfg.company_name}.",
+        "",
+        "Goal: prepare a local CI/CD fix branch with a commit and a proposed PR message. Do not push the branch or open/update a PR yet.",
+        "",
+        f"Repository: {repo}",
+        f"Failed run: {diagnosis.get('run_url')}",
+        f"Run id: {run_id}",
+        f"Branch: {branch}",
+        f"Commit: {diagnosis.get('diagnosis', {}).get('metadata', {}).get('headSha') or 'unknown'}",
+        f"PR: #{pr_context.get('number')} {pr_context.get('url')}" if pr_context else "PR: not found",
+        f"Resolution status: {diagnosis.get('resolution_status')}",
+        "",
+        "Likely cause:",
+        str(diagnosis.get("diagnosis", {}).get("likely_cause") or "unknown"),
+        "",
+        "Relevant log lines:",
+        *(f"- {line}" for line in diagnosis.get("diagnosis", {}).get("important_log_lines", [])[:12]),
+        "",
+        "Execution rules:",
+        "1. Re-check that the PR/branch is still open and the latest CI is still failing before making changes.",
+        "2. Work only inside the named repository and only on the CI fix scope.",
+        "3. Create a focused local fix branch and commit the fix locally with a clear commit message.",
+        "4. Reproduce the failing command locally when possible, then run the smallest relevant test/typecheck/build command that proves the fix.",
+        "5. Perform a self-audit second pass on your own code fixes before committing: inspect the diff, look for regressions, edge cases, security issues, unintended scope creep, and test gaps. Fix any issues the second pass finds.",
+        "6. Draft a PR title and PR body using the same evidence-backed summary as the commit message if appropriate.",
+        f"7. Do not push the branch, do not open or update a PR, and do not merge. Visibility OS will show the configured approver a separate Push branch button after review.",
+        "8. Include before/after CI evidence, commands run, and self-audit findings in the proposed PR body.",
+        f"9. Do not deploy, merge, alter production infrastructure, rotate secrets, or touch repositories outside the configured GitHub organisations: {cfg.github_scope_label}.",
+        "",
+        "Final response must be JSON with: branch, commit_sha, commit_message, pr_title, pr_body, verification, changed_files, self_audit, ready_to_push.",
+        "self_audit must be an object with: audit_status, issues_found, fixes_applied, notes.",
+    ])
+    return {
+        "lane": "fix_ci",
+        "repo": repo,
+        "run_id": run_id,
+        "run_url": diagnosis.get("run_url"),
+        "pr_context": pr_context,
+        "diagnosis": diagnosis.get("diagnosis"),
+        "resolution_status": diagnosis.get("resolution_status"),
+        "should_create_fix_branch": diagnosis.get("should_create_fix_branch"),
+        "prompt": prompt,
+        "command": ["hermes", "chat", "--query", "__PROMPT__", "--quiet", "--source", "visibility-os-ci-fix", "--toolsets", "terminal,file"],
+        "safety_gates": [
+            "stale_ci_recheck",
+            "configured_org_only",
+            "local_verification_before_push",
+            "self_audit_before_push",
+            "no_push_until_human_approves",
+            "no_deploy_no_merge",
+            "final_evidence_required",
+        ],
+    }
+
+
+def _build_github_issue_fix_lane_payload(opportunity: dict[str, Any]) -> dict[str, Any]:
+    ref = _github_issue_ref(opportunity.get("source_url"))
+    if not ref:
+        raise ValueError("Opportunity is not a GitHub issue URL")
+    repo, issue_number = ref
+    cfg = get_visibility_config()
+    if not cfg.github_repo_allowed(repo):
+        raise ValueError(f"Visibility OS is restricted to configured GitHub repositories: {cfg.github_scope_label}")
+    metadata = opportunity.get("metadata") or {}
+    labels = [str(label.get("name") or label) for label in metadata.get("labels") or []]
+    issue_body = str(metadata.get("body") or metadata.get("description") or opportunity.get("description") or "")
+    prompt = "\n".join([
+        f"You are running the Visibility OS automated GitHub issue fix lane for {cfg.company_name}.",
+        "",
+        f"Goal: Fix GitHub issue #{issue_number} by preparing a local code/docs fix branch with a commit and proposed PR message. Do not push the branch or open/update a PR yet.",
+        "",
+        f"Repository: {repo}",
+        f"Issue: #{issue_number}",
+        f"Issue URL: {opportunity.get('source_url')}",
+        f"Issue title: {metadata.get('title') or opportunity.get('title') or ''}",
+        f"Labels: {', '.join(labels) if labels else 'none'}",
+        "",
+        "Issue body / opportunity description:",
+        issue_body[:4000],
+        "",
+        "Execution rules:",
+        "1. Re-check the issue is still open and understand the requested bug fix, documentation change, or implementation task before editing.",
+        "2. Work only inside the named repository and only on the scope described by the issue.",
+        "3. Create a focused local branch and commit the fix locally with a clear commit message.",
+        "4. Add or update the smallest relevant tests/docs and run the smallest relevant verification command that proves the issue fix.",
+        "5. Perform a self-audit second pass on your own fix before committing: inspect the diff, look for regressions, edge cases, security issues, unintended scope creep, and test gaps. Fix any issues the second pass finds.",
+        "6. Draft a PR title and PR body that references the issue with a closing keyword, for example: Fixes #" + str(issue_number) + ".",
+        "7. Do not push the branch, do not open or update a PR, and do not merge. Visibility OS will show the configured approver a separate Push branch button after review.",
+        "8. Include commands run, files changed, and self-audit findings in the proposed PR body.",
+        f"9. Do not deploy, merge, alter production infrastructure, rotate secrets, or touch repositories outside the configured GitHub organisations: {cfg.github_scope_label}.",
+        "",
+        "Final response must be JSON with: branch, commit_sha, commit_message, pr_title, pr_body, verification, changed_files, self_audit, ready_to_push.",
+        "self_audit must be an object with: audit_status, issues_found, fixes_applied, notes.",
+    ])
+    return {
+        "lane": "fix_github_issue",
+        "repo": repo,
+        "issue_number": issue_number,
+        "issue_url": opportunity.get("source_url"),
+        "issue_title": metadata.get("title") or opportunity.get("title"),
+        "issue_body": issue_body,
+        "prompt": prompt,
+        "command": ["hermes", "chat", "--query", "__PROMPT__", "--quiet", "--source", "visibility-os-issue-fix", "--toolsets", "terminal,file"],
+        "safety_gates": [
+            "issue_open_recheck",
+            "configured_org_only",
+            "local_verification_before_push",
+            "self_audit_before_push",
+            "independent_review_before_push",
+            "no_push_until_human_approves",
+            "no_deploy_no_merge",
+            "final_evidence_required",
+        ],
+    }
+
+
+def _important_log_lines(log: str) -> list[str]:
+    patterns = re.compile(r"(error:|error\b|failed|failure|exception|traceback|assertionerror|npm err|pytest|fatal:|missing|denied)", re.I)
+    lines = []
+    for raw in (log or "").splitlines():
+        line = raw.strip()
+        if not line or len(line) > 500:
+            continue
+        if patterns.search(line):
+            lines.append(line)
+        if len(lines) >= 20:
+            break
+    return lines
+
+
+def draft_action_from_opportunity(opportunity_id: str, *, action_kind: str, target_location: str | None = None, actor: str = "visibility_os") -> dict[str, Any]:
+    opportunity = get_opportunity(opportunity_id)
+    evidence_links = _evidence_links(opportunity)
+    if action_kind == "github_actions_diagnosis":
+        payload = _diagnose_github_actions(opportunity)
+        return create_action(
+            proposed_by_agent=actor,
+            action_type="github_actions_diagnosis",
+            target_system="github",
+            target_location=target_location or opportunity.get("source_url") or "",
+            title=f"Diagnose CI: {opportunity.get('title', '')[:90]}",
+            summary=f"Diagnosed failed GitHub Actions run for opportunity {opportunity_id}.",
+            proposed_payload=payload,
+            evidence_links=evidence_links,
+            risk_level="low",
+            opportunity_id=opportunity_id,
+            impact_score=opportunity.get("impact_score"),
+            visibility_score=opportunity.get("visibility_score"),
+            effort_score=opportunity.get("effort_score"),
+            approval_reason="Read-only CI diagnosis queued for human review before any fix work.",
+        )
+    if action_kind == "ci_fix_lane":
+        payload = _build_ci_fix_lane_payload(opportunity)
+        title = f"Start Fix CI lane: {opportunity.get('title', '')[:80]}"
+        workstream = create_workstream(
+            opportunity_id=opportunity_id,
+            root_action_id=None,
+            lane_kind="ci_fix_lane",
+            title=title,
+            repo=payload.get("repo"),
+            source_url=opportunity.get("source_url"),
+            actor=actor,
+            summary=f"Agentic CI remediation for {payload.get('repo')} run {payload.get('run_id')}",
+        )
+        payload["workstream_id"] = workstream["id"]
+        action = create_action(
+            proposed_by_agent=actor,
+            action_type="ci_fix_lane",
+            target_system="hermes",
+            target_location=target_location or f"{payload.get('repo')}#{payload.get('run_id')}",
+            title=title,
+            summary=f"Approval-gated Hermes Fix CI lane for opportunity {opportunity_id}.",
+            proposed_payload=payload,
+            evidence_links=evidence_links,
+            risk_level="high",
+            opportunity_id=opportunity_id,
+            impact_score=opportunity.get("impact_score"),
+            visibility_score=opportunity.get("visibility_score"),
+            effort_score=opportunity.get("effort_score"),
+            approval_reason="Automated CI repair may create local branches and commits, so it requires human approval before execution. Pushing is queued as a separate explicit action.",
+        )
+        bind_root_action(workstream["id"], action["id"])
+        return action
+    if action_kind == "github_issue_fix_lane":
+        payload = _build_github_issue_fix_lane_payload(opportunity)
+        title = f"Fix GitHub issue #{payload.get('issue_number')}: {opportunity.get('title', '')[:80]}"
+        workstream = create_workstream(
+            opportunity_id=opportunity_id,
+            root_action_id=None,
+            lane_kind="github_issue_fix_lane",
+            title=title,
+            repo=payload.get("repo"),
+            source_url=opportunity.get("source_url"),
+            actor=actor,
+            summary=f"Agentic issue remediation for {payload.get('repo')} issue #{payload.get('issue_number')}",
+        )
+        payload["workstream_id"] = workstream["id"]
+        action = create_action(
+            proposed_by_agent=actor,
+            action_type="github_issue_fix_lane",
+            target_system="hermes",
+            target_location=target_location or f"{payload.get('repo')}#{payload.get('issue_number')}",
+            title=title,
+            summary=f"Approval-gated Hermes issue fix lane for opportunity {opportunity_id}.",
+            proposed_payload=payload,
+            evidence_links=evidence_links,
+            risk_level="high",
+            opportunity_id=opportunity_id,
+            impact_score=opportunity.get("impact_score"),
+            visibility_score=opportunity.get("visibility_score"),
+            effort_score=opportunity.get("effort_score"),
+            approval_reason="Automated issue repair may create local branches and commits, so it requires human approval before execution. Pushing is queued as a separate explicit action.",
+        )
+        bind_root_action(workstream["id"], action["id"])
+        return action
+    if action_kind == "github_pr_comment":
+        action_type = "github_pr_comment"
+        target_system = "github"
+        destination = target_location or opportunity.get("source_url")
+        payload_key = "body"
+        risk_level = "low"
+    elif action_kind == "github_issue_comment":
+        action_type = "github_issue_comment"
+        target_system = "github"
+        destination = target_location or opportunity.get("source_url")
+        payload_key = "body"
+        risk_level = "low"
+    elif action_kind == "slack_update":
+        action_type = "slack_message"
+        target_system = "slack"
+        destination = target_location or _team_channel_default()
+        payload_key = "text"
+        risk_level = "medium"
+    else:
+        raise ValueError(f"Unsupported opportunity action kind: {action_kind}")
+
+    text = _body_for(opportunity, action_kind=action_kind)
+    validate_message(text, status="queued", evidence_links=evidence_links, team_visible=(target_system == "slack"))
+    return create_action(
+        proposed_by_agent=actor,
+        action_type=action_type,
+        target_system=target_system,
+        target_location=destination or "",
+        title=f"{_recommended_label(action_kind)}: {opportunity.get('title', '')[:80]}",
+        summary=f"Drafted from opportunity {opportunity_id}: {opportunity.get('description') or opportunity.get('title')}",
+        proposed_payload={payload_key: text},
+        evidence_links=evidence_links,
+        risk_level=risk_level,
+        opportunity_id=opportunity_id,
+        impact_score=opportunity.get("impact_score"),
+        visibility_score=opportunity.get("visibility_score"),
+        effort_score=opportunity.get("effort_score"),
+        approval_reason="External/reputation-sensitive write drafted from a Visibility OS opportunity.",
+    )
+
+
+def _recommended_label(action_kind: str) -> str:
+    return {
+        "github_actions_diagnosis": "Diagnose CI",
+        "ci_fix_lane": "Start Fix CI lane",
+        "github_issue_fix_lane": "Fix issue",
+        "github_pr_comment": "Draft PR coordination comment",
+        "github_issue_comment": "Draft issue coordination comment",
+        "slack_update": "Draft Slack update",
+    }.get(action_kind, "Draft action")

--- a/plugins/visibility_os/core/policies.py
+++ b/plugins/visibility_os/core/policies.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+class ActionPolicyError(RuntimeError):
+    """Raised when an action violates approval/execution policy."""
+
+
+WRITE_ACTIONS_REQUIRE_APPROVAL = {
+    "slack_message", "slack_thread_reply", "github_issue_comment", "github_pr_comment",
+    "github_pr_review_draft", "github_pr_creation", "github_pr_merge", "github_branch_push", "jira_ticket_update",
+    "jira_ticket_creation", "docs_publication", "incident_update", "release_note",
+    "deployment", "production_config_change", "weekly_update_draft",
+}
+
+HARD_BLOCKED_ACTIONS = {
+    "merge_pull_request", "github_pr_merge", "production_deploy", "deployment", "delete_branch",
+    "close_customer_ticket", "mute_alert", "change_permissions", "send_message_to_executive_channel",
+    "production_config_change",
+}
+
+VALID_STATUSES = {
+    "drafted", "queued", "needs_review", "approved", "rejected", "edited_by_human",
+    "executed", "failed", "cancelled", "expired",
+}
+
+VALID_TRANSITIONS = {
+    "drafted": {"queued", "cancelled"},
+    "queued": {"approved", "rejected", "needs_review", "edited_by_human", "cancelled", "expired"},
+    "needs_review": {"queued", "rejected", "cancelled"},
+    "edited_by_human": {"approved", "queued", "rejected", "cancelled", "edited_by_human"},
+    "approved": {"executed", "failed", "cancelled"},
+    "rejected": set(), "executed": set(), "failed": set(), "cancelled": set(), "expired": set(),
+}
+
+
+def validate_transition(current: str, new: str) -> None:
+    if current not in VALID_TRANSITIONS or new not in VALID_STATUSES:
+        raise ActionPolicyError(f"Unknown action status transition {current!r} -> {new!r}")
+    if new not in VALID_TRANSITIONS[current]:
+        raise ActionPolicyError(f"Invalid action status transition {current!r} -> {new!r}")

--- a/plugins/visibility_os/core/pr_audit.py
+++ b/plugins/visibility_os/core/pr_audit.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+from .actions import create_action
+from .config import get_visibility_config
+from .opportunities import get_opportunity
+
+
+@dataclass(frozen=True)
+class PullRequestRef:
+    repo: str
+    number: int
+    url: str
+
+
+def _parse_pr_url(url: str | None) -> PullRequestRef:
+    match = re.match(r"https://github\.com/([^/]+/[^/]+)/pull/(\d+)(?:[/?#].*)?$", url or "")
+    if not match:
+        raise ValueError(f"Opportunity source_url is not a GitHub PR URL: {url}")
+    repo = match.group(1)
+    cfg = get_visibility_config()
+    if not cfg.github_repo_allowed(repo):
+        raise ValueError(f"Visibility OS PR audit is restricted to configured repositories: {cfg.github_scope_label}")
+    return PullRequestRef(repo=repo, number=int(match.group(2)), url=url or "")
+
+
+def _gh(args: list[str], *, timeout: int = 120) -> str:
+    result = subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"Command failed: {' '.join(args)}")
+    return result.stdout
+
+
+def _pr_view(ref: PullRequestRef) -> dict[str, Any]:
+    raw = _gh(["gh", "pr", "view", str(ref.number), "--repo", ref.repo, "--json", "headRefOid,title,author,baseRefName,headRefName,url,files,additions,deletions,changedFiles,body"], timeout=60)
+    try:
+        return json.loads(raw or "{}")
+    except Exception:
+        return {}
+
+
+def _pr_diff(ref: PullRequestRef) -> str:
+    return _gh(["gh", "pr", "diff", str(ref.number), "--repo", ref.repo], timeout=180)
+
+
+def _iter_added_lines(diff: str):
+    path: str | None = None
+    new_line = 0
+    for raw in diff.splitlines():
+        file_match = re.match(r"diff --git a/(.*?) b/(.*)$", raw)
+        if file_match:
+            path = file_match.group(2)
+            new_line = 0
+            continue
+        hunk_match = re.match(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@", raw)
+        if hunk_match:
+            new_line = int(hunk_match.group(1))
+            continue
+        if raw.startswith("+++") or raw.startswith("---"):
+            continue
+        if raw.startswith("+"):
+            yield path or "unknown", new_line, raw[1:], "added"
+            new_line += 1
+        elif raw.startswith("-"):
+            continue
+        else:
+            if new_line:
+                yield path or "unknown", new_line, raw[1:] if raw.startswith(" ") else raw, "context"
+                new_line += 1
+
+
+def _without_long_dashes(text: str) -> str:
+    """Keep casual review comments free of em/en dashes."""
+    return re.sub(r"\s*[—–]\s*", ", ", text).strip()
+
+
+def _casual_comment(title: str, detail: str, solution: str) -> str:
+    lower = title.lower()
+    if "sql injection" in lower:
+        return _without_long_dashes("Is this SQL injection safe? It looks like we're executing a formatted query here, I think we should switch this to a parameterized call.")
+    if "shell" in lower:
+        return _without_long_dashes("This looks like it can run through the shell with dynamic input. Can we avoid shell=True and pass args explicitly instead?")
+    if "secret" in lower or "credential" in lower:
+        return _without_long_dashes("This looks like a real secret might be getting committed. Can we move it into env/secrets and rotate it if needed?")
+    if "test" in lower:
+        return _without_long_dashes("I think this needs a test before we merge, otherwise it's hard to tell if this path is safe.")
+    if "large pr" in lower:
+        return _without_long_dashes("This PR is getting pretty big. I think we should either split it or add a reviewer guide so the risky parts don't get missed.")
+    return _without_long_dashes(f"I’m flagging this because {detail[:160].rstrip('.')}. I think the fix is: {solution[:160].rstrip('.')}")
+
+
+def _diff_anchor(path: str, line: int) -> str:
+    safe = re.sub(r"[^A-Za-z0-9]+", "-", path).strip("-") or "file"
+    return f"diff-{safe}R{line or 1}"
+
+
+def _finding(*, severity: str, path: str, line: int, title: str, detail: str, solution: str, code: str, source: str = "deterministic", casual_comment: str | None = None) -> dict[str, Any]:
+    return {
+        "severity": severity,
+        "path": path,
+        "line": line,
+        "title": title,
+        "detail": detail,
+        "solution": solution,
+        "code": code.strip(),
+        "source": source,
+        "status": "open",
+        "casual_comment": _without_long_dashes(casual_comment or _casual_comment(title, detail, solution)),
+        "diff_anchor": _diff_anchor(path, line),
+    }
+
+
+def audit_diff(diff: str) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    pending_sql_fstring: dict[str, Any] | None = None
+    changed_files: set[str] = set()
+    test_files: set[str] = set()
+
+    for path, line, code, status in _iter_added_lines(diff):
+        if status == "added":
+            changed_files.add(path)
+        if re.search(r"(^|/)(test_|.*_test\.|tests?/)", path):
+            test_files.add(path)
+        lower = code.lower()
+
+        if status != "added":
+            if re.search(r"\bf['\"].*\b(SELECT|INSERT|UPDATE|DELETE)\b", code, re.I):
+                pending_sql_fstring = {"path": path, "line": line, "code": code}
+            continue
+        if re.search(r"\b(api[_-]?key|secret|password|token|private[_-]?key)\b\s*=\s*['\"][^'\"]{6,}['\"]", code, re.I):
+            findings.append(_finding(
+                severity="critical", path=path, line=line,
+                title="Possible hardcoded secret or credential",
+                detail="The added line appears to assign a secret-like value directly in source code.",
+                solution="Move the value to a secret manager or environment variable, rotate the exposed value if it is real, and add a test/config guard that does not require committing credentials.",
+                code=code,
+            ))
+
+        if "shell=true" in lower or re.search(r"os\.system\s*\(", code):
+            findings.append(_finding(
+                severity="critical", path=path, line=line,
+                title="Shell injection risk",
+                detail="The added line executes through a shell. If any interpolated value is user- or environment-controlled, this can allow command injection.",
+                solution="Use subprocess.run([...], shell=False, check=True) with an argument list. Validate or constrain the path/input before passing it to the process.",
+                code=code,
+            ))
+
+        if re.search(r"\bf['\"].*\b(SELECT|INSERT|UPDATE|DELETE)\b", code, re.I):
+            pending_sql_fstring = {"path": path, "line": line, "code": code}
+
+        if re.search(r"\.execute\s*\((query|sql)\)", code) and pending_sql_fstring and pending_sql_fstring["path"] == path:
+            findings.append(_finding(
+                severity="critical", path=pending_sql_fstring["path"], line=pending_sql_fstring["line"],
+                title="SQL injection risk from formatted query",
+                detail="A SQL statement is constructed with an f-string and then executed. Interpolated values can alter the query.",
+                solution="Use parameterized queries, e.g. cursor.execute('SELECT * FROM orders WHERE user_id = ?', (user_id,)) or the parameter style used by this project's DB adapter.",
+                code=pending_sql_fstring["code"],
+            ))
+
+        if re.search(r"\bexcept\s+Exception\s*:\s*(pass)?\s*$", code):
+            findings.append(_finding(
+                severity="warning", path=path, line=line,
+                title="Broad exception handling can hide failures",
+                detail="Catching Exception without logging or re-raising can suppress production failures.",
+                solution="Catch the specific exception type and log or return enough context for operators to diagnose the failure.",
+                code=code,
+            ))
+
+        if "todo" in lower or "fixme" in lower:
+            findings.append(_finding(
+                severity="suggestion", path=path, line=line,
+                title="TODO/FIXME added in changed code",
+                detail="The PR adds unfinished-work markers that may need tracking before merge.",
+                solution="Either complete the work now or link the TODO to a tracked issue with owner and expected follow-up.",
+                code=code,
+            ))
+
+    production_changes = [p for p in changed_files if p not in test_files and not re.search(r"(^|/)(docs?|README|CHANGELOG)", p, re.I)]
+    if production_changes and not test_files:
+        findings.append(_finding(
+            severity="warning",
+            path=production_changes[0],
+            line=1,
+            title="Production code changed without test changes",
+            detail="The diff changes production files but does not include an obvious test file change.",
+            solution="Add or update tests that exercise the changed behavior, including at least one failure/edge path where applicable.",
+            code="",
+        ))
+
+    severity_order = {"critical": 0, "warning": 1, "suggestion": 2}
+    return sorted(findings, key=lambda f: (severity_order.get(f["severity"], 9), f["path"], f["line"]))
+
+
+def _verdict(findings: list[dict[str, Any]]) -> str:
+    if any(f["severity"] == "critical" for f in findings):
+        return "REQUEST_CHANGES"
+    if any(f["severity"] == "warning" for f in findings):
+        return "COMMENT"
+    return "APPROVE"
+
+
+def _review_body(*, opportunity: dict[str, Any], ref: PullRequestRef, findings: list[dict[str, Any]], verdict: str, depth: str = "standard", review_notes: list[str] | None = None) -> str:
+    counts = {sev: sum(1 for f in findings if f["severity"] == sev) for sev in ("critical", "warning", "suggestion")}
+    heading = {
+        "deep": "Hermes Deep PR Review",
+        "agentic": "Hermes Agentic Deep PR Review",
+    }.get(depth, "Hermes PR Audit")
+    lines = [
+        f"## {heading}",
+        "",
+        f"**Verdict:** {verdict}",
+        f"**Depth:** {depth}",
+        f"**Scope:** {opportunity.get('title') or ref.url}",
+        f"**Findings:** {counts['critical']} critical, {counts['warning']} warning, {counts['suggestion']} suggestion",
+        "",
+    ]
+    if review_notes:
+        lines.extend(["### Review context", ""])
+        lines.extend([f"- {note}" for note in review_notes])
+        lines.append("")
+    if not findings:
+        lines.extend(["No blocking findings detected by the automated audit heuristics.", "", "Manual reviewer should still validate product intent and domain correctness."])
+    else:
+        for f in findings:
+            location = f"{f['path']}:{f['line']}" if f.get("line") else f["path"]
+            lines.extend([
+                f"### {f['severity'].upper()} — {location}",
+                f"**Comment:** {f.get('casual_comment') or f['title']}",
+                f"**Issue:** {f['title']}",
+                f"**Detail:** {f['detail']}",
+                f"**Suggested fix:** {f['solution']}",
+                "",
+            ])
+    return "\n".join(lines).strip()
+
+
+def _github_diff_url(ref: PullRequestRef, finding: dict[str, Any]) -> str:
+    return f"{ref.url}/files#{finding.get('diff_anchor') or _diff_anchor(finding.get('path') or 'file', int(finding.get('line') or 1))}"
+
+
+def _finding_comment(finding: dict[str, Any]) -> str:
+    location = f"{finding.get('path')}:{finding.get('line')}"
+    return f"{finding.get('casual_comment') or finding.get('title')}\n\n{location}\n\nSuggested change: {finding.get('solution')}"
+
+
+def _enrich_findings_for_pr(findings: list[dict[str, Any]], ref: PullRequestRef, *, default_source: str | None = None) -> list[dict[str, Any]]:
+    enriched = []
+    for finding in findings:
+        item = dict(finding)
+        if default_source and not item.get("source"):
+            item["source"] = default_source
+        item.setdefault("source", "deterministic")
+        item.setdefault("status", "open")
+        item.setdefault("casual_comment", _casual_comment(str(item.get("title") or ""), str(item.get("detail") or ""), str(item.get("solution") or "")))
+        item["casual_comment"] = _without_long_dashes(str(item.get("casual_comment") or ""))
+        item.setdefault("diff_anchor", _diff_anchor(str(item.get("path") or "file"), int(item.get("line") or 1)))
+        item["github_diff_url"] = _github_diff_url(ref, item)
+        item["copy_comment"] = _finding_comment(item)
+        enriched.append(item)
+    return enriched
+
+
+def _findings_summary(findings: list[dict[str, Any]]) -> dict[str, int]:
+    return {key: sum(1 for f in findings if f.get("severity") == key) for key in ("critical", "warning", "suggestion")}
+
+
+def _findings_by_file(findings: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for finding in findings:
+        path = str(finding.get("path") or "unknown")
+        counts[path] = counts.get(path, 0) + 1
+    return counts
+
+
+def _changed_file_names(diff: str, view: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for item in view.get("files") or []:
+        if isinstance(item, dict) and item.get("path"):
+            names.add(str(item["path"]))
+    for match in re.finditer(r"^diff --git a/(.*?) b/(.*?)$", diff, re.M):
+        names.add(match.group(2))
+    return names
+
+
+def _deep_review_findings(*, diff: str, view: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
+    """PR-level review checks that go beyond single-line diff heuristics."""
+    findings: list[dict[str, Any]] = []
+    notes: list[str] = []
+    files = _changed_file_names(diff, view)
+    test_files = {p for p in files if re.search(r"(^|/)(test_|.*_test\.|tests?/|__tests__/|specs?/)", p, re.I)}
+    production_files = {p for p in files if p not in test_files and not re.search(r"(^|/)(docs?|README|CHANGELOG|package-lock\.json|yarn\.lock|pnpm-lock\.yaml)", p, re.I)}
+    changed_count = int(view.get("changedFiles") or len(files) or 0)
+    additions = int(view.get("additions") or 0)
+    deletions = int(view.get("deletions") or 0)
+
+    if files:
+        notes.append(f"Reviewed PR-level context across {changed_count or len(files)} changed file(s), +{additions}/-{deletions} when available.")
+    else:
+        notes.append("Reviewed diff context; GitHub did not return a changed-file list.")
+
+    if production_files and not test_files:
+        findings.append(_finding(
+            severity="warning",
+            path=sorted(production_files)[0],
+            line=1,
+            title="Deep review found product code changes without tests",
+            detail="The PR changes non-documentation production files, but the changed-file set does not include obvious tests/specs. This should be validated before merge, especially for business logic and regression-prone paths.",
+            solution="Add focused tests for the changed behavior or document why existing coverage is sufficient in the PR before approving.",
+            code="",
+        ))
+
+    risky_patterns = [
+        (r"(^|/)(contracts?|src/.*\.sol$|.*\.sol$)", "Smart contract or Solidity changes need domain/security review", "Run the relevant contract tests, review economic/security invariants, and ensure any audit/remediation notes are linked before merge."),
+        (r"(^|/)(infra|terraform|pulumi|k8s|helm|charts|\.github/workflows)/", "Infrastructure/CI changes need operational rollback review", "Confirm blast radius, secrets handling, deployment order, and rollback steps before merge."),
+        (r"(^|/)(migrations?|prisma/migrations|db/migrations)/", "Database migration changes need rollback/data-safety review", "Confirm forward/backward compatibility, migration runtime, rollback strategy, and data backfill/repair plan."),
+    ]
+    for pattern, title, solution in risky_patterns:
+        matched = sorted(p for p in production_files if re.search(pattern, p, re.I))
+        if matched:
+            findings.append(_finding(
+                severity="warning",
+                path=matched[0],
+                line=1,
+                title=title,
+                detail="Deep review identified a changed file in a high-blast-radius area. The automated line-level audit may not catch product, security, or operational regressions here.",
+                solution=solution,
+                code="",
+            ))
+
+    if changed_count >= 20 or additions + deletions >= 800:
+        findings.append(_finding(
+            severity="suggestion",
+            path=sorted(files)[0] if files else "PR",
+            line=1,
+            title="Large PR may need split or staged review",
+            detail="The PR is large enough that reviewers are likely to miss semantic issues, especially around edge cases and integration behavior.",
+            solution="Consider splitting into smaller PRs or add a reviewer guide that explains the change graph, test plan, and riskiest areas.",
+            code="",
+        ))
+
+    body = (view.get("body") or "").lower()
+    if production_files and not re.search(r"test plan|testing|validated|verification|how tested", body):
+        findings.append(_finding(
+            severity="suggestion",
+            path="PR description",
+            line=1,
+            title="PR description does not include an obvious test plan",
+            detail="Deep review did not find test-plan language in the PR description. That makes human approval harder to audit later.",
+            solution="Add a concise test plan or verification note to the PR description before merge.",
+            code="",
+        ))
+
+    notes.append("Generated a human-approved GitHub review draft; nothing is posted automatically.")
+    return findings, notes
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError("Agent review output did not contain a JSON object")
+    return json.loads(text[start:end + 1])
+
+
+def _normalize_agent_finding(raw: dict[str, Any]) -> dict[str, Any]:
+    severity = str(raw.get("severity") or "suggestion").lower()
+    if severity not in {"critical", "warning", "suggestion"}:
+        severity = "suggestion"
+    try:
+        line = int(raw.get("line") or 1)
+    except Exception:
+        line = 1
+    return _finding(
+        severity=severity,
+        path=str(raw.get("path") or "PR"),
+        line=line,
+        title=str(raw.get("title") or "Agent review finding")[:180],
+        detail=str(raw.get("detail") or raw.get("description") or "The agent flagged this during deep review."),
+        solution=str(raw.get("solution") or raw.get("suggested_fix") or "Review and address before merge if applicable."),
+        code=str(raw.get("code") or raw.get("snippet") or ""),
+        source="agentic",
+        casual_comment=str(raw.get("casual_comment") or raw.get("comment") or "") or None,
+    )
+
+
+def _agentic_review_pr(ref: PullRequestRef, *, opportunity: dict[str, Any], view: dict[str, Any], diff: str) -> dict[str, Any]:
+    review_root = Path(get_hermes_home()) / "visibility_os_reviews"
+    review_root.mkdir(parents=True, exist_ok=True)
+    checkout_dir = review_root / ref.repo.replace("/", "__") / f"pr-{ref.number}"
+    checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    if not checkout_dir.exists():
+        _gh(["gh", "repo", "clone", ref.repo, str(checkout_dir), "--", "--filter=blob:none"], timeout=300)
+    result = subprocess.run(
+        ["gh", "pr", "checkout", str(ref.number), "--repo", ref.repo],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+        cwd=str(checkout_dir),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "Failed to checkout PR branch")
+
+    changed_files = sorted(_changed_file_names(diff, view))
+    cfg = get_visibility_config()
+    prompt = f"""
+You are doing a proper agentic deep review for {cfg.company_name} / Visibility OS.
+
+Repository: {ref.repo}
+Pull request: {ref.url}
+PR title: {view.get('title') or opportunity.get('title')}
+Changed files: {', '.join(changed_files[:80])}
+
+You are running inside a local checkout of the PR branch. Inspect the codebase, read surrounding files, and run the most relevant tests or static checks that are practical. Focus on correctness, product/domain behavior, edge cases, security, tests, migrations/infrastructure risk, and regressions. Do not post to GitHub.
+
+Return ONLY a JSON object with this schema:
+{{
+  "verdict": "REQUEST_CHANGES" | "COMMENT" | "APPROVE",
+  "findings": [
+    {{
+      "severity": "critical" | "warning" | "suggestion",
+      "path": "relative/file/path",
+      "line": 1,
+      "title": "short finding title",
+      "detail": "specific explanation grounded in the code",
+      "solution": "specific coding or testing fix",
+      "casual_comment": "human-sounding review comment with no em dash or en dash characters, e.g. 'Is this SQL injection safe?' or 'this variable gets overwritten below, I think we should split it into abc instead'",
+      "code": "optional relevant snippet"
+    }}
+  ],
+  "review_notes": ["commands run, files inspected, or limits encountered"]
+}}
+""".strip()
+    result = subprocess.run(
+        ["hermes", "chat", "-Q", "-q", prompt, "--toolsets", "terminal,file"],
+        capture_output=True,
+        text=True,
+        timeout=1200,
+        check=False,
+        cwd=str(checkout_dir),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "Hermes agentic PR review failed")
+    payload = _extract_json_object(result.stdout or "")
+    findings = [_normalize_agent_finding(f) for f in payload.get("findings") or [] if isinstance(f, dict)]
+    verdict = str(payload.get("verdict") or _verdict(findings)).upper()
+    if verdict not in {"REQUEST_CHANGES", "COMMENT", "APPROVE"}:
+        verdict = _verdict(findings)
+    notes = [str(n) for n in (payload.get("review_notes") or [])]
+    notes.insert(0, f"Checked out {ref.repo} PR #{ref.number} locally and ran Hermes agentic review in {checkout_dir}.")
+    return {"verdict": verdict, "findings": findings, "review_notes": notes, "checkout_dir": str(checkout_dir)}
+
+
+def audit_pr_from_opportunity(opportunity_id: str, *, actor: str = "visibility_os") -> dict[str, Any]:
+    opportunity = get_opportunity(opportunity_id)
+    ref = _parse_pr_url(opportunity.get("source_url"))
+    view = _pr_view(ref)
+    diff = _pr_diff(ref)
+    findings = _enrich_findings_for_pr(audit_diff(diff), ref, default_source="deterministic")
+    verdict = _verdict(findings)
+    body = _review_body(opportunity=opportunity, ref=ref, findings=findings, verdict=verdict)
+    return create_action(
+        proposed_by_agent=actor,
+        action_type="github_pr_review_draft",
+        target_system="github",
+        target_location=ref.url,
+        title=f"PR audit: {opportunity.get('title', ref.url)[:90]}",
+        summary=f"Audited PR #{ref.number} with {len(findings)} finding(s); verdict {verdict}.",
+        proposed_payload={
+            "body": body,
+            "verdict": verdict,
+            "findings": findings,
+            "findings_summary": _findings_summary(findings),
+            "findings_by_file": _findings_by_file(findings),
+            "review_event": verdict,
+            "head_sha": view.get("headRefOid"),
+            "repo": ref.repo,
+            "pr_number": ref.number,
+        },
+        evidence_links=[{"type": "pull_request", "url": ref.url}],
+        risk_level="medium" if verdict == "REQUEST_CHANGES" else "low",
+        opportunity_id=opportunity_id,
+        impact_score=opportunity.get("impact_score"),
+        visibility_score=opportunity.get("visibility_score"),
+        effort_score=opportunity.get("effort_score"),
+        approval_reason="PR audit draft; human approval required before posting review feedback.",
+    )
+
+
+def deep_review_pr_from_opportunity(opportunity_id: str, *, actor: str = "visibility_os") -> dict[str, Any]:
+    opportunity = get_opportunity(opportunity_id)
+    ref = _parse_pr_url(opportunity.get("source_url"))
+    view = _pr_view(ref)
+    diff = _pr_diff(ref)
+    deterministic_findings = audit_diff(diff)
+    deep_findings, deterministic_notes = _deep_review_findings(diff=diff, view=view)
+    agent_review = _agentic_review_pr(ref, opportunity=opportunity, view=view, diff=diff)
+
+    severity_order = {"critical": 0, "warning": 1, "suggestion": 2}
+    findings = sorted(
+        deterministic_findings + deep_findings + agent_review["findings"],
+        key=lambda f: (severity_order.get(f["severity"], 9), f["path"], f["line"]),
+    )
+    findings = _enrich_findings_for_pr(findings, ref)
+    verdict = agent_review.get("verdict") or _verdict(findings)
+    if verdict == "APPROVE" and _verdict(findings) != "APPROVE":
+        verdict = _verdict(findings)
+    review_notes = deterministic_notes + agent_review["review_notes"]
+    body = _review_body(opportunity=opportunity, ref=ref, findings=findings, verdict=verdict, depth="agentic", review_notes=review_notes)
+    return create_action(
+        proposed_by_agent=actor,
+        action_type="github_pr_review_draft",
+        target_system="github",
+        target_location=ref.url,
+        title=f"Agentic deep PR review: {opportunity.get('title', ref.url)[:78]}",
+        summary=f"Agentic deep-reviewed PR #{ref.number} with {len(findings)} finding(s); verdict {verdict}.",
+        proposed_payload={
+            "body": body,
+            "verdict": verdict,
+            "findings": findings,
+            "findings_summary": _findings_summary(findings),
+            "findings_by_file": _findings_by_file(findings),
+            "review_event": verdict,
+            "head_sha": view.get("headRefOid"),
+            "repo": ref.repo,
+            "pr_number": ref.number,
+            "review_depth": "deep",
+            "agentic": True,
+            "checkout_dir": agent_review.get("checkout_dir"),
+            "review_notes": review_notes,
+            "changed_files": sorted(_changed_file_names(diff, view)),
+        },
+        evidence_links=[{"type": "pull_request", "url": ref.url}],
+        risk_level="medium" if verdict == "REQUEST_CHANGES" else "low",
+        opportunity_id=opportunity_id,
+        impact_score=opportunity.get("impact_score"),
+        visibility_score=opportunity.get("visibility_score"),
+        effort_score=opportunity.get("effort_score"),
+        approval_reason="Agentic deep PR review draft; human approval required before posting review feedback.",
+    )

--- a/plugins/visibility_os/core/scanner.py
+++ b/plugins/visibility_os/core/scanner.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+import json
+
+from . import db
+from .connectors.github import GitHubConnector
+from .opportunities import upsert_opportunity, list_opportunities, mark_opportunity_resolved_by_source
+from .scoring import score_opportunity
+
+
+def _labels(item: dict[str, Any]) -> set[str]:
+    return {str(l.get("name", "")).lower() for l in item.get("labels") or [] if isinstance(l, dict)}
+
+
+def _has_successful_check(pr: dict[str, Any], workflow_name: str | None = None) -> bool:
+    checks = [c for c in pr.get("statusCheckRollup") or [] if isinstance(c, dict)]
+    if workflow_name:
+        checks = [c for c in checks if str(c.get("name") or c.get("workflowName") or "").lower() == workflow_name.lower()]
+    return any(str(c.get("conclusion") or "").upper() == "SUCCESS" for c in checks)
+
+
+def _run_is_resolved_in_merged_code(run: dict[str, Any], connector: GitHubConnector) -> bool:
+    branch = run.get("headBranch")
+    if not branch or not hasattr(connector, "prs_for_branch"):
+        return False
+    try:
+        prs = connector.prs_for_branch(str(branch))
+    except Exception:
+        return False
+    for pr in prs:
+        if str(pr.get("state") or "").upper() == "MERGED":
+            return True
+        if _has_successful_check(pr, run.get("workflowName")):
+            return True
+    return False
+
+
+def scan_github(connector: GitHubConnector | None = None) -> list[dict[str, Any]]:
+    db.init_db()
+    connector = connector or GitHubConnector()
+    run_id = f"scan_{uuid.uuid4().hex}"
+    with db.connect() as conn:
+        conn.execute("INSERT INTO scan_runs(id, scanner_name, status) VALUES (?, ?, ?)", (run_id, "github", "running"))
+    found: list[dict[str, Any]] = []
+    source_errors: dict[str, str] = {}
+
+    def _safe_fetch(source: str, fn):
+        try:
+            return fn()
+        except Exception as exc:
+            # Fine-grained GitHub tokens and repos with disabled Issues may deny
+            # one surface while PRs/actions are still readable. Keep the scan
+            # useful and record the partial failure in scan_runs.
+            source_errors[source] = str(exc)
+            return []
+
+    try:
+        for issue in _safe_fetch("issues", connector.issues):
+            labels = _labels(issue)
+            title_l = (issue.get("title") or "").lower()
+            if labels & {"bug", "test", "flaky", "docs", "documentation"} or any(w in title_l for w in ("flake", "flaky", "ci", "docs", "bug")):
+                category = "flaky_tests_and_ci_failures" if any(w in title_l for w in ("flake", "flaky", "ci", "test")) else "small_customer_facing_bug_fixes" if "bug" in labels else "documentation_and_runbooks"
+                s = score_opportunity(impact=4 if category != "documentation_and_runbooks" else 3, visibility=4, effort=4, safety=5, risk_penalty=0)
+                found.append(upsert_opportunity(
+                    source_system="github", source_url=issue.get("url"), title=issue.get("title") or "GitHub issue",
+                    description=f"Issue #{issue.get('number')} appears relevant for {category.replace('_', ' ')}.", category=category,
+                    impact_score=s.impact, visibility_score=s.visibility, effort_score=s.effort, safety_score=s.safety,
+                    risk_penalty=s.risk_penalty, priority_score=s.priority_score,
+                    suggested_artifacts=["pull_request", "issue_comment", "slack_update"], metadata=issue,
+                ))
+        for pr in _safe_fetch("pull_requests", connector.prs):
+            checks = pr.get("statusCheckRollup") or []
+            title_l = (pr.get("title") or "").lower()
+            failing = any((c.get("conclusion") or "").upper() == "FAILURE" for c in checks if isinstance(c, dict))
+            review_decision = pr.get("reviewDecision")
+            review_required = (not pr.get("isDraft")) and review_decision in {"REVIEW_REQUIRED", "CHANGES_REQUESTED", None, ""}
+            wip_but_visible = bool(pr.get("isDraft")) or "wip" in title_l
+            if failing or review_required or wip_but_visible:
+                category = "flaky_tests_and_ci_failures" if failing else "pr_review_acceleration" if review_required else "stale_wip_handoff"
+                s = score_opportunity(impact=4, visibility=4, effort=5 if review_required else 3, safety=5 if review_required else 4, risk_penalty=0)
+                found.append(upsert_opportunity(
+                    source_system="github", source_url=pr.get("url"), title=pr.get("title") or "GitHub PR",
+                    description=f"PR #{pr.get('number')} may need {'CI attention' if failing else 'review acceleration' if review_required else 'WIP clarification or handoff'}.", category=category,
+                    impact_score=s.impact, visibility_score=s.visibility, effort_score=s.effort, safety_score=s.safety,
+                    risk_penalty=s.risk_penalty, priority_score=s.priority_score,
+                    suggested_artifacts=["review_comment", "risk_note", "slack_update"], metadata=pr,
+                ))
+        for run in _safe_fetch("workflow_runs", connector.runs):
+            if run.get("conclusion") != "failure":
+                continue
+            if _run_is_resolved_in_merged_code(run, connector):
+                mark_opportunity_resolved_by_source(
+                    "github",
+                    run.get("url"),
+                    "flaky_tests_and_ci_failures",
+                    reason="Linked branch/PR is merged or has a later successful CI check.",
+                )
+                continue
+            s = score_opportunity(impact=4, visibility=4, effort=4, safety=5, risk_penalty=0)
+            found.append(upsert_opportunity(
+                source_system="github", source_url=run.get("url"), title=f"Failing CI: {run.get('displayTitle') or run.get('workflowName')}",
+                description="A recent GitHub Actions run failed and may be a visible unblock opportunity.", category="flaky_tests_and_ci_failures",
+                impact_score=s.impact, visibility_score=s.visibility, effort_score=s.effort, safety_score=s.safety,
+                risk_penalty=s.risk_penalty, priority_score=s.priority_score,
+                suggested_artifacts=["ci_before_after", "pull_request", "issue_comment"], metadata=run,
+            ))
+        with db.connect() as conn:
+            status = "completed" if not source_errors else "partial"
+            conn.execute("UPDATE scan_runs SET status = ?, finished_at = ?, result_payload = ? WHERE id = ?", (status, _now(), json.dumps({"count": len(found), "source_errors": source_errors}), run_id))
+    except Exception as exc:
+        with db.connect() as conn:
+            conn.execute("UPDATE scan_runs SET status = ?, finished_at = ?, result_payload = ? WHERE id = ?", ("failed", _now(), json.dumps({"error": str(exc)}), run_id))
+        raise
+    return sorted(found, key=lambda o: o["priority_score"], reverse=True)
+
+
+def current_opportunities() -> list[dict[str, Any]]:
+    return list_opportunities()
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/plugins/visibility_os/core/scoring.py
+++ b/plugins/visibility_os/core/scoring.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScoreResult:
+    impact: int
+    visibility: int
+    effort: int
+    safety: int
+    risk_penalty: int
+    priority_score: int
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, int(value)))
+
+
+def score_opportunity(*, impact: int, visibility: int, effort: int, safety: int, risk_penalty: int) -> ScoreResult:
+    impact = _clamp(impact, 0, 5)
+    visibility = _clamp(visibility, 0, 5)
+    effort = _clamp(effort, 1, 5)
+    safety = _clamp(safety, 1, 5)
+    risk_penalty = _clamp(risk_penalty, 0, 10)
+    return ScoreResult(
+        impact=impact,
+        visibility=visibility,
+        effort=effort,
+        safety=safety,
+        risk_penalty=risk_penalty,
+        priority_score=(impact * 3) + (visibility * 2) + effort + safety - risk_penalty,
+    )

--- a/plugins/visibility_os/core/workstreams.py
+++ b/plugins/visibility_os/core/workstreams.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from . import db
+
+ACTIVE_STATUSES = {"active", "queued"}
+TERMINAL_STAGES = {"completed", "failed", "cancelled", "pushed"}
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value or {}, sort_keys=True)
+
+
+def _decode(value: str | None, default: Any) -> Any:
+    if not value:
+        return default
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+def _row_to_workstream(row) -> dict[str, Any]:
+    d = dict(row)
+    d["result_payload"] = _decode(d.get("result_payload"), {})
+    return d
+
+
+def _row_to_event(row) -> dict[str, Any]:
+    d = dict(row)
+    d["payload"] = _decode(d.get("payload"), {})
+    return d
+
+
+def _row_to_artifact(row) -> dict[str, Any]:
+    d = dict(row)
+    d["payload"] = _decode(d.get("payload"), {})
+    return d
+
+
+def _events(conn, workstream_id: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT * FROM workstream_events WHERE workstream_id = ? ORDER BY created_at, rowid",
+        (workstream_id,),
+    ).fetchall()
+    return [_row_to_event(row) for row in rows]
+
+
+def _artifacts(conn, workstream_id: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT * FROM workstream_artifacts WHERE workstream_id = ? ORDER BY created_at, rowid",
+        (workstream_id,),
+    ).fetchall()
+    return [_row_to_artifact(row) for row in rows]
+
+
+def _hydrate(conn, row) -> dict[str, Any]:
+    ws = _row_to_workstream(row)
+    ws["events"] = _events(conn, ws["id"])
+    ws["artifacts"] = _artifacts(conn, ws["id"])
+    ws["pending_human_action"] = _pending_human_action(conn, ws)
+    return ws
+
+
+def _pending_human_action(conn, ws: dict[str, Any]) -> dict[str, Any] | None:
+    rows = conn.execute(
+        """
+        SELECT id, action_type, title, status, target_system
+        FROM action_queue
+        WHERE opportunity_id IS ?
+          AND status IN ('queued', 'needs_review', 'drafted')
+          AND action_type IN ('github_push_branch', 'github_pr_comment', 'github_issue_comment')
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (ws.get("opportunity_id"),),
+    ).fetchall()
+    if not rows:
+        return None
+    return dict(rows[0])
+
+
+def create_workstream(
+    *,
+    opportunity_id: str | None,
+    root_action_id: str | None,
+    lane_kind: str,
+    title: str,
+    repo: str | None = None,
+    source_url: str | None = None,
+    actor: str = "visibility_os",
+    summary: str = "",
+) -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        if opportunity_id:
+            row = conn.execute(
+                """
+                SELECT * FROM workstreams
+                WHERE opportunity_id = ? AND lane_kind = ? AND status = 'active'
+                ORDER BY updated_at DESC LIMIT 1
+                """,
+                (opportunity_id, lane_kind),
+            ).fetchone()
+            if row:
+                ws = _hydrate(conn, row)
+                if root_action_id and not ws.get("root_action_id"):
+                    conn.execute("UPDATE workstreams SET root_action_id = ?, updated_at = datetime('now') WHERE id = ?", (root_action_id, ws["id"]))
+                    row = conn.execute("SELECT * FROM workstreams WHERE id = ?", (ws["id"],)).fetchone()
+                    ws = _hydrate(conn, row)
+                return ws
+        workstream_id = f"ws_{uuid.uuid4().hex}"
+        conn.execute(
+            """
+            INSERT INTO workstreams(id, opportunity_id, root_action_id, lane_kind, title, repo, source_url, stage, status, started_at, summary, current_step, progress_percent)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'queued', 'active', datetime('now'), ?, 'Queued for agent work', 0)
+            """,
+            (workstream_id, opportunity_id, root_action_id, lane_kind, title, repo, source_url, summary),
+        )
+        conn.execute(
+            """
+            INSERT INTO workstream_events(id, workstream_id, event_type, stage, actor, message, payload)
+            VALUES (?, ?, 'created', 'queued', ?, ?, '{}')
+            """,
+            (f"wse_{uuid.uuid4().hex}", workstream_id, actor, f"Created workstream for {lane_kind}"),
+        )
+        row = conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone()
+        return _hydrate(conn, row)
+
+
+def bind_root_action(workstream_id: str, action_id: str) -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        conn.execute("UPDATE workstreams SET root_action_id = ?, updated_at = datetime('now') WHERE id = ?", (action_id, workstream_id))
+        row = conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone()
+        if not row:
+            raise KeyError(f"Workstream not found: {workstream_id}")
+        return _hydrate(conn, row)
+
+
+def get_workstream(workstream_id: str) -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        row = conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone()
+        if not row:
+            raise KeyError(f"Workstream not found: {workstream_id}")
+        return _hydrate(conn, row)
+
+
+def list_workstreams(*, status: str | None = None, opportunity_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    db.init_db()
+    clauses = []
+    values: list[Any] = []
+    if status:
+        if status == "active":
+            clauses.append("status = 'active'")
+        else:
+            clauses.append("status = ?")
+            values.append(status)
+    if opportunity_id:
+        clauses.append("opportunity_id = ?")
+        values.append(opportunity_id)
+    where = " WHERE " + " AND ".join(clauses) if clauses else ""
+    values.append(limit)
+    with db.connect() as conn:
+        rows = conn.execute(f"SELECT * FROM workstreams{where} ORDER BY updated_at DESC LIMIT ?", tuple(values)).fetchall()
+        return [_hydrate(conn, row) for row in rows]
+
+
+def update_stage(
+    workstream_id: str,
+    *,
+    stage: str,
+    status: str | None = None,
+    current_step: str = "",
+    progress_percent: int | None = None,
+    actor: str = "system",
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    db.init_db()
+    payload = payload or {}
+    if status is None:
+        status = "completed" if stage in {"completed", "pushed"} else "failed" if stage == "failed" else "active"
+    progress = max(0, min(100, int(progress_percent if progress_percent is not None else 0)))
+    with db.connect() as conn:
+        row = conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone()
+        if not row:
+            raise KeyError(f"Workstream not found: {workstream_id}")
+        if progress_percent is None:
+            progress = int(row["progress_percent"] or 0)
+        completed_at_sql = ", completed_at = datetime('now')" if status in {"completed", "failed", "cancelled"} else ""
+        conn.execute(
+            f"""
+            UPDATE workstreams
+            SET stage = ?, status = ?, current_step = ?, progress_percent = ?, updated_at = datetime('now') {completed_at_sql}
+            WHERE id = ?
+            """,
+            (stage, status, current_step, progress, workstream_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO workstream_events(id, workstream_id, event_type, stage, actor, message, payload)
+            VALUES (?, ?, 'stage_changed', ?, ?, ?, ?)
+            """,
+            (f"wse_{uuid.uuid4().hex}", workstream_id, stage, actor, current_step or stage.replace("_", " ").title(), _json(payload)),
+        )
+        updated = conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone()
+        return _hydrate(conn, updated)
+
+
+def record_workstream_event(
+    workstream_id: str,
+    *,
+    event_type: str,
+    message: str,
+    actor: str = "system",
+    stage: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        ws = conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone()
+        if not ws:
+            raise KeyError(f"Workstream not found: {workstream_id}")
+        conn.execute(
+            """
+            INSERT INTO workstream_events(id, workstream_id, event_type, stage, actor, message, payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (f"wse_{uuid.uuid4().hex}", workstream_id, event_type, stage or ws["stage"], actor, message, _json(payload or {})),
+        )
+        conn.execute("UPDATE workstreams SET updated_at = datetime('now') WHERE id = ?", (workstream_id,))
+        return _hydrate(conn, conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone())
+
+
+def add_workstream_artifact(
+    workstream_id: str,
+    *,
+    artifact_type: str,
+    title: str,
+    summary: str = "",
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        ws = conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone()
+        if not ws:
+            raise KeyError(f"Workstream not found: {workstream_id}")
+        conn.execute(
+            """
+            INSERT INTO workstream_artifacts(id, workstream_id, artifact_type, title, summary, payload)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (f"wsa_{uuid.uuid4().hex}", workstream_id, artifact_type, title, summary, _json(payload or {})),
+        )
+        conn.execute("UPDATE workstreams SET updated_at = datetime('now') WHERE id = ?", (workstream_id,))
+        return _hydrate(conn, conn.execute("SELECT * FROM workstreams WHERE id = ?", (workstream_id,)).fetchone())
+
+
+def latest_for_opportunity(opportunity_id: str) -> dict[str, Any] | None:
+    streams = list_workstreams(opportunity_id=opportunity_id, limit=1)
+    return streams[0] if streams else None

--- a/plugins/visibility_os/dashboard/__init__.py
+++ b/plugins/visibility_os/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Dashboard API for Hermes Visibility OS."""

--- a/plugins/visibility_os/dashboard/dist/index.js
+++ b/plugins/visibility_os/dashboard/dist/index.js
@@ -14,7 +14,7 @@
   function ActionButton(props) {
     const disabled = props && props.disabled;
     const extraClass = props && props.className ? ' ' + props.className : '';
-    const className = 'inline-flex items-center justify-center rounded border border-current/20 bg-midground px-3 py-2 text-sm font-semibold leading-none tracking-normal normal-case whitespace-nowrap hover:bg-midground/90 disabled:opacity-50 disabled:cursor-not-allowed' + extraClass;
+    const className = 'visibility-os-action-button inline-flex items-center justify-center rounded border border-current/20 bg-midground px-2 py-1 text-xs font-semibold leading-none tracking-normal normal-case whitespace-nowrap hover:bg-midground/90 disabled:opacity-50 disabled:cursor-not-allowed' + extraClass;
     const style = Object.assign({ color: '#061512', letterSpacing: 'normal', textTransform: 'none', fontFamily: 'Arial, Helvetica, sans-serif', fontWeight: 700, lineHeight: 1.1 }, props && props.style ? props.style : {});
     return h('button', Object.assign({}, props || {}, { type: (props && props.type) || 'button', disabled: disabled, className: className, style: style }), props && props.children);
   }
@@ -330,12 +330,22 @@
     function boardItemCard(item) {
       const title = item.title || item.opportunity_title || item.summary || item.id;
       const description = item.kind === 'opportunity' ? item.description : item.summary;
-      return h('div', { key: item.kind + ':' + item.id, className: 'rounded border border-current/10 bg-black/20 p-3 text-xs space-y-2' },
-        h('div', { className: 'flex items-start justify-between gap-2' },
-          h('div', { className: 'font-semibold text-sm leading-snug' }, title),
+      return h('div', {
+        key: item.kind + ':' + item.id,
+        className: 'hermes-kanban-card visibility-os-card',
+        'data-visibility-kind': item.kind,
+        draggable: true,
+        onDragStart: function (e) {
+          e.dataTransfer.setData('application/vnd.visibility-os-card', JSON.stringify({ kind: item.kind, id: item.id }));
+          e.dataTransfer.effectAllowed = 'move';
+        }
+      },
+        h('div', { className: 'hermes-kanban-card-content' },
+        h('div', { className: 'hermes-kanban-card-row visibility-os-card-head' },
+          h('div', { className: 'hermes-kanban-card-title' }, title),
           h(Badge, null, item.kind === 'opportunity' ? 'Opportunity' : 'Action')
         ),
-        h('div', { className: 'flex gap-1 flex-wrap' },
+        h('div', { className: 'hermes-kanban-card-row hermes-kanban-card-meta' },
           item.repo && h(Badge, null, item.repo),
           item.source_repo && h(Badge, null, item.source_repo),
           item.category && h(Badge, null, item.category),
@@ -343,30 +353,55 @@
           item.priority_score && h(Badge, null, 'P' + item.priority_score),
           item.board_state_actor && h(Badge, null, 'manual')
         ),
-        description && h('p', { className: 'text-text-secondary line-clamp-3' }, description),
-        item.current_step && h('div', { className: 'text-text-secondary' }, item.current_step),
+        description && h('p', { className: 'visibility-os-card-description' }, description),
+        item.current_step && h('div', { className: 'visibility-os-card-step' }, item.current_step),
         item.workstream_id && workstreamBadge(item),
         item.action_type === 'github_push_branch' && proposedPRView(item),
         findingsView(item),
         sectionActions(item)
+        )
       );
     }
     function kanbanColumn(key, title, emptyText) {
       const items = allItems.filter(function (i) { return (i.board_state || 'todo') === key; });
-      return h('div', { className: 'rounded border border-current/10 bg-black/10 min-h-[18rem]' },
-        h('div', { className: 'sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-current/10 bg-background/95 px-3 py-3' },
-          h('div', { className: 'font-bold text-midground' }, title),
-          h(Badge, null, items.length)
+      const help = {
+        todo: 'Unstarted opportunities and queued work.',
+        in_progress: 'Agent or human work currently moving.',
+        in_review: 'Proposed PRs and decisions waiting on review.',
+        done: 'Completed, resolved, rejected, or failed work.',
+        archived: 'Hidden history kept for auditability.'
+      }[key] || '';
+      function handleDrop(e) {
+        e.preventDefault();
+        let raw = e.dataTransfer.getData('application/vnd.visibility-os-card');
+        if (!raw) return;
+        try {
+          const payload = JSON.parse(raw);
+          const item = allItems.find(function (i) { return i.kind === payload.kind && i.id === payload.id; });
+          if (item && item.board_state !== key) moveBoardState(item, key);
+        } catch (_) {}
+      }
+      return h('div', {
+        className: 'hermes-kanban-column visibility-os-column',
+        'data-kanban-column': key,
+        onDragOver: function (e) { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; },
+        onDrop: handleDrop
+      },
+        h('div', { className: 'hermes-kanban-column-header', title: help },
+          h('span', { className: 'hermes-kanban-dot visibility-os-dot visibility-os-dot-' + key }),
+          h('span', { className: 'hermes-kanban-column-label' }, title),
+          h('span', { className: 'hermes-kanban-column-count' }, items.length)
         ),
-        h('div', { className: 'p-3 space-y-3' },
-          !items.length && h('div', { className: 'rounded border border-dashed border-current/20 p-4 text-xs text-text-secondary' }, emptyText),
+        h('div', { className: 'hermes-kanban-column-sub' }, help),
+        h('div', { className: 'hermes-kanban-column-body' },
+          !items.length && h('div', { className: 'hermes-kanban-empty' }, emptyText),
           items.map(boardItemCard)
         )
       );
     }
     const allItems = feed.items || [];
     const boardCounts = (feed.counts && feed.counts.board) || {};
-    return h('div', { className: 'h-full min-h-0 overflow-auto p-6 space-y-4' },
+    return h('div', { className: 'hermes-kanban visibility-os-kanban h-full min-h-0 overflow-auto p-6 space-y-4' },
       h('div', { className: 'flex items-center justify-between gap-4' },
         h('div', null,
           h('h1', { className: 'text-2xl font-bold text-midground' }, 'Hermes Visibility OS'),
@@ -406,14 +441,14 @@
           )
         )
       ),
-      h('div', { className: 'grid grid-cols-2 md:grid-cols-5 gap-3' },
+      h('div', { className: 'visibility-os-metrics' },
         h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.todo || 0), h('div', { className: 'text-xs text-text-secondary' }, 'Todo'))),
         h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.in_progress || 0), h('div', { className: 'text-xs text-text-secondary' }, 'In progress'))),
         h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.in_review || 0), h('div', { className: 'text-xs text-text-secondary' }, 'In review'))),
         h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.done || 0), h('div', { className: 'text-xs text-text-secondary' }, 'Done'))),
         h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.archived || 0), h('div', { className: 'text-xs text-text-secondary' }, 'Archived')))
       ),
-      h('div', { className: 'flex items-center justify-between gap-2 flex-wrap rounded border border-current/10 bg-black/10 p-3' },
+      h('div', { className: 'visibility-os-board-toolbar' },
         h('div', null,
           h('div', { className: 'text-sm font-bold text-midground' }, 'Kanban board'),
           h('div', { className: 'text-xs text-text-secondary' }, 'Move cards through Todo, In progress, In review, Done, then archive them out of the active board.')
@@ -423,13 +458,13 @@
           'Show archived'
         )
       ),
-      h('div', { className: 'grid grid-cols-1 xl:grid-cols-4 gap-3 items-start' },
+      h('div', { className: 'hermes-kanban-columns visibility-os-kanban-columns' },
         kanbanColumn('todo', 'Todo', 'No unstarted opportunities.'),
         kanbanColumn('in_progress', 'In progress', 'No agent or human work in progress.'),
         kanbanColumn('in_review', 'In review', 'No proposed PRs or decisions waiting.'),
-        kanbanColumn('done', 'Done', 'No completed work yet.')
-      ),
-      showArchived && h('div', { className: 'grid grid-cols-1 gap-3' }, kanbanColumn('archived', 'Archived', 'Nothing archived yet.'))
+        kanbanColumn('done', 'Done', 'No completed work yet.'),
+        showArchived ? kanbanColumn('archived', 'Archived', 'Nothing archived yet.') : null
+      )
     );
   }
   plugins.register('visibility-os', VisibilityOS);

--- a/plugins/visibility_os/dashboard/dist/index.js
+++ b/plugins/visibility_os/dashboard/dist/index.js
@@ -1,0 +1,436 @@
+(function () {
+  const sdk = window.__HERMES_PLUGIN_SDK__;
+  const plugins = window.__HERMES_PLUGINS__;
+  if (!sdk || !plugins) return;
+  const React = sdk.React;
+  const h = React.createElement;
+  const fetchJSON = sdk.fetchJSON;
+  const Card = sdk.components.Card;
+  const CardHeader = sdk.components.CardHeader;
+  const CardTitle = sdk.components.CardTitle;
+  const CardContent = sdk.components.CardContent;
+  const Badge = sdk.components.Badge;
+
+  function ActionButton(props) {
+    const disabled = props && props.disabled;
+    const extraClass = props && props.className ? ' ' + props.className : '';
+    const className = 'inline-flex items-center justify-center rounded border border-current/20 bg-midground px-3 py-2 text-sm font-semibold leading-none tracking-normal normal-case whitespace-nowrap hover:bg-midground/90 disabled:opacity-50 disabled:cursor-not-allowed' + extraClass;
+    const style = Object.assign({ color: '#061512', letterSpacing: 'normal', textTransform: 'none', fontFamily: 'Arial, Helvetica, sans-serif', fontWeight: 700, lineHeight: 1.1 }, props && props.style ? props.style : {});
+    return h('button', Object.assign({}, props || {}, { type: (props && props.type) || 'button', disabled: disabled, className: className, style: style }), props && props.children);
+  }
+
+  function payloadText(action) {
+    const p = action.final_payload || action.proposed_payload || {};
+    return p.text || p.body || JSON.stringify(p, null, 2);
+  }
+
+  function VisibilityOS() {
+    const hooks = sdk.hooks;
+    const [feed, setFeed] = hooks.useState({ items: [], counts: {} });
+    const [error, setError] = hooks.useState(null);
+    const [busy, setBusy] = hooks.useState(false);
+    const [selectedOpportunity, setSelectedOpportunity] = hooks.useState(null);
+    const [selectedWorkstream, setSelectedWorkstream] = hooks.useState(null);
+    const [slackTarget, setSlackTarget] = hooks.useState('');
+    const [severityFilter, setSeverityFilter] = hooks.useState('all');
+    const [sourceFilter, setSourceFilter] = hooks.useState('all');
+    const [showArchived, setShowArchived] = hooks.useState(false);
+    const [findingStatus, setFindingStatus] = hooks.useState({});
+    const load = hooks.useCallback(function () {
+      setBusy(true);
+      fetchJSON('/api/plugins/visibility-os/feed' + (showArchived ? '?include_archived=true' : ''))
+        .then(setFeed)
+        .catch(function (e) { setError(String(e)); })
+        .finally(function () { setBusy(false); });
+    }, [showArchived]);
+    hooks.useEffect(load, [load]);
+    hooks.useEffect(function () {
+      fetchJSON('/api/plugins/visibility-os/config')
+        .then(function (cfg) { if (cfg && cfg.default_slack_channel) setSlackTarget(cfg.default_slack_channel); })
+        .catch(function () {});
+    }, []);
+    function post(path, body) {
+      setBusy(true);
+      fetchJSON(path, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body || {}) })
+        .then(load)
+        .catch(function (e) { setError(String(e)); setBusy(false); });
+    }
+    function moveBoardState(item, boardState) {
+      post('/api/plugins/visibility-os/board-state', { item_kind: item.kind, item_id: item.id, board_state: boardState, actor: 'human' });
+    }
+    function viewOpportunity(id) {
+      setBusy(true);
+      fetchJSON('/api/plugins/visibility-os/opportunities/' + id)
+        .then(function (detail) { setSelectedOpportunity(detail); })
+        .catch(function (e) { setError(String(e)); })
+        .finally(function () { setBusy(false); });
+    }
+    function viewWorkstream(id) {
+      if (!id) return;
+      setBusy(true);
+      fetchJSON('/api/plugins/visibility-os/workstreams/' + id)
+        .then(function (detail) { setSelectedWorkstream(detail); })
+        .catch(function (e) { setError(String(e)); })
+        .finally(function () { setBusy(false); });
+    }
+    function draftOpportunity(detail, actionKind) {
+      const body = { action_kind: actionKind, actor: 'human' };
+      if (actionKind === 'slack_update' && slackTarget) body.target_location = slackTarget;
+      post('/api/plugins/visibility-os/opportunities/' + detail.id + '/draft-action', body);
+      setSelectedOpportunity(null);
+    }
+    function auditOpportunity(detail) {
+      post('/api/plugins/visibility-os/opportunities/' + detail.id + '/audit-pr', { actor: 'human' });
+      setSelectedOpportunity(null);
+    }
+    function deepReviewOpportunity(detail) {
+      post('/api/plugins/visibility-os/opportunities/' + detail.id + '/deep-review-pr', { actor: 'human' });
+      setSelectedOpportunity(null);
+    }
+    function fixCI(item) {
+      const opportunityId = item.opportunity_id || item.id;
+      post('/api/plugins/visibility-os/opportunities/' + opportunityId + '/fix-ci', { actor: 'human' });
+    }
+    function fixIssue(item) {
+      const opportunityId = item.opportunity_id || item.id;
+      post('/api/plugins/visibility-os/opportunities/' + opportunityId + '/fix-issue', { actor: 'human' });
+    }
+    function pushBranchNow(item) {
+      post('/api/plugins/visibility-os/actions/' + item.id + '/approve', { actor: 'human', execute_immediately: true });
+    }
+    function scoreLine(detail) {
+      return 'Impact ' + detail.impact_score + ' · Visibility ' + detail.visibility_score + ' · Effort ' + detail.effort_score + ' · Safety ' + detail.safety_score + ' · Risk penalty ' + detail.risk_penalty;
+    }
+    function editPayload(item) {
+      const current = payloadText(item);
+      const next = window.prompt('Edit reviewed payload before approval', current);
+      if (next === null) return;
+      const key = (item.proposed_payload && item.proposed_payload.body !== undefined) ? 'body' : 'text';
+      post('/api/plugins/visibility-os/actions/' + item.id + '/edit', { actor: 'human', final_payload: { [key]: next } });
+    }
+    function evidenceLinks(item) {
+      const links = item.evidence_links || [];
+      if (!links.length) return h('div', { className: 'text-xs text-amber-300' }, 'No evidence links attached');
+      return h('div', { className: 'flex gap-2 flex-wrap' }, links.map(function (link, idx) {
+        const url = link.url || link.href || String(link);
+        return h('a', { key: idx, className: 'text-xs underline text-midground', href: url, target: '_blank' }, link.type ? link.type + ': ' + url : url);
+      }));
+    }
+    function displayValue(value) {
+      if (value === null || value === undefined) return '';
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return String(value);
+      if (Array.isArray(value)) return value.map(displayValue).filter(Boolean).join(', ');
+      if (typeof value === 'object') {
+        if (value.path && value.change) return value.path + ' — ' + value.change;
+        if (value.path && value.summary) return value.path + ' — ' + value.summary;
+        if (value.path) return String(value.path);
+        if (value.file) return String(value.file);
+        if (value.name) return String(value.name);
+        return JSON.stringify(value);
+      }
+      return String(value);
+    }
+    function listItems(values) {
+      return (values || []).map(function (value, idx) {
+        const text = displayValue(value);
+        return h('li', { key: text + ':' + idx }, text);
+      });
+    }
+    function proposedPRView(item) {
+      if (item.action_type !== 'github_push_branch') return null;
+      const p = item.final_payload || item.proposed_payload || {};
+      return h('div', { className: 'rounded border border-emerald-500/30 bg-emerald-500/10 p-4 space-y-3' },
+        h('div', { className: 'flex items-center justify-between gap-2 flex-wrap' },
+          h('div', null,
+            h('div', { className: 'text-sm font-bold text-midground' }, 'Proposed PR'),
+            h('div', { className: 'text-xs text-text-secondary' }, 'Hermes prepared this locally. Nothing is pushed until you choose Push branch.')
+          ),
+          h(Badge, null, p.branch || 'branch pending')
+        ),
+        h('div', { className: 'grid grid-cols-1 md:grid-cols-2 gap-3 text-xs' },
+          h('div', { className: 'rounded bg-black/20 p-2' }, h('div', { className: 'font-semibold text-text-secondary' }, 'Commit message'), h('div', null, p.commit_message || 'not provided')),
+          h('div', { className: 'rounded bg-black/20 p-2' }, h('div', { className: 'font-semibold text-text-secondary' }, 'PR title'), h('div', null, p.pr_title || p.commit_message || 'not provided'))
+        ),
+        p.changed_files && p.changed_files.length && h('div', { className: 'text-xs' }, h('div', { className: 'font-semibold text-text-secondary' }, 'Changed files'), h('ul', { className: 'list-disc pl-4' }, listItems(p.changed_files))),
+        p.verification && p.verification.length && h('div', { className: 'text-xs' }, h('div', { className: 'font-semibold text-text-secondary' }, 'Verification'), h('ul', { className: 'list-disc pl-4' }, listItems(p.verification))),
+        p.self_audit && h('div', { className: 'text-xs rounded bg-black/20 p-2' }, h('div', { className: 'font-semibold text-text-secondary' }, 'Self-audit'), h('div', null, 'Status: ' + (p.self_audit.audit_status || 'unknown')), p.self_audit.issues_found && h('div', null, 'Issues found: ' + p.self_audit.issues_found.length), p.self_audit.fixes_applied && h('div', null, 'Fixes applied: ' + p.self_audit.fixes_applied.length)),
+        p.independent_review && h('div', { className: 'text-xs rounded bg-black/20 p-2' }, h('div', { className: 'font-semibold text-text-secondary' }, 'Independent review'), h('div', null, 'Status: ' + (p.independent_review.review_status || 'unknown')), p.independent_review.findings && h('div', null, 'Findings: ' + p.independent_review.findings.length), p.independent_review.fixes_required && h('div', null, 'Fixes required: ' + p.independent_review.fixes_required.length)),
+        h('details', { className: 'text-xs' }, h('summary', { className: 'cursor-pointer font-semibold text-text-secondary' }, 'PR body'), h('pre', { className: 'mt-2 whitespace-pre-wrap rounded bg-black/40 p-3' }, p.pr_body || 'not provided'))
+      );
+    }
+    function actionPayloadView(item) {
+      if (item.action_type === 'github_push_branch') return proposedPRView(item);
+      return h('details', { className: 'text-xs' },
+        h('summary', { className: 'cursor-pointer text-text-secondary' }, 'Raw payload'),
+        h('pre', { className: 'mt-2 whitespace-pre-wrap rounded bg-black/40 p-3 text-xs' }, payloadText(item))
+      );
+    }
+    function progressBar(value) {
+      const pct = Math.max(0, Math.min(100, Number(value || 0)));
+      return h('div', { className: 'h-2 rounded bg-black/30 overflow-hidden' }, h('div', { className: 'h-full bg-emerald-400', style: { width: pct + '%' } }));
+    }
+    function workstreamBadge(item) {
+      if (!item.workstream_id) return h(Badge, null, 'Not started');
+      return h(ActionButton, { onClick: function () { viewWorkstream(item.workstream_id); }, className: 'border-emerald-500/40' }, (item.workstream_stage || 'workstream').replace(/_/g, ' '));
+    }
+    function workstreamDetailView(ws) {
+      if (!ws) return null;
+      const artifacts = ws.artifacts || [];
+      const proposed = artifacts.find(function (a) { return a.artifact_type === 'proposed_pr'; });
+      const diff = artifacts.find(function (a) { return a.artifact_type === 'diff_summary'; });
+      const review = artifacts.find(function (a) { return a.artifact_type === 'review_findings'; });
+      return h(Card, { className: 'border-emerald-500/40' },
+        h(CardHeader, null, h(CardTitle, null, 'Workstream: ' + ws.title)),
+        h(CardContent, { className: 'space-y-4' },
+          h('div', { className: 'flex gap-2 flex-wrap' }, h(Badge, null, ws.status), h(Badge, null, (ws.stage || '').replace(/_/g, ' ')), ws.repo && h(Badge, null, ws.repo), h(Badge, null, ws.lane_kind)),
+          h('div', { className: 'space-y-1' }, h('div', { className: 'text-xs text-text-secondary' }, ws.current_step || 'No current step recorded'), progressBar(ws.progress_percent)),
+          ws.source_url && h('a', { className: 'text-xs underline text-midground', href: ws.source_url, target: '_blank' }, ws.source_url),
+          h('div', { className: 'grid grid-cols-1 md:grid-cols-2 gap-3' },
+            h('div', { className: 'rounded border border-current/10 p-3 space-y-2' },
+              h('div', { className: 'text-sm font-bold text-midground' }, 'Timeline'),
+              (ws.events || []).map(function (ev) { return h('div', { key: ev.id, className: 'text-xs rounded bg-black/20 p-2' }, h('div', { className: 'font-semibold' }, (ev.stage || ev.event_type || '').replace(/_/g, ' ')), h('div', { className: 'text-text-secondary' }, ev.message), h('div', { className: 'text-[10px] text-text-secondary' }, ev.created_at)); })
+            ),
+            h('div', { className: 'rounded border border-current/10 p-3 space-y-2' },
+              h('div', { className: 'text-sm font-bold text-midground' }, 'Artifacts'),
+              !artifacts.length && h('div', { className: 'text-xs text-text-secondary' }, 'No artifacts yet'),
+              artifacts.map(function (a) { return h('details', { key: a.id, className: 'text-xs rounded bg-black/20 p-2' }, h('summary', { className: 'cursor-pointer font-semibold' }, a.artifact_type + ': ' + a.title), h('div', { className: 'text-text-secondary py-1' }, a.summary), h('pre', { className: 'whitespace-pre-wrap rounded bg-black/40 p-2' }, JSON.stringify(a.payload || {}, null, 2))); })
+            )
+          ),
+          proposed && h('div', { className: 'rounded border border-emerald-500/30 bg-emerald-500/10 p-3 space-y-2 text-xs' },
+            h('div', { className: 'text-sm font-bold text-midground' }, 'Proposed PR'),
+            h('div', null, 'Branch: ' + ((proposed.payload || {}).branch || 'unknown')),
+            h('div', null, 'Title: ' + ((proposed.payload || {}).pr_title || 'not provided')),
+            (proposed.payload || {}).changed_files && h('ul', { className: 'list-disc pl-4' }, listItems(proposed.payload.changed_files || []))
+          ),
+          diff && h('div', { className: 'rounded border border-current/10 p-3 text-xs' }, h('div', { className: 'text-sm font-bold text-midground' }, 'Change summary'), h('ul', { className: 'list-disc pl-4' }, listItems((diff.payload || {}).changed_files || []))),
+          review && h('div', { className: 'rounded border border-current/10 p-3 text-xs' }, h('div', { className: 'text-sm font-bold text-midground' }, 'Review findings'), h('pre', { className: 'whitespace-pre-wrap rounded bg-black/40 p-2' }, JSON.stringify(review.payload || {}, null, 2))),
+          h(ActionButton, { onClick: function () { setSelectedWorkstream(null); } }, 'Close workstream')
+        )
+      );
+    }
+    function findingsSummaryView(findings) {
+      const counts = findings.reduce(function (acc, f) { acc[f.severity || 'suggestion'] = (acc[f.severity || 'suggestion'] || 0) + 1; return acc; }, { critical: 0, warning: 0, suggestion: 0 });
+      return h('div', { className: 'grid grid-cols-3 gap-2 text-xs' },
+        ['critical', 'warning', 'suggestion'].map(function (sev) {
+          return h('div', { key: sev, className: 'rounded border border-current/10 bg-black/20 p-2' },
+            h('div', { className: 'text-lg font-bold' }, counts[sev] || 0),
+            h('div', { className: 'text-text-secondary capitalize' }, sev)
+          );
+        })
+      );
+    }
+    function groupFindingsByFile(findings) {
+      return findings.reduce(function (acc, f) {
+        const key = f.path || 'unknown';
+        (acc[key] = acc[key] || []).push(f);
+        return acc;
+      }, {});
+    }
+    function copyFindingComment(f) {
+      const text = f.copy_comment || ((f.casual_comment || f.title || 'Finding') + '\n\n' + (f.path || 'unknown') + ':' + (f.line || '?') + '\n\nSuggested change: ' + (f.solution || ''));
+      if (navigator.clipboard) navigator.clipboard.writeText(text);
+      else window.prompt('Copy review comment', text);
+    }
+    function markFindingStatus(item, idx, status) {
+      const key = item.id + ':' + idx;
+      setFindingStatus(function (prev) { return Object.assign({}, prev, { [key]: status }); });
+    }
+    function findingCard(item, f, idx) {
+      const status = findingStatus[item.id + ':' + idx] || f.status || 'open';
+      return h('div', { key: idx, className: 'rounded border border-current/10 bg-black/20 p-3 text-xs space-y-2' },
+        h('div', { className: 'flex gap-2 flex-wrap items-center' },
+          h(Badge, null, f.severity || 'suggestion'),
+          h(Badge, null, f.source || 'deterministic'),
+          h(Badge, null, status),
+          h(Badge, null, (f.path || 'unknown') + ':' + (f.line || '?'))
+        ),
+        h('div', { className: 'rounded bg-emerald-500/10 border border-emerald-500/20 p-2 text-sm font-medium' }, f.casual_comment || f.title),
+        h('details', { className: 'space-y-2' },
+          h('summary', { className: 'cursor-pointer text-text-secondary' }, 'Structured detail'),
+          h('div', { className: 'font-semibold pt-2' }, f.title),
+          h('div', { className: 'text-text-secondary' }, f.detail),
+          h('div', null, h('span', { className: 'text-text-secondary' }, 'Suggested fix: '), f.solution)
+        ),
+        f.code && h('pre', { className: 'whitespace-pre-wrap rounded bg-black/40 p-2 border-l-2 border-midground' }, f.code),
+        h('div', { className: 'flex gap-2 flex-wrap' },
+          f.github_diff_url && h('a', { className: 'text-xs underline text-midground', href: f.github_diff_url, target: '_blank' }, 'Open diff line'),
+          h(ActionButton, { onClick: function () { copyFindingComment(f); } }, 'Copy comment'),
+          h(ActionButton, { onClick: function () { markFindingStatus(item, idx, 'checked'); } }, 'Mark checked'),
+          h(ActionButton, { onClick: function () { markFindingStatus(item, idx, 'needs follow-up'); } }, 'Needs follow-up')
+        )
+      );
+    }
+    function findingsView(item) {
+      const p = item.final_payload || item.proposed_payload || {};
+      const findings = p.findings || [];
+      if (!findings.length) return null;
+      const filtered = findings.filter(function (f) {
+        return (severityFilter === 'all' || f.severity === severityFilter) && (sourceFilter === 'all' || (f.source || 'deterministic') === sourceFilter);
+      });
+      const bySource = {
+        agentic: filtered.filter(function (f) { return f.source === 'agentic'; }),
+        deterministic: filtered.filter(function (f) { return (f.source || 'deterministic') !== 'agentic'; })
+      };
+      function sourceSection(title, rows) {
+        const grouped = groupFindingsByFile(rows);
+        return h('div', { className: 'space-y-2' },
+          h('div', { className: 'text-xs font-bold text-midground' }, title + ' (' + rows.length + ')'),
+          Object.keys(grouped).sort().map(function (file) {
+            return h('details', { key: file, open: true, className: 'rounded border border-current/10 p-2 space-y-2' },
+              h('summary', { className: 'cursor-pointer text-xs font-semibold' }, file + ' · ' + grouped[file].length + ' finding(s)'),
+              h('div', { className: 'space-y-2 pt-2' }, grouped[file].map(function (f) { return findingCard(item, f, findings.indexOf(f)); }))
+            );
+          })
+        );
+      }
+      return h('div', { className: 'space-y-3 rounded border border-current/10 p-3' },
+        h('div', { className: 'flex items-center justify-between gap-2 flex-wrap' },
+          h('div', { className: 'text-sm font-bold text-midground' }, 'Audit findings'),
+          h('div', { className: 'flex gap-2 flex-wrap' },
+            h('select', { className: 'rounded bg-black/40 px-2 py-1 text-xs border border-current/20', value: severityFilter, onChange: function (e) { setSeverityFilter(e.target.value); } }, ['all','critical','warning','suggestion'].map(function (v) { return h('option', { key: v, value: v }, 'severity: ' + v); })),
+            h('select', { className: 'rounded bg-black/40 px-2 py-1 text-xs border border-current/20', value: sourceFilter, onChange: function (e) { setSourceFilter(e.target.value); } }, ['all','agentic','deterministic'].map(function (v) { return h('option', { key: v, value: v }, 'source: ' + v); }))
+          )
+        ),
+        findingsSummaryView(findings),
+        p.review_notes && p.review_notes.length && h('details', { className: 'rounded bg-black/20 p-2 text-xs' }, h('summary', { className: 'cursor-pointer font-semibold' }, 'Review notes'), h('ul', { className: 'list-disc pl-4 pt-2 space-y-1' }, listItems(p.review_notes))),
+        sourceSection('Agentic findings', bySource.agentic),
+        sourceSection('Deterministic findings', bySource.deterministic)
+      );
+    }
+    function sectionActions(item) {
+      return h('div', { className: 'flex gap-2 flex-wrap pt-1' },
+        item.kind === 'opportunity' && h(ActionButton, { disabled: busy, onClick: function () { viewOpportunity(item.id); } }, 'Open opportunity'),
+        item.kind === 'opportunity' && item.can_diagnose_ci && h(ActionButton, { disabled: busy, onClick: function () { fixCI(item); }, className: 'border-emerald-500/50' }, 'Fix CI'),
+        item.kind === 'opportunity' && item.can_fix_issue && h(ActionButton, { disabled: busy, onClick: function () { fixIssue(item); }, className: 'border-emerald-500/50' }, 'Fix Issue'),
+        item.workstream_id && h(ActionButton, { disabled: busy, onClick: function () { viewWorkstream(item.workstream_id); } }, 'Open workstream'),
+        item.action_type === 'github_push_branch' && ['queued','edited_by_human'].includes(item.status) && h(ActionButton, { disabled: busy, onClick: function () { pushBranchNow(item); }, className: 'border-emerald-500/50' }, 'Push branch'),
+        item.board_state !== 'in_progress' && h(ActionButton, { disabled: busy, onClick: function () { moveBoardState(item, 'in_progress'); } }, 'Move to In progress'),
+        item.board_state !== 'in_review' && h(ActionButton, { disabled: busy, onClick: function () { moveBoardState(item, 'in_review'); } }, 'Move to Review'),
+        item.board_state !== 'done' && h(ActionButton, { disabled: busy, onClick: function () { moveBoardState(item, 'done'); } }, 'Mark done'),
+        item.board_state !== 'archived' && h(ActionButton, { disabled: busy, onClick: function () { moveBoardState(item, 'archived'); } }, 'Archive'),
+        item.board_state === 'archived' && h(ActionButton, { disabled: busy, onClick: function () { moveBoardState(item, 'done'); } }, 'Unarchive')
+      );
+    }
+    function sectionCard(title, items, emptyText) {
+      return h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, title + ' (' + items.length + ')')),
+        h(CardContent, { className: 'space-y-2' },
+          !items.length && h('div', { className: 'text-xs text-text-secondary' }, emptyText),
+          items.slice(0, 8).map(function (item) {
+            return h('div', { key: item.kind + ':' + item.id, className: 'rounded bg-black/20 p-2 text-xs space-y-1' },
+              h('div', { className: 'font-semibold' }, item.title || item.opportunity_title || item.summary),
+              h('div', { className: 'flex gap-1 flex-wrap' }, item.repo && h(Badge, null, item.repo), item.workstream_stage && h(Badge, null, item.workstream_stage.replace(/_/g, ' ')), item.status && h(Badge, null, item.status)),
+              item.current_step && h('div', { className: 'text-text-secondary' }, item.current_step),
+              sectionActions(item)
+            );
+          })
+        )
+      );
+    }
+    function boardItemCard(item) {
+      const title = item.title || item.opportunity_title || item.summary || item.id;
+      const description = item.kind === 'opportunity' ? item.description : item.summary;
+      return h('div', { key: item.kind + ':' + item.id, className: 'rounded border border-current/10 bg-black/20 p-3 text-xs space-y-2' },
+        h('div', { className: 'flex items-start justify-between gap-2' },
+          h('div', { className: 'font-semibold text-sm leading-snug' }, title),
+          h(Badge, null, item.kind === 'opportunity' ? 'Opportunity' : 'Action')
+        ),
+        h('div', { className: 'flex gap-1 flex-wrap' },
+          item.repo && h(Badge, null, item.repo),
+          item.source_repo && h(Badge, null, item.source_repo),
+          item.category && h(Badge, null, item.category),
+          item.status && h(Badge, null, item.status),
+          item.priority_score && h(Badge, null, 'P' + item.priority_score),
+          item.board_state_actor && h(Badge, null, 'manual')
+        ),
+        description && h('p', { className: 'text-text-secondary line-clamp-3' }, description),
+        item.current_step && h('div', { className: 'text-text-secondary' }, item.current_step),
+        item.workstream_id && workstreamBadge(item),
+        item.action_type === 'github_push_branch' && proposedPRView(item),
+        findingsView(item),
+        sectionActions(item)
+      );
+    }
+    function kanbanColumn(key, title, emptyText) {
+      const items = allItems.filter(function (i) { return (i.board_state || 'todo') === key; });
+      return h('div', { className: 'rounded border border-current/10 bg-black/10 min-h-[18rem]' },
+        h('div', { className: 'sticky top-0 z-10 flex items-center justify-between gap-2 border-b border-current/10 bg-background/95 px-3 py-3' },
+          h('div', { className: 'font-bold text-midground' }, title),
+          h(Badge, null, items.length)
+        ),
+        h('div', { className: 'p-3 space-y-3' },
+          !items.length && h('div', { className: 'rounded border border-dashed border-current/20 p-4 text-xs text-text-secondary' }, emptyText),
+          items.map(boardItemCard)
+        )
+      );
+    }
+    const allItems = feed.items || [];
+    const boardCounts = (feed.counts && feed.counts.board) || {};
+    return h('div', { className: 'h-full min-h-0 overflow-auto p-6 space-y-4' },
+      h('div', { className: 'flex items-center justify-between gap-4' },
+        h('div', null,
+          h('h1', { className: 'text-2xl font-bold text-midground' }, 'Hermes Visibility OS'),
+          h('p', { className: 'text-sm text-text-secondary' }, 'Evidence-backed opportunities and human-approved write actions.')
+        ),
+        h('div', { className: 'flex gap-2 flex-wrap justify-end' },
+          h(ActionButton, { onClick: load, disabled: busy }, busy ? 'Loading…' : 'Refresh'),
+          h(ActionButton, { onClick: function () { post('/api/plugins/visibility-os/scan/github/all', {}); }, disabled: busy }, 'Scan GitHub Repos'),
+          h(ActionButton, { onClick: function () { post('/api/plugins/visibility-os/daily-plan', {}); }, disabled: busy }, 'Generate Daily Plan')
+        )
+      ),
+      error && h('div', { className: 'rounded border border-red-500/40 p-3 text-red-300' }, error),
+      selectedWorkstream && workstreamDetailView(selectedWorkstream),
+      selectedOpportunity && h(Card, { className: 'border-emerald-500/40' },
+        h(CardHeader, null, h(CardTitle, null, 'Opportunity detail: ' + selectedOpportunity.title)),
+        h(CardContent, { className: 'space-y-3' },
+          h('div', { className: 'flex gap-2 flex-wrap' },
+            h(Badge, null, selectedOpportunity.source_repo || selectedOpportunity.source_system),
+            h(Badge, null, selectedOpportunity.category),
+            h(Badge, null, 'Priority ' + selectedOpportunity.priority_score)
+          ),
+          h('p', { className: 'text-sm text-text-secondary' }, selectedOpportunity.why_it_matters || selectedOpportunity.description),
+          h('p', { className: 'text-xs text-text-secondary' }, scoreLine(selectedOpportunity)),
+          h('pre', { className: 'whitespace-pre-wrap rounded bg-black/40 p-3 text-xs' }, selectedOpportunity.score_explanation),
+          evidenceLinks(selectedOpportunity),
+          h('div', { className: 'flex items-center gap-2 flex-wrap' },
+            h('label', { className: 'text-xs text-text-secondary' }, 'Slack target'),
+            h('input', { className: 'rounded bg-black/40 px-2 py-1 text-xs border border-current/20', value: slackTarget, onChange: function (e) { setSlackTarget(e.target.value); } })
+          ),
+          h('div', { className: 'flex gap-2 flex-wrap' },
+            selectedOpportunity.source_url && selectedOpportunity.source_url.indexOf('/pull/') !== -1 && h(ActionButton, { disabled: busy, onClick: function () { auditOpportunity(selectedOpportunity); } }, 'Audit PR'),
+            selectedOpportunity.source_url && selectedOpportunity.source_url.indexOf('/pull/') !== -1 && h(ActionButton, { disabled: busy, onClick: function () { deepReviewOpportunity(selectedOpportunity); } }, 'Deep Review PR'),
+            (selectedOpportunity.recommended_actions || []).map(function (a) {
+              return h(ActionButton, { key: a.action_kind, disabled: busy, onClick: function () { draftOpportunity(selectedOpportunity, a.action_kind); } }, a.label);
+            }),
+            h(ActionButton, { disabled: busy, onClick: function () { setSelectedOpportunity(null); } }, 'Close')
+          )
+        )
+      ),
+      h('div', { className: 'grid grid-cols-2 md:grid-cols-5 gap-3' },
+        h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.todo || 0), h('div', { className: 'text-xs text-text-secondary' }, 'Todo'))),
+        h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.in_progress || 0), h('div', { className: 'text-xs text-text-secondary' }, 'In progress'))),
+        h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.in_review || 0), h('div', { className: 'text-xs text-text-secondary' }, 'In review'))),
+        h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.done || 0), h('div', { className: 'text-xs text-text-secondary' }, 'Done'))),
+        h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.archived || 0), h('div', { className: 'text-xs text-text-secondary' }, 'Archived')))
+      ),
+      h('div', { className: 'flex items-center justify-between gap-2 flex-wrap rounded border border-current/10 bg-black/10 p-3' },
+        h('div', null,
+          h('div', { className: 'text-sm font-bold text-midground' }, 'Kanban board'),
+          h('div', { className: 'text-xs text-text-secondary' }, 'Move cards through Todo, In progress, In review, Done, then archive them out of the active board.')
+        ),
+        h('label', { className: 'inline-flex items-center gap-2 text-xs text-text-secondary' },
+          h('input', { type: 'checkbox', checked: showArchived, onChange: function (e) { setShowArchived(e.target.checked); } }),
+          'Show archived'
+        )
+      ),
+      h('div', { className: 'grid grid-cols-1 xl:grid-cols-4 gap-3 items-start' },
+        kanbanColumn('todo', 'Todo', 'No unstarted opportunities.'),
+        kanbanColumn('in_progress', 'In progress', 'No agent or human work in progress.'),
+        kanbanColumn('in_review', 'In review', 'No proposed PRs or decisions waiting.'),
+        kanbanColumn('done', 'Done', 'No completed work yet.')
+      ),
+      showArchived && h('div', { className: 'grid grid-cols-1 gap-3' }, kanbanColumn('archived', 'Archived', 'Nothing archived yet.'))
+    );
+  }
+  plugins.register('visibility-os', VisibilityOS);
+})();

--- a/plugins/visibility_os/dashboard/dist/index.js
+++ b/plugins/visibility_os/dashboard/dist/index.js
@@ -31,6 +31,7 @@
     const [busy, setBusy] = hooks.useState(false);
     const [selectedOpportunity, setSelectedOpportunity] = hooks.useState(null);
     const [selectedWorkstream, setSelectedWorkstream] = hooks.useState(null);
+    const [selectedTicket, setSelectedTicket] = hooks.useState(null);
     const [slackTarget, setSlackTarget] = hooks.useState('');
     const [severityFilter, setSeverityFilter] = hooks.useState('all');
     const [sourceFilter, setSourceFilter] = hooks.useState('all');
@@ -208,6 +209,75 @@
         )
       );
     }
+    function modalShell(title, subtitle, onClose, content) {
+      return h('div', { className: 'visibility-os-modal-backdrop', role: 'presentation', onMouseDown: function (e) { if (e.target === e.currentTarget) onClose(); } },
+        h('div', { className: 'visibility-os-modal', role: 'dialog', 'aria-modal': 'true', 'aria-label': title },
+          h('div', { className: 'visibility-os-modal-header' },
+            h('div', null,
+              h('div', { className: 'visibility-os-modal-kicker' }, subtitle || 'Visibility OS ticket'),
+              h('h2', { className: 'visibility-os-modal-title' }, title)
+            ),
+            h(ActionButton, { onClick: onClose, className: 'visibility-os-modal-close' }, 'Close')
+          ),
+          h('div', { className: 'visibility-os-modal-body' }, content)
+        )
+      );
+    }
+    function ticketModalView(item) {
+      if (!item) return null;
+      const title = item.title || item.opportunity_title || item.summary || item.id;
+      const description = item.kind === 'opportunity' ? item.description : item.summary;
+      return modalShell(title, item.kind === 'opportunity' ? 'Opportunity' : 'Action', function () { setSelectedTicket(null); },
+        h('div', { className: 'space-y-4' },
+          h('div', { className: 'flex gap-2 flex-wrap' },
+            h(Badge, null, item.kind || 'ticket'),
+            item.repo && h(Badge, null, item.repo),
+            item.source_repo && h(Badge, null, item.source_repo),
+            item.category && h(Badge, null, item.category),
+            item.status && h(Badge, null, item.status),
+            item.priority_score && h(Badge, null, 'Priority ' + item.priority_score),
+            item.board_state && h(Badge, null, item.board_state.replace(/_/g, ' '))
+          ),
+          description && h('p', { className: 'text-sm text-text-secondary' }, description),
+          item.current_step && h('div', { className: 'rounded border border-current/10 bg-black/20 p-3 text-xs' }, item.current_step),
+          item.source_url && h('a', { className: 'text-xs underline text-midground', href: item.source_url, target: '_blank' }, item.source_url),
+          item.workstream_id && h('div', { className: 'text-xs' }, workstreamBadge(item)),
+          item.kind === 'action' && actionPayloadView(item),
+          item.kind === 'action' && evidenceLinks(item),
+          item.action_type === 'github_push_branch' && h('div', { className: 'text-xs text-text-secondary' }, 'Review the prepared PR here, then use Push branch when you are ready.'),
+          findingsView(item),
+          h('div', { className: 'visibility-os-modal-actions' }, sectionActions(item))
+        )
+      );
+    }
+    function opportunityModalView(detail) {
+      if (!detail) return null;
+      return modalShell('Opportunity detail: ' + detail.title, detail.source_repo || detail.source_system || 'Opportunity', function () { setSelectedOpportunity(null); },
+        h('div', { className: 'space-y-3' },
+          h('div', { className: 'flex gap-2 flex-wrap' },
+            h(Badge, null, detail.source_repo || detail.source_system),
+            h(Badge, null, detail.category),
+            h(Badge, null, 'Priority ' + detail.priority_score)
+          ),
+          h('p', { className: 'text-sm text-text-secondary' }, detail.why_it_matters || detail.description),
+          h('p', { className: 'text-xs text-text-secondary' }, scoreLine(detail)),
+          detail.source_url && h('a', { className: 'text-xs underline text-midground', href: detail.source_url, target: '_blank' }, detail.source_url),
+          detail.score_explanation && h('pre', { className: 'whitespace-pre-wrap rounded bg-black/40 p-3 text-xs' }, detail.score_explanation),
+          evidenceLinks(detail),
+          h('div', { className: 'flex items-center gap-2 flex-wrap' },
+            h('label', { className: 'text-xs text-text-secondary' }, 'Slack target'),
+            h('input', { className: 'rounded bg-black/40 px-2 py-1 text-xs border border-current/20', value: slackTarget, onChange: function (e) { setSlackTarget(e.target.value); } })
+          ),
+          h('div', { className: 'visibility-os-modal-actions' },
+            detail.source_url && detail.source_url.indexOf('/pull/') !== -1 && h(ActionButton, { disabled: busy, onClick: function () { auditOpportunity(detail); } }, 'Audit PR'),
+            detail.source_url && detail.source_url.indexOf('/pull/') !== -1 && h(ActionButton, { disabled: busy, onClick: function () { deepReviewOpportunity(detail); } }, 'Deep Review PR'),
+            (detail.recommended_actions || []).map(function (a) {
+              return h(ActionButton, { key: a.action_kind, disabled: busy, onClick: function () { draftOpportunity(detail, a.action_kind); } }, a.label);
+            })
+          )
+        )
+      );
+    }
     function findingsSummaryView(findings) {
       const counts = findings.reduce(function (acc, f) { acc[f.severity || 'suggestion'] = (acc[f.severity || 'suggestion'] || 0) + 1; return acc; }, { critical: 0, warning: 0, suggestion: 0 });
       return h('div', { className: 'grid grid-cols-3 gap-2 text-xs' },
@@ -335,6 +405,19 @@
         className: 'hermes-kanban-card visibility-os-card',
         'data-visibility-kind': item.kind,
         draggable: true,
+        role: 'button',
+        tabIndex: 0,
+        onClick: function (e) {
+          if (e.target && e.target.closest && e.target.closest('button, a, input, select, textarea, summary, details')) return;
+          if (item.kind === 'opportunity') viewOpportunity(item.id);
+          else setSelectedTicket(item);
+        },
+        onKeyDown: function (e) {
+          if (e.key !== 'Enter' && e.key !== ' ') return;
+          e.preventDefault();
+          if (item.kind === 'opportunity') viewOpportunity(item.id);
+          else setSelectedTicket(item);
+        },
         onDragStart: function (e) {
           e.dataTransfer.setData('application/vnd.visibility-os-card', JSON.stringify({ kind: item.kind, id: item.id }));
           e.dataTransfer.effectAllowed = 'move';
@@ -415,32 +498,8 @@
       ),
       error && h('div', { className: 'rounded border border-red-500/40 p-3 text-red-300' }, error),
       selectedWorkstream && workstreamDetailView(selectedWorkstream),
-      selectedOpportunity && h(Card, { className: 'border-emerald-500/40' },
-        h(CardHeader, null, h(CardTitle, null, 'Opportunity detail: ' + selectedOpportunity.title)),
-        h(CardContent, { className: 'space-y-3' },
-          h('div', { className: 'flex gap-2 flex-wrap' },
-            h(Badge, null, selectedOpportunity.source_repo || selectedOpportunity.source_system),
-            h(Badge, null, selectedOpportunity.category),
-            h(Badge, null, 'Priority ' + selectedOpportunity.priority_score)
-          ),
-          h('p', { className: 'text-sm text-text-secondary' }, selectedOpportunity.why_it_matters || selectedOpportunity.description),
-          h('p', { className: 'text-xs text-text-secondary' }, scoreLine(selectedOpportunity)),
-          h('pre', { className: 'whitespace-pre-wrap rounded bg-black/40 p-3 text-xs' }, selectedOpportunity.score_explanation),
-          evidenceLinks(selectedOpportunity),
-          h('div', { className: 'flex items-center gap-2 flex-wrap' },
-            h('label', { className: 'text-xs text-text-secondary' }, 'Slack target'),
-            h('input', { className: 'rounded bg-black/40 px-2 py-1 text-xs border border-current/20', value: slackTarget, onChange: function (e) { setSlackTarget(e.target.value); } })
-          ),
-          h('div', { className: 'flex gap-2 flex-wrap' },
-            selectedOpportunity.source_url && selectedOpportunity.source_url.indexOf('/pull/') !== -1 && h(ActionButton, { disabled: busy, onClick: function () { auditOpportunity(selectedOpportunity); } }, 'Audit PR'),
-            selectedOpportunity.source_url && selectedOpportunity.source_url.indexOf('/pull/') !== -1 && h(ActionButton, { disabled: busy, onClick: function () { deepReviewOpportunity(selectedOpportunity); } }, 'Deep Review PR'),
-            (selectedOpportunity.recommended_actions || []).map(function (a) {
-              return h(ActionButton, { key: a.action_kind, disabled: busy, onClick: function () { draftOpportunity(selectedOpportunity, a.action_kind); } }, a.label);
-            }),
-            h(ActionButton, { disabled: busy, onClick: function () { setSelectedOpportunity(null); } }, 'Close')
-          )
-        )
-      ),
+      selectedTicket && ticketModalView(selectedTicket),
+      selectedOpportunity && opportunityModalView(selectedOpportunity),
       h('div', { className: 'visibility-os-metrics' },
         h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.todo || 0), h('div', { className: 'text-xs text-text-secondary' }, 'Todo'))),
         h(Card, null, h(CardContent, { className: 'p-4' }, h('div', { className: 'text-2xl font-bold' }, boardCounts.in_progress || 0), h('div', { className: 'text-xs text-text-secondary' }, 'In progress'))),

--- a/plugins/visibility_os/dashboard/dist/style.css
+++ b/plugins/visibility_os/dashboard/dist/style.css
@@ -1,0 +1,34 @@
+/* Visibility OS adopts the native Hermes Kanban board visual language. */
+.visibility-os-kanban { width: 100%; }
+.visibility-os-metrics { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 0.75rem; }
+@media (max-width: 900px) { .visibility-os-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+.visibility-os-board-toolbar { display:flex; align-items:center; justify-content:space-between; gap:0.75rem; flex-wrap:wrap; padding:0.75rem; border:1px solid var(--color-border); border-radius:var(--radius); background: color-mix(in srgb, var(--color-card) 85%, transparent); }
+.hermes-kanban-columns.visibility-os-kanban-columns { display:flex; gap:0.75rem; align-items:start; overflow-x:auto; scrollbar-width:none; padding-bottom:0.5rem; }
+.hermes-kanban-columns.visibility-os-kanban-columns::-webkit-scrollbar { display:none; }
+.visibility-os-column.hermes-kanban-column { flex:0 0 320px; display:flex; flex-direction:column; background:color-mix(in srgb, var(--color-card) 85%, transparent); border:1px solid var(--color-border); border-radius:var(--radius); padding:0.5rem; min-height:420px; max-height:calc(100vh - 300px); }
+.hermes-kanban-column-header { display:flex; align-items:center; gap:0.5rem; padding:0.25rem 0.25rem 0.35rem; font-weight:600; font-size:0.85rem; color:var(--color-foreground); }
+.hermes-kanban-column-label { flex:1; letter-spacing:0.01em; }
+.hermes-kanban-column-count { font-variant-numeric:tabular-nums; color:var(--color-muted-foreground); font-size:0.75rem; font-weight:500; }
+.hermes-kanban-column-sub { padding:0 0.25rem 0.5rem; font-size:0.7rem; color:var(--color-muted-foreground); border-bottom:1px solid color-mix(in srgb, var(--color-border) 60%, transparent); margin-bottom:0.5rem; }
+.hermes-kanban-column-body { display:flex; flex-direction:column; gap:0.5rem; overflow-y:auto; padding-right:0.15rem; }
+.hermes-kanban-empty { border:1px dashed color-mix(in srgb, var(--color-border) 80%, transparent); border-radius:var(--radius-sm, 0.25rem); color:var(--color-muted-foreground); font-size:0.75rem; padding:0.75rem; text-align:center; }
+.hermes-kanban-dot { width:0.55rem; height:0.55rem; border-radius:999px; display:inline-block; background:var(--color-muted-foreground); box-shadow:0 0 0 2px color-mix(in srgb, currentColor 12%, transparent); }
+.visibility-os-dot-todo { background:#94a3b8; }
+.visibility-os-dot-in_progress { background:#38bdf8; }
+.visibility-os-dot-in_review { background:#f59e0b; }
+.visibility-os-dot-done { background:#22c55e; }
+.visibility-os-dot-archived { background:#64748b; }
+.visibility-os-card.hermes-kanban-card { cursor:grab; border:1px solid var(--color-border); border-radius:var(--radius-sm, 0.25rem); background:color-mix(in srgb, var(--color-card) 92%, var(--color-foreground) 4%); transition:box-shadow 100ms ease, transform 100ms ease; }
+.visibility-os-card.hermes-kanban-card:hover { box-shadow:0 1px 0 0 var(--color-ring) inset, 0 0 0 1px var(--color-ring) inset; }
+.hermes-kanban-card-content { padding:0.6rem !important; display:flex; flex-direction:column; gap:0.38rem; }
+.hermes-kanban-card-row { display:flex; align-items:center; gap:0.35rem; flex-wrap:wrap; }
+.visibility-os-card-head { align-items:flex-start; }
+.hermes-kanban-card-title { flex:1; min-width:0; font-size:0.85rem; font-weight:600; line-height:1.3; color:var(--color-foreground); word-break:break-word; }
+.hermes-kanban-card-meta { font-size:0.7rem; color:var(--color-muted-foreground); gap:0.35rem; }
+.visibility-os-card-description { color:var(--color-muted-foreground); font-size:0.75rem; line-height:1.35; display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
+.visibility-os-card-step { color:var(--color-muted-foreground); font-size:0.72rem; }
+.visibility-os-card .visibility-os-action-button { padding:0.32rem 0.45rem; font-size:0.68rem; }
+.visibility-os-card details, .visibility-os-card pre { max-width:100%; overflow:auto; }
+
+.visibility-os-column.hermes-kanban-column:hover { border-color: color-mix(in srgb, var(--color-ring) 45%, var(--color-border)); }
+.visibility-os-card.hermes-kanban-card:active { cursor:grabbing; transform:scale(0.995); }

--- a/plugins/visibility_os/dashboard/dist/style.css
+++ b/plugins/visibility_os/dashboard/dist/style.css
@@ -32,3 +32,13 @@
 
 .visibility-os-column.hermes-kanban-column:hover { border-color: color-mix(in srgb, var(--color-ring) 45%, var(--color-border)); }
 .visibility-os-card.hermes-kanban-card:active { cursor:grabbing; transform:scale(0.995); }
+.visibility-os-card.hermes-kanban-card:focus { outline:2px solid color-mix(in srgb, var(--color-ring) 75%, transparent); outline-offset:2px; }
+.visibility-os-modal-backdrop { position:fixed; inset:0; z-index:70; display:flex; align-items:center; justify-content:center; padding:1.25rem; background:rgba(2, 6, 12, 0.72); backdrop-filter:blur(8px); }
+.visibility-os-modal { width:min(920px, calc(100vw - 2rem)); max-height:min(86vh, 920px); display:flex; flex-direction:column; overflow:hidden; border:1px solid color-mix(in srgb, var(--color-ring) 40%, var(--color-border)); border-radius:calc(var(--radius, 0.5rem) * 1.4); background:color-mix(in srgb, var(--color-card) 96%, #020617 12%); box-shadow:0 24px 80px rgba(0,0,0,0.48), 0 0 0 1px rgba(255,255,255,0.04) inset; }
+.visibility-os-modal-header { display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; padding:1rem 1.1rem 0.8rem; border-bottom:1px solid color-mix(in srgb, var(--color-border) 70%, transparent); }
+.visibility-os-modal-kicker { color:var(--color-muted-foreground); font-size:0.7rem; font-weight:700; text-transform:uppercase; letter-spacing:0.08em; }
+.visibility-os-modal-title { margin:0.12rem 0 0; color:var(--color-foreground); font-size:1.05rem; font-weight:750; line-height:1.25; }
+.visibility-os-modal-body { overflow:auto; padding:1rem 1.1rem 1.1rem; }
+.visibility-os-modal-actions { display:flex; flex-wrap:wrap; gap:0.5rem; padding-top:0.25rem; }
+.visibility-os-modal-close { flex:0 0 auto; }
+@media (max-width: 700px) { .visibility-os-modal-backdrop { align-items:flex-end; padding:0.75rem; } .visibility-os-modal { width:100%; max-height:90vh; } }

--- a/plugins/visibility_os/dashboard/manifest.json
+++ b/plugins/visibility_os/dashboard/manifest.json
@@ -6,5 +6,6 @@
   "version": "0.1.0",
   "tab": { "path": "/visibility-os", "position": "after:kanban" },
   "entry": "dist/index.js",
+  "css": "dist/style.css",
   "api": "plugin_api.py"
 }

--- a/plugins/visibility_os/dashboard/manifest.json
+++ b/plugins/visibility_os/dashboard/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "visibility-os",
+  "label": "Visibility OS",
+  "description": "Evidence-backed engineering impact feed and human approval queue",
+  "icon": "Eye",
+  "version": "0.1.0",
+  "tab": { "path": "/visibility-os", "position": "after:kanban" },
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/visibility_os/dashboard/plugin_api.py
+++ b/plugins/visibility_os/dashboard/plugin_api.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+from typing import Any
+import json
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from plugins.visibility_os.core.actions import (
+    approve_action,
+    create_action,
+    edit_action,
+    get_action,
+    list_actions,
+    list_audit_log,
+    reject_action,
+    save_for_later,
+)
+from plugins.visibility_os.core.executors import execute_approved_action
+from plugins.visibility_os.core.impact_picker import generate_daily_plan
+from plugins.visibility_os.core.opportunities import get_opportunity, list_opportunities
+from plugins.visibility_os.core.opportunity_actions import build_opportunity_detail, draft_action_from_opportunity
+from plugins.visibility_os.core.workstreams import get_workstream, latest_for_opportunity, list_workstreams
+from plugins.visibility_os.core.board import get_board_states, set_board_state
+from plugins.visibility_os.core.pr_audit import audit_pr_from_opportunity, deep_review_pr_from_opportunity
+from plugins.visibility_os.core.scanner import scan_github
+from plugins.visibility_os.core.connectors.github import GitHubConnector
+from plugins.visibility_os.core import db
+from plugins.visibility_os.core.config import get_visibility_config
+
+router = APIRouter()
+
+class ActionCreate(BaseModel):
+    proposed_by_agent: str
+    action_type: str
+    target_system: str
+    target_location: str
+    title: str
+    summary: str
+    proposed_payload: dict[str, Any]
+    evidence_links: list[dict[str, Any]] = Field(default_factory=list)
+    risk_level: str = "low"
+    opportunity_id: str | None = None
+    impact_score: int | None = None
+    visibility_score: int | None = None
+    effort_score: int | None = None
+    approval_reason: str | None = None
+
+class ActorBody(BaseModel):
+    actor: str = "human"
+    execute_immediately: bool = False
+
+class EditBody(BaseModel):
+    final_payload: dict[str, Any]
+    actor: str = "human"
+
+class RejectBody(BaseModel):
+    reason: str
+    actor: str = "human"
+
+class ScanBody(BaseModel):
+    repo: str | None = None
+
+class OpportunityDraftBody(BaseModel):
+    action_kind: str
+    target_location: str | None = None
+    actor: str = "visibility_os"
+
+class OpportunityAuditBody(BaseModel):
+    actor: str = "visibility_os"
+
+class BoardStateBody(BaseModel):
+    item_kind: str
+    item_id: str
+    board_state: str
+    actor: str = "human"
+
+def _is_github_actions_run_url(url: str | None) -> bool:
+    return bool(url and "/actions/runs/" in url)
+
+
+def _is_github_issue_url(url: str | None) -> bool:
+    return bool(url and "/issues/" in url)
+
+
+def _workstream_rollup(opportunity_id: str | None) -> dict[str, Any]:
+    if not opportunity_id:
+        return {
+            "workstream_id": None,
+            "workstream_status": None,
+            "workstream_stage": None,
+            "agent_has_worked_on_this": False,
+            "last_agent_activity_at": None,
+            "pending_human_action": None,
+        }
+    ws = latest_for_opportunity(opportunity_id)
+    if not ws:
+        return {
+            "workstream_id": None,
+            "workstream_status": None,
+            "workstream_stage": None,
+            "agent_has_worked_on_this": False,
+            "last_agent_activity_at": None,
+            "pending_human_action": None,
+        }
+    return {
+        "workstream_id": ws.get("id"),
+        "workstream_status": ws.get("status"),
+        "workstream_stage": ws.get("stage"),
+        "agent_has_worked_on_this": True,
+        "last_agent_activity_at": ws.get("updated_at"),
+        "pending_human_action": ws.get("pending_human_action"),
+    }
+
+
+def _feed_action(action: dict[str, Any]) -> dict[str, Any]:
+    item = {"kind": "action", **action}
+    opportunity_id = action.get("opportunity_id")
+    item.update(_workstream_rollup(opportunity_id))
+    if not opportunity_id:
+        return item
+    try:
+        opportunity = get_opportunity(opportunity_id)
+    except KeyError:
+        return item
+    source_url = opportunity.get("source_url")
+    item["opportunity_source_url"] = source_url
+    item["opportunity_title"] = opportunity.get("title")
+    item["can_diagnose_ci"] = _is_github_actions_run_url(source_url)
+    item["can_fix_issue"] = _is_github_issue_url(source_url)
+    return item
+
+
+def _derived_board_state(item: dict[str, Any]) -> str:
+    if item.get("action_type") == "github_push_branch" and item.get("status") in {"queued", "edited_by_human"}:
+        return "in_review"
+    if item.get("pending_human_action"):
+        return "in_review"
+    stage = item.get("workstream_stage")
+    if stage in {"ready_for_push", "review_ready", "self_auditing", "independent_reviewing"}:
+        return "in_review"
+    if stage in {"pushed", "completed"} or item.get("workstream_status") == "completed":
+        return "done"
+    if item.get("kind") == "action" and item.get("status") in {"executed", "completed", "rejected", "failed"}:
+        return "done"
+    if item.get("kind") == "opportunity" and item.get("status") in {"resolved", "closed", "done"}:
+        return "done"
+    if item.get("workstream_id") and item.get("workstream_status") == "active":
+        return "in_progress"
+    if item.get("kind") == "action" and item.get("status") in {"approved"}:
+        return "in_progress"
+    return "todo"
+
+
+def _apply_board_state(items: list[dict[str, Any]], include_archived: bool = False) -> list[dict[str, Any]]:
+    overrides = get_board_states()
+    out = []
+    for item in items:
+        kind = str(item.get("kind") or "")
+        item_id = str(item.get("id") or "")
+        override = overrides.get((kind, item_id))
+        board_state = override["board_state"] if override else _derived_board_state(item)
+        item["board_state"] = board_state
+        item["board_state_updated_at"] = override.get("updated_at") if override else None
+        item["board_state_actor"] = override.get("actor") if override else None
+        if include_archived or board_state != "archived":
+            out.append(item)
+    return out
+
+
+def _github_repo_allowed(repo: str | None) -> bool:
+    return get_visibility_config().github_repo_allowed(repo)
+
+
+@router.get("/config")
+async def visibility_config() -> dict[str, Any]:
+    cfg = get_visibility_config()
+    return {
+        "company_name": cfg.company_name,
+        "github_orgs": sorted(cfg.github_orgs),
+        "github_repos": cfg.github_repos,
+        "default_slack_channel": cfg.default_slack_channel,
+    }
+
+
+@router.get("/health")
+async def health() -> dict[str, Any]:
+    return {"ok": True, "plugin": "visibility-os"}
+
+@router.get("/feed")
+async def feed(include_archived: bool = False) -> dict[str, Any]:
+    actions = list_actions()
+    opportunities = list_opportunities(limit=100)
+    items = []
+    for a in actions:
+        items.append(_feed_action(a))
+    for o in opportunities:
+        source_url = o.get("source_url")
+        items.append({"kind": "opportunity", "can_diagnose_ci": _is_github_actions_run_url(source_url), "can_fix_issue": _is_github_issue_url(source_url), **_workstream_rollup(o.get("id")), **o})
+    items = _apply_board_state(items, include_archived=include_archived)
+    items.sort(key=lambda x: (x.get("created_at") or x.get("updated_at") or ""), reverse=True)
+    counts_by_state: dict[str, int] = {"todo": 0, "in_progress": 0, "in_review": 0, "done": 0, "archived": 0}
+    for item in items:
+        state = item.get("board_state") or "todo"
+        counts_by_state[state] = counts_by_state.get(state, 0) + 1
+    return {"items": items, "counts": {"actions": len(actions), "opportunities": len(opportunities), "board": counts_by_state}}
+
+@router.post("/board-state")
+async def update_board_state(body: BoardStateBody) -> dict[str, Any]:
+    try:
+        return set_board_state(item_kind=body.item_kind, item_id=body.item_id, board_state=body.board_state, actor=body.actor)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.get("/actions")
+async def actions(status: str | None = None) -> dict[str, Any]:
+    return {"actions": list_actions(status=status)}
+
+@router.post("/actions")
+async def post_action(body: ActionCreate) -> dict[str, Any]:
+    return create_action(**body.model_dump())
+
+@router.get("/actions/{action_id}")
+async def action_detail(action_id: str) -> dict[str, Any]:
+    try:
+        return get_action(action_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+@router.post("/actions/{action_id}/approve")
+async def approve(action_id: str, body: ActorBody) -> dict[str, Any]:
+    try:
+        approved = approve_action(action_id, actor=body.actor)
+        if body.execute_immediately:
+            return execute_approved_action(action_id, actor=body.actor)
+        return approved
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/actions/{action_id}/edit")
+async def edit(action_id: str, body: EditBody) -> dict[str, Any]:
+    try:
+        return edit_action(action_id, final_payload=body.final_payload, actor=body.actor)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/actions/{action_id}/reject")
+async def reject(action_id: str, body: RejectBody) -> dict[str, Any]:
+    try:
+        return reject_action(action_id, reason=body.reason, actor=body.actor)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/actions/{action_id}/save")
+async def save(action_id: str, body: ActorBody) -> dict[str, Any]:
+    return save_for_later(action_id, actor=body.actor)
+
+@router.post("/actions/{action_id}/execute")
+async def execute(action_id: str, body: ActorBody) -> dict[str, Any]:
+    try:
+        return execute_approved_action(action_id, actor=body.actor)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.get("/audit-log")
+async def audit_log(action_id: str | None = None) -> dict[str, Any]:
+    return {"events": list_audit_log(action_id=action_id)}
+
+@router.get("/opportunities")
+async def opportunities() -> dict[str, Any]:
+    return {"opportunities": list_opportunities(limit=100)}
+
+@router.get("/workstreams")
+async def workstreams(status: str | None = None) -> dict[str, Any]:
+    return {"workstreams": list_workstreams(status=status)}
+
+@router.get("/workstreams/{workstream_id}")
+async def workstream_detail(workstream_id: str) -> dict[str, Any]:
+    try:
+        return get_workstream(workstream_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+@router.get("/opportunities/{opportunity_id}/workstreams")
+async def opportunity_workstreams(opportunity_id: str) -> dict[str, Any]:
+    try:
+        get_opportunity(opportunity_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {"workstreams": list_workstreams(opportunity_id=opportunity_id)}
+
+@router.get("/opportunities/{opportunity_id}")
+async def opportunity_detail(opportunity_id: str) -> dict[str, Any]:
+    try:
+        return build_opportunity_detail(opportunity_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+@router.post("/opportunities/{opportunity_id}/draft-action")
+async def draft_opportunity_action(opportunity_id: str, body: OpportunityDraftBody) -> dict[str, Any]:
+    try:
+        return draft_action_from_opportunity(opportunity_id, action_kind=body.action_kind, target_location=body.target_location, actor=body.actor)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/opportunities/{opportunity_id}/fix-ci")
+async def fix_ci_opportunity(opportunity_id: str, body: ActorBody) -> dict[str, Any]:
+    try:
+        action = draft_action_from_opportunity(opportunity_id, action_kind="ci_fix_lane", actor=body.actor)
+        approve_action(action["id"], actor=body.actor)
+        return execute_approved_action(action["id"], actor=body.actor)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/opportunities/{opportunity_id}/fix-issue")
+async def fix_issue_opportunity(opportunity_id: str, body: ActorBody) -> dict[str, Any]:
+    try:
+        action = draft_action_from_opportunity(opportunity_id, action_kind="github_issue_fix_lane", actor=body.actor)
+        approve_action(action["id"], actor=body.actor)
+        return execute_approved_action(action["id"], actor=body.actor)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/opportunities/{opportunity_id}/audit-pr")
+async def audit_pr_opportunity(opportunity_id: str, body: OpportunityAuditBody) -> dict[str, Any]:
+    try:
+        return audit_pr_from_opportunity(opportunity_id, actor=body.actor)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/opportunities/{opportunity_id}/deep-review-pr")
+async def deep_review_pr_opportunity(opportunity_id: str, body: OpportunityAuditBody) -> dict[str, Any]:
+    try:
+        return deep_review_pr_from_opportunity(opportunity_id, actor=body.actor)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/scan/github")
+async def scan(body: ScanBody) -> dict[str, Any]:
+    cfg = get_visibility_config()
+    if not _github_repo_allowed(body.repo):
+        raise HTTPException(status_code=400, detail=f"Visibility OS is restricted to configured GitHub organisations: {cfg.github_scope_label}")
+    try:
+        return {"opportunities": scan_github(GitHubConnector(repo=body.repo))}
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+@router.post("/scan/github/all")
+async def scan_all_github() -> dict[str, Any]:
+    db.init_db()
+    cfg = get_visibility_config()
+    repos = cfg.github_repos
+    if not repos:
+        with db.connect() as conn:
+            row = conn.execute("SELECT state_payload FROM connector_state WHERE connector_name = ?", ("github_repos",)).fetchone()
+        if row:
+            repos = json.loads(row["state_payload"]).get("repos") or []
+    repos = [repo for repo in repos if _github_repo_allowed(repo)]
+    if not repos:
+        raise HTTPException(status_code=400, detail="No configured GitHub repos found. Set VISIBILITY_OS_GITHUB_REPOS and VISIBILITY_OS_GITHUB_ORGS in .env.")
+    results = []
+    for repo in repos:
+        try:
+            opportunities = scan_github(GitHubConnector(repo=repo))
+            results.append({"repo": repo, "ok": True, "count": len(opportunities)})
+        except Exception as exc:
+            results.append({"repo": repo, "ok": False, "error": str(exc)})
+    return {"results": results, "opportunities": list_opportunities(limit=100)}
+
+@router.get("/connectors")
+async def connectors() -> dict[str, Any]:
+    db.init_db()
+    with db.connect() as conn:
+        rows = conn.execute("SELECT connector_name, state_payload, updated_at FROM connector_state ORDER BY connector_name").fetchall()
+    return {"connectors": [{"name": r["connector_name"], "state": json.loads(r["state_payload"]), "updated_at": r["updated_at"]} for r in rows]}
+
+@router.post("/daily-plan")
+async def daily_plan() -> dict[str, Any]:
+    return generate_daily_plan()

--- a/tests/plugins/visibility_os/test_visibility_os_core.py
+++ b/tests/plugins/visibility_os/test_visibility_os_core.py
@@ -1,0 +1,1495 @@
+import json
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def patch_db(tmp_path, monkeypatch):
+    from plugins.visibility_os.core import db
+    monkeypatch.setenv("VISIBILITY_OS_GITHUB_ORGS", "acme-inc")
+    monkeypatch.setattr(db, "get_db_path", lambda: tmp_path / "visibility_os.db")
+    return db
+
+
+def test_visibility_os_config_is_env_driven(monkeypatch):
+    monkeypatch.setenv("VISIBILITY_OS_COMPANY_NAME", "Acme Robotics")
+    monkeypatch.setenv("VISIBILITY_OS_GITHUB_ORGS", "acme-inc,acme-labs")
+    monkeypatch.setenv("VISIBILITY_OS_GITHUB_REPOS", "acme-inc/api, acme-labs/web")
+    monkeypatch.setenv("VISIBILITY_OS_DEFAULT_SLACK_CHANNEL", "#builds")
+    from plugins.visibility_os.core.config import get_visibility_config
+
+    cfg = get_visibility_config()
+
+    assert cfg.company_name == "Acme Robotics"
+    assert cfg.github_orgs == {"acme-inc", "acme-labs"}
+    assert cfg.github_repos == ["acme-inc/api", "acme-labs/web"]
+    assert cfg.default_slack_channel == "#builds"
+    assert cfg.github_repo_allowed("acme-inc/api")
+    assert not cfg.github_repo_allowed("acme-inc/web-app")
+
+
+def test_db_init_creates_profile_scoped_tables(tmp_path, monkeypatch):
+    db = patch_db(tmp_path, monkeypatch)
+    db.init_db()
+    conn = sqlite3.connect(tmp_path / "visibility_os.db")
+    names = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"schema_migrations", "opportunities", "action_queue", "audit_log", "daily_summaries", "weekly_summaries", "scan_runs", "connector_state", "board_item_states"} <= names
+
+
+def test_scoring_formula_and_clamping():
+    from plugins.visibility_os.core.scoring import score_opportunity
+    score = score_opportunity(impact=4, visibility=5, effort=4, safety=5, risk_penalty=0)
+    assert score.priority_score == 31
+    clamped = score_opportunity(impact=99, visibility=-1, effort=99, safety=-1, risk_penalty=99)
+    assert (clamped.impact, clamped.visibility, clamped.effort, clamped.safety, clamped.risk_penalty) == (5, 0, 5, 1, 10)
+
+
+def test_action_queue_state_machine_and_audit(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.actions import create_action, approve_action, reject_action, get_action, list_audit_log, execute_action_guard
+    from plugins.visibility_os.core.policies import ActionPolicyError
+
+    action = create_action(
+        proposed_by_agent="communications_agent",
+        action_type="slack_message",
+        target_system="slack",
+        target_location="#team-updates",
+        title="Post CI update",
+        summary="Draft update about CI flake",
+        proposed_payload={"text": "I found a likely cause and am testing a fix. Evidence: https://github.com/org/repo/issues/1"},
+        evidence_links=[{"type": "issue", "url": "https://github.com/org/repo/issues/1"}],
+        risk_level="low",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=5,
+    )
+    assert action["status"] == "queued"
+    approved = approve_action(action["id"], actor="reviewer")
+    assert approved["status"] == "approved"
+    assert execute_action_guard(action["id"])["id"] == action["id"]
+    events = list_audit_log(action_id=action["id"])
+    assert [e["event_type"] for e in events] == ["created", "approved"]
+
+    rejected = create_action(
+        proposed_by_agent="communications_agent",
+        action_type="github_issue_comment",
+        target_system="github",
+        target_location="org/repo/issues/1",
+        title="Comment",
+        summary="Comment",
+        proposed_payload={"body": "I found a likely cause."},
+        evidence_links=[{"type": "issue", "url": "https://github.com/org/repo/issues/1"}],
+        risk_level="low",
+    )
+    reject_action(rejected["id"], actor="reviewer", reason="Tone wrong")
+    assert get_action(rejected["id"])["status"] == "rejected"
+    with pytest.raises(ActionPolicyError):
+        approve_action(rejected["id"], actor="reviewer")
+
+
+def test_hard_blocked_actions_cannot_execute(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.actions import create_action, approve_action, execute_action_guard
+    from plugins.visibility_os.core.policies import ActionPolicyError
+    action = create_action(
+        proposed_by_agent="implementation_agent",
+        action_type="production_deploy",
+        target_system="deployment",
+        target_location="prod",
+        title="Deploy",
+        summary="Deploy",
+        proposed_payload={"ref": "main"},
+        evidence_links=[{"type": "pr", "url": "https://github.com/org/repo/pull/1"}],
+        risk_level="critical",
+    )
+    approve_action(action["id"], actor="reviewer")
+    with pytest.raises(ActionPolicyError):
+        execute_action_guard(action["id"])
+
+
+def test_executor_rejects_unsupported_slack_action_and_overclaim_before_write(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.actions import create_action, approve_action, list_audit_log
+    from plugins.visibility_os.core.executors import execute_approved_action
+
+    action = create_action(
+        proposed_by_agent="communications_agent",
+        action_type="weekly_update_draft",
+        target_system="slack",
+        target_location="#team-updates",
+        title="Weekly draft",
+        summary="Draft only",
+        proposed_payload={"text": "I found a likely cause. https://github.com/org/repo/issues/1"},
+        evidence_links=[{"type": "issue", "url": "https://github.com/org/repo/issues/1"}],
+        risk_level="medium",
+    )
+    approve_action(action["id"], actor="reviewer")
+    with pytest.raises(Exception, match="Unsupported Slack action type"):
+        execute_approved_action(action["id"], actor="reviewer")
+    assert any(e["event_type"] == "execution_attempt_started" for e in list_audit_log(action_id=action["id"]))
+
+    overclaim = create_action(
+        proposed_by_agent="communications_agent",
+        action_type="slack_message",
+        target_system="slack",
+        target_location="#team-updates",
+        title="Overclaim",
+        summary="Should not post",
+        proposed_payload={"text": "Fixed and shipped the CI flake. https://github.com/org/repo/pull/1"},
+        evidence_links=[{"type": "pr", "url": "https://github.com/org/repo/pull/1"}],
+        risk_level="medium",
+    )
+    approve_action(overclaim["id"], actor="reviewer")
+    with pytest.raises(Exception, match="before work is executed"):
+        execute_approved_action(overclaim["id"], actor="reviewer")
+
+
+def test_create_action_cannot_bypass_approval_state(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.actions import create_action
+    from plugins.visibility_os.core.policies import ActionPolicyError
+    with pytest.raises(ActionPolicyError):
+        create_action(
+            proposed_by_agent="bad_agent",
+            action_type="slack_message",
+            target_system="slack",
+            target_location="#team-updates",
+            title="Bypass",
+            summary="Bypass",
+            proposed_payload={"text": "hello"},
+            evidence_links=[],
+            risk_level="low",
+            status="approved",
+        )
+
+
+def test_language_guard_blocks_overclaiming_without_execution():
+    from plugins.visibility_os.core.language_guard import validate_message, LanguageGuardError
+    with pytest.raises(LanguageGuardError):
+        validate_message("Fixed and shipped the CI flake", status="queued", evidence_links=[{"url": "https://github.com/org/repo/pull/1"}])
+    validate_message("I found a likely cause and am testing a fix. https://github.com/org/repo/issues/1", status="queued", evidence_links=[{"url": "https://github.com/org/repo/issues/1"}], team_visible=True)
+
+
+def test_evidence_builder_requires_completion_fields():
+    from plugins.visibility_os.core.evidence import EvidencePackage, EvidenceError
+    pkg = EvidencePackage(problem_statement="CI flakes", tests_run="pytest tests/auth -q", evidence_links=[{"type": "pr", "url": "https://github.com/org/repo/pull/1"}], actual_status="executed")
+    assert pkg.validate_for_completion() is True
+    with pytest.raises(EvidenceError):
+        EvidencePackage(problem_statement="CI flakes", actual_status="drafted").validate_for_completion()
+
+
+def test_communications_drafter_queues_safe_action(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.communications import draft_progress_update
+    action = draft_progress_update(
+        problem="Auth CI is flaky",
+        diagnosis="mock readiness can race first request",
+        action_underway="testing explicit readiness wait",
+        next_step="open PR with before/after CI output",
+        target_location="#team-updates",
+        evidence_links=[{"type": "issue", "url": "https://github.com/org/repo/issues/1"}],
+    )
+    assert action["action_type"] == "slack_message"
+    assert action["status"] == "queued"
+    assert "Problem:" in action["proposed_payload"]["text"]
+
+
+def test_opportunity_detail_explains_scores_and_drafts_actions(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.opportunity_actions import build_opportunity_detail, draft_action_from_opportunity
+
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/platform/pull/623",
+        title="READY remove gradual hedging and fix flow",
+        description="PR #623 may need review acceleration.",
+        category="pr_review_acceleration",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=5,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=30,
+        suggested_artifacts=["review_comment", "slack_update"],
+        metadata={"number": 623, "author": {"login": "engineer-a"}, "reviewDecision": "REVIEW_REQUIRED"},
+    )
+
+    detail = build_opportunity_detail(opportunity["id"])
+    assert detail["id"] == opportunity["id"]
+    assert detail["source_repo"] == "acme-inc/platform"
+    assert detail["recommended_actions"][0]["action_kind"] == "github_pr_comment"
+    assert detail["recommended_actions"][0]["label"] == "Draft PR coordination comment"
+    assert any(e["url"] == opportunity["source_url"] for e in detail["evidence_links"])
+    assert "priority_score" in detail["score_explanation"]
+
+    github_action = draft_action_from_opportunity(opportunity["id"], action_kind="github_pr_comment")
+    assert github_action["status"] == "queued"
+    assert github_action["opportunity_id"] == opportunity["id"]
+    assert github_action["target_system"] == "github"
+    assert github_action["target_location"] == opportunity["source_url"]
+    assert "Coordination note" in github_action["proposed_payload"]["body"]
+    assert "not performed a code review" in github_action["proposed_payload"]["body"]
+
+    slack_action = draft_action_from_opportunity(opportunity["id"], action_kind="slack_update", target_location="#team-updates")
+    assert slack_action["target_system"] == "slack"
+    assert slack_action["target_location"] == "#team-updates"
+    assert "Next step:" in slack_action["proposed_payload"]["text"]
+
+
+def test_api_routes_cover_opportunity_detail_and_action_drafting(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.dashboard.plugin_api import router
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/infrastructure/pull/657",
+        title="revert: SES wildcard back to specific noreply@ identity",
+        description="PR #657 may need review acceleration.",
+        category="pr_review_acceleration",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=5,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=30,
+        suggested_artifacts=["review_comment", "slack_update"],
+        metadata={"number": 657, "reviewDecision": "REVIEW_REQUIRED"},
+    )
+
+    detail = client.get(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}")
+    assert detail.status_code == 200
+    assert detail.json()["source_repo"] == "acme-inc/infrastructure"
+
+    drafted = client.post(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}/draft-action", json={"action_kind": "github_pr_comment"})
+    assert drafted.status_code == 200
+    assert drafted.json()["action_type"] == "github_pr_comment"
+    assert drafted.json()["status"] == "queued"
+
+
+def test_pr_audit_from_opportunity_queues_line_level_findings(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.pr_audit import audit_pr_from_opportunity
+
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/platform/pull/623",
+        title="READY remove gradual hedging and fix flow",
+        description="PR #623 may need review acceleration.",
+        category="pr_review_acceleration",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=5,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=30,
+        suggested_artifacts=["review_comment"],
+        metadata={"number": 623},
+    )
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        joined = " ".join(args)
+        if "pr diff" in joined:
+            r.stdout = '''diff --git a/src/orders.py b/src/orders.py
+--- a/src/orders.py
++++ b/src/orders.py
+@@ -40,6 +40,8 @@ def load_order(user_id):
+     query = f"SELECT * FROM orders WHERE user_id = {user_id}"
++    cursor.execute(query)
++    return cursor.fetchall()
+diff --git a/src/shell.py b/src/shell.py
+--- a/src/shell.py
++++ b/src/shell.py
+@@ -10,4 +10,5 @@ def clean(path):
++    subprocess.run(f"rm -rf {path}", shell=True)
+'''
+        elif "pr view" in joined:
+            r.stdout = '{"headRefOid":"abc123","title":"READY remove gradual hedging and fix flow"}'
+        else:
+            r.stdout = ""
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    action = audit_pr_from_opportunity(opportunity["id"])
+    payload = action["proposed_payload"]
+    assert action["action_type"] == "github_pr_review_draft"
+    assert payload["verdict"] == "REQUEST_CHANGES"
+    sql_finding = next(f for f in payload["findings"] if f["title"] == "SQL injection risk from formatted query")
+    assert sql_finding["severity"] == "critical"
+    assert sql_finding["path"] == "src/orders.py"
+    assert sql_finding["line"] >= 40
+    assert "parameterized" in sql_finding["solution"].lower()
+    assert sql_finding["source"] == "deterministic"
+    assert sql_finding["status"] == "open"
+    assert "SQL injection safe" in sql_finding["casual_comment"]
+    assert "—" not in sql_finding["casual_comment"]
+    assert "–" not in sql_finding["casual_comment"]
+    assert payload["findings_summary"]["critical"] >= 1
+    assert payload["findings_by_file"]["src/orders.py"] >= 1
+    assert payload["findings"][0]["github_diff_url"].startswith("https://github.com/acme-inc/platform/pull/623/files")
+    assert any(f["path"] == "src/shell.py" and f["severity"] == "critical" for f in payload["findings"])
+
+
+def test_github_actions_opportunity_can_queue_ci_diagnosis(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.opportunity_actions import build_opportunity_detail, draft_action_from_opportunity
+
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/actions/runs/25928548133",
+        title="Failing CI: PENDING: Email verification UI for whitelist signup",
+        description="A recent GitHub Actions run failed and may be a visible unblock opportunity.",
+        category="flaky_tests_and_ci_failures",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["ci_before_after"],
+        metadata={"databaseId": 25928548133, "workflowName": "test", "conclusion": "failure"},
+    )
+
+    detail = build_opportunity_detail(opportunity["id"])
+    assert any(a["action_kind"] == "github_actions_diagnosis" and a["label"] == "Diagnose CI" for a in detail["recommended_actions"])
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] == ["gh", "run", "view"] and "--json" in args:
+            r.stdout = json.dumps({
+                "name": "PENDING: Email verification UI for whitelist signup",
+                "conclusion": "failure",
+                "status": "completed",
+                "event": "pull_request",
+                "headBranch": "email-verification-ui",
+                "headSha": "abc123",
+                "jobs": [{"name": "build", "conclusion": "failure", "steps": [{"name": "npm test", "conclusion": "failure"}]}],
+                "url": opportunity["source_url"],
+            })
+        elif args[:3] == ["gh", "pr", "list"]:
+            r.stdout = json.dumps([{
+                "number": 132,
+                "title": "PENDING: Email verification UI for whitelist signup",
+                "state": "MERGED",
+                "url": "https://github.com/acme-inc/web-app/pull/132",
+                "headRefName": "email-verification-ui",
+                "headRefOid": "fixed456",
+                "baseRefName": "main",
+                "mergedAt": "2026-05-15T16:34:49Z",
+                "statusCheckRollup": [{"name": "typecheck", "conclusion": "SUCCESS", "status": "COMPLETED"}],
+            }])
+        else:
+            r.stdout = "build\tnpm test\tError: expected verification banner\nbuild\tnpm test\tAssertionError: banner missing"
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    action = draft_action_from_opportunity(opportunity["id"], action_kind="github_actions_diagnosis", actor="human")
+    assert action["action_type"] == "github_actions_diagnosis"
+    assert action["target_system"] == "github"
+    assert action["status"] == "queued"
+    payload = action["proposed_payload"]
+    assert payload["run_id"] == "25928548133"
+    assert payload["repo"] == "acme-inc/web-app"
+    assert payload["diagnosis"]["failed_jobs"] == ["build"]
+    assert payload["pr_context"]["number"] == 132
+    assert payload["pr_context"]["state"] == "MERGED"
+    assert payload["pr_context"]["branch"] == "email-verification-ui"
+    assert payload["resolution_status"] == "resolved_merged"
+    assert payload["should_create_fix_branch"] is False
+    assert "already been merged" in payload["body"]
+    assert "expected verification banner" in payload["body"]
+    assert payload["next_steps"][0].startswith("No new fix branch")
+
+
+def test_actionable_github_actions_opportunity_can_queue_fix_ci_lane(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.opportunity_actions import build_opportunity_detail, draft_action_from_opportunity
+
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/actions/runs/26000000001",
+        title="Failing CI: Typecheck",
+        description="A recent GitHub Actions run failed and may be a visible unblock opportunity.",
+        category="flaky_tests_and_ci_failures",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["ci_before_after", "pull_request"],
+        metadata={"databaseId": 26000000001, "workflowName": "Typecheck", "conclusion": "failure"},
+    )
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] == ["gh", "run", "view"] and "--json" in args:
+            r.stdout = json.dumps({
+                "name": "Typecheck",
+                "conclusion": "failure",
+                "status": "completed",
+                "event": "pull_request",
+                "headBranch": "feat/broken-types",
+                "headSha": "abc123",
+                "jobs": [{"name": "typecheck", "conclusion": "failure", "steps": [{"name": "npm run typecheck", "conclusion": "failure"}]}],
+                "url": opportunity["source_url"],
+            })
+        elif args[:3] == ["gh", "pr", "list"]:
+            r.stdout = json.dumps([{
+                "number": 144,
+                "title": "Add typed signup flow",
+                "state": "OPEN",
+                "url": "https://github.com/acme-inc/web-app/pull/144",
+                "headRefName": "feat/broken-types",
+                "headRefOid": "abc123",
+                "baseRefName": "main",
+                "mergedAt": None,
+                "statusCheckRollup": [{"name": "Typecheck", "conclusion": "FAILURE", "status": "COMPLETED"}],
+            }])
+        else:
+            r.stdout = "typecheck\tnpm run typecheck\tError: Type 'string' is not assignable to type 'Address'"
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    detail = build_opportunity_detail(opportunity["id"])
+    assert any(a["action_kind"] == "ci_fix_lane" and a["label"] == "Start Fix CI lane" for a in detail["recommended_actions"])
+
+    action = draft_action_from_opportunity(opportunity["id"], action_kind="ci_fix_lane", actor="human")
+    assert action["action_type"] == "ci_fix_lane"
+    assert action["target_system"] == "hermes"
+    assert action["risk_level"] == "high"
+    payload = action["proposed_payload"]
+    assert payload["lane"] == "fix_ci"
+    assert payload["repo"] == "acme-inc/web-app"
+    assert payload["run_id"] == "26000000001"
+    assert payload["pr_context"]["number"] == 144
+    assert payload["should_create_fix_branch"] is True
+    assert "Type 'string' is not assignable" in payload["prompt"]
+    assert "Do not deploy" in payload["prompt"]
+    assert "self-audit" in payload["prompt"].lower()
+    assert "audit_status" in payload["prompt"]
+    assert "self_audit_before_push" in payload["safety_gates"]
+
+
+def test_fix_ci_lane_refuses_stale_or_resolved_ci(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.opportunity_actions import draft_action_from_opportunity
+
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/actions/runs/25928548133",
+        title="Failing CI: already merged",
+        description="A historical failed run.",
+        category="flaky_tests_and_ci_failures",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["ci_before_after"],
+        metadata={"databaseId": 25928548133},
+    )
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] == ["gh", "run", "view"] and "--json" in args:
+            r.stdout = json.dumps({"conclusion": "failure", "status": "completed", "headBranch": "done", "headSha": "old", "jobs": []})
+        elif args[:3] == ["gh", "pr", "list"]:
+            r.stdout = json.dumps([{"number": 132, "state": "MERGED", "url": "https://github.com/acme-inc/web-app/pull/132", "headRefName": "done", "headRefOid": "new", "baseRefName": "main", "mergedAt": "2026-05-15T16:34:49Z", "statusCheckRollup": []}])
+        else:
+            r.stdout = "test\tstep\tError: old failure"
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    with pytest.raises(ValueError, match="not actionable"):
+        draft_action_from_opportunity(opportunity["id"], action_kind="ci_fix_lane", actor="human")
+
+
+def test_hermes_executor_prepares_fix_and_queues_push_branch_action(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.actions import create_action, approve_action, list_actions
+    from plugins.visibility_os.core.executors import execute_approved_action
+
+    calls = []
+
+    def fake_run(args, capture_output, text, timeout, check, cwd=None, input=None):
+        calls.append({"args": args, "cwd": cwd, "input": input})
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if "visibility-os-ci-review" in args:
+            r.stdout = json.dumps({
+                "review_status": "passed",
+                "findings": [],
+                "fixes_required": [],
+                "notes": "Independent fresh-session review found no blockers.",
+            })
+        else:
+            r.stdout = json.dumps({
+                "branch": "fix/ci-typecheck-address",
+                "commit_sha": "abc987",
+                "commit_message": "fix: repair CI type mismatch",
+                "pr_title": "Fix CI type mismatch in signup flow",
+                "pr_body": "## What changed\n- Fixed Address typing\n\n## Verification\n- npm run typecheck",
+                "verification": ["npm run typecheck"],
+                "changed_files": ["src/routes/__root.tsx"],
+                "self_audit": {"audit_status": "passed", "issues_found": [], "fixes_applied": [], "notes": "Second-pass review found no issues."},
+                "ready_to_push": True,
+            })
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    action = create_action(
+        proposed_by_agent="human",
+        action_type="ci_fix_lane",
+        target_system="hermes",
+        target_location="acme-inc/web-app#26000000001",
+        title="Start Fix CI lane",
+        summary="Prepare a local CI repair branch.",
+        proposed_payload={
+            "lane": "fix_ci",
+            "repo": "acme-inc/web-app",
+            "run_id": "26000000001",
+            "prompt": "Fix the actionable CI failure. Do not push. Do not deploy.",
+            "command": ["hermes", "chat", "--query", "__PROMPT__", "--quiet", "--source", "visibility-os-ci-fix", "--toolsets", "terminal,file"],
+            "workdir": str(tmp_path),
+        },
+        evidence_links=[{"type": "run", "url": "https://github.com/acme-inc/web-app/actions/runs/26000000001"}],
+        risk_level="high",
+    )
+    approve_action(action["id"], actor="reviewer")
+    executed = execute_approved_action(action["id"], actor="reviewer")
+
+    assert executed["status"] == "executed"
+    assert calls[0]["cwd"] == str(tmp_path)
+    assert calls[0]["args"][3] == "Fix the actionable CI failure. Do not push. Do not deploy."
+    assert len([c for c in calls if c["args"] and c["args"][0] == "hermes"]) == 2
+    assert any("visibility-os-ci-review" in c["args"] for c in calls)
+    review_call = next(c for c in calls if "visibility-os-ci-review" in c["args"])
+    assert "Fix the actionable CI failure" not in review_call["args"][3]
+    assert "fresh session" in review_call["args"][3].lower()
+    result = executed["execution_result"]
+    assert result["prepared_branch"] == "fix/ci-typecheck-address"
+    assert result["push_action_id"]
+
+    push_action = next(a for a in list_actions() if a["id"] == result["push_action_id"])
+    assert push_action["status"] == "queued"
+    assert push_action["action_type"] == "github_push_branch"
+    assert push_action["target_system"] == "github"
+    assert push_action["proposed_payload"]["branch"] == "fix/ci-typecheck-address"
+    assert push_action["proposed_payload"]["pr_title"] == "Fix CI type mismatch in signup flow"
+    assert push_action["proposed_payload"]["self_audit"]["audit_status"] == "passed"
+    assert push_action["proposed_payload"]["independent_review"]["review_status"] == "passed"
+    assert result["self_audit"]["audit_status"] == "passed"
+    assert result["independent_review"]["review_status"] == "passed"
+    assert "npm run typecheck" in push_action["proposed_payload"]["pr_body"]
+
+
+
+def test_issue_opportunity_exposes_fix_lane_and_builds_payload(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.opportunity_actions import build_opportunity_detail, draft_action_from_opportunity
+
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/issues/42",
+        title="Bug: settings save fails on mobile",
+        description="Issue #42 appears relevant for small customer facing bug fixes.",
+        category="small_customer_facing_bug_fixes",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["pull_request", "issue_comment", "slack_update"],
+        metadata={
+            "number": 42,
+            "title": "Bug: settings save fails on mobile",
+            "body": "Saving settings on mobile returns a validation error.",
+            "labels": [{"name": "bug"}],
+            "url": "https://github.com/acme-inc/web-app/issues/42",
+        },
+    )
+
+    detail = build_opportunity_detail(opportunity["id"])
+    assert any(a["action_kind"] == "github_issue_fix_lane" and a["label"] == "Fix issue" for a in detail["recommended_actions"])
+
+    action = draft_action_from_opportunity(opportunity["id"], action_kind="github_issue_fix_lane", actor="human")
+    assert action["action_type"] == "github_issue_fix_lane"
+    assert action["target_system"] == "hermes"
+    assert action["risk_level"] == "high"
+    payload = action["proposed_payload"]
+    assert payload["lane"] == "fix_github_issue"
+    assert payload["repo"] == "acme-inc/web-app"
+    assert payload["issue_number"] == 42
+    assert payload["issue_url"] == opportunity["source_url"]
+    assert "Fix GitHub issue #42" in payload["prompt"]
+    assert "Saving settings on mobile" in payload["prompt"]
+    assert "Do not push" in payload["prompt"]
+    assert "visibility-os-issue-fix" in payload["command"]
+
+
+def test_hermes_executor_prepares_issue_fix_and_queues_push_branch_action(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.actions import create_action, approve_action, list_actions
+    from plugins.visibility_os.core.executors import execute_approved_action
+
+    calls = []
+
+    def fake_run(args, capture_output, text, timeout, check, cwd=None, input=None):
+        calls.append({"args": args, "cwd": cwd, "input": input})
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if "visibility-os-issue-review" in args:
+            r.stdout = json.dumps({
+                "review_status": "passed",
+                "findings": [],
+                "fixes_required": [],
+                "notes": "Fresh-session review found no blockers.",
+            })
+        else:
+            r.stdout = json.dumps({
+                "branch": "fix/issue-42-settings-save-mobile",
+                "commit_sha": "def456",
+                "commit_message": "fix: repair mobile settings save",
+                "pr_title": "Fix mobile settings save validation",
+                "pr_body": "## What changed\n- Fixed mobile settings validation\n\nFixes #42\n\n## Verification\n- pytest tests/settings",
+                "verification": ["pytest tests/settings"],
+                "changed_files": ["src/settings.py"],
+                "self_audit": {"audit_status": "passed", "issues_found": [], "fixes_applied": [], "notes": "Second-pass review found no issues."},
+                "ready_to_push": True,
+            })
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    action = create_action(
+        proposed_by_agent="human",
+        action_type="github_issue_fix_lane",
+        target_system="hermes",
+        target_location="acme-inc/web-app#42",
+        title="Fix GitHub issue #42",
+        summary="Prepare a local issue fix branch.",
+        proposed_payload={
+            "lane": "fix_github_issue",
+            "repo": "acme-inc/web-app",
+            "issue_number": 42,
+            "issue_url": "https://github.com/acme-inc/web-app/issues/42",
+            "prompt": "Fix GitHub issue #42. Do not push. Do not deploy.",
+            "command": ["hermes", "chat", "--query", "__PROMPT__", "--quiet", "--source", "visibility-os-issue-fix", "--toolsets", "terminal,file"],
+            "workdir": str(tmp_path),
+        },
+        evidence_links=[{"type": "issue", "url": "https://github.com/acme-inc/web-app/issues/42"}],
+        risk_level="high",
+    )
+    approve_action(action["id"], actor="reviewer")
+    executed = execute_approved_action(action["id"], actor="reviewer")
+
+    assert executed["status"] == "executed"
+    assert len([c for c in calls if c["args"] and c["args"][0] == "hermes"]) == 2
+    review_call = next(c for c in calls if "visibility-os-issue-review" in c["args"])
+    assert "Fix GitHub issue #42" not in review_call["args"][3]
+    assert "fresh session" in review_call["args"][3].lower()
+    result = executed["execution_result"]
+    assert result["lane"] == "fix_github_issue"
+    assert result["prepared_branch"] == "fix/issue-42-settings-save-mobile"
+    assert result["push_action_id"]
+
+    push_action = next(a for a in list_actions() if a["id"] == result["push_action_id"])
+    assert push_action["status"] == "queued"
+    assert push_action["action_type"] == "github_push_branch"
+    assert push_action["proposed_payload"]["issue_number"] == 42
+    assert push_action["proposed_payload"]["issue_url"] == "https://github.com/acme-inc/web-app/issues/42"
+    assert push_action["proposed_payload"]["independent_review"]["review_status"] == "passed"
+    assert "Fixes #42" in push_action["proposed_payload"]["pr_body"]
+
+
+def test_api_one_click_fix_ci_drafts_approves_executes_and_queues_push(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.actions import list_actions
+    from plugins.visibility_os.dashboard.plugin_api import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/actions/runs/26000000001",
+        title="Failing CI: Typecheck",
+        description="A recent GitHub Actions run failed.",
+        category="flaky_tests_and_ci_failures",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["ci_before_after", "pull_request"],
+        metadata={"databaseId": 26000000001},
+    )
+
+    def fake_run(args, capture_output, text, timeout, check, cwd=None, input=None):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] == ["gh", "run", "view"] and "--json" in args:
+            r.stdout = json.dumps({"conclusion": "failure", "status": "completed", "event": "pull_request", "headBranch": "feat/broken-types", "headSha": "abc123", "jobs": [], "url": opportunity["source_url"]})
+        elif args[:3] == ["gh", "pr", "list"]:
+            r.stdout = json.dumps([{"number": 144, "title": "Add typed signup flow", "state": "OPEN", "url": "https://github.com/acme-inc/web-app/pull/144", "headRefName": "feat/broken-types", "headRefOid": "abc123", "baseRefName": "main", "mergedAt": None, "statusCheckRollup": [{"name": "Typecheck", "conclusion": "FAILURE", "status": "COMPLETED"}]}])
+        elif args and args[0] == "hermes" and "visibility-os-ci-review" in args:
+            r.stdout = json.dumps({"review_status": "passed", "findings": [], "fixes_required": [], "notes": "Independent review passed"})
+        elif args and args[0] == "hermes":
+            r.stdout = json.dumps({
+                "branch": "fix/ci-typecheck-address",
+                "commit_sha": "abc987",
+                "commit_message": "fix: repair CI type mismatch",
+                "pr_title": "Fix CI type mismatch in signup flow",
+                "pr_body": "## Verification\n- npm run typecheck",
+                "verification": ["npm run typecheck"],
+                "changed_files": ["src/routes/__root.tsx"],
+                "self_audit": {"audit_status": "passed", "issues_found": [], "fixes_applied": [], "notes": "ok"},
+                "ready_to_push": True,
+            })
+        else:
+            r.stdout = "typecheck\tnpm run typecheck\tError: Type 'string' is not assignable to type 'Address'"
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    response = client.post(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}/fix-ci", json={"actor": "reviewer"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "executed"
+    assert body["action_type"] == "ci_fix_lane"
+    assert body["execution_result"]["prepared_branch"] == "fix/ci-typecheck-address"
+
+    push_actions = [a for a in list_actions() if a["action_type"] == "github_push_branch"]
+    assert len(push_actions) == 1
+    assert push_actions[0]["status"] == "queued"
+    assert push_actions[0]["proposed_payload"]["self_audit"]["audit_status"] == "passed"
+    assert push_actions[0]["proposed_payload"]["independent_review"]["review_status"] == "passed"
+
+
+
+def test_api_one_click_fix_issue_drafts_approves_executes_and_queues_push(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.actions import list_actions
+    from plugins.visibility_os.dashboard.plugin_api import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/issues/42",
+        title="Bug: settings save fails on mobile",
+        description="Issue #42 appears relevant for small customer facing bug fixes.",
+        category="small_customer_facing_bug_fixes",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["pull_request", "issue_comment"],
+        metadata={"number": 42, "title": "Bug: settings save fails on mobile", "body": "Saving settings on mobile returns a validation error.", "labels": [{"name": "bug"}]},
+    )
+
+    def fake_run(args, capture_output, text, timeout, check, cwd=None, input=None):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args and args[0] == "hermes" and "visibility-os-issue-review" in args:
+            r.stdout = json.dumps({"review_status": "passed", "findings": [], "fixes_required": [], "notes": "Independent review passed"})
+        elif args and args[0] == "hermes":
+            r.stdout = json.dumps({
+                "branch": "fix/issue-42-settings-save-mobile",
+                "commit_sha": "def456",
+                "commit_message": "fix: repair mobile settings save",
+                "pr_title": "Fix mobile settings save validation",
+                "pr_body": "## Verification\n- pytest tests/settings\n\nFixes #42",
+                "verification": ["pytest tests/settings"],
+                "changed_files": ["src/settings.py"],
+                "self_audit": {"audit_status": "passed", "issues_found": [], "fixes_applied": [], "notes": "ok"},
+                "ready_to_push": True,
+            })
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    response = client.post(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}/fix-issue", json={"actor": "reviewer"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "executed"
+    assert body["action_type"] == "github_issue_fix_lane"
+    assert body["execution_result"]["lane"] == "fix_github_issue"
+    assert body["execution_result"]["issue_number"] == 42
+
+    push_actions = [a for a in list_actions() if a["action_type"] == "github_push_branch"]
+    assert len(push_actions) == 1
+    assert push_actions[0]["status"] == "queued"
+    assert push_actions[0]["proposed_payload"]["issue_number"] == 42
+    assert push_actions[0]["proposed_payload"]["independent_review"]["review_status"] == "passed"
+
+
+def test_github_executor_pushes_prepared_branch_and_creates_pr(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.actions import create_action, approve_action
+    from plugins.visibility_os.core.executors import execute_approved_action
+
+    calls = []
+
+    def fake_run(args, capture_output, text, timeout, check, cwd=None):
+        calls.append({"args": args, "cwd": cwd})
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] == ["gh", "pr", "create"]:
+            r.stdout = "https://github.com/acme-inc/web-app/pull/145\n"
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    action = create_action(
+        proposed_by_agent="visibility_os",
+        action_type="github_push_branch",
+        target_system="github",
+        target_location="acme-inc/web-app#fix/ci-typecheck-address",
+        title="Push prepared CI fix branch",
+        summary="Push local branch and create PR.",
+        proposed_payload={
+            "repo": "acme-inc/web-app",
+            "branch": "fix/ci-typecheck-address",
+            "base_branch": "main",
+            "workdir": str(tmp_path),
+            "pr_title": "Fix CI type mismatch in signup flow",
+            "pr_body": "## Verification\n- npm run typecheck",
+        },
+        evidence_links=[{"type": "run", "url": "https://github.com/acme-inc/web-app/actions/runs/26000000001"}],
+        risk_level="high",
+    )
+    approve_action(action["id"], actor="reviewer")
+    executed = execute_approved_action(action["id"], actor="reviewer")
+    assert executed["status"] == "executed"
+    assert calls[0]["args"] == ["git", "push", "-u", "origin", "fix/ci-typecheck-address"]
+    assert calls[0]["cwd"] == str(tmp_path)
+    assert calls[1]["args"][:3] == ["gh", "pr", "create"]
+    assert executed["execution_result"]["pr_url"] == "https://github.com/acme-inc/web-app/pull/145"
+
+
+def test_api_route_diagnoses_github_actions_opportunity(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.dashboard.plugin_api import router
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/risk-engine/actions/runs/22456835234",
+        title="Failing CI: Deploy Risk Engine - Staging",
+        description="A recent GitHub Actions run failed and may be a visible unblock opportunity.",
+        category="flaky_tests_and_ci_failures",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["ci_before_after"],
+        metadata={"databaseId": 22456835234},
+    )
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        r.stdout = json.dumps({"jobs": [{"name": "deploy", "conclusion": "failure", "steps": []}], "conclusion": "failure"}) if "--json" in args else "deploy\tterraform apply\tError: missing AWS credentials"
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    response = client.post(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}/draft-action", json={"action_kind": "github_actions_diagnosis", "actor": "human"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["action_type"] == "github_actions_diagnosis"
+    assert "missing AWS credentials" in body["proposed_payload"]["body"]
+
+
+def test_api_route_audits_pr_opportunity(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.dashboard.plugin_api import router
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/infrastructure/pull/657",
+        title="revert: SES wildcard back to specific noreply@ identity",
+        description="PR #657 may need review acceleration.",
+        category="pr_review_acceleration",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=5,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=30,
+        suggested_artifacts=["review_comment"],
+        metadata={"number": 657},
+    )
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        r.stdout = '{"headRefOid":"abc123"}' if "view" in args else 'diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1,1 +1,2 @@\n+password = "supersecret"\n'
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    response = client.post(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}/audit-pr", json={"actor": "human"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["action_type"] == "github_pr_review_draft"
+    assert body["proposed_payload"]["findings"][0]["path"] == "app.py"
+
+
+def test_api_route_deep_reviews_pr_opportunity(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.dashboard.plugin_api import router
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/platform/pull/700",
+        title="update hedging flow",
+        description="PR #700 may need review acceleration.",
+        category="pr_review_acceleration",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=5,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=30,
+        suggested_artifacts=["review_comment"],
+        metadata={"number": 700},
+    )
+
+    calls = []
+
+    def fake_run(args, capture_output, text, timeout, check, cwd=None):
+        calls.append((args, cwd))
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] == ["gh", "pr", "view"]:
+            r.stdout = json.dumps({
+                "headRefOid": "abc123",
+                "changedFiles": 2,
+                "additions": 25,
+                "deletions": 3,
+                "body": "Implements hedging change.",
+                "files": [{"path": "src/hedging/flow.py"}, {"path": "README.md"}],
+            })
+        elif args[:3] == ["gh", "pr", "diff"]:
+            r.stdout = "diff --git a/src/hedging/flow.py b/src/hedging/flow.py\n--- a/src/hedging/flow.py\n+++ b/src/hedging/flow.py\n@@ -1,1 +1,2 @@\n+def rebalance():\n+    return True\n"
+        elif args[:3] == ["gh", "repo", "clone"] or args[:3] == ["gh", "pr", "checkout"]:
+            r.stdout = ""
+        elif args and args[0] == "hermes":
+            r.stdout = json.dumps({
+                "verdict": "COMMENT",
+                "findings": [{
+                    "severity": "warning",
+                    "path": "src/hedging/flow.py",
+                    "line": 1,
+                    "title": "Agent found missing hedging edge-case coverage",
+                    "detail": "The new rebalance path should be covered for empty positions.",
+                    "solution": "Add a test for empty-position rebalance behavior.",
+                    "code": "def rebalance():",
+                    "casual_comment": "This rebalance path looks like it might skip empty-position handling — can we cover that before merging?",
+                }],
+                "review_notes": ["Checked out the PR branch locally and reviewed with Hermes agent."],
+            })
+        else:
+            r.stdout = ""
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    response = client.post(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}/deep-review-pr", json={"actor": "human"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["action_type"] == "github_pr_review_draft"
+    assert body["proposed_payload"]["review_depth"] == "deep"
+    assert body["proposed_payload"]["agentic"] is True
+    assert "Hermes Agentic Deep PR Review" in body["proposed_payload"]["body"]
+    assert any(args and args[0] == "hermes" for args, _cwd in calls)
+    assert any(args[:3] == ["gh", "repo", "clone"] for args, _cwd in calls)
+    assert any(f["title"] == "Agent found missing hedging edge-case coverage" for f in body["proposed_payload"]["findings"])
+    agent_finding = next(f for f in body["proposed_payload"]["findings"] if f["title"] == "Agent found missing hedging edge-case coverage")
+    assert agent_finding["source"] == "agentic"
+    assert "empty-position" in agent_finding["casual_comment"]
+    assert "—" not in agent_finding["casual_comment"]
+    assert "–" not in agent_finding["casual_comment"]
+    assert agent_finding["github_diff_url"].endswith("#diff-src-hedging-flow-pyR1")
+
+
+def test_visibility_os_dashboard_shows_single_fix_ci_button():
+    js = Path("plugins/visibility_os/dashboard/dist/index.js").read_text()
+    assert "fixCI" in js
+    assert "Fix CI" in js
+    assert "/fix-ci" in js
+    assert "fixIssue" in js
+    assert "Fix Issue" in js
+    assert "/fix-issue" in js
+    assert "Start Fix CI lane" not in js
+    assert "Diagnose CI" not in js
+    assert "github_actions_diagnosis" not in js
+    assert "pushBranchNow" in js
+    assert "Push branch" in js
+    assert "Proposed PR" in js
+    assert "Self-audit" in js
+    assert "Independent review" in js
+    assert "review_status" in js
+    assert "github_push_branch" in js
+    assert "item.can_diagnose_ci" in js
+    assert "item.opportunity_id || item.id" in js
+    assert "sectionActions" in js
+    assert "Open opportunity" in js
+    assert "viewOpportunity(item.id)" in js
+    assert "Kanban board" in js
+    assert "kanbanColumn('todo'" in js
+    assert "kanbanColumn('in_progress'" in js
+    assert "kanbanColumn('in_review'" in js
+    assert "kanbanColumn('done'" in js
+    assert "Move to In progress" in js
+    assert "Move to Review" in js
+    assert "Mark done" in js
+    assert "Archive" in js
+    assert "Show archived" in js
+    assert "/api/plugins/visibility-os/board-state" in js
+    assert "/api/plugins/visibility-os/config" in js
+    assert "default_slack_channel" in js
+    assert "#engineering" not in js
+
+
+def test_visibility_os_config_endpoint_uses_env(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    monkeypatch.setenv("VISIBILITY_OS_COMPANY_NAME", "Example Co")
+    monkeypatch.setenv("VISIBILITY_OS_GITHUB_ORGS", "example-org")
+    monkeypatch.setenv("VISIBILITY_OS_GITHUB_REPOS", "example-org/app,example-org/api")
+    monkeypatch.setenv("VISIBILITY_OS_DEFAULT_SLACK_CHANNEL", "#ci-alerts")
+    from plugins.visibility_os.dashboard.plugin_api import router
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+
+    response = client.get("/api/plugins/visibility-os/config")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "company_name": "Example Co",
+        "github_orgs": ["example-org"],
+        "github_repos": ["example-org/app", "example-org/api"],
+        "default_slack_channel": "#ci-alerts",
+    }
+
+
+def test_kanban_board_state_endpoint_moves_and_archives_items(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.dashboard.plugin_api import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/issues/99",
+        title="Bug: hard to read queue",
+        description="Board should make work easier to scan.",
+        category="dashboard_ux",
+        impact_score=4,
+        visibility_score=5,
+        effort_score=3,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=32,
+        suggested_artifacts=["ui"],
+        metadata={"number": 99},
+    )
+
+    feed = client.get("/api/plugins/visibility-os/feed").json()
+    card = next(item for item in feed["items"] if item["id"] == opportunity["id"])
+    assert card["board_state"] == "todo"
+    assert feed["counts"]["board"]["todo"] >= 1
+
+    moved = client.post("/api/plugins/visibility-os/board-state", json={"item_kind": "opportunity", "item_id": opportunity["id"], "board_state": "in_progress", "actor": "reviewer"})
+    assert moved.status_code == 200
+    feed = client.get("/api/plugins/visibility-os/feed").json()
+    card = next(item for item in feed["items"] if item["id"] == opportunity["id"])
+    assert card["board_state"] == "in_progress"
+    assert card["board_state_actor"] == "reviewer"
+
+    archived = client.post("/api/plugins/visibility-os/board-state", json={"item_kind": "opportunity", "item_id": opportunity["id"], "board_state": "archived", "actor": "reviewer"})
+    assert archived.status_code == 200
+    assert all(item["id"] != opportunity["id"] for item in client.get("/api/plugins/visibility-os/feed").json()["items"])
+    archived_feed = client.get("/api/plugins/visibility-os/feed?include_archived=true").json()
+    archived_card = next(item for item in archived_feed["items"] if item["id"] == opportunity["id"])
+    assert archived_card["board_state"] == "archived"
+
+
+def test_dashboard_plugin_manifest_entries_point_to_existing_assets():
+    for manifest_path in Path("plugins").glob("*/dashboard/manifest.json"):
+        manifest = json.loads(manifest_path.read_text())
+        entry = manifest.get("entry")
+        if entry:
+            assert (manifest_path.parent / entry).is_file(), f"{manifest_path} entry {entry} is missing"
+
+
+def test_visibility_os_dashboard_does_not_render_object_payloads_as_react_children():
+    node_script = r'''
+const path = require('path');
+const feed = {
+  items: [{
+    kind: 'action',
+    id: 'act_1',
+    title: 'Push prepared branch',
+    summary: 'Prepared locally',
+    status: 'queued',
+    target_system: 'github',
+    risk_level: 'high',
+    action_type: 'github_push_branch',
+    proposed_payload: {
+      branch: 'fix/object-render',
+      commit_message: 'fix: render changed files safely',
+      pr_title: 'Fix object render',
+      pr_body: '## Summary',
+      changed_files: [{path: 'src/app.js', change: 'updated rendering'}],
+      verification: [{path: 'pytest', change: 'passed'}],
+      self_audit: {audit_status: 'passed', issues_found: [], fixes_applied: []},
+      independent_review: {review_status: 'passed', findings: [], fixes_required: []}
+    },
+    evidence_links: []
+  }],
+  counts: {actions: 1, opportunities: 0}
+};
+function isElement(value) { return value && typeof value === 'object' && value.__element === true; }
+function checkChild(child) {
+  if (Array.isArray(child)) return child.forEach(checkChild);
+  if (child === null || child === undefined || child === false || child === true) return;
+  if (typeof child === 'object' && !isElement(child)) throw new Error('Plain object rendered: ' + JSON.stringify(child));
+}
+const React = {
+  createElement: function(type, props) {
+    const children = Array.prototype.slice.call(arguments, 2);
+    children.forEach(checkChild);
+    return {__element: true, type, props: props || {}, children};
+  }
+};
+let stateCall = 0;
+global.window = {
+  __HERMES_PLUGIN_SDK__: {
+    React,
+    fetchJSON: function () { return Promise.resolve({}); },
+    hooks: {
+      useState: function(initial) { stateCall += 1; return [stateCall === 1 ? feed : initial, function () {}]; },
+      useCallback: function(fn) { return fn; },
+      useEffect: function() {}
+    },
+    components: {
+      Card: 'Card', CardHeader: 'CardHeader', CardTitle: 'CardTitle', CardContent: 'CardContent', Badge: 'Badge'
+    }
+  },
+  __HERMES_PLUGINS__: {
+    register: function(name, Component) { Component(); }
+  },
+  prompt: function () { return null; }
+};
+global.navigator = {clipboard: {writeText: function () {}}};
+require(path.resolve('plugins/visibility_os/dashboard/dist/index.js'));
+'''
+    result = subprocess.run(["node", "-e", node_script], cwd=Path.cwd(), text=True, capture_output=True, timeout=10)
+    assert result.returncode == 0, result.stderr
+
+
+def test_visibility_os_dashboard_renders_rich_audit_finding_controls():
+    js = Path("plugins/visibility_os/dashboard/dist/index.js").read_text()
+    for expected in [
+        "severityFilter",
+        "sourceFilter",
+        "findingsSummaryView",
+        "groupFindingsByFile",
+        "copyFindingComment",
+        "Open diff line",
+        "markFindingStatus",
+        "Agentic findings",
+        "Deterministic findings",
+    ]:
+        assert expected in js
+
+
+def test_visibility_os_dashboard_uses_readable_non_overlapping_action_buttons():
+    js = Path("plugins/visibility_os/dashboard/dist/index.js").read_text()
+    assert "function ActionButton" in js
+    assert "tracking-normal" in js
+    assert "normal-case" in js
+    assert "whitespace-nowrap" in js
+    assert "props && props.children" in js
+    assert "letterSpacing: 'normal'" in js
+    assert "textTransform: 'none'" in js
+    assert "fontFamily: 'Arial, Helvetica, sans-serif'" in js
+    assert "h(Button" not in js
+
+
+def test_api_routes_cover_action_review_flow(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.dashboard.plugin_api import router
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    create = client.post("/api/plugins/visibility-os/actions", json={
+        "proposed_by_agent": "communications_agent",
+        "action_type": "github_issue_comment",
+        "target_system": "github",
+        "target_location": "org/repo/issues/1",
+        "title": "Diagnosis",
+        "summary": "Post diagnosis",
+        "proposed_payload": {"body": "I found a likely cause. https://github.com/org/repo/issues/1"},
+        "evidence_links": [{"type": "issue", "url": "https://github.com/org/repo/issues/1"}],
+        "risk_level": "low"
+    })
+    assert create.status_code == 200
+    action_id = create.json()["id"]
+    assert client.post(f"/api/plugins/visibility-os/actions/{action_id}/edit", json={"final_payload": {"body": "Edited body https://github.com/org/repo/issues/1"}, "actor": "reviewer"}).status_code == 200
+    assert client.post(f"/api/plugins/visibility-os/actions/{action_id}/approve", json={"actor": "reviewer"}).status_code == 200
+    feed = client.get("/api/plugins/visibility-os/feed").json()
+    assert any(item["id"] == action_id for item in feed["items"])
+    assert client.get("/api/plugins/visibility-os/audit-log").json()["events"]
+
+
+def test_feed_marks_actions_linked_to_ci_opportunities_as_diagnosable(tmp_path, monkeypatch):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.opportunity_actions import draft_action_from_opportunity
+    from plugins.visibility_os.dashboard.plugin_api import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/actions/runs/25928548133",
+        title="Failing CI: PENDING: Email verification UI for whitelist signup",
+        description="A recent GitHub Actions run failed and may be a visible unblock opportunity.",
+        category="flaky_tests_and_ci_failures",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=4,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=29,
+        suggested_artifacts=["ci_before_after"],
+        metadata={"databaseId": 25928548133},
+    )
+    action = draft_action_from_opportunity(opportunity["id"], action_kind="slack_update", target_location="#team-updates")
+
+    feed = client.get("/api/plugins/visibility-os/feed").json()
+    action_card = next(item for item in feed["items"] if item["id"] == action["id"])
+    assert action_card["kind"] == "action"
+    assert action_card["opportunity_id"] == opportunity["id"]
+    assert action_card["opportunity_source_url"] == opportunity["source_url"]
+    assert action_card["can_diagnose_ci"] is True
+
+
+def test_workstream_schema_core_api_and_feed_rollups(tmp_path, monkeypatch):
+    db = patch_db(tmp_path, monkeypatch)
+    db.init_db()
+    conn = sqlite3.connect(tmp_path / "visibility_os.db")
+    names = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"workstreams", "workstream_events", "workstream_artifacts"} <= names
+
+    from plugins.visibility_os.core.opportunities import upsert_opportunity
+    from plugins.visibility_os.core.opportunity_actions import draft_action_from_opportunity
+    from plugins.visibility_os.core.workstreams import (
+        add_workstream_artifact,
+        get_workstream,
+        list_workstreams,
+        update_stage,
+    )
+    from plugins.visibility_os.dashboard.plugin_api import router
+
+    opportunity = upsert_opportunity(
+        source_system="github",
+        source_url="https://github.com/acme-inc/web-app/issues/42",
+        title="Bug: negative add support",
+        description="A visible bug fix opportunity.",
+        category="bug_fix",
+        impact_score=4,
+        visibility_score=4,
+        effort_score=3,
+        safety_score=5,
+        risk_penalty=0,
+        priority_score=30,
+        suggested_artifacts=["tests"],
+        metadata={"url": "https://github.com/acme-inc/web-app/issues/42"},
+    )
+
+    action = draft_action_from_opportunity(opportunity["id"], action_kind="github_issue_fix_lane", actor="human")
+    workstream_id = action["proposed_payload"]["workstream_id"]
+    assert workstream_id.startswith("ws_")
+
+    ws = get_workstream(workstream_id)
+    assert ws["opportunity_id"] == opportunity["id"]
+    assert ws["root_action_id"] == action["id"]
+    assert ws["stage"] == "queued"
+    assert ws["status"] == "active"
+    assert ws["events"][0]["event_type"] == "created"
+
+    update_stage(workstream_id, stage="editing", current_step="Agent is editing files", progress_percent=35, actor="agent")
+    add_workstream_artifact(workstream_id, artifact_type="proposed_pr", title="Prepared PR", payload={"branch": "fix/issue-42", "changed_files": ["app.py"]})
+    ws = get_workstream(workstream_id)
+    assert ws["stage"] == "editing"
+    assert ws["current_step"] == "Agent is editing files"
+    assert ws["progress_percent"] == 35
+    assert ws["events"][-1]["stage"] == "editing"
+    assert ws["artifacts"][0]["artifact_type"] == "proposed_pr"
+
+    assert list_workstreams(status="active")[0]["id"] == workstream_id
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/plugins/visibility-os")
+    client = TestClient(app)
+
+    workstreams = client.get("/api/plugins/visibility-os/workstreams?status=active").json()["workstreams"]
+    assert workstreams[0]["id"] == workstream_id
+    detail = client.get(f"/api/plugins/visibility-os/workstreams/{workstream_id}").json()
+    assert detail["artifacts"][0]["payload"]["branch"] == "fix/issue-42"
+    opportunity_workstreams = client.get(f"/api/plugins/visibility-os/opportunities/{opportunity['id']}/workstreams").json()["workstreams"]
+    assert opportunity_workstreams[0]["id"] == workstream_id
+
+    feed = client.get("/api/plugins/visibility-os/feed").json()
+    opportunity_card = next(item for item in feed["items"] if item["kind"] == "opportunity" and item["id"] == opportunity["id"])
+    assert opportunity_card["workstream_id"] == workstream_id
+    assert opportunity_card["workstream_stage"] == "editing"
+    assert opportunity_card["agent_has_worked_on_this"] is True
+    assert opportunity_card["pending_human_action"] is None
+
+
+def test_github_scanner_normalizes_mocked_gh(monkeypatch, tmp_path):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.connectors.github import GitHubConnector
+    from plugins.visibility_os.core.scanner import scan_github
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] == ["gh", "issue", "list"]:
+            r.stdout = json.dumps([{"number": 1, "title": "Flaky auth test", "url": "https://github.com/org/repo/issues/1", "labels": [{"name": "bug"}], "updatedAt": "2026-05-25T00:00:00Z", "assignees": []}])
+        elif args[:3] == ["gh", "pr", "list"]:
+            if "--state" in args:
+                r.stdout = "[]"
+            else:
+                r.stdout = json.dumps([{"number": 2, "title": "Docs update", "url": "https://github.com/org/repo/pull/2", "updatedAt": "2026-05-20T00:00:00Z", "reviewDecision": "REVIEW_REQUIRED", "statusCheckRollup": []}])
+        else:
+            r.stdout = json.dumps([{"databaseId": 3, "status": "completed", "conclusion": "failure", "displayTitle": "CI", "workflowName": "test", "url": "https://github.com/org/repo/actions/runs/3", "headBranch": "ci-failure", "createdAt": "2026-05-25T00:00:00Z"}])
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    opportunities = scan_github(GitHubConnector(repo="org/repo"))
+    assert len(opportunities) >= 3
+    assert opportunities[0]["priority_score"] >= opportunities[-1]["priority_score"]
+
+
+def test_github_scanner_skips_failed_runs_from_merged_prs(monkeypatch, tmp_path):
+    patch_db(tmp_path, monkeypatch)
+    from plugins.visibility_os.core.connectors.github import GitHubConnector
+    from plugins.visibility_os.core.scanner import scan_github
+
+    def fake_run(args, capture_output, text, timeout, check):
+        class R:
+            returncode = 0
+            stderr = ""
+            stdout = ""
+        r = R()
+        if args[:3] in (["gh", "issue", "list"], ["gh", "pr", "list"]) and "--state" not in args:
+            r.stdout = "[]"
+        elif args[:3] == ["gh", "pr", "list"] and "--state" in args:
+            r.stdout = json.dumps([{
+                "number": 132,
+                "title": "PENDING: Email verification UI for whitelist signup",
+                "state": "MERGED",
+                "url": "https://github.com/acme-inc/web-app/pull/132",
+                "headRefName": "feat/email-guard",
+                "headRefOid": "fixed456",
+                "baseRefName": "main",
+                "mergedAt": "2026-05-15T16:34:49Z",
+                "statusCheckRollup": [{"name": "typecheck", "conclusion": "SUCCESS", "status": "COMPLETED"}],
+            }])
+        else:
+            r.stdout = json.dumps([{
+                "databaseId": 25928548133,
+                "status": "completed",
+                "conclusion": "failure",
+                "displayTitle": "PENDING: Email verification UI for whitelist signup",
+                "workflowName": "Typecheck",
+                "url": "https://github.com/acme-inc/web-app/actions/runs/25928548133",
+                "headBranch": "feat/email-guard",
+                "headSha": "decbc10",
+                "createdAt": "2026-05-15T16:17:23Z",
+            }])
+        return r
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    preexisting = scan_github(GitHubConnector(repo="acme-inc/web-app"))
+    assert preexisting == []
+

--- a/tests/plugins/visibility_os/test_visibility_os_core.py
+++ b/tests/plugins/visibility_os/test_visibility_os_core.py
@@ -1103,6 +1103,13 @@ def test_visibility_os_dashboard_shows_single_fix_ci_button():
     assert "sectionActions" in js
     assert "Open opportunity" in js
     assert "viewOpportunity(item.id)" in js
+    assert "ticketModalView" in js
+    assert "opportunityModalView" in js
+    assert "visibility-os-modal-backdrop" in js
+    assert "role: 'dialog'" in js
+    assert "aria-modal" in js
+    assert "setSelectedTicket(item)" in js
+    assert "onKeyDown" in js
     assert "Kanban board" in js
     assert "kanbanColumn('todo'" in js
     assert "kanbanColumn('in_progress'" in js


### PR DESCRIPTION
## Summary
- add the Visibility OS dashboard plugin with profile-scoped SQLite state, opportunities, action queue, workstreams, and approval-gated executors
- make the Visibility OS UI a Kanban board with Todo, In progress, In review, Done, and Archived states
- add persisted board-state overrides, archive/unarchive actions, and feed derivation from workstream/action state
- add implementation plans and regression coverage for the Visibility OS workflow

## Test Plan
- python -m pytest tests/plugins/visibility_os/test_visibility_os_core.py -q
- node --check plugins/visibility_os/dashboard/dist/index.js