### PR TITLE
fix(security): harden Hermes file permissions

### DIFF
--- a/.hermes/plans/memory-system-architecture.md
+++ b/.hermes/plans/memory-system-architecture.md
@@ -1,0 +1,335 @@
+# Hermes memory system architecture recon + plan
+
+Date: 2026-05-22
+Worktree: `/home/oscar/workspace/hermes-agent-memory`
+Branch: `feat/personal-memory-architecture`
+Scope: read-only recon + planning. No code changes made.
+
+## Current implementation map
+
+### Built-in always-on memory
+
+- Implementation: `tools/memory_tool.py`
+- Storage:
+  - `$HERMES_HOME/MEMORY.md`
+  - `$HERMES_HOME/USER.md`
+- Entry delimiter: `\n§\n`
+- Defaults from `hermes_cli/config.py`:
+  - `memory.memory_enabled: true`
+  - `memory.user_profile_enabled: true`
+  - `memory.memory_char_limit: 2200`
+  - `memory.user_char_limit: 1375`
+- Writes:
+  - `add`, `replace`, `remove`
+  - substring replace/remove, with ambiguous-match protection
+  - file locking + atomic temp-file rename
+  - exact duplicate rejection
+  - prompt-injection / exfil / invisible Unicode scan before add/replace
+- Prompt behavior:
+  - `MemoryStore.load_from_disk()` captures a frozen system-prompt snapshot
+  - mid-session writes persist to disk but do not affect the active prompt until prompt rebuild/session restart/compression invalidation
+  - `agent/system_prompt.py` injects memory/user blocks into the volatile prompt tier
+
+### External memory provider layer
+
+- Interface: `agent/memory_provider.py`
+- Orchestrator: `agent/memory_manager.py`
+- Discovery: `plugins/memory/__init__.py`
+- Config selection: `memory.provider` in config; empty means built-in only
+- Current local status: built-in only; no external provider enabled
+- Installed provider plugins:
+  - `byterover`
+  - `hindsight`
+  - `holographic`
+  - `honcho`
+  - `mem0`
+  - `openviking`
+  - `retaindb`
+  - `supermemory`
+- Constraint: only one external provider can be active at a time; built-in memory is additive and always separate
+- Provider hooks available:
+  - `system_prompt_block()`
+  - `prefetch(query)`
+  - `queue_prefetch(query)`
+  - `sync_turn(user, assistant)`
+  - `on_turn_start(turn_number, message, **kwargs)`
+  - `on_session_end(messages)`
+  - `on_session_switch(new_session_id, ...)`
+  - `on_pre_compress(messages)`
+  - `on_memory_write(action, target, content, metadata=None)`
+  - `on_delegation(task, result, ...)`
+  - provider-specific tools via `get_tool_schemas()` / `handle_tool_call()`
+
+### Turn lifecycle
+
+- Startup: `agent/agent_init.py`
+  - initializes built-in `MemoryStore` unless `skip_memory`
+  - loads selected external provider from `memory.provider`
+  - passes platform/profile/session/chat identity into provider initialization
+- Before model call: `agent/conversation_loop.py`
+  - calls `memory_manager.on_turn_start(...)`
+  - calls `memory_manager.prefetch_all(original_user_message)` once per turn
+  - injects returned external memory context only into the current user API message
+- Injection fence:
+  - `build_memory_context_block()` wraps external prefetch in `<memory-context>`
+  - system note says recalled memory is not new user input but is authoritative reference data
+  - `StreamingContextScrubber` prevents memory-context leakage into streamed UI deltas
+- After completed turn: `run_agent.py::_sync_external_memory_for_turn`
+  - skips interrupted turns
+  - calls `sync_all(original_user_message, final_response)`
+  - calls `queue_prefetch_all(original_user_message)`
+- Session/compression boundaries:
+  - `commit_memory_session()` calls provider `on_session_end()` without shutting providers down
+  - `shutdown_memory_provider()` calls `on_session_end()` then provider shutdown
+  - context compression calls `on_pre_compress()` before dropping old context
+
+### Built-in-to-external bridge
+
+- Built-in memory tool writes are mirrored to external providers for `add` and `replace` only.
+- Bridge locations:
+  - `agent/tool_executor.py`
+  - `agent/agent_runtime_helpers.py`
+- Metadata includes execution provenance such as task/tool/session/platform context.
+- `remove` is intentionally not bridged by current tests (`test_on_memory_write_remove_not_bridged`).
+
+## Constraints / design pressure
+
+1. Prompt budget is intentionally tiny.
+   - `MEMORY.md`: 2200 chars
+   - `USER.md`: 1375 chars
+   - This forces kernel-style durable facts, not diary logs.
+
+2. Prompt caching matters.
+   - Built-in memory is snapshotted and system prompt is cached.
+   - Mid-session mutable memory injection would hurt cache stability unless isolated outside the cached prompt.
+
+3. External memory context already has the right place to be dynamic.
+   - Per-turn recalled context is injected into the current user API message only.
+   - It is fenced/scrubbed and does not mutate session history.
+
+4. External providers are best-effort.
+   - Exceptions are swallowed or logged.
+   - A broken memory backend must not block responses.
+
+5. One external provider only.
+   - This avoids tool schema bloat and conflicting memory semantics.
+   - Any architecture that wants multiple stores needs either a meta-provider or a new memory-manager policy.
+
+6. Current docs still contain at least one stale/undesirable recommendation.
+   - `website/docs/user-guide/features/memory.md` says completed work can be saved to memory.
+   - Current system/user preference says stale task logs do not belong in core memory.
+
+7. Current active profile is already nearly full.
+   - Live prompt shows memory/user stores at ~98% / ~96%.
+   - This validates the need for better routing, compaction, and non-prompt storage.
+
+## Main architecture recommendation
+
+Build a layered personal memory architecture that **keeps `USER.md` and `MEMORY.md` small** while adding real capacity through operational references, deeper memories, and selectively loaded notes. The problem is not merely bad routing; the current files are small, easy to overfill with low-value crap, and already full before the assistant/user relationship has much history. The replacement target is: core kernels stay tiny, while larger memory/preference growth lands in an Obsidian/knowledge-db-backed operational memory layer.
+
+### Layer 0: Core prompt kernel
+
+Keep current `MEMORY.md` / `USER.md` as the smallest always-on kernel.
+
+Purpose:
+- durable user preferences
+- durable environment facts
+- durable routing rules
+- stable conventions that should influence every turn
+
+Non-goals:
+- task progress
+- PR/issue/commit logs
+- per-project scratch state
+- contacts/entities
+- long procedural workflows
+
+Implementation direction:
+- update docs/tool guidance to strongly discourage diary/task-log memory
+- optionally add memory pressure nudges when usage crosses ~85-90%
+- preserve frozen-snapshot/prompt-cache behavior
+- treat these files as bootloader/kernel config, not the database
+- keep only the preferences/facts that must influence nearly every turn
+
+### Layer 1: Operational references + expanded memories
+
+Use an Obsidian/knowledge-db-backed note layer for larger memories, preference history, operational references, and rich context that should be searchable/selectively loaded but not always injected.
+
+Likely locations:
+- `/home/oscar/workspace/_vault/Ops/` for operational references/runbooks
+- `/home/oscar/workspace/_vault/memory/` for deeper personal memory/preference notes
+- `(dropped — unused empty db)` for an optional search/index layer
+
+Purpose:
+- store more memories and preferences as the assistant/user relationship develops
+- keep richer context human-readable and auditable
+- support selective retrieval into turns without bloating the system prompt
+- provide a place for "this matters, but not every turn" facts
+
+Access path:
+- search/load relevant notes on demand
+- optionally add a thin `memory_ref`/`ops_ref` retrieval tool later
+- do not inject the whole vault; this is not prompt stuffing with better furniture
+
+### Layer 2: Entity/project files
+
+Use structured files outside the core prompt for entities, contacts, projects, recurring systems.
+
+Likely locations:
+- `~/.hermes/profiles/<profile>/entities/*.json` or similar for profile-private entities
+- `/home/oscar/workspace/_vault/` for human-readable long-lived notes
+- project-local `.hermes/` files for project-specific state
+
+Purpose:
+- relationship graph
+- project profiles
+- service inventories
+- operational runbooks
+- non-global facts that should be fetched when relevant
+
+Access path:
+- explicit tools/skills/search, not always-on injection
+
+### Layer 3: Procedural skills
+
+Use skills for workflows and repeatable procedures.
+
+Purpose:
+- debugging playbooks
+- deployment procedures
+- project-specific recurring workflows
+- lessons learned that are procedural, not facts
+
+Implementation direction:
+- keep authoring/maintenance through existing skill tooling
+- after complex tasks, save workflow as skill instead of memory
+- possible future consolidation with Obsidian is explicitly out of scope for the first pass
+
+### Layer 4: Session search / transcript recall
+
+Use session DB for ephemeral history and completed-work recall.
+
+Purpose:
+- "what did we do last time?"
+- PR/issue/commit numbers
+- task progress and stale artifacts
+- conversation breadcrumbs
+
+Implementation direction:
+- avoid copying stale artifacts into core memory
+- improve agent guidance to call `session_search` when user references prior work
+
+### Layer 5: External semantic memory provider
+
+Use one provider for scalable semantic recall.
+
+Best candidates by current constraints:
+- `holographic`: local, inspectable SQLite, no API dependency; good default for experimentation and privacy
+- `honcho`: richer user modeling/cross-session dialectic; stronger but network/API/config heavier
+- `openviking`/`hindsight`: worth evaluating if the desired shape is knowledge-base/tree plus retrieval
+
+Implementation direction:
+- start with a local provider if we want safe dogfooding without external cost/secrets
+- keep provider context dynamic via existing `prefetch_all` path, not system prompt expansion
+- measure latency/token impact before enabling broadly
+
+## Proposed phases
+
+### Phase 1: Documentation + guardrails + routing semantics
+
+No behavioral risk.
+
+- Update memory docs to match current routing policy:
+  - global durable facts -> core memory
+  - workflow -> skill
+  - project/contact/entity -> structured entity/project file
+  - temporary/task progress -> session search
+- Add/adjust tests that forbid diary/task-progress language in memory tool docs/schema.
+- Optional: add a compact `memory-routing.md` developer/user reference.
+- Define the new three-way memory split explicitly:
+  - core kernel: `USER.md` / `MEMORY.md`
+  - expanded memories/preferences: Obsidian/knowledge DB notes
+  - scoped state: contacts/projects/entities/kanban/session search
+
+### Phase 2: Obsidian/knowledge-db operational memory layer
+
+Primary capacity fix.
+
+- Create/standardize vault folders for ops refs and expanded memory notes.
+- Add a small retrieval convention before adding code: predictable paths, headings, tags, and search terms.
+- Decide whether retrieval is initially skill/file-tool driven or exposed through a dedicated Hermes tool.
+- Keep the core memory tool from dumping large facts into `MEMORY.md`; route expanded facts to notes.
+
+### Phase 3: Core memory pressure UX
+
+Small behavior changes; low risk.
+
+- Improve full-memory errors with routing suggestions.
+- Add a status command or nudge that names likely candidates for migration/consolidation.
+- Keep writes manual/agent-driven; do not auto-delete core memory.
+
+### Phase 4: Local structured entity/project store
+
+Medium scope.
+
+- Add a small profile-scoped entity/project store with JSON files and search/list/get/update tools.
+- Make routing explicit: memory tool remains for global kernel; entity tool is for scoped durable records.
+- Use `get_hermes_home()` and profile-safe paths.
+- Do not inject entity store globally; retrieve on demand or via skills.
+
+### Phase 5: External provider dogfood
+
+Medium/high variance depending on provider.
+
+- Enable `holographic` or another local provider in a test profile first.
+- Verify:
+  - init works
+  - per-turn prefetch is fenced and not persisted into history
+  - interrupted turns are not synced
+  - session/compression boundaries call provider hooks
+  - latency is acceptable
+- Only then consider production assistant profile.
+
+### Phase 6: Meta-provider / multi-store policy, only if needed
+
+Higher-risk architecture.
+
+- Current `MemoryManager` enforces one external provider.
+- If multiple retrieval backends are needed, build a single umbrella provider that routes internally rather than weakening global manager constraints immediately.
+
+## Test targets for any code work
+
+Run targeted tests first:
+
+```bash
+python -m pytest tests/tools/test_memory_tool.py -q -o 'addopts='
+python -m pytest tests/agent/test_memory_provider.py -q -o 'addopts='
+python -m pytest tests/agent/test_streaming_context_scrubber.py -q -o 'addopts='
+python -m pytest tests/run_agent/test_commit_memory_session_context_engine.py -q -o 'addopts='
+python -m pytest tests/run_agent/test_memory_provider_init.py -q -o 'addopts='
+```
+
+Then area tests for any provider touched:
+
+```bash
+python -m pytest tests/plugins/memory -q -o 'addopts='
+python -m pytest tests/honcho_plugin -q -o 'addopts='
+```
+
+Full suite before PR:
+
+```bash
+python -m pytest tests/ -q -o 'addopts='
+```
+
+## Open questions before code work
+
+1. Should expanded memories/preferences live in plain Markdown first, or Markdown plus SQLite index immediately?
+2. Should retrieval be initially skill/file-tool driven, or should we add a dedicated `memory_ref`/`ops_ref` tool?
+3. What exact vault taxonomy should be canonical: `ops/`, `memory/`, `projects/`, `entities/`, or a different split?
+4. Should memory pressure management stay advisory, or should there be an explicit assisted compaction/migration command?
+5. Should `remove` built-in memory writes be mirrored to external providers, or is the current add/replace-only bridge intentional enough to keep?
+
+## Current recommendation
+
+Do Phase 1 and Phase 2 first. Phase 1 aligns the docs/tests with the intended routing policy. Phase 2 is the actual capacity fix: add an Obsidian/knowledge-db operational memory layer so Aster can grow richer preferences and memories without bloating the always-on prompt kernel. Entity/project/kanban stores remain separate and structured; skills consolidation is explicitly out of scope for this pass.

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -16,7 +16,7 @@ import re
 import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, secure_dir, secure_file
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -156,29 +156,12 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     return normalized
 
 
-def _secure_dir(path: Path):
-    """Set directory to owner-only access (0700). No-op on Windows."""
-    try:
-        os.chmod(path, 0o700)
-    except (OSError, NotImplementedError):
-        pass  # Windows or other platforms where chmod is not supported
-
-
-def _secure_file(path: Path):
-    """Set file to owner-only read/write (0600). No-op on Windows."""
-    try:
-        if path.exists():
-            os.chmod(path, 0o600)
-    except (OSError, NotImplementedError):
-        pass
-
-
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
     CRON_DIR.mkdir(parents=True, exist_ok=True)
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    _secure_dir(CRON_DIR)
-    _secure_dir(OUTPUT_DIR)
+    secure_dir(CRON_DIR)
+    secure_dir(OUTPUT_DIR)
 
 
 # =============================================================================
