### PR TITLE
feat: add /qstatus slash command for queue depth visibility

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8673,28 +8673,31 @@ class GatewayRunner:
         return "\n".join(lines)
 
     async def _handle_qstatus_command(self, event: MessageEvent) -> str:
-        """Handle /qstatus — show queue depth for this session and totals."""
+        """Handle /qstatus — show queue depth for the caller's session.
+
+        Cross-session aggregates (total queued across all sessions, global
+        active-agent count) are live-activity data for OTHER users, so they
+        are gated behind configured-admin authorization — the same boundary
+        that restricts cross-origin command data elsewhere. Non-admins see
+        only their own queue.
+        """
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
         adapter = self.adapters.get(source.platform) if source else None
 
-        # Current session depth
+        # Current session depth — always visible to the caller (own data).
         my_depth = self._queue_depth(session_key, adapter=adapter)
-
-        # Total across all sessions
         queued_events = getattr(self, "_queued_events", None) or {}
-        total_overflow = sum(len(v) for v in queued_events.values())
-        # Count adapter-level pending slots
-        total_slots = 0
-        for adap in self.adapters.values():
-            pending = getattr(adap, "_pending_messages", None) or {}
-            total_slots += len(pending)
-        total_depth = total_overflow + total_slots
 
-        # Running agents count
-        running = getattr(self, "_running_agents", {}) or {}
-        running_count = len(running)
+        # Cross-session totals are only shown to admins. When no admin list is
+        # configured for this scope (policy.enabled is False), the scope is
+        # unrestricted and everyone is effectively trusted, so allow it too.
+        from gateway.slash_access import policy_for_source as _policy_for_source
+
+        policy = _policy_for_source(self.config, source)
+        user_id = (source.user_id if source else None) or ""
+        show_global = (not policy.enabled) or policy.is_admin(user_id)
 
         lines = ["📋 Queue Status", ""]
 
@@ -8703,13 +8706,26 @@ class GatewayRunner:
         else:
             lines.append("This session: empty")
 
-        if total_depth > my_depth:
-            lines.append(f"Total (all sessions): {total_depth} queued")
+        if show_global:
+            # Total across all sessions (slot + overflow).
+            total_overflow = sum(len(v) for v in queued_events.values())
+            total_slots = 0
+            for adap in self.adapters.values():
+                pending = getattr(adap, "_pending_messages", None) or {}
+                total_slots += len(pending)
+            total_depth = total_overflow + total_slots
 
-        if running_count:
-            lines.append(f"Active agents: {running_count}")
+            running_count = len(getattr(self, "_running_agents", {}) or {})
 
-        # Show pending items for current session if any
+            if total_depth > my_depth:
+                lines.append(f"Total (all sessions): {total_depth} queued")
+            if running_count:
+                lines.append(f"Active agents: {running_count}")
+        else:
+            total_depth = my_depth
+            running_count = 0
+
+        # Show pending items for current session if any (own data).
         if my_depth and adapter:
             pending_slot = getattr(adapter, "_pending_messages", None) or {}
             if session_key in pending_slot:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6172,6 +6172,10 @@ class GatewayRunner:
                     return "Queued for the next turn."
                 return f"Queued for the next turn. ({depth} queued)"
 
+            # /qstatus — show queue depth without adding anything.
+            if event.get_command() in {"qstatus", "qs"}:
+                return await self._handle_qstatus_command(event)
+
             # /steer <prompt> — inject mid-run after the next tool call.
             # Unlike /queue (turn boundary), /steer lands BETWEEN tool-call
             # iterations inside the same agent run, by appending to the
@@ -6543,6 +6547,9 @@ class GatewayRunner:
 
         if canonical == "agents":
             return await self._handle_agents_command(event)
+
+        if canonical == "qstatus":
+            return await self._handle_qstatus_command(event)
 
         if canonical == "platform":
             return await self._handle_platform_command(event)
@@ -8662,6 +8669,69 @@ class GatewayRunner:
             "",
             t("gateway.status.platforms", platforms=', '.join(connected_platforms)),
         ])
