### PR TITLE
Add cockpit AG-UI bridge and run event replay

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -11,6 +11,9 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
+- GET  /v1/runs/{run_id}/events/replay — JSON replay/audit log of lifecycle events
+- GET  /v1/runs/{run_id}/agui-events — AG-UI protocol SSE stream for cockpit UIs
+- POST /v1/agui/runs               — AG-UI-style run request with immediate SSE stream
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
 - GET  /health                     — health check
@@ -62,6 +65,185 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+
+
+_AGUI_ID_SAFE_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+
+
+def _agui_safe_id(value: Any, fallback: str) -> str:
+    """Return an AG-UI-friendly ID component without leaking arbitrary text."""
+    raw = str(value or fallback).strip() or fallback
+    cleaned = _AGUI_ID_SAFE_RE.sub("_", raw)
+    return cleaned[:128] or fallback
+
+
+def _agui_message_id(run_id: str) -> str:
+    return f"{_agui_safe_id(run_id, 'run')}_message"
+
+
+def _agui_tool_call_id(run_id: str, tool_name: Any) -> str:
+    return f"{_agui_safe_id(run_id, 'run')}_{_agui_safe_id(tool_name, 'tool')}"
+
+
+def _agui_events_from_run_event(event: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Map Hermes /v1/runs lifecycle events to AG-UI protocol events.
+
+    AG-UI is event-based.  Hermes already has a run event stream, so this
+    adapter keeps Hermes' native run API as the source of truth and exposes a
+    protocol-shaped view for CopilotKit/AG-UI clients.
+    """
+    event_name = str(event.get("event") or "")
+    run_id = str(event.get("run_id") or event.get("runId") or "run")
+    message_id = _agui_message_id(run_id)
+
+    if event_name == "message.delta":
+        return [{
+            "type": "TEXT_MESSAGE_CONTENT",
+            "runId": run_id,
+            "messageId": message_id,
+            "delta": str(event.get("delta") or ""),
+        }]
+
+    if event_name == "tool.started":
+        tool_name = event.get("tool") or "tool"
+        return [{
+            "type": "TOOL_CALL_START",
+            "runId": run_id,
+            "toolCallId": _agui_tool_call_id(run_id, tool_name),
+            "toolCallName": str(tool_name),
+            "parentMessageId": message_id,
+            "args": {"preview": event.get("preview") or ""},
+        }]
+
+    if event_name == "tool.completed":
+        tool_name = event.get("tool") or "tool"
+        agui_event: Dict[str, Any] = {
+            "type": "TOOL_CALL_END",
+            "runId": run_id,
+            "toolCallId": _agui_tool_call_id(run_id, tool_name),
+            "toolCallName": str(tool_name),
+            "parentMessageId": message_id,
+            "duration": event.get("duration"),
+            "error": bool(event.get("error", False)),
+        }
+        return [agui_event]
+
+    if event_name == "approval.request":
+        return [{
+            "type": "TOOL_CALL_REQUIRES_ACTION",
+            "runId": run_id,
+            "toolCallId": _agui_tool_call_id(run_id, event.get("tool") or "approval"),
+            "parentMessageId": message_id,
+            "action": {
+                "kind": "approval",
+                "choices": event.get("choices") or ["once", "session", "always", "deny"],
+                "payload": event,
+            },
+        }]
+
+    if event_name == "approval.responded":
+        return [{
+            "type": "TOOL_CALL_RESULT",
+            "runId": run_id,
+            "toolCallId": _agui_tool_call_id(run_id, "approval"),
+            "parentMessageId": message_id,
+            "result": {
+                "choice": event.get("choice"),
+                "resolved": event.get("resolved"),
+            },
+        }]
+
+    if event_name == "reasoning.available":
+        return [{
+            "type": "CUSTOM",
+            "runId": run_id,
+            "name": "hermes.reasoning.available",
+            "value": {"text": event.get("text") or ""},
+        }]
+
+    if event_name == "run.completed":
+        return [
+            {
+                "type": "TEXT_MESSAGE_END",
+                "runId": run_id,
+                "messageId": message_id,
+            },
+            {
+                "type": "RUN_FINISHED",
+                "runId": run_id,
+                "result": event.get("output") or "",
+                "usage": event.get("usage") or {},
+            },
+        ]
+
+    if event_name in {"run.failed", "run.cancelled"}:
+        return [{
+            "type": "RUN_ERROR" if event_name == "run.failed" else "RUN_CANCELLED",
+            "runId": run_id,
+            "message": event.get("error") or event_name,
+        }]
+
+    return [{
+        "type": "CUSTOM",
+        "runId": run_id,
+        "name": f"hermes.{event_name or 'event'}",
+        "value": event,
+    }]
+
+
+def _normalize_agui_message_content(content: Any) -> str:
+    """Flatten AG-UI message content into the text shape Hermes runs accept."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: List[str] = []
+        for part in content[:MAX_CONTENT_LIST_SIZE]:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text") or part.get("content") or ""
+                if text:
+                    parts.append(str(text))
+        return " ".join(parts)[:MAX_NORMALIZED_TEXT_LENGTH]
+    return str(content)[:MAX_NORMALIZED_TEXT_LENGTH]
+
+
+def _runs_body_from_agui_input(body: Dict[str, Any]) -> Dict[str, Any]:
+    """Translate a minimal AG-UI RunAgentInput body to Hermes /v1/runs input."""
+    messages = body.get("messages")
+    if messages is None:
+        messages = body.get("input")
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("AG-UI request requires a non-empty 'messages' array")
+
+    normalized_messages: List[Dict[str, str]] = []
+    for i, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise ValueError(f"messages[{i}] must be an object")
+        role = str(message.get("role") or "user")
+        content = _normalize_agui_message_content(message.get("content"))
+        if not content:
+            continue
+        normalized_messages.append({"role": role, "content": content})
+
+    if not normalized_messages:
+        raise ValueError("AG-UI request contains no text content")
+
+    run_body: Dict[str, Any] = {
+        "input": normalized_messages,
+        "model": body.get("model"),
+    }
+    if body.get("instructions"):
+        run_body["instructions"] = str(body["instructions"])
+    if body.get("threadId"):
+        run_body["session_id"] = str(body["threadId"])
+    if body.get("runId"):
+        run_body["agui_run_id"] = str(body["runId"])
+    if body.get("previous_response_id"):
+        run_body["previous_response_id"] = str(body["previous_response_id"])
+    return {key: value for key, value in run_body.items() if value is not None}
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -692,6 +874,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
+        # Replayable per-run event audit logs. These are in-memory, bounded,
+        # and retained alongside terminal run status so dashboards/operators can
+        # reconnect after completion and reconstruct what happened.
+        self._run_event_logs: Dict[str, List[Dict[str, Any]]] = {}
+        self._run_event_seq: Dict[str, int] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
         # in-flight run by run_id.
@@ -1082,6 +1269,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
+                "run_event_replay": True,
+                "run_events_agui_sse": True,
+                "agui_run_streaming": True,
                 "run_stop": True,
                 "run_approval_response": True,
                 "tool_progress_events": True,
@@ -1099,6 +1289,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 "runs": {"method": "POST", "path": "/v1/runs"},
                 "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
+                "run_event_replay": {"method": "GET", "path": "/v1/runs/{run_id}/events/replay"},
+                "run_agui_events": {"method": "GET", "path": "/v1/runs/{run_id}/agui-events"},
+                "agui_runs": {"method": "POST", "path": "/v1/agui/runs"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
             },
@@ -1497,7 +1690,8 @@ class APIServerAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
             while True:
                 try:
-                    delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
+                    poll_timeout = min(0.5, max(0.01, CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS))
+                    delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=poll_timeout))
                 except _q.Empty:
                     if agent_task.done():
                         # Drain any remaining items