@@ -462,7 +445,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, JOBS_FILE)
-        _secure_file(JOBS_FILE)
+        secure_file(JOBS_FILE)
     except BaseException:
         try:
             os.unlink(tmp_path)
@@ -1097,7 +1080,7 @@ def save_job_output(job_id: str, output: str):
     ensure_dirs()
     job_output_dir = _job_output_dir(job_id)
     job_output_dir.mkdir(parents=True, exist_ok=True)
-    _secure_dir(job_output_dir)
+    secure_dir(job_output_dir)
     
     timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
     output_file = job_output_dir / f"{timestamp}.md"
@@ -1109,7 +1092,7 @@ def save_job_output(job_id: str, output: str):
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, output_file)
-        _secure_file(output_file)
+        secure_file(output_file)
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/docs/hermes-dashboard-phone-access-runbook.md
+++ b/docs/hermes-dashboard-phone-access-runbook.md
@@ -1,0 +1,125 @@
+# Hermes Dashboard Phone Access Runbook
+
+## Scope
+
+This runbook covers the authenticated phone-accessible Hermes dashboard for the default `/home/oscar/.hermes` runtime. The public listener is an HTTPS reverse proxy. The Hermes dashboard itself stays bound to loopback.
+
+## Runtime
+
+- Local dashboard service: `hermes-dashboard.service`
+- Public auth proxy service: `hermes-dashboard-auth-proxy.service`
+- Browser-trusted quick tunnel service: `hermes-dashboard-cloudflared.service`
+- Local dashboard upstream: `http://127.0.0.1:9119`
+- Direct phone URL: `https://5.161.56.251:9443` (self-signed certificate warning expected)
+- Browser-trusted phone URL: read the current `trycloudflare.com` URL from `/home/oscar/.hermes/cloudflared/dashboard-tunnel.log`
+- Auth model: browser Basic auth at the proxy, then Hermes dashboard session-token protection for dashboard API routes
+- Username: `oscar`
+- Password file on host: `/home/oscar/.hermes/dashboard-access/password`
+- TLS certificate: self-signed certificate with SANs for `5.161.56.251`, `127.0.0.1`, and `localhost`
+
+The password is intentionally not stored in this runbook, Kanban comments, dashboard config, or logs.
+
+## Start
+
+```bash
+systemctl --user start hermes-dashboard.service
+systemctl --user start hermes-dashboard-auth-proxy.service
+systemctl --user start hermes-dashboard-cloudflared.service
+```
+
+## Stop
+
+```bash
+systemctl --user stop hermes-dashboard-auth-proxy.service
+systemctl --user stop hermes-dashboard-cloudflared.service
+systemctl --user stop hermes-dashboard.service
+```
+
+## Restart
+
+```bash
+systemctl --user restart hermes-dashboard.service
+systemctl --user restart hermes-dashboard-auth-proxy.service
+systemctl --user restart hermes-dashboard-cloudflared.service
+```
+
+## Status
+
+```bash
+systemctl --user status hermes-dashboard.service --no-pager
+systemctl --user status hermes-dashboard-auth-proxy.service --no-pager
+systemctl --user status hermes-dashboard-cloudflared.service --no-pager
+```
+
+## Health Checks
+
+Unauthenticated requests must fail:
+
+```bash
+curl -k -I https://5.161.56.251:9443/
+```
+
+Expected: `401 Unauthorized`.
+
+Authenticated dashboard status must work:
+
+```bash
+curl -k -u "oscar:$(cat /home/oscar/.hermes/dashboard-access/password)" \
+  https://5.161.56.251:9443/api/status
+```
+
+Expected: `200 OK` JSON response.
+
+Kanban plugin discovery must include the bundled Kanban tab:
+
+```bash
+curl -k -u "oscar:$(cat /home/oscar/.hermes/dashboard-access/password)" \
+  https://5.161.56.251:9443/api/dashboard/plugins
+```
+
+Expected: an entry named `kanban` with tab path `/kanban`.
+
+Kanban board API must load the Hermes Agent dev board:
+
+```bash
+curl -k -u "oscar:$(cat /home/oscar/.hermes/dashboard-access/password)" \
+  "https://5.161.56.251:9443/api/plugins/kanban/board?board=hermes-agent-dev"
+```
+
+Expected: `200 OK` JSON with Kanban columns and tasks.
+
+To get the browser-trusted URL:
+
+```bash
+grep -o 'https://[-a-z0-9]*\.trycloudflare\.com' /home/oscar/.hermes/cloudflared/dashboard-tunnel.log | tail -1
+```
+
+Quick tunnels do not require a Cloudflare login, but the hostname can change if `hermes-dashboard-cloudflared.service` restarts. Use a named Cloudflare Tunnel on a real domain if a stable no-warning URL is needed.
+
+## Rollback
+
+Stop and disable the phone-facing proxy first:
+
+```bash
+systemctl --user disable --now hermes-dashboard-auth-proxy.service
+systemctl --user disable --now hermes-dashboard-cloudflared.service
+```
+
+If needed, stop the local dashboard too:
+
+```bash
+systemctl --user disable --now hermes-dashboard.service
+```
+
+The dashboard remains available locally only if restarted with:
+
+```bash
+HERMES_HOME=/home/oscar/.hermes /home/oscar/.hermes/runtime/hermes-agent/.venv/bin/python -m hermes_cli.main dashboard --port 9119 --host 127.0.0.1 --no-open
+```
+
+## Security Notes
+
+- Do not run `hermes dashboard --host 0.0.0.0 --insecure` for phone access.
+- Do not put the password in Kanban comments, docs, dashboard config, or service logs.
+- Rotate the password by replacing the password file and restarting `hermes-dashboard-auth-proxy.service`.
+- The Chat/TUI tab is not enabled by these services.

