### PR TITLE
fix(copy): use latest-relative response numbering

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5735,13 +5735,14 @@ class HermesCLI:
 
         if arg:
             try:
-                idx = int(arg) - 1
+                n = int(arg)
             except ValueError:
                 _cprint("  Usage: /copy [number]")
                 return
-            if idx < 0 or idx >= len(assistant):
+            if n < 1 or n > len(assistant):
                 _cprint(f"  Invalid response number. Use 1-{len(assistant)}.")
                 return
+            idx = len(assistant) - n
         else:
             idx = len(assistant) - 1
             while idx >= 0 and not _assistant_copy_text(assistant[idx].get("content")):
@@ -5757,7 +5758,8 @@ class HermesCLI:
 
         try:
             self._write_osc52_clipboard(text)
-            _cprint(f"  Copied assistant response #{idx + 1} to clipboard")
+            ordinal = len(assistant) - idx
+            _cprint(f"  Copied assistant response #{ordinal} from latest to clipboard")
         except Exception as e:
             _cprint(f"  Clipboard copy failed: {e}")
 

--- a/tests/cli/test_cli_copy_command.py
+++ b/tests/cli/test_cli_copy_command.py
@@ -32,17 +32,18 @@ def test_copy_copies_latest_assistant_message():
     mock_copy.assert_called_once_with("latest")
 
 
-def test_copy_with_index_uses_requested_assistant_message():
+def test_copy_with_index_uses_nth_latest_assistant_message():
     cli_obj = _make_cli()
     cli_obj.conversation_history = [
         {"role": "assistant", "content": "one"},
         {"role": "assistant", "content": "two"},
+        {"role": "assistant", "content": "three"},
     ]
 
     with patch.object(cli_obj, "_write_osc52_clipboard") as mock_copy:
-        cli_obj.process_command("/copy 1")
+        cli_obj.process_command("/copy 2")
 
-    mock_copy.assert_called_once_with("one")
+    mock_copy.assert_called_once_with("two")
 
 
 def test_copy_strips_reasoning_blocks_before_copy():

--- a/ui-tui/src/__tests__/slashParity.test.ts
+++ b/ui-tui/src/__tests__/slashParity.test.ts
@@ -2,9 +2,15 @@ import { execFileSync } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { findSlashCommand, SLASH_COMMANDS } from '../app/slash/registry.js'
+import { writeClipboardText } from '../lib/clipboard.js'
+import type { SlashRunCtx } from '../app/slash/types.js'
+
+vi.mock('../lib/clipboard.js', () => ({
+  writeClipboardText: vi.fn(() => Promise.resolve(true))
+}))
 
 type CommandRoute = 'fallback' | 'local' | 'native'
 
@@ -88,6 +94,10 @@ const classifyRoute = (name: string): CommandRoute => {
 }
 
 describe('slash parity matrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   if (commandRegistry.error) {
     it.skip(`Python command registry unavailable: ${skipReason}`, () => {})
   }
@@ -119,5 +129,30 @@ describe('slash parity matrix', () => {
     const cmd = findSlashCommand('q')
     expect(cmd, '/q must resolve to a command').toBeDefined()
     expect(cmd!.name).toBe('queue')
+  })
+
+  it('/copy number selects the nth-latest assistant response', () => {
+    const cmd = findSlashCommand('copy')
+    expect(cmd, '/copy must resolve to a command').toBeDefined()
+
+    const sysMessages: string[] = []
+    const history = [
+      { role: 'assistant', text: 'one' },
+      { role: 'user', text: 'ignore me' },
+      { role: 'assistant', text: 'two' },
+      { role: 'assistant', text: 'three' }
+    ]
+    const ctx = {
+      composer: { hasSelection: false },
+      local: { getHistoryItems: () => history },
+      stale: () => false,
+      transcript: { sys: (message: string) => sysMessages.push(message) }
+    } as unknown as SlashRunCtx
+
+    cmd!.run('2', ctx, 'copy')
+
+    expect(writeClipboardText).toHaveBeenCalledWith('two')
+    expect(writeClipboardText).not.toHaveBeenCalledWith('one')
+    expect(writeClipboardText).not.toHaveBeenCalledWith('three')
   })
 })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -374,16 +374,22 @@ export const coreCommands: SlashCommand[] = [
         }
       }
 
-      if (arg && Number.isNaN(parseInt(arg, 10))) {
+      const all = ctx.local.getHistoryItems().filter(m => m.role === 'assistant')
+      const n = arg ? parseInt(arg, 10) : 1
+
+      if (Number.isNaN(n)) {
         return sys('usage: /copy [number]')
       }
 
-      const all = ctx.local.getHistoryItems().filter(m => m.role === 'assistant')
-      const target = all[arg ? Math.min(parseInt(arg, 10), all.length) - 1 : all.length - 1]
-
-      if (!target) {
+      if (!all.length) {
         return sys('nothing to copy — start a conversation first')
       }
+
+      if (n < 1 || n > all.length) {
+        return sys(`invalid response number. Use 1-${all.length}`)
+      }
+
+      const target = all[all.length - n]
 
       void writeClipboardText(target.text)
         .then(nativeOk => {


### PR DESCRIPTION
## Summary

- make `/copy N` select the Nth-latest assistant response in both classic CLI and TUI
- stop silently clamping out-of-range TUI response numbers
- add CLI/TUI regression coverage for latest-relative numbering

Closes #32584
Related: #11835

This PR fixes the numeric selection bug after `/copy` already exists. The broader feature request #11835 tracks introducing/documenting the command generally; this PR is specifically about the counting direction for `/copy N`.

## Test Plan

- `python -m pytest tests/cli/test_cli_copy_command.py -q`
- `vitest run src/__tests__/slashParity.test.ts`