### PR TITLE
fix(memory): recover corrupt holographic store (#32495)

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -30,6 +30,11 @@ from hermes_cli.config import cfg_get
 
 logger = logging.getLogger(__name__)
 
+_UNAVAILABLE_ERROR = (
+    "holographic memory is unavailable — the configured database failed to initialize. "
+    "Check errors.log and the configured db_path before relying on fact_store."
+)
+
 
 # ---------------------------------------------------------------------------
 # Tool schemas (unchanged from original PR)
@@ -182,7 +187,11 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def system_prompt_block(self) -> str:
         if not self._store:
-            return ""
+            return (
+                "# Holographic Memory\n"
+                "Unavailable — fact storage failed to initialize. "
+                "Check errors.log before relying on fact_store."
+            )
         try:
             total = self._store._conn.execute(
                 "SELECT COUNT(*) FROM facts"
@@ -268,6 +277,8 @@ class HolographicMemoryProvider(MemoryProvider):
     # -- Tool handlers -------------------------------------------------------
 
     def _handle_fact_store(self, args: dict) -> str:
+        if self._store is None or self._retriever is None:
+            return tool_error(_UNAVAILABLE_ERROR)
         try:
             action = args["action"]
             store = self._store
@@ -355,6 +366,8 @@ class HolographicMemoryProvider(MemoryProvider):
             return tool_error(str(exc))
 
     def _handle_fact_feedback(self, args: dict) -> str:
+        if self._store is None:
+            return tool_error(_UNAVAILABLE_ERROR)
         try:
             fact_id = int(args["fact_id"])
             helpful = args["action"] == "helpful"

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -3,6 +3,7 @@ SQLite-backed fact store with entity resolution and trust scoring.
 Single-user Hermes memory store plugin.
 """
 
+import logging
 import re
 import sqlite3
 import threading
@@ -75,6 +76,15 @@ CREATE TABLE IF NOT EXISTS memory_banks (
 );
 """
 
+logger = logging.getLogger(__name__)
+
+_CORRUPT_DB_MARKERS = (
+    "file is not a database",
+    "database disk image is malformed",
+    "file is encrypted or is not a database",
+    "unsupported file format",
+)
+
 # Trust adjustment constants
 _HELPFUL_DELTA   =  0.05
 _UNHELPFUL_DELTA = -0.10
@@ -127,6 +137,7 @@ class MemoryStore:
         self.default_trust = _clamp_trust(default_trust)
         self.hrr_dim = hrr_dim
         self._hrr_available = hrr._HAS_NUMPY
+        self._entry = None
 
         # Acquire (or open) the process-wide shared connection for this DB.
         # resolve() (not just expanduser) so symlinked/relative paths to the
@@ -136,32 +147,90 @@ class MemoryStore:
             self._key = str(self.db_path.resolve())
         except OSError:
             self._key = str(self.db_path)
+
+        self._acquire_shared_connection()
+        try:
+            self._ensure_ready()
+        except sqlite3.DatabaseError as exc:
+            if not self._is_corrupt_database_error(exc):
+                self.close()
+                raise
+            self._recover_corrupt_database(exc)
+            self._acquire_shared_connection()
+            self._ensure_ready()
+
+    def _open_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            self._key,
+            check_same_thread=False,
+            timeout=10.0,
+            # Autocommit: every statement is its own transaction, so a
+            # write that raises mid-method can never leave a dangling
+            # transaction (and its write lock) open. The explicit
+            # commit() calls below become harmless no-ops.
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _acquire_shared_connection(self) -> None:
         with MemoryStore._shared_guard:
             entry = MemoryStore._shared.get(self._key)
             if entry is None:
-                conn = sqlite3.connect(
-                    self._key,
-                    check_same_thread=False,
-                    timeout=10.0,
-                    # Autocommit: every statement is its own transaction, so a
-                    # write that raises mid-method can never leave a dangling
-                    # transaction (and its write lock) open. The explicit
-                    # commit() calls below become harmless no-ops.
-                    isolation_level=None,
-                )
-                conn.row_factory = sqlite3.Row
-                entry = {"conn": conn, "lock": threading.RLock(), "refs": 0, "ready": False}
+                entry = {
+                    "conn": self._open_connection(),
+                    "lock": threading.RLock(),
+                    "refs": 0,
+                    "ready": False,
+                }
                 MemoryStore._shared[self._key] = entry
             entry["refs"] += 1
             self._entry = entry
             self._conn = entry["conn"]
             self._lock = entry["lock"]
 
+    def _ensure_ready(self) -> None:
         # Initialise the schema once per shared connection.
         with self._lock:
             if not self._entry["ready"]:
                 self._init_db()
                 self._entry["ready"] = True
+
+    @staticmethod
+    def _is_corrupt_database_error(exc: sqlite3.DatabaseError) -> bool:
+        error = str(exc).lower()
+        return any(marker in error for marker in _CORRUPT_DB_MARKERS)
+
+    def _recover_corrupt_database(self, exc: sqlite3.DatabaseError) -> None:
+        """Quarantine a corrupt SQLite store and rebuild the shared registry entry."""
+        old_entry = self._entry
+        with MemoryStore._shared_guard:
+            if old_entry is not None:
+                try:
+                    old_entry["conn"].close()
+                finally:
+                    if MemoryStore._shared.get(self._key) is old_entry:
+                        MemoryStore._shared.pop(self._key, None)
+            self._entry = None
+
+        backup_path = self.db_path.with_name(f"{self.db_path.name}.corrupt")
+        counter = 1
+        while backup_path.exists():
+            backup_path = self.db_path.with_name(f"{self.db_path.name}.corrupt.{counter}")
+            counter += 1
+
+        logger.warning(
+            "Holographic memory database at %s is unreadable (%s); moving it to %s and creating a fresh store",
+            self.db_path,
+            exc,
+            backup_path,
+        )
+        if self.db_path.exists():
+            self.db_path.replace(backup_path)
+        for sidecar_suffix in ("-wal", "-shm"):
+            sidecar = self.db_path.with_name(f"{self.db_path.name}{sidecar_suffix}")
+            if sidecar.exists():
+                sidecar.unlink()
 
     # ------------------------------------------------------------------
     # Initialisation

--- a/tests/plugins/test_holographic_memory_corruption.py
+++ b/tests/plugins/test_holographic_memory_corruption.py
@@ -1,0 +1,95 @@
+import json
+import sqlite3
+
+import pytest
+
+from plugins.memory.holographic import HolographicMemoryProvider
+from plugins.memory.holographic.store import MemoryStore
+
+
+def test_memory_store_quarantines_corrupt_database_with_shared_registry(tmp_path):
+    db_path = tmp_path / "memory_store.db"
+    db_path.write_bytes(b"not a sqlite database")
+    (tmp_path / "memory_store.db-wal").write_bytes(b"stale wal")
+    (tmp_path / "memory_store.db-shm").write_bytes(b"stale shm")
+
+    store = MemoryStore(db_path=db_path)
+
+    try:
+        assert db_path.exists()
+        assert (tmp_path / "memory_store.db.corrupt").read_bytes() == b"not a sqlite database"
+        wal = tmp_path / "memory_store.db-wal"
+        shm = tmp_path / "memory_store.db-shm"
+        if wal.exists():
+            assert wal.read_bytes() != b"stale wal"
+        if shm.exists():
+            assert shm.read_bytes() != b"stale shm"
+        assert store._entry["ready"] is True
+        assert MemoryStore._shared[store._key] is store._entry
+
+        store.add_fact("Hermes remembers the moonlit path")
+        assert store.list_facts()[0]["content"] == "Hermes remembers the moonlit path"
+        sqlite3.connect(db_path).execute("SELECT COUNT(*) FROM facts").fetchone()
+    finally:
+        store.close()
+
+
+def test_memory_store_reuses_recovered_shared_connection(tmp_path):
+    db_path = tmp_path / "memory_store.db"
+    db_path.write_bytes(b"not a sqlite database")
+
+    first = MemoryStore(db_path=db_path)
+    second = MemoryStore(db_path=db_path)
+    try:
+        assert first._entry is second._entry
+        first.add_fact("shared recovery works")
+        assert second.list_facts()[0]["content"] == "shared recovery works"
+    finally:
+        first.close()
+        second.close()
+
+
+def test_memory_store_does_not_quarantine_transient_database_errors(tmp_path, monkeypatch):
+    db_path = tmp_path / "memory_store.db"
+    db_path.write_bytes(b"valid user data")
+
+    def raise_locked(self):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(MemoryStore, "_init_db", raise_locked)
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        MemoryStore(db_path=db_path)
+
+    assert db_path.read_bytes() == b"valid user data"
+    assert not (tmp_path / "memory_store.db.corrupt").exists()
+
+
+def test_fact_store_returns_clear_error_when_provider_uninitialized():
+    provider = HolographicMemoryProvider(config={})
+
+    result = json.loads(provider.handle_tool_call("fact_store", {"action": "list"}))
+
+    assert "holographic memory is unavailable" in result["error"]
+    assert "configured database" in result["error"]
+    assert "~/.hermes" not in result["error"]
+    assert "NoneType" not in result["error"]
+
+
+def test_fact_feedback_returns_clear_error_when_provider_uninitialized():
+    provider = HolographicMemoryProvider(config={})
+
+    result = json.loads(provider.handle_tool_call("fact_feedback", {"action": "helpful", "fact_id": 1}))
+
+    assert "holographic memory is unavailable" in result["error"]
+    assert "configured database" in result["error"]
+    assert "~/.hermes" not in result["error"]
+    assert "NoneType" not in result["error"]
+
+
+def test_system_prompt_reports_unavailable_memory_when_uninitialized():
+    provider = HolographicMemoryProvider(config={})
+    prompt = provider.system_prompt_block()
+
+    assert "Unavailable" in prompt
+    assert "fact storage failed to initialize" in prompt


### PR DESCRIPTION
## What does this PR do?

When `MemoryStore.__init__` encounters a corrupt `memory_store.db` (e.g. after a crash mid-WAL-checkpoint), it now automatically quarantines the broken file and creates a fresh database instead of crashing and leaving the provider in a dead state with `self._store = None`.

Additionally, the handler methods (`_handle_fact_store`, `_handle_fact_feedback`) guard against `None` store/retriever and return clear error messages instead of letting `AttributeError` propagate as cryptic `NoneType has no attribute` errors. The `system_prompt_block()` also reports the unavailability instead of returning an empty string.

**Root cause:** `MemoryStore.__init__` called `sqlite3.connect()` + `_init_db()` inline with no recovery path. If the DB file was corrupt, `sqlite3.DatabaseError` propagated up, `MemoryManager.initialize_all()` caught it with a single WARNING log, and the provider stayed registered with `_store = None`. Subsequent tool calls then hit `NoneType` attribute errors.

**Fix (3 layers):**
1. `store.py`: `_recover_corrupt_database()` detects known corruption markers (`file is not a database`, `database disk image is malformed`, etc.), quarantines the broken `.db` (with sidecar cleanup), and creates a fresh store. Transient errors (locked, busy) are NOT treated as corruption.
2. `__init__.py`: `_handle_fact_store` / `_handle_fact_feedback` guard `_store is None` / `_retriever is None` and return actionable error messages.
3. `__init__.py`: `system_prompt_block()` reports unavailability instead of returning empty string when store is None.

## Related Issue

Refs #32495

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/holographic/store.py`: Extract `_connect()`, add `_recover_corrupt_database()` with corruption marker detection and quarantine logic
- `plugins/memory/holographic/__init__.py`: Add `_UNAVAILABLE_ERROR` constant, null-store guards in handlers, availability reporting in `system_prompt_block()`
- `tests/plugins/test_holographic_memory_corruption.py`: 5 tests covering corrupt DB quarantine, transient error pass-through, null-store handler guards, and system prompt reporting

## How to Test

1. `pytest tests/plugins/test_holographic_memory_corruption.py -v`
2. All 5 tests should pass
3. Fail-without-fix proof: revert production files to upstream → 4 tests fail (corrupt DB crashes, handlers return `NoneType` errors, system prompt is empty)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Note

An open PR #32545 by @akaponym-byte addresses the same issue by adding null-store guards to the handler methods. This PR includes those same symptom guards **and additionally** fixes the root cause by adding corrupt-DB auto-recovery in `MemoryStore.__init__` (quarantine + fresh DB creation), plus fixes `system_prompt_block()` to report unavailability instead of silently returning an empty string.
