### PR TITLE
Handle provider prelude events in Codex Responses streams

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4367,6 +4367,10 @@ class AIAgent:
             except RuntimeError as exc:
                 err_text = str(exc)
                 missing_completed = "response.completed" in err_text
+                unexpected_initial_event = (
+                    "Expected to have received `response.created` before" in err_text
+                    or "When snapshot hasn't been set yet, expected 'response.created' event" in err_text
+                )
                 if missing_completed and attempt < max_stream_retries:
                     logger.debug(
                         "Responses stream closed before completion (attempt %s/%s); retrying. %s",
@@ -4379,6 +4383,14 @@ class AIAgent:
                     logger.debug(
                         "Responses stream did not emit response.completed; falling back to create(stream=True). %s",
                         self._client_log_context(),
+                    )
+                    return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+                if unexpected_initial_event:
+                    logger.debug(
+                        "Responses stream received a provider-specific prelude event; "
+                        "falling back to create(stream=True). %s error=%s",
+                        self._client_log_context(),
+                        exc,
                     )
                     return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
                 raise

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -344,6 +344,35 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
     assert response.output[0].content[0].text == "create fallback ok"
 
 
+def test_run_codex_stream_falls_back_on_provider_prelude_event(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            final_error=RuntimeError(
+                "Expected to have received `response.created` before `codex.rate_limits`"
+            )
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("create fallback ok")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert calls["stream"] == 1
+    assert calls["create"] == 1
+    assert response.output[0].content[0].text == "create fallback ok"
+
+
 def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"stream": 0, "create": 0}


### PR DESCRIPTION
## Summary
- Fall back to the existing `responses.create(stream=True)` path when the OpenAI SDK rejects a Responses stream because a provider-specific prelude event appears before `response.created`.
- Covers events such as `codex.rate_limits`, which some Codex-compatible providers emit before the standard Responses lifecycle event.
- Adds a regression test for the fallback path.

## Test
- `/root/.hermes/hermes-agent/venv/bin/pytest tests/run_agent/test_run_agent_codex_responses.py -q`
- `41 passed`