### PR TITLE
fix(dashboard): merge PUT /api/config with on-disk config (preserves custom_providers)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -42,11 +42,13 @@ from hermes_cli.config import (
     get_hermes_home,
     load_config,
     load_env,
+    read_raw_config,
     save_config,
     save_env_value,
     remove_env_value,
     check_config_version,
     redact_key,
+    _deep_merge,
 )
 from gateway.status import get_running_pid, read_runtime_status
 from utils import env_var_enabled
@@ -1192,7 +1194,15 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate):
     try:
-        save_config(_denormalize_config_from_web(body.config))
+        # The dashboard form is schema-driven (see CONFIG_SCHEMA). Any root
+        # key absent from the schema — most visibly ``custom_providers``, but
+        # also ``agent.personalities``, ``terminal.lifetime_seconds``, etc. —
+        # is not sent in the PUT body. A full-replace save would silently
+        # drop those keys. Deep-merge incoming over what's on disk so the
+        # frontend can only overwrite what it explicitly sends.
+        existing = read_raw_config()
+        incoming = _denormalize_config_from_web(body.config)
+        save_config(_deep_merge(existing, incoming))
         return {"ok": True}
     except Exception:
         _log.exception("PUT /api/config failed")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -520,6 +520,74 @@ class TestConfigRoundTrip:
         web_config["agent"]["max_turns"] = original_turns
         self.client.put("/api/config", json={"config": web_config})
 
+    def test_round_trip_preserves_custom_providers(self):
+        """``custom_providers`` is not in the dashboard schema, so the
+        frontend never sends it in PUT bodies. Saving must still preserve
+        it on disk — otherwise every dashboard click that saves silently
+        wipes the user's custom endpoints."""
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "model": {"default": "test/model", "provider": "custom:myprov"},
+            "custom_providers": [
+                {
+                    "name": "myprov",
+                    "base_url": "https://example.invalid/v1",
+                    "key_env": "MYPROV_API_KEY",
+                    "api_mode": "chat_completions",
+                    "model": "test/model",
+                },
+            ],
+        })
+
+        # Frontend behaviour: GET full config, then PUT without keys the
+        # schema doesn't know about (custom_providers is the prime example).
+        web_config = self.client.get("/api/config").json()
+        web_config.pop("custom_providers", None)
+        resp = self.client.put("/api/config", json={"config": web_config})
+        assert resp.status_code == 200
+
+        after = load_config()
+        cps = after.get("custom_providers")
+        assert isinstance(cps, list) and len(cps) == 1, \
+            f"custom_providers wiped by lossy PUT: {cps!r}"
+        assert cps[0].get("name") == "myprov"
+        assert cps[0].get("base_url") == "https://example.invalid/v1"
+
+    def test_round_trip_preserves_schema_invisible_nested_keys(self):
+        """Nested keys that aren't in CONFIG_SCHEMA must also survive a
+        round-trip. Deep-merge is required — a shallow merge would drop
+        ``agent.<custom_key>`` when the frontend sends a partial ``agent``
+        dict containing only schema-known sub-fields."""
+        from hermes_cli.config import load_config, read_raw_config, save_config
+
+        # Seed config with a key under `agent` that isn't in the schema.
+        # Use a sentinel name to avoid colliding with future schema fields.
+        save_config({
+            "agent": {
+                "max_turns": 50,
+                "x_dashboard_invisible_test_key": {"nested": "value"},
+            },
+        })
+
+        # PUT only schema-known agent fields, exactly like the dashboard.
+        web_config = self.client.get("/api/config").json()
+        web_config.setdefault("agent", {})
+        web_config["agent"]["max_turns"] = 75
+        # Strip our sentinel so we're sending what the schema-driven form
+        # would send.
+        web_config["agent"].pop("x_dashboard_invisible_test_key", None)
+
+        resp = self.client.put("/api/config", json={"config": web_config})
+        assert resp.status_code == 200
+
+        on_disk = read_raw_config()
+        assert on_disk.get("agent", {}).get("max_turns") == 75
+        assert on_disk.get("agent", {}).get("x_dashboard_invisible_test_key") \
+            == {"nested": "value"}, \
+            "Shallow-merge regression: agent.x_dashboard_invisible_test_key " \
+            "was wiped when the frontend sent a partial agent dict."
+
     def test_schema_types_match_config_values(self):
         """Every schema field should have a matching-type value in the config."""
         config = self.client.get("/api/config").json()


