### PR TITLE
feat(gateway): disclose implicit paid-cloud credentials at startup (#32524)

### DIFF
--- a/gateway/credential_disclosure.py
+++ b/gateway/credential_disclosure.py
@@ -1,0 +1,417 @@
+"""Gateway startup disclosure for implicit paid-cloud credentials.
+
+Motivation — issue #32524
+-------------------------
+
+A user reported that ``hermes gateway run`` silently adopted
+``ANTHROPIC_API_KEY`` from their shell environment and billed roughly
+**$80** of Claude usage against their account before they noticed.
+There was no startup line announcing which provider had been chosen,
+no warning that the active credential came from an environment
+variable (rather than from a deliberate ``hermes auth add`` step or
+an explicit ``providers:`` config entry), and no indication that the
+target was a paid cloud API.
+
+This module fills the disclosure gap: every gateway startup runs the
+resolved runtime credentials through :func:`classify_runtime_credential`
+and emits a single, prominent banner via :func:`build_disclosure_lines`.
+The banner always names the active provider + model + credential
+source.  When the active provider is a paid cloud API **and** its
+credential came implicitly from an environment variable (no auth
+store entry, no explicit config wiring), the banner upgrades to a
+``WARNING``-level multi-line block so operators can't miss it scrolling
+past in ``gateway.log``.
+
+The module is intentionally pure-Python and side-effect free — the
+gateway is responsible for actually emitting the lines through its
+logger.  This keeps the helper trivially unit-testable and lets
+non-gateway callers (a future ``hermes status`` enhancement, the
+dashboard, etc.) reuse the same classification without taking on a
+``gateway.run`` import.
+
+What counts as "implicit env"?
+------------------------------
+
+Heuristic (kept deliberately conservative — false negatives are fine,
+false positives erode trust):
+
+1. ``runtime["source"]`` resolves to a value indicating env-var pickup
+   (``"env"``, ``"environment"``, ``"env-var"``, ``"env_fallback"``).
+2. The :data:`PAID_CLOUD_PROVIDERS` allowlist contains the resolved
+   provider id.
+3. Neither the on-disk auth store nor the user's ``providers:`` /
+   ``custom_providers:`` config sections explicitly mention the
+   provider — this is checked via :func:`_provider_is_explicitly_configured`
+   so any of those three "I meant to use this" signals suppresses the
+   warning to a routine INFO disclosure.
+
+When all three hold, the banner is the WARNING flavour; otherwise it's
+the routine INFO flavour (or suppressed entirely when neither provider
+nor model is known — typically because the gateway is failing closed
+before any credentials resolved).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+
+# ─── Paid cloud allowlist ───────────────────────────────────────────────
+
+
+# Providers whose env-var-only adoption should emit the loud (WARNING)
+# disclosure variant. The criterion is "real money flows the moment we
+# send a request" — local servers (LM Studio, Ollama, llama.cpp), free
+# OAuth subscriptions (xai-oauth Premium+, Claude Code OAuth via
+# ``ANTHROPIC_TOKEN`` — those are subscription-billed, not metered), and
+# Nous Portal (subscription) are intentionally excluded.
+#
+# Aggregators (OpenRouter, Vercel AI Gateway, ai-gateway) are paid: even
+# with prepaid credit, surprise usage drains the wallet. Same for
+# OpenAI/Anthropic raw API keys, Gemini AI Studio, Z.AI/GLM, DeepSeek,
+# xAI direct, Kimi/Moonshot, GMI, NVIDIA, MiniMax, Alibaba Dashscope.
+#
+# Bedrock and Vertex are excluded because their credential chain is
+# governed by the cloud provider's IAM/console (the user did
+# ``aws configure`` / ``gcloud auth``) — discovering AWS keys in a shell
+# env is qualitatively different from discovering a raw ``ANTHROPIC_API_KEY``.
+PAID_CLOUD_PROVIDERS: frozenset[str] = frozenset(
+    {
+        "anthropic",
+        "openai",
+        "openai-api",
+        "openrouter",
+        "gemini",
+        "deepseek",
+        "xai",
+        "zai",
+        "kimi-coding",
+        "kimi-coding-cn",
+        "minimax",
+        "minimax-cn",
+        "alibaba",
+        "alibaba-coding-plan",
+        "stepfun",
+        "arcee",
+        "gmi",
+        "nvidia",
+        "ai-gateway",
+        "groq",
+        "cerebras",
+        "sambanova",
+        "fireworks",
+        "together",
+        "perplexity",
+        "mistral",
+        "cohere",
+        "huggingface",
+    }
+)
+
+
+_ENV_SOURCE_TOKENS: frozenset[str] = frozenset(
+    {"env", "environment", "env-var", "env_var", "env_fallback"}
+)
+
+
+# ─── Public API ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CredentialDisclosure:
+    """Structured view of a resolved runtime credential.
+
+    Returned by :func:`classify_runtime_credential` and consumed by
+    :func:`build_disclosure_lines`.  Frozen so callers can safely cache
+    or compare instances across requests.
+    """
+
+    provider: str
+    model: str
+    base_url: str
+    source: str
+    env_var: Optional[str]
+    is_paid_cloud: bool
+    is_implicit_env: bool
+
+    @property
+    def is_warning_worthy(self) -> bool:
+        return self.is_paid_cloud and self.is_implicit_env
+
+
+def classify_runtime_credential(
+    runtime: Mapping[str, Any],
+    *,
+    model: str = "",
+    auth_store: Optional[Mapping[str, Any]] = None,
+    user_config: Optional[Mapping[str, Any]] = None,
+    env: Optional[Mapping[str, str]] = None,
+) -> CredentialDisclosure:
+    """Classify a resolved runtime dict for startup disclosure.
+
+    ``runtime`` is the shape returned by
+    ``hermes_cli.runtime_provider.resolve_runtime_provider`` (and
+    re-exposed by ``gateway.run._resolve_runtime_agent_kwargs``).  The
+    only fields read are ``provider``, ``base_url``, ``source``, and
+    optionally ``api_key`` (used together with ``env`` to identify the
+    *specific* env var that supplied the key, so the warning can name
+    it back to the user instead of saying "some env var").
+
+    All other arguments are optional injection points for testing:
+
+    * ``auth_store`` — pre-loaded ``hermes_cli.auth._load_auth_store()``
+      dict.  When omitted, the store is loaded lazily so callers don't
+      pay the I/O cost when the classifier short-circuits.
+    * ``user_config`` — pre-loaded ``hermes_cli.config.load_config()``
+      dict.  Same lazy-load semantics.
+    * ``env`` — process environment mapping; defaults to ``os.environ``.
+    """
+    provider = str(runtime.get("provider") or "").strip().lower()
+    source = str(runtime.get("source") or "").strip().lower()
+    base_url = str(runtime.get("base_url") or "").strip()
+    api_key = str(runtime.get("api_key") or "")
+
+    env_map = env if env is not None else os.environ
+
+    is_paid_cloud = provider in PAID_CLOUD_PROVIDERS
+    env_var = _identify_env_var_for_key(provider, api_key, env_map) if api_key else None
+
+    # Only resolve auth_store / config when we actually need them — the
+    # common case (non-paid local provider, or env-only source false) is
+    # decided in two attribute reads.
+    explicit = False
+    if is_paid_cloud and source in _ENV_SOURCE_TOKENS:
+        explicit = _provider_is_explicitly_configured(
+            provider, auth_store=auth_store, user_config=user_config
+        )
+
+    is_implicit_env = (
+        is_paid_cloud
+        and source in _ENV_SOURCE_TOKENS
+        and not explicit
+    )
+
+    return CredentialDisclosure(
+        provider=provider,
+        model=str(model or "").strip(),
+        base_url=base_url,
+        source=source or "(unknown)",
+        env_var=env_var,
+        is_paid_cloud=is_paid_cloud,
+        is_implicit_env=is_implicit_env,
+    )
+
+
+def build_disclosure_lines(info: CredentialDisclosure) -> List[Tuple[int, str]]:
+    """Build the log lines for the gateway startup disclosure banner.
+
+    Returns a list of ``(log_level, message)`` tuples so the caller can
+    forward each line through ``logger.log(level, msg)``.  The first
+    line is always an informational summary (``logging.INFO``); when
+    :attr:`CredentialDisclosure.is_warning_worthy` is True, additional
+    ``logging.WARNING`` lines explain the billing exposure and point at
+    the remediation path (``hermes auth add ...`` or
+    ``hermes auth pool ...``).
+    """
+    if not info.provider:
+        return []
+
+    summary = _format_summary(info)
+    lines: List[Tuple[int, str]] = [(logging.INFO, summary)]
+
+    if not info.is_warning_worthy:
+        return lines
+
+    # The reporter's pain point: no disclosure of the fact that a paid
+    # cloud key was being used, no warning that it came from an env
+    # var rather than a deliberate hermes auth step. Spell every piece
+    # of that out so an operator scanning gateway.log can immediately
+    # confirm the bill is going to land on this provider.
+    env_var_hint = (
+        f"environment variable {info.env_var}"
+        if info.env_var
+        else "an environment variable"
+    )
+    lines.append(
+        (
+            logging.WARNING,
+            (
+                f"⚠ {info.provider}: paid cloud API selected via {env_var_hint}. "
+                "Every gateway message will be billed against this provider."
+            ),
+        )
+    )
+    lines.append(
+        (
+            logging.WARNING,
+            (
+                "  This account was not added via `hermes auth add` and is not "
+                "pinned in config.yaml — Hermes inferred it from the environment."
+            ),
+        )
+    )
+    lines.append(
+        (
+            logging.WARNING,
+            (
+                "  To silence this warning intentionally: run "
+                f"`hermes auth add {info.provider}` (or pin the provider in "
+                "config.yaml `providers:`). To disable disclosure entirely: "
+                "set `gateway.warn_implicit_paid_credentials: false` in "
+                "config.yaml. See issue #32524 for context."
+            ),
+        )
+    )
+    return lines
+
+
+def should_emit_disclosure(cfg: Optional[Mapping[str, Any]]) -> bool:
+    """Return True when the gateway startup banner should be emitted.
+
+    Reads ``gateway.warn_implicit_paid_credentials`` from the merged
+    config.  Defaults to True when the key is missing — disclosure is
+    on by default (the whole point of #32524) and operators must opt
+    out, never opt in.
+    """
+    if not isinstance(cfg, Mapping):
+        return True
+    gw = cfg.get("gateway")
+    if not isinstance(gw, Mapping):
+        return True
+    flag = gw.get("warn_implicit_paid_credentials")
+    if flag is None:
+        return True
+    if isinstance(flag, bool):
+        return flag
+    if isinstance(flag, str):
+        return flag.strip().lower() not in {"0", "false", "no", "off"}
+    return bool(flag)
+
+
+# ─── Internals ──────────────────────────────────────────────────────────
+
+
+def _format_summary(info: CredentialDisclosure) -> str:
+    parts = [f"Gateway active provider: {info.provider}"]
+    if info.model:
+        parts.append(f"model={info.model}")
+    if info.base_url:
+        parts.append(f"base_url={info.base_url}")
+    parts.append(f"credential_source={info.source}")
+    if info.env_var:
+        parts.append(f"env_var={info.env_var}")
+    return " | ".join(parts)
+
+
+def _identify_env_var_for_key(
+    provider: str, api_key: str, env: Mapping[str, str]
+) -> Optional[str]:
+    """Best-effort lookup: which env var supplied this api_key?
+
+    We can't always know — the credential resolver may have munged the
+    raw env value (e.g. trimming whitespace) — but the common case is a
+    verbatim match against one of the provider's known env-var slots.
+    """
+    if not api_key or not provider:
+        return None
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY  # heavy import — keep lazy
+    except Exception:
+        return None
+    pcfg = PROVIDER_REGISTRY.get(provider)
+    candidates: Iterable[str]
+    if pcfg and pcfg.api_key_env_vars:
+        candidates = pcfg.api_key_env_vars
+    else:
+        # Fall back to common conventions when the provider isn't in the
+        # registry (custom user providers, plugin-defined providers).
+        candidates = (
+            f"{provider.upper()}_API_KEY",
+            f"{provider.replace('-', '_').upper()}_API_KEY",
+        )
+    for name in candidates:
+        val = env.get(name)
+        if val and val.strip() == api_key.strip():
+            return name
+    return None
+
+
+def _provider_is_explicitly_configured(
+    provider: str,
+    *,
+    auth_store: Optional[Mapping[str, Any]] = None,
+    user_config: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    """True when the user has signalled deliberate use of ``provider``.
+
+    Three explicit signals suppress the warning:
+
+    1. An entry in ``~/.hermes/auth.json`` ``providers`` map — i.e. the
+       user ran ``hermes auth add <provider>``.
+    2. An entry in the auth store's ``credential_pool`` for the
+       provider — i.e. ``hermes auth pool add <provider> ...``.
+    3. A matching entry in the merged config's ``providers:`` or
+       ``custom_providers:`` sections — i.e. the user hand-edited
+       ``config.yaml`` and named the provider via ``key_env`` or
+       ``base_url``.
+    """
+    provider_norm = (provider or "").strip().lower()
+    if not provider_norm:
+        return False
+
+    if auth_store is None:
+        try:
+            from hermes_cli.auth import _load_auth_store
+
+            auth_store = _load_auth_store()
+        except Exception:
+            auth_store = None
+
+    if isinstance(auth_store, Mapping):
+        providers = auth_store.get("providers")
+        if isinstance(providers, Mapping):
+            for key in providers.keys():
+                if str(key).strip().lower() == provider_norm:
+                    return True
+        pool = auth_store.get("credential_pool")
+        if isinstance(pool, Mapping):
+            for key in pool.keys():
+                if str(key).strip().lower() == provider_norm:
+                    return True
+
+    if user_config is None:
+        try:
+            from hermes_cli.config import load_config
+
+            user_config = load_config()
+        except Exception:
+            user_config = None
+
+    if isinstance(user_config, Mapping):
+        # providers: (keyed dict) — name match counts.
+        providers_cfg = user_config.get("providers")
+        if isinstance(providers_cfg, Mapping):
+            for key in providers_cfg.keys():
+                if str(key).strip().lower() == provider_norm:
+                    return True
+        # custom_providers: (list of dicts) — name match counts.
+        cps = user_config.get("custom_providers")
+        if isinstance(cps, list):
+            for entry in cps:
+                if not isinstance(entry, Mapping):
+                    continue
+                name = str(entry.get("name") or "").strip().lower()
+                if name == provider_norm:
+                    return True
+        # model.provider pinned to this provider counts too — the user
+        # explicitly told the gateway to route here.
+        model_cfg = user_config.get("model")
+        if isinstance(model_cfg, Mapping):
+            pinned = str(model_cfg.get("provider") or "").strip().lower()
+            if pinned == provider_norm:
+                return True
+
+    return False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3925,6 +3925,45 @@ class GatewayRunner:
                 logger.info("Active profile: %s", _profile)
         except Exception:
             pass
+
+        # Active-provider disclosure (#32524). Resolve credentials once
+        # here, name the provider+model+source in gateway.log, and (if
+        # the credential was picked up implicitly from a process env
+        # var for a paid cloud API) raise a WARNING-level block so the
+        # operator can't miss that real money is now on the line.
+        # Best-effort — credential resolution may legitimately fail at
+        # this point (e.g. operator boots the gateway before adding any
+        # keys, expecting to hot-add via the dashboard); we never block
+        # startup on it.
+        try:
+            from gateway.credential_disclosure import (
+                build_disclosure_lines,
+                classify_runtime_credential,
+                should_emit_disclosure,
+            )
+            from hermes_cli.config import load_config as _disclosure_load_config
+
+            _disclosure_cfg = _disclosure_load_config() or {}
+            if should_emit_disclosure(_disclosure_cfg):
+                _disclosure_model = ""
+                _model_cfg = _disclosure_cfg.get("model")
+                if isinstance(_model_cfg, dict):
+                    _disclosure_model = str(
+                        _model_cfg.get("default") or _model_cfg.get("name") or ""
+                    ).strip()
+                _disclosure_runtime = _resolve_runtime_agent_kwargs()
+                _disclosure = classify_runtime_credential(
+                    _disclosure_runtime,
+                    model=_disclosure_model,
+                    user_config=_disclosure_cfg,
+                )
+                for _lvl, _line in build_disclosure_lines(_disclosure):
+                    logger.log(_lvl, "%s", _line)
+        except Exception:
+            logger.debug(
+                "credential disclosure banner failed", exc_info=True
+            )
+
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(gateway_state="starting", exit_reason=None)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1717,6 +1717,16 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Disclosure banner for implicit paid-cloud credentials (#32524).
+        # When the gateway boots and the resolved runtime credential came
+        # from an environment variable (e.g. ANTHROPIC_API_KEY) for a
+        # paid cloud provider that was never explicitly added via
+        # ``hermes auth add`` and isn't pinned in ``providers:`` /
+        # ``custom_providers:``, log a prominent WARNING block so the
+        # operator knows the gateway will bill against that account.
+        # Set to false to silence the warning (the routine INFO line
+        # naming the active provider stays either way).
+        "warn_implicit_paid_credentials": True,
         # Extra directories from which model-emitted bare file paths may be
         # uploaded as native gateway attachments. Files inside the Hermes
         # cache (~/.hermes/cache/{documents,images,audio,video,screenshots})

--- a/tests/gateway/test_credential_disclosure.py
+++ b/tests/gateway/test_credential_disclosure.py
@@ -1,0 +1,450 @@
+"""Tests for ``gateway.credential_disclosure``.
+
+Regression coverage for issue #32524 — the gateway must announce which
+provider it has adopted at startup and, when that adoption came from a
+process env var for a paid cloud API with no deliberate
+``hermes auth add`` / config-pin signal, the announcement must escalate
+to a WARNING-level multi-line block so operators can't miss it
+scrolling past in ``gateway.log``.
+
+The tests below are deliberately classifier-level (pure-Python, no
+gateway/asyncio bootstrap). The intent is that any future refactor of
+the gateway startup wiring still has to satisfy these invariants —
+the classifier is the contract.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from gateway.credential_disclosure import (
+    PAID_CLOUD_PROVIDERS,
+    CredentialDisclosure,
+    build_disclosure_lines,
+    classify_runtime_credential,
+    should_emit_disclosure,
+)
+
+
+# ─── classify_runtime_credential ────────────────────────────────────────
+
+
+class TestImplicitEnvDetection:
+    """Implicit-env detection is the heart of the #32524 fix.
+
+    "Implicit" means: the credential resolver landed on a paid cloud
+    provider, the credential came from a process env var, and the user
+    never deliberately wired that provider through ``hermes auth add``
+    or pinned it in ``config.yaml``.
+    """
+
+    def test_anthropic_api_key_with_no_auth_store_or_config_is_implicit(self, monkeypatch):
+        """The exact incident shape from #32524 — bare ANTHROPIC_API_KEY
+        in the environment, no auth store entry, no config pin. Must
+        classify as implicit and warning-worthy.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-1234567890")
+        runtime = {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "sk-ant-test-1234567890",
+            "source": "env",
+        }
+
+        info = classify_runtime_credential(
+            runtime,
+            model="claude-sonnet-4-20250514",
+            auth_store={"providers": {}, "credential_pool": {}},
+            user_config={},  # no model.provider pin, no providers: entry
+        )
+
+        assert info.is_paid_cloud is True
+        assert info.is_implicit_env is True
+        assert info.is_warning_worthy is True
+        assert info.env_var == "ANTHROPIC_API_KEY"
+        assert info.provider == "anthropic"
+        assert info.model == "claude-sonnet-4-20250514"
+
+    def test_explicit_hermes_auth_add_suppresses_warning(self, monkeypatch):
+        """User ran ``hermes auth add anthropic`` → auth store carries
+        a providers entry → the env-var pickup is no longer "implicit"."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-1234567890")
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "sk-ant-test-1234567890",
+            "source": "env",
+        }
+
+        info = classify_runtime_credential(
+            runtime,
+            auth_store={"providers": {"anthropic": {"api_key": "..."}}},
+            user_config={},
+        )
+
+        assert info.is_paid_cloud is True
+        assert info.is_implicit_env is False
+        assert info.is_warning_worthy is False
+
+    def test_credential_pool_entry_suppresses_warning(self, monkeypatch):
+        """``hermes auth pool add anthropic ...`` is also explicit."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "sk-ant-test",
+            "source": "env",
+        }
+
+        info = classify_runtime_credential(
+            runtime,
+            auth_store={
+                "providers": {},
+                "credential_pool": {"anthropic": [{"api_key": "..."}]},
+            },
+            user_config={},
+        )
+
+        assert info.is_implicit_env is False
+        assert info.is_warning_worthy is False
+
+    def test_model_provider_pinned_to_anthropic_suppresses_warning(self, monkeypatch):
+        """A user who set ``model.provider: anthropic`` in config.yaml
+        has explicitly chosen the provider — env-var pickup is no
+        longer surprising."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "sk-ant-test",
+            "source": "env",
+        }
+
+        info = classify_runtime_credential(
+            runtime,
+            auth_store={"providers": {}},
+            user_config={"model": {"provider": "anthropic", "default": "claude-3-5-sonnet"}},
+        )
+
+        assert info.is_implicit_env is False
+        assert info.is_warning_worthy is False
+
+    def test_providers_dict_entry_suppresses_warning(self, monkeypatch):
+        """A keyed ``providers: anthropic:`` entry counts as explicit."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "sk-ant-test",
+            "source": "env",
+        }
+
+        info = classify_runtime_credential(
+            runtime,
+            auth_store={"providers": {}},
+            user_config={
+                "providers": {
+                    "anthropic": {
+                        "base_url": "https://api.anthropic.com",
+                        "key_env": "ANTHROPIC_API_KEY",
+                    }
+                }
+            },
+        )
+
+        assert info.is_implicit_env is False
+        assert info.is_warning_worthy is False
+
+    def test_custom_providers_entry_suppresses_warning(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "sk-ant-test",
+            "source": "env",
+        }
+
+        info = classify_runtime_credential(
+            runtime,
+            auth_store={"providers": {}},
+            user_config={
+                "custom_providers": [
+                    {"name": "Anthropic", "base_url": "https://api.anthropic.com"},
+                ]
+            },
+        )
+
+        assert info.is_implicit_env is False
+        assert info.is_warning_worthy is False
+
+    def test_explicit_provider_match_is_case_insensitive(self, monkeypatch):
+        """User-typed config entries may differ in case from the
+        canonical slug. The check must normalise both sides."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "sk-ant-test",
+            "source": "env",
+        }
+        info = classify_runtime_credential(
+            runtime,
+            auth_store={"providers": {"Anthropic": {}}},
+            user_config={},
+        )
+        assert info.is_implicit_env is False
+
+
+class TestPaidCloudAllowlist:
+    """Free / local / OAuth-subscription providers must NOT trigger the
+    paid-cloud warning even when picked up from an env var."""
+
+    def test_lmstudio_local_endpoint_is_not_paid_cloud(self):
+        runtime = {
+            "provider": "lmstudio",
+            "base_url": "http://127.0.0.1:1234/v1",
+            "api_key": "lm-studio",
+            "source": "env",
+        }
+        info = classify_runtime_credential(runtime)
+        assert info.is_paid_cloud is False
+        assert info.is_warning_worthy is False
+
+    def test_nous_subscription_is_not_paid_cloud(self):
+        # Nous billing is portal-subscription, not metered per call.
+        runtime = {
+            "provider": "nous",
+            "api_key": "nous-test",
+            "source": "portal",
+        }
+        info = classify_runtime_credential(runtime)
+        assert info.is_paid_cloud is False
+        assert info.is_warning_worthy is False
+
+    def test_bedrock_is_excluded_from_paid_cloud_check(self):
+        """AWS credentials come through the operator's IAM console, not
+        a stray ``ANTHROPIC_API_KEY`` discovered on PATH — qualitatively
+        different from raw cloud API keys and out of scope for #32524."""
+        runtime = {
+            "provider": "bedrock",
+            "api_key": "aws-sdk",
+            "source": "AWS_ACCESS_KEY_ID",
+        }
+        info = classify_runtime_credential(runtime)
+        assert info.is_paid_cloud is False
+        assert info.is_warning_worthy is False
+
+    def test_oauth_token_source_is_not_implicit_env(self, monkeypatch):
+        """Claude Code OAuth (``ANTHROPIC_TOKEN`` / refresh-token file)
+        is a deliberate subscription — even though the source label is
+        ``env``, the user went through the OAuth dance. We treat the
+        ``oauth`` source label as non-env regardless of provider.
+        """
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-test")
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "sk-ant-oat01-test",
+            "source": "claude-code-oauth",
+        }
+        info = classify_runtime_credential(runtime)
+        # source is not in the ENV token set → not implicit-env.
+        assert info.is_implicit_env is False
+        assert info.is_warning_worthy is False
+
+
+class TestEnvVarIdentification:
+    """The warning prose should name the actual env var that supplied
+    the credential so the operator can grep their shell rc files for
+    the offending export."""
+
+    def test_anthropic_api_key_round_trips(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-abc123")
+        runtime = {"provider": "anthropic", "api_key": "sk-ant-abc123", "source": "env"}
+        info = classify_runtime_credential(runtime, auth_store={"providers": {}}, user_config={})
+        assert info.env_var == "ANTHROPIC_API_KEY"
+
+    def test_anthropic_token_takes_precedence_in_lookup(self, monkeypatch):
+        """The registry lists ANTHROPIC_API_KEY first, but ANTHROPIC_TOKEN
+        is also valid — whichever env var actually matches the key wins."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat-xyz")
+        runtime = {"provider": "anthropic", "api_key": "sk-ant-oat-xyz", "source": "env"}
+        info = classify_runtime_credential(runtime, auth_store={"providers": {}}, user_config={})
+        assert info.env_var == "ANTHROPIC_TOKEN"
+
+    def test_openai_env_var(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+        runtime = {"provider": "openai", "api_key": "sk-openai-test", "source": "env"}
+        info = classify_runtime_credential(runtime, auth_store={"providers": {}}, user_config={})
+        # ``openai`` isn't in PROVIDER_REGISTRY by that slug (the
+        # registry uses ``openai-api``), so we fall through to the
+        # convention-based lookup.
+        assert info.env_var == "OPENAI_API_KEY"
+
+    def test_missing_env_match_returns_none(self):
+        """When we can't confirm which env var sourced the key (e.g. the
+        gateway is reading from a credential pool that mangled the
+        value), env_var is None — the warning still fires, it just
+        can't name the variable."""
+        runtime = {
+            "provider": "anthropic",
+            "api_key": "no-matching-env-var",
+            "source": "env",
+        }
+        info = classify_runtime_credential(
+            runtime, auth_store={"providers": {}}, user_config={}, env={}
+        )
+        assert info.env_var is None
+        assert info.is_warning_worthy is True
+
+
+# ─── build_disclosure_lines ─────────────────────────────────────────────
+
+
+class TestBuildDisclosureLines:
+    def test_routine_disclosure_is_single_info_line(self):
+        info = CredentialDisclosure(
+            provider="lmstudio",
+            model="qwen3-coder",
+            base_url="http://127.0.0.1:1234/v1",
+            source="env",
+            env_var=None,
+            is_paid_cloud=False,
+            is_implicit_env=False,
+        )
+        lines = build_disclosure_lines(info)
+        assert len(lines) == 1
+        level, msg = lines[0]
+        assert level == logging.INFO
+        assert "lmstudio" in msg
+        assert "qwen3-coder" in msg
+        assert "127.0.0.1" in msg
+
+    def test_warning_worthy_disclosure_includes_remediation(self):
+        info = CredentialDisclosure(
+            provider="anthropic",
+            model="claude-sonnet-4-20250514",
+            base_url="https://api.anthropic.com",
+            source="env",
+            env_var="ANTHROPIC_API_KEY",
+            is_paid_cloud=True,
+            is_implicit_env=True,
+        )
+        lines = build_disclosure_lines(info)
+        levels = [lvl for lvl, _ in lines]
+        text = "\n".join(msg for _, msg in lines)
+
+        # Exactly one INFO summary + three WARNING lines (banner +
+        # rationale + remediation).  Pinning the count keeps the test
+        # honest about what we promise to log — drift here without a
+        # test update breaks operator playbooks.
+        assert levels[0] == logging.INFO
+        assert levels[1:] == [logging.WARNING, logging.WARNING, logging.WARNING]
+        assert "ANTHROPIC_API_KEY" in text
+        assert "hermes auth add anthropic" in text
+        assert "gateway.warn_implicit_paid_credentials" in text
+        # The reporter's concrete pain point — must mention billing
+        # explicitly so a skimming operator can't miss the implication.
+        assert "billed" in text.lower()
+
+    def test_empty_provider_emits_no_lines(self):
+        """If credential resolution failed entirely (no provider known),
+        the banner should be silent rather than emit a misleading line."""
+        info = CredentialDisclosure(
+            provider="",
+            model="",
+            base_url="",
+            source="(unknown)",
+            env_var=None,
+            is_paid_cloud=False,
+            is_implicit_env=False,
+        )
+        assert build_disclosure_lines(info) == []
+
+    def test_warning_handles_unknown_env_var_gracefully(self):
+        info = CredentialDisclosure(
+            provider="anthropic",
+            model="claude-3-5-sonnet",
+            base_url="https://api.anthropic.com",
+            source="env",
+            env_var=None,
+            is_paid_cloud=True,
+            is_implicit_env=True,
+        )
+        lines = build_disclosure_lines(info)
+        text = "\n".join(msg for _, msg in lines)
+        assert "an environment variable" in text
+
+
+# ─── should_emit_disclosure ─────────────────────────────────────────────
+
+
+class TestShouldEmitDisclosure:
+    """Operators must be able to silence the warning via config — but
+    the default has to be ON so a fresh install can never be #32524'd."""
+
+    def test_missing_config_defaults_to_on(self):
+        assert should_emit_disclosure(None) is True
+        assert should_emit_disclosure({}) is True
+
+    def test_missing_gateway_section_defaults_to_on(self):
+        assert should_emit_disclosure({"model": {"provider": "anthropic"}}) is True
+
+    def test_explicit_true_passes_through(self):
+        cfg = {"gateway": {"warn_implicit_paid_credentials": True}}
+        assert should_emit_disclosure(cfg) is True
+
+    def test_explicit_false_silences(self):
+        cfg = {"gateway": {"warn_implicit_paid_credentials": False}}
+        assert should_emit_disclosure(cfg) is False
+
+    @pytest.mark.parametrize("value", ["false", "False", "0", "no", "off", "OFF"])
+    def test_string_falsy_values_silence(self, value):
+        cfg = {"gateway": {"warn_implicit_paid_credentials": value}}
+        assert should_emit_disclosure(cfg) is False
+
+    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on", ""])
+    def test_string_truthy_values_enable(self, value):
+        # Empty string is treated as ON — for a security disclosure the
+        # safer failure mode is to err on the side of more logging when
+        # the operator's config value is malformed/blank.
+        cfg = {"gateway": {"warn_implicit_paid_credentials": value}}
+        assert should_emit_disclosure(cfg) is True
+
+
+# ─── Allowlist contract ─────────────────────────────────────────────────
+
+
+class TestPaidCloudAllowlistContract:
+    """Don't change-detector the exact list — but keep the invariants
+    that motivated the allowlist in the first place. Drift here without
+    a test update would silently re-open #32524 for whatever provider
+    quietly slipped out of the set."""
+
+    def test_anthropic_must_be_paid_cloud(self):
+        # The literal incident provider.
+        assert "anthropic" in PAID_CLOUD_PROVIDERS
+
+    def test_openai_must_be_paid_cloud(self):
+        # Same threat shape: env-discovered OPENAI_API_KEY → silent metered billing.
+        assert "openai" in PAID_CLOUD_PROVIDERS
+        assert "openai-api" in PAID_CLOUD_PROVIDERS
+
+    def test_local_providers_must_not_be_paid_cloud(self):
+        for slug in ("lmstudio", "ollama", "ollama-cloud", "llama-cpp"):
+            assert slug not in PAID_CLOUD_PROVIDERS, (
+                f"{slug} is local / free-tier and must not trigger "
+                "the paid-cloud disclosure warning."
+            )
+
+    def test_oauth_subscription_providers_must_not_be_paid_cloud(self):
+        # OAuth-backed subscription endpoints — user already went
+        # through a deliberate auth flow, billing is subscription not
+        # per-request.
+        for slug in ("nous", "openai-codex", "xai-oauth", "google-gemini-cli", "qwen-oauth"):
+            assert slug not in PAID_CLOUD_PROVIDERS, (
+                f"{slug} is subscription-billed; warning would be noise."
+            )
+
+    def test_cloud_iam_providers_must_not_be_paid_cloud(self):
+        # AWS / GCP cred chains are governed by the cloud console — out of
+        # scope for the "stray env var" threat model #32524 describes.
+        for slug in ("bedrock",):
+            assert slug not in PAID_CLOUD_PROVIDERS