@@ -2887,6 +3081,7 @@ class APIServerAdapter(BasePlatformAdapter):
     _MAX_CONCURRENT_RUNS = 10  # Prevent unbounded resource allocation
     _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
+    _RUN_EVENT_LOG_MAX = 1000  # bounded in-memory replay/audit events per run
 
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
@@ -2903,21 +3098,59 @@ class APIServerAdapter(BasePlatformAdapter):
         self._run_statuses[run_id] = current
         return current
 
+    def _record_run_event(self, run_id: str, event: Dict[str, Any]) -> Dict[str, Any]:
+        """Append a bounded, sequence-numbered event to the run replay log."""
+        recorded = dict(event)
+        recorded.setdefault("run_id", run_id)
+        recorded.setdefault("timestamp", time.time())
+        next_seq = self._run_event_seq.get(run_id, 0) + 1
+        self._run_event_seq[run_id] = next_seq
+        recorded["seq"] = next_seq
+
+        log = self._run_event_logs.setdefault(run_id, [])
+        log.append(recorded)
+        if len(log) > self._RUN_EVENT_LOG_MAX:
+            del log[: len(log) - self._RUN_EVENT_LOG_MAX]
+        return recorded
+
+    def _publish_run_event(
+        self,
+        run_id: str,
+        event: Dict[str, Any],
+        loop: Optional["asyncio.AbstractEventLoop"] = None,
+    ) -> Dict[str, Any]:
+        """Record a run event, update status metadata, and fan it out to SSE."""
+        recorded = self._record_run_event(run_id, event)
+        self._set_run_status(
+            run_id,
+            self._run_statuses.get(run_id, {}).get("status", "running"),
+            last_event=recorded.get("event"),
+        )
+        q = self._run_streams.get(run_id)
+        if q is not None:
+            try:
+                if loop is not None:
+                    loop.call_soon_threadsafe(q.put_nowait, recorded)
+                else:
+                    q.put_nowait(recorded)
+            except Exception:
+                pass
+        return recorded
+
+    def _close_run_event_stream(self, run_id: str) -> None:
+        """Signal an active SSE stream to close without adding a replay event."""
+        q = self._run_streams.get(run_id)
+        if q is None:
+            return
+        try:
+            q.put_nowait(None)
+        except Exception:
+            pass
+
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
         def _push(event: Dict[str, Any]) -> None:
-            self._set_run_status(
-                run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
-                last_event=event.get("event"),
-            )
-            q = self._run_streams.get(run_id)
-            if q is None:
-                return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
-            except Exception:
-                pass
+            self._publish_run_event(run_id, event, loop=loop)
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
@@ -3027,7 +3260,16 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        run_id = f"run_{uuid.uuid4().hex}"
+        requested_run_id = body.get("run_id") or body.get("agui_run_id")
+        if requested_run_id:
+            run_id = _agui_safe_id(requested_run_id, f"run_{uuid.uuid4().hex}")
+            if run_id in self._run_streams or run_id in self._run_statuses:
+                return web.json_response(
+                    _openai_error(f"Run already exists: {run_id}", code="run_already_exists"),
+                    status=409,
+                )
+        else:
+            run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
@@ -3044,15 +3286,16 @@ class APIServerAdapter(BasePlatformAdapter):
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, {
+            self._publish_run_event(
+                run_id,
+                {
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
                     "delta": delta,
-                })
-            except Exception:
-                pass
+                },
+                loop=loop,
+            )
 
         self._set_run_status(
             run_id,
@@ -3087,10 +3330,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "waiting_for_approval",
                         last_event="approval.request",
                     )
-                    try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
-                    except Exception:
-                        pass
+                    self._publish_run_event(run_id, event, loop=loop)
 
                 def _run_sync():
                     from gateway.session_context import clear_session_vars, set_session_vars
@@ -3146,7 +3386,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 # block below never fires — issue #15561).
                 if isinstance(result, dict) and result.get("failed"):
                     error_msg = result.get("error") or "agent run failed"
