### PR TITLE
fix(holographic-memory): surface init failure instead of cryptic AttributeError

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -256,7 +256,17 @@ class HolographicMemoryProvider(MemoryProvider):
 
     # -- Tool handlers -------------------------------------------------------
 
+    _UNAVAILABLE_MSG = (
+        "Holographic memory is unavailable — provider initialization failed "
+        "(typically a corrupt $HERMES_HOME/memory_store.db, e.g. after a "
+        "crash mid-WAL-checkpoint). Check the hermes errors log for the "
+        "underlying exception. Recovery: stop hermes, remove or restore "
+        "memory_store.db, then restart."
+    )
+
     def _handle_fact_store(self, args: dict) -> str:
+        if self._store is None or self._retriever is None:
+            return tool_error(self._UNAVAILABLE_MSG)
         try:
             action = args["action"]
             store = self._store
@@ -344,6 +354,8 @@ class HolographicMemoryProvider(MemoryProvider):
             return tool_error(str(exc))
 
     def _handle_fact_feedback(self, args: dict) -> str:
+        if self._store is None:
+            return tool_error(self._UNAVAILABLE_MSG)
         try:
             fact_id = int(args["fact_id"])
             helpful = args["action"] == "helpful"

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -119,6 +119,10 @@ class HolographicMemoryProvider(MemoryProvider):
         self._config = config or _load_plugin_config()
         self._store = None
         self._retriever = None
+        # Resolved database path, captured in initialize() before the
+        # MemoryStore is constructed so the unavailable-handler message can
+        # name the exact file even when initialize() failed. None until then.
+        self._db_path = None
         self._min_trust = float(self._config.get("min_trust_threshold", 0.3))
 
     @property
@@ -166,6 +170,10 @@ class HolographicMemoryProvider(MemoryProvider):
         if isinstance(db_path, str):
             db_path = db_path.replace("$HERMES_HOME", _hermes_home)
             db_path = db_path.replace("${HERMES_HOME}", _hermes_home)
+        # Record the resolved path before constructing MemoryStore: if that
+        # construction raises (e.g. corrupt DB), _unavailable_msg() can still
+        # point recovery at the actual file, default or configured.
+        self._db_path = db_path
         default_trust = float(self._config.get("default_trust", 0.5))
         hrr_dim = int(self._config.get("hrr_dim", 1024))
         hrr_weight = float(self._config.get("hrr_weight", 0.3))
@@ -256,17 +264,25 @@ class HolographicMemoryProvider(MemoryProvider):
 
     # -- Tool handlers -------------------------------------------------------
 
-    _UNAVAILABLE_MSG = (
-        "Holographic memory is unavailable — provider initialization failed "
-        "(typically a corrupt $HERMES_HOME/memory_store.db, e.g. after a "
-        "crash mid-WAL-checkpoint). Check the hermes errors log for the "
-        "underlying exception. Recovery: stop hermes, remove or restore "
-        "memory_store.db, then restart."
-    )
+    def _unavailable_msg(self) -> str:
+        # db_path is configurable, so name the resolved file when we captured
+        # it in initialize(); fall back to a generic reference otherwise (e.g.
+        # initialize() never ran, or failed before path resolution).
+        if self._db_path:
+            where = f"the holographic database at {self._db_path}"
+        else:
+            where = "the configured holographic database (see the db_path setting)"
+        return (
+            "Holographic memory is unavailable — provider initialization "
+            "failed (typically a corrupt database, e.g. after a crash "
+            "mid-WAL-checkpoint). Check the hermes errors log for the "
+            "underlying exception. Recovery: stop hermes, remove or restore "
+            f"{where}, then restart."
+        )
 
     def _handle_fact_store(self, args: dict) -> str:
         if self._store is None or self._retriever is None:
-            return tool_error(self._UNAVAILABLE_MSG)
+            return tool_error(self._unavailable_msg())
         try:
             action = args["action"]
             store = self._store
@@ -355,7 +371,7 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def _handle_fact_feedback(self, args: dict) -> str:
         if self._store is None:
