### PR TITLE
Add `whatsapp.suppress_notifications`: drop gateway notices on human-facing platforms

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1390,7 +1390,7 @@ def run_conversation(
                             agent._persist_session(messages, conversation_history)
                             agent.clear_interrupt()
                             return {
-                                "final_response": f"Operation interrupted during retry ({_failure_hint}, attempt {retry_count}/{max_retries}).",
+                                "final_response": None if agent._suppress_platform_notifications() else f"Operation interrupted during retry ({_failure_hint}, attempt {retry_count}/{max_retries}).",
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
@@ -1810,7 +1810,7 @@ def run_conversation(
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 agent._persist_session(messages, conversation_history)
                 interrupted = True
-                final_response = f"Operation interrupted: waiting for model response ({api_elapsed:.1f}s elapsed)."
+                final_response = "" if agent._suppress_platform_notifications() else f"Operation interrupted: waiting for model response ({api_elapsed:.1f}s elapsed)."
                 break
 
             except Exception as api_error:
@@ -2404,7 +2404,7 @@ def run_conversation(
                     agent._persist_session(messages, conversation_history)
                     agent.clear_interrupt()
                     return {
-                        "final_response": f"Operation interrupted: handling API error ({error_type}: {agent._clean_error_message(str(api_error))}).",
+                        "final_response": None if agent._suppress_platform_notifications() else f"Operation interrupted: handling API error ({error_type}: {agent._clean_error_message(str(api_error))}).",
                         "messages": messages,
                         "api_calls": api_call_count,
                         "completed": False,
@@ -3057,7 +3057,7 @@ def run_conversation(
                         agent._persist_session(messages, conversation_history)
                         agent.clear_interrupt()
                         return {
-                            "final_response": f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries}).",
+                            "final_response": None if agent._suppress_platform_notifications() else f"Operation interrupted: retrying API call after error (retry {retry_count}/{max_retries}).",
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -298,6 +298,15 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # When True, the gateway delivers ONLY genuine agent replies on this
+    # platform and drops every gateway-originated "notice" (status, lifecycle,
+    # cron headers, STT/home-channel/footer prompts, "still working", shutdown,
+    # session-reset, etc.).  Intended for platforms shared with human contacts
+    # (e.g. WhatsApp) where internal bubbles are reputationally bad.  Enforced
+    # at the adapter send() chokepoint via the _delivering_agent_reply marker
+    # set by BasePlatformAdapter._send_with_retry.  Default False = unchanged.
+    suppress_notifications: bool = False
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
 
@@ -307,6 +316,7 @@ class PlatformConfig:
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
+            "suppress_notifications": self.suppress_notifications,
         }
         if self.token:
             result["token"] = self.token
@@ -337,6 +347,9 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            suppress_notifications=_coerce_bool(
+                data.get("suppress_notifications"), False
+            ),
             extra=data.get("extra", {}),
         )
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,6 +6,7 @@ and implement the required methods.
 """
 
 import asyncio
+import contextvars
 import inspect
 import ipaddress
 import logging
@@ -23,6 +24,17 @@ from urllib.parse import urlsplit
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
+
+# Task-local marker: True only while delivering a genuine agent reply through
+# ``_send_with_retry`` (the single funnel both the background and synchronous
+# message paths use for the model's text response, including slash-command
+# replies the user explicitly requested).  Adapters can consult this to drop
+# gateway-internal "bubble" sends (status/lifecycle/cron/notice messages that
+# call ``send()`` directly) on platforms where the user disabled them — see
+# WhatsAppAdapter.send().  Task-local so concurrent sessions never cross-talk.
+_delivering_agent_reply: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "hermes_delivering_agent_reply", default=False
+)
 
 # Audio file extensions Hermes recognizes for native audio delivery.
 # Kept in sync with tools/send_message_tool.py and cron/scheduler.py via
@@ -2773,6 +2785,34 @@ class BasePlatformAdapter(ABC):
         return response, 0
 
     async def _send_with_retry(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Any = None,
+        max_retries: int = 2,
+        base_delay: float = 2.0,
+    ) -> "SendResult":
+        """Deliver a genuine agent reply, marking it for adapters.
+
+        Sets ``_delivering_agent_reply`` for the duration so platform adapters
+        can distinguish the model's actual reply from gateway-internal bubble
+        sends.  The real retry/fallback logic lives in ``_send_with_retry_impl``.
+        """
+        _reply_token = _delivering_agent_reply.set(True)
+        try:
+            return await self._send_with_retry_impl(
+                chat_id=chat_id,
+                content=content,
+                reply_to=reply_to,
+                metadata=metadata,
+                max_retries=max_retries,
+                base_delay=base_delay,
+            )
+        finally:
+            _delivering_agent_reply.reset(_reply_token)
+
+    async def _send_with_retry_impl(
         self,
         chat_id: str,
         content: str,

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -886,6 +886,45 @@ class WhatsAppAdapter(BasePlatformAdapter):
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
 
+        # Notification suppression (single outbound chokepoint).  Genuine agent
+        # replies are delivered through base._send_with_retry, which sets
+        # _delivering_agent_reply for the call.  Every gateway-originated notice
+        # (status, lifecycle, cron, STT/home-channel/footer prompts, "still
+        # working", shutdown, session-reset, etc.) calls send() directly WITHOUT
+        # that marker.  When whatsapp.suppress_notifications is true, drop any
+        # send that is not a genuine reply.  This catches new notice types
+        # automatically without per-call-site patching.
+        try:
+            from gateway.platforms.base import _delivering_agent_reply
+            if not _delivering_agent_reply.get():
+                from hermes_cli.config import read_raw_config
+                _raw = read_raw_config()
+                # Dedicated first-class flag: whatsapp.suppress_notifications.
+                # Read from the raw config dict (always reflects config.yaml);
+                # fall back to the typed PlatformConfig field if present.
+                _wa = _raw.get("whatsapp") or {}
+                _suppress = bool(_wa.get(
+                    "suppress_notifications",
+                    getattr(self.config, "suppress_notifications", False),
+                ))
+                if not _suppress:
+                    # Legacy fallback: display.platforms.whatsapp.interim_assistant_messages: false
+                    from gateway.display_config import resolve_display_setting
+                    from gateway.config import is_truthy_value
+                    _interim = resolve_display_setting(
+                        _raw, "whatsapp", "interim_assistant_messages"
+                    )
+                    _suppress = not is_truthy_value(_interim, default=True)
+                if _suppress:
+                    logger.debug(
+                        "[Whatsapp] Suppressed non-reply notice "
+                        "(whatsapp.suppress_notifications): %.80s",
+                        content.replace("\n", " "),
+                    )
+                    return SendResult(success=True, message_id=None)
+        except Exception:
+            pass
+
         try:
             import aiohttp
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1957,6 +1957,29 @@ class AIAgent:
             pass
         return True  # safe default: verifier on
 
+    def _suppress_platform_notifications(self) -> bool:
+        """True when the active platform drops gateway notices.
+
+        Reads ``<platform>.suppress_notifications`` from config.yaml (e.g.
+        WhatsApp shared with a human contact).  Interrupt / API-error status
+        strings are assigned to ``final_response`` and so ride the genuine
+        agent-reply path — they bypass the adapter notice chokepoint, which
+        only catches separate ``send()`` notices.  Gate them on this so they
+        stay silent on suppressed platforms; CLI/TUI and every other platform
+        are unaffected.  Fail-open (return False) on any error so a config
+        glitch can never swallow a normal reply.
+        """
+        try:
+            from hermes_cli.config import load_config as _load_config
+            _cfg = _load_config() or {}
+            _plat = (getattr(self, "platform", None) or "").lower().strip()
+            _plat_cfg = _cfg.get(_plat) if (_plat and isinstance(_cfg, dict)) else None
+            if isinstance(_plat_cfg, dict) and _plat_cfg.get("suppress_notifications"):
+                return True
+        except Exception:
+            pass
+        return False
+
     @staticmethod
     def _format_file_mutation_failure_footer(failed: Dict[str, Dict[str, Any]]) -> str:
         """Render the per-turn failed-mutation dict as a user-facing footer.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1937,6 +1937,19 @@ class AIAgent:
                 _cfg = _load_config() or {}
             except Exception:
                 _cfg = {}
+            # Per-platform suppression: this footer is appended to the assistant
+            # reply (not a separate send), so it bypasses the adapter notice
+            # chokepoint.  On platforms that drop gateway notices
+            # (<platform>.suppress_notifications, e.g. WhatsApp shared with human
+            # contacts) skip the developer-facing verifier footer too.  CLI/TUI
+            # and other platforms keep it.
+            try:
+                _plat = (getattr(self, "platform", None) or "").lower().strip()
+                _plat_cfg = _cfg.get(_plat) if (_plat and isinstance(_cfg, dict)) else None
+                if isinstance(_plat_cfg, dict) and _plat_cfg.get("suppress_notifications"):
+                    return False
+            except Exception:
+                pass
             _display = _cfg.get("display") if isinstance(_cfg, dict) else None
             if isinstance(_display, dict) and "file_mutation_verifier" in _display:
                 return bool(_display.get("file_mutation_verifier"))


### PR DESCRIPTION
## Summary

Adds a per-platform flag, `whatsapp.suppress_notifications` (default `false`),
that delivers **only genuine agent replies** on WhatsApp and drops every
gateway-originated "notice" (status/lifecycle, "still working", shutdown,
session-reset, STT hints, runtime footer, "no home channel", kanban pings, cron
headers, etc.).

It's enforced at the single outbound chokepoint rather than per call site, so
new notice types are suppressed automatically.

One class of leak can't be caught at the adapter chokepoint: text that is
**appended to the genuine reply** rather than sent as a separate message. The
per-turn file-mutation verifier footer (`⚠️ File-mutation verifier: N file(s)
were NOT modified…`) rides the real reply, so it carries the reply marker and
the chokepoint must let it through. That one is gated in the core instead — see
the `run_agent.py` change below. This is the general pattern for any
reply-embedded developer-facing text: gate it on `<platform>.suppress_notifications`
where it is produced, since the adapter guard only sees standalone sends.

## Motivation

When Hermes drives a WhatsApp number that's also used to talk to **human
contacts**, internal bubbles leak into those human chats and are confusing /
reputationally damaging. `display.platforms.whatsapp.interim_assistant_messages:
false` only covered part of this — many notices call `adapter.send()` directly
and ignored it, so suppression became per-call-site whack-a-mole and regressed
whenever a new notice type was added.

## Approach

Every genuine reply (background path, synchronous path, and slash-command
responses) is delivered through `BasePlatformAdapter._send_with_retry`. Gateway
notices call `adapter.send()` directly. We use that asymmetry:

1. **Reply marker** — a task-local `contextvars.ContextVar`
   (`_delivering_agent_reply`) set `True` only while inside `_send_with_retry`
   (split into a wrapper + `_send_with_retry_impl`). Task-local ⇒ no cross-talk
   between concurrent sessions, and it's reset in `finally` so it can't bleed
   into later sends in the same task.
2. **Chokepoint guard** — at the top of `WhatsAppAdapter.send()`, if the send is
   *not* a marked reply and `whatsapp.suppress_notifications` is set, drop it
   (return success, log at DEBUG).

This inverts the burden: replies are tagged in one well-tested place; everything
else is treated as a notice. A missed reply tag would be the only risk (it would
drop a real reply), which is why tagging lives at the single shared funnel.

## Changes

- `gateway/platforms/base.py` — `import contextvars`; module-level
  `_delivering_agent_reply` ContextVar; split `_send_with_retry` into a
  marker-setting wrapper + `_send_with_retry_impl` (body unchanged).
- `gateway/platforms/whatsapp.py` — guard at the top of `send()` (after the
  empty-content check).
- `gateway/config.py` — `PlatformConfig.suppress_notifications: bool = False`
  (+ `to_dict`/`from_dict`).
- `run_agent.py` — in `AIAgent._file_mutation_verifier_enabled()`, return
  `False` when `<platform>.suppress_notifications` is set, so the reply-embedded
  verifier footer is dropped on suppressed platforms while CLI/TUI keep it.

See `hermes-suppress-notifications.patch` (attached) — validated `git apply
--check` clean against `main` @ `2517917`. (A variant for the v0.14.0 release
tag is in `hermes-suppress-notifications-v0.14.0.patch`; the only difference is
the `config.py from_dict` context, which `main` rewrote to bridge
`gateway_restart_notification` through `extra`.)

## Config

```yaml
# Either layout works:
whatsapp:
  suppress_notifications: true        # top-level convenience layout (read from raw config)

# or
platforms:
  whatsapp:
    suppress_notifications: true      # typed PlatformConfig layout
```

The adapter reads the flag from the raw config dict
(`hermes_cli.config.read_raw_config()`), so it works for the top-level
`whatsapp:` layout that doesn't currently flow through
`PlatformConfig.from_dict`. The typed field is also populated for the
`platforms:` layout.

## Backward compatibility

- Default `false` ⇒ no behavior change for existing users.
- When `suppress_notifications` is unset, the guard falls back to
  `display.platforms.<platform>.interim_assistant_messages: false`, so installs
  already relying on that keep their suppression. (Optional — drop if undesired.)

## Extending to other platforms

The reply marker is platform-agnostic; enabling `<platform>.suppress_notifications`
elsewhere is just the same ~10-line guard at the top of that adapter's `send()`.

## Testing

- Isolated: a fake adapter confirms `_send_with_retry` ⇒ marker `True` (sent),
  direct `send()` ⇒ marker `False` (suppressed when flag on), and the marker
  resets after `_send_with_retry` returns.
- Config: `PlatformConfig.from_dict({'suppress_notifications': True})` round-trips
  through `to_dict()`.
- Runtime: gateway restarts cleanly; WhatsApp connects; genuine replies still
  delivered.
- Footer gate: with `whatsapp.suppress_notifications: true`, the file-mutation
  verifier footer is absent from WhatsApp replies; with the flag off (or on
  CLI/TUI) the footer still appends as before.

## Notes / open questions for maintainers

- Naming: `suppress_notifications` vs `notices_enabled` (inverted) — happy to
  rename.
- Whether to keep the `interim_assistant_messages` backcompat fallback.
- Could generalize the guard into a shared base helper if you'd prefer a
  `send()`-wrapper-in-base refactor over per-adapter guards.


---

## Update — reply-embedded interrupt notices (2nd commit)

The adapter chokepoint only catches separate `send()` notices. Four
interrupt / API-error strings in `run_conversation()` are assigned to
`final_response`, so they ride the genuine agent-reply path and bypass the
chokepoint — they leaked into WhatsApp as e.g.
`Operation interrupted: waiting for model response (3.9s elapsed)`.

Fix (same pattern as the file-mutation footer gate): add
`AIAgent._suppress_platform_notifications()` and gate all four sites on it,
emitting `""` / `None` instead of the notice when the platform suppresses.
Every site already sets `interrupted=True`, so the emptied reply is silent:
`_normalize_empty_agent_response` does not resurrect empty responses on
interrupted turns. CLI/TUI and other platforms keep the notices.
