### PR TITLE
fix(slack): split reply threading defaults by surface

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -291,6 +291,12 @@ class PlatformConfig:
     # - "all": All chunks in multi-part replies thread to user's message
     reply_to_mode: str = "first"
 
+    # Slack/Telegram legacy reply-thread toggle. ``None`` means use the
+    # platform-specific defaults below; when set, it applies to both surfaces.
+    reply_in_thread: Optional[bool] = None
+    reply_in_thread_dm: bool = False
+    reply_in_thread_channel: bool = True
+
     # Whether the gateway is allowed to send "♻️ Gateway online" /
     # "♻ Gateway restarted" lifecycle notifications on this platform.
     # Default True preserves prior behavior. Set False on platforms used
@@ -306,8 +312,12 @@ class PlatformConfig:
             "enabled": self.enabled,
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
+            "reply_in_thread_dm": self.reply_in_thread_dm,
+            "reply_in_thread_channel": self.reply_in_thread_channel,
             "gateway_restart_notification": self.gateway_restart_notification,
         }
+        if self.reply_in_thread is not None:
+            result["reply_in_thread"] = self.reply_in_thread
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -330,14 +340,30 @@ class PlatformConfig:
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
 
+        extra = data.get("extra", {})
+        _rit = data.get("reply_in_thread")
+        if _rit is None:
+            _rit = extra.get("reply_in_thread")
+        _rit_dm = data.get("reply_in_thread_dm")
+        if _rit_dm is None:
+            _rit_dm = extra.get("reply_in_thread_dm")
+        _rit_channel = data.get("reply_in_thread_channel")
+        if _rit_channel is None:
+            _rit_channel = extra.get("reply_in_thread_channel")
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
+            reply_in_thread=(
+                _coerce_bool(_rit, True) if _rit is not None else None
+            ),
+            reply_in_thread_dm=_coerce_bool(_rit_dm, False),
+            reply_in_thread_channel=_coerce_bool(_rit_channel, True),
             gateway_restart_notification=_coerce_bool(_grn, True),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 
