### PR TITLE
fix(delegate): pass per-task model override and explicit credentials to runtime provider

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2063,7 +2063,7 @@ def delegate_task(
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=t.get("model") or creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2429,7 +2429,12 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
+        runtime = resolve_runtime_provider(
+            requested=configured_provider,
+            target_model=configured_model,
+            explicit_api_key=configured_api_key,
+            explicit_base_url=configured_base_url,
+        )
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "


### PR DESCRIPTION
## Summary

Two fixes in `delegate_task()` that cause delegation failures with non-default providers:

### Fix 1: Per-task model override ignored (L2066)

```diff
- model=creds["model"],
+ model=t.get("model") or creds["model"],
```

When using `delegate_task` with batch tasks that specify different models per task, the `model` field was completely ignored — all subagents got the provider default.

### Fix 2: Custom provider credentials not forwarded (L2432)

```diff
- runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
+ runtime = resolve_runtime_provider(
+     requested=configured_provider,
+     target_model=configured_model,
+     explicit_api_key=configured_api_key,
+     explicit_base_url=configured_base_url,
+ )
```

`_resolve_delegation_credentials` resolves `configured_api_key` and `configured_base_url` from config, but never passes them to `resolve_runtime_provider`. Custom/named providers that need explicit credentials (API key + base URL) fail to resolve correctly.