+
+        return "\n".join(lines)
+
+    async def _handle_qstatus_command(self, event: MessageEvent) -> str:
+        """Handle /qstatus — show queue depth for this session and totals."""
+        source = event.source
+        session_entry = self.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
+        adapter = self.adapters.get(source.platform) if source else None
+
+        # Current session depth
+        my_depth = self._queue_depth(session_key, adapter=adapter)
+
+        # Total across all sessions
+        queued_events = getattr(self, "_queued_events", None) or {}
+        total_overflow = sum(len(v) for v in queued_events.values())
+        # Count adapter-level pending slots
+        total_slots = 0
+        for adap in self.adapters.values():
+            pending = getattr(adap, "_pending_messages", None) or {}
+            total_slots += len(pending)
+        total_depth = total_overflow + total_slots
+
+        # Running agents count
+        running = getattr(self, "_running_agents", {}) or {}
+        running_count = len(running)
+
+        lines = ["📋 Queue Status", ""]
+
+        if my_depth:
+            lines.append(f"This session: {my_depth} queued")
+        else:
+            lines.append("This session: empty")
+
+        if total_depth > my_depth:
+            lines.append(f"Total (all sessions): {total_depth} queued")
+
+        if running_count:
+            lines.append(f"Active agents: {running_count}")
+
+        # Show pending items for current session if any
+        if my_depth and adapter:
+            pending_slot = getattr(adapter, "_pending_messages", None) or {}
+            if session_key in pending_slot:
+                evt = pending_slot[session_key]
+                preview = getattr(evt, "text", "")[:60]
+                if len(getattr(evt, "text", "")) > 60:
+                    preview += "..."
+                lines.append(f"\nNext up: \"{preview}\"")
+
+            overflow = queued_events.get(session_key, [])
+            if overflow:
+                lines.append(f"Overflow: {len(overflow)} more item(s)")
+                for i, evt in enumerate(overflow[:3], 1):
+                    preview = getattr(evt, "text", "")[:50]
+                    if len(getattr(evt, "text", "")) > 50:
+                        preview += "..."
+                    lines.append(f"  {i}. \"{preview}\"")
+                if len(overflow) > 3:
+                    lines.append(f"  ...and {len(overflow) - 3} more")
+
+        if not my_depth and not total_depth and not running_count:
+            lines.append("All clear — nothing queued, no active agents.")
 
         return "\n".join(lines)
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -100,6 +100,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("tasks",)),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
                aliases=("q",), args_hint="<prompt>"),
+    CommandDef("qstatus", "Show queue depth and pending items across sessions", "Session",
+               aliases=("qs",)),
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
                args_hint="<prompt>"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -337,6 +337,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "help",
         "new",
         "profile",
+        "qstatus",
         "queue",
         "restart",
         "status",

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -545,6 +545,162 @@ async def test_status_command_bypasses_active_session_guard():
     assert session_key not in adapter._pending_messages, "/status was incorrectly queued"
 
 