### PR DESCRIPTION
## Description

The reporter ran ``hermes gateway run`` as a background service on a home server with ``ANTHROPIC_API_KEY`` set in their shell environment. Every inbound Telegram message silently spawned a full agent session against ``claude-sonnet-4-20250514`` — **\~$80 of unintended Claude charges accumulated in a single night** before they noticed by grepping ``agent.log``.

The gateway never:

* announced which provider had been chosen,
* warned that the active credential came from a process env var (rather than a deliberate ``hermes auth add`` step or an explicit ``providers:`` config entry),
* indicated that the target was a paid cloud API.

This PR fills the **disclosure gap**. The cost-cap / per-request billing visibility / context-growth warnings the reporter also asked for are scoped for follow-up issues — disclosure is the foundation: once the operator knows what's happening, they can act.

### Root cause

``resolve_runtime_provider()`` correctly returns the resolved credential dict to the gateway (``provider``, ``api_key``, ``source``), but the gateway then logs nothing about it. ``GatewayRunner.start()`` already emits prominent banners for adjacent operator-safety facts (redaction status, security advisories, allowlist sanity), but **not** for the active inference provider.

Compounding the silence: ``resolve_anthropic_token()`` accepts ``ANTHROPIC_API_KEY`` from the environment as a 4th-priority fallback (after ``ANTHROPIC_TOKEN`` / ``CLAUDE_CODE_OAUTH_TOKEN`` / Claude Code OAuth files). For an operator who set ``ANTHROPIC_API_KEY`` years ago for an unrelated tool and forgot, that env var alone is enough to route every gateway message through the paid Messages API.

