### PR TITLE
fix(patch): prevent file corruption from overlapping matches in fuzzy matching

### DIFF
--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -166,6 +166,60 @@ class TestReplaceAll:
         assert count == 2
         assert new == "ccc bbb ccc"
 
+    def test_overlapping_matches_replace_all(self):
+        """Overlapping occurrences must not produce double-counted matches.
+
+        In "aaaa" the substring "aa" occurs at offsets 0 and 2 (non-overlapping).
+        Before the fix, the scan advanced by 1 instead of len(pattern), yielding
+        3 overlapping matches and a corrupt result.
+        """
+        new, count, _, err = fuzzy_find_and_replace("aaaa", "aa", "b", replace_all=True)
+        assert err is None
+        assert count == 2
+        assert new == "bb"
+
+    def test_overlapping_matches_without_flag_errors(self):
+        """Overlapping occurrences should still report the non-overlapping count."""
+        new, count, _, err = fuzzy_find_and_replace("aaaa", "aa", "b", replace_all=False)
+        assert count == 0
+        assert "2 matches" in err
+
+    def test_overlapping_single_char_pattern(self):
+        """Single-char pattern: 'aaa' replacing 'a' with 'b' must give 'bbb'."""
+        new, count, _, err = fuzzy_find_and_replace("aaa", "a", "b", replace_all=True)
+        assert err is None
+        assert count == 3
+        assert new == "bbb"
+
+    def test_overlapping_with_surrounding_content(self):
+        """Overlapping region embedded in larger content — non-overlapping parts
+        must be preserved exactly."""
+        content = "prefix aaaa suffix"
+        new, count, _, err = fuzzy_find_and_replace(content, "aa", "b", replace_all=True)
+        assert err is None
+        assert count == 2
+        assert new == "prefix bb suffix"
+
+    def test_overlapping_multiline(self):
+        """Overlapping short string across multi-line code content."""
+        content = "x = 0\nx = 0\nx = 0\n"
+        new, count, _, err = fuzzy_find_and_replace(
+            content, "x = 0\n", "y = 1\n", replace_all=True
+        )
+        assert err is None
+        assert count == 3
+        assert new == "y = 1\ny = 1\ny = 1\n"
+
+    def test_no_false_overlaps_when_pattern_is_longer(self):
+        """When the pattern is longer than any possible self-overlap, there is
+        nothing to regress — this documents the benign case."""
+        new, count, _, err = fuzzy_find_and_replace(
+            "foo bar foo bar", "foo bar", "baz", replace_all=True
+        )
+        assert err is None
+        assert count == 2
+        assert new == "baz baz"
+
 
 class TestUnicodeNormalized:
     """Tests for the unicode_normalized strategy (Bug 5)."""
@@ -543,4 +597,110 @@ class TestEscapeNormalizedNewString:
         assert err is None
         assert count == 1
         assert "return 2" in new
