### PR TITLE
feat(skills): add ARDmag image generation workflow

### DIFF
--- a/optional-skills/creative/ardmag-image-generation/SKILL.md
+++ b/optional-skills/creative/ardmag-image-generation/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: ardmag-image-generation
+description: Produce hero / social images for ARDmag blog articles by detecting the real products mentioned in the article, mapping them to real product assets under backend/static/images/<handle>/, and assembling an organic workshop-scene prompt. Refuses to reuse generic category assets when specific products are named, refuses collage/cutout/floating-product framing, and emits a cache-busting semantic filename plus a production-validation checklist.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [creative, image-generation, ardmag, blog, hero, social]
+    related_skills: [visual-asset-review, baoyu-article-illustrator]
+    category: creative
+    homepage: https://ardmag.ro
+---
+
+# ARDmag Image Generation
+
+Generate hero and social images for ARDmag blog articles that look like editorial photography from a stone workshop, with the actual products from the article integrated organically into the scene.
+
+## When to Use
+
+- A new ARDmag blog article needs a hero image
+- An existing hero is conceptually wrong (generic, missing product labels, doesn't match the article's products)
+- Social / OG previews are needed for an existing article
+- The production site still shows an old hero after a hero swap (cache-busting may be required)
+
+This skill is for the `ardmag.com/site` content repo. Articles live at `backend-storefront/content/blog/*.md`. Product assets live at `backend/static/images/<handle>/`.
+
+## Required Inputs
+
+- Path to the article `.md` (frontmatter + body)
+- Asset root: `<site-root>/backend/static/images/`
+- Optional: catalog CSV at `<site-root>/docs/catalog_products-*.csv` or `<site-root>/resources/Wix Products Catalog.csv`
+
+## Procedure
+
+### 1. Build the image brief
+
+Find the skill's script dir:
+
+```bash
+SKILL_DIR=$(dirname "$(find ~/.hermes/skills -path '*/ardmag-image-generation/SKILL.md' 2>/dev/null | head -1)")
+# If the skill is not yet installed into the hub, fall back to the repo copy:
+SKILL_DIR=${SKILL_DIR:-/home/dc/.hermes/hermes-agent/optional-skills/creative/ardmag-image-generation}
+```
+
+Run the brief builder:
+
+```bash
+python "$SKILL_DIR/scripts/ardmag_brief.py" build-brief \
+  --article path/to/article.md \
+  --assets-root path/to/backend/static/images \
+  --catalog path/to/catalog.csv     # optional
+```
+
+The brief is JSON with:
+
+- `brand` — inferred brand (`delta-research`, `tenax`, `mixed`, or `none`)
+- `products` — list of `{name, slug, asset_dir, sample_image, in_catalog}` for every product mentioned in the article
+- `prompt` — the assembled image-gen prompt, ready to pass to `image_generate`
+- `suggested_filename` — semantic, cache-busting filename for the new hero
+- `frontmatter_patch` — the new `heroImage:` value to write to the article frontmatter
+- `validation_checklist` — steps to verify in production after deploy
+
+If `products` is empty or only contains generic category matches (e.g. `solutii-delta`, `tratamente-specifice`), STOP and ask the user. Generic-only matches are the failure mode this skill exists to prevent.
+
+### 2. Generate the image
+
+Pass `brief.prompt` to `image_generate`. The prompt is pre-loaded with anti-collage / anti-cutout guidance and references the real product names. Do not strip those instructions.
+
+```python
+result = image_generate(prompt=brief["prompt"], aspect_ratio="landscape")
+```
+
+Save the generated image to the article's media directory using `brief.suggested_filename`:
+
+```
+<site-root>/backend-storefront/public/blog/<article-slug>/<suggested_filename>
+```
+
+### 3. Update the article
+
+Open the article markdown and replace the `heroImage:` frontmatter value with `brief.frontmatter_patch`. Do NOT overwrite the existing image file with the same filename — use the new semantic name from the brief. Cache-busting is the whole point.
+
+### 4. Verify locally
+
+```bash
+cd <site-root>
+npm run build           # Next build with dummy env if needed
+```
+
+The build must succeed and the new image must resolve.
+
+### 5. Commit, push, validate in production
+
+```bash
+git add backend-storefront/content/blog/<article>.md
+git add backend-storefront/public/blog/<article-slug>/<suggested_filename>
+git commit -m "Replace <article> hero with real product scene"
+git push
+```
+
+Then run the validation checklist from `brief.validation_checklist`:
+
+1. CI green on GitHub
+2. Production article page returns 200 and HTML contains the new filename (not the old one)
+3. Production blog list page shows the new hero card
+4. The new image URL returns 200 with the expected size
+5. Visual confirmation (screenshot) — products labeled, integrated, no collage
+
+If production still shows the OLD image, the cause is one of:
+- deploy hasn't completed → wait and retry
+- CDN cache on the old filename → if you reused the old filename, this is why we use a new one
+- frontmatter still points to the old file → re-check the patch landed
+
+## Hard Rules (Non-Negotiable)
+
+These rules are encoded in `prompts/hero_image.md` and applied by the brief builder. They exist because of a real incident (Delta Research hero, 2026-05-26) where each was violated:
+
+1. **No collages.** No grid of cropped product shots. No cutouts pasted onto a background.
+2. **No floating products.** No products hovering against a solid color or studio gradient.
+3. **No unlabeled bottles.** If the article names specific Delta Research / Tenax products, the bottles in the scene must show those labels legibly.
+4. **No wrong-brand products.** If the article is about Delta Research, do not put Tenax bottles in the scene.
+5. **No generic-category-only mapping.** If the article names `SEAL`, `QUASAR`, `IDROREP` etc., the prompt must reference those specific products — not just "treatment products" or `solutii-delta`.
+6. **No filename reuse.** When replacing a conceptually wrong hero, use a new semantic filename (e.g. `hero-delta-research-tratamente.webp`), not the old `hero.webp`.
+7. **No "done" without production validation.** Build success is not the bar. The production HTML must reference the new filename and the image must render correctly.
+
+## Pitfalls
+
+- **Re-optimizing the old image instead of replacing it.** If the concept is wrong, optimization doesn't fix it. The brief builder flags articles where the current hero is named `hero.webp` / `hero.jpg` / `hero.png` (generic) as needing a semantic rename.
+- **Stopping at "I pushed".** A push that doesn't propagate to production is not done.
+- **Trusting frontmatter `tags` alone.** Tags may say "delta research" while the body names specific products. The detector reads both.
+- **Latinized vs Romanian product names.** `Total Wet`, `Wet Seal`, `Eco Stone Pro` may appear with mixed casing. The detector normalizes case and diacritics.
+
+## Verification
+
+The image is acceptable if:
+
+- The brief's `products` list is non-empty and at least one entry has `asset_dir` populated
+- The generated image shows the named products with readable labels, integrated on stone / workshop context, no collage
+- `suggested_filename` differs from any existing hero filename for that article
+- After push, production HTML contains `suggested_filename` and the image URL returns 200