--- a/docs/hermes-file-permission-migration.md
+++ b/docs/hermes-file-permission-migration.md
@@ -1,0 +1,40 @@
+# Hermes File Permission Hardening
+
+Security hardening adds explicit `chmod 0600` and `chmod 0700` to newly
+created Hermes state files, cron files, Kanban databases, worker logs, and
+scratch workspaces. Existing files keep their current permissions until they
+are touched again or manually migrated.
+
+## What Changed
+
+- Sensitive files are owner-readable and owner-writable only: `0600`.
+- Sensitive directories are owner-accessible only: `0700`.
+- `HERMES_HOME_MODE` is honored for Hermes-owned state directories when set.
+- Managed installs that intentionally share state with a Hermes group keep
+  directories group-accessible (`2770`) and log files group-readable and
+  group-writable (`0660`).
+
+## Suggested Migration
+
+Stop running Hermes processes first, then inspect current permissions:
+
+```bash
+find ~/.hermes -maxdepth 4 -type f \( -name '*.db' -o -name '*.log' -o -name jobs.json -o -name '.env' -o -name config.yaml \) -ls
+find ~/.hermes -maxdepth 4 -type d \( -name logs -o -name workspaces -o -name cron \) -ls
+```
+
+Tighten sensitive files:
+
+```bash
+find ~/.hermes -type f \( -name '*.db' -o -name '*.log' -o -name jobs.json -o -name '.env' -o -name config.yaml \) -exec chmod 600 {} +
+```
+
+Tighten sensitive directories:
+
+```bash
+find ~/.hermes -type d \( -name logs -o -name workspaces -o -name cron -o -name output \) -exec chmod 700 {} +
+```
+
+For managed group-sharing deployments, keep group-owned state directories at
+`2770` and log files at `0660` if the service account and operator accounts
+both rely on that access.

--- a/docs/hermes-file-permission-migration.md
+++ b/docs/hermes-file-permission-migration.md
@@ -9,8 +9,10 @@ are touched again or manually migrated.
 
 - Sensitive files are owner-readable and owner-writable only: `0600`.
 - Sensitive directories are owner-accessible only: `0700`.
-- Managed installs that intentionally share logs with a Hermes group keep log
-  files group-readable and group-writable: `0660`.
+- `HERMES_HOME_MODE` is honored for Hermes-owned state directories when set.
+- Managed installs that intentionally share state with a Hermes group keep
+  directories group-accessible (`2770`) and log files group-readable and
+  group-writable (`0660`).
 
 ## Suggested Migration
 
