### PR TITLE
fix: keep blocked kanban tasks blocked

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2195,73 +2195,26 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
-def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Return True when ``task_id`` is sticky-blocked by an explicit
-    worker/operator ``kanban_block`` call (#28712).
-
-    A ``blocked`` status can come from two very different sources:
-
-    * **Worker- or operator-initiated** — a worker called
-      ``kanban_block(reason="review-required: ...")`` (or somebody ran
-      ``hermes kanban block <id>``).  This is a deliberate handoff that
-      should stay blocked until an operator unblocks it.  The block tool
-      emits a ``"blocked"`` event row in ``task_events``.
-
-    * **Circuit-breaker** — ``_record_task_failure`` tripped after
-      repeated crashes / spawn failures / timeouts.  This emits
-      ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
-      automatically once the underlying conditions change (e.g. parents
-      finish, transient infra error clears).
-
-    The cheapest signal that distinguishes the two is the most recent
-    ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
-
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
-    for that path.
-    """
-    row = conn.execute(
-        "SELECT kind FROM task_events "
-        "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
-        "ORDER BY id DESC LIMIT 1",
-        (task_id,),
-    ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
-
-
 def recompute_ready(conn: sqlite3.Connection) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
     Returns the number of tasks promoted.  Safe to call inside or outside
     an existing transaction; it opens its own IMMEDIATE txn.
 
-    ``blocked`` tasks are also considered for promotion (so a task
-    blocked purely by a parent dependency unblocks itself when the
-    parent completes), *except* when the most recent block event was a
-    worker-initiated ``kanban_block`` — those stay blocked until an
-    explicit ``kanban_unblock`` (#28712).  Without that guard, a
-    ``review-required`` handoff would auto-respawn, the fresh worker
-    would find nothing to do, exit cleanly, get recorded as a protocol
-    violation, and the cycle would repeat indefinitely.
+    ``blocked`` is a terminal human/ops gate for the dispatcher: once a
+    task has ``status='blocked'``, automatic ticks must not infer that it
+    is runnable again, even if it has no parents or all parents are done.
+    The only dispatcher-visible path out of blocked is an explicit
+    ``unblock_task`` / operator action, which re-gates parent completion
+    before setting the task back to ``ready`` or ``todo``.
     """
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status FROM tasks WHERE status IN ('todo', 'blocked')"
+            "SELECT id FROM tasks WHERE status = 'todo'"
         ).fetchall()
         for row in todo_rows:
             task_id = row["id"]
-            cur_status = row["status"]
-            if cur_status == "blocked" and _has_sticky_block(conn, task_id):
-                # Worker / operator asked for human review — do not
-                # silently auto-recover.  ``unblock_task`` is the only
-                # legitimate exit (it emits ``"unblocked"`` which flips
-                # this predicate back).
-                continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
@@ -2269,21 +2222,10 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                 (task_id,),
             ).fetchall()
             if all(p["status"] in ("done", "archived") for p in parents):
-                # Blocked tasks also get their failure counters reset —
-                # this is effectively an auto-unblock (circuit-breaker
-                # recovery; worker-initiated blocks are skipped above).
-                if cur_status == "blocked":
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready', "
-                        "consecutive_failures = 0, last_failure_error = NULL "
-                        "WHERE id = ? AND status = 'blocked'",
-                        (task_id,),
-                    )
-                else:
-                    conn.execute(
-                        "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
-                        (task_id,),
-                    )
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready' WHERE id = ? AND status = 'todo'",
+                    (task_id,),
+                )
                 _append_event(conn, task_id, "promoted", None)
                 promoted += 1
     return promoted

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -1,22 +1,19 @@
-"""Regression tests for #28712 — kanban dispatcher must not auto-promote
-worker-initiated ``kanban_block`` (sticky blocks), but must keep
-auto-recovering circuit-breaker blocks.
+"""Regression tests for blocked kanban tasks staying blocked.
 
