### PR TITLE
test: avoid provider catalog size snapshots

### DIFF
--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -21,14 +21,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def _clear_provider_caches():
     """Force providers/__init__.py to re-discover on next list_providers()."""
     import providers as _pkg
+
     _pkg._REGISTRY.clear()
     _pkg._ALIASES.clear()
     _pkg._discovered = False
     # Evict any cached plugin modules so the next import re-executes.
     for mod in list(sys.modules.keys()):
-        if (
-            mod.startswith("plugins.model_providers")
-            or mod.startswith("_hermes_user_provider")
+        if mod.startswith("plugins.model_providers") or mod.startswith(
+            "_hermes_user_provider"
         ):
             del sys.modules[mod]
 
@@ -39,26 +39,41 @@ def test_bundled_plugins_discovered():
     assert plugins_dir.is_dir(), f"Missing {plugins_dir}"
 
     child_dirs = [c for c in plugins_dir.iterdir() if c.is_dir()]
-    assert len(child_dirs) >= 28, f"Expected at least 28 provider plugins, found {len(child_dirs)}"
+    assert child_dirs, f"Expected provider plugins under {plugins_dir}"
 
     for child in child_dirs:
         assert (child / "__init__.py").exists(), f"{child.name} missing __init__.py"
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_provider_profiles_register():
+    """Discovery registers bundled provider profiles without catalog snapshots."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == len(set(names)), f"Duplicate provider profiles: {names}"
+
+    plugin_names = sorted(
+        child.name
+        for child in (REPO_ROOT / "plugins" / "model-providers").iterdir()
+        if child.is_dir()
+    )
+    missing = sorted(set(plugin_names) - set(names))
+    assert not missing, f"Bundled provider plugins did not register: {missing}"
 
     # Spot-check representative providers from different categories
     for required in (
-        "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
-        "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "openrouter",
+        "anthropic",
+        "custom",
+        "bedrock",
+        "openai-codex",
+        "minimax-oauth",
+        "gmi",
+        "xiaomi",
+        "alibaba-coding-plan",
     ):
         assert required in names, f"Missing profile: {required}"
 
@@ -122,9 +137,7 @@ def test_general_plugin_manager_skips_model_provider_kind(tmp_path, monkeypatch)
     user_plugin = hermes_home / "plugins" / "test-model-provider"
     user_plugin.mkdir(parents=True)
     (user_plugin / "plugin.yaml").write_text(
-        "name: test-model-provider\n"
-        "kind: model-provider\n"
-        "version: 0.0.1\n"
+        "name: test-model-provider\nkind: model-provider\nversion: 0.0.1\n"
     )
     (user_plugin / "__init__.py").write_text(
         # Intentionally broken import — if the general loader tries to


### PR DESCRIPTION
## Summary
- Replace the provider-discovery exact catalog-size assertion with discovery invariants.
- Keep representative provider spot checks while allowing new provider plugins to register without breaking CI.

## Tests
- .venv Windows pytest: tests/providers/test_plugin_discovery.py -q --timeout-method=thread
- ruff check tests/providers/test_plugin_discovery.py
- ruff format --check tests/providers/test_plugin_discovery.py