@@ -33,5 +35,6 @@ Tighten sensitive directories:
 find ~/.hermes -type d \( -name logs -o -name workspaces -o -name cron -o -name output \) -exec chmod 700 {} +
 ```
 
-For managed group-sharing deployments, keep the group-owned log files at
-`0660` if the service account and operator accounts both rely on that access.
+For managed group-sharing deployments, keep group-owned state directories at
+`2770` and log files at `0660` if the service account and operator accounts
+both rely on that access.

--- a/docs/hermes-file-permission-migration.md
+++ b/docs/hermes-file-permission-migration.md
@@ -1,0 +1,37 @@
+# Hermes File Permission Hardening
+
+Security hardening adds explicit `chmod 0600` and `chmod 0700` to newly
+created Hermes state files, cron files, Kanban databases, worker logs, and
+scratch workspaces. Existing files keep their current permissions until they
+are touched again or manually migrated.
+
+## What Changed
+
+- Sensitive files are owner-readable and owner-writable only: `0600`.
+- Sensitive directories are owner-accessible only: `0700`.
+- Managed installs that intentionally share logs with a Hermes group keep log
+  files group-readable and group-writable: `0660`.
+
+## Suggested Migration
+
+Stop running Hermes processes first, then inspect current permissions:
+
+```bash
+find ~/.hermes -maxdepth 4 -type f \( -name '*.db' -o -name '*.log' -o -name jobs.json -o -name '.env' -o -name config.yaml \) -ls
+find ~/.hermes -maxdepth 4 -type d \( -name logs -o -name workspaces -o -name cron \) -ls
+```
+
+Tighten sensitive files:
+
+```bash
+find ~/.hermes -type f \( -name '*.db' -o -name '*.log' -o -name jobs.json -o -name '.env' -o -name config.yaml \) -exec chmod 600 {} +
+```
+
+Tighten sensitive directories:
+
+```bash
+find ~/.hermes -type d \( -name logs -o -name workspaces -o -name cron -o -name output \) -exec chmod 700 {} +
+```
+
+For managed group-sharing deployments, keep the group-owned log files at
+`0660` if the service account and operator accounts both rely on that access.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -824,11 +824,22 @@ class APIServerAdapter(BasePlatformAdapter):
         Validate Bearer token from Authorization header.
 
         Returns None if auth is OK, or a 401 web.Response on failure.
-        If no API key is configured, all requests are allowed (only when API
-        server is local).
+        If no API key is configured, only loopback requests are allowed;
+        non-loopback or unresolvable requests fail closed.
         """
         if not self._api_key:
-            return None  # No key configured — allow all (local-only use)
+            remote = getattr(request, "remote", None)
+            if isinstance(remote, str) and not is_network_accessible(remote):
+                return None  # No key configured, but loopback/local-only use.
+
+            logger.warning(
+                "API server rejected unauthenticated non-local request: %s",
+                self._request_audit_log_suffix(request),
+            )
+            return web.json_response(
+                {"error": {"message": "Authentication required", "type": "invalid_request_error", "code": "invalid_api_key"}},
+                status=401,
+            )
 
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
@@ -1008,8 +1019,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Returns gateway state, connected platforms, PID, and uptime so the
         dashboard can display full status without needing a shared PID file or
-        /proc access.  No authentication required.
+        /proc access.  Authentication required.
         """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
         from gateway.status import read_runtime_status
 
         runtime = read_runtime_status() or {}

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -182,7 +182,7 @@ class WebhookAdapter(BasePlatformAdapter):
                         f"real target (telegram, discord, slack, github_comment, etc.)."
                     )
 
-        app = web.Application()
+        app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
 
@@ -372,9 +372,26 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"error": "Payload too large"}, status=413
             )
 
-        # Read body (must be done before any validation)
+        # Read body with bounded streaming. Chunked/no-Content-Length
+        # requests must not bypass the size cap before HMAC validation.
         try:
-            raw_body = await request.read()
+            chunks: List[bytes] = []
+            total_size = 0
+            while True:
+                chunk = await request.content.read(8192)
+                if not chunk:
+                    break
+                total_size += len(chunk)
+                if total_size > self._max_body_bytes:
+                    return web.json_response(
+                        {"error": "Payload too large"}, status=413
+                    )
+                chunks.append(chunk)
+            raw_body = b"".join(chunks)
+        except web.HTTPRequestEntityTooLarge:
+            return web.json_response(
+                {"error": "Payload too large"}, status=413
+            )
         except Exception as e:
             logger.error("[webhook] Failed to read body: %s", e)
             return web.json_response({"error": "Bad request"}, status=400)

--- a/hermes_cli/dashboard_auth_proxy.py
+++ b/hermes_cli/dashboard_auth_proxy.py
@@ -1,0 +1,236 @@
+"""Authenticated HTTPS reverse proxy for a local Hermes dashboard.
+
+This module is intentionally small and operational: it lets an operator keep
+``hermes dashboard`` bound to loopback while exposing a separate, fail-closed
+HTTPS listener protected by Basic auth.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hmac
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator, Mapping
+from urllib.parse import urlsplit
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+from starlette.background import BackgroundTask
+
+
+DEFAULT_UPSTREAM = "http://127.0.0.1:9119"
+DEFAULT_LISTEN_HOST = "0.0.0.0"
+DEFAULT_LISTEN_PORT = 9443
+
+AUTH_REALM = "Hermes Dashboard"
+USERNAME_ENV = "HERMES_DASHBOARD_PROXY_USERNAME"
+PASSWORD_FILE_ENV = "HERMES_DASHBOARD_PROXY_PASSWORD_FILE"
+UPSTREAM_ENV = "HERMES_DASHBOARD_PROXY_UPSTREAM"
+HOST_ENV = "HERMES_DASHBOARD_PROXY_HOST"
+PORT_ENV = "HERMES_DASHBOARD_PROXY_PORT"
+CERT_FILE_ENV = "HERMES_DASHBOARD_PROXY_CERT_FILE"
+KEY_FILE_ENV = "HERMES_DASHBOARD_PROXY_KEY_FILE"
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+SECURITY_HEADERS = {
+    "Strict-Transport-Security": "max-age=31536000",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+}
+
+
+@asynccontextmanager
+async def _lifespan(fastapi_app: FastAPI) -> AsyncIterator[None]:
+    fastapi_app.state.client = httpx.AsyncClient(follow_redirects=False, timeout=None)
+    try:
+        yield
+    finally:
+        client = getattr(fastapi_app.state, "client", None)
+        if client is not None:
+            await client.aclose()
+
+
+app = FastAPI(title="Hermes Dashboard Auth Proxy", lifespan=_lifespan)
+
+
+def _password_from_file() -> str | None:
+    path = os.environ.get(PASSWORD_FILE_ENV, "").strip()
+    if not path:
+        return None
+    try:
+        first_line = Path(path).read_text(encoding="utf-8").splitlines()[0]
+    except (OSError, IndexError):
+        return None
+    password = first_line.strip()
+    return password or None
+
+
+def _configured_credentials() -> tuple[str, str] | None:
+    username = os.environ.get(USERNAME_ENV, "").strip()
+    password = _password_from_file()
+    if not username or not password:
+        return None
+    return username, password
+
+
+def _basic_auth_valid(header: str, credentials: tuple[str, str]) -> bool:
+    prefix = "Basic "
+    if not header.startswith(prefix):
+        return False
+    try:
+        decoded = base64.b64decode(header[len(prefix):], validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        return False
+    if ":" not in decoded:
+        return False
+    username, password = decoded.split(":", 1)
+    expected_username, expected_password = credentials
+    return hmac.compare_digest(username, expected_username) and hmac.compare_digest(
+        password,
+        expected_password,
+    )
+
+
+def _auth_challenge() -> Response:
+    return Response(
+        status_code=401,
+        headers={
+            "WWW-Authenticate": f'Basic realm="{AUTH_REALM}", charset="UTF-8"',
+            **SECURITY_HEADERS,
+        },
+    )
+
+
+def _with_security_headers(response: Response) -> Response:
+    for key, value in SECURITY_HEADERS.items():
+        response.headers.setdefault(key, value)
+    return response
+
+
+def _upstream_base() -> str:
+    return os.environ.get(UPSTREAM_ENV, DEFAULT_UPSTREAM).rstrip("/")
+
+
+def _upstream_url(path: str, query: str) -> str:
+    url = f"{_upstream_base()}/{path}"
+    if query:
+        url = f"{url}?{query}"
+    return url
+
+
+def _proxy_headers(request_headers: Mapping[str, str]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    upstream_host = urlsplit(_upstream_base()).netloc
+    for key, value in request_headers.items():
+        lower = key.lower()
+        if lower in HOP_BY_HOP_HEADERS or lower in {"authorization", "host"}:
+            continue
+        headers[key] = value
+    if upstream_host:
+        headers["Host"] = upstream_host
+    return headers
+
+
+def _response_headers(upstream_headers: Mapping[str, str]) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for key, value in upstream_headers.items():
+        if key.lower() in HOP_BY_HOP_HEADERS:
+            continue
+        headers[key] = value
+    headers.update(SECURITY_HEADERS)
+    return headers
+
+
+async def _client() -> httpx.AsyncClient:
+    client = getattr(app.state, "client", None)
+    if client is None:
+        client = httpx.AsyncClient(follow_redirects=False, timeout=None)
+        app.state.client = client
+    return client
+
+
+@app.middleware("http")
+async def _auth_middleware(request: Request, call_next):
+    credentials = _configured_credentials()
+    if credentials is None:
+        return _with_security_headers(
+            JSONResponse(
+                status_code=503,
+                content={"detail": "Dashboard proxy credentials are not configured."},
+            ),
+        )
+    if not _basic_auth_valid(request.headers.get("authorization", ""), credentials):
+        return _auth_challenge()
+    response = await call_next(request)
+    return _with_security_headers(response)
+
+
+async def _proxy_to_upstream(request: Request, path: str) -> Response:
+    client = await _client()
+    body = await request.body()
+    upstream_request = client.build_request(
+        request.method,
+        _upstream_url(path, request.url.query),
+        headers=_proxy_headers(request.headers),
+        content=body,
+    )
+    try:
+        upstream_response = await client.send(upstream_request, stream=True)
+    except httpx.RequestError as exc:
+        return JSONResponse(
+            status_code=502,
+            content={"detail": f"Dashboard upstream unavailable: {exc.__class__.__name__}"},
+            headers=SECURITY_HEADERS,
+        )
+
+    return StreamingResponse(
+        upstream_response.aiter_raw(),
+        status_code=upstream_response.status_code,
+        headers=_response_headers(upstream_response.headers),
+        background=BackgroundTask(upstream_response.aclose),
+    )
+
+
+@app.api_route(
+    "/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+)
+async def proxy(request: Request, path: str = "") -> Response:
+    return await _proxy_to_upstream(request, path)
+
+
+def main() -> None:
+    cert_file = os.environ.get(CERT_FILE_ENV)
+    key_file = os.environ.get(KEY_FILE_ENV)
+    if not cert_file or not key_file:
+        raise SystemExit(
+            f"{CERT_FILE_ENV} and {KEY_FILE_ENV} are required for HTTPS.",
+        )
+    uvicorn.run(
+        app,
+        host=os.environ.get(HOST_ENV, DEFAULT_LISTEN_HOST),
+        port=int(os.environ.get(PORT_ENV, str(DEFAULT_LISTEN_PORT))),
+        ssl_certfile=cert_file,
+        ssl_keyfile=key_file,
+        log_level=os.environ.get("HERMES_DASHBOARD_PROXY_LOG_LEVEL", "warning"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -87,6 +87,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from hermes_constants import secure_dir, secure_file
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -1160,6 +1161,7 @@ def connect(
     else:
         path = kanban_db_path(board=board)
     path.parent.mkdir(parents=True, exist_ok=True)
+    secure_file(path)
     # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
     # and other invalid-header cases without opening a sqlite connection.
     _validate_sqlite_header(path)
@@ -1170,6 +1172,7 @@ def connect(
     resolved = str(path.resolve())
     conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
     try:
+        secure_file(path)
         conn.row_factory = sqlite3.Row
         with _INIT_LOCK:
             # WAL activation can take an exclusive lock while SQLite creates the
@@ -3929,8 +3932,12 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
                     f"{task.workspace_path!r}; workspace paths must be absolute"
                 )
         else:
-            p = workspaces_root(board=board) / task.id
+            root = workspaces_root(board=board)
+            p = root / task.id
         p.mkdir(parents=True, exist_ok=True)
+        if not task.workspace_path:
+            secure_dir(root)
+        secure_dir(p)
         return p
     if kind == "dir":
         if not task.workspace_path:
@@ -5788,12 +5795,14 @@ def _default_spawn(
     # logs don't collide across boards that happen to share task ids.
     log_dir = worker_logs_dir(board=board)
     log_dir.mkdir(parents=True, exist_ok=True)
+    secure_dir(log_dir)
     log_path = log_dir / f"{task.id}.log"
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
     # Use 'a' so a re-run on unblock appends rather than overwrites.
     log_f = open(log_path, "ab")
+    secure_file(log_path)
     try:
         proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
             cmd,

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -255,6 +255,49 @@ def secure_parent_dir(path: Path) -> None:
         pass
 
 
+def secure_file(path: Path) -> None:
+    """Set an existing file to owner-only read/write permissions.
+
+    Missing files, unsupported platforms, and chmod failures are ignored so
+    callers can use this as a best-effort post-create hardening step.
+    """
+    try:
+        if path.exists():
+            os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def _secure_dir_mode(default: int = 0o700) -> int:
+    """Return the chmod mode for Hermes-owned state directories."""
+    raw_managed = os.environ.get("HERMES_MANAGED", "").strip()
+    if raw_managed:
+        return 0o2770
+    try:
+        if (get_hermes_home() / ".managed").exists():
+            return 0o2770
+    except OSError:
+        pass
+
+    try:
+        mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
+        return int(mode_str, 8) if mode_str else default
+    except ValueError:
+        return default
+
+
+def secure_dir(path: Path) -> None:
+    """Set secure permissions on an existing Hermes-owned directory."""
+    try:
+        resolved = path.resolve()
+        if resolved == Path("/") or len(resolved.parts) < 3:
+            return
+        if resolved.exists():
+            os.chmod(resolved, _secure_dir_mode())
+    except (OSError, NotImplementedError):
+        pass
+
+
 def get_subprocess_home() -> str | None:
     """Return a per-profile HOME directory for subprocesses, or None.
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -268,14 +268,32 @@ def secure_file(path: Path) -> None:
         pass
 
 
+def _secure_dir_mode(default: int = 0o700) -> int:
+    """Return the chmod mode for Hermes-owned state directories."""
+    raw_managed = os.environ.get("HERMES_MANAGED", "").strip()
+    if raw_managed:
+        return 0o2770
+    try:
+        if (get_hermes_home() / ".managed").exists():
+            return 0o2770
+    except OSError:
+        pass
+
+    try:
+        mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
+        return int(mode_str, 8) if mode_str else default
+    except ValueError:
+        return default
+
+
 def secure_dir(path: Path) -> None:
-    """Set an existing directory to owner-only access permissions."""
+    """Set secure permissions on an existing Hermes-owned directory."""
     try:
         resolved = path.resolve()
         if resolved == Path("/") or len(resolved.parts) < 3:
             return
         if resolved.exists():
-            os.chmod(resolved, 0o700)
+            os.chmod(resolved, _secure_dir_mode())
     except (OSError, NotImplementedError):
         pass
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -255,6 +255,31 @@ def secure_parent_dir(path: Path) -> None:
         pass
 
 
+def secure_file(path: Path) -> None:
+    """Set an existing file to owner-only read/write permissions.
+
+    Missing files, unsupported platforms, and chmod failures are ignored so
+    callers can use this as a best-effort post-create hardening step.
+    """
+    try:
+        if path.exists():
+            os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def secure_dir(path: Path) -> None:
+    """Set an existing directory to owner-only access permissions."""
+    try:
+        resolved = path.resolve()
+        if resolved == Path("/") or len(resolved.parts) < 3:
+            return
+        if resolved.exists():
+            os.chmod(resolved, 0o700)
+    except (OSError, NotImplementedError):
+        pass
+
+
 def get_subprocess_home() -> str | None:
     """Return a per-profile HOME directory for subprocesses, or None.
 

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -30,7 +30,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional, Sequence
 
-from hermes_constants import get_config_path, get_hermes_home
+from hermes_constants import get_config_path, get_hermes_home, secure_dir
 
 # Sentinel to track whether setup_logging() has already run.  The function
 # is idempotent — calling it twice is safe but the second call is a no-op
@@ -198,6 +198,7 @@ def setup_logging(
     home = hermes_home or get_hermes_home()
     log_dir = home / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
+    secure_dir(log_dir)
 
     # Read config defaults (best-effort — config may not be loaded yet).
     cfg_level, cfg_max_size, cfg_backup = _read_logging_config()
@@ -296,13 +297,13 @@ def setup_verbose_logging() -> None:
 # ---------------------------------------------------------------------------
 
 class _ManagedRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that ensures group-writable perms in managed mode.
+    """RotatingFileHandler that applies secure permissions after creation.
 
     In managed mode (NixOS), the stateDir uses setgid (2770) so new files
     inherit the hermes group. However, both _open() (initial creation) and
     doRollover() create files via open(), which uses the process umask —
-    typically 0022, producing 0644. This subclass applies chmod 0660 after
-    both operations so the gateway and interactive users can share log files.
+    typically 0022, producing 0644. Managed installs keep group sharing with
+    0660; all other installs use owner-only 0600.
     """
 
     def __init__(self, *args, **kwargs):
@@ -310,21 +311,20 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         self._managed = is_managed()
         super().__init__(*args, **kwargs)
 
-    def _chmod_if_managed(self):
-        if self._managed:
-            try:
-                os.chmod(self.baseFilename, 0o660)
-            except OSError:
-                pass
+    def _chmod_secure(self):
+        try:
+            os.chmod(self.baseFilename, 0o660 if self._managed else 0o600)
+        except OSError:
+            pass
 
     def _open(self):
         stream = super()._open()
-        self._chmod_if_managed()
+        self._chmod_secure()
         return stream
 
     def doRollover(self):
         super().doRollover()
-        self._chmod_if_managed()
+        self._chmod_secure()
 
 
 def _add_rotating_handler(
@@ -355,6 +355,7 @@ def _add_rotating_handler(
             return  # already attached
 
     path.parent.mkdir(parents=True, exist_ok=True)
+    secure_dir(path.parent)
     handler = _ManagedRotatingFileHandler(
         str(path), maxBytes=max_bytes, backupCount=backup_count,
         encoding="utf-8",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -24,7 +24,7 @@ import time
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, secure_file
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
@@ -352,6 +352,7 @@ class SessionDB:
                 isolation_level=None,
             )
             self._conn.row_factory = sqlite3.Row
+            secure_file(self.db_path)
             apply_wal_with_fallback(self._conn, db_label="state.db")
             self._conn.execute("PRAGMA foreign_keys=ON")
 
@@ -3276,4 +3277,3 @@ class SessionDB:
                 (error[:500], session_id),
             )
         self._execute_write(_do)
-

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -349,23 +349,70 @@
   // -------------------------------------------------------------------------
   // Touch drag-drop helper.
   //
-  // HTML5 DnD is desktop-only. On touch devices we attach a pointerdown
-  // handler that simulates a drag proxy and fires a custom event on the
-  // column under the finger when released. Columns listen for both the
-  // standard `drop` event and our `hermes-kanban:drop` event.
+  // HTML5 DnD is desktop-only. On touch devices we attach a delayed
+  // pointerdown handler that simulates a drag proxy and fires a custom
+  // event on the column under the finger when released. The delay is
+  // intentional: horizontal board swipes and vertical card-list scrolling
+  // must keep their native browser handling unless the user holds on a card.
   // -------------------------------------------------------------------------
+
+  const TOUCH_DRAG_HOLD_MS = 300;
+  const TOUCH_DRAG_MOVE_CANCEL_PX = 10;
 
   function attachTouchDrag(el, taskId) {
     if (!el) return;
     function onDown(e) {
       if (e.pointerType !== "touch") return;
-      e.preventDefault();
-      const proxy = el.cloneNode(true);
-      proxy.classList.add("hermes-kanban-touch-proxy");
-      document.body.appendChild(proxy);
+      if (e.target && e.target.closest && e.target.closest("input, button, textarea, select, a, label")) {
+        return;
+      }
+      const startX = e.clientX;
+      const startY = e.clientY;
+      let proxy = null;
       let lastTarget = null;
+      let dragging = false;
+      let cancelled = false;
+      let holdTimer = window.setTimeout(function () {
+        if (cancelled || dragging) return;
+        dragging = true;
+        proxy = el.cloneNode(true);
+        proxy.classList.add("hermes-kanban-touch-proxy");
+        document.body.appendChild(proxy);
+        proxy.style.position = "fixed";
+        proxy.style.pointerEvents = "none";
+        proxy.style.opacity = "0.85";
+        proxy.style.zIndex = "9999";
+        proxy.style.width = `${el.offsetWidth}px`;
+        proxy.style.left = `${startX - el.offsetWidth / 2}px`;
+        proxy.style.top = `${startY - 24}px`;
+        try { el.setPointerCapture && el.setPointerCapture(e.pointerId); } catch (_err) { /* noop */ }
+      }, TOUCH_DRAG_HOLD_MS);
+
+      function suppressNextClick() {
+        const suppressClick = function (ev) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          el.removeEventListener("click", suppressClick, true);
+        };
+        el.addEventListener("click", suppressClick, true);
+        window.setTimeout(function () {
+          el.removeEventListener("click", suppressClick, true);
+        }, 1200);
+      }
 
       function move(ev) {
+        if (!dragging) {
+          const dx = ev.clientX - startX;
+          const dy = ev.clientY - startY;
+          if (Math.sqrt(dx * dx + dy * dy) > TOUCH_DRAG_MOVE_CANCEL_PX) {
+            cancelled = true;
+            clearTimeout(holdTimer);
+            suppressNextClick();
+            cleanup(false);
+          }
+          return;
+        }
+        ev.preventDefault();
         proxy.style.left = `${ev.clientX - proxy.offsetWidth / 2}px`;
         proxy.style.top = `${ev.clientY - 24}px`;
         proxy.style.display = "none";
@@ -380,11 +427,13 @@
           lastTarget = target;
         }
       }
-      function up() {
+      function cleanup(shouldDrop) {
         document.removeEventListener("pointermove", move);
         document.removeEventListener("pointerup", up);
-        document.removeEventListener("pointercancel", up);
-        if (lastTarget) {
+        document.removeEventListener("pointercancel", cancel);
+        clearTimeout(holdTimer);
+        if (lastTarget) lastTarget.classList.remove("hermes-kanban-column--drop");
+        if (dragging && shouldDrop && lastTarget) {
           lastTarget.classList.remove("hermes-kanban-column--drop");
           const status = lastTarget.getAttribute("data-kanban-column");
           const isTrash = lastTarget.hasAttribute("data-kanban-trash");
@@ -400,19 +449,21 @@
             }));
           }
         }
-        proxy.remove();
+        if (proxy) proxy.remove();
+        if (dragging) {
+          suppressNextClick();
+        }
+        try { el.releasePointerCapture && el.releasePointerCapture(e.pointerId); } catch (_err) { /* noop */ }
       }
-      // Kick off proxy at the pointer origin.
-      proxy.style.position = "fixed";
-      proxy.style.pointerEvents = "none";
-      proxy.style.opacity = "0.85";
-      proxy.style.zIndex = "9999";
-      proxy.style.width = `${el.offsetWidth}px`;
-      proxy.style.left = `${e.clientX - el.offsetWidth / 2}px`;
-      proxy.style.top = `${e.clientY - 24}px`;
-      document.addEventListener("pointermove", move);
+      function up() {
+        cleanup(true);
+      }
+      function cancel() {
+        cleanup(false);
+      }
+      document.addEventListener("pointermove", move, { passive: false });
       document.addEventListener("pointerup", up);
-      document.addEventListener("pointercancel", up);
+      document.addEventListener("pointercancel", cancel);
     }
     el.addEventListener("pointerdown", onDown);
     return function () { el.removeEventListener("pointerdown", onDown); };

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -67,6 +67,8 @@
   gap: 0.75rem;
   align-items: start;
   overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
 }
 .hermes-kanban-columns::-webkit-scrollbar {
@@ -75,6 +77,7 @@
 
 .hermes-kanban-column {
   flex: 0 0 280px;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);
@@ -227,6 +230,7 @@
 
 .hermes-kanban-card {
   cursor: grab;
+  touch-action: pan-x pan-y pinch-zoom;
   transition: transform 100ms ease, box-shadow 100ms ease;
 }
 .hermes-kanban-card:hover {
@@ -1503,6 +1507,7 @@
 
 .hermes-kanban-trash {
   display: flex;
+  box-sizing: border-box;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -1538,4 +1543,33 @@
 
 .hermes-kanban-trash-label {
   font-weight: 500;
+}
+
+/* ---- Mobile column swipe mode --------------------------------------- */
+
+@media (max-width: 767px) {
+  .hermes-kanban {
+    overflow-x: hidden;
+  }
+
+  .hermes-kanban-columns {
+    scroll-snap-type: x mandatory;
+  }
+
+  .hermes-kanban-column,
+  .hermes-kanban-trash {
+    flex-basis: 100%;
+    min-width: 100%;
+    max-width: 100%;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+  }
+
+  .hermes-kanban-column {
+    max-height: calc(100dvh - 220px);
+  }
+
+  .hermes-kanban-trash:not(.hermes-kanban-trash--active) {
+    display: none;
+  }
 }

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -120,15 +120,15 @@ class TestConfigFilePermissions(unittest.TestCase):
 
 
 class TestSecureHelpers(unittest.TestCase):
-    """Test the _secure_file and _secure_dir helpers."""
+    """Test the shared secure_file and secure_dir helpers."""
 
     def test_secure_file_nonexistent_no_error(self):
-        from cron.jobs import _secure_file
-        _secure_file(Path("/nonexistent/path/file.json"))  # Should not raise
+        from hermes_constants import secure_file
+        secure_file(Path("/nonexistent/path/file.json"))  # Should not raise
 
     def test_secure_dir_nonexistent_no_error(self):
-        from cron.jobs import _secure_dir
-        _secure_dir(Path("/nonexistent/path"))  # Should not raise
+        from hermes_constants import secure_dir
+        secure_dir(Path("/nonexistent/path"))  # Should not raise
 
 
 if __name__ == "__main__":

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -345,12 +345,41 @@ class TestAdapterInit:
 
 
 class TestAuth:
-    def test_no_key_configured_allows_all(self):
+    def test_no_key_configured_loopback_allows(self):
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
         mock_request = MagicMock()
         mock_request.headers = {}
+        mock_request.remote = "127.0.0.1"
         assert adapter._check_auth(mock_request) is None
+
+    def test_no_key_non_loopback_returns_401(self):
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.remote = "10.0.0.1"
+        result = adapter._check_auth(mock_request)
+        assert result is not None
+        assert result.status == 401
+
+    def test_no_key_ipv6_loopback_allows(self):
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.remote = "::1"
+        assert adapter._check_auth(mock_request) is None
+
+    def test_no_key_no_remote_fails_closed(self):
+        config = PlatformConfig(enabled=True)
+        adapter = APIServerAdapter(config)
+        mock_request = MagicMock()
+        mock_request.headers = {}
+        mock_request.remote = None
+        result = adapter._check_auth(mock_request)
+        assert result is not None
+        assert result.status == 401
 
     def test_valid_key_passes(self):
         config = PlatformConfig(enabled=True, extra={"key": "sk-test123"})
@@ -551,13 +580,35 @@ class TestHealthDetailedEndpoint:
                 assert data["platforms"] == {}
 
     @pytest.mark.asyncio
-    async def test_health_detailed_does_not_require_auth(self, auth_adapter):
-        """Health detailed endpoint should be accessible without auth, like /health."""
+    async def test_health_detailed_requires_auth_when_key_configured(self, auth_adapter):
+        """With an API key configured, /health/detailed requires authentication."""
         app = _create_app(auth_adapter)
         with patch("gateway.status.read_runtime_status", return_value=None):
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
+                assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_health_detailed_with_valid_auth_passes(self, auth_adapter):
+        """A valid bearer token can read /health/detailed."""
+        app = _create_app(auth_adapter)
+        with patch("gateway.status.read_runtime_status", return_value={
+            "gateway_state": "running",
+            "platforms": {"telegram": {"state": "connected"}},
+            "active_agents": 2,
+            "exit_reason": None,
+            "updated_at": "2026-04-14T00:00:00Z",
+        }):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get(
+                    "/health/detailed",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
                 assert resp.status == 200
+                data = await resp.json()
+                assert data["status"] == "ok"
+                assert data["gateway_state"] == "running"
+                assert isinstance(data["pid"], int)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -713,6 +713,95 @@ class TestBodySize:
             )
             assert resp.status == 413
 
+    @pytest.mark.asyncio
+    async def test_chunked_no_content_length_oversized_rejected(self):
+        """Chunked requests without Content-Length still enforce max_body_bytes."""
+        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        max_bytes = 100
+        adapter = _make_adapter(routes=routes, max_body_bytes=max_bytes)
+
+        async def _chunked_body():
+            chunk = b"x" * 64
+            total = 0
+            target = max_bytes + 200
+            while total < target:
+                size = min(len(chunk), target - total)
+                yield chunk[:size]
+                total += size
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/big",
+                data=_chunked_body(),
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_chunked_no_content_length_within_limit_accepted(self):
+        """Chunked requests within max_body_bytes are accepted."""
+        routes = {"small": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, max_body_bytes=1024)
+        adapter.handle_message = AsyncMock()
+
+        async def _chunked_body():
+            yield b'{"status": "ok"}'
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/small",
+                data=_chunked_body(),
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_hmac_validation_on_chunked_body(self):
+        """HMAC validation uses the exact streamed body."""
+        secret = "test-hmac-secret"
+        routes = {
+            "secure": {
+                "secret": secret,
+                "events": ["push"],
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        body = b'{"event": "push", "data": "test"}'
+        valid_sig = _github_signature(body, secret)
+
+        async def _chunked_body():
+            yield body
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/secure",
+                data=_chunked_body(),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": valid_sig,
+                    "X-GitHub-Event": "push",
+                },
+            )
+            assert resp.status == 202
+
+            resp = await cli.post(
+                "/webhooks/secure",
+                data=_chunked_body(),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": "sha256=badbadbad",
+                    "X-GitHub-Event": "push",
+                },
+            )
+            assert resp.status == 401
+
 
 # ===================================================================
 # INSECURE_NO_AUTH
@@ -1031,4 +1120,3 @@ class TestInsecureNoAuthSafetyRail:
             assert result is True
         finally:
             await adapter.disconnect()
-

--- a/tests/hermes_cli/test_dashboard_auth_proxy.py
+++ b/tests/hermes_cli/test_dashboard_auth_proxy.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi import Response
+from fastapi.testclient import TestClient
+
+from hermes_cli import dashboard_auth_proxy as proxy
+
+
+def _basic(username: str, password: str) -> str:
+    raw = f"{username}:{password}".encode()
+    return "Basic " + base64.b64encode(raw).decode()
+
+
+@pytest.fixture(autouse=True)
+def _proxy_env(monkeypatch, tmp_path):
+    monkeypatch.delenv(proxy.USERNAME_ENV, raising=False)
+    monkeypatch.delenv(proxy.PASSWORD_FILE_ENV, raising=False)
+    monkeypatch.delenv(proxy.UPSTREAM_ENV, raising=False)
+    password_file = tmp_path / "password"
+    password_file.write_text("secret\n", encoding="utf-8")
+    return password_file
+
+
+def test_proxy_fails_closed_without_credentials():
+    client = TestClient(proxy.app)
+
+    response = client.get("/")
+
+    assert response.status_code == 503
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_proxy_rejects_missing_or_bad_basic_auth(monkeypatch, _proxy_env):
+    monkeypatch.setenv(proxy.USERNAME_ENV, "oscar")
+    monkeypatch.setenv(proxy.PASSWORD_FILE_ENV, str(_proxy_env))
+    client = TestClient(proxy.app)
+
+    missing = client.get("/")
+    bad = client.get("/", headers={"Authorization": _basic("oscar", "wrong")})
+
+    assert missing.status_code == 401
+    assert bad.status_code == 401
+    assert missing.headers["WWW-Authenticate"].startswith("Basic")
+
+
+def test_proxy_accepts_valid_basic_auth(monkeypatch, _proxy_env):
+    monkeypatch.setenv(proxy.USERNAME_ENV, "oscar")
+    monkeypatch.setenv(proxy.PASSWORD_FILE_ENV, str(_proxy_env))
+
+    async def fake_proxy_to_upstream(request, path):
+        return Response(f"proxied:{path}")
+
+    monkeypatch.setattr(proxy, "_proxy_to_upstream", fake_proxy_to_upstream)
+    client = TestClient(proxy.app)
+
+    response = client.get("/kanban", headers={"Authorization": _basic("oscar", "secret")})
+
+    assert response.status_code == 200
+    assert response.text == "proxied:kanban"
+    assert response.headers["X-Frame-Options"] == "DENY"
+
+
+def test_proxy_strips_proxy_auth_and_sets_upstream_host(monkeypatch):
+    monkeypatch.setenv(proxy.UPSTREAM_ENV, "http://127.0.0.1:9119")
+
+    headers = proxy._proxy_headers(
+        {
+            "Authorization": "Basic abc",
+            "Host": "public.example",
+            "X-Hermes-Session-Token": "session",
+            "Connection": "keep-alive",
+        },
+    )
+
+    assert "Authorization" not in headers
+    assert headers["Host"] == "127.0.0.1:9119"
+    assert headers["X-Hermes-Session-Token"] == "session"
+    assert "Connection" not in headers

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import sqlite3
+import stat
 import time
 from pathlib import Path
 
@@ -2592,6 +2593,58 @@ def test_task_dict_survives_corrupt_created_at(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# File permissions
+# ---------------------------------------------------------------------------
+
+def test_connect_creates_private_kanban_db(kanban_home):
+    db_path = kb.kanban_db_path()
+    assert stat.S_IMODE(os.stat(db_path).st_mode) == 0o600
+
+
+def test_connect_resecures_existing_kanban_db(kanban_home):
+    db_path = kb.kanban_db_path()
+    os.chmod(db_path, 0o644)
+
+    conn = kb.connect()
+    conn.close()
+
+    assert stat.S_IMODE(os.stat(db_path).st_mode) == 0o600
+
+
+def test_resolve_workspace_creates_private_scratch_dir(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="workspace", assignee="worker")
+        task = kb.get_task(conn, tid)
+
+    workspace = kb.resolve_workspace(task)
+
+    assert stat.S_IMODE(os.stat(kb.workspaces_root()).st_mode) == 0o700
+    assert stat.S_IMODE(os.stat(workspace).st_mode) == 0o700
+
+
+def test_default_spawn_creates_private_worker_log(kanban_home, monkeypatch, tmp_path):
+    class FakePopen:
+        def __init__(self, *args, **kwargs):
+            stdout = kwargs.get("stdout")
+            if stdout is not None:
+                stdout.close()
+            self.pid = 12345
+
+    monkeypatch.setattr("subprocess.Popen", FakePopen)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="spawn", assignee="worker")
+        task = kb.get_task(conn, tid)
+
+    kb._default_spawn(task, str(tmp_path), board=None)
+
+    log_dir = kb.worker_logs_dir()
+    log_path = log_dir / f"{tid}.log"
+    assert stat.S_IMODE(os.stat(log_dir).st_mode) == 0o700
+    assert stat.S_IMODE(os.stat(log_path).st_mode) == 0o600
+
+
+# ---------------------------------------------------------------------------
 # Board-level default_workdir
 # ---------------------------------------------------------------------------
 
@@ -3338,4 +3391,3 @@ def test_maybe_emit_scratch_tip_skips_non_scratch_workspaces(kanban_home, caplog
                 "SELECT kind FROM task_events WHERE task_id = ?", (tid,),
             ).fetchall()
             assert "tip_scratch_workspace" not in [e["kind"] for e in events]
-

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2195,3 +2195,44 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_dashboard_mobile_columns_snap_one_bucket_per_swipe():
+    """Phone-sized screens should snap to one full-width bucket at a time."""
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "scroll-snap-type: x proximity" not in css
+    assert "@media (max-width: 767px)" in css
+    assert "scroll-snap-type: x mandatory" in css
+    assert ".hermes-kanban-column,\n  .hermes-kanban-trash" in css
+    assert "flex-basis: 100%" in css
+    assert "min-width: 100%" in css
+    assert "scroll-snap-align: start" in css
+    assert "scroll-snap-stop: always" in css
+    assert "-webkit-overflow-scrolling: touch" in css
+    assert (
+        ".hermes-kanban-trash:not(.hermes-kanban-trash--active) {\n"
+        "    display: none;\n"
+        "  }"
+    ) in css
+
+
+def test_dashboard_touch_drag_does_not_hijack_swipes():
+    """Touch card dragging must wait for a hold so board swipes stay native."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "const TOUCH_DRAG_HOLD_MS = 300;" in js
+    assert "const TOUCH_DRAG_MOVE_CANCEL_PX = 10;" in js
+    assert "let holdTimer = window.setTimeout(function ()" in js
+    assert "Math.sqrt(dx * dx + dy * dy) > TOUCH_DRAG_MOVE_CANCEL_PX" in js
+    assert "function suppressNextClick()" in js
+    assert "suppressNextClick();\n            cleanup(false);" in js
+    assert "document.addEventListener(\"pointermove\", move, { passive: false });" in js
+    assert "document.addEventListener(\"pointercancel\", cancel);" in js
+    assert "function cancel() {\n        cleanup(false);" in js
+    assert "}, 1200);" in js
+    assert ".hermes-kanban-card" in css
+    assert "touch-action: pan-x pan-y pinch-zoom" in css

--- a/tests/test_hermes_file_security.py
+++ b/tests/test_hermes_file_security.py
@@ -1,0 +1,158 @@
+"""Tests for shared file permission hardening helpers."""
+
+import logging
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import secure_dir, secure_file
+
+
+class TestSecureFile:
+    def test_sets_0600_on_existing_file(self, tmp_path):
+        target = tmp_path / "state.db"
+        target.write_text("data")
+        os.chmod(target, 0o644)
+
+        secure_file(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+
+    def test_noop_on_nonexistent_file(self):
+        secure_file(Path("/nonexistent/path/file.db"))
+
+    @pytest.mark.skipif(os.name != "posix", reason="chmod test")
+    def test_idempotent(self, tmp_path):
+        target = tmp_path / "state.db"
+        target.write_text("data")
+
+        secure_file(target)
+        secure_file(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+
+
+class TestSecureDir:
+    def test_sets_0700_on_existing_dir(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        target = tmp_path / "logs"
+        target.mkdir()
+        os.chmod(target, 0o755)
+
+        secure_dir(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o700
+
+    def test_honors_hermes_home_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME_MODE", "0750")
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        target = tmp_path / "logs"
+        target.mkdir()
+        os.chmod(target, 0o755)
+
+        secure_dir(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o750
+
+    def test_managed_mode_keeps_group_access(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_MANAGED", "true")
+        target = tmp_path / "logs"
+        target.mkdir()
+        os.chmod(target, 0o755)
+
+        secure_dir(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o2770
+
+    def test_noop_on_nonexistent_dir(self):
+        secure_dir(Path("/nonexistent/path"))
+
+
+class TestStateDBPermissions:
+    def test_sessiondb_creates_0600_state_db(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            assert stat.S_IMODE(os.stat(db_path).st_mode) == 0o600
+        finally:
+            db.close()
+
+    def test_sessiondb_parent_dir_not_changed(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "subdir" / "state.db"
+        db_path.parent.mkdir()
+        parent_mode_before = stat.S_IMODE(os.stat(db_path.parent).st_mode)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert stat.S_IMODE(os.stat(db_path.parent).st_mode) == parent_mode_before
+        finally:
+            db.close()
+
+
+class TestLogFilePermissions:
+    def test_setup_logging_creates_private_log_dir_and_files(self, tmp_path, monkeypatch):
+        import hermes_cli.config as config
+        import hermes_logging
+
+        monkeypatch.setattr(config, "is_managed", lambda: False)
+        monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        root = logging.getLogger()
+        before_handlers = set(root.handlers)
+        before_initialized = hermes_logging._logging_initialized
+
+        log_dir = hermes_logging.setup_logging(
+            hermes_home=tmp_path,
+            mode="gateway",
+            force=True,
+        )
+        try:
+            assert stat.S_IMODE(os.stat(log_dir).st_mode) == 0o700
+            for name in ("agent.log", "errors.log", "gateway.log"):
+                path = log_dir / name
+                assert path.exists()
+                assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+        finally:
+            for handler in list(root.handlers):
+                if handler not in before_handlers:
+                    root.removeHandler(handler)
+                    handler.close()
+            hermes_logging._logging_initialized = before_initialized
+
+    def test_setup_logging_keeps_managed_group_access(self, tmp_path, monkeypatch):
+        import hermes_cli.config as config
+        import hermes_logging
+
+        monkeypatch.setattr(config, "is_managed", lambda: True)
+        monkeypatch.setenv("HERMES_MANAGED", "true")
+        root = logging.getLogger()
+        before_handlers = set(root.handlers)
+        before_initialized = hermes_logging._logging_initialized
+
+        log_dir = hermes_logging.setup_logging(
+            hermes_home=tmp_path,
+            mode="gateway",
+            force=True,
+        )
+        try:
+            assert stat.S_IMODE(os.stat(log_dir).st_mode) == 0o2770
+            for name in ("agent.log", "errors.log", "gateway.log"):
+                path = log_dir / name
+                assert path.exists()
+                assert stat.S_IMODE(os.stat(path).st_mode) == 0o660
+        finally:
+            for handler in list(root.handlers):
+                if handler not in before_handlers:
+                    root.removeHandler(handler)
+                    handler.close()
+            hermes_logging._logging_initialized = before_initialized

--- a/tests/test_hermes_file_security.py
+++ b/tests/test_hermes_file_security.py
@@ -35,7 +35,9 @@ class TestSecureFile:
 
 
 class TestSecureDir:
-    def test_sets_0700_on_existing_dir(self, tmp_path):
+    def test_sets_0700_on_existing_dir(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME_MODE", raising=False)
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
         target = tmp_path / "logs"
         target.mkdir()
         os.chmod(target, 0o755)
@@ -43,6 +45,27 @@ class TestSecureDir:
         secure_dir(target)
 
         assert stat.S_IMODE(os.stat(target).st_mode) == 0o700
+
+    def test_honors_hermes_home_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME_MODE", "0750")
+        monkeypatch.delenv("HERMES_MANAGED", raising=False)
+        target = tmp_path / "logs"
+        target.mkdir()
+        os.chmod(target, 0o755)
+
+        secure_dir(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o750
+
+    def test_managed_mode_keeps_group_access(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_MANAGED", "true")
+        target = tmp_path / "logs"
+        target.mkdir()
+        os.chmod(target, 0o755)
+
+        secure_dir(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o2770
 
     def test_noop_on_nonexistent_dir(self):
         secure_dir(Path("/nonexistent/path"))

--- a/tests/test_hermes_file_security.py
+++ b/tests/test_hermes_file_security.py
@@ -1,0 +1,102 @@
+"""Tests for shared file permission hardening helpers."""
+
+import logging
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import secure_dir, secure_file
+
+
+class TestSecureFile:
+    def test_sets_0600_on_existing_file(self, tmp_path):
+        target = tmp_path / "state.db"
+        target.write_text("data")
+        os.chmod(target, 0o644)
+
+        secure_file(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+
+    def test_noop_on_nonexistent_file(self):
+        secure_file(Path("/nonexistent/path/file.db"))
+
+    @pytest.mark.skipif(os.name != "posix", reason="chmod test")
+    def test_idempotent(self, tmp_path):
+        target = tmp_path / "state.db"
+        target.write_text("data")
+
+        secure_file(target)
+        secure_file(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+
+
+class TestSecureDir:
+    def test_sets_0700_on_existing_dir(self, tmp_path):
+        target = tmp_path / "logs"
+        target.mkdir()
+        os.chmod(target, 0o755)
+
+        secure_dir(target)
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o700
+
+    def test_noop_on_nonexistent_dir(self):
+        secure_dir(Path("/nonexistent/path"))
+
+
+class TestStateDBPermissions:
+    def test_sessiondb_creates_0600_state_db(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path)
+        try:
+            assert stat.S_IMODE(os.stat(db_path).st_mode) == 0o600
+        finally:
+            db.close()
+
+    def test_sessiondb_parent_dir_not_changed(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "subdir" / "state.db"
+        db_path.parent.mkdir()
+        parent_mode_before = stat.S_IMODE(os.stat(db_path.parent).st_mode)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            assert stat.S_IMODE(os.stat(db_path.parent).st_mode) == parent_mode_before
+        finally:
+            db.close()
+
+
+class TestLogFilePermissions:
+    def test_setup_logging_creates_private_log_dir_and_files(self, tmp_path, monkeypatch):
+        import hermes_cli.config as config
+        import hermes_logging
+
+        monkeypatch.setattr(config, "is_managed", lambda: False)
+        root = logging.getLogger()
+        before_handlers = set(root.handlers)
+        before_initialized = hermes_logging._logging_initialized
+
+        log_dir = hermes_logging.setup_logging(
+            hermes_home=tmp_path,
+            mode="gateway",
+            force=True,
+        )
+        try:
+            assert stat.S_IMODE(os.stat(log_dir).st_mode) == 0o700
+            for name in ("agent.log", "errors.log", "gateway.log"):
+                path = log_dir / name
+                assert path.exists()
+                assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+        finally:
+            for handler in list(root.handlers):
+                if handler not in before_handlers:
+                    root.removeHandler(handler)
+                    handler.close()
+            hermes_logging._logging_initialized = before_initialized

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -569,7 +569,9 @@ def test_complete_retry_with_corrected_created_cards_succeeds(worker_env):
     # Create a real child via the tool so it gets the worker-profile
     # attribution the gate trusts.
     child = json.loads(kt._handle_create({
-        "title": "real child", "assignee": "peer",
+        "title": "real child",
+        "assignee": "test-worker",
+        "parents": [worker_env],
     }))
     assert child["ok"]
     real_id = child["task_id"]
@@ -751,7 +753,7 @@ def test_create_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({
         "title": "child task",
-        "assignee": "peer",
+        "assignee": "test-worker",
         "parents": [worker_env],
     })
     d = json.loads(out)
@@ -763,7 +765,7 @@ def test_create_happy_path(worker_env):
     try:
         child = kb.get_task(conn, d["task_id"])
         assert child.title == "child task"
-        assert child.assignee == "peer"
+        assert child.assignee == "test-worker"
     finally:
         conn.close()
 
@@ -778,7 +780,7 @@ def test_create_stamps_session_id_from_env(monkeypatch, worker_env):
     from hermes_cli import kanban_db as kb
     out = kt._handle_create({
         "title": "from chat",
-        "assignee": "peer",
+        "assignee": "test-worker",
         "parents": [worker_env],
     })
     d = json.loads(out)
@@ -801,7 +803,7 @@ def test_create_session_id_arg_overrides_env(monkeypatch, worker_env):
     from hermes_cli import kanban_db as kb
     out = kt._handle_create({
         "title": "explicit override",
-        "assignee": "peer",
+        "assignee": "test-worker",
         "parents": [worker_env],
         "session_id": "explicit-arg",
     })
@@ -824,7 +826,7 @@ def test_create_session_id_absent_when_env_unset(monkeypatch, worker_env):
     from hermes_cli import kanban_db as kb
     out = kt._handle_create({
         "title": "no session",
-        "assignee": "peer",
+        "assignee": "test-worker",
         "parents": [worker_env],
     })
     d = json.loads(out)
@@ -859,7 +861,8 @@ def test_create_parses_triage_string_false(worker_env):
     from hermes_cli import kanban_db as kb
     out = kt._handle_create({
         "title": "not triage",
-        "assignee": "peer",
+        "assignee": "test-worker",
+        "parents": [worker_env],
         "triage": "false",
     })
     d = json.loads(out)
@@ -867,7 +870,7 @@ def test_create_parses_triage_string_false(worker_env):
     conn = kb.connect()
     try:
         task = kb.get_task(conn, d["task_id"])
-        assert task.status == "ready"
+        assert task.status == "todo"
     finally:
         conn.close()
 
@@ -877,7 +880,8 @@ def test_create_parses_triage_string_true(worker_env):
     from hermes_cli import kanban_db as kb
     out = kt._handle_create({
         "title": "needs triage",
-        "assignee": "peer",
+        "assignee": "test-worker",
+        "parents": [worker_env],
         "triage": "true",
     })
     d = json.loads(out)
@@ -904,7 +908,7 @@ def test_create_accepts_string_parent(worker_env):
     """Convenience: a single parent id as string is coerced to [id]."""
     from tools import kanban_tools as kt
     out = kt._handle_create({
-        "title": "t", "assignee": "a", "parents": worker_env,
+        "title": "t", "assignee": "test-worker", "parents": worker_env,
     })
     assert json.loads(out)["ok"]
 
@@ -915,7 +919,8 @@ def test_create_accepts_skills_list(worker_env):
     from hermes_cli import kanban_db as kb
     out = kt._handle_create({
         "title": "skilled",
-        "assignee": "linguist",
+        "assignee": "test-worker",
+        "parents": [worker_env],
         "skills": ["translation", "github-code-review"],
     })
     d = json.loads(out)
@@ -931,7 +936,8 @@ def test_create_accepts_skills_string(worker_env):
     from hermes_cli import kanban_db as kb
     out = kt._handle_create({
         "title": "one-skill",
-        "assignee": "a",
+        "assignee": "test-worker",
+        "parents": [worker_env],
         "skills": "translation",
     })
     d = json.loads(out)
@@ -1042,7 +1048,7 @@ def test_worker_lifecycle_through_tools(worker_env):
     # 4. spawn a child task for follow-up
     child_out = json.loads(kt._handle_create({
         "title": "write integration test",
-        "assignee": "qa",
+        "assignee": "test-worker",
         "parents": [worker_env],
     }))
     assert child_out["ok"]
@@ -1171,8 +1177,8 @@ def test_kanban_guidance_prompt_size_bounded(monkeypatch, tmp_path):
 # kanban_unblock) must refuse to operate
 # on any OTHER task id, even if the caller supplies an explicit `task_id`
 # argument. Workers legitimately call kanban_show / kanban_list /
-# kanban_comment / kanban_create / kanban_link on other tasks, so those
-# are unrestricted.
+# kanban_comment / kanban_link on other tasks. kanban_create is allowed
+# only for constrained child-task fan-out.
 #
 # Orchestrator profiles (no HERMES_KANBAN_TASK in env) are intentionally
 # exempt — their job is routing, and they sometimes close out child
@@ -1279,6 +1285,139 @@ def test_worker_can_comment_on_foreign_task(worker_env):
         assert comments[0].body.startswith("handoff:")
     finally:
         conn.close()
+
+
+def test_worker_create_requires_current_task_parent(worker_env):
+    """A task-scoped worker cannot create orphaned follow-up work."""
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "orphan",
+        "assignee": "test-worker",
+    })
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "parents" in d.get("error", "")
+
+
+def test_worker_create_rejects_persistent_workspace(worker_env):
+    """Workers cannot point child tasks at shared dir/worktree workspaces."""
+    from tools import kanban_tools as kt
+
+    for workspace_kind in ("dir", "worktree"):
+        out = kt._handle_create({
+            "title": "bad workspace",
+            "assignee": "test-worker",
+            "parents": [worker_env],
+            "workspace_kind": workspace_kind,
+        })
+        d = json.loads(out)
+        assert d.get("ok") is not True
+        assert "workspace_kind" in d.get("error", "")
+
+
+def test_worker_create_rejects_explicit_workspace_path(worker_env):
+    """Workers must use auto-allocated scratch workspaces."""
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "bad path",
+        "assignee": "test-worker",
+        "parents": [worker_env],
+        "workspace_path": "/tmp/not-worker-owned",
+    })
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "workspace_path" in d.get("error", "")
+
+
+def test_worker_create_rejects_cross_profile_assignee(worker_env):
+    """Workers cannot assign follow-up tasks to arbitrary profiles."""
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "privileged follow-up",
+        "assignee": "privileged-profile",
+        "parents": [worker_env],
+    })
+    d = json.loads(out)
+    assert d.get("ok") is not True
+    assert "allowed_cross_profile_assignees" in d.get("error", "")
+
+
+def test_worker_create_allows_self_assignee(worker_env):
+    """Workers can create child tasks for their own profile."""
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "self follow-up",
+        "assignee": "test-worker",
+        "parents": [worker_env],
+    })
+    d = json.loads(out)
+    assert d.get("ok") is True
+    assert d["task_id"]
+
+
+def test_worker_create_allowed_cross_profile(monkeypatch, tmp_path):
+    """Config can opt specific profiles into worker-created handoffs."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "kanban:\n"
+        "  allowed_cross_profile_assignees:\n"
+        "    - reviewer\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "builder")
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent", assignee="builder")
+        kb.claim_task(conn, parent)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", parent)
+
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "review",
+        "assignee": "reviewer",
+        "parents": [parent],
+    })
+    d = json.loads(out)
+    assert d.get("ok") is True
+
+    rejected = kt._handle_create({
+        "title": "security review",
+        "assignee": "security",
+        "parents": [parent],
+    })
+    assert json.loads(rejected).get("ok") is not True
+
+
+def test_worker_create_remains_constrained_with_kanban_toolset(monkeypatch, worker_env, tmp_path):
+    """Task scope wins over profile kanban toolset config for create policy."""
+    home = tmp_path / ".hermes"
+    home.mkdir(exist_ok=True)
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "still constrained",
+        "assignee": "someone-else",
+        "parents": [worker_env],
+    })
+    d = json.loads(out)
+    assert d.get("ok") is not True
 
 
 def test_worker_unblock_rejects_foreign_task_id(worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -91,6 +91,82 @@ def _check_kanban_orchestrator_mode() -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Worker privilege guard
+# ---------------------------------------------------------------------------
+
+def _normalize_profile_for_policy(value: Any) -> str:
+    """Normalize profile names before comparing worker create privileges."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    try:
+        from hermes_cli.profiles import normalize_profile_name
+
+        return normalize_profile_name(text)
+    except Exception:
+        return text
+
+
+def _allowed_cross_profile_assignees() -> set[str]:
+    """Configured assignees a task-scoped worker may delegate to."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        configured = cfg.get("kanban", {}).get(
+            "allowed_cross_profile_assignees", []
+        )
+    except Exception:
+        return set()
+    if not isinstance(configured, (list, tuple, set)):
+        return set()
+    return {
+        normalized
+        for item in configured
+        if (normalized := _normalize_profile_for_policy(item))
+    }
+
+
+def _enforce_worker_create_policy(args: dict, parents: list[str]) -> Optional[str]:
+    """Restrict kanban_create when running inside a task-scoped worker."""
+    current_task = os.environ.get("HERMES_KANBAN_TASK")
+    if not current_task:
+        return None
+
+    if current_task not in parents:
+        return tool_error(
+            "kanban_create from a worker context requires parents to include "
+            f"the current task ({current_task})."
+        )
+
+    workspace_kind = str(args.get("workspace_kind") or "scratch")
+    if workspace_kind != "scratch":
+        return tool_error(
+            "kanban_create from a worker context only supports "
+            f"workspace_kind='scratch' (got {workspace_kind!r})."
+        )
+
+    if args.get("workspace_path"):
+        return tool_error(
+            "kanban_create from a worker context does not support explicit "
+            "workspace_path. Scratch workspaces are auto-allocated."
+        )
+
+    assignee = _normalize_profile_for_policy(args.get("assignee"))
+    worker_profile = _normalize_profile_for_policy(os.environ.get("HERMES_PROFILE"))
+    if not worker_profile or assignee != worker_profile:
+        allowed = _allowed_cross_profile_assignees()
+        if assignee not in allowed:
+            return tool_error(
+                "kanban_create from a worker context can only assign tasks to "
+                "the worker profile or profiles listed in "
+                "kanban.allowed_cross_profile_assignees."
+            )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 
@@ -681,6 +757,10 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(
             f"parents must be a list of task ids, got {type(parents).__name__}"
         )
+    parents = [str(parent) for parent in parents]
+    privilege_err = _enforce_worker_create_policy(args, parents)
+    if privilege_err:
+        return privilege_err
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -1051,8 +1131,11 @@ KANBAN_CREATE_SCHEMA = {
         "one (pass the current task id in ``parents``). Used by "
         "orchestrator workers to fan out — decompose work into child "
         "tasks with specific assignees, link them into a pipeline, "
-        "then complete your own task. The dispatcher picks up the new "
-        "tasks on its next tick and spawns the assigned profiles."
+        "then complete your own task. Task-scoped workers may only create "
+        "scratch child tasks parented to their current task and assigned to "
+        "their own profile unless cross-profile assignees are explicitly "
+        "allowed in config. The dispatcher picks up the new tasks on its "
+        "next tick and spawns the assigned profiles."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## Summary

This PR hardens permissions for Hermes state that can contain local transcripts, task metadata, runtime logs, or worker output:

- adds shared `secure_file()` and `secure_dir()` helpers for best-effort chmod after sensitive files/directories are created
- applies owner-only file permissions to `state.db`, Kanban databases, worker logs, and non-managed log files
- applies secure directory permissions to log directories and auto-created Kanban scratch workspaces
- preserves existing managed-install group sharing by keeping managed directories at `2770` and managed log files at `0660`
- documents a manual migration path for existing files that predate the hardening

## Scope note

This intentionally avoids changing cron file/directory ownership or `HERMES_HOME_MODE` cron behavior. There are already open cron-specific permission PRs in that area, so this PR keeps the state/log/Kanban hardening separate to avoid overlap.

## Why

Several Hermes-managed files can contain sensitive local data: conversation state, Kanban task metadata, worker logs, and agent logs. Creation paths currently rely on process umask or library defaults in a few places, which can leave those files broader than intended on shared hosts.

## Behavior

- Missing files/directories and platforms without chmod support are ignored, matching existing best-effort permission helpers.
- `secure_dir()` refuses to chmod `/` or top-level directories to avoid dangerous behavior if a path is unexpectedly broad.
- Managed installs keep group-sharing semantics so service accounts and operator accounts can continue to share the managed state directory.

## Tests

Local checks run:

```bash
uv run --with pytest --with pytest-asyncio python -m pytest \
  tests/test_hermes_file_security.py \
  tests/hermes_cli/test_kanban_db.py::test_connect_creates_private_kanban_db \
  tests/hermes_cli/test_kanban_db.py::test_connect_resecures_existing_kanban_db \
  tests/hermes_cli/test_kanban_db.py::test_resolve_workspace_creates_private_scratch_dir \
  tests/hermes_cli/test_kanban_db.py::test_default_spawn_creates_private_worker_log \
  -q
```

Result: `15 passed`.

```bash
uv run --with ruff python -m ruff check \
  hermes_constants.py hermes_logging.py hermes_state.py hermes_cli/kanban_db.py \
  tests/test_hermes_file_security.py tests/hermes_cli/test_kanban_db.py
```

Result: `All checks passed!`.

```bash
uv run python scripts/check-windows-footguns.py
```

Result: `No Windows footguns found`.