-            return tool_error(self._UNAVAILABLE_MSG)
+            return tool_error(self._unavailable_msg())
         try:
             fact_id = int(args["fact_id"])
             helpful = args["action"] == "helpful"

--- a/tests/plugins/memory/test_holographic_provider.py
+++ b/tests/plugins/memory/test_holographic_provider.py
@@ -1,0 +1,84 @@
+"""Tests for plugins/memory/holographic/__init__.py.
+
+Most coverage of the holographic provider lives in
+``tests/agent/test_memory_provider.py`` (discovery + manager wiring). This
+file holds focused tests for behaviour that's specific to the provider
+itself — currently the null-store guard that turns silent ``AttributeError``
+fallout into an actionable error after a failed ``initialize()``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins.memory.holographic import HolographicMemoryProvider
+
+
+def _unwrap_tool_error(payload: str) -> str:
+    """Return the human-readable error text from a tool_error JSON envelope."""
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        return payload
+    if isinstance(parsed, dict):
+        for key in ("error", "message", "detail"):
+            value = parsed.get(key)
+            if isinstance(value, str):
+                return value
+    return payload
+
+
+@pytest.fixture
+def uninitialized_provider() -> HolographicMemoryProvider:
+    """Provider in the state it lands in after a failed ``initialize()``.
+
+    ``MemoryStore.__init__`` raises on a corrupt DB (e.g. crash during WAL
+    checkpoint), ``HolographicMemoryProvider.initialize()`` re-raises, and
+    ``MemoryManager.initialize_all()`` catches the exception, logs a
+    WARNING, and leaves ``self._store`` at its constructor default of
+    ``None``. The tool dispatcher keeps the provider registered, so the
+    agent can still call ``fact_store`` / ``fact_feedback`` — every call
+    hits ``None`` and falls through to the catch-all in the handlers.
+    """
+    return HolographicMemoryProvider(config={})
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"action": "list"},
+        {"action": "add", "content": "hi"},
+        {"action": "search", "query": "x"},
+        {"action": "probe", "entity": "alice"},
+    ],
+)
+def test_fact_store_returns_actionable_error_when_store_uninitialized(
+    uninitialized_provider, args,
+):
+    payload = uninitialized_provider._handle_fact_store(args)
+    text = _unwrap_tool_error(payload).lower()
+
+    # The error must NOT be the cryptic AttributeError we get from None._method()
+    assert "nonetype" not in text, (
+        f"handler should guard None _store instead of leaking AttributeError: {payload!r}"
+    )
+    # It SHOULD tell the user what's wrong and roughly how to recover.
+    assert "memory" in text and "unavailable" in text, (
+        f"error should name the affected subsystem and surface the unavailability: {payload!r}"
+    )
+
+
+def test_fact_feedback_returns_actionable_error_when_store_uninitialized(
+    uninitialized_provider,
+):
+    payload = uninitialized_provider._handle_fact_feedback(
+        {"action": "helpful", "fact_id": 1}
+    )
+    text = _unwrap_tool_error(payload).lower()
+
+    assert "nonetype" not in text, (
+        f"handler should guard None _store instead of leaking AttributeError: {payload!r}"
+    )
+    assert "memory" in text and "unavailable" in text, payload

--- a/tests/plugins/memory/test_holographic_provider.py
+++ b/tests/plugins/memory/test_holographic_provider.py
@@ -82,3 +82,40 @@ def test_fact_feedback_returns_actionable_error_when_store_uninitialized(
         f"handler should guard None _store instead of leaking AttributeError: {payload!r}"
     )
     assert "memory" in text and "unavailable" in text, payload
+
+
+def test_unavailable_message_names_configured_db_path(tmp_path):
+    """When initialize() fails, the error must point recovery at the actual
+    configured database, not the hard-coded default path.
+
+    A directory can't be opened as a SQLite file, so pointing ``db_path`` at
+    one drives ``MemoryStore.__init__`` to raise — the real failure mode —
+    while ``initialize()`` has already captured the resolved path.
+    """
+    custom_db = str(tmp_path)  # a directory: sqlite can't open it as a DB file
+    provider = HolographicMemoryProvider(config={"db_path": custom_db})
+
+    with pytest.raises(Exception):
+        provider.initialize(session_id="s")
+
+    # Path was captured before the failing MemoryStore construction.
+    assert provider._db_path == custom_db
+    assert provider._store is None
+
+    text = _unwrap_tool_error(provider._handle_fact_store({"action": "list"}))
+    # Recovery text names the configured file, not the default memory_store.db.
+    assert custom_db in text, (
+        f"error should point recovery at the configured db_path: {text!r}"
+    )
+
+
+def test_unavailable_message_is_generic_before_initialize():
+    """Before initialize() runs there is no resolved path, so the message
+    falls back to a generic reference instead of naming a wrong file."""
+    provider = HolographicMemoryProvider(config={})
+    assert provider._db_path is None
+
+    text = _unwrap_tool_error(provider._handle_fact_store({"action": "list"})).lower()
+    assert "db_path" in text, (
+        f"generic fallback should reference the db_path setting: {text!r}"
+    )


### PR DESCRIPTION
Refs #32495.

## Summary

`HolographicMemoryProvider.__init__` defaults `self._store = None`. If
`MemoryStore.__init__` then raises during `initialize()` — the reporter's
case was a corrupt `memory_store.db` after a crash mid-WAL-checkpoint —
`MemoryManager.initialize_all()` catches the exception, logs a single
`WARNING`, and leaves the provider registered. The tool schemas stay in
the agent's tool surface, so the agent keeps calling `fact_store` /
`fact_feedback`.

Every call falls through to `None.<method>`. The catch-all
`except Exception` at the bottom of each handler wraps that as
`tool_error("'NoneType' object has no attribute 'list_facts'")` — no
actionable signal for the agent, no chat-level error for the user. The
reporter in #32495 spent 18 days / 300+ session initializations in this
state before noticing the symptom.

## Fix

Add an explicit `None` guard at the top of `_handle_fact_store` and
`_handle_fact_feedback` that returns a `tool_error` naming:

- the affected subsystem (\`Holographic memory\`),
- the typical cause (\`corrupt \$HERMES_HOME/memory_store.db\`),
- where to look (\`hermes errors log for the underlying exception\`),
- and the recovery step (\`remove or restore memory_store.db, then restart\`).

The guard sits **before** the existing try/except so genuine `MemoryStore`
runtime failures still take the existing `except Exception` path — there
is no behaviour change when \`_store\` is alive.

## Scope intentionally narrow

The issue lists four candidate fixes. This PR is just #1 (the minimal,
no-regression one). The others are deferred:

- **Auto-recover from corrupt DB** (#2 in the issue). Deletes user data
  if the heuristic misclassifies a legitimate file. Wants maintainer
  sign-off on the recovery policy before landing.
- **Unregister tools when init fails** (#4 in the issue). Architectural
  change to \`MemoryManager\`; applies to every provider, not just
  holographic. Belongs in its own PR.
- **\`system_prompt_block()\` honesty** (#3 in the issue). The current
  code already returns an empty string when \`_store is None\` (\`line
  184: if not self._store: return \"\"\`), so the system prompt is silent
  rather than lying. No change needed.

## Test plan

- [x] New \`tests/plugins/memory/test_holographic_provider.py\` matches
  the pattern of the other in-tree memory providers
  (\`test_openviking_provider.py\`, \`test_mem0_v2.py\`, etc.). It
  constructs a provider without calling \`initialize()\` so \`_store\`
  stays at its constructor default of \`None\`, exercises every
  \`fact_store\` action shape (\`list\`/\`add\`/\`search\`/\`probe\`)
  and \`fact_feedback\`, and asserts the error text neither leaks
  \`NoneType\` nor swallows the failure silently. Without the guard the
  test fails with the exact payload reported in #32495:
  \`{\"error\": \"'NoneType' object has no attribute 'list_facts'\"}\`.
- [x] \`pytest tests/plugins/memory/ tests/agent/test_memory_provider.py\`
  — 240 passed (no regressions).
- [x] \`ruff check plugins/memory/holographic/__init__.py
  tests/plugins/memory/test_holographic_provider.py\` — clean.