+
+class TestMapNormalizedNoOverlap:
+    """Regression tests for trailing-whitespace expansion causing overlapping
+    matches in _map_normalized_positions.  The expansion was removed because
+    it greedily consumed spaces/tabs beyond the matched region, making
+    adjacent matches overlap and corrupting files under replace_all=True.
+    """
+
+    def test_whitespace_normalized_no_trailing_spillover(self):
+        """Adjacent whitespace-normalized matches must not overlap in original space."""
+        content = "a  a  a  a"
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "a a", "BB", replace_all=True
+        )
+        assert err is None, err
+        assert count == 2
+        assert new == "BB  BB"
+
+    def test_single_match_preserves_trailing_spaces(self):
+        """Trailing spaces after a matched region must NOT be swallowed."""
+        content = "foo   bar baz"
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "foo bar", "X Y"
+        )
+        assert err is None, err
+        assert count == 1
+        assert new == "X Y baz"
+
+    def test_full_string_match_via_whitespace_normalized(self):
+        """When old_string spans the entire content, result is just new_string."""
+        content = "hello   world"
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "hello world", "hi there"
+        )
+        assert err is None, err
+        assert count == 1
+        assert new == "hi there"
+
+    def test_trailing_spaces_in_normalized_match(self):
+        """Trailing spaces in original must be fully captured by the mapping.
+
+        Regression: the char-mapping loop checked == before space-collapsing,
+        so when original ends with multiple spaces and normalized ends with one,
+        the first space consumed the norm position and the rest fell into
+        Fill-remaining, mapping past the normalized end.  The result was that
+        trailing spaces were only partially replaced.
+        """
+        content = "hello    world    "  # 4 spaces mid, 4 trailing
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "hello world ", "hi"
+        )
+        assert err is None, err
+        assert count == 1
+        assert new == "hi"
+
+    def test_trailing_tabs_in_normalized_match(self):
+        """Trailing tabs must also be fully captured."""
+        content = "hello    world\t\t\t"  # 4 spaces mid, 3 tabs trailing
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "hello world\t", "hi"
+        )
+        assert err is None, err
+        assert count == 1
+        assert new == "hi"
+
+    def test_match_prefix_only_preserves_rest(self):
+        """Partial match (prefix) must leave unmatched trailing content intact."""
+        content = "a    b    c"
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "a b", "X"
+        )
+        assert err is None, err
+        assert count == 1
+        assert new == "X    c"
+
+    def test_match_suffix_only_preserves_leading(self):
+        """Partial match (suffix) must leave leading content intact."""
+        content = "a    b    c"
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "b c", "Y"
+        )
+        assert err is None, err
+        assert count == 1
+        assert new == "a    Y"
+
+    def test_replace_all_with_trailing_spaces_no_overlap(self):
+        """replace_all must not overlap when matches have trailing spaces."""
+        content = "foo   bar   foo   bar   "
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "foo bar ", "X", replace_all=True
+        )
+        assert err is None, err
+        assert count == 2
+        assert new == "XX"
+
+    def test_multiline_trailing_spaces(self):
+        """Multiline match with trailing spaces on last line."""
+        content = "def  foo():\n    return  42  "
+        new, count, strat, err = fuzzy_find_and_replace(
+            content, "def foo():\n    return 42  ", "X"
+        )
+        assert err is None, err
+        assert count == 1
+        assert new == "X"
+
+
 

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -349,7 +349,7 @@ def _strategy_exact(content: str, pattern: str) -> List[Tuple[int, int]]:
         if pos == -1:
             break
         matches.append((pos, pos + len(pattern)))
-        start = pos + 1
+        start = pos + len(pattern)
     return matches
 
 
