### PR TITLE
fix: preserve runtime credential and voice workflows

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -866,30 +866,41 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
-    # Try macOS Keychain first (covers Claude Code >=2.1.114)
+    def _read_credentials_file() -> Optional[Dict[str, Any]]:
+        cred_path = Path.home() / ".claude" / ".credentials.json"
+        if cred_path.exists():
+            try:
+                data = json.loads(cred_path.read_text(encoding="utf-8"))
+                oauth_data = data.get("claudeAiOauth")
+                if oauth_data and isinstance(oauth_data, dict):
+                    access_token = oauth_data.get("accessToken", "")
+                    if access_token:
+                        return {
+                            "accessToken": access_token,
+                            "refreshToken": oauth_data.get("refreshToken", ""),
+                            "expiresAt": oauth_data.get("expiresAt", 0),
+                            "source": "claude_code_credentials_file",
+                        }
+            except (json.JSONDecodeError, OSError, IOError) as e:
+                logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
+        return None
+
+    # Try macOS Keychain first (covers Claude Code >=2.1.114), but do not let
+    # an expired/unrefreshable Keychain entry shadow a still-valid JSON-file
+    # credential. Claude Code migrations can leave both stores populated, and
+    # the Keychain entry may be stale while ~/.claude/.credentials.json is fresh.
     kc_creds = _read_claude_code_credentials_from_keychain()
-    if kc_creds:
+    file_creds = _read_credentials_file()
+
+    if kc_creds and is_claude_code_token_valid(kc_creds):
         return kc_creds
+    if file_creds and is_claude_code_token_valid(file_creds):
+        return file_creds
 
-    # Fall back to JSON file
-    cred_path = Path.home() / ".claude" / ".credentials.json"
-    if cred_path.exists():
-        try:
-            data = json.loads(cred_path.read_text(encoding="utf-8"))
-            oauth_data = data.get("claudeAiOauth")
-            if oauth_data and isinstance(oauth_data, dict):
-                access_token = oauth_data.get("accessToken", "")
-                if access_token:
-                    return {
-                        "accessToken": access_token,
-                        "refreshToken": oauth_data.get("refreshToken", ""),
-                        "expiresAt": oauth_data.get("expiresAt", 0),
-                        "source": "claude_code_credentials_file",
-                    }
-        except (json.JSONDecodeError, OSError, IOError) as e:
-            logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
-
-    return None
+    # If neither credential is currently valid, prefer Keychain so the refresh
+    # path still uses Claude Code's newest storage location; otherwise fall back
+    # to the JSON file credential.
+    return kc_creds or file_creds
 
 
 def read_claude_managed_key() -> Optional[str]:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1821,6 +1821,20 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             except Exception as e:
                 logger.debug("check_fn for %s raised: %s", entry.name, e)
                 continue
+
+            # check_fn() is dependency availability for many platform plugins,
+            # not credential readiness.  Do not auto-enable a plugin platform
+            # unless its declared required env vars are actually present;
+            # otherwise installed-but-unconfigured adapters (notably Discord)
+            # enter reconnect loops even when config.yaml says enabled: false.
+            if entry.required_env:
+                missing_required = [
+                    env_name for env_name in entry.required_env
+                    if not (os.getenv(env_name) or "").strip()
+                ]
+                if missing_required:
+                    continue
+
             platform = Platform(entry.name)
             existing_cfg = config.platforms.get(platform)
             # Seed candidate extras from ``env_enablement_fn`` so plugins

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3569,6 +3569,49 @@ class TelegramAdapter(BasePlatformAdapter):
             )
         return error
 
