### PR TITLE
feat(decay): proactive skill content decay in conversation context

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -148,6 +148,7 @@ def init_agent(
     args: list[str] | None = None,
     model: str = "",
     max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+    skill_decay_distance: int = 6,  # Decay <hermes-skill> loads older than N msgs from tail (0 disables)
     tool_delay: float = 1.0,
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
@@ -255,6 +256,10 @@ def init_agent(
 
     agent.model = model
     agent.max_iterations = max_iterations
+    # Skill-decay threshold: <hermes-skill> loads more than N messages from
+    # the tail are replaced with a reload-hint placeholder at request-build
+    # time. 0 (or negative) disables decay entirely.
+    agent.skill_decay_distance = skill_decay_distance
     # Shared iteration budget — parent creates, children inherit.
     # Consumed by every LLM turn across parent + all subagents.
     agent.iteration_budget = iteration_budget or IterationBudget(max_iterations)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -817,8 +817,24 @@ def run_conversation(
             )
 
         api_messages = []
+        _total_msgs = len(messages)
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
+
+            # Proactive skill decay — shrink old <hermes-skill> loads that are
+            # far from the tail so stale skill payloads don't bloat the request.
+            # Applied to the ephemeral api_msg copy ONLY: the persistent
+            # `messages` list (and therefore the session transcript) is never
+            # mutated, and — because a message past the decay threshold renders
+            # identically every turn — the cached request prefix stays stable
+            # across turns (a block decays once, then holds).
+            if api_msg.get("role") == "tool":
+                _decayed = agent._decay_skill_content(
+                    api_msg.get("content"),
+                    distance=_total_msgs - idx - 1,
+                )
+                if _decayed is not None:
+                    api_msg["content"] = _decayed
 
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks

--- a/run_agent.py
+++ b/run_agent.py
@@ -359,6 +359,7 @@ class AIAgent:
         args: list[str] | None = None,
         model: str = "",
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+        skill_decay_distance: int = 6,  # Decay <hermes-skill> loads older than N msgs from tail (0 disables)
         tool_delay: float = 1.0,
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,
@@ -428,6 +429,7 @@ class AIAgent:
             args=args,
             model=model,
             max_iterations=max_iterations,
+            skill_decay_distance=skill_decay_distance,
             tool_delay=tool_delay,
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
@@ -4150,6 +4152,41 @@ class AIAgent:
         """Forwarder — see ``agent.chat_completion_helpers.handle_max_iterations``."""
         from agent.chat_completion_helpers import handle_max_iterations
         return handle_max_iterations(self, messages, api_call_count)
+
+    _SKILL_BLOCK_PATTERN = re.compile(
+        r'<hermes-skill name="([^"]+)">.*?</hermes-skill>', re.DOTALL
+    )
+
+    def _decay_skill_content(self, content: Any, *, distance: int) -> Optional[str]:
+        """Return a decayed copy of ``content`` when it holds a stale skill load.
+
+        A ``<hermes-skill name="X">…</hermes-skill>`` block whose message sits
+        more than ``self.skill_decay_distance`` messages from the tail is
+        replaced with a short placeholder pointing the model back at
+        ``skill_view("X")``.  Text outside the block (e.g. steer injections
+        appended after the closing tag) is preserved.
+
+        Returns ``None`` when nothing should change (wrong type, no skill
+        block, or the message is still recent). Callers apply the result to
+        an ephemeral per-request message copy — never to the persistent
+        history — so the stored transcript is untouched and, because a decayed
+        message renders identically on every subsequent turn, the request
+        prefix cache stays stable.
+        """
+        if not isinstance(content, str):
+            return None
+        # A threshold of 0 (or negative) disables decay entirely.
+        if self.skill_decay_distance <= 0 or distance <= self.skill_decay_distance:
+            return None
+        match = self._SKILL_BLOCK_PATTERN.search(content)
+        if not match:
+            return None
+        skill_name = match.group(1)
+        placeholder = (
+            f'[Skill "{skill_name}" content decayed after {distance} messages. '
+            f'Reload with skill_view("{skill_name}").]'
+        )
+        return self._SKILL_BLOCK_PATTERN.sub(placeholder, content)
 
     def run_conversation(
         self,

--- a/tests/run_agent/test_skill_decay.py
+++ b/tests/run_agent/test_skill_decay.py
@@ -1,0 +1,95 @@
+"""Tests for proactive skill-content decay (_decay_skill_content).
+
+Covers the cache-stability and transcript-safety guarantees the design
+depends on: decay operates on an ephemeral per-request content copy and
+never touches the persistent history, and a decayed message renders
+identically on every subsequent turn.
+"""
+
+from run_agent import AIAgent
+
+
+def _agent(distance: int = 6) -> AIAgent:
+    """Bare AIAgent with only the decay knob installed (matches the
+    object.__new__ stub pattern used across the run_agent test suite)."""
+    agent = object.__new__(AIAgent)
+    agent.skill_decay_distance = distance
+    return agent
+
+
+SKILL_BLOCK = '<hermes-skill name="brainstorm">\nlots of skill body text here\n</hermes-skill>'
+
+
+def test_decays_block_past_threshold():
+    agent = _agent(distance=6)
+    out = agent._decay_skill_content(SKILL_BLOCK, distance=10)
+    assert out is not None
+    assert "<hermes-skill" not in out
+    assert 'skill_view("brainstorm")' in out
+    assert "decayed after 10 messages" in out
+
+
+def test_keeps_recent_block_within_threshold():
+    agent = _agent(distance=6)
+    # distance == threshold is still "recent" (only strictly greater decays).
+    assert agent._decay_skill_content(SKILL_BLOCK, distance=6) is None
+    assert agent._decay_skill_content(SKILL_BLOCK, distance=1) is None
+
+
+def test_no_skill_block_returns_none():
+    agent = _agent(distance=6)
+    assert agent._decay_skill_content("just a normal tool result", distance=99) is None
+
+
+def test_non_string_content_returns_none():
+    agent = _agent(distance=6)
+    assert agent._decay_skill_content([{"type": "text", "text": "x"}], distance=99) is None
+    assert agent._decay_skill_content(None, distance=99) is None
+
+
+def test_zero_distance_disables_decay():
+    agent = _agent(distance=0)
+    assert agent._decay_skill_content(SKILL_BLOCK, distance=1000) is None
+    agent_neg = _agent(distance=-1)
+    assert agent_neg._decay_skill_content(SKILL_BLOCK, distance=1000) is None
+
+
+def test_preserves_trailing_steer_text():
+    """Text appended after </hermes-skill> (e.g. a steer injection) must
+    survive decay so mid-run steering is not silently dropped."""
+    agent = _agent(distance=6)
+    content = SKILL_BLOCK + "\n\n[STEER] focus on the auth bug"
+    out = agent._decay_skill_content(content, distance=20)
+    assert out is not None
+    assert "[STEER] focus on the auth bug" in out
+    assert "<hermes-skill" not in out
+
+
+def test_decay_is_idempotent_and_stable_across_turns():
+    """Cache-stability guarantee: once decayed, the same message decays to
+    byte-identical output every turn, so the cached request prefix holds."""
+    agent = _agent(distance=6)
+    first = agent._decay_skill_content(SKILL_BLOCK, distance=10)
+    # Re-running on the already-decayed content is a no-op (no skill block
+    # left to match) — the ephemeral copy is regenerated from the pristine
+    # persistent message each turn, and produces the same bytes.
+    again = agent._decay_skill_content(SKILL_BLOCK, distance=10)
+    assert first == again
+    assert agent._decay_skill_content(first, distance=10) is None
+
+
+def test_persistent_message_not_mutated_by_caller_pattern():
+    """The decay helper is pure: it returns a new string and never edits
+    its input, so applying it to an ephemeral api_msg copy cannot corrupt
+    the persistent transcript."""
+    agent = _agent(distance=6)
+    original = {"role": "tool", "content": SKILL_BLOCK}
+    api_copy = original.copy()
+    decayed = agent._decay_skill_content(api_copy.get("content"), distance=10)
+    if decayed is not None:
+        api_copy["content"] = decayed
+    # Persistent message still holds the full skill payload.
+    assert original["content"] == SKILL_BLOCK
+    assert "<hermes-skill" in original["content"]
+    # Ephemeral copy is decayed.
+    assert "<hermes-skill" not in api_copy["content"]

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1379,6 +1379,15 @@ def skill_view(
                     "Could not preprocess skill content for %s", skill_name, exc_info=True
                 )
 
+        # Wrap skill content with a marker so run_agent.py can proactively
+        # decay old skill loads from conversation context.
+        if rendered_content and isinstance(rendered_content, str):
+            rendered_content = (
+                f'<hermes-skill name="{skill_name}">\n'
+                f"{rendered_content}\n"
+                f"</hermes-skill>"
+            )
+
         result = {
             "success": True,
             "name": skill_name,


### PR DESCRIPTION
## Summary

Adds a lightweight `skill_decay_distance` mechanism (default: 6 messages) that proactively replaces old `<hermes-skill>` blocks in tool messages with short placeholders, preventing skill payloads from bloating the context window over long sessions.

## Problem

When the agent loads skills via `skill_view()`, the full content (often 2-5k tokens) stays in conversation history forever. Over a 20+ turn session, this wastes significant context budget on content the model no longer needs.

## Solution

Three surgical changes:

### 1. Wrap skill output (`tools/skills_tool.py`)
`skill_view()` now wraps its output in `<hermes-skill name="...">...</hermes-skill>` tags so the decay mechanism can identify them.

### 2. Decay method (`run_agent.py`)
New `_decay_loaded_skills()` on `AIAgent` — walks tool messages, finds old skill blocks (distance > `skill_decay_distance` from end), replaces with:
```
[Skill "skill-name" content decayed after 7 messages. Reload with skill_view("skill-name").]
```
Preserves any steer injections appended after `</hermes-skill>`.

### 3. Hook into the loop (`agent/conversation_loop.py`)
Calls `agent._decay_loaded_skills(messages)` before each API request, right after steer processing.

## Design choices
- **Distance-based, not time-based** — simpler, no timestamps, works across session gaps
- **Configurable** via `self.skill_decay_distance` (default 6, override in agent init)
- **Non-destructive** — original content stays in SQLite session store for `session_search`
- **Opt-in tag wrapping** — only `skill_view` output gets tagged; other tool outputs unaffected