@@ -718,17 +718,20 @@ def _map_normalized_positions(original: str, normalized: str,
     norm_idx = 0
     
     while orig_idx < len(original) and norm_idx < len(normalized):
-        if original[orig_idx] == normalized[norm_idx]:
-            orig_to_norm.append(norm_idx)
-            orig_idx += 1
-            norm_idx += 1
-        elif original[orig_idx] in ' \t' and normalized[norm_idx] == ' ':
-            # Original has space/tab, normalized collapsed to space
+        if original[orig_idx] in ' \t' and normalized[norm_idx] == ' ':
+            # Original has space/tab, normalized collapsed to single space.
+            # Check this BEFORE the equality test — when both characters are
+            # spaces the == branch would advance norm_idx prematurely,
+            # causing subsequent whitespace to mis-map (Fill-remaining bug).
             orig_to_norm.append(norm_idx)
             orig_idx += 1
             # Don't advance norm_idx yet - wait until all whitespace consumed
             if orig_idx < len(original) and original[orig_idx] not in ' \t':
                 norm_idx += 1
+        elif original[orig_idx] == normalized[norm_idx]:
+            orig_to_norm.append(norm_idx)
+            orig_idx += 1
+            norm_idx += 1
         elif original[orig_idx] in ' \t':
             # Extra whitespace in original
             orig_to_norm.append(norm_idx)
@@ -767,11 +770,17 @@ def _map_normalized_positions(original: str, normalized: str,
             orig_end = norm_to_orig_end[norm_end - 1] + 1
         else:
             orig_end = orig_start + (norm_end - norm_start)
-        
-        # Expand to include trailing whitespace that was normalized
-        while orig_end < len(original) and original[orig_end] in ' \t':
-            orig_end += 1
-        
+
+        # NOTE: the original code had a while-loop here that greedily
+        # expanded orig_end past trailing spaces/tabs.  That was a
+        # workaround for a mapping bug above (see the char-mapping
+        # loop): the == test fired before the space-collapsing test,
+        # so consecutive spaces were mis-mapped and trailing ones
+        # landed in the Fill-remaining zone.  Now that the condition
+        # order is fixed, the norm_to_orig_end reverse mapping already
+        # captures the full original span — no post-hoc expansion
+        # needed.
+
         original_matches.append((orig_start, min(orig_end, len(original))))
     
     return original_matches


### PR DESCRIPTION
## What does this PR do?

Fixes three interrelated bugs in `tools/fuzzy_match.py` that silently corrupt files when `replace_all=True` is used with the patch tool.

## Problem

An AI agent using `replace_all=True` to batch-replace a short or whitespace-flexible string in a file where that string appears in close succession gets a **silently corrupted file** — characters eaten, spaces swallowed, wrong match count.

### Bug 1: `_strategy_exact` overlapping matches (line 295)

Scan cursor advanced by `pos + 1` instead of `pos + len(pattern)`, producing overlapping matches. For `"aaaa"` with pattern `"aa"`, it found 3 matches (positions 0,1,2) instead of 2 (positions 0,2). `_apply_replacements` processes in reverse order, so the second replacement operates on already-modified content using stale offsets.

```python
# Before fix:
fuzzy_find_and_replace("aaaa", "aa", "b", replace_all=True)
# Returns: ("ba", 3, ...)  ← corrupt

# After fix:
# Returns: ("bb", 2, ...)  ← correct, same as str.replace()
```

**Fix:** advance by `len(pattern)` — aligns with Python's `str.replace()` semantics.

### Bug 2: `_map_normalized_positions` condition order (lines ~700)

When mapping a `whitespace_normalized` match back to original positions, the code checked `original[i] == normalized[j]` **before** the space-collapsing branch. When both characters were spaces, the `==` branch fired and advanced `norm_idx` prematurely. Subsequent whitespace then fell through to the fill-remaining zone and mapped past the normalized match end.

```python
# Before fix:
fuzzy_find_and_replace("foo   bar   baz", "foo  bar", "X")
# Returns: "Xbaz"  ← bar后面的 "   baz" 的空格被吞掉了

# After fix:
# Returns: "X   baz"  ← 正确，只替换匹配部分
```

**Fix:** swap the condition order — check space-collapsing before `==`.

### Bug 3: trailing whitespace while-loop (lines 714-716)

The removed while-loop was a partial workaround for Bug 2: it greedily expanded `orig_end` past any following spaces/tabs. This could eat into the next match's territory when adjacent matches existed.

**Fix:** with Bug 2 properly fixed, the reverse mapping already captures the full span — the loop is no longer needed and its removal eliminates the greedy overreach.

## Changes Made

- `tools/fuzzy_match.py` line 295: `_strategy_exact` scan advance changed from `pos + 1` to `pos + len(pattern)`
- `tools/fuzzy_match.py`: `_map_normalized_positions` swapped condition order (space-collapsing before `==`)
- `tools/fuzzy_match.py` lines 714-716: removed trailing whitespace expansion while-loop
- `tests/tools/test_fuzzy_match.py`: added 15 regression tests

New tests:
- `test_overlapping_matches_replace_all` — `"aaaa"` / `"aa"` → `"bb"`
- `test_overlapping_matches_without_flag_errors` — ambiguity error without flag
- `test_overlapping_single_char_pattern` — `"aaa"` / `"a"` → `"bbb"`
- `test_overlapping_with_surrounding_content` — preserves edges
- `test_overlapping_multiline` — multi-line batch replace
- `test_no_false_overlaps_when_pattern_is_longer` — benign case
- `test_whitespace_normalized_no_trailing_spillover` — adjacent matches don't overlap
- `test_single_match_preserves_trailing_spaces` — spaces after match not swallowed
- `test_full_string_match_via_whitespace_normalized` — full-string replacement
- `test_trailing_spaces_in_normalized_match` — trailing spaces correctly mapped
- `test_trailing_tabs_in_normalized_match` — trailing tabs correctly mapped
- `test_match_prefix_only_preserves_rest` — partial match preserves remainder
- `test_match_suffix_only_preserves_leading` — partial match preserves leading
- `test_replace_all_with_trailing_spaces_no_overlap` — replace_all + spaces no cross-contamination
- `test_multiline_trailing_spaces` — multiline with trailing spaces

## How to Test

1. `pytest tests/tools/test_fuzzy_match.py -v` — all 55 tests pass
2. Quick reproduction:
   ```python
   from tools.fuzzy_match import fuzzy_find_and_replace
   # Bug 1 — was: ("ba", 3), now: ("bb", 2)
   fuzzy_find_and_replace("aaaa", "aa", "b", replace_all=True)
   # Bug 2+3 — was: "Xbaz", now: "X   baz"
   fuzzy_find_and_replace("foo   bar   baz", "foo  bar", "X")
   ```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] N/A — no config keys, architecture changes, or tool behavior changes beyond the bug fix