-The bug: when a worker called ``kanban_block(reason="review-required:
-...")`` to hand off to a human, the dispatcher's ``recompute_ready``
-would promote the task back to ``ready`` on the next tick.  The fresh
-worker found nothing to do (work already applied), exited cleanly, and
-got recorded as a ``protocol_violation`` → ``gave_up`` → promote → loop
-until manual intervention.
+The bug: when a task reached ``status='blocked'``, the dispatcher's
+``recompute_ready`` could promote it back to ``ready`` on the next tick
+if it had no parents or all parents were done.  The next dispatcher pass
+could then claim/spawn it without an explicit human unblock.
 
 These tests pin down:
 
-* Worker / operator-initiated blocks are sticky and survive
-  ``recompute_ready``.
+* Any task with ``status='blocked'`` survives ``recompute_ready``.
+* No-parent approval gates and parent-completion paths do not silently
+  become runnable again.
 * Circuit-breaker blocks (``gave_up`` event, status flipped via
-  ``_record_task_failure``) still auto-recover — the original intent
-  of #40c1decb3 is preserved.
-* An explicit ``kanban_unblock`` clears the sticky state.
+  ``_record_task_failure``) require explicit unblock like every other
+  blocked task.
+* An explicit ``kanban_unblock`` clears the blocked state.
 * The full block → promote → crash → ``gave_up`` loop is broken after
   this fix: subsequent ticks leave the task blocked.
 
@@ -76,6 +73,49 @@ def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path)
             assert kb.get_task(conn, tid).status == "blocked"
 
 
+def test_no_parent_blocked_task_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:
+    """A blocked approval gate with no parents must not auto-promote.
+
+    The dangerous edge case is ``all([]) == True``: if ``recompute_ready``
+    scans blocked rows, a standalone blocked task can become ready and be
+    claimed/spawned on the same dispatcher tick.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="standalone approval gate", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_dispatch_once_does_not_claim_or_spawn_no_parent_blocked_task(kanban_home: Path) -> None:
+    """Dispatcher ticks must not turn a blocked no-parent gate into work."""
+    spawned: list[str] = []
+
+    def spawn_fn(task: kb.Task, workspace: str) -> int:
+        spawned.append(task.id)
+        return 12345
+
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="blocked gate",
+            assignee="default",
+            initial_status="blocked",
+        )
+
+        result = kb.dispatch_once(conn, spawn_fn=spawn_fn)
+
+        assert result.promoted == 0
+        assert result.spawned == []
+        assert spawned == []
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.current_run_id is None
+
+
 def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Path) -> None:
     """The parent-completion path is the one ``recompute_ready`` was
     designed for, so it's the most dangerous false-positive: even when
