### PR TITLE
fix(gateway): refresh cached agent max_iterations after per-turn config reload

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15256,7 +15256,12 @@ class GatewayRunner:
                 self._agent_cache.pop(session_key, None)
 
     @staticmethod
-    def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
+    def _init_cached_agent_for_turn(
+        agent: Any,
+        interrupt_depth: int,
+        *,
+        max_iterations: Optional[int] = None,
+    ) -> None:
         """Reset per-turn state on a cached agent before a new turn starts.
 
         Both _last_activity_ts and _last_activity_desc are only reset for
@@ -15268,11 +15273,19 @@ class GatewayRunner:
         timeout (#15654).  The depth-0 reset is still needed: a session
         idle for 29 min would otherwise trip the watchdog before the new
         turn makes its first API call (#9051).
+
+        ``max_iterations`` is refreshed on every turn when provided. The
+        gateway allows ``agent.max_turns`` edits while it keeps reusing the
+        same cached AIAgent instance; without updating the live attribute
+        here, cached sessions would silently keep the old budget until some
+        unrelated cache-busting event rebuilt the agent.
         """
         if interrupt_depth == 0:
             agent._last_activity_ts = time.time()
             agent._last_activity_desc = "starting new turn (cached)"
         agent._api_call_count = 0
+        if max_iterations is not None:
+            agent.max_iterations = max_iterations
 
     def _release_evicted_agent_soft(self, agent: Any) -> None:
         """Soft cleanup for cache-evicted agents — preserves session tool state.
@@ -16426,9 +16439,6 @@ class GatewayRunner:
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
             os.environ["HERMES_SESSION_KEY"] = session_key or ""
 
-            # Read from env var or use default (same as CLI)
-            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
-            
             # Map platform enum to the platform hint key the agent understands.
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
@@ -16446,6 +16456,11 @@ class GatewayRunner:
             # keys may change without restart). Keep config.yaml authoritative for
             # runtime budget settings bridged into env vars.
             _reload_runtime_env_preserving_config_authority()
+
+            # Read runtime budgets AFTER the per-turn reload so edits to
+            # config.yaml agent.max_turns (or fresh dotenv fallbacks when the
+            # config key is absent) take effect on this very turn.
+            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(
@@ -16603,7 +16618,11 @@ class GatewayRunner:
                                 _cache.move_to_end(session_key)
                             except KeyError:
                                 pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                        self._init_cached_agent_for_turn(
+                            agent,
+                            _interrupt_depth,
+                            max_iterations=max_iterations,
+                        )
                         logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1323,6 +1323,38 @@ class TestCachedAgentInactivityReset:
         assert agent_fresh._api_call_count == 0
         assert agent_interrupted._api_call_count == 0
 
+    def test_max_iterations_refreshes_on_fresh_turn(self):
+        """Cached agents must pick up updated agent.max_turns immediately."""
+        from gateway.run import GatewayRunner
+
+        agent = self._fake_agent()
+        agent.max_iterations = 90
+
+        with patch("gateway.run.time") as mock_time:
+            mock_time.time.return_value = _FAKE_NOW
+            GatewayRunner._init_cached_agent_for_turn(
+                agent,
+                interrupt_depth=0,
+                max_iterations=12,
+            )
+
+        assert agent.max_iterations == 12
+
+    def test_max_iterations_refreshes_on_interrupt_recursive_turn(self):
+        """Interrupt-recursive cache reuse must still refresh the budget."""
+        from gateway.run import GatewayRunner
+
+        agent = self._fake_agent()
+        agent.max_iterations = 90
+
+        GatewayRunner._init_cached_agent_for_turn(
+            agent,
+            interrupt_depth=2,
+            max_iterations=7,
+        )
+
+        assert agent.max_iterations == 7
+
     def test_watchdog_accumulation_across_recursive_turns(self):
         """Scenario: stuck turn + user interrupt → recursive turn.
 


### PR DESCRIPTION
## Summary

This fixes a gateway stale-state bug where `agent.max_turns` changes were not applied reliably on the next turn.

In the cached-agent path, the gateway could continue using an outdated `max_iterations` value even after the per-turn config/env reload completed.

Fixes #<issue-id>

## Changes

- read `HERMES_MAX_ITERATIONS` after `_reload_runtime_env_preserving_config_authority()`
- refresh `max_iterations` when reusing a cached `AIAgent`
- add regression coverage for cached-turn budget refresh

## Files

- `gateway/run.py`
- `tests/gateway/test_agent_cache.py`

## Validation

Ran locally:

```bash
python -m pytest tests/gateway/test_agent_cache.py -q --timeout-method=thread
python -m pytest tests/gateway/test_runtime_env_reload_config_authority.py -q --timeout-method=thread

Passed:

tests/gateway/test_agent_cache.py
tests/gateway/test_runtime_env_reload_config_authority.py