### PR TITLE
feat: add /context composition command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Change model | `/model [provider:model]` | `/model [provider:model]` |
 | Set a personality | `/personality [name]` | `/personality [name]` |
 | Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
-| Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
+| Compress context / inspect usage | `/compress`, `/usage`, `/context`, `/insights [--days N]` | `/compress`, `/usage`, `/context`, `/insights [days]` |
 | Browse skills | `/skills` or `/<skill-name>` | `/<skill-name>` |
 | Interrupt current work | `Ctrl+C` or send a new message | `/stop` or send a new message |
 | Platform-specific status | `/platforms` | `/status`, `/sethome` |

--- a/agent/context_report.py
+++ b/agent/context_report.py
@@ -1,0 +1,315 @@
+"""Context-window composition diagnostics for CLI, gateway, and TUI."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+from agent.model_metadata import estimate_messages_tokens_rough
+
+
+def _text_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return (len(text) + 3) // 4
+
+
+def _value_tokens(value: Any) -> int:
+    if value is None:
+        return 0
+    return _text_tokens(str(value))
+
+
+def _pct(part: int, total: int) -> float:
+    return (part / total * 100.0) if total else 0.0
+
+
+def _bar(percent: float, width: int = 12) -> str:
+    safe = max(0.0, min(100.0, percent))
+    filled = round((safe / 100.0) * width)
+    return "[" + ("#" * filled) + ("." * max(0, width - filled)) + "]"
+
+
+def _fmt_tokens(value: int) -> str:
+    return f"{int(value):,}"
+
+
+def _format_row(label: str, tokens: int, total: int, note: str = "") -> str:
+    percent = _pct(tokens, total)
+    suffix = f"  {note}" if note else ""
+    return f"  {label:<22} {_fmt_tokens(tokens):>10} tok  {_bar(percent)} {percent:5.1f}%{suffix}"
+
+
+def _tool_function_name(tool: Any) -> str:
+    if not isinstance(tool, dict):
+        return "tool"
+    fn = tool.get("function")
+    if isinstance(fn, dict):
+        return str(fn.get("name") or "tool")
+    return str(tool.get("name") or "tool")
+
+
+def _message_tokens(message: Dict[str, Any]) -> int:
+    try:
+        return estimate_messages_tokens_rough([message])
+    except Exception:
+        return _value_tokens(message)
+
+
+def _extract_tool_calls(message: Dict[str, Any]) -> Iterable[tuple[str, str, str]]:
+    calls = message.get("tool_calls") if isinstance(message, dict) else None
+    if not isinstance(calls, list):
+        return []
+    out: list[tuple[str, str, str]] = []
+    for call in calls:
+        if not isinstance(call, dict):
+            continue
+        call_id = str(call.get("id") or call.get("call_id") or "")
+        fn = call.get("function")
+        if isinstance(fn, dict):
+            name = str(fn.get("name") or "")
+            args = str(fn.get("arguments") or "")
+        else:
+            name = str(call.get("name") or "")
+            args = str(call.get("arguments") or "")
+        if call_id or name:
+            out.append((call_id, name, args))
+    return out
+
+
+def _parse_skill_name(args_json: str, content: Any) -> Optional[str]:
+    try:
+        args = json.loads(args_json) if args_json else {}
+        if isinstance(args, dict) and args.get("name"):
+            return str(args.get("name"))
+    except Exception:
+        pass
+    try:
+        data = json.loads(content) if isinstance(content, str) else content
+        if isinstance(data, dict) and data.get("name"):
+            return str(data.get("name"))
+    except Exception:
+        pass
+    return None
+
+
+def _message_breakdown(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    role_totals: dict[str, int] = {}
+    role_counts: dict[str, int] = {}
+    tool_call_by_id: dict[str, tuple[str, str]] = {}
+    top_messages: list[dict[str, Any]] = []
+    top_tool_results: list[dict[str, Any]] = []
+    loaded_skills: list[dict[str, Any]] = []
+
+    for idx, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown")
+        tokens = _message_tokens(message)
+        role_totals[role] = role_totals.get(role, 0) + tokens
+        role_counts[role] = role_counts.get(role, 0) + 1
+        top_messages.append({"index": idx, "role": role, "tokens": tokens})
+
+        for call_id, name, args in _extract_tool_calls(message):
+            if call_id:
+                tool_call_by_id[call_id] = (name, args)
+
+        if role == "tool":
+            call_id = str(message.get("tool_call_id") or "")
+            tool_name, args_json = tool_call_by_id.get(call_id, ("tool", ""))
+            entry = {
+                "index": idx,
+                "tool": tool_name or "tool",
+                "tokens": tokens,
+            }
+            top_tool_results.append(entry)
+            if tool_name == "skill_view":
+                skill_name = _parse_skill_name(args_json, message.get("content"))
+                loaded_skills.append(
+                    {
+                        "name": skill_name or "skill_view",
+                        "tokens": tokens,
+                        "index": idx,
+                    }
+                )
+
+    top_messages.sort(key=lambda item: item["tokens"], reverse=True)
+    top_tool_results.sort(key=lambda item: item["tokens"], reverse=True)
+    loaded_skills.sort(key=lambda item: item["tokens"], reverse=True)
+    return {
+        "total": sum(role_totals.values()),
+        "role_totals": role_totals,
+        "role_counts": role_counts,
+        "top_messages": top_messages[:8],
+        "top_tool_results": top_tool_results[:8],
+        "loaded_skills": loaded_skills[:8],
+    }
+
+
+def _skills_index_breakdown(system_prompt: str) -> Dict[str, Any]:
+    start = system_prompt.find("<available_skills>")
+    end = system_prompt.find("</available_skills>")
+    if start == -1 or end == -1 or end <= start:
+        return {"tokens": 0, "entries": []}
+
+    block = system_prompt[start : end + len("</available_skills>")]
+    entries: list[dict[str, Any]] = []
+    for line in block.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        body = stripped[2:]
+        name = body.split(":", 1)[0].strip() or "skill"
+        entries.append({"name": name, "tokens": _text_tokens(stripped)})
+    entries.sort(key=lambda item: item["tokens"], reverse=True)
+    return {"tokens": _text_tokens(block), "entries": entries[:8]}
+
+
+def build_context_report(
+    agent: Any,
+    messages: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Return an estimated prompt-composition report for the next request."""
+    messages = list(messages or getattr(agent, "_session_messages", None) or [])
+
+    parts: dict[str, str] = {}
+    try:
+        parts = agent._build_system_prompt_parts(None)
+    except Exception:
+        parts = {}
+    cached_prompt = getattr(agent, "_cached_system_prompt", None) or ""
+    if not cached_prompt and parts:
+        cached_prompt = "\n\n".join(
+            p for p in (parts.get("stable", ""), parts.get("context", ""), parts.get("volatile", "")) if p
+        )
+    if not cached_prompt:
+        try:
+            cached_prompt = agent._build_system_prompt(None)
+        except Exception:
+            cached_prompt = ""
+
+    tools = list(getattr(agent, "tools", None) or [])
+    tool_entries = [
+        {"name": _tool_function_name(tool), "tokens": _value_tokens(tool)}
+        for tool in tools
+    ]
+    tool_entries.sort(key=lambda item: item["tokens"], reverse=True)
+    tools_total = _value_tokens(tools)
+
+    system_total = _text_tokens(cached_prompt)
+    system_parts = {
+        "stable": _text_tokens(parts.get("stable", "")),
+        "context": _text_tokens(parts.get("context", "")),
+        "volatile": _text_tokens(parts.get("volatile", "")),
+    }
+    message_info = _message_breakdown(messages)
+    skills_index = _skills_index_breakdown(cached_prompt)
+
+    total = system_total + tools_total + message_info["total"]
+    comp = getattr(agent, "context_compressor", None)
+    context_length = int(getattr(comp, "context_length", 0) or 0) if comp else 0
+    threshold_tokens = int(getattr(comp, "threshold_tokens", 0) or 0) if comp else 0
+    last_prompt_tokens = int(getattr(comp, "last_prompt_tokens", 0) or 0) if comp else 0
+
+    return {
+        "model": getattr(agent, "model", "") or "",
+        "provider": getattr(agent, "provider", "") or "",
+        "context_length": context_length,
+        "threshold_tokens": threshold_tokens,
+        "compression_count": int(getattr(comp, "compression_count", 0) or 0) if comp else 0,
+        "last_prompt_tokens": last_prompt_tokens,
+        "estimated_total": total,
+        "components": {
+            "system_prompt": system_total,
+            "tools_schema": tools_total,
+            "messages": message_info["total"],
+        },
+        "system_parts": system_parts,
+        "message_info": message_info,
+        "tools": {
+            "count": len(tools),
+            "top": tool_entries[:8],
+        },
+        "skills_index": skills_index,
+    }
+
+
+def format_context_report(report: Dict[str, Any]) -> str:
+    total = int(report.get("estimated_total") or 0)
+    context_length = int(report.get("context_length") or 0)
+    window_pct = _pct(total, context_length)
+    lines: list[str] = []
+
+    model = report.get("model") or "unknown"
+    provider = report.get("provider") or ""
+    title_model = f"{provider}:{model}" if provider and provider not in str(model) else str(model)
+    lines.append("Context composition")
+    lines.append(f"Model: {title_model}")
+    if context_length:
+        lines.append(f"Estimated next prompt: {_fmt_tokens(total)} / {_fmt_tokens(context_length)} tokens ({window_pct:.1f}% of window)")
+    else:
+        lines.append(f"Estimated next prompt: {_fmt_tokens(total)} tokens")
+
+    threshold = int(report.get("threshold_tokens") or 0)
+    if threshold:
+        lines.append(f"Compression threshold: {_fmt_tokens(threshold)} tokens")
+    last_prompt = int(report.get("last_prompt_tokens") or 0)
+    if last_prompt and abs(last_prompt - total) > max(1024, int(total * 0.05)):
+        lines.append(f"Last provider-reported prompt: {_fmt_tokens(last_prompt)} tokens")
+    lines.append(f"Compressions: {int(report.get('compression_count') or 0)}")
+    lines.append("")
+
+    components = report.get("components") or {}
+    lines.append("Top-level buckets")
+    lines.append(_format_row("System prompt", int(components.get("system_prompt") or 0), total))
+    lines.append(_format_row("Tools schema", int(components.get("tools_schema") or 0), total, f"({(report.get('tools') or {}).get('count', 0)} tools)"))
+    lines.append(_format_row("Messages", int(components.get("messages") or 0), total))
+
+    system_parts = report.get("system_parts") or {}
+    if any(system_parts.values()):
+        lines.append("")
+        lines.append("System prompt tiers")
+        for label, key in (("Stable", "stable"), ("Context files", "context"), ("Volatile", "volatile")):
+            value = int(system_parts.get(key) or 0)
+            if value:
+                lines.append(_format_row(label, value, total))
+
+    message_info = report.get("message_info") or {}
+    role_totals = message_info.get("role_totals") or {}
+    role_counts = message_info.get("role_counts") or {}
+    if role_totals:
+        lines.append("")
+        lines.append("Messages by role")
+        for role, tokens in sorted(role_totals.items(), key=lambda item: item[1], reverse=True):
+            lines.append(_format_row(f"{role} ({role_counts.get(role, 0)})", int(tokens), total))
+
+    tools = report.get("tools") or {}
+    if tools.get("top"):
+        lines.append("")
+        lines.append("Largest tool schemas")
+        for item in tools["top"]:
+            lines.append(_format_row(str(item["name"])[:22], int(item["tokens"]), total))
+
+    if message_info.get("top_tool_results"):
+        lines.append("")
+        lines.append("Largest tool results in messages")
+        for item in message_info["top_tool_results"]:
+            note = f"(message #{item['index']})"
+            lines.append(_format_row(str(item["tool"])[:22], int(item["tokens"]), total, note))
+
+    skills_index = report.get("skills_index") or {}
+    loaded_skills = message_info.get("loaded_skills") or []
+    if int(skills_index.get("tokens") or 0) or loaded_skills:
+        lines.append("")
+        lines.append("Skill-related context")
+        if int(skills_index.get("tokens") or 0):
+            lines.append(_format_row("Skills index", int(skills_index["tokens"]), total))
+        for item in loaded_skills:
+            note = f"(loaded, message #{item['index']})"
+            lines.append(_format_row(str(item["name"])[:22], int(item["tokens"]), total, note))
+        if skills_index.get("entries"):
+            lines.append("  Largest skill index entries:")
+            for item in skills_index["entries"][:5]:
+                lines.append(f"    - {item['name']}: ~{_fmt_tokens(int(item['tokens']))} tok")
+
+    return "\n".join(lines)