@@ -100,15 +140,14 @@ def test_worker_block_on_child_with_done_parents_is_still_sticky(kanban_home: Pa
 
 
 # ---------------------------------------------------------------------------
-# Circuit-breaker blocks still auto-recover (preserve #40c1decb3 intent)
+# Circuit-breaker blocks require explicit unblock too
 # ---------------------------------------------------------------------------
 
 
-def test_circuit_breaker_block_still_auto_promotes(kanban_home: Path) -> None:
-    """A child that was put into ``blocked`` *without* a worker-issued
-    ``kanban_block`` (e.g. circuit-breaker after repeated spawn
-    failures, manual DB triage) must still get auto-promoted when its
-    parents complete — preserves the pre-#28712 recovery semantics."""
+def test_circuit_breaker_block_does_not_auto_promote(kanban_home: Path) -> None:
+    """A child that was put into ``blocked`` without a worker-issued
+    ``kanban_block`` (e.g. circuit-breaker after repeated spawn failures,
+    manual DB triage) must still require explicit unblock."""
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent")
         child = kb.create_task(conn, title="child", parents=[parent])
@@ -125,18 +164,17 @@ def test_circuit_breaker_block_still_auto_promotes(kanban_home: Path) -> None:
         conn.commit()
 
         promoted = kb.recompute_ready(conn)
-        assert promoted == 1
+        assert promoted == 0
         task = kb.get_task(conn, child)
-        assert task.status == "ready"
-        assert task.consecutive_failures == 0
-        assert task.last_failure_error is None
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 5
+        assert task.last_failure_error == "persistent error"
 
 
-def test_gave_up_event_alone_does_not_make_block_sticky(kanban_home: Path) -> None:
-    """The circuit-breaker emits ``gave_up`` (not ``blocked``).  Make
-    sure ``_has_sticky_block`` doesn't accidentally treat ``gave_up``
-    as sticky — otherwise we'd regress the safety net for genuinely
-    transient crashes."""
+def test_gave_up_event_alone_still_leaves_blocked_task_blocked(kanban_home: Path) -> None:
+    """The circuit-breaker emits ``gave_up`` (not ``blocked``), but the
+    durable state is still ``status='blocked'`` and must not auto-promote."""
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent")
         child = kb.create_task(conn, title="child", parents=[parent])
@@ -155,20 +193,19 @@ def test_gave_up_event_alone_does_not_make_block_sticky(kanban_home: Path) -> No
         conn.commit()
 
         promoted = kb.recompute_ready(conn)
-        assert promoted == 1
-        assert kb.get_task(conn, child).status == "ready"
+        assert promoted == 0
+        assert kb.get_task(conn, child).status == "blocked"
 
 
 # ---------------------------------------------------------------------------
-# unblock_task clears the sticky state
+# unblock_task clears the blocked state
 # ---------------------------------------------------------------------------
 
 
-def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -> None:
+def test_unblock_clears_blocked_state_and_later_blocks_stay_blocked(kanban_home: Path) -> None:
     """``hermes kanban unblock`` (or the ``kanban_unblock`` tool) is
-    the only legitimate way out of a worker-initiated block.  After
-    unblock, a *subsequent* circuit-breaker block on the same task
-    must again be eligible for auto-recovery."""
+    the only legitimate way out of a blocked task.  A later block on the
+    same task must also require explicit unblock."""
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="t")
         kb.claim_task(conn, tid)
@@ -182,17 +219,16 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
         assert kb.get_task(conn, tid).status == "ready"
 
         # Now simulate a *later* circuit-breaker block (no new
-        # ``blocked`` event, just status flip).  The most recent
-        # block/unblock event is ``unblocked`` → guard does not fire
-        # → recompute can recover.
+        # ``blocked`` event, just status flip).  A blocked task remains
+        # blocked until the operator explicitly unblocks it again.
         conn.execute(
             "UPDATE tasks SET status='blocked' WHERE id=?", (tid,),
         )
         conn.commit()
 
         promoted = kb.recompute_ready(conn)
-        assert promoted == 1
-        assert kb.get_task(conn, tid).status == "ready"
+        assert promoted == 0
+        assert kb.get_task(conn, tid).status == "blocked"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -266,8 +266,8 @@ def test_recompute_ready_cascades_through_chain(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
-def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
-    """blocked tasks with all parents done should be promoted to ready."""
+def test_recompute_ready_does_not_promote_blocked_with_done_parents(kanban_home):
+    """blocked tasks with all parents done stay blocked until explicit unblock."""
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
         child = kb.create_task(
@@ -285,13 +285,14 @@ def test_recompute_ready_promotes_blocked_with_done_parents(kanban_home):
         )
         conn.commit()
         assert kb.get_task(conn, child).status == "blocked"
-        # recompute_ready should promote blocked → ready and reset failures
+        # recompute_ready must not promote blocked -> ready or clear failures
         promoted = kb.recompute_ready(conn)
-        assert promoted == 1
+        assert promoted == 0
         task = kb.get_task(conn, child)
-        assert task.status == "ready"
-        assert task.consecutive_failures == 0
-        assert task.last_failure_error is None
+        assert task is not None
+        assert task.status == "blocked"
+        assert task.consecutive_failures == 5
+        assert task.last_failure_error == "persistent error"
 
 
 def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):


### PR DESCRIPTION
## Summary
- Prevent `recompute_ready()` from auto-promoting `status='blocked'` Kanban tasks.
- Add regressions for no-parent blocked approval gates, blocked children with done parents, dispatcher claim/spawn behavior, circuit-breaker blocked state, and explicit unblock.
- Keeps blocked tasks as a true human/operator gate until explicit unblock.

## Test Plan
- `python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_db.py -q -o 'addopts='` — 180 passed
- Kanban final verifier evidence from Janis runtime: `t_6eed0ef4` GREEN after gateway reload; blocked tasks did not promote/claim/spawn.