### Related issue

Closes #32524

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

### Changes made

* **``gateway/credential_disclosure.py``** (new) — pure-Python classifier + banner builder. Inspects a resolved runtime dict and returns a frozen ``CredentialDisclosure`` naming the active provider, model, base URL, credential source, and (best-effort) the actual env var that supplied the API key. Flags a credential as **implicit env** only when all three hold:
  1. ``source`` is one of the env-pickup tokens (``env`` / ``environment`` / ``env-var`` / ``env_fallback``);
  2. the resolved provider is in ``PAID_CLOUD_PROVIDERS`` — paid metered APIs only, so local servers (LM Studio, Ollama), subscription portals (Nous, ``xai-oauth``, Claude Code OAuth via ``ANTHROPIC_TOKEN``), and cloud-IAM-governed providers (Bedrock) don't trip it;
  3. neither ``~/.hermes/auth.json`` (providers map *or* credential pool) nor the user's ``providers:`` / ``custom_providers:`` / ``model.provider`` config sections explicitly mention the provider — so a deliberate ``hermes auth add`` or config pin silences the warning to a routine INFO line.

* **``hermes_cli/config.py``** — new ``gateway.warn_implicit_paid_credentials`` knob (default ``true``). Operators who deliberately rely on env-var pickup can silence the warning without losing the routine INFO line. Default-on is the safer failure mode for a security-adjacent disclosure.

