### PR TITLE
fix(memory): accept old_string as alias for old_text in memory tool

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -635,6 +635,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 target=target,
                 content=function_args.get("content"),
                 old_text=function_args.get("old_text"),
+                old_string=function_args.get("old_string"),
                 store=agent._memory_store,
             )
             # Bridge: notify external memory provider of built-in memory writes

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -605,6 +605,7 @@ def memory_tool(
     target: str = "memory",
     content: str = None,
     old_text: str = None,
+    old_string: Optional[str] = None,  # alias for old_text (LLM sometimes confuses with patch tool)
     store: Optional[MemoryStore] = None,
 ) -> str:
     """
@@ -617,6 +618,10 @@ def memory_tool(
 
     if target not in {"memory", "user"}:
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
+
+    # Compatibility: accept old_string as alias for old_text
+    if old_text is None and old_string is not None:
+        old_text = old_string
 
     if action == "add":
         if not content:
@@ -672,7 +677,7 @@ MEMORY_SCHEMA = {
         "- 'user': who the user is -- name, role, preferences, communication style, pet peeves\n"
         "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
         "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
-        "remove (delete -- old_text identifies it).\n\n"
+        "remove (delete -- old_text identifies it). Pass either `old_text` or `old_string` for replace/remove.\n\n"
         "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
     ),
     "parameters": {
@@ -695,6 +700,10 @@ MEMORY_SCHEMA = {
             "old_text": {
                 "type": "string",
                 "description": "Short unique substring identifying the entry to replace or remove."
+            },
+            "old_string": {
+                "type": "string",
+                "description": "Alias for old_text. Use either old_text or old_string for replace/remove actions."
             },
         },
         "required": ["action", "target"],


### PR DESCRIPTION
## Problem

The memory tool uses `old_text` as its parameter name for replace/remove operations, while `patch` and `skill_manage` tools use `old_string`. LLM models frequently confuse these two parameter names when switching between tools, causing replace/remove operations to fail with `'old_text is required for "replace" action.'` errors.

This has been reported in multiple issues:
- #20735 — Inconsistent parameter naming across tools
- #21844 — replace/remove operations fail due to parameter mismatch
- #15843 — Memory tool cannot delete/replace old data

## Solution

Add `old_string` as an accepted alias parameter in the memory tool, alongside the existing `old_text`:

1. **`tools/memory_tool.py`** — Added `old_string` parameter to `memory_tool()` function. If `old_text` is None but `old_string` is provided, it's automatically mapped to `old_text`.
2. **`tools/memory_tool.py` MEMORY_SCHEMA** — Added `old_string` to the tool schema properties and updated the description to mention both parameter names.
3. **`agent/tool_executor.py`** — Updated the memory tool call to forward `old_string` from function args.

## Testing

The change is backward-compatible: existing calls using `old_text` continue to work unchanged. Calls using `old_string` (the common LLM confusion case) now resolve correctly.

Closes #20735, #21844, #15843