@@ -828,6 +854,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "reply_in_thread" in platform_cfg:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
+                if "reply_in_thread_dm" in platform_cfg:
+                    bridged["reply_in_thread_dm"] = platform_cfg["reply_in_thread_dm"]
+                if "reply_in_thread_channel" in platform_cfg:
+                    bridged["reply_in_thread_channel"] = platform_cfg["reply_in_thread_channel"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -784,7 +784,7 @@ class SlackAdapter(BasePlatformAdapter):
             # Split long messages, preserving code block boundaries
             chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
 
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             last_result = None
 
             # reply_broadcast: also post thread replies to the main channel.
@@ -848,7 +848,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         try:
             formatted = self.format_message(content)
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             kwargs = {
                 "channel": chat_id,
                 "user": user_id,
@@ -962,39 +962,67 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        chat_id: Optional[str] = None,
     ) -> Optional[str]:
         """Resolve the correct thread_ts for a Slack API call.
 
         Prefers metadata thread_id (the thread parent's ts, set by the
         gateway) over reply_to (which may be a child message's ts).
 
-        When ``reply_in_thread`` is ``false`` in the platform extra config,
-        top-level channel messages receive direct channel replies instead of
-        thread replies.  Messages that originate inside an existing thread are
-        always replied to in-thread to preserve conversation context.
+        ``reply_in_thread_dm`` and ``reply_in_thread_channel`` control
+        top-level replies by surface.  Legacy ``reply_in_thread`` overrides
+        both for backcompat.  Messages that originate inside an existing
+        thread are always replied to in-thread to preserve context.
         """
-        # When reply_in_thread is disabled (default: True for backward compat),
-        # only thread messages that are already part of an existing thread.
-        # For top-level channel messages, the inbound handler sets
-        # metadata.thread_id to the message's own ts as a session-keying
-        # fallback (see the `thread_ts = event.get("thread_ts") or ts` branch),
-        # so metadata alone can't distinguish a real thread reply from a
-        # top-level message. reply_to is the incoming message's own id, so
-        # when thread_id == reply_to the "thread" is synthetic and we reply
-        # directly in the channel instead.
-        if not self.config.extra.get("reply_in_thread", True):
-            md = metadata or {}
-            existing_thread = md.get("thread_id") or md.get("thread_ts")
-            if existing_thread and reply_to and existing_thread == reply_to:
-                existing_thread = None
-            return existing_thread or None
+        md = metadata or {}
+        existing_thread = md.get("thread_id") or md.get("thread_ts")
+        anchor = reply_to or md.get("message_id")
+        synthetic_thread = bool(existing_thread and anchor and existing_thread == anchor)
 
-        if metadata:
-            if metadata.get("thread_id"):
-                return metadata["thread_id"]
-            if metadata.get("thread_ts"):
-                return metadata["thread_ts"]
-        return reply_to
+        if existing_thread and not synthetic_thread:
+            return existing_thread
+
+        top_level_thread = None if synthetic_thread else existing_thread
+        if top_level_thread:
+            return top_level_thread
+
+        if self._reply_in_thread_enabled_for_surface(md, chat_id):
+            return reply_to
+        return None
+
+    def _reply_in_thread_enabled_for_surface(
+        self,
+        metadata: Dict[str, Any],
+        chat_id: Optional[str],
+    ) -> bool:
+        """Return whether top-level Slack replies should thread on this surface."""
+        legacy = self.config.extra.get("reply_in_thread")
+        if legacy is None:
+            legacy = getattr(self.config, "reply_in_thread", None)
+        if legacy is not None:
+            return str(legacy).strip().lower() in {"1", "true", "yes", "on"}
+
+        channel_type = str(
+            metadata.get("channel_type")
+            or metadata.get("chat_type")
+            or metadata.get("platform_kind")
+            or ""
+        ).lower()
+        is_dm = channel_type in {"dm", "im", "mpim", "direct", "direct_message"}
+        if not channel_type and chat_id:
+            is_dm = str(chat_id).startswith("D")
+
+        if is_dm:
+            value = self.config.extra.get(
+                "reply_in_thread_dm",
+                getattr(self.config, "reply_in_thread_dm", False),
+            )
+        else:
+            value = self.config.extra.get(
+                "reply_in_thread_channel",
+                getattr(self.config, "reply_in_thread_channel", True),
+            )
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
 
     async def _upload_file(
         self,
@@ -1011,7 +1039,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
 
-        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
         last_exc = None
         for attempt in range(3):
             try:
@@ -1067,7 +1095,7 @@ class SlackAdapter(BasePlatformAdapter):
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
 
-        thread_ts = self._resolve_thread_ts(None, metadata)
+        thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
 
         CHUNK = 10
         chunks = [images[i:i + CHUNK] for i in range(0, len(images), CHUNK)]
@@ -1445,7 +1473,7 @@ class SlackAdapter(BasePlatformAdapter):
                 response = await client.get(image_url)
                 response.raise_for_status()
 
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             result = await self._get_client(chat_id).files_upload_v2(
                 channel=chat_id,
                 content=response.content,
@@ -1512,7 +1540,7 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"Video file not found: {video_path}")
 
         try:
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+            thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
             last_exc = None
             for attempt in range(3):
                 try:
@@ -1569,7 +1597,7 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"File not found: {file_path}")
 
         display_name = file_name or os.path.basename(file_path)
-        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        thread_ts = self._resolve_thread_ts(reply_to, metadata, chat_id=chat_id)
 
         try:
             last_exc = None
@@ -2187,6 +2215,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_id=user_id,
             user_name=user_name,
             thread_id=thread_ts,
+            message_id=ts,
         )
 
         # Per-channel ephemeral prompt
@@ -2254,7 +2283,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         try:
             cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