* **``gateway/run.py``** — wires the classifier into ``GatewayRunner.start()`` next to the existing security-warning block. Every boot now logs one INFO line (``Gateway active provider: anthropic | model=claude-sonnet-4-* | base_url=... | credential_source=env | env_var=ANTHROPIC_API_KEY``); the warning-worthy case adds three WARNING lines spelling out the billing exposure, why it was inferred, and the remediation path. Wrapped in a best-effort ``try`` — never blocks startup.

* **``tests/gateway/test_credential_disclosure.py``** (new) — 40 tests covering the exact #32524 incident shape, each explicit-suppression signal, the paid-cloud allowlist contract (anthropic + openai in; local + OAuth-subscription + cloud-IAM out), env-var round-trip, the disclosure banner's line count + remediation prose, and the config knob's string / bool / missing behaviour.

Three small commits, sole author:

| # | Commit |
| - | ------ |
| 1 | ``feat(gateway): classifier for implicit paid-cloud credentials (#32524)`` |
| 2 | ``feat(gateway): emit startup disclosure banner for active credentials`` |
| 3 | ``test(gateway): pin implicit paid-credential disclosure behaviour`` |

### Sample log output

Before this PR — gateway boots, processes Telegram messages, silently bills Anthropic:

```
INFO Starting Hermes Gateway...
INFO Session storage: /home/op/.hermes/sessions
INFO Agent budget: max_iterations=90 ...
INFO Secret redaction: ENABLED ...
[silence — operator has no idea Anthropic is being used]
```

With this PR, same boot:

```
INFO Starting Hermes Gateway...
INFO Session storage: /home/op/.hermes/sessions
INFO Agent budget: max_iterations=90 ...
INFO Secret redaction: ENABLED ...
INFO Gateway active provider: anthropic | model=claude-sonnet-4-20250514 | base_url=https://api.anthropic.com | credential_source=env | env_var=ANTHROPIC_API_KEY
WARNING ⚠ anthropic: paid cloud API selected via environment variable ANTHROPIC_API_KEY. Every gateway message will be billed against this provider.
WARNING   This account was not added via `hermes auth add` and is not pinned in config.yaml — Hermes inferred it from the environment.
WARNING   To silence this warning intentionally: run `hermes auth add anthropic` (or pin the provider in config.yaml `providers:`). To disable disclosure entirely: set `gateway.warn_implicit_paid_credentials: false` in config.yaml. See issue #32524 for context.
```

After the operator runs ``hermes auth add anthropic`` (or adds ``model.provider: anthropic`` to config.yaml), the WARNING block disappears and the INFO line remains — a single grep-able audit trail of what's billing.

### How to test

1. ``export ANTHROPIC_API_KEY=sk-ant-test-1234`` in a fresh shell with no ``~/.hermes/auth.json`` and no ``model:`` config pin.
2. ``hermes gateway run``.
3. **Before this PR:** gateway boots silently and starts billing Anthropic on the first Telegram message.
4. **With this PR:** gateway logs the four-line banner above to ``gateway.log`` and stderr (when ``-v`` or above) so the operator sees it before any message is processed.
5. ``hermes auth add anthropic`` (paste the same key when prompted) and restart — the WARNING block disappears; the INFO line remains, naming the credential source as something other than ``env``.
6. ``echo 'gateway: {warn_implicit_paid_credentials: false}' >> ~/.hermes/config.yaml`` to silence the WARNING block entirely while still keeping the INFO line.

Automated coverage:

```
scripts/run_tests.sh tests/gateway/test_credential_disclosure.py \
                     tests/hermes_cli/test_config.py \
                     tests/hermes_cli/test_config_drift.py \
                     tests/hermes_cli/test_config_validation.py \
                     tests/hermes_cli/test_runtime_provider_resolution.py \
                     tests/hermes_cli/test_detect_api_mode_for_url.py \
                     tests/gateway/test_auth_fallback.py
# → 7 files, 296 tests passed
```

### Scope notes

The reporter also asked for cost-per-request visibility, session-context growth warnings, and a spending cap. Those are separate features each deserving their own PR:

* **Cost-per-request visibility** — needs a pricing table per provider/model + a per-turn aggregator; touches the agent loop, not the gateway startup.
* **Context-growth warnings** — already partially covered by the agent's compression layer; surfacing the unsummarised token total in the per-turn delivery line is a delivery-router change.
* **Spending cap** — needs a persistent counter store (probably ``~/.hermes/spending.json`` keyed by provider + month) and a hard-stop gate in ``_resolve_runtime_agent_kwargs()``. Non-trivial.

Disclosure is the prerequisite for all three. This PR ships disclosure; the rest is left to follow-up issues.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