--- a/optional-skills/creative/ardmag-image-generation/prompts/hero_image.md
+++ b/optional-skills/creative/ardmag-image-generation/prompts/hero_image.md
@@ -1,0 +1,27 @@
+# Hero image prompt template
+
+The brief builder formats this template with the detected product context. Variables in `{braces}` are substituted at build time.
+
+---
+
+Editorial product photograph for an ARDmag blog article titled "{article_title}".
+
+Scene: a real stone-workshop / atelier context. {scene_surfaces} samples (slabs, off-cuts, polished and rough sections), natural workshop lighting, shallow depth of field, photographed from a comfortable working angle. Mood is informational and trustworthy, not commercial.
+
+Featured products (must be visibly present and clearly labeled in the scene):
+{product_list_block}
+
+The bottles, cans, or containers of the products above must appear with their real-style {brand_label} labels facing the camera, readable but not over-emphasised. Place them on the stone samples or on a worn wooden workbench beside the samples. Integrate them organically — they belong in the scene, not in front of it.
+
+Style: editorial, magazine-quality. Soft natural light from a workshop window or large softbox. Color palette dominated by stone tones (graphite, travertine cream, granite mottling) with the product labels providing the small accent of color.
+
+Hard prohibitions — do not produce:
+- Collage or grid layouts. One single coherent scene.
+- Cutout / packshot bottles floating on a solid background.
+- White, gradient, or studio-seamless backgrounds.
+- Bottles without legible labels or with the wrong brand name.
+- Products that are not in the "Featured products" list above.
+- Dark patches / black bars under logos.
+- Generic "treatment products" stand-ins when specific products were named.
+
+Aspect ratio: {aspect_ratio}. Output a single photograph.

--- a/optional-skills/creative/ardmag-image-generation/references/visual-rules.md
+++ b/optional-skills/creative/ardmag-image-generation/references/visual-rules.md
@@ -1,0 +1,41 @@
+# ARDmag visual rules — quick reference
+
+Captured from the 2026-05-26 Delta Research hero incident and from the broader ARDmag visual direction. The brief builder enforces the prompt-level rules automatically; this document captures the editorial intent that humans should also check.
+
+## Source-of-truth principles
+
+1. **Organic realistic scenes.** Stone workshop / atelier with actual stone samples and worn wood. Not a studio backdrop, not a website hero gradient, not a 3D render.
+2. **Same-source previews.** The OG / social preview and the article hero share the same scene. No swapping in a different aesthetic for social.
+3. **Article-specific products only.** Use the exact products the article names. If the article says SEAL and QUASAR, the bottles in the image are SEAL and QUASAR.
+4. **Generic categories are a fallback, not a default.** Mapping a Delta Research article to `solutii-delta/` instead of to the specific products is the bug, not the feature.
+5. **Tenax appears only when the article is about Tenax.** Cross-brand bottles in a Delta scene are wrong, even if they look photogenic.
+6. **Varied makers in industry-overview articles.** When an article surveys the category (e.g. "how to choose"), more than one brand may appear — but the brand assignment must still match what the article names.
+7. **Context-correct products.** A hydrophobic treatment article should not feature polishing pads in the foreground.
+8. **No dark logo patches.** No black bar/strip behind logos.
+
+## Cache-busting filename convention
+
+When replacing a hero whose concept was wrong, do not reuse the existing filename. Pattern:
+
+```
+hero-<brand-slug>-<topic-slug>.webp
+```
+
+Examples:
+- `hero-delta-research-tratamente.webp`
+- `hero-tenax-mastici.webp`
+- `hero-pad-uri-velcro-7-gradatii.webp` (no brand → just topic)
+
+If the existing hero is `hero.webp`, `hero.jpg`, `hero.png`, or `cover.*`, that's a "generic name" signal — rename on replacement.
+
+## Production validation steps
+
+After push and CI green:
+
+1. `curl -sI https://ardmag.ro/blog/<article-slug>/` → 200
+2. View source, grep for the new filename → must be present, old must be absent
+3. Hit the image URL directly → 200, expected dimensions
+4. Open the blog list page → new card thumbnail matches
+5. Take a screenshot of the live page → file with the run
+
+If any step fails, the work is not done. Do not report success on local build alone.

