### PR TITLE
fix: harden dependency update paths

### DIFF
--- a/tests/hermes_cli/test_psutil_android_safe_extract.py
+++ b/tests/hermes_cli/test_psutil_android_safe_extract.py
@@ -1,0 +1,48 @@
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.psutil_android import (
+    PsutilAndroidInstallError,
+    _safe_extract_tar_gz,
+)
+
+
+def _write_tar(path: Path, member_name: str, data: bytes = b"payload") -> None:
+    info = tarfile.TarInfo(member_name)
+    info.size = len(data)
+    with tarfile.open(path, "w:gz") as tar:
+        tar.addfile(info, io.BytesIO(data))
+
+
+def test_install_script_rejects_tar_path_traversal(tmp_path):
+    archive = tmp_path / "evil.tar.gz"
+    _write_tar(archive, "../evil.txt")
+    destination = tmp_path / "extract"
+    destination.mkdir()
+
+    with pytest.raises(PsutilAndroidInstallError, match="Unsafe archive member path"):
+        _safe_extract_tar_gz(archive, destination)
+
+    assert not (tmp_path / "evil.txt").exists()
+
+
+def test_update_android_psutil_rejects_tar_path_traversal_before_install(tmp_path):
+    archive = tmp_path / "evil.tar.gz"
+    _write_tar(archive, "../evil.txt")
+
+    from hermes_cli.main import _install_psutil_android_compat
+
+    def fake_urlretrieve(_url, dest):
+        Path(dest).write_bytes(archive.read_bytes())
+        return dest, None
+
+    with patch("urllib.request.urlretrieve", side_effect=fake_urlretrieve), \
+         patch("hermes_cli.main._run_install_with_heartbeat") as install, \
+         pytest.raises(PsutilAndroidInstallError, match="Unsafe archive member path"):
+        _install_psutil_android_compat(["python", "-m", "pip"])
+
+    install.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -3351,11 +3351,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
﻿## Summary
- refresh `scripts/whatsapp-bridge/package-lock.json` so Express resolves to the patched `qs` line through Express 4.22.2 / body-parser 1.20.5
- keep the psutil Android tar-extraction regression coverage on the current shared `hermes_cli.psutil_android` helper
- refresh the lockfile for Pygments on top of current `main`

## Security review notes
- This branch was rebased onto current `upstream/main`; the psutil Android installer implementation has since moved into `hermes_cli.psutil_android`, so the PR now keeps the regression test against that shared helper instead of reintroducing an inline extractor.
- `npm audit --omit=dev` in `scripts/whatsapp-bridge` no longer reports the prior Express/qs advisory from this PR's original scope. It currently reports separate Baileys/protobufjs/ws advisories; Baileys is being handled in the dedicated WhatsApp dependency PR stream.

## Validation
- `uv run pytest -q tests\hermes_cli\test_psutil_android_safe_extract.py -o addopts=`
- `uv run ruff check hermes_cli\psutil_android.py hermes_cli\main.py scripts\install_psutil_android.py tests\hermes_cli\test_psutil_android_safe_extract.py`
- `uv lock --check`
- `npm audit --omit=dev --json` in `scripts/whatsapp-bridge` reviewed; remaining findings are outside the Express/qs scope of this PR.