--- a/agent/context_report.py
+++ b/agent/context_report.py
@@ -40,6 +40,12 @@ def _format_row(label: str, tokens: int, total: int, note: str = "") -> str:
     return f"  {label:<22} {_fmt_tokens(tokens):>10} tok  {_bar(percent)} {percent:5.1f}%{suffix}"
 
 
+def _format_compact_row(label: str, tokens: int, denominator: int, note: str = "") -> str:
+    percent = _pct(tokens, denominator)
+    suffix = f", {note}" if note else ""
+    return f"{label}: {_fmt_tokens(tokens)} tok ({percent:.1f}%{suffix})"
+
+
 def _tool_function_name(tool: Any) -> str:
     if not isinstance(tool, dict):
         return "tool"
@@ -234,7 +240,112 @@ def build_context_report(
     }
 
 
-def format_context_report(report: Dict[str, Any]) -> str:
+def format_context_report_compact(report: Dict[str, Any]) -> str:
+    """Return a Telegram-friendly context report without alignment bars."""
+    total = int(report.get("estimated_total") or 0)
+    context_length = int(report.get("context_length") or 0)
+    denominator = context_length or total
+    window_pct = _pct(total, context_length)
+    lines: list[str] = []
+
+    model = report.get("model") or "unknown"
+    provider = report.get("provider") or ""
+    title_model = f"{provider}:{model}" if provider and provider not in str(model) else str(model)
+
+    lines.append("🧠 Context Window")
+    lines.append(f"Model: {title_model}")
+    if context_length:
+        lines.append(f"Estimate: {_fmt_tokens(total)} / {_fmt_tokens(context_length)} tok ({window_pct:.1f}%)")
+    else:
+        lines.append(f"Estimate: {_fmt_tokens(total)} tok")
+
+    threshold = int(report.get("threshold_tokens") or 0)
+    if threshold:
+        lines.append(f"Compression threshold: {_fmt_tokens(threshold)} tok")
+    last_prompt = int(report.get("last_prompt_tokens") or 0)
+    if last_prompt and abs(last_prompt - total) > max(1024, int(total * 0.05)):
+        lines.append(f"Last provider prompt: {_fmt_tokens(last_prompt)} tok")
+    compressions = int(report.get("compression_count") or 0)
+    if compressions:
+        lines.append(f"Compressions: {compressions}")
+
+    components = report.get("components") or {}
+    lines.append("")
+    lines.append("📦 Buckets")
+    lines.append(_format_compact_row("System prompt", int(components.get("system_prompt") or 0), denominator))
+    lines.append(_format_compact_row(
+        "Tools schema",
+        int(components.get("tools_schema") or 0),
+        denominator,
+        f"{(report.get('tools') or {}).get('count', 0)} tools",
+    ))
+    lines.append(_format_compact_row("Messages", int(components.get("messages") or 0), denominator))
+
+    system_parts = report.get("system_parts") or {}
+    if any(system_parts.values()):
+        lines.append("")
+        lines.append("🧩 System prompt")
+        for label, key in (("Stable", "stable"), ("Context files", "context"), ("Volatile", "volatile")):
+            value = int(system_parts.get(key) or 0)
+            if value:
+                lines.append(_format_compact_row(label, value, denominator))
+
+    message_info = report.get("message_info") or {}
+    role_totals = message_info.get("role_totals") or {}
+    role_counts = message_info.get("role_counts") or {}
+    if role_totals:
+        lines.append("")
+        lines.append("💬 Messages")
+        for role, tokens in sorted(role_totals.items(), key=lambda item: item[1], reverse=True):
+            lines.append(_format_compact_row(f"{role} ({role_counts.get(role, 0)})", int(tokens), denominator))
+
+    tools = report.get("tools") or {}
+    if tools.get("top"):
+        lines.append("")
+        lines.append("🛠 Heaviest tool schemas")
+        for item in tools["top"][:5]:
+            lines.append(_format_compact_row(str(item["name"])[:28], int(item["tokens"]), denominator))
+
+    if message_info.get("top_tool_results"):
+        lines.append("")
+        lines.append("📎 Heaviest tool results")
+        for item in message_info["top_tool_results"][:5]:
+            lines.append(_format_compact_row(
+                str(item["tool"])[:28],
+                int(item["tokens"]),
+                denominator,
+                f"msg #{item['index']}",
+            ))
+
+    skills_index = report.get("skills_index") or {}
+    loaded_skills = message_info.get("loaded_skills") or []
+    if int(skills_index.get("tokens") or 0) or loaded_skills:
+        lines.append("")
+        lines.append("🎯 Skills")
+        if int(skills_index.get("tokens") or 0):
+            lines.append(_format_compact_row("Skills index", int(skills_index["tokens"]), denominator))
+        for item in loaded_skills[:5]:
+            lines.append(_format_compact_row(
+                str(item["name"])[:28],
+                int(item["tokens"]),
+                denominator,
+                f"loaded, msg #{item['index']}",
+            ))
+        if skills_index.get("entries"):
+            names = ", ".join(
+                f"{item['name']} ~{_fmt_tokens(int(item['tokens']))} tok"
+                for item in skills_index["entries"][:3]
+            )
+            if names:
+                lines.append(f"Index entries: {names}")
+
+    return "\n".join(lines)
+
+
+def format_context_report(report: Dict[str, Any], *, compact: bool = False) -> str:
+    if compact:
+        return format_context_report_compact(report)
+
     total = int(report.get("estimated_total") or 0)
     context_length = int(report.get("context_length") or 0)
     window_pct = _pct(total, context_length)