--- a/optional-skills/creative/ardmag-image-generation/scripts/ardmag_brief.py
+++ b/optional-skills/creative/ardmag-image-generation/scripts/ardmag_brief.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Build an image-generation brief for an ARDmag blog article.
+
+The brief encodes the article's real products, maps them to real asset
+directories, drafts an organic workshop-scene prompt, and emits a
+cache-busting filename plus a production-validation checklist.
+
+Subcommands:
+    detect-products   — extract product names from an article (tags + body)
+    resolve-assets    — map detected products to asset dirs / sample images
+    suggest-filename  — propose a cache-busting hero filename
+    build-brief       — do all of the above and emit a full JSON brief
+
+All output is JSON on stdout. Errors exit non-zero with a JSON error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+import unicodedata
+from pathlib import Path
+from typing import Any, Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SKILL_DIR = SCRIPT_DIR.parent
+PROMPT_TEMPLATE_PATH = SKILL_DIR / "prompts" / "hero_image.md"
+
+# Slugs that indicate generic-category mappings; these are a fallback only.
+GENERIC_CATEGORY_SLUGS = {
+    "solutii-delta",
+    "solutii-tenax",
+    "tratamente-specifice",
+    "tratamente-piatra",
+    "categorii-generale",
+}
+
+# Tokens commonly bolded in articles that aren't products. Lowercase, slugged.
+NON_PRODUCT_TOKENS = {
+    "interior",
+    "exterior",
+    "natural",
+    "umed",
+    "baza-de-apa",
+    "baza-de-solvent",
+    "apa",
+    "solvent",
+    "verticala",
+    "orizontala",
+    "blat",
+    "scari",
+    "pavaj",
+    "fatada",
+    "gard",
+    "test",
+    "plus",
+    "ce-trebuie-sa-stii",
+    "important",
+    "atentie",
+    "nota",
+    "pentru",
+    "caracteristici-tehnice",
+    "intaritorul-este-incluse",
+    "1-kit",
+}
+
+BRAND_TAGS = {
+    "delta research": "delta-research",
+    "delta-research": "delta-research",
+    "delta": "delta-research",
+    "tenax": "tenax",
+}
+
+
+def _err(msg: str, **extra: Any) -> None:
+    payload = {"ok": False, "error": msg}
+    payload.update(extra)
+    print(json.dumps(payload))
+    sys.exit(1)
+
+
+def _ok(payload: dict[str, Any]) -> None:
+    payload = {"ok": True, **payload}
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+
+# ── slug / normalize ─────────────────────────────────────────────────────────
+
+
+def slugify(value: str) -> str:
+    """Lowercase, strip diacritics, replace non-alnum with single hyphen."""
+    value = unicodedata.normalize("NFKD", value)
+    value = "".join(c for c in value if not unicodedata.combining(c))
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value).strip("-")
+    return value
+
+
+# ── frontmatter parser ───────────────────────────────────────────────────────
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Return (frontmatter_dict, body). Frontmatter must be the YAML-ish
+    block at the top of the file between '---' lines. We avoid pulling in
+    PyYAML by parsing the handful of keys we need (title, tags, heroImage,
+    kicker, description, publishedAt, author)."""
+    if not text.startswith("---"):
+        return {}, text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}, text
+    block = text[3:end].strip()
+    body = text[end + 4 :].lstrip("\n")
+
+    fm: dict[str, Any] = {}
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            inner = value[1:-1]
+            items = [
+                _strip_quotes(item.strip())
+                for item in re.split(r",(?![^\[]*\])", inner)
+                if item.strip()
+            ]
+            fm[key] = items
+        else:
+            fm[key] = _strip_quotes(value)
+    return fm, body
+
+
+def _strip_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+# ── product detector ────────────────────────────────────────────────────────
+
+
+# Capture `**Foo**` or `**Foo Bar**` runs that look like product names.
+# We require the inner text to start with a letter and not contain inline
+# punctuation that signals a sentence fragment.
+BOLD_RE = re.compile(r"\*\*([^*\n]+?)\*\*")
+
+
+def extract_bold_mentions(body: str) -> list[str]:
+    mentions: list[str] = []
+    seen: set[str] = set()
+    for match in BOLD_RE.finditer(body):
+        candidate = match.group(1).strip()
+        if not candidate or len(candidate) < 2:
+            continue
+        if candidate.endswith("?") or candidate.endswith(":"):
+            continue
+        # Skip sentence-like fragments (multiple words with lowercase
+        # connectors like "și", "sau", "de la", commas, etc.).
+        if "," in candidate:
+            continue
+        words = candidate.split()
+        if len(words) > 4:
+            continue
+        slug = slugify(candidate)
+        if not slug or slug in NON_PRODUCT_TOKENS:
+            continue
+        if slug in seen:
+            continue
+        seen.add(slug)
+        mentions.append(candidate)
+    return mentions
+
+
+def infer_brand(tags: Iterable[str], body: str) -> str:
+    found: set[str] = set()
+    for tag in tags:
+        key = tag.strip().lower()
+        if key in BRAND_TAGS:
+            found.add(BRAND_TAGS[key])
+    low = body.lower()
+    if "delta research" in low or "delta-research" in low:
+        found.add("delta-research")
+    if " tenax" in low or "tenax " in low:
+        found.add("tenax")
+    if not found:
+        return "none"
+    if len(found) == 1:
+        return next(iter(found))
+    return "mixed"
+
+
+def load_catalog(catalog_path: Path) -> list[dict[str, str]]:
+    """Load the Wix catalog CSV. We only need handleId, name, brand."""
+    rows: list[dict[str, str]] = []
+    with catalog_path.open("r", encoding="utf-8-sig", newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            name = (row.get("name") or "").strip()
+            if not name:
+                continue
+            rows.append(
+                {
+                    "handleId": (row.get("handleId") or "").strip(),
+                    "name": name,
+                    "brand": (row.get("brand") or "").strip(),
+                }
+            )
+    return rows
+
+
+def catalog_match(mention: str, catalog: list[dict[str, str]]) -> dict[str, str] | None:
+    """Find a catalog row whose name matches the mention (case-insensitive,
+    diacritic-insensitive). Prefers exact match over substring."""
+    target = slugify(mention)
+    if not target:
+        return None
+    exact = None
+    sub = None
+    for row in catalog:
+        name_slug = slugify(row["name"])
+        if name_slug == target:
+            exact = row
+            break
+        if name_slug and (target in name_slug.split("-") or name_slug == target):
+            sub = sub or row
+        elif name_slug and target in name_slug:
+            sub = sub or row
+    return exact or sub
+
+
+def detect_products(
+    article_path: Path,
+    catalog_path: Path | None = None,
+) -> dict[str, Any]:
+    text = article_path.read_text(encoding="utf-8")
+    fm, body = parse_frontmatter(text)
+    tags = fm.get("tags") or []
+    if isinstance(tags, str):
+        tags = [tags]
+    bold = extract_bold_mentions(body)
+    brand = infer_brand(tags, body)
+
+    catalog = load_catalog(catalog_path) if catalog_path else []
+
+    products: list[dict[str, Any]] = []
+    for mention in bold:
+        entry: dict[str, Any] = {
+            "name": mention,
+            "slug": slugify(mention),
+        }
+        if catalog:
+            match = catalog_match(mention, catalog)
+            if match:
+                entry["catalog_name"] = match["name"]
+                entry["catalog_handle"] = match["handleId"]
+                entry["catalog_brand"] = match["brand"]
+                entry["in_catalog"] = True
+            else:
+                entry["in_catalog"] = False
+        products.append(entry)
+
+    return {
+        "article": str(article_path),
+        "title": fm.get("title", ""),
+        "tags": tags,
+        "brand": brand,
+        "products": products,
+        "frontmatter_hero_image": fm.get("heroImage", ""),
+    }
+
+
+# ── asset resolver ──────────────────────────────────────────────────────────
+
+
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp"}
+
+
+def resolve_assets(
+    products: list[dict[str, Any]],
+    assets_root: Path,
+) -> list[dict[str, Any]]:
+    if not assets_root.exists():
+        return [
+            {**p, "asset_dir": None, "sample_image": None, "is_generic": False}
+            for p in products
+        ]
+    available = {d.name: d for d in assets_root.iterdir() if d.is_dir()}
+    resolved: list[dict[str, Any]] = []
+    for product in products:
+        slug = product["slug"]
+        candidates = [slug, slug.replace("-", "_")]
+        # Try a couple of variants for multi-word names.
+        if "-" in slug:
+            candidates.append(slug.split("-")[0])
+        asset_dir = None
+        for cand in candidates:
+            if cand in available:
+                asset_dir = available[cand]
+                break
+        sample = None
+        if asset_dir is not None:
+            for child in sorted(asset_dir.iterdir()):
+                if child.is_file() and child.suffix.lower() in IMAGE_EXTS:
+                    sample = child
+                    break
+        resolved.append(
+            {
+                **product,
+                "asset_dir": str(asset_dir) if asset_dir else None,
+                "sample_image": str(sample) if sample else None,
+                "is_generic": slug in GENERIC_CATEGORY_SLUGS,
+            }
+        )
+    return resolved
+
+
+# ── filename suggester ──────────────────────────────────────────────────────
+
+
+GENERIC_HERO_NAMES = {"hero", "cover", "thumbnail", "main", "image"}
+
+
+def suggest_filename(
+    article_slug: str,
+    brand: str,
+    products: list[dict[str, Any]],
+    current_hero: str = "",
+) -> dict[str, Any]:
+    current_stem = Path(current_hero).stem if current_hero else ""
+    current_stem_lower = current_stem.lower()
+    is_generic_current = (
+        not current_stem
+        or current_stem_lower in GENERIC_HERO_NAMES
+        or current_stem_lower.startswith("hero.")
+    )
+
+    parts = ["hero"]
+    if brand and brand not in ("none", "mixed"):
+        parts.append(brand)
+    topic = slugify(article_slug)
+    if topic:
+        topic_short = "-".join(topic.split("-")[:4])
+        parts.append(topic_short)
+    elif products:
+        parts.append(products[0]["slug"])
+
+    name = "-".join(p for p in parts if p)
+    filename = f"{name}.webp"
+    if current_hero:
+        current_filename = Path(current_hero).name
+        if filename == current_filename:
+            filename = f"{name}-v2.webp"
+
+    return {
+        "suggested_filename": filename,
+        "needs_cache_busting": is_generic_current,
+        "current_hero": current_hero,
+    }
+
+
+# ── prompt builder ──────────────────────────────────────────────────────────
+
+
+def _scene_surfaces_for(brand: str, products: list[dict[str, Any]]) -> str:
+    # Default surfaces for stone-treatment / polishing topics.
+    return "granite, marble, travertine and andesite stone"
+
+
+def build_prompt(
+    title: str,
+    brand: str,
+    products: list[dict[str, Any]],
+    aspect_ratio: str = "landscape",
+) -> str:
+    template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    # Strip the markdown frontmatter / heading block — keep only the body
+    # after the first `---` separator.
+    body_start = template.find("---\n")
+    body = template[body_start + 4 :] if body_start != -1 else template
+
+    product_lines: list[str] = []
+    for product in products:
+        if product.get("is_generic"):
+            continue
+        line = f"- {product['name']}"
+        if product.get("catalog_name") and product["catalog_name"].upper() != product["name"].upper():
+            line += f" ({product['catalog_name']})"
+        if product.get("asset_dir"):
+            line += f"  [reference: {product['asset_dir']}]"
+        product_lines.append(line)
+
+    if not product_lines:
+        product_lines.append(
+            "- (NONE — refuse to generate until at least one specific product is identified)"
+        )
+
+    brand_label = {
+        "delta-research": "Delta Research",
+        "tenax": "Tenax",
+        "mixed": "Delta Research and Tenax",
+        "none": "ARDmag",
+    }.get(brand, "ARDmag")
+
+    return body.format(
+        article_title=title or "(untitled)",
+        scene_surfaces=_scene_surfaces_for(brand, products),
+        product_list_block="\n".join(product_lines),
+        brand_label=brand_label,
+        aspect_ratio=aspect_ratio,
+    )
+
+
+# ── full brief ──────────────────────────────────────────────────────────────
+
+
+def build_brief(
+    article_path: Path,
+    assets_root: Path | None,
+    catalog_path: Path | None,
+    aspect_ratio: str = "landscape",
+) -> dict[str, Any]:
+    detection = detect_products(article_path, catalog_path)
+    products = detection["products"]
+    if assets_root is not None:
+        products = resolve_assets(products, assets_root)
+
+    article_slug = article_path.stem
+    fn = suggest_filename(
+        article_slug=article_slug,
+        brand=detection["brand"],
+        products=products,
+        current_hero=detection["frontmatter_hero_image"],
+    )
+
+    specific_products = [p for p in products if not p.get("is_generic")]
+    only_generic = bool(products) and not specific_products
+    no_products = not products
+
+    blockers: list[str] = []
+    if no_products:
+        blockers.append(
+            "No products detected in article body. Skill is configured to "
+            "refuse generation without at least one specific product."
+        )
+    if only_generic:
+        blockers.append(
+            "Only generic-category matches found "
+            f"({', '.join(p['slug'] for p in products)}). Refusing — the "
+            "article likely names specific products that were missed by "
+            "the detector. Re-run after tightening detection or naming the "
+            "products manually."
+        )
+
+    prompt = build_prompt(
+        title=detection["title"],
+        brand=detection["brand"],
+        products=products,
+        aspect_ratio=aspect_ratio,
+    )
+
+    new_filename = fn["suggested_filename"]
+    article_dir_url = f"/blog/{article_slug}/"
+    frontmatter_patch = f"{article_dir_url}{new_filename}"
+
+    checklist = [
+        "Local Next build succeeds with the new heroImage path",
+        "CI on GitHub is green",
+        f"Production article HTML contains '{new_filename}'",
+        "Production blog list shows the new hero card",
+        f"GET on the production image URL ({frontmatter_patch}) returns 200",
+        "Visual confirmation: labels readable, products integrated, no collage",
+    ]
+
+    return {
+        "article": str(article_path),
+        "article_slug": article_slug,
+        "title": detection["title"],
+        "tags": detection["tags"],
+        "brand": detection["brand"],
+        "products": products,
+        "prompt": prompt,
+        "suggested_filename": new_filename,
+        "frontmatter_patch": frontmatter_patch,
+        "needs_cache_busting": fn["needs_cache_busting"],
+        "current_hero": fn["current_hero"],
+        "blockers": blockers,
+        "validation_checklist": checklist,
+    }
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_detect = sub.add_parser("detect-products")
+    p_detect.add_argument("--article", required=True)
+    p_detect.add_argument("--catalog", default=None)
+
+    p_resolve = sub.add_parser("resolve-assets")
+    p_resolve.add_argument("--article", required=True)
+    p_resolve.add_argument("--assets-root", required=True)
+    p_resolve.add_argument("--catalog", default=None)
+
+    p_filename = sub.add_parser("suggest-filename")
+    p_filename.add_argument("--article", required=True)
+    p_filename.add_argument("--catalog", default=None)
+
+    p_brief = sub.add_parser("build-brief")
+    p_brief.add_argument("--article", required=True)
+    p_brief.add_argument("--assets-root", default=None)
+    p_brief.add_argument("--catalog", default=None)
+    p_brief.add_argument("--aspect-ratio", default="landscape")
+
+    args = parser.parse_args(argv)
+
+    article = Path(args.article)
+    if not article.exists():
+        _err(f"article not found: {article}")
+    catalog = Path(args.catalog) if getattr(args, "catalog", None) else None
+    if catalog and not catalog.exists():
+        _err(f"catalog not found: {catalog}")
+
+    if args.cmd == "detect-products":
+        _ok(detect_products(article, catalog))
+    elif args.cmd == "resolve-assets":
+        assets_root = Path(args.assets_root)
+        if not assets_root.exists():
+            _err(f"assets-root not found: {assets_root}")
+        detection = detect_products(article, catalog)
+        resolved = resolve_assets(detection["products"], assets_root)
+        _ok({**detection, "products": resolved})
+    elif args.cmd == "suggest-filename":
+        detection = detect_products(article, catalog)
+        result = suggest_filename(
+            article_slug=article.stem,
+            brand=detection["brand"],
+            products=detection["products"],
+            current_hero=detection["frontmatter_hero_image"],
+        )
+        _ok(result)
+    elif args.cmd == "build-brief":
+        assets_root = Path(args.assets_root) if args.assets_root else None
+        if assets_root and not assets_root.exists():
+            _err(f"assets-root not found: {assets_root}")
+        _ok(
+            build_brief(
+                article_path=article,
+                assets_root=assets_root,
+                catalog_path=catalog,
+                aspect_ratio=args.aspect_ratio,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_ardmag_image_generation.py
+++ b/tests/skills/test_ardmag_image_generation.py
@@ -1,0 +1,352 @@
+"""Tests for optional-skills/creative/ardmag-image-generation/scripts/ardmag_brief.py.
+
+Cover the behaviors codified after the 2026-05-26 Delta Research hero
+incident: specific products preferred over generic categories, cache-busting
+filename when the current hero is generic, and a refusal-style brief when the
+detector finds nothing usable.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "creative"
+    / "ardmag-image-generation"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import ardmag_brief  # noqa: E402
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+DELTA_ARTICLE = """---
+title: "Tratamente pentru piatră naturală: cum alegi soluția potrivită"
+description: "Ghid practic Delta Research..."
+kicker: "Ghid tehnic · Delta Research"
+publishedAt: "2026-05-26"
+author: "Echipa ardmag"
+tags: ["delta research", "tratamente", "impregnare", "piatra naturala", "ghid"]
+heroImage: "/blog/delta-tratamente-piatra-naturala/hero.webp"
+---
+
+Articolul grupează criteriile de alegere și produsele **Delta Research** relevante.
+
+Pentru suprafețele orizontale: **Seal**, **Quasar**, **Wet Seal**, **Nano Wet**,
+**Eco Stone Pro** și **Eco Toner**.
+
+Pentru verticale: **Idrorep** și **Total Wet**.
+
+Notă: efectul vizual contează — alegi **natural** sau efect umed.
+"""
+
+
+GENERIC_ONLY_ARTICLE = """---
+title: "Generic article"
+tags: ["tratamente"]
+heroImage: "/blog/foo/hero.webp"
+---
+
+Pentru articolul ăsta se foloseste **Tratamente Specifice** și nimic concret.
+"""
+
+
+@pytest.fixture
+def delta_article(tmp_path: Path) -> Path:
+    p = tmp_path / "delta-tratamente-piatra-naturala.md"
+    p.write_text(DELTA_ARTICLE, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def generic_article(tmp_path: Path) -> Path:
+    p = tmp_path / "generic-foo.md"
+    p.write_text(GENERIC_ONLY_ARTICLE, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def assets_root(tmp_path: Path) -> Path:
+    """Build a fake backend/static/images/ tree with the slugs the Delta
+    article will resolve against, plus the generic category we want to avoid."""
+    root = tmp_path / "images"
+    root.mkdir()
+    for slug in [
+        "seal",
+        "quasar",
+        "wet-seal",
+        "nano-wet",
+        "eco-stone-pro",
+        "eco-toner",
+        "idrorep",
+        "total-wet",
+        "solutii-delta",  # generic category — must be flagged
+        "ager",  # unrelated, must not be matched
+    ]:
+        sub = root / slug
+        sub.mkdir()
+        (sub / f"{slug}-001.jpg").write_bytes(b"\x00")
+    return root
+
+
+@pytest.fixture
+def catalog_csv(tmp_path: Path) -> Path:
+    p = tmp_path / "catalog.csv"
+    with p.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["handleId", "name", "brand"])
+        writer.writerow(["product_seal", "SEAL", "Delta Research"])
+        writer.writerow(["product_quasar", "QUASAR", "Delta Research"])
+        writer.writerow(["product_wet_seal", "WET SEAL", "Delta Research"])
+        writer.writerow(["product_idrorep", "IDROREP", "Delta Research"])
+        writer.writerow(["product_eco_stone_pro", "ECO STONE PRO", "Delta Research"])
+        writer.writerow(["product_eco_toner", "ECO TONER", "Delta Research"])
+        writer.writerow(["product_total_wet", "TOTAL WET", "Delta Research"])
+        writer.writerow(["product_nano_wet", "NANO WET", "Delta Research"])
+        writer.writerow(["product_solutii_delta", "SOLUTII DELTA", "Delta Research"])
+    return p
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _run(capsys, argv: list[str]) -> dict:
+    with mock.patch("sys.argv", ["ardmag_brief"] + argv):
+        ardmag_brief.main()
+    return json.loads(capsys.readouterr().out)
+
+
+# ── slugify / frontmatter primitives ────────────────────────────────────────
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert ardmag_brief.slugify("Eco Stone Pro") == "eco-stone-pro"
+
+    def test_diacritics_stripped(self):
+        assert ardmag_brief.slugify("Tratămente pentru piatră") == "tratamente-pentru-piatra"
+
+    def test_collapses_punctuation(self):
+        assert ardmag_brief.slugify("WET-SEAL!!!") == "wet-seal"
+
+    def test_empty(self):
+        assert ardmag_brief.slugify("---") == ""
+
+
+class TestFrontmatter:
+    def test_parses_tags_list(self):
+        fm, body = ardmag_brief.parse_frontmatter(DELTA_ARTICLE)
+        assert fm["tags"] == [
+            "delta research",
+            "tratamente",
+            "impregnare",
+            "piatra naturala",
+            "ghid",
+        ]
+        assert fm["heroImage"] == "/blog/delta-tratamente-piatra-naturala/hero.webp"
+        assert "Articolul grupează" in body
+
+    def test_no_frontmatter(self):
+        fm, body = ardmag_brief.parse_frontmatter("just body\n")
+        assert fm == {}
+        assert body == "just body\n"
+
+
+# ── detect-products ─────────────────────────────────────────────────────────
+
+
+class TestDetectProducts:
+    def test_extracts_delta_products_from_body(self, capsys, delta_article):
+        result = _run(capsys, ["detect-products", "--article", str(delta_article)])
+        names = [p["name"] for p in result["products"]]
+        for required in ["Seal", "Quasar", "Wet Seal", "Eco Stone Pro", "Idrorep", "Total Wet"]:
+            assert required in names, f"missing {required}: got {names}"
+
+    def test_infers_delta_brand_from_tags(self, capsys, delta_article):
+        result = _run(capsys, ["detect-products", "--article", str(delta_article)])
+        assert result["brand"] == "delta-research"
+
+    def test_skips_non_product_bold_words(self, capsys, delta_article):
+        result = _run(capsys, ["detect-products", "--article", str(delta_article)])
+        slugs = [p["slug"] for p in result["products"]]
+        assert "natural" not in slugs
+        assert "interior" not in slugs
+
+    def test_catalog_match_adds_handle(self, capsys, delta_article, catalog_csv):
+        result = _run(
+            capsys,
+            ["detect-products", "--article", str(delta_article), "--catalog", str(catalog_csv)],
+        )
+        by_slug = {p["slug"]: p for p in result["products"]}
+        assert by_slug["seal"]["in_catalog"] is True
+        assert by_slug["seal"]["catalog_handle"] == "product_seal"
+        assert by_slug["eco-stone-pro"]["catalog_brand"] == "Delta Research"
+
+    def test_generic_only_article_brand_none(self, capsys, generic_article):
+        result = _run(capsys, ["detect-products", "--article", str(generic_article)])
+        assert result["brand"] == "none"
+
+
+# ── resolve-assets ──────────────────────────────────────────────────────────
+
+
+class TestResolveAssets:
+    def test_maps_each_product_to_its_asset_dir(self, capsys, delta_article, assets_root):
+        result = _run(
+            capsys,
+            [
+                "resolve-assets",
+                "--article",
+                str(delta_article),
+                "--assets-root",
+                str(assets_root),
+            ],
+        )
+        by_slug = {p["slug"]: p for p in result["products"]}
+        assert by_slug["seal"]["asset_dir"].endswith("/seal")
+        assert by_slug["seal"]["sample_image"].endswith(".jpg")
+        assert by_slug["eco-stone-pro"]["asset_dir"].endswith("/eco-stone-pro")
+        assert by_slug["idrorep"]["asset_dir"].endswith("/idrorep")
+
+    def test_unknown_product_has_no_asset(self, capsys, tmp_path, assets_root):
+        article = tmp_path / "mystery.md"
+        article.write_text(
+            "---\ntitle: x\ntags: [tenax]\nheroImage: /blog/x/hero.webp\n---\n"
+            "Folosim **Whoknows**.\n",
+            encoding="utf-8",
+        )
+        result = _run(
+            capsys,
+            ["resolve-assets", "--article", str(article), "--assets-root", str(assets_root)],
+        )
+        assert result["products"][0]["asset_dir"] is None
+        assert result["products"][0]["sample_image"] is None
+
+    def test_generic_category_flagged(self, capsys, generic_article, assets_root):
+        # Generic article mentions **Tratamente Specifice** which slugifies
+        # to a generic-category slug; this should still resolve to no specific
+        # asset_dir (it is not in our fake tree) and is_generic must be False
+        # because the slug is "tratamente-specifice" — present in
+        # GENERIC_CATEGORY_SLUGS — so is_generic must be True.
+        result = _run(
+            capsys,
+            ["resolve-assets", "--article", str(generic_article), "--assets-root", str(assets_root)],
+        )
+        by_slug = {p["slug"]: p for p in result["products"]}
+        assert by_slug["tratamente-specifice"]["is_generic"] is True
+
+
+# ── suggest-filename ────────────────────────────────────────────────────────
+
+
+class TestSuggestFilename:
+    def test_replaces_generic_hero_name(self, capsys, delta_article):
+        result = _run(capsys, ["suggest-filename", "--article", str(delta_article)])
+        assert result["suggested_filename"].endswith(".webp")
+        assert result["needs_cache_busting"] is True
+        assert result["suggested_filename"] != "hero.webp"
+        # Brand and topic must be present in the new name.
+        assert "delta-research" in result["suggested_filename"]
+
+    def test_already_semantic_filename_not_busted(self, capsys, tmp_path):
+        article = tmp_path / "article.md"
+        article.write_text(
+            '---\ntitle: T\ntags: [delta research]\n'
+            'heroImage: "/blog/article/hero-delta-research-tratamente.webp"\n---\n'
+            'Folosim **Seal**.\n',
+            encoding="utf-8",
+        )
+        result = _run(capsys, ["suggest-filename", "--article", str(article)])
+        assert result["needs_cache_busting"] is False
+
+
+# ── build-brief ─────────────────────────────────────────────────────────────
+
+
+class TestBuildBrief:
+    def test_full_brief_for_delta_article(
+        self, capsys, delta_article, assets_root, catalog_csv
+    ):
+        result = _run(
+            capsys,
+            [
+                "build-brief",
+                "--article",
+                str(delta_article),
+                "--assets-root",
+                str(assets_root),
+                "--catalog",
+                str(catalog_csv),
+            ],
+        )
+        # The brief must surface the real products, the new filename and a
+        # validation checklist that includes the production HTML check.
+        assert result["brand"] == "delta-research"
+        product_slugs = [p["slug"] for p in result["products"]]
+        for required in ["seal", "quasar", "idrorep", "eco-stone-pro"]:
+            assert required in product_slugs
+
+        # Filename is semantic and points away from the generic hero.webp.
+        assert result["suggested_filename"] != "hero.webp"
+        assert result["frontmatter_patch"].startswith("/blog/delta-tratamente-piatra-naturala/")
+        assert result["frontmatter_patch"].endswith(result["suggested_filename"])
+        assert result["needs_cache_busting"] is True
+
+        # Prompt encodes the anti-collage rules and references the real products.
+        prompt_lower = result["prompt"].lower()
+        assert "hard prohibitions" in prompt_lower
+        assert "collage" in prompt_lower
+        assert "cutout" in prompt_lower
+        assert "Seal" in result["prompt"]
+        assert "Quasar" in result["prompt"]
+        # Delta Research brand label is present.
+        assert "Delta Research" in result["prompt"]
+
+        # Validation checklist is non-empty and mentions production HTML.
+        assert any("Production article HTML" in step for step in result["validation_checklist"])
+        assert any(result["suggested_filename"] in step for step in result["validation_checklist"])
+
+        # No blockers for a well-formed article.
+        assert result["blockers"] == []
+
+    def test_no_products_yields_blocker(self, capsys, tmp_path, assets_root):
+        article = tmp_path / "empty.md"
+        article.write_text(
+            "---\ntitle: nothing\ntags: []\nheroImage: /blog/nothing/hero.webp\n---\n"
+            "no bold mentions here.\n",
+            encoding="utf-8",
+        )
+        result = _run(
+            capsys,
+            ["build-brief", "--article", str(article), "--assets-root", str(assets_root)],
+        )
+        assert result["products"] == []
+        assert any("No products detected" in b for b in result["blockers"])
+
+    def test_generic_only_yields_blocker(
+        self, capsys, generic_article, assets_root
+    ):
+        result = _run(
+            capsys,
+            [
+                "build-brief",
+                "--article",
+                str(generic_article),
+                "--assets-root",
+                str(assets_root),
+            ],
+        )
+        # The detector picks up "Tratamente Specifice" but it slugifies to a
+        # generic category, so the brief must refuse with a blocker.
+        assert any("generic-category" in b for b in result["blockers"])


### PR DESCRIPTION
## Summary
- Adds optional `ardmag-image-generation` skill for ARDmag hero/social-image workflows.
- Adds a brief-builder script that detects concrete products from blog articles, maps them to real `backend/static/images/<handle>/` assets, refuses generic-only matches, emits organic workshop-scene prompts, and suggests semantic cache-busting hero filenames.
- Adds tests covering Delta Research product detection, asset resolution, generic-category blockers, prompt rules, and production-validation checklist output.

## Test Plan
- `python -m pytest tests/skills/test_ardmag_image_generation.py -v`
- `python -m pytest tests/skills/`

## Context
This codifies the 2026-05-26 ARDmag Delta Research hero incident: the first pass optimized a generic cached `hero.webp`; the desired behavior is to use article-specific real product assets, avoid collage/cutout/generic bottles, use cache-busting filenames, and verify production output.