-            thread_ts = self._resolve_thread_ts(None, metadata)
+            thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
 
             blocks = [
                 {
@@ -2329,7 +2358,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         try:
             body = message[:2900] + "..." if len(message) > 2900 else message
-            thread_ts = self._resolve_thread_ts(None, metadata)
+            thread_ts = self._resolve_thread_ts(None, metadata, chat_id=chat_id)
             # Encode session_key and confirm_id into the button value so the
             # callback handler can resolve without extra bookkeeping.
             value = f"{session_key}|{confirm_id}"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13698,6 +13698,11 @@ class GatewayRunner:
         if thread_id is None:
             return None
         metadata: Dict[str, Any] = {"thread_id": thread_id}
+        if getattr(source, "platform", None) == Platform.SLACK:
+            metadata["chat_type"] = getattr(source, "chat_type", None)
+            anchor = reply_to_message_id or getattr(source, "message_id", None)
+            if anchor is not None:
+                metadata["message_id"] = str(anchor)
         if (
             getattr(source, "platform", None) == Platform.TELEGRAM
             and getattr(source, "chat_type", None) == "dm"

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2713,6 +2713,42 @@ class TestProgressMessageThread:
     ts) so they appear in the thread instead of the DM root.
     """
 
+    def test_resolve_thread_ts_splits_dm_and_channel_defaults(self, adapter):
+        """Top-level DMs reply directly; top-level channels still thread."""
+        assert adapter._resolve_thread_ts(
+            reply_to="111.000",
+            metadata={"thread_id": "111.000", "message_id": "111.000", "chat_type": "dm"},
+            chat_id="D_DM",
+        ) is None
+
+        assert adapter._resolve_thread_ts(
+            reply_to="222.000",
+            metadata={"thread_id": "222.000", "message_id": "222.000", "chat_type": "group"},
+            chat_id="C_CHAN",
+        ) == "222.000"
+
+    def test_resolve_thread_ts_honors_existing_threads(self, adapter):
+        """Existing Slack threads stay threaded regardless of surface defaults."""
+        assert adapter._resolve_thread_ts(
+            reply_to="111.500",
+            metadata={"thread_id": "111.000", "message_id": "111.500", "chat_type": "dm"},
+            chat_id="D_DM",
+        ) == "111.000"
+
+        assert adapter._resolve_thread_ts(
+            reply_to="222.500",
+            metadata={"thread_id": "222.000", "message_id": "222.500", "chat_type": "group"},
+            chat_id="C_CHAN",
+        ) == "222.000"
+
+    def test_resolve_thread_ts_legacy_reply_in_thread_overrides_both_surfaces(self, adapter):
+        """Legacy reply_in_thread remains a backcompat override for both knobs."""
+        adapter.config.extra["reply_in_thread"] = True
+        assert adapter._resolve_thread_ts(reply_to="111.000", metadata={}, chat_id="D_DM") == "111.000"
+
+        adapter.config.extra["reply_in_thread"] = False
+        assert adapter._resolve_thread_ts(reply_to="222.000", metadata={}, chat_id="C_CHAN") is None
+
     @pytest.mark.asyncio
     async def test_dm_toplevel_progress_uses_message_ts_as_thread(self, adapter):
         """Progress messages for a top-level DM should go into the reply thread."""

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -495,6 +495,32 @@ def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
     ) == "171.000"
 
 
+def test_config_bridges_slack_reply_in_thread_surface_knobs(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  reply_in_thread_dm: true\n"
+        "  reply_in_thread_channel: false\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    config = load_gateway_config()
+
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.extra.get("reply_in_thread_dm") is True
+    assert slack_config.extra.get("reply_in_thread_channel") is False
+
+    adapter = SlackAdapter(slack_config)
+    assert adapter._resolve_thread_ts(reply_to="171.000", metadata={}, chat_id="D123") == "171.000"
+    assert adapter._resolve_thread_ts(reply_to="172.000", metadata={}, chat_id="C123") is None
+
+
 def test_config_bridges_slack_strict_mention(monkeypatch, tmp_path):
     from gateway.config import load_gateway_config
 


### PR DESCRIPTION
## Summary
- split Slack reply threading defaults by surface: DMs default to direct replies, channels keep threaded replies
- preserve legacy `reply_in_thread` as an override for both surfaces
- include Slack chat type/message id in thread metadata so synthetic top-level threads are not mistaken for real threads by progress/final sends

## Linear
- OTO-497

## Tests
- `python -m pytest tests/gateway/test_slack.py::TestProgressMessageThread::test_resolve_thread_ts_splits_dm_and_channel_defaults tests/gateway/test_slack.py::TestProgressMessageThread::test_resolve_thread_ts_honors_existing_threads tests/gateway/test_slack.py::TestProgressMessageThread::test_resolve_thread_ts_legacy_reply_in_thread_overrides_both_surfaces tests/gateway/test_slack_mention.py::test_config_bridges_slack_reply_in_thread_surface_knobs -q -o 'addopts='`
- `python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/gateway/test_config.py tests/gateway/test_config_env_bridge_authority.py -q -o 'addopts='`

Note: this is a salvage of the closed PR #30088 approach; commit authorship is credited to the original author.