### PR TITLE
fix(gateway): ensure service restart exit 75 terminates process

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4854,11 +4854,24 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
         print("\nGateway stopped.")
         return
     except SystemExit as e:
+        exit_code = getattr(e, "code", None)
         _exit_diag(
             "asyncio.run.SystemExit",
-            code=getattr(e, "code", None),
+            code=exit_code,
             traceback=_traceback.format_exc(),
         )
+        if exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE:
+            # A plain re-raise here only unwinds the main thread; if any
+            # non-daemon worker/network thread survived start_gateway()'s
+            # teardown, the interpreter stays alive waiting on it and
+            # systemd/launchd never observes exit 75, so
+            # RestartForceExitStatus=75 never respawns the service. Delegate
+            # to the shared hard-exit backstop (gateway.run, cde3ca4eb /
+            # #53107) instead of duplicating its PID-file/runtime-lock
+            # release and bounded log-queue drain here.
+            from gateway.run import _exit_after_graceful_shutdown
+
+            _exit_after_graceful_shutdown(exit_code)
         raise
     except BaseException as e:
         # Absolutely everything else: Exception, asyncio.CancelledError,

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -61,6 +61,62 @@ def test_run_gateway_exits_cleanly_on_keyboard_interrupt(monkeypatch, capsys):
     assert "Gateway stopped." in out
 
 
+class _HardExitCalled(Exception):
+    """Sentinel raised by the fake backstop so control never returns, like os._exit."""
+
+
+def test_run_gateway_hard_exits_on_service_restart_code(monkeypatch):
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        return object()
+
+    def fake_asyncio_run(coro):
+        raise SystemExit(gateway.GATEWAY_SERVICE_RESTART_EXIT_CODE)
+
+    def fake_exit_after_graceful_shutdown(exit_code):
+        calls.append(exit_code)
+        raise _HardExitCalled
+
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    sys.modules["gateway.run"]._exit_after_graceful_shutdown = (
+        fake_exit_after_graceful_shutdown
+    )
+    monkeypatch.setattr(gateway.asyncio, "run", fake_asyncio_run)
+
+    with pytest.raises(_HardExitCalled):
+        gateway.run_gateway()
+
+    assert calls == [gateway.GATEWAY_SERVICE_RESTART_EXIT_CODE]
+
+
+@pytest.mark.parametrize("exit_code", [0, 1, None])
+def test_run_gateway_reraises_non_restart_system_exit(monkeypatch, exit_code):
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        return object()
+
+    def fake_asyncio_run(coro):
+        raise SystemExit(exit_code)
+
+    def fake_exit_after_graceful_shutdown(code):
+        calls.append(code)
+        raise _HardExitCalled
+
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    sys.modules["gateway.run"]._exit_after_graceful_shutdown = (
+        fake_exit_after_graceful_shutdown
+    )
+    monkeypatch.setattr(gateway.asyncio, "run", fake_asyncio_run)
+
+    with pytest.raises(SystemExit) as exc_info:
+        gateway.run_gateway()
+
+    assert exc_info.value.code == exit_code
+    assert calls == []
+
+
 def test_run_gateway_exits_nonzero_when_start_gateway_reports_failure(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Summary

After a planned service-managed restart, `run_gateway()` could leave the Python process alive even after raising `SystemExit(75)`. The service manager therefore never observed exit 75, `RestartForceExitStatus=75` did not fire, and the messaging adapters stayed silently disconnected while the gateway PID still looked active.

## Root cause

`hermes_cli/gateway.py:4856` re-raises `SystemExit(75)` after the async runner returns. A plain `raise` only exits the main thread — if non-daemon worker or network threads (e.g. ones spawned by adapter clients) survived the async teardown, the Python interpreter keeps the process alive waiting on them. By that point the adapters have already disconnected, so the gateway PID lingers in a degraded "alive but unreachable" state. systemd still sees the unit as active and the launchd relaunch contract from #28341 never gets a chance to fire.

## Fix

In the `except SystemExit` branch in `run_gateway()`, when `exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE` (75), delegate to `gateway.run._exit_after_graceful_shutdown` (added by #53107) instead of a plain `raise` — it flushes stdio, releases the PID file and runtime lock, bound-drains the async `QueueListener` log queue, then `os._exit(75)`. All other `SystemExit` codes (startup failure, root guard, etc.) keep the existing `raise`.

The hard exit is gated on the planned-restart code specifically because that path is already the documented service-manager handoff — the async runner has finished graceful teardown and is asking the service manager to relaunch. Other `SystemExit` codes don't have that guarantee.

## Changes

- `hermes_cli/gateway.py` — `run_gateway()`'s `except SystemExit` branch: on the restart code, call `gateway.run._exit_after_graceful_shutdown(75)` instead of re-raising.
- `tests/hermes_cli/test_gateway.py` — two regression tests built on the existing `_install_fake_gateway_run` helper: one asserting `_exit_after_graceful_shutdown(75)` fires for `SystemExit(75)`, one asserting other codes still propagate via `raise`. The backstop's own PID-file/lock/drain behavior is already covered by `tests/gateway/test_gateway_process_exit.py` and isn't duplicated here.

## Validation

|  | Before | After |
|---|---|---|
| `pytest tests/hermes_cli/test_gateway.py -k "hard_exits_on_service_restart_code or reraises_non_restart_system_exit"` | tests don't exist | 4 passed (2 test functions, one parametrized over 3 exit codes) |
| Linux systemd `/restart` end-to-end | `SystemExit: 75` logged, old PID alive, systemd sees unit active, Telegram silently dead | old PID exits immediately, systemd respawns, Telegram reconnects |

Refs #11258, #12875, #31162.
Complements #28341 by making the recently-established exit-code-75 contract reliable when non-daemon threads survive teardown.
Intentionally narrower than #27116, which targets clean shutdown / `KeyboardInterrupt` via `sys.exit` and does not touch the `except SystemExit` block.
