### PR TITLE
Fix #32504：removed redundant _budget_grace_call and _budget_exhausted_

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -486,15 +486,6 @@ def init_agent(
     except Exception:
         pass
 
-    # Iteration budget: the LLM is only notified when it actually exhausts
-    # the iteration budget (api_call_count >= max_iterations).  At that
-    # point we inject ONE message, allow one final API call, and if the
-    # model doesn't produce a text response, force a user-message asking
-    # it to summarise.  No intermediate pressure warnings — they caused
-    # models to "give up" prematurely on complex tasks (#7915).
-    agent._budget_exhausted_injected = False
-    agent._budget_grace_call = False
-
     # Activity tracking — updated on each API call, tool execution, and
     # stream chunk.  Used by the gateway timeout handler to report what the
     # agent was doing when it was killed, and by the "still working"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -672,7 +672,7 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0):
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -688,12 +688,7 @@ def run_conversation(
         agent._api_call_count = api_call_count
         agent._touch_activity(f"starting API call #{api_call_count}")
 
-        # Grace call: the budget is exhausted but we gave the model one
-        # more chance.  Consume the grace flag so the loop exits after
-        # this iteration regardless of outcome.
-        if agent._budget_grace_call:
-            agent._budget_grace_call = False
-        elif not agent.iteration_budget.consume():
+        if not agent.iteration_budget.consume():
             _turn_exit_reason = "budget_exhausted"
             if not agent.quiet_mode:
                 agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4345,14 +4345,6 @@ class TestSystemPromptStability:
         # Empty string is falsy, so should fall through to fresh build
         assert "Hermes Agent" in agent._cached_system_prompt
 
-class TestBudgetPressure:
-    """Budget exhaustion grace call system."""
-
-    def test_grace_call_flags_initialized(self, agent):
-        """Agent should have budget grace call flags."""
-        assert agent._budget_exhausted_injected is False
-        assert agent._budget_grace_call is False
-
 
 class TestSafeWriter:
     """Verify _SafeWriter guards stdout against OSError (broken pipes)."""


### PR DESCRIPTION
This PR removed redundant “_budget_grace_call” and ”_budget_exhausted_” in business logic path and tests.
They are the leftover of a removed feature “a graceful last retry”.

This code change should not affect Hermes' behavior at all, just removing some leftovers.

## Related Issue

https://github.com/NousResearch/hermes-agent/issues/32504


