### PR TITLE
[codex] fix Groq transcription local fallback

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -834,6 +834,36 @@ class TestTranscribeAudioDispatch:
         assert result["provider"] == "groq"
         mock_groq.assert_called_once()
 
+    def test_groq_can_fallback_to_local_when_configured(self, sample_ogg):
+        config = {"provider": "groq", "fallback_provider": "local", "local": {"model": "base"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="groq"), \
+             patch("tools.transcription_tools._transcribe_groq",
+                   return_value={"success": False, "transcript": "", "error": "Connection error"}) as mock_groq, \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "hi", "provider": "local"}) as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result == {"success": True, "transcript": "hi", "provider": "local", "fallback_from": "groq"}
+        mock_groq.assert_called_once()
+        mock_local.assert_called_once_with(sample_ogg, "base")
+
+    def test_groq_failure_without_fallback_still_returns_error(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "groq"}), \
+             patch("tools.transcription_tools._get_provider", return_value="groq"), \
+             patch("tools.transcription_tools._transcribe_groq",
+                   return_value={"success": False, "transcript": "", "error": "Connection error"}), \
+             patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._transcribe_local") as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is False
+        assert result["error"] == "Connection error"
+        mock_local.assert_not_called()
+
     def test_dispatches_to_local(self, sample_ogg):
         with patch("tools.transcription_tools._load_stt_config", return_value={}), \
              patch("tools.transcription_tools._get_provider", return_value="local"), \

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1553,7 +1553,40 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     if provider == "groq":
         model_name = model or DEFAULT_GROQ_STT_MODEL
-        return _transcribe_groq(file_path, model_name)
+        result = _transcribe_groq(file_path, model_name)
+        if result.get("success"):
+            return result
+
+        fallback_provider = stt_config.get("fallback_provider")
+        if fallback_provider == "local":
+            local_cfg = stt_config.get("local", {})
+            local_model_name = _normalize_local_model(
+                local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+            )
+            if _HAS_FASTER_WHISPER:
+                fallback_result = _transcribe_local(file_path, local_model_name)
+                if fallback_result.get("success"):
+                    fallback_result["fallback_from"] = "groq"
+                    return fallback_result
+            if _has_local_command():
+                command_model_name = _normalize_local_command_model(local_model_name)
+                fallback_result = _transcribe_local_command(file_path, command_model_name)
+                if fallback_result.get("success"):
+                    fallback_result["fallback_from"] = "groq"
+                    return fallback_result
+
+        if fallback_provider == "local_command":
+            local_cfg = stt_config.get("local", {})
+            command_model_name = _normalize_local_command_model(
+                local_cfg.get("model", DEFAULT_LOCAL_MODEL)
+            )
+            if _has_local_command():
+                fallback_result = _transcribe_local_command(file_path, command_model_name)
+                if fallback_result.get("success"):
+                    fallback_result["fallback_from"] = "groq"
+                    return fallback_result
+
+        return result
 
     if provider == "openai":
         openai_cfg = stt_config.get("openai", {})


### PR DESCRIPTION
## Summary
- allow Groq STT failures to fall back to configured local transcription
- support both local faster-whisper and local command fallbacks
- mark successful fallback responses with `fallback_from: groq`
- add regression coverage for configured fallback and no-fallback behavior

## Why
When Groq transcription fails transiently, installations with a local STT fallback configured should still be able to transcribe audio instead of returning the cloud-provider error immediately.

## Validation
- /home/hermes/.hermes/hermes-agent/venv/bin/python -m py_compile tools/transcription_tools.py
- /home/hermes/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts= -q tests/tools/test_transcription_tools.py -q

Note: full default pytest addopts on the fresh upstream worktree require pytest-timeout, which is not installed in the production venv, so the targeted test was run with addopts cleared.