### PR TITLE
feat(agent): detect intentional silence in thinking-only responses

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -15130,6 +15130,42 @@ class AIAgent:
                             or getattr(assistant_message, "reasoning_details", None)
                             or _has_inline_thinking
                         )
+                        # Early-exit when the model's reasoning signals that
+                        # the empty visible response is intentional (e.g. the
+                        # agent persona chose to stay silent).  Skipping the
+                        # prefill and empty-response retry loop saves 4–5
+                        # unnecessary API calls per silent turn.
+                        if _has_structured and self._thinking_prefill_retries == 0:
+                            _raw_reasoning = (
+                                getattr(assistant_message, "reasoning", None)
+                                or getattr(assistant_message, "reasoning_content", None)
+                                or ""
+                            )
+                            if isinstance(_raw_reasoning, list):
+                                _raw_reasoning = " ".join(
+                                    (b.get("thinking") or b.get("text") or "")
+                                    if isinstance(b, dict) else str(b)
+                                    for b in _raw_reasoning
+                                )
+                            _SILENCE_SIGNALS = (
+                                "stay silent", "should stay silent",
+                                "not respond", "not answer", "should not respond",
+                                "stay quiet", "give them the floor",
+                                "let them respond", "give her the floor",
+                                "give him the floor", "let her respond",
+                                "let him respond", "addressed to someone else",
+                                "not addressed to me", "directed at someone else",
+                            )
+                            if any(sig in _raw_reasoning.lower() for sig in _SILENCE_SIGNALS):
+                                logger.info(
+                                    "Thinking-only response signals intentional silence "
+                                    "— skipping prefill retries (reasoning: %s)",
+                                    _raw_reasoning[:200],
+                                )
+                                _turn_exit_reason = "intentional_silence"
+                                self._drop_trailing_empty_response_scaffolding(messages)
+                                final_response = ""
+                                break
                         if _has_structured and self._thinking_prefill_retries < 2:
                             self._thinking_prefill_retries += 1
                             logger.info(


### PR DESCRIPTION
## Summary

When a model produces a thinking-only response (reasoning present, no visible text), the existing recovery path runs 2 prefill retries followed by 3 empty-response retries before giving up — **5 unnecessary API calls** when the silence is intentional.

This PR adds a fast-exit check on the **first** thinking-only response: if the reasoning text contains known silence-intent phrases (`"stay silent"`, `"not respond"`, `"not addressed to me"`, etc.), the turn exits immediately with `turn_exit_reason = "intentional_silence"` rather than entering the retry loop.

## Motivation

Multi-persona or multi-participant setups often instruct an agent persona to yield to another participant when a message is directed at them. The model correctly reasons "I should not respond here" and produces no visible output — but the generic retry loop treats this as a failure and wastes 5 API calls before giving up, then delivers a confusing `(empty)` or `⚠️` result.

## Changed files

- `run_agent.py` — silence-signal detection block inserted before the `_thinking_prefill_retries < 2` check in the thinking-only handler

## Silence signals checked

```python
"stay silent", "should stay silent",
"not respond", "not answer", "should not respond",
"stay quiet", "give them the floor",
"let them respond", "give her the floor",
"give him the floor", "let her respond",
"let him respond", "addressed to someone else",
"not addressed to me", "directed at someone else",
```

## Test plan

- [ ] Message that triggers intentional silence → single API call, `turn_exit_reason = "intentional_silence"`, no retry bubbles
- [ ] Normal thinking-only response (no silence signal in reasoning) → existing prefill retry behaviour unchanged
- [ ] Reasoning as list payload (some providers return structured thinking blocks) → phrases correctly extracted and matched

🤖 Generated with [Claude Code](https://claude.com/claude-code)