+def _make_qstatus_runner(session_entry, *, admin_ids=None, user_commands=None,
+                         platform: Platform = Platform.TELEGRAM):
+    """Runner for /qstatus tests. ``admin_ids`` set → slash gating enabled
+    for the scope, so only listed admins see cross-session aggregates.
+    ``user_commands`` are the slash commands non-admins may reach at all."""
+    extra: dict = {}
+    if admin_ids:
+        extra["allow_admin_from"] = list(admin_ids)
+    if user_commands:
+        extra["user_allowed_commands"] = list(user_commands)
+    runner = _make_runner(session_entry, platform=platform)
+    runner.config = GatewayConfig(
+        platforms={platform: PlatformConfig(enabled=True, token="***", extra=extra)}
+    )
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_qstatus_reports_local_queue_depth():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_qstatus_runner(session_entry)
+    session_key = session_entry.session_key
+    runner._queued_events = {session_key: [SimpleNamespace(text="hi there")]}
+
+    result = await runner._handle_message(_make_event("/qstatus"))
+
+    assert "Queue Status" in result
+    assert "This session: 1 queued" in result
+    assert '"hi there"' in result
+
+
+@pytest.mark.asyncio
+async def test_qstatus_alias_qs_routes_to_qstatus():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_qstatus_runner(session_entry)
+
+    result = await runner._handle_message(_make_event("/qs"))
+
+    assert "Queue Status" in result
+    assert "This session: empty" in result
+
+
+@pytest.mark.asyncio
+async def test_qstatus_hides_cross_session_totals_from_non_admin():
+    """Non-admins (gating enabled, not listed) see only their own queue —
+    never other sessions' live activity or the global active-agent count."""
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    # Caller "u1" is NOT an admin, but the operator lets non-admins run
+    # /qstatus. The command reaches the handler, which must still hide
+    # cross-session data from the non-admin.
+    runner = _make_qstatus_runner(
+        session_entry, admin_ids=["admin-99"], user_commands=["qstatus"]
+    )
+    # Another session has queued items and there's a running agent.
+    runner._queued_events = {"other-session": [SimpleNamespace(text="x"), SimpleNamespace(text="y")]}
+    runner._running_agents = {"other-session": MagicMock()}
+
+    result = await runner._handle_message(_make_event("/qstatus"))
+
+    assert "This session: empty" in result
+    assert "Total (all sessions)" not in result
+    assert "Active agents" not in result
+
+
+@pytest.mark.asyncio
+async def test_qstatus_shows_cross_session_totals_to_admin():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    # Caller "u1" IS the configured admin → cross-session aggregates visible.
+    runner = _make_qstatus_runner(session_entry, admin_ids=["u1"])
+    runner._queued_events = {"other-session": [SimpleNamespace(text="x"), SimpleNamespace(text="y")]}
+    runner._running_agents = {"other-session": MagicMock()}
+
+    result = await runner._handle_message(_make_event("/qstatus"))
+
+    assert "Total (all sessions): 2 queued" in result
+    assert "Active agents: 1" in result
+
+
+@pytest.mark.asyncio
+async def test_qstatus_bypasses_active_session_guard():
+    """When an agent is running, /qstatus must be dispatched immediately —
+    not queued or treated as an interrupt (mirrors /status behavior)."""
+    import asyncio
+    from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+
+    source = _make_source()
+    session_key = build_session_key(source)
+    handler_called_with = []
+
+    async def fake_handler(event):
+        handler_called_with.append(event)
+        return "📋 Queue Status\nThis session: empty"
+
+    class _ConcreteAdapter(BasePlatformAdapter):
+        platform = Platform.TELEGRAM
+
+        async def connect(self): pass
+        async def disconnect(self): pass
+        async def send(self, chat_id, content, **kwargs): pass
+        async def get_chat_info(self, chat_id): return {}
+
+    adapter = _ConcreteAdapter(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+    adapter.set_message_handler(fake_handler)
+
+    sent = []
+
+    async def fake_send_with_retry(chat_id, content, reply_to=None, metadata=None):
+        sent.append(content)
+
+    adapter._send_with_retry = fake_send_with_retry
+
+    interrupt_event = asyncio.Event()
+    adapter._active_sessions[session_key] = interrupt_event
+
+    event = MessageEvent(
+        text="/qstatus",
+        source=source,
+        message_id="m1",
+        message_type=MessageType.COMMAND,
+    )
+    await adapter.handle_message(event)
+
+    assert handler_called_with, "/qstatus handler was never called (event was queued or dropped)"
+    assert sent, "/qstatus response was never sent"
+    assert not interrupt_event.is_set(), "/qstatus incorrectly triggered an agent interrupt"
+    assert session_key not in adapter._pending_messages, "/qstatus was incorrectly queued"
+
+
 @pytest.mark.asyncio
 async def test_profile_command_reports_custom_root_profile(monkeypatch, tmp_path):
     """Gateway /profile detects custom-root profiles (not under ~/.hermes)."""


### PR DESCRIPTION
## Summary

Adds a lightweight `/qstatus` (alias: `/qs`) slash command that shows queue depth and pending items — both for the current session and across all sessions.

## What it does

- **Current session depth** — how many `/queue` items are pending
- **Cross-session totals** — total queued items across all gateway sessions
- **Active agents count** — how many agents are currently running
- **Item previews** — shows the first 60 chars of the next queued item, plus overflow count

## Why

`/status` already includes queue depth, but it's buried in a verbose output with session IDs, tokens, platform info, etc. When you're actively queuing items and want a quick sanity check, `/qstatus` gives you just the queue info in a clean format.

Also useful for multi-session scenarios (e.g., Telegram + CLI running concurrently) where you want to see the total queue depth across all sessions.

## Example output

```
📋 Queue Status

This session: 3 queued
Active agents: 1

Next up: "Research GRPO papers and write summary"
Overflow: 2 more item(s)
  1. "Build REST API for user management"
  2. "Add rate limiting middleware"
```

When empty:
```
📋 Queue Status

This session: empty
All clear — nothing queued, no active agents.
```

## Implementation

- `hermes_cli/commands.py` — added `CommandDef("qstatus", ...)` with alias `"qs"`
- `gateway/run.py` — added `_handle_qstatus_command()` method + dispatch in both running-agent fast-path and cold-path

The command is read-only and lightweight — no side effects, no agent interaction.

## Test plan

- [ ] `/qstatus` with nothing queued → "All clear"
- [ ] `/queue test` then `/qstatus` → shows "1 queued"
- [ ] `/qstatus` while agent is running → shows active agents count
- [ ] Alias `/qs` works identically