### PR DESCRIPTION
## What does this PR do?

`PUT /api/config` currently does a full-file replace of `config.yaml` with whatever the dashboard sends. The dashboard form is built from `CONFIG_SCHEMA`, which doesn't enumerate every root-level YAML key — most visibly **`custom_providers`** is recognized by `_KNOWN_ROOT_KEYS` but is **not in the schema**, so the frontend never includes it in the PUT body. As a result, every dashboard action that triggers a save (model picker, toggling a setting, "Reset to defaults", etc.) silently wipes `custom_providers` from disk. Other casualties are masked by `DEFAULT_CONFIG` re-injection on load (`agent.personalities`, `agent.reasoning_effort`, `terminal.lifetime_seconds`, …), so `custom_providers` is the user-visible smoking gun.

This change makes `update_config` read the raw on-disk config and **deep-merge** the incoming PUT body on top of it. The frontend can only overwrite what it explicitly sends; everything else is preserved verbatim. Uses the existing `_deep_merge` helper from `hermes_cli.config`.

## Repro on main

1. Add a custom provider to `~/.hermes/config.yaml`:
   ```yaml
   custom_providers:
     - name: myprov
       base_url: https://example.invalid/v1
       key_env: MYPROV_API_KEY
       api_mode: chat_completions
       model: test/model
   ```
2. Open the dashboard. Change any visible setting (e.g. `agent.max_turns`) and save.
3. `grep custom_providers ~/.hermes/config.yaml` → **gone**.

## Related Issue

No existing issue filed — happy to open one and link if maintainers prefer.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py:1192` — `update_config` now does `save_config(_deep_merge(read_raw_config(), _denormalize_config_from_web(body.config)))`.
- `hermes_cli/web_server.py:36` — added `read_raw_config, _deep_merge` to the existing `hermes_cli.config` import block.
- `tests/hermes_cli/test_web_server.py` — added two regression tests in `TestConfigRoundTrip`:
  - `test_round_trip_preserves_custom_providers` — exercises the exact bug.
  - `test_round_trip_preserves_schema_invisible_nested_keys` — covers nested keys, would catch a future shallow-merge regression.

## How to Test

```
uv run python -m pytest tests/hermes_cli/test_web_server.py::TestConfigRoundTrip -q
```

Both new tests fail on `main` (verified with `git stash` of the `web_server.py` change before running) and pass with this patch. All other tests in `TestConfigRoundTrip` and the wider `TestWebServerEndpoints` continue to pass.

I also verified the fix end-to-end on a running deployment (bind-mounted the patched file into a `domovoy/hermes-agent:local` container) by:
1. GET `/api/config` → strip `custom_providers` from the body → PUT it back.
2. Confirm `custom_providers` is still on disk.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs for duplicates
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/hermes_cli/ -q -k config` and the relevant tests pass (579 passed, 1 skipped; 3 unrelated `TestPtyWebSocket` failures pre-exist on main due to a Starlette `TestClient` change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.6 (dev) + Linux arm64 (deployment)

### Documentation & Housekeeping

- [x] N/A — no public API changes, no new config keys, no architecture change
- [x] No `cli-config.yaml.example` changes — `custom_providers` is already documented there
- [x] Cross-platform impact: none (pure Python, no OS-specific code)

## Notes for reviewers

- Uses the existing module-private `_deep_merge` from `hermes_cli.config`. Happy to either keep the cross-module import of a private name (smaller diff) or rename `_deep_merge` → `deep_merge` and update both call sites in `config.py` — let me know the preference.
- The fix is in `update_config` rather than `save_config` because every other `save_config` caller already passes the full config dict (`load_config()` → mutate → `save_config(cfg)`), so moving the merge to `save_config` would be a no-op for them. Keeping the merge at the HTTP boundary minimizes blast radius.
- `read_raw_config` (vs `load_config`) is used deliberately so we don't inflate the user's `config.yaml` by writing all of `DEFAULT_CONFIG` back to disk on every save.