--- a/cli.py
+++ b/cli.py
@@ -8567,6 +8567,8 @@ class HermesCLI:
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
+        elif canonical == "context":
+            self._show_context()
         elif canonical == "insights":
             self._show_insights(cmd_original)
         elif canonical == "copy":
@@ -10159,6 +10161,20 @@ class HermesCLI:
             # into stream-retry events, credential rotations, etc.
             # Console quietness is enforced by hermes_logging not
             # installing a console StreamHandler in non-verbose mode.
+
+    def _show_context(self):
+        """Show an estimated breakdown of the current context window."""
+        if not self.agent:
+            print("(._.) No active agent -- send a message first.")
+            return
+
+        from agent.context_report import build_context_report, format_context_report
+
+        try:
+            report = build_context_report(self.agent, self.conversation_history)
+            print(format_context_report(report))
+        except Exception as e:
+            print(f"  Context report failed: {e}")
 
     def _show_insights(self, command: str = "/insights"):
         """Show usage insights and analytics from session history."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7691,6 +7691,9 @@ class GatewayRunner:
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "context":
+            return await self._handle_context_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
@@ -13394,6 +13397,47 @@ class GatewayRunner:
         if account_lines:
             return "\n".join(account_lines)
         return t("gateway.usage.no_data")
+
+    async def _handle_context_command(self, event: MessageEvent) -> str:
+        """Handle /context -- show what occupies the current prompt window."""
+        source = event.source
+        session_key = self._session_key_for_source(source)
+
+        agent = self._running_agents.get(session_key)
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            _cache = getattr(self, "_agent_cache", None)
+            if _cache_lock and _cache is not None:
+                with _cache_lock:
+                    cached = _cache.get(session_key)
+                    if cached:
+                        agent = cached[0]
+
+        session_entry = self.session_store.get_or_create_session(source)
+        history = self.session_store.load_transcript(session_entry.session_id)
+        messages = list(getattr(agent, "_session_messages", None) or history or [])
+        if not agent:
+            if history:
+                from agent.model_metadata import estimate_messages_tokens_rough
+
+                msgs = [m for m in history if m.get("role") in {"user", "assistant", "tool", "system"}]
+                approx = estimate_messages_tokens_rough(msgs)
+                return (
+                    "Context composition\n"
+                    f"Estimated messages: {approx:,} tokens\n"
+                    f"Messages: {len(msgs)}\n"
+                    "Detailed system/tool breakdown is available after the first agent turn."
+                )
+            return "No context data yet -- send a message first."
+
+        try:
+            from agent.context_report import build_context_report, format_context_report
+
+            report = build_context_report(agent, messages)
+            return format_context_report(report)
+        except Exception as e:
+            logger.warning("Context command failed: %s", e)
+            return f"Context report failed: {e}"
 
     async def _handle_insights_command(self, event: MessageEvent) -> str:
         """Handle /insights command -- show usage insights and analytics."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13423,8 +13423,8 @@ class GatewayRunner:
                 msgs = [m for m in history if m.get("role") in {"user", "assistant", "tool", "system"}]
                 approx = estimate_messages_tokens_rough(msgs)
                 return (
-                    "Context composition\n"
-                    f"Estimated messages: {approx:,} tokens\n"
+                    "🧠 Context Window\n"
+                    f"Estimated messages: {approx:,} tok\n"
                     f"Messages: {len(msgs)}\n"
                     "Detailed system/tool breakdown is available after the first agent turn."
                 )
