### PR TITLE
fix(agent): inject memory/plugin context into multimodal user messages

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -837,6 +837,9 @@ def run_conversation(
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):
                         api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                    elif isinstance(_base, list):
+                        injection_text = "\n\n".join(_injections)
+                        api_msg["content"] = [{"type": "text", "text": injection_text}, *_base]
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved

--- a/tests/run_agent/test_memory_inject_multimodal.py
+++ b/tests/run_agent/test_memory_inject_multimodal.py
@@ -1,0 +1,86 @@
+"""Tests for memory/plugin context injection into multimodal user messages.
+
+When a user sends an image, ``api_msg["content"]`` is a list of content parts
+(text + image_url blocks), not a plain string.  The injection block in
+``run_conversation`` must handle both shapes — this file verifies that.
+
+Regression tests for https://github.com/NousResearch/hermes-agent/issues/32546
+"""
+
+from __future__ import annotations
+
+import copy
+
+
+def _apply_injections(api_msg: dict, injections: list[str]) -> dict:
+    """Replicate the injection logic from conversation_loop.py."""
+    msg = copy.deepcopy(api_msg)
+    if injections:
+        _base = msg.get("content", "")
+        if isinstance(_base, str):
+            msg["content"] = _base + "\n\n" + "\n\n".join(injections)
+        elif isinstance(_base, list):
+            injection_text = "\n\n".join(injections)
+            msg["content"] = [{"type": "text", "text": injection_text}, *_base]
+    return msg
+
+
+MEMORY_BLOCK = (
+    "<memory-context>\n"
+    "[System note: recalled memory context]\n\n"
+    "User prefers dark mode.\n"
+    "</memory-context>"
+)
+
+PLUGIN_CONTEXT = "[plugin] Today is Monday."
+
+MULTIMODAL_CONTENT = [
+    {"type": "text", "text": "Analyze this screenshot"},
+    {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+]
+
+
+class TestStringContentInjection:
+    """Existing str path must not regress."""
+
+    def test_str_content_gets_injections_appended(self):
+        msg = {"role": "user", "content": "hello"}
+        result = _apply_injections(msg, [MEMORY_BLOCK, PLUGIN_CONTEXT])
+        assert isinstance(result["content"], str)
+        assert result["content"].startswith("hello\n\n")
+        assert MEMORY_BLOCK in result["content"]
+        assert PLUGIN_CONTEXT in result["content"]
+
+
+class TestMultimodalContentInjection:
+    """List-shaped content (image + text) must receive injections."""
+
+    def test_list_content_gets_prepended_text_block(self):
+        msg = {"role": "user", "content": copy.deepcopy(MULTIMODAL_CONTENT)}
+        result = _apply_injections(msg, [MEMORY_BLOCK])
+        content = result["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "text"
+        assert MEMORY_BLOCK in content[0]["text"]
+
+    def test_original_blocks_preserved(self):
+        msg = {"role": "user", "content": copy.deepcopy(MULTIMODAL_CONTENT)}
+        result = _apply_injections(msg, [MEMORY_BLOCK, PLUGIN_CONTEXT])
+        content = result["content"]
+        assert content[1] == MULTIMODAL_CONTENT[0]
+        assert content[2] == MULTIMODAL_CONTENT[1]
+
+    def test_empty_injections_no_change(self):
+        original = copy.deepcopy(MULTIMODAL_CONTENT)
+        msg = {"role": "user", "content": copy.deepcopy(MULTIMODAL_CONTENT)}
+        result = _apply_injections(msg, [])
+        assert result["content"] == original
+
+    def test_exactly_one_block_prepended(self):
+        msg = {"role": "user", "content": copy.deepcopy(MULTIMODAL_CONTENT)}
+        result = _apply_injections(msg, [MEMORY_BLOCK, PLUGIN_CONTEXT])
+        content = result["content"]
+        assert len(content) == len(MULTIMODAL_CONTENT) + 1
+        assert content[0]["type"] == "text"
+        assert MEMORY_BLOCK in content[0]["text"]
+        assert PLUGIN_CONTEXT in content[0]["text"]


### PR DESCRIPTION
## Summary

- When a user sends an image, `api_msg["content"]` is a multimodal list (`[{"type": "text", ...}, {"type": "image_url", ...}]`), not a string
- The `isinstance(_base, str)` gate in the injection block silently discarded all memory prefetch and plugin context for these turns
- Added `elif isinstance(_base, list)` branch that prepends injections as a leading `{"type": "text"}` block, preserving all original parts

Closes #32546

## Changes

- `agent/conversation_loop.py`: 3-line `elif` branch (line 840–842)
- `tests/run_agent/test_memory_inject_multimodal.py`: 5 regression tests covering str path (no regression), list content injection, original block preservation, empty injection no-op, and single-block prepend

## Test plan

- [ ] `pytest tests/run_agent/test_memory_inject_multimodal.py -v` — 5 new tests pass
- [ ] `pytest tests/run_agent/ -v` — all 1451+ existing tests pass (no regression)
- [ ] Manual: send message with image + memory provider enabled → memory context appears in model input

🤖 Generated with [Claude Code](https://claude.com/claude-code)