+    async def play_tts(
+        self,
+        chat_id: str,
+        audio_path: str,
+        **kwargs,
+    ) -> SendResult:
+        """Send auto-TTS as a Telegram voice bubble when possible.
+
+        Telegram exposes playback speed controls on voice notes.  Edge TTS and
+        some other providers produce MP3/WAV files, which Telegram's Bot API
+        treats as music/audio attachments without the same voice-note UX.  For
+        auto-TTS replies, convert playable audio to Opus/Ogg first and then use
+        sendVoice; keep normal MEDIA: MP3 attachments on the document/audio
+        route unless they explicitly opt into voice delivery.
+        """
+        ext = os.path.splitext(audio_path)[1].lower()
+        if ext not in {".ogg", ".opus"}:
+            converted_path: Optional[str] = None
+            try:
+                from tools.tts_tool import _convert_to_opus
+
+                converted_path = await asyncio.to_thread(_convert_to_opus, audio_path)
+                if converted_path and os.path.exists(converted_path):
+                    return await self.send_voice(
+                        chat_id=chat_id,
+                        audio_path=converted_path,
+                        **kwargs,
+                    )
+            except Exception as convert_err:
+                logger.warning(
+                    "[%s] Auto-TTS Opus conversion failed; sending original audio: %s",
+                    self.name,
+                    convert_err,
+                )
+            finally:
+                if converted_path and converted_path != audio_path:
+                    try:
+                        os.remove(converted_path)
+                    except OSError:
+                        pass
+
+        return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
+
     async def send_voice(
         self,
         chat_id: str,

--- a/tests/agent/test_claude_code_credentials_resolution.py
+++ b/tests/agent/test_claude_code_credentials_resolution.py
@@ -1,0 +1,65 @@
+"""Regression tests for Claude Code OAuth credential source selection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.anthropic_adapter import read_claude_code_credentials
+
+
+def _cred(access_token: str, expires_at: int) -> dict:
+    return {
+        "accessToken": access_token,
+        "refreshToken": f"refresh-{access_token}",
+        "expiresAt": expires_at,
+    }
+
+
+def test_expired_keychain_does_not_shadow_valid_credentials_file(tmp_path: Path):
+    """Claude Code migrations can leave stale Keychain data plus fresh file data."""
+    valid_expiry_ms = 4_102_444_800_000  # 2100-01-01T00:00:00Z
+    expired_expiry_ms = 1_577_836_800_000  # 2020-01-01T00:00:00Z
+    cred_dir = tmp_path / ".claude"
+    cred_dir.mkdir()
+    (cred_dir / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": _cred("file-token", valid_expiry_ms)}),
+        encoding="utf-8",
+    )
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            return_value={**_cred("keychain-token", expired_expiry_ms), "source": "macos_keychain"},
+        ),
+    ):
+        creds = read_claude_code_credentials()
+
+    assert creds is not None
+    assert creds["accessToken"] == "file-token"
+    assert creds["source"] == "claude_code_credentials_file"
+
+
+def test_valid_keychain_still_wins_over_credentials_file(tmp_path: Path):
+    valid_expiry_ms = 4_102_444_800_000  # 2100-01-01T00:00:00Z
+    cred_dir = tmp_path / ".claude"
+    cred_dir.mkdir()
+    (cred_dir / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": _cred("file-token", valid_expiry_ms)}),
+        encoding="utf-8",
+    )
+
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            return_value={**_cred("keychain-token", valid_expiry_ms), "source": "macos_keychain"},
+        ),
+    ):
+        creds = read_claude_code_credentials()
+
+    assert creds is not None
+    assert creds["accessToken"] == "keychain-token"
+    assert creds["source"] == "macos_keychain"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -169,9 +169,13 @@ def _is_blocked_device(filepath: str) -> bool:
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
-    "/private/etc/", "/private/var/",
+    "/private/etc/",
+    # macOS mirrors sensitive /var state under /private/var.  Keep the guard
+    # focused on system-owned locations; /private/var/folders is the normal
+    # per-user temp root used by pytest/tmp_path and is safe to write.
+    "/private/var/db/", "/private/var/root/", "/private/var/run/",
 )
-_SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
+_SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock", "/private/var/run/docker.sock"}
 
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -840,9 +840,24 @@ def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -
 # ===========================================================================
 # ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
 # ===========================================================================
+def _resolve_ffmpeg() -> Optional[str]:
+    """Return an ffmpeg executable path, including common macOS service paths."""
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+    for candidate in (
+        "/opt/homebrew/bin/ffmpeg",  # Apple Silicon Homebrew, often absent from launchd PATH
+        "/usr/local/bin/ffmpeg",     # Intel Homebrew / common user install
+        "/opt/local/bin/ffmpeg",     # MacPorts
+    ):
+        if os.path.exists(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def _has_ffmpeg() -> bool:
     """Check if ffmpeg is available on the system."""
-    return shutil.which("ffmpeg") is not None
+    return _resolve_ffmpeg() is not None
 
 
 def _convert_to_opus(mp3_path: str) -> Optional[str]:
@@ -855,13 +870,14 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     Returns:
         Path to the .ogg file, or None if conversion fails.
     """
-    if not _has_ffmpeg():
+    ffmpeg = _resolve_ffmpeg()
+    if not ffmpeg:
         return None
 
     ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
+            [ffmpeg, "-i", mp3_path, "-acodec", "libopus",
              "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
             capture_output=True, timeout=30,
         )
@@ -899,11 +915,17 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     edge_config = tts_config.get("edge", {})
     voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
     speed = float(edge_config.get("speed", tts_config.get("speed", 1.0)))
+    pitch = edge_config.get("pitch", tts_config.get("pitch"))
+    volume = edge_config.get("volume", tts_config.get("volume"))
 
     kwargs = {"voice": voice}
     if speed != 1.0:
         pct = round((speed - 1.0) * 100)
         kwargs["rate"] = f"{pct:+d}%"
+    if pitch:
+        kwargs["pitch"] = str(pitch)
+    if volume:
+        kwargs["volume"] = str(volume)
 
     communicate = _edge_tts.Communicate(text, **kwargs)
     await communicate.save(output_path)
@@ -1865,7 +1887,15 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    # Prefer Opus/Ogg when running inside Telegram so audio arrives as a
+    # native voice bubble.  Some tool invocations are launched outside the
+    # gateway request task, so HERMES_SESSION_PLATFORM can be unavailable even
+    # though the user is chatting from Telegram.  ``tts.prefer_opus`` gives
+    # Telegram-heavy installs a safe config-level override while preserving the
+    # default MP3 behavior for CLI/desktop users.
+    want_opus = (platform == "telegram") or bool(
+        tts_config.get("prefer_opus") or tts_config.get("telegram_voice")
+    )
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## Summary
- prefer a still-valid Claude Code credentials file when a stale Keychain entry exists
- avoid auto-enabling plugin platforms when required credentials are missing
- convert Telegram auto-TTS audio to Opus voice notes when possible
- allow macOS per-user temp paths while keeping sensitive system path guards

## Test Plan
- python -m pytest tests/agent/test_claude_code_credentials_resolution.py tests/agent/test_anthropic_keychain.py tests/tools/test_tts_opus_routing.py tests/tools/test_approval.py -q -k 'claude or keychain or opus or sensitive or private or docker or approval_blocks' -o 'addopts='
- git diff --check main...HEAD

Note: a broader targeted run including all of tests/tools/test_approval.py produced 4 pre-existing approval/cron-mode failures unrelated to this branch; the relevant sensitive-path subset passes.