### PR TITLE
feat(tts): read ElevenLabs VoiceSettings from config

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -822,6 +822,20 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     else:
         output_format = "mp3_44100_128"
 
+    voice_settings = None
+    _vs_keys = ("stability", "similarity_boost", "style", "use_speaker_boost")
+    if any(k in el_config for k in _vs_keys):
+        try:
+            from elevenlabs import VoiceSettings as _VoiceSettings
+            voice_settings = _VoiceSettings(
+                stability=float(el_config.get("stability", 0.5)),
+                similarity_boost=float(el_config.get("similarity_boost", 0.75)),
+                style=float(el_config.get("style", 0.0)),
+                use_speaker_boost=bool(el_config.get("use_speaker_boost", True)),
+            )
+        except Exception:
+            pass
+
     ElevenLabs = _import_elevenlabs()
     client = ElevenLabs(api_key=api_key)
     audio_generator = client.text_to_speech.convert(
@@ -829,6 +843,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
         voice_id=voice_id,
         model_id=model_id,
         output_format=output_format,
+        **( {"voice_settings": voice_settings} if voice_settings is not None else {} ),
     )
 
     # audio_generator yields chunks -- write them all


### PR DESCRIPTION
## Summary

`_generate_elevenlabs()` previously ignored `stability`, `similarity_boost`, `style`, and `use_speaker_boost` from the `tts.elevenlabs` config block, always falling back to ElevenLabs API defaults.

This PR reads these four parameters from config when present and passes them as a `VoiceSettings` object to `client.text_to_speech.convert()`.

## Changed files

- `tools/tts_tool.py` — `VoiceSettings` construction block in `_generate_elevenlabs()`

## Behaviour

- Falls back gracefully (`voice_settings=None`, API defaults apply) if the `elevenlabs` package does not expose `VoiceSettings` or if none of the four keys are present in config
- No change in behaviour when the keys are absent

## Example config

```yaml
tts:
  elevenlabs:
    stability: 0.55
    similarity_boost: 0.80
    style: 0.20
    use_speaker_boost: true
```

## Test plan

- [ ] Config with all four keys → `VoiceSettings` constructed and passed to `convert()`
- [ ] Config with no voice-settings keys → `voice_settings=None`, no kwarg passed, API defaults apply
- [ ] Import failure of `VoiceSettings` → exception swallowed, `voice_settings=None`, graceful fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)