@@ -13434,7 +13434,7 @@ class GatewayRunner:
             from agent.context_report import build_context_report, format_context_report
 
             report = build_context_report(agent, messages)
-            return format_context_report(report)
+            return format_context_report(report, compact=True)
         except Exception as e:
             logger.warning("Context command failed: %s", e)
             return f"Context report failed: {e}"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -202,6 +202,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("context", "Show what is occupying the current context window", "Info"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",

--- a/tests/agent/test_context_report.py
+++ b/tests/agent/test_context_report.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+from agent.context_report import build_context_report, format_context_report
+
+
+def test_context_report_breaks_down_prompt_tools_messages_and_skills():
+    messages = [
+        {"role": "user", "content": "please inspect the repo"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_skill",
+                    "function": {
+                        "name": "skill_view",
+                        "arguments": '{"name": "hermes-agent"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_skill",
+            "content": '{"success": true, "name": "hermes-agent", "content": "'
+            + ("skill guidance " * 200)
+            + '"}',
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_terminal",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": '{"command": "rg context"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_terminal",
+            "content": "terminal output\n" + ("line\n" * 500),
+        },
+    ]
+    system_parts = {
+        "stable": (
+            "base guidance\n"
+            "<available_skills>\n"
+            "  dev:\n"
+            "    - hermes-agent: Hermes Agent operations and config\n"
+            "    - tiny: Small helper\n"
+            "</available_skills>"
+        ),
+        "context": "AGENTS.md instructions",
+        "volatile": "Conversation started: Tuesday, May 26, 2026",
+    }
+    agent = SimpleNamespace(
+        model="gpt-5.5",
+        provider="openai-codex",
+        tools=[
+            {"type": "function", "function": {"name": "terminal", "description": "x" * 800}},
+            {"type": "function", "function": {"name": "skill_view", "description": "x" * 200}},
+        ],
+        context_compressor=SimpleNamespace(
+            context_length=272_000,
+            threshold_tokens=217_600,
+            compression_count=1,
+            last_prompt_tokens=68_529,
+        ),
+        _cached_system_prompt="\n\n".join(system_parts.values()),
+        _session_messages=messages,
+        _build_system_prompt_parts=lambda _system_message=None: system_parts,
+    )
+
+    report = build_context_report(agent, messages)
+    rendered = format_context_report(report)
+
+    assert report["components"]["system_prompt"] > 0
+    assert report["components"]["tools_schema"] > 0
+    assert report["components"]["messages"] > 0
+    assert report["message_info"]["loaded_skills"][0]["name"] == "hermes-agent"
+    top_tools = {item["tool"] for item in report["message_info"]["top_tool_results"]}
+    assert {"skill_view", "terminal"} <= top_tools
+    assert report["skills_index"]["tokens"] > 0
+
+    assert "Context composition" in rendered
+    assert "Top-level buckets" in rendered
+    assert "Largest tool schemas" in rendered
+    assert "Largest tool results in messages" in rendered
+    assert "Skill-related context" in rendered
+    assert "hermes-agent" in rendered

--- a/tests/agent/test_context_report.py
+++ b/tests/agent/test_context_report.py
@@ -92,3 +92,12 @@ def test_context_report_breaks_down_prompt_tools_messages_and_skills():
     assert "Largest tool results in messages" in rendered
     assert "Skill-related context" in rendered
     assert "hermes-agent" in rendered
+
+    compact = format_context_report(report, compact=True)
+    assert "🧠 Context Window" in compact
+    assert "📦 Buckets" in compact
+    assert "System prompt:" in compact
+    assert "tok (" in compact
+    assert "[#" not in compact
+    assert "🎯 Skills" in compact
+    assert "hermes-agent" in compact

--- a/tests/gateway/test_context_command.py
+++ b/tests/gateway/test_context_command.py
@@ -72,12 +72,14 @@ class TestContextCommand:
         runner = _make_runner(SK, cached_agent=_make_agent())
         result = await runner._handle_context_command(SimpleNamespace(source="src"))
 
-        assert "Context composition" in result
+        assert "🧠 Context Window" in result
         assert "Model: openai-codex:gpt-5.5" in result
-        assert "Top-level buckets" in result
+        assert "📦 Buckets" in result
         assert "System prompt" in result
         assert "Tools schema" in result
-        assert "Largest tool results in messages" in result
+        assert "📎 Heaviest tool results" in result
+        assert "tok (" in result
+        assert "[#" not in result
         assert "terminal" in result
 
     @pytest.mark.asyncio
@@ -85,6 +87,6 @@ class TestContextCommand:
         runner = _make_runner(SK, history=[{"role": "user", "content": "hello"}])
         result = await runner._handle_context_command(SimpleNamespace(source="src"))
 
-        assert "Context composition" in result
+        assert "🧠 Context Window" in result
         assert "Estimated messages:" in result
         assert "Detailed system/tool breakdown is available after the first agent turn." in result

--- a/tests/gateway/test_context_command.py
+++ b/tests/gateway/test_context_command.py
@@ -1,0 +1,90 @@
+"""Tests for gateway /context command composition reporting."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+SK = "agent:main:telegram:private:12345"
+
+
+def _make_runner(session_key, agent=None, cached_agent=None, history=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SimpleNamespace(session_id="sid")
+    runner.session_store.load_transcript.return_value = history or []
+    runner._session_key_for_source = MagicMock(return_value=session_key)
+
+    if agent is not None:
+        runner._running_agents[session_key] = agent
+    if cached_agent is not None:
+        runner._agent_cache[session_key] = (cached_agent, "sig")
+
+    return runner
+
+
+def _make_agent():
+    system_parts = {
+        "stable": "base guidance",
+        "context": "AGENTS.md instructions",
+        "volatile": "Conversation started: Tuesday, May 26, 2026",
+    }
+    messages = [
+        {"role": "user", "content": "inspect context"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_terminal",
+                    "function": {"name": "terminal", "arguments": '{"command": "pwd"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_terminal", "content": "/tmp/project\n"},
+    ]
+    return SimpleNamespace(
+        model="gpt-5.5",
+        provider="openai-codex",
+        tools=[{"type": "function", "function": {"name": "terminal", "description": "run commands"}}],
+        context_compressor=SimpleNamespace(
+            context_length=272_000,
+            threshold_tokens=217_600,
+            compression_count=0,
+            last_prompt_tokens=0,
+        ),
+        _cached_system_prompt="\n\n".join(system_parts.values()),
+        _session_messages=messages,
+        _build_system_prompt_parts=lambda _system_message=None: system_parts,
+    )
+
+
+class TestContextCommand:
+    @pytest.mark.asyncio
+    async def test_cached_agent_shows_context_report(self):
+        runner = _make_runner(SK, cached_agent=_make_agent())
+        result = await runner._handle_context_command(SimpleNamespace(source="src"))
+
+        assert "Context composition" in result
+        assert "Model: openai-codex:gpt-5.5" in result
+        assert "Top-level buckets" in result
+        assert "System prompt" in result
+        assert "Tools schema" in result
+        assert "Largest tool results in messages" in result
+        assert "terminal" in result
+
+    @pytest.mark.asyncio
+    async def test_history_without_agent_returns_basic_estimate(self):
+        runner = _make_runner(SK, history=[{"role": "user", "content": "hello"}])
+        result = await runner._handle_context_command(SimpleNamespace(source="src"))
+
+        assert "Context composition" in result
+        assert "Estimated messages:" in result
+        assert "Detailed system/tool breakdown is available after the first agent turn." in result

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -98,6 +98,7 @@ class TestResolveCommand:
         assert resolve_command("background").name == "background"
         assert resolve_command("copy").name == "copy"
         assert resolve_command("agents").name == "agents"
+        assert resolve_command("context").name == "context"
 
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2742,6 +2742,40 @@ def _(rid, params: dict) -> dict:
     )
 
 
+@method("session.context")
+def _(rid, params: dict) -> dict:
+    session, err = _sess_nowait(params, rid)
+    if err:
+        return err
+    agent = session.get("agent")
+    if agent is None:
+        history = list(session.get("history", []))
+        try:
+            from agent.model_metadata import estimate_messages_tokens_rough
+
+            return _ok(
+                rid,
+                {
+                    "output": (
+                        "Context composition\n"
+                        f"Estimated messages: {estimate_messages_tokens_rough(history):,} tokens\n"
+                        f"Messages: {len(history)}\n"
+                        "Detailed system/tool breakdown is available after the first agent turn."
+                    )
+                },
+            )
+        except Exception:
+            return _ok(rid, {"output": "No context data yet -- send a message first."})
+    try:
+        from agent.context_report import build_context_report, format_context_report
+
+        messages = list(session.get("history", []) or getattr(agent, "_session_messages", None) or [])
+        report = build_context_report(agent, messages)
+        return _ok(rid, {"output": format_context_report(report)})
+    except Exception as e:
+        return _err(rid, 5025, f"Context report failed: {e}")
+
+
 @method("session.status")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -7,6 +7,7 @@ import type {
   ImageAttachResponse,
   SessionBranchResponse,
   SessionCompressResponse,
+  SessionContextResponse,
   SessionUsageResponse,
   VoiceToggleResponse
 } from '../../../gatewayTypes.js'
@@ -549,6 +550,19 @@ export const sessionCommands: SlashCommand[] = [
 
         ctx.transcript.panel('Usage', sections)
       })
+    }
+  },
+
+  {
+    help: 'show current context-window composition',
+    name: 'context',
+    run: (_arg, ctx) => {
+      ctx.gateway.rpc<SessionContextResponse>('session.context', { session_id: ctx.sid }).then(r => {
+        if (ctx.stale()) {
+          return
+        }
+        ctx.transcript.sys(r.output || 'no context data yet')
+      }).catch(ctx.guardedErr)
     }
   }
 ]

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -213,6 +213,10 @@ export interface SessionUsageResponse {
   total?: number
 }
 
+export interface SessionContextResponse {
+  output?: string
+}
+
 export interface SessionStatusResponse {
   output?: string
 }

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -102,6 +102,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 |---------|-------------|
 | `/help` | Show this help message |
 | `/usage` | Show token usage, cost breakdown, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits / plan usage pulled live from the provider's API. |
+| `/context` | Show what is occupying the current context window: system prompt, tools schema, messages by role, largest tool results, and skill-related context. |
 | `/insights` | Show usage insights and analytics (last 30 days) |
 | `/platforms` (alias: `/gateway`) | Show gateway/messaging platform status (CLI-only summary view). |
 | `/platform <list\|pause\|resume> [name]` | Operate a running gateway platform. `/platform list` lists every adapter and its state (running, paused-by-breaker, manually-paused); `/platform pause <name>` stops dispatching new messages to that adapter without unloading it; `/platform resume <name>` re-enables it. The gateway also auto-pauses an adapter when its circuit breaker trips on repeated retryable failures (network / rate-limit / 5xx) — use `/platform resume <name>` to clear the breaker once the upstream is healthy. Available wherever the gateway is reachable (CLI session, Telegram, Discord, …). |
@@ -211,6 +212,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/title [name]` | Set or show the session title. |
 | `/resume [name]` | Resume a previously named session. |
 | `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |
+| `/context` | Show what is occupying the current context window: system prompt, tools schema, messages by role, largest tool results, and skill-related context. |
 | `/insights [days]` | Show usage analytics. |
 | `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display. |
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -88,7 +88,7 @@ The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 5
 | Orange | 80–95% | Approaching limit |
 | Red | ≥ 95% | Near overflow — consider `/compress` |
 
-Use `/usage` for a detailed breakdown including per-category costs (input vs output tokens).
+Use `/usage` for a detailed breakdown including per-category costs (input vs output tokens). Use `/context` to inspect what is occupying the current context window, including system prompt, tools, messages, tool results, and skill-related context.
 
 ### Session Resume Display
 
@@ -132,6 +132,7 @@ Common examples:
 | `/voice tts` | Toggle spoken playback for Hermes replies |
 | `/reasoning high` | Increase reasoning effort |
 | `/title My Session` | Name the current session |
+| `/context` | Show what is occupying the current context window |
 | `/status` | Show session info — model/profile/tokens/duration — followed by a local **Session recap** block (recent turn counts, top tools used, files touched, latest user prompt + assistant reply). Pure local compute; no LLM call. |
 | `/sessions` | Open an interactive session picker right inside the classic CLI (same surface the TUI uses). Type to filter, arrow keys to navigate, Enter to resume. |
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -148,6 +148,7 @@ hermes gateway status --system         # Linux only: inspect the system service 
 | `/title [name]` | Set or show the session title |
 | `/resume [name]` | Resume a previously named session |
 | `/usage` | Show token usage for this session |
+| `/context` | Show what is occupying the current context window |
 | `/insights [days]` | Show usage insights and analytics |
 | `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display |
 | `/voice [on\|off\|tts\|join\|leave\|status]` | Control messaging voice replies and Discord voice-channel behavior |

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -104,6 +104,7 @@ All slash commands work unchanged. A few are TUI-owned — they produce richer o
 | `/skin` | Live preview — theme change applies as you browse |
 | `/details` | Toggle verbose tool-call details (global or per-section) |
 | `/usage` | Rich token / cost / context panel |
+| `/context` | Inline context-window composition report |
 | `/agents` (alias `/tasks`) | Observability overlay — live subagent tree with kill/pause controls, per-branch cost / token / file rollups, turn-by-turn history |
 | `/reload` | Re-reads `~/.hermes/.env` into the running TUI process so newly added API keys take effect without a restart |
 | `/mouse [on\|off\|toggle\|wheel\|buttons\|all]` | Pick a mouse tracking preset at runtime (also persists to `display.mouse_tracking` in `config.yaml`). `wheel` (1000+1006) keeps scroll-wheel scrolling without the hover events that make tmux spam "No image in clipboard" over the prompt row; `buttons` adds drag-to-select; `all` is the default with hover-driven UI. |


### PR DESCRIPTION
## What does this PR do?

Adds a `/context` slash command that explains what is occupying the current prompt window instead of only showing the aggregate count available from `/usage`.

The report is computed locally from the active/cached agent state and includes system prompt, tools schema, messages by role, largest tool results, and skill-related context. CLI/TUI get a detailed report; messaging gateways get a compact Telegram-friendly report without ASCII progress bars, using `N tok (P%)` rows that fit narrow chat bubbles better.

This is useful when a session is getting large and users need to decide whether to compress, prune tool-heavy history, reduce skills/context files, or disable tools.

## Related Issue

Fixes #4253

Related: #10617, #7607

This PR is intentionally narrower than the broader telemetry/usage discussions: it adds the user-facing `/context` inspection command with focused tests and docs, without changing provider accounting or `/usage` semantics.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `agent/context_report.py` to build and format context-window composition reports.
- Added CLI `/context` handling in `cli.py`.
- Added gateway `/context` handling in `gateway/run.py`, including cached-agent lookup between turns and history fallback before an agent exists.
- Added TUI `session.context` RPC and slash command wiring.
- Registered `/context` in the central slash command registry.
- Updated README and user/reference docs for CLI, TUI, and messaging surfaces.
- Added tests for the report builder, gateway command behavior, and command registry resolution.

## How to Test

1. Run the focused Python tests:

   ```bash
   /usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts='' \
     tests/agent/test_context_report.py \
     tests/gateway/test_context_command.py \
     tests/hermes_cli/test_commands.py \
     tests/gateway/test_command_bypass_active_session.py
   ```

   Result: `187 passed, 1 warning`.

2. Run syntax checks:

   ```bash
   /usr/local/lib/hermes-agent/venv/bin/python -m py_compile \
     agent/context_report.py cli.py gateway/run.py tui_gateway/server.py
   git diff --check
   ```

   Result: passed.

3. Manual Telegram smoke test: send `/context` in an active Telegram session and verify the compact report renders as short `tok (%)` rows without progress bars.

4. Attempted TUI JS test:

   ```bash
   npm --prefix ui-tui test -- --run src/__tests__/createSlashHandler.test.ts
   ```

   This environment does not currently have `vitest` installed, so the command exits with `sh: 1: vitest: not found`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Telegram compact `/context` output:

![Telegram /context screenshot](https://gist.githubusercontent.com/Qwinty/0515124834b09a5d86f8b72b8fb7bc46/raw/d73313dc7eef5e04e21dddf56a65710dce088ce1/context_screenshot.png)
