### PR TITLE
fix(gateway,weixin): extend MEDIA regex whitelist + add retry on session errors

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2159,7 +2159,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|md|json|yaml|yml|toml|log)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2145,11 +2145,35 @@ async def send_weixin_direct(
         adapter._token_store = token_store
 
         last_result: Optional[SendResult] = None
-        cleaned = adapter.format_message(message)
-        if cleaned:
-            last_result = await adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
+        
+        async def _try_send_with_refresh() -> Optional[SendResult]:
+            nonlocal last_result
+            cleaned = adapter.format_message(message)
+            if cleaned:
+                last_result = await adapter.send(chat_id, cleaned)
+            return last_result
+        
+        # Retry once on session/rate-limit errors, then give an
+        # actionable error so cron/send_message can surface it.
+        for _retry in range(2):
+            last_result = await _try_send_with_refresh()
+            if last_result and last_result.success:
+                break
+            err = last_result.error if last_result else ""
+            is_rate = "rate limited" in err or "ret=-2" in err
+            is_session = "session" in err.lower()
+            if not is_rate and not is_session:
+                break
+            # Clear stale context_token and retry once without it
+            if context_token:
+                token_store._cache.pop(
+                    token_store._key(account_id, chat_id), None
+                )
+                context_token = None
+            await asyncio.sleep(3.0)
+        
+        if not last_result or not last_result.success:
+            return {"error": f"Weixin send failed: {last_result.error if last_result else 'unknown'}"}
 
         for media_path, _is_voice in media_files or []:
             ext = Path(media_path).suffix.lower()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -347,6 +347,19 @@ class TestExtractMedia:
         assert media == [("/tmp/x.jpg", False)]  # voice flag stays False
         assert "[[as_document]]" not in cleaned
 
+    @pytest.mark.parametrize(
+        "ext",
+        ["md", "json", "yaml", "yml", "toml", "log"],
+    )
+    def test_media_tag_accepts_text_config_extensions(self, ext):
+        """MEDIA: tags must extract text/config artifact paths so callers can
+        deliver them as file attachments instead of leaving the raw tag in
+        the platform message body (see issue #32601, bug 1)."""
+        content = f"MEDIA:/tmp/notes.{ext}"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [(f"/tmp/notes.{ext}", False)]
+        assert "MEDIA:" not in cleaned
+
     def test_both_directives_can_coexist(self):
         """A response could (rarely) contain both [[audio_as_voice]] for an
         ogg file AND [[as_document]] for an attached image. The voice flag


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in the WeChat (weixin) message delivery path:

### 1. MEDIA tag leaks for common file types

`BasePlatformAdapter.extract_media()` regex whitelist was missing `.md`, `.json`, `.yaml`, `.yml`, `.toml`, `.log`. When `MEDIA:/path/to/file.md` was used, the regex did not match → the MEDIA tag appeared as raw text on WeChat/Feishu/Telegram etc. instead of the file being routed through document-upload paths.

**Fix:** Added `md|json|yaml|yml|toml|log` to the regex alternation (single-line change). All other parts of the pattern (path wrapping, quote/backtick stripping, trailing-delimiter lookahead, `[[audio_as_voice]]` / `[[as_document]]` directives) are unchanged.

### 2. No retry on session/rate-limit errors

`send_weixin_direct()` fallback path returned immediately on errors like `ret=-2` (rate limit) or `errcode=-14` (session timeout) without any retry or context_token refresh. After gateway restart, stale context_tokens caused persistent failures.

**Fix:** Added a retry loop (up to 2 attempts) that clears the stale `context_token` before retrying. On session errors, the retry sends without a context token (tokenless fallback), with a 3-second backoff between attempts.

## Related Issue

Closes #32601

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## Changes Made

- `gateway/platforms/base.py` — extend the MEDIA tag regex alternation with `md|json|yaml|yml|toml|log` (+1/-1 lines)
- `gateway/platforms/weixin.py` — add retry loop in `send_weixin_direct()` fallback path for session/rate-limit errors (+29/-5 lines)
- `tests/gateway/test_platform_base.py` — add parametrized test `test_media_tag_accepts_text_config_extensions` covering each new extension (+13 lines)

## How to Test

```bash
# Test the regex fix (20 tests: 14 existing + 6 new parametrized)
python3 -m pytest tests/gateway/test_platform_base.py -v -k TestExtractMedia

# Test the retry logic
python3 -m pytest tests/gateway/test_weixin.py -v
```

### Manual verification

- Sent `.md`, `.json`, `.yaml`, `.yml`, `.toml`, `.log` files via `MEDIA:` tag → all delivered correctly
- Restarted gateway → verified retry fires and uses tokenless fallback
- Existing file types (`.txt`, `.pdf`, `.png`) still work correctly

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(weixin): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I have run focused tests for the touched code and all pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I have updated relevant documentation — N/A (regex-internal + retry-internal change)
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact — regex matches absolute (`/...`) and tilde (`~/...`) paths consistently with the existing pattern; no Windows-path coupling
- [x] I have updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Issue #32601 lists two bugs. Both are addressed in this single PR because:

| Bug | Scope | File |
|-----|-------|------|
| 1 | MEDIA tag leaks for text/config file types | `gateway/platforms/base.py` — global (all platforms) |
| 2 | `send_weixin_direct()` returns immediately on errors | `gateway/platforms/weixin.py` — WeChat-only |

Keeping these together makes sense because they were discovered together in a real deployment scenario (WeChat delivery path), and the retry logic in bug 2 is the fallback path that fires when file delivery (which bug 1 affects) hits transient errors.

This PR is part of a cluster of MEDIA regex fixes. Compared to siblings:
- **#29609** (dynamic allowlist from `SUPPORTED_DOCUMENT_TYPES`) — preferable long-term, but this PR also fixes the WeChat retry issue which #29609 does not cover
- **#32611, #32751 (closed)** — same regex fix, without retry logic
- The retry fix in `weixin.py` is orthogonal to whichever regex approach lands, and can be cherry-picked independently