-                    q.put_nowait({
+                    self._publish_run_event(run_id, {
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
@@ -3160,7 +3400,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    q.put_nowait({
+                    self._publish_run_event(run_id, {
                         "event": "run.completed",
                         "run_id": run_id,
                         "timestamp": time.time(),
@@ -3181,7 +3421,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     last_event="run.cancelled",
                 )
                 try:
-                    q.put_nowait({
+                    self._publish_run_event(run_id, {
                         "event": "run.cancelled",
                         "run_id": run_id,
                         "timestamp": time.time(),
@@ -3198,7 +3438,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     last_event="run.failed",
                 )
                 try:
-                    q.put_nowait({
+                    self._publish_run_event(run_id, {
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
@@ -3219,10 +3459,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 except Exception:
                     pass
                 # Sentinel: signal SSE stream to close
-                try:
-                    q.put_nowait(None)
-                except Exception:
-                    pass
+                self._close_run_event_stream(run_id)
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
@@ -3259,6 +3496,57 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=404,
             )
         return web.json_response(status)
+
+    async def _handle_run_event_replay(self, request: Any) -> Any:
+        """GET /v1/runs/{run_id}/events/replay — return recorded lifecycle events."""
+        web_mod = web
+        if web_mod is None:
+            raise RuntimeError("aiohttp is required for API server")
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        run_id = request.match_info["run_id"]
+        status = self._run_statuses.get(run_id)
+        events = list(self._run_event_logs.get(run_id, []))
+        if status is None and not events:
+            return web_mod.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
+
+        try:
+            after = int(request.query.get("after", "0") or 0)
+        except (TypeError, ValueError):
+            return web_mod.json_response(
+                _openai_error("Invalid 'after' cursor; expected integer sequence", code="invalid_cursor"),
+                status=400,
+            )
+        if after < 0:
+            return web_mod.json_response(
+                _openai_error("Invalid 'after' cursor; expected non-negative integer", code="invalid_cursor"),
+                status=400,
+            )
+
+        try:
+            limit = int(request.query.get("limit", str(self._RUN_EVENT_LOG_MAX)) or self._RUN_EVENT_LOG_MAX)
+        except (TypeError, ValueError):
+            return web_mod.json_response(
+                _openai_error("Invalid 'limit'; expected integer", code="invalid_limit"),
+                status=400,
+            )
+        limit = max(1, min(limit, self._RUN_EVENT_LOG_MAX))
+        filtered = [event for event in events if int(event.get("seq", 0) or 0) > after][:limit]
+        next_after = filtered[-1]["seq"] if filtered else after
+
+        return web_mod.json_response({
+            "object": "hermes.run.events",
+            "run_id": run_id,
+            "status": status.get("status") if status else None,
+            "events": filtered,
+            "next_after": next_after,
+            "has_more": len([event for event in events if int(event.get("seq", 0) or 0) > next_after]) > 0,
+        })
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
@@ -3309,6 +3597,120 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return response
 
+    async def _stream_agui_events_for_run(self, request: Any, run_id: str) -> Any:
+        """Stream AG-UI events for an already-created Hermes run."""
+        web_mod = web
+        if web_mod is None:
+            raise RuntimeError("aiohttp is required for API server")
+
+        # Match the native event endpoint's small registration race window.
+        for _ in range(20):
+            if run_id in self._run_streams:
+                break
+            await asyncio.sleep(0.05)
+        else:
+            return web_mod.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+
+        q = self._run_streams[run_id]
+        message_id = _agui_message_id(run_id)
+        status = self._run_statuses.get(run_id, {})
+
+        response = web_mod.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+        await response.prepare(request)
+
+        async def _write_agui_event(agui_event: Dict[str, Any]) -> None:
+            payload = f"event: {agui_event.get('type', 'CUSTOM')}\n"
+            payload += f"data: {json.dumps(agui_event)}\n\n"
+            await response.write(payload.encode())
+
+        try:
+            await _write_agui_event({
+                "type": "RUN_STARTED",
+                "runId": run_id,
+                "threadId": status.get("session_id") or run_id,
+            })
+            await _write_agui_event({
+                "type": "TEXT_MESSAGE_START",
+                "runId": run_id,
+                "messageId": message_id,
+                "role": "assistant",
+            })
+
+            while True:
+                try:
+                    event = await asyncio.wait_for(q.get(), timeout=30.0)
+                except asyncio.TimeoutError:
+                    await response.write(b": keepalive\n\n")
+                    continue
+                if event is None:
+                    await response.write(b": stream closed\n\n")
+                    break
+                for agui_event in _agui_events_from_run_event(event):
+                    await _write_agui_event(agui_event)
+        except Exception as exc:
+            logger.debug("[api_server] AG-UI SSE stream error for run %s: %s", run_id, exc)
+        finally:
+            self._run_streams.pop(run_id, None)
+            self._run_streams_created.pop(run_id, None)
+
+        return response
+
+    async def _handle_run_agui_events(self, request: Any) -> Any:
+        """GET /v1/runs/{run_id}/agui-events — AG-UI shaped SSE stream."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        return await self._stream_agui_events_for_run(request, request.match_info["run_id"])
+
+    async def _handle_agui_runs(self, request: Any) -> Any:
+        """POST /v1/agui/runs — AG-UI RunAgentInput in, AG-UI SSE stream out."""
+        web_mod = web
+        if web_mod is None:
+            raise RuntimeError("aiohttp is required for API server")
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            agui_body = await request.json()
+            if not isinstance(agui_body, dict):
+                raise ValueError("request body must be a JSON object")
+            run_body = _runs_body_from_agui_input(agui_body)
+        except ValueError as exc:
+            return web_mod.json_response(_openai_error(str(exc)), status=400)
+        except Exception:
+            return web_mod.json_response(_openai_error("Invalid JSON"), status=400)
+
+        class _JSONRequestShim:
+            def __init__(self, source: Any, payload: Dict[str, Any]):
+                self.headers = source.headers
+                self.method = source.method
+                self.path_qs = source.path_qs
+                self.remote = getattr(source, "remote", None)
+                self.transport = getattr(source, "transport", None)
+                self.match_info = {}
+                self._payload = payload
+
+            async def json(self) -> Dict[str, Any]:
+                return self._payload
+
+        create_response = await self._handle_runs(_JSONRequestShim(request, run_body))
+        if getattr(create_response, "status", 500) != 202:
+            return create_response
+        try:
+            created = json.loads(create_response.text or "{}")
+            run_id = str(created["run_id"])
+        except Exception:
+            return web_mod.json_response(_openai_error("Failed to create AG-UI run"), status=500)
+
+        return await self._stream_agui_events_for_run(request, run_id)
 
     async def _handle_run_approval(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs/{run_id}/approval — resolve a pending run approval."""
@@ -3381,7 +3783,7 @@ class APIServerAdapter(BasePlatformAdapter):
         q = self._run_streams.get(run_id)
         if q is not None:
             try:
-                q.put_nowait({
+                self._publish_run_event(run_id, {
                     "event": "approval.responded",
                     "run_id": run_id,
                     "timestamp": time.time(),
@@ -3472,6 +3874,8 @@ class APIServerAdapter(BasePlatformAdapter):
             ]
             for run_id in stale_statuses:
                 self._run_statuses.pop(run_id, None)
+                self._run_event_logs.pop(run_id, None)
+                self._run_event_seq.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # BasePlatformAdapter interface
@@ -3507,8 +3911,11 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
+            self._app.router.add_post("/v1/agui/runs", self._handle_agui_runs)
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            self._app.router.add_get("/v1/runs/{run_id}/events/replay", self._handle_run_event_replay)
+            self._app.router.add_get("/v1/runs/{run_id}/agui-events", self._handle_run_agui_events)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
             # Start background sweep to clean up orphaned (unconsumed) run streams

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -54,7 +55,7 @@ from utils import env_var_enabled
 try:
     from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
+    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response, StreamingResponse
     from fastapi.staticfiles import StaticFiles
     from pydantic import BaseModel
 except ImportError:
@@ -66,7 +67,7 @@ except ImportError:
         _lazy_ensure("tool.dashboard", prompt=False)
         from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
         from fastapi.middleware.cors import CORSMiddleware
-        from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
+        from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response, StreamingResponse
         from fastapi.staticfiles import StaticFiles
         from pydantic import BaseModel
     except Exception:
@@ -639,6 +640,148 @@ async def get_status():
         "gateway_updated_at": gateway_updated_at,
         "active_sessions": active_sessions,
     }
+
+
+# ---------------------------------------------------------------------------
+# Cockpit bridge: dashboard-local proxy to the gateway API Server / AG-UI.
+# ---------------------------------------------------------------------------
+
+
+def _cockpit_env_value(name: str, default: str = "") -> str:
+    try:
+        env = load_env()
+    except Exception:
+        env = {}
+    value = os.getenv(name) or env.get(name) or default
+    return str(value) if value is not None else default
+
+
+def _cockpit_key_preview(key: str) -> str:
+    if not key:
+        return ""
+    if len(key) <= 6:
+        return "set"
+    return f"{key[:3]}…{key[-3:]}"
+
+
+def _cockpit_api_server_settings() -> Dict[str, Any]:
+    cfg = load_config()
+    platform_cfg: Dict[str, Any] = {}
+    for root_key in ("gateway", ""):
+        root = cfg.get(root_key, cfg) if root_key else cfg
+        if isinstance(root, dict):
+            platforms = root.get("platforms")
+            if isinstance(platforms, dict) and isinstance(platforms.get("api_server"), dict):
+                platform_cfg = platforms["api_server"]
+                break
+
+    raw_extra = platform_cfg.get("extra")
+    extra: Dict[str, Any] = raw_extra if isinstance(raw_extra, dict) else {}
+    enabled_raw = platform_cfg.get("enabled")
+    enabled = (
+        bool(enabled_raw)
+        if enabled_raw is not None
+        else _cockpit_env_value("API_SERVER_ENABLED").lower() in {"1", "true", "yes"}
+    )
+    host = str(
+        extra.get("host")
+        or _cockpit_env_value("API_SERVER_HOST", "127.0.0.1")
+        or "127.0.0.1"
+    )
+    port_raw = extra.get("port") or _cockpit_env_value("API_SERVER_PORT", "8765") or "8765"
+    try:
+        port = int(port_raw)
+    except (TypeError, ValueError):
+        port = 8765
+    key = str(extra.get("key") or _cockpit_env_value("API_SERVER_KEY", "") or "")
+    connect_host = "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+    base_url = f"http://{connect_host}:{port}"
+    configured = enabled or bool(key) or bool(platform_cfg)
+    return {
+        "configured": configured,
+        "enabled": enabled,
+        "host": host,
+        "port": port,
+        "base_url": base_url,
+        "auth_configured": bool(key),
+        "key": key,
+        "key_preview": _cockpit_key_preview(key),
+    }
+
+
+def _cockpit_api_request(base_url: str, key: str, path: str, *, method: str = "GET", body: bytes | None = None, timeout: float = 5.0):
+    headers: Dict[str, str] = {"Accept": "application/json"}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    req = urllib.request.Request(f"{base_url.rstrip('/')}{path}", data=body, headers=headers, method=method)
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def _cockpit_probe_capabilities(base_url: str, key: str) -> Tuple[bool, Dict[str, Any]]:
+    try:
+        with _cockpit_api_request(base_url, key, "/v1/capabilities", timeout=2.0) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return True, data if isinstance(data, dict) else {}
+    except Exception:
+        return False, {}
+
+
+def _cockpit_stream_agui_run(path: str, payload: Dict[str, Any]):
+    settings = _cockpit_api_server_settings()
+    body = json.dumps(payload).encode("utf-8")
+    try:
+        with _cockpit_api_request(
+            settings["base_url"],
+            settings.get("key", ""),
+            path,
+            method="POST",
+            body=body,
+            timeout=300.0,
+        ) as resp:
+            while True:
+                chunk = resp.readline()
+                if not chunk:
+                    break
+                yield chunk
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        yield f"event: error\ndata: {json.dumps({'error': detail or str(exc), 'status': exc.code})}\n\n".encode("utf-8")
+    except Exception as exc:
+        yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n".encode("utf-8")
+
+
+@app.get("/api/cockpit/status")
+async def get_cockpit_status():
+    settings = _cockpit_api_server_settings()
+    reachable = False
+    capabilities: Dict[str, Any] = {}
+    if settings.get("configured"):
+        reachable, capabilities = _cockpit_probe_capabilities(
+            settings["base_url"], settings.get("key", "")
+        )
+    public_settings = {k: v for k, v in settings.items() if k != "key"}
+    public_settings["reachable"] = reachable
+    return {"api_server": public_settings, "capabilities": capabilities}
+
+
+@app.post("/api/cockpit/agui/runs")
+async def post_cockpit_agui_run(request: Request):
+    settings = _cockpit_api_server_settings()
+    if not settings.get("configured"):
+        raise HTTPException(
+            status_code=409,
+            detail="API Server is not configured. Set API_SERVER_ENABLED=true and restart the gateway.",
+        )
+    payload = await request.json()
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Expected JSON object")
+    return StreamingResponse(
+        _cockpit_stream_agui_run("/v1/agui/runs", payload),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -655,8 +655,14 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_event_replay"] is True
+            assert data["features"]["run_events_agui_sse"] is True
+            assert data["features"]["agui_run_streaming"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
+            assert data["endpoints"]["run_event_replay"]["path"] == "/v1/runs/{run_id}/events/replay"
+            assert data["endpoints"]["run_agui_events"]["path"] == "/v1/runs/{run_id}/agui-events"
+            assert data["endpoints"]["agui_runs"]["path"] == "/v1/agui/runs"
 
     @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -21,6 +21,8 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    _agui_events_from_run_event,
+    _runs_body_from_agui_input,
     cors_middleware,
     security_headers_middleware,
 )
@@ -47,8 +49,11 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app = web.Application(middlewares=mws)
     app["api_server_adapter"] = adapter
     app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_post("/v1/agui/runs", adapter._handle_agui_runs)
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_get("/v1/runs/{run_id}/events", adapter._handle_run_events)
+    app.router.add_get("/v1/runs/{run_id}/events/replay", adapter._handle_run_event_replay)
+    app.router.add_get("/v1/runs/{run_id}/agui-events", adapter._handle_run_agui_events)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
     app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     return app
@@ -277,6 +282,75 @@ class TestRunStatus:
 # ---------------------------------------------------------------------------
 
 
+class TestAGUIEventMapping:
+    def test_translates_agui_input_to_runs_body(self):
+        body = _runs_body_from_agui_input({
+            "threadId": "thread-1",
+            "runId": "run-client-1",
+            "messages": [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": [{"type": "text", "text": "hi"}]},
+            ],
+        })
+
+        assert body["session_id"] == "thread-1"
+        assert body["agui_run_id"] == "run-client-1"
+        assert body["input"] == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+    def test_maps_message_delta_to_text_message_content(self):
+        events = _agui_events_from_run_event({
+            "event": "message.delta",
+            "run_id": "run_123",
+            "delta": "hello",
+        })
+
+        assert events == [{
+            "type": "TEXT_MESSAGE_CONTENT",
+            "runId": "run_123",
+            "messageId": "run_123_message",
+            "delta": "hello",
+        }]
+
+    def test_maps_tool_and_run_events_to_agui_types(self):
+        tool_events = _agui_events_from_run_event({
+            "event": "tool.started",
+            "run_id": "run_123",
+            "tool": "terminal",
+            "preview": "pytest",
+        })
+        completed_events = _agui_events_from_run_event({
+            "event": "run.completed",
+            "run_id": "run_123",
+            "output": "done",
+            "usage": {"total_tokens": 3},
+        })
+
+        assert tool_events == [{
+            "type": "TOOL_CALL_START",
+            "runId": "run_123",
+            "toolCallId": "run_123_terminal",
+            "toolCallName": "terminal",
+            "parentMessageId": "run_123_message",
+            "args": {"preview": "pytest"},
+        }]
+        assert completed_events == [
+            {
+                "type": "TEXT_MESSAGE_END",
+                "runId": "run_123",
+                "messageId": "run_123_message",
+            },
+            {
+                "type": "RUN_FINISHED",
+                "runId": "run_123",
+                "result": "done",
+                "usage": {"total_tokens": 3},
+            },
+        ]
+
+
 class TestRunEvents:
     @pytest.mark.asyncio
     async def test_events_stream_returns_completed(self, adapter):
@@ -305,6 +379,149 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+    @pytest.mark.asyncio
+    async def test_event_replay_returns_auditable_completed_events(self, adapter):
+        """Completed run events should remain replayable after the SSE stream closes."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "Replay me"}
+                mock_agent.session_prompt_tokens = 2
+                mock_agent.session_completion_tokens = 3
+                mock_agent.session_total_tokens = 5
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                replay_resp = await cli.get(f"/v1/runs/{run_id}/events/replay")
+                assert replay_resp.status == 200
+                replay = await replay_resp.json()
+
+        assert replay["object"] == "hermes.run.events"
+        assert replay["run_id"] == run_id
+        assert replay["status"] == "completed"
+        assert replay["events"]
+        assert [event["seq"] for event in replay["events"]] == list(range(1, len(replay["events"]) + 1))
+        completed = replay["events"][-1]
+        assert completed["event"] == "run.completed"
+        assert completed["output"] == "Replay me"
+        assert completed["usage"]["total_tokens"] == 5
+        assert replay["next_after"] == completed["seq"]
+
+    @pytest.mark.asyncio
+    async def test_event_replay_after_filters_prior_events(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                for _ in range(20):
+                    status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                first_resp = await cli.get(f"/v1/runs/{run_id}/events/replay")
+                first = await first_resp.json()
+                replay_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events/replay",
+                    params={"after": str(first["next_after"])},
+                )
+                replay = await replay_resp.json()
+
+        assert replay_resp.status == 200
+        assert replay["events"] == []
+        assert replay["next_after"] == first["next_after"]
+
+    @pytest.mark.asyncio
+    async def test_event_replay_requires_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs/run_any/events/replay")
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_agui_events_stream_maps_run_events(self, adapter):
+        """AG-UI stream should expose run events using AG-UI event names."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "Hello AG-UI"}
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 2
+                mock_agent.session_total_tokens = 3
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/agui-events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+                assert "RUN_STARTED" in body
+                assert "TEXT_MESSAGE_END" in body
+                assert "RUN_FINISHED" in body
+                assert "Hello AG-UI" in body
+    @pytest.mark.asyncio
+    async def test_agui_post_starts_run_and_streams_events(self, adapter):
+        """AG-UI POST endpoint should accept RunAgentInput and stream AG-UI events."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "Hello direct AG-UI"}
+                mock_agent.session_prompt_tokens = 1
+                mock_agent.session_completion_tokens = 2
+                mock_agent.session_total_tokens = 3
+                mock_create.return_value = mock_agent
+
+                events_resp = await cli.post(
+                    "/v1/agui/runs",
+                    json={
+                        "threadId": "thread-direct",
+                        "runId": "run-direct",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    },
+                )
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+                assert "RUN_STARTED" in body
+                assert '"runId": "run-direct"' in body
+                assert '"threadId": "thread-direct"' in body
+                assert "RUN_FINISHED" in body
+                assert "Hello direct AG-UI" in body
+
+    @pytest.mark.asyncio
+    async def test_agui_post_rejects_missing_messages(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/agui/runs", json={"threadId": "thread-empty"})
+            assert resp.status == 400
+            data = await resp.json()
+        assert "messages" in data["error"]["message"]
 
 
 

--- a/tests/hermes_cli/test_web_cockpit.py
+++ b/tests/hermes_cli/test_web_cockpit.py
@@ -1,0 +1,109 @@
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.web_server import _SESSION_TOKEN, app
+
+
+HEADERS = {"X-Hermes-Session-Token": _SESSION_TOKEN}
+
+
+def test_cockpit_status_reports_api_server_config_and_capabilities(monkeypatch):
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: {
+            "gateway": {
+                "platforms": {
+                    "api_server": {
+                        "enabled": True,
+                        "extra": {
+                            "host": "127.0.0.1",
+                            "port": 8765,
+                            "key": "secret-key",
+                        },
+                    }
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_cockpit_probe_capabilities",
+        lambda base_url, key: (True, {"features": {"agui_run_streaming": True}}),
+    )
+
+    client = TestClient(app)
+    response = client.get("/api/cockpit/status", headers=HEADERS)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["api_server"]["configured"] is True
+    assert body["api_server"]["reachable"] is True
+    assert body["api_server"]["base_url"] == "http://127.0.0.1:8765"
+    assert body["api_server"]["auth_configured"] is True
+    assert body["api_server"]["key_preview"] == "sec…key"
+    assert body["capabilities"] == {"features": {"agui_run_streaming": True}}
+    assert "secret-key" not in response.text
+
+
+def test_cockpit_agui_run_proxy_streams_gateway_sse(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        web_server,
+        "_cockpit_api_server_settings",
+        lambda: {
+            "configured": True,
+            "enabled": True,
+            "base_url": "http://127.0.0.1:8765",
+            "key": "secret-key",
+            "host": "127.0.0.1",
+            "port": 8765,
+            "auth_configured": True,
+            "key_preview": "sec…key",
+        },
+    )
+
+    def fake_stream(path, payload):
+        calls.append((path, payload))
+        yield b"event: RUN_STARTED\n"
+        yield b"data: {\"type\":\"RUN_STARTED\"}\n\n"
+
+    monkeypatch.setattr(web_server, "_cockpit_stream_agui_run", fake_stream)
+
+    client = TestClient(app)
+    with client.stream(
+        "POST",
+        "/api/cockpit/agui/runs",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        json={"threadId": "dash", "messages": [{"role": "user", "content": "hi"}]},
+    ) as response:
+        body = response.read().decode("utf-8")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert "RUN_STARTED" in body
+    assert calls == [
+        (
+            "/v1/agui/runs",
+            {"threadId": "dash", "messages": [{"role": "user", "content": "hi"}]},
+        )
+    ]
+
+
+def test_cockpit_agui_run_proxy_requires_configured_api_server(monkeypatch):
+    monkeypatch.setattr(
+        web_server,
+        "_cockpit_api_server_settings",
+        lambda: {"configured": False, "enabled": False, "base_url": "", "key": ""},
+    )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/cockpit/agui/runs",
+        headers={**HEADERS, "Content-Type": "application/json"},
+        json={"messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 409
+    assert "API Server" in response.json()["detail"]

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "test": "node --experimental-strip-types tests/agui-parser.test.ts",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,6 +67,7 @@ import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
 import ChatPage from "@/pages/ChatPage";
+import CockpitPage from "@/pages/CockpitPage";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
@@ -108,6 +109,7 @@ const CHAT_NAV_ITEM: NavItem = {
 const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/": RootRedirect,
   "/sessions": SessionsPage,
+  "/cockpit": CockpitPage,
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
@@ -134,6 +136,11 @@ const BUILTIN_NAV_REST: NavItem[] = [
     labelKey: "sessions",
     label: "Sessions",
     icon: MessageSquare,
+  },
+  {
+    path: "/cockpit",
+    label: "Cockpit",
+    icon: Activity,
   },
   {
     path: "/analytics",

--- a/web/src/lib/agui.ts
+++ b/web/src/lib/agui.ts
@@ -1,0 +1,66 @@
+export type AguiEvent = {
+  type: string;
+  [key: string]: unknown;
+};
+
+export class AguiSseDecoder {
+  private buffer = "";
+
+  push(chunk: string): AguiEvent[] {
+    this.buffer += chunk;
+    const events: AguiEvent[] = [];
+
+    while (true) {
+      const sep = this.findSeparator();
+      if (sep.index < 0) break;
+      const block = this.buffer.slice(0, sep.index);
+      this.buffer = this.buffer.slice(sep.index + sep.length);
+      const event = parseAguiSseBlock(block);
+      if (event) events.push(event);
+    }
+
+    return events;
+  }
+
+  flush(): AguiEvent[] {
+    if (!this.buffer.trim()) {
+      this.buffer = "";
+      return [];
+    }
+    const event = parseAguiSseBlock(this.buffer);
+    this.buffer = "";
+    return event ? [event] : [];
+  }
+
+  private findSeparator(): { index: number; length: number } {
+    const lf = this.buffer.indexOf("\n\n");
+    const crlf = this.buffer.indexOf("\r\n\r\n");
+    if (lf < 0) return { index: crlf, length: crlf >= 0 ? 4 : 0 };
+    if (crlf < 0) return { index: lf, length: 2 };
+    return lf < crlf ? { index: lf, length: 2 } : { index: crlf, length: 4 };
+  }
+}
+
+export function parseAguiSse(text: string): AguiEvent[] {
+  const decoder = new AguiSseDecoder();
+  return [...decoder.push(text), ...decoder.flush()];
+}
+
+export function parseAguiSseBlock(block: string): AguiEvent | null {
+  const dataLines: string[] = [];
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trimEnd();
+    if (!line || line.startsWith(":")) continue;
+    if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trimStart());
+    }
+  }
+  if (!dataLines.length) return null;
+  const payload = dataLines.join("\n");
+  if (payload === "[DONE]") return { type: "DONE" };
+  const parsed = JSON.parse(payload) as unknown;
+  if (!parsed || typeof parsed !== "object" || !("type" in parsed)) {
+    return null;
+  }
+  return parsed as AguiEvent;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -18,6 +18,7 @@ export const HERMES_BASE_PATH = readBasePath();
 const BASE = HERMES_BASE_PATH;
 
 import type { DashboardTheme } from "@/themes/types";
+import { AguiSseDecoder, type AguiEvent } from "./agui";
 
 // Ephemeral session token for protected endpoints.
 // Injected into index.html by the server — never fetched via API.
@@ -281,6 +282,41 @@ export const api = {
       `/api/actions/${encodeURIComponent(name)}/status?lines=${lines}`,
     ),
 
+  // Cockpit / AG-UI
+  getCockpitStatus: () => fetchJSON<CockpitStatusResponse>("/api/cockpit/status"),
+  streamCockpitAguiRun: async (
+    body: CockpitAguiRunRequest,
+    onEvent: (event: AguiEvent) => void,
+    signal?: AbortSignal,
+  ) => {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    const token = window.__HERMES_SESSION_TOKEN__;
+    if (token) setSessionHeader(headers, token);
+    const res = await fetch(`${BASE}/api/cockpit/agui/runs`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText);
+      throw new Error(`${res.status}: ${text}`);
+    }
+    if (!res.body) throw new Error("Streaming response body unavailable");
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    const sse = new AguiSseDecoder();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      for (const event of sse.push(decoder.decode(value, { stream: true }))) {
+        onEvent(event);
+      }
+    }
+    for (const event of sse.flush()) onEvent(event);
+  },
+
   // Dashboard plugins
   getPlugins: () =>
     fetchJSON<PluginManifestResponse[]>("/api/dashboard/plugins"),
@@ -360,6 +396,33 @@ export interface ActionStatusResponse {
   name: string;
   pid: number | null;
   running: boolean;
+}
+
+export interface CockpitStatusResponse {
+  api_server: {
+    configured: boolean;
+    enabled: boolean;
+    host: string;
+    port: number;
+    base_url: string;
+    auth_configured: boolean;
+    key_preview: string;
+    reachable: boolean;
+  };
+  capabilities: Record<string, unknown>;
+}
+
+export interface CockpitAguiMessage {
+  id?: string;
+  role: "user" | "assistant" | "system" | string;
+  content: string | Array<{ type?: string; text?: string; content?: string }>;
+}
+
+export interface CockpitAguiRunRequest {
+  threadId?: string;
+  runId?: string;
+  state?: Record<string, unknown>;
+  messages: CockpitAguiMessage[];
 }
 
 export interface PlatformStatus {

--- a/web/src/pages/CockpitPage.tsx
+++ b/web/src/pages/CockpitPage.tsx
@@ -1,0 +1,297 @@
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Typography } from "@/components/NouiTypography";
+import { usePageHeader } from "@/contexts/usePageHeader";
+import { api, type CockpitStatusResponse } from "@/lib/api";
+import type { AguiEvent } from "@/lib/agui";
+import { cn } from "@/lib/utils";
+import { Bot, CheckCircle2, CircleAlert, CircleDot, Radio, Send, Square, Wrench } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type TimelineItem = {
+  id: string;
+  type: string;
+  title: string;
+  detail?: string;
+  ts: number;
+  tone?: "ok" | "warn" | "error" | "info";
+};
+
+type Message = { role: "user" | "assistant"; content: string };
+
+function eventDetail(event: AguiEvent): string {
+  const content = event.delta ?? event.content ?? event.message ?? event.error ?? event.result;
+  if (typeof content === "string") return content;
+  if (content == null) return "";
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+function titleForEvent(event: AguiEvent): string {
+  if (event.type === "TOOL_CALL_START") return `Tool started: ${String(event.toolCallName ?? "tool")}`;
+  if (event.type === "TOOL_CALL_END") return `Tool finished: ${String(event.toolCallName ?? "tool")}`;
+  if (event.type === "TOOL_CALL_REQUIRES_ACTION") return "Approval needed";
+  if (event.type === "RUN_STARTED") return "Run started";
+  if (event.type === "RUN_FINISHED") return "Run finished";
+  if (event.type === "RUN_ERROR") return "Run failed";
+  if (event.type === "TEXT_MESSAGE_CONTENT") return "Assistant streamed text";
+  return event.type;
+}
+
+function eventTone(event: AguiEvent): TimelineItem["tone"] {
+  if (event.type === "RUN_ERROR" || event.error) return "error";
+  if (event.type === "TOOL_CALL_REQUIRES_ACTION") return "warn";
+  if (event.type === "RUN_FINISHED" || event.type === "TOOL_CALL_END") return "ok";
+  return "info";
+}
+
+function buildTimelineItem(event: AguiEvent, index: number): TimelineItem {
+  return {
+    id: `${Date.now()}-${index}-${event.type}`,
+    type: event.type,
+    title: titleForEvent(event),
+    detail: event.type === "TEXT_MESSAGE_CONTENT" ? undefined : eventDetail(event),
+    ts: Date.now(),
+    tone: eventTone(event),
+  };
+}
+
+function StatusPill({ status }: { status: CockpitStatusResponse | null }) {
+  const apiServer = status?.api_server;
+  const ready = Boolean(apiServer?.configured && apiServer?.reachable);
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm",
+        ready
+          ? "border-emerald-400/40 bg-emerald-400/10 text-emerald-100"
+          : "border-amber-400/40 bg-amber-400/10 text-amber-100",
+      )}
+    >
+      <CircleDot className="h-3.5 w-3.5" />
+      {ready ? "AG-UI online" : apiServer?.configured ? "API Server unreachable" : "API Server not configured"}
+    </div>
+  );
+}
+
+export default function CockpitPage() {
+  const { setAfterTitle, setTitle } = usePageHeader();
+  const [status, setStatus] = useState<CockpitStatusResponse | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState("Give me a concise status check and say what tools you can use from this cockpit.");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [assistantDraft, setAssistantDraft] = useState("");
+  const [timeline, setTimeline] = useState<TimelineItem[]>([]);
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    setTitle("Cockpit");
+    setAfterTitle(<span className="text-sm text-white/45">AG-UI live run control</span>);
+    return () => {
+      setTitle(null);
+      setAfterTitle(null);
+    };
+  }, [setAfterTitle, setTitle]);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getCockpitStatus()
+      .then((next) => {
+        if (!cancelled) setStatus(next);
+      })
+      .catch((err) => {
+        if (!cancelled) setStatusError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const ready = Boolean(status?.api_server.configured && status?.api_server.reachable);
+  const featureReady = Boolean(
+    (status?.capabilities as { features?: { agui_run_streaming?: unknown } } | null)?.features
+      ?.agui_run_streaming,
+  );
+
+  const visibleMessages = useMemo(() => {
+    const out = [...messages];
+    if (assistantDraft) out.push({ role: "assistant", content: assistantDraft });
+    return out;
+  }, [assistantDraft, messages]);
+
+  async function startRun() {
+    const text = prompt.trim();
+    if (!text || running) return;
+    setRunError(null);
+    setAssistantDraft("");
+    setMessages((prev) => [...prev, { role: "user", content: text }]);
+    setTimeline([]);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setRunning(true);
+    let assistantText = "";
+    let eventIndex = 0;
+
+    try {
+      await api.streamCockpitAguiRun(
+        {
+          threadId: "dashboard-cockpit",
+          messages: [{ role: "user", content: text }],
+        },
+        (event) => {
+          if (event.type === "TEXT_MESSAGE_CONTENT") {
+            const delta = String(event.delta ?? event.content ?? "");
+            assistantText += delta;
+            setAssistantDraft(assistantText);
+          }
+          if (event.type === "RUN_ERROR") {
+            setRunError(eventDetail(event) || "Run failed");
+          }
+          if (event.type !== "TEXT_MESSAGE_START" && event.type !== "TEXT_MESSAGE_END") {
+            setTimeline((prev) => [buildTimelineItem(event, eventIndex++), ...prev].slice(0, 80));
+          }
+        },
+        controller.signal,
+      );
+      if (assistantText) {
+        setMessages((prev) => [...prev, { role: "assistant", content: assistantText }]);
+      }
+      setAssistantDraft("");
+    } catch (err) {
+      if ((err as { name?: string }).name !== "AbortError") {
+        setRunError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      setRunning(false);
+      abortRef.current = null;
+    }
+  }
+
+  function stopRun() {
+    abortRef.current?.abort();
+    setRunning(false);
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-5 overflow-auto p-4 md:p-6">
+      <section className="rounded-3xl border border-white/10 bg-gradient-to-br from-[#123131] to-[#071c1c] p-5 shadow-2xl">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-3">
+              <Typography as="h2" variant="lg" className="font-bold">Hermes Cockpit</Typography>
+              <StatusPill status={status} />
+            </div>
+            <Typography className="max-w-2xl text-white/65">
+              Start an agent run through the AG-UI bridge and watch structured lifecycle events,
+              tool calls, approvals, and streamed assistant text in one place.
+            </Typography>
+          </div>
+          <div className="grid min-w-64 gap-2 rounded-2xl border border-white/10 bg-black/20 p-3 text-sm text-white/70">
+            <div className="flex justify-between gap-3"><span>Endpoint</span><span>{status?.api_server.base_url ?? "checking..."}</span></div>
+            <div className="flex justify-between gap-3"><span>Auth</span><span>{status?.api_server.auth_configured ? status.api_server.key_preview : "not set"}</span></div>
+            <div className="flex justify-between gap-3"><span>AG-UI</span><span>{featureReady ? "advertised" : "unknown"}</span></div>
+          </div>
+        </div>
+        {statusError && <div className="mt-4 rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{statusError}</div>}
+      </section>
+
+      <div className="grid min-h-[620px] gap-5 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <section className="flex min-h-0 flex-col rounded-3xl border border-white/10 bg-[#0b2323] shadow-xl">
+          <div className="border-b border-white/10 p-4">
+            <Typography as="h3" variant="sm" className="font-bold uppercase">Run console</Typography>
+          </div>
+          <div className="min-h-0 flex-1 space-y-3 overflow-auto p-4">
+            {visibleMessages.length === 0 ? (
+              <div className="flex h-full min-h-72 items-center justify-center rounded-2xl border border-dashed border-white/10 text-center text-white/50">
+                <div>
+                  <Bot className="mx-auto mb-3 h-8 w-8" />
+                  Send a prompt to start a cockpit run.
+                </div>
+              </div>
+            ) : (
+              visibleMessages.map((message, idx) => (
+                <div
+                  key={`${message.role}-${idx}`}
+                  className={cn(
+                    "max-w-[85%] rounded-2xl px-4 py-3 text-sm leading-6",
+                    message.role === "user"
+                      ? "ml-auto bg-emerald-300 text-emerald-950"
+                      : "bg-white/8 text-white/85",
+                  )}
+                >
+                  <div className="mb-1 text-xs uppercase tracking-wide opacity-60">{message.role}</div>
+                  <div className="whitespace-pre-wrap">{message.content}</div>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="border-t border-white/10 p-4">
+            {runError && <div className="mb-3 rounded-xl border border-red-400/30 bg-red-500/10 p-3 text-sm text-red-100">{runError}</div>}
+            <div className="flex flex-col gap-3 md:flex-row">
+              <textarea
+                className="min-h-24 flex-1 resize-none rounded-2xl border border-white/10 bg-black/25 p-3 text-sm text-white outline-none placeholder:text-white/35 focus:border-emerald-300/60"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                onKeyDown={(e) => {
+                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") void startRun();
+                }}
+                placeholder="Ask Hermes to do something..."
+              />
+              <div className="flex gap-2 md:flex-col">
+                <Button onClick={startRun} disabled={!prompt.trim() || running || !ready} className="gap-2">
+                  <Send className="h-4 w-4" />
+                  Start
+                </Button>
+                <Button onClick={stopRun} disabled={!running} className="gap-2">
+                  <Square className="h-4 w-4" />
+                  Stop
+                </Button>
+              </div>
+            </div>
+            {!ready && <p className="mt-2 text-xs text-amber-100/80">Enable and restart the API Server to run cockpit prompts.</p>}
+          </div>
+        </section>
+
+        <aside className="flex min-h-0 flex-col rounded-3xl border border-white/10 bg-[#0b2323] shadow-xl">
+          <div className="flex items-center gap-2 border-b border-white/10 p-4">
+            <Radio className="h-4 w-4 text-emerald-200" />
+            <Typography as="h3" variant="sm" className="font-bold uppercase">Live events</Typography>
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-4">
+            {timeline.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-white/10 p-5 text-sm text-white/50">
+                AG-UI events will appear here as soon as a run starts.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {timeline.map((item) => (
+                  <div key={item.id} className="rounded-2xl border border-white/10 bg-black/20 p-3">
+                    <div className="flex items-start gap-3">
+                      {item.tone === "ok" ? (
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 text-emerald-300" />
+                      ) : item.tone === "warn" || item.tone === "error" ? (
+                        <CircleAlert className="mt-0.5 h-4 w-4 text-amber-300" />
+                      ) : (
+                        <Wrench className="mt-0.5 h-4 w-4 text-sky-300" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-white/90">{item.title}</div>
+                        <div className="text-xs text-white/35">{new Date(item.ts).toLocaleTimeString()}</div>
+                        {item.detail && <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap rounded-xl bg-black/25 p-2 text-xs text-white/60">{item.detail}</pre>}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/web/tests/agui-parser.test.ts
+++ b/web/tests/agui-parser.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { AguiSseDecoder, parseAguiSse } from "../src/lib/agui.ts";
+
+const parsed = parseAguiSse(
+  'event: RUN_STARTED\ndata: {"type":"RUN_STARTED","runId":"run_1"}\n\n' +
+    ': keepalive\n\n' +
+    'event: TEXT_MESSAGE_CONTENT\ndata: {"type":"TEXT_MESSAGE_CONTENT","delta":"hi"}\n\n',
+);
+assert.deepEqual(parsed, [
+  { type: "RUN_STARTED", runId: "run_1" },
+  { type: "TEXT_MESSAGE_CONTENT", delta: "hi" },
+]);
+
+const decoder = new AguiSseDecoder();
+assert.deepEqual(decoder.push('data: {"type":"TEXT_MESSAGE'), []);
+assert.deepEqual(decoder.push('_START","messageId":"m1"}\n\n'), [
+  { type: "TEXT_MESSAGE_START", messageId: "m1" },
+]);
+assert.deepEqual(decoder.flush(), []);
+
+assert.deepEqual(parseAguiSse("data: [DONE]\n\n"), [{ type: "DONE" }]);
+
+console.log("agui parser tests passed");

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -86,8 +86,11 @@ Endpoints:
 POST /v1/chat/completions        OpenAI Chat Completions (streaming via SSE)
 POST /v1/responses               OpenAI Responses API (stateful)
 POST /v1/runs                    Start a run, returns run_id (202)
+POST /v1/agui/runs               AG-UI RunAgentInput, returns AG-UI SSE stream
 GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
+GET  /v1/runs/{id}/events/replay JSON replay/audit log with seq pagination
+GET  /v1/runs/{id}/agui-events   AG-UI SSE stream for cockpit UIs
 POST /v1/runs/{id}/approval      Resolve a pending approval
 POST /v1/runs/{id}/stop          Interrupt the run
 GET  /v1/capabilities            Machine-readable feature flags
@@ -96,6 +99,17 @@ GET  /health, /health/detailed
 ```
 
 Setup, headers (`X-Hermes-Session-Id`, `X-Hermes-Session-Key`), and frontend wiring: [API Server](../user-guide/features/api-server).
+
+### Dashboard Cockpit proxy
+
+The built-in dashboard does **not** call `/v1/agui/runs` directly from the browser. It uses two same-origin endpoints in `hermes_cli/web_server.py`:
+
+```text
+GET  /api/cockpit/status       Probe API-server config and /v1/capabilities
+POST /api/cockpit/agui/runs    Proxy RunAgentInput to /v1/agui/runs and stream SSE
+```
+
+This keeps `API_SERVER_KEY` server-side, avoids CORS setup for the dashboard, and gives the React page a stable same-origin API. The frontend parser lives in `web/src/lib/agui.ts`; the page lives in `web/src/pages/CockpitPage.tsx`.
 
 ---
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -53,6 +53,19 @@ curl http://localhost:8642/v1/chat/completions \
 
 Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI integration guide](/user-guide/messaging/open-webui) for step-by-step instructions.
 
+## Dashboard Cockpit
+
+Hermes Dashboard includes a built-in **Cockpit** tab for the AG-UI bridge. It is a local control surface for starting a run and watching live structured events: run lifecycle, streamed assistant text, tool starts/completions, and approval-required events.
+
+To use it:
+
+1. Enable and start the API server as shown above.
+2. Start the dashboard with `hermes dashboard`.
+3. Open **Cockpit** in the sidebar.
+4. Send a prompt. The page calls the dashboard-local proxy at `/api/cockpit/agui/runs`, which forwards to `/v1/agui/runs` with the configured bearer key.
+
+The browser never receives `API_SERVER_KEY`; the dashboard backend reads the local config/env, probes `/v1/capabilities`, and proxies the AG-UI SSE stream. The status pill shows whether the API server is configured and reachable.
+
 ## Endpoints
 
 ### POST /v1/chat/completions
@@ -214,6 +227,9 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
+    "run_event_replay": true,
+    "run_events_agui_sse": true,
+    "agui_run_streaming": true,
     "run_stop": true
   }
 }
@@ -267,6 +283,56 @@ Statuses are retained briefly after terminal states (`completed`, `failed`, or `
 ### GET /v1/runs/\{run_id\}/events
 
 Server-Sent Events stream of the run's tool-call progress, token deltas, and lifecycle events. Designed for dashboards and thick clients that want to attach/detach without losing state.
+
+### GET /v1/runs/\{run_id\}/events/replay
+
+JSON replay/audit log of recorded lifecycle events for a run. This is useful when an operator dashboard reconnects after a network drop, when a run has already completed, or when a client wants deterministic pagination instead of holding an SSE stream open.
+
+```bash
+curl "http://127.0.0.1:8642/v1/runs/run_abc123/events/replay?after=0&limit=100"
+```
+
+Response:
+
+```json
+{
+  "object": "hermes.run.events",
+  "run_id": "run_abc123",
+  "status": "completed",
+  "events": [
+    {"seq": 1, "event": "message.delta", "delta": "Working..."},
+    {"seq": 2, "event": "tool.started", "tool": "terminal"},
+    {"seq": 3, "event": "run.completed", "output": "Done."}
+  ],
+  "next_after": 3,
+  "has_more": false
+}
+```
+
+Events are sequence-numbered per run. Pass the previous `next_after` value as `after` to fetch only newer events. Logs are bounded in memory and retained with the run's terminal status, so they are an operator reconciliation aid rather than permanent storage.
+
+### GET /v1/runs/\{run_id\}/agui-events
+
+Server-Sent Events stream of the same run lifecycle mapped to [AG-UI](https://docs.ag-ui.com/) event names. Use this when a cockpit UI or CopilotKit-style client has already created a Hermes run with `POST /v1/runs` and wants protocol-shaped events such as `RUN_STARTED`, `TEXT_MESSAGE_CONTENT`, `TOOL_CALL_START`, `TOOL_CALL_END`, `TOOL_CALL_REQUIRES_ACTION`, and `RUN_FINISHED`.
+
+This endpoint consumes the same live run queue as `/events`; attach either the native stream or the AG-UI stream for a given run, not both.
+
+### POST /v1/agui/runs
+
+AG-UI-style single-call run endpoint. The request accepts a minimal `RunAgentInput` shape and immediately returns an AG-UI SSE stream:
+
+```bash
+curl -N http://127.0.0.1:8642/v1/agui/runs \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "threadId": "cockpit-thread-1",
+    "runId": "cockpit-run-1",
+    "messages": [{"role": "user", "content": "Check the repo status"}]
+  }'
+```
+
+Hermes maps `threadId` to its API-server `session_id` so dashboard threads line up with run status and long-running work. `runId` is optional; if supplied, Hermes uses a sanitized version as the run ID and rejects duplicates with `409`.
 
 ### POST /v1/runs/\{run_id\}/stop
 


### PR DESCRIPTION
## Summary
- add AG-UI-compatible run streaming endpoints and dashboard Cockpit proxy/UI for live operator control
- add bounded per-run event replay/audit logs with sequence pagination at GET /v1/runs/{run_id}/events/replay
- advertise replay/AG-UI capabilities and document the integration surface

## Verification
- ulimit -n 4096; python -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py tests/hermes_cli/test_web_cockpit.py -q -o 'addopts='
- cd web; npm test
- cd web; npm run build

Note: unrelated untracked tinker-atropos/ was left untouched.