### PR TITLE
fix(update): suppress npm postinstall demos

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6515,12 +6515,14 @@ def _run_npm_install_deterministic(
     the working tree dirty and causes the next ``hermes update`` to stash the
     lockfile — repeatedly.
     """
+    env = {**os.environ, "CI": os.environ.get("CI") or "1"}
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
         ci_cmd = [npm, "ci", *extra_args]
         ci_result = subprocess.run(
             ci_cmd,
             cwd=cwd,
+            env=env,
             capture_output=capture_output,
             text=True,
             encoding="utf-8",
@@ -6535,6 +6537,7 @@ def _run_npm_install_deterministic(
     return subprocess.run(
         install_cmd,
         cwd=cwd,
+        env=env,
         capture_output=capture_output,
         text=True,
         encoding="utf-8",

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -125,11 +125,14 @@ class TestBuildWebUISkipsWhenFresh:
         (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
 
         mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
-        with patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+        with patch.dict(os.environ, {}, clear=True), patch(
+            "hermes_cli.main.subprocess.run", return_value=mock_cp
+        ) as mock_run:
             result = _run_npm_install_deterministic("/usr/bin/npm", web_dir)
 
         assert result.returncode == 0
         _, kwargs = mock_run.call_args
+        assert kwargs["env"]["CI"] == "1"
         assert kwargs["text"] is True
         assert kwargs["encoding"] == "utf-8"
         assert kwargs["errors"] == "replace"


### PR DESCRIPTION
## Summary
- run Hermes-managed npm installs with CI=1 so noisy dependency postinstall demos are suppressed
- preserve existing npm install behavior, including streamed update output and UTF-8 error handling
- add regression coverage for the CI env passed to npm installs

Closes #31816

## Tests
- .venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_web_ui_build.py tests/hermes_cli/test_cmd_update.py -q