### PR TITLE
Harden Hermes web tooling and process guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ cli-config.yaml
 skills/.hub/
 ignored/
 .worktrees/
+.hermes/
 environments/benchmarks/evals/
 
 # Web UI build output

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -807,6 +807,9 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
 
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
+    if os.getenv("HERMES_DISABLE_MACOS_KEYCHAIN", "").strip().lower() in {"1", "true", "yes"}:
+        return None
+
     if platform.system() != "Darwin":
         return None
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -34,21 +34,22 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+SUMMARY_MARKER = "[CONTEXT COMPACTION — REFERENCE ONLY]"
 SUMMARY_PREFIX = (
-    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
-    "into the summary below. This is a handoff from a previous context "
+    f"{SUMMARY_MARKER} Earlier turns were compacted into "
+    "the summary below. This is a handoff from a previous context "
     "window — treat it as background reference, NOT as active instructions. "
     "Do NOT answer questions or fulfill requests mentioned in this summary; "
     "they were already addressed. "
-    "Your current task is identified in the '## Active Task' section of the "
-    "summary — resume exactly from there. "
+    "If the summary contains a '## Active Task' section, use it only as "
+    "continuity context and still respond ONLY to the latest user message "
+    "that appears AFTER this summary. "
     "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
     "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
-    "memory content due to this compaction note. "
-    "Respond ONLY to the latest user message "
-    "that appears AFTER this summary. The current session state (files, "
-    "config, etc.) may reflect work described here — avoid repeating it:"
+    "memory content due to this compaction note. The current session state "
+    "(files, config, etc.) may reflect work described here — avoid repeating it:"
 )
+SUMMARY_FALLBACK_PREFIX = "[CONTEXT COMPACTION FALLBACK — REFERENCE ONLY]"
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
 # Minimum tokens for the summary output
@@ -74,6 +75,125 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 # for tail-cut decisions.
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+
+_LOCAL_PATH_ROOT = r"(?:[A-Za-z]:[\\/]|~[\\/]|/(?:Users|home|tmp|var/folders|private/(?:tmp|var/folders)|Volumes)[\\/])"
+_QUOTED_LOCAL_PATH_RE = re.compile(
+    r"([`'\"])("
+    + _LOCAL_PATH_ROOT
+    + r"(?:[^`'\";\r\n<>|]+[\\/])*[^`'\";\r\n<>|]+)\1"
+)
+_WINDOWS_COLON_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"[A-Za-z]:[\\/]"
+    r"(?:[^\\/:*?\"<>|;\r\n]+[\\/])*"
+    r"[^\\/:*?\"<>|;\r\n]+"
+    r"(?=:\s)"
+)
+_UNIX_COLON_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?:~|/(?:Users|home|tmp|var/folders|private/(?:tmp|var/folders)|Volumes))[\\/]"
+    r"(?:[^/;\r\n`'\"<>|:]+/)*"
+    r"[^/;\r\n`'\"<>|:]+"
+    r"(?=:\s)"
+)
+_SPACED_NO_EXTENSION_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    + _LOCAL_PATH_ROOT
+    + r"(?=[^;,\r\n`'\"<>|]*\s)"
+    + r"(?:[^\\/;,\r\n`'\"<>|:]+[\\/])*"
+    + r"[^\\/.;,\s\r\n`'\"<>|:][^\\/.;,\r\n`'\"<>|:]*"
+    + r"(?=\s(?:failed|denied|missing|unavailable|not\s+found|permission\s+denied|no\s+such\s+file|could\s+not|cannot)\b|$)",
+    re.IGNORECASE,
+)
+_WINDOWS_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"[A-Za-z]:[\\/]"
+    r"(?:[^\\/:*?\"<>|;\r\n]+[\\/])*"
+    r"(?:[^\\/:*?\"<>|;\r\n]*\.[A-Za-z0-9]{1,16}|[^\\/:*?\"<>|;\s\r\n]+)"
+    r"(?=$|[\s;,:.)\]}>'\"`])"
+)
+_UNIX_LOCAL_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?:~|/(?:Users|home|tmp|var/folders|private/(?:tmp|var/folders)|Volumes))[\\/]"
+    r"(?:[^/;\r\n`'\"<>|:]+/)*"
+    r"(?:[^/;\r\n`'\"<>|:]*\.[A-Za-z0-9]{1,16}|[^/;\s\r\n`'\"<>|:]+)"
+    r"(?=$|[\s;,:.)\]}>'\"`])"
+)
+_USER_WARNING_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:"
+    r"sk[-_][A-Za-z0-9_.=-]{3,}"
+    r"|pplx-[A-Za-z0-9_.=-]{3,}"
+    r"|gh[opurs]_[A-Za-z0-9_.=-]{3,}"
+    r"|github_pat_[A-Za-z0-9_.=-]{3,}"
+    r"|xox[baprs]-[A-Za-z0-9_.=-]{3,}"
+    r"|AIza[A-Za-z0-9_.=-]{3,}"
+    r"|fal_[A-Za-z0-9_.=-]{3,}"
+    r"|fc-[A-Za-z0-9_.=-]{3,}"
+    r"|hf_[A-Za-z0-9_.=-]{3,}"
+    r"|tvly-[A-Za-z0-9_.=-]{3,}"
+    r"|exa_[A-Za-z0-9_.=-]{3,}"
+    r"|gsk_[A-Za-z0-9_.=-]{3,}"
+    r")(?=$|[^A-Za-z0-9_.=-])"
+)
+_USER_WARNING_AUTH_HEADER_RE = re.compile(
+    r"(Authorization:\s*Bearer\s+)([^\s;,.)\]}>'\"`]+)",
+    re.IGNORECASE,
+)
+_USER_WARNING_ENV_SECRET_RE = re.compile(
+    r"([A-Z0-9_]{0,50}(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)[A-Z0-9_]{0,50})"
+    r"\s*=\s*(['\"]?)([^\s;,.)\]}>'\"`]+)\2",
+    re.IGNORECASE,
+)
+
+
+def _redact_user_visible_secrets(text: str) -> str:
+    """Fully mask credential-shaped values for chat-visible warnings.
+
+    ``redact_sensitive_text`` intentionally keeps short token prefixes/suffixes
+    for logs. Gateway warnings are public/user-facing surfaces, so even
+    already-log-masked fragments like ``pplx-a...7890`` must be removed.
+    """
+    if not text:
+        return text
+    text = _USER_WARNING_AUTH_HEADER_RE.sub(lambda m: m.group(1) + "[secret]", text)
+    text = _USER_WARNING_ENV_SECRET_RE.sub(lambda m: f"{m.group(1)}=[secret]", text)
+    return _USER_WARNING_TOKEN_RE.sub("[secret]", text)
+
+
+def _redact_local_paths_for_warning(text: str) -> str:
+    """Hide local filesystem paths in user-visible warning details.
+
+    Path components may contain spaces (``Program Files``, ``Jane Doe``), so
+    whitespace cannot be a blanket delimiter.  The final component is kept
+    stricter to avoid swallowing surrounding prose such as ``...file for C:\\``.
+    """
+    if not text:
+        return text
+    text = _QUOTED_LOCAL_PATH_RE.sub(lambda m: f"{m.group(1)}[local path]{m.group(1)}", text)
+    text = _WINDOWS_COLON_LOCAL_PATH_RE.sub("[local path]", text)
+    text = _UNIX_COLON_LOCAL_PATH_RE.sub("[local path]", text)
+    text = _SPACED_NO_EXTENSION_LOCAL_PATH_RE.sub("[local path]", text)
+    text = _WINDOWS_LOCAL_PATH_RE.sub("[local path]", text)
+    text = _UNIX_LOCAL_PATH_RE.sub("[local path]", text)
+    return text
+
+
+def _safe_user_warning_detail(value: Any, *, max_len: int = 220) -> str:
+    """Return a bounded, secret/path-redacted detail for gateway-visible warnings."""
+    if isinstance(value, BaseException):
+        detail = str(value).strip() or value.__class__.__name__
+    else:
+        detail = str(value).strip() if value is not None else ""
+    if not detail:
+        detail = "unknown error"
+
+    detail = _redact_user_visible_secrets(detail)
+    detail = redact_sensitive_text(detail, force=True)
+    detail = _redact_user_visible_secrets(detail)
+    detail = _redact_local_paths_for_warning(detail)
+    if len(detail) > max_len:
+        detail = detail[: max_len - 3].rstrip() + "..."
+    return detail
 
 
 def _content_length_for_budget(raw_content: Any) -> int:
@@ -903,10 +1023,7 @@ class ContextCompressor(ContextEngine):
             "Falling back to main model '%s' for compression.",
             self.summary_model, reason, e, self.model,
         )
-        _err_text = str(e).strip() or e.__class__.__name__
-        if len(_err_text) > 220:
-            _err_text = _err_text[:217].rstrip() + "..."
-        self._last_aux_model_failure_error = _err_text
+        self._last_aux_model_failure_error = _safe_user_warning_detail(e)
         self._last_aux_model_failure_model = self.summary_model
         self.summary_model = ""  # empty = use main model
         self._summary_failure_cooldown_until = 0.0  # no cooldown — retry immediately
@@ -1179,10 +1296,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # streaming-closed since those conditions can self-resolve quickly.
             _transient_cooldown = 30 if (_is_json_decode or _is_streaming_closed) else 60
             self._summary_failure_cooldown_until = time.monotonic() + _transient_cooldown
-            err_text = str(e).strip() or e.__class__.__name__
-            if len(err_text) > 220:
-                err_text = err_text[:217].rstrip() + "..."
-            self._last_summary_error = err_text
+            self._last_summary_error = _safe_user_warning_detail(e)
             logger.warning(
                 "Failed to generate context summary: %s. "
                 "Further summary attempts paused for %d seconds.",
@@ -1193,11 +1307,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
     @staticmethod
     def _strip_summary_prefix(summary: str) -> str:
-        """Return summary body without the current or legacy handoff prefix."""
+        """Return summary body without the current, fallback, or legacy handoff prefix."""
         text = (summary or "").strip()
-        for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX):
+        for prefix in (SUMMARY_PREFIX, SUMMARY_FALLBACK_PREFIX, LEGACY_SUMMARY_PREFIX):
             if text.startswith(prefix):
                 return text[len(prefix):].lstrip()
+        if text.startswith(SUMMARY_MARKER):
+            # Compatibility: older persisted summaries used the same stable
+            # marker with different prose. Treat the marker line as the handoff
+            # preamble and keep only the body after it.
+            _marker_line, sep, body = text.partition("\n")
+            return body.lstrip() if sep else ""
         return text
 
     @classmethod
@@ -1207,9 +1327,18 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         return f"{SUMMARY_PREFIX}\n{text}" if text else SUMMARY_PREFIX
 
     @staticmethod
+    def _is_fallback_summary_content(content: Any) -> bool:
+        text = _content_text_for_contains(content).lstrip()
+        return text.startswith(SUMMARY_FALLBACK_PREFIX)
+
+    @staticmethod
     def _is_context_summary_content(content: Any) -> bool:
         text = _content_text_for_contains(content).lstrip()
-        return text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX)
+        return (
+            text.startswith(SUMMARY_MARKER)
+            or text.startswith(SUMMARY_FALLBACK_PREFIX)
+            or text.startswith(LEGACY_SUMMARY_PREFIX)
+        )
 
     @classmethod
     def _find_latest_context_summary(
@@ -1222,6 +1351,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         for idx in range(end - 1, start - 1, -1):
             content = messages[idx].get("content")
             if cls._is_context_summary_content(content):
+                if cls._is_fallback_summary_content(content):
+                    return idx, ""
                 return idx, cls._strip_summary_prefix(_content_text_for_contains(content))
         return None, ""
 
@@ -1602,6 +1733,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         # Phase 3: Generate structured summary
         summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+        summary_failed = not summary
+
+        # If LLM summary failed, non-system protected head turns are unsafe to
+        # preserve verbatim. In long gateway sessions the first user turn can be
+        # an obsolete handoff/task; keeping it as role="user" next to a static
+        # fallback can make it look like the active request. Preserve only the
+        # system prompt (if present), and count every skipped historical head
+        # turn as dropped because it was not summarized.
+        head_copy_end = compress_start
+        if summary_failed:
+            head_copy_end = 1 if messages and messages[0].get("role") == "system" else 0
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):
@@ -1631,7 +1773,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         # Phase 4: Assemble compressed message list
         compressed = []
-        for i in range(compress_start):
+        for i in range(head_copy_end):
             msg = messages[i].copy()
             if i == 0 and msg.get("role") == "system":
                 existing = msg.get("content")
@@ -1646,22 +1788,30 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         # Legacy fallback path: LLM summary failed and abort_on_summary_failure
         # is False (the default).  Insert a static placeholder so the model
         # knows context was lost rather than silently dropping everything.
-        if not summary:
+        if summary_failed:
             if not self.quiet_mode:
                 logger.warning("Summary generation failed — inserting static fallback context marker")
-            n_dropped = compress_end - compress_start
+            n_dropped = compress_end - head_copy_end
             self._last_summary_dropped_count = n_dropped
             self._last_summary_fallback_used = True
             summary = (
-                f"{SUMMARY_PREFIX}\n"
-                f"Summary generation was unavailable. {n_dropped} message(s) were "
-                f"removed to free context space but could not be summarized. The removed "
-                f"messages contained earlier work in this session. Continue based on the "
-                f"recent messages below and the current state of any files or resources."
+                f"{SUMMARY_FALLBACK_PREFIX}\n"
+                f"Summary generation was unavailable. {n_dropped} historical message(s) "
+                f"were removed to free context space but could not be summarized. This "
+                f"fallback contains NO active task. Do NOT treat any user request before "
+                f"this marker, including protected first-turn handoff/task messages, as "
+                f"active. Use only a clear, explicit user request after this marker as "
+                f"the current task. If the latest post-marker user request is missing, "
+                f"ambiguous, or conflicts with the visible recent topic, ask the user "
+                f"to confirm before using tools or performing side effects such as file "
+                f"writes, commits, deploys, runtime restarts, smoke tests, memory writes, "
+                f"or external mutations. Continue only from the recent messages below "
+                f"and the current state of any files or resources."
             )
+            self._previous_summary = None
 
         _merge_summary_into_tail = False
-        last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
+        last_head_role = compressed[-1].get("role", "assistant") if compressed else "assistant"
         first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
         # Pick a role that avoids consecutive same-role with both neighbors.
         # Priority: avoid colliding with head (already committed), then tail.

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -25,10 +26,33 @@ def _hermes_root_path() -> Path:
         return Path(os.path.expanduser("~/.hermes"))
 
 
+def _hermes_config_roots() -> set[Path]:
+    """Return Hermes roots whose config/env files must be write-denied."""
+    roots = {_hermes_home_path(), Path(os.path.expanduser("~/.hermes"))}
+    try:
+        from hermes_constants import get_default_hermes_root  # local import to avoid cycles
+
+        roots.add(get_default_hermes_root())
+    except Exception:
+        pass
+    return roots
+
+
 def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
-    hermes_home = _hermes_home_path()
-    hermes_root = _hermes_root_path()
+    hermes_config_paths = []
+    for root in _hermes_config_roots():
+        hermes_config_paths.extend(
+            [
+                # Profile/root .env, config.yaml, and Anthropic PKCE credential
+                # store. Overwriting a top-level .env leaks credentials across
+                # every profile that inherits from root (#15981); the default
+                # credential store stays sensitive even when a profile is active.
+                str(root / ".env"),
+                str(root / "config.yaml"),
+                str(root / ".anthropic_oauth.json"),
+            ]
+        )
     return {
         os.path.realpath(p)
         for p in [
@@ -36,16 +60,7 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".ssh", "id_rsa"),
             os.path.join(home, ".ssh", "id_ed25519"),
             os.path.join(home, ".ssh", "config"),
-            # Active profile .env (or top-level .env when not in profile mode).
-            str(hermes_home / ".env"),
-            # Top-level .env, even when running under a profile — overwriting it
-            # leaks credentials across every profile that inherits from root (#15981).
-            str(hermes_root / ".env"),
-            # Active profile Anthropic PKCE credential store.
-            str(hermes_home / ".anthropic_oauth.json"),
-            # Top-level Anthropic PKCE credential store remains sensitive even
-            # when a profile is active; default/non-profile sessions still read it.
-            str(hermes_root / ".anthropic_oauth.json"),
+            *hermes_config_paths,
             os.path.join(home, ".bashrc"),
             os.path.join(home, ".zshrc"),
             os.path.join(home, ".profile"),
@@ -95,12 +110,16 @@ def get_safe_write_root() -> Optional[str]:
 
 def is_write_denied(path: str) -> bool:
     """Return True if path is blocked by the write denylist or safe root."""
-    home = os.path.realpath(os.path.expanduser("~"))
-    resolved = os.path.realpath(os.path.expanduser(str(path)))
+    def norm(p: str) -> str:
+        resolved_path = os.path.normcase(os.path.realpath(os.path.expanduser(str(p))))
+        return resolved_path.lower() if sys.platform == "darwin" else resolved_path
 
-    if resolved in build_write_denied_paths(home):
+    home = norm("~")
+    resolved = norm(path)
+
+    if resolved in {norm(p) for p in build_write_denied_paths(home)}:
         return True
-    for prefix in build_write_denied_prefixes(home):
+    for prefix in {norm(p) for p in build_write_denied_prefixes(home)}:
         if resolved.startswith(prefix):
             return True
 
@@ -142,6 +161,7 @@ def is_write_denied(path: str) -> bool:
             pass
 
     safe_root = get_safe_write_root()
+    safe_root = norm(safe_root) if safe_root else None
     if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
         return True
 

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``perplexity`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "perplexity",
     "searxng",
     "brave-free",
     "ddgs",
@@ -148,7 +149,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → perplexity → searxng → brave-free → ddgs) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/gateway/memory_monitor.py
+++ b/gateway/memory_monitor.py
@@ -49,6 +49,56 @@ _interval_seconds: float = 300.0  # 5 minutes
 _lock = threading.Lock()
 
 
+def _handler_stream_is_closed(handler: logging.Handler) -> bool:
+    """True when a logging handler points at a closed stream.
+
+    Python's logging package catches ``ValueError: I/O operation on closed
+    file`` inside ``Handler.handleError()`` and prints a noisy
+    ``--- Logging error ---`` traceback to stderr instead of raising it back to
+    our ``try`` block. Long-running daemon monitor threads can outlive pytest
+    capture streams or process-wrapper streams, so prune already-closed stream
+    handlers before emitting the periodic memory line.
+    """
+    stream = getattr(handler, "stream", None)
+    try:
+        return bool(stream is not None and getattr(stream, "closed", False))
+    except Exception:
+        return False
+
+
+def _prune_closed_stream_handlers() -> None:
+    """Detach closed stream handlers from this logger and propagating parents."""
+    current: Optional[logging.Logger] = logger
+    seen: set[int] = set()
+    while current is not None:
+        for handler in list(current.handlers):
+            marker = id(handler)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            if _handler_stream_is_closed(handler):
+                try:
+                    current.removeHandler(handler)
+                except Exception:
+                    pass
+        if not current.propagate:
+            break
+        parent = current.parent
+        current = parent if isinstance(parent, logging.Logger) else None
+
+
+def _safe_memory_info(message: str, *args) -> None:
+    """Emit a memory-monitor INFO line without noisy closed-stream tracebacks."""
+    _prune_closed_stream_handlers()
+    try:
+        logger.info(message, *args)
+    except (ValueError, OSError):
+        # Some custom handlers do raise directly instead of delegating to
+        # logging.handleError(). Memory monitoring is diagnostic only and must
+        # never affect gateway shutdown or tests.
+        pass
+
+
 def _get_rss_mb() -> Optional[int]:
     """Return current process resident set size in MB, or None if unavailable.
 
@@ -108,7 +158,7 @@ def log_memory_usage(prefix: str = "") -> None:
 
     tag = f"{prefix} " if prefix else ""
     if rss is None:
-        logger.info(
+        _safe_memory_info(
             "[MEMORY] %srss=unavailable gc=%s threads=%d uptime=%ds",
             tag,
             gc_counts,
@@ -116,7 +166,7 @@ def log_memory_usage(prefix: str = "") -> None:
             uptime,
         )
     else:
-        logger.info(
+        _safe_memory_info(
             "[MEMORY] %srss=%dMB gc=%s threads=%d uptime=%ds",
             tag,
             rss,
@@ -186,7 +236,7 @@ def start_memory_monitoring(interval_seconds: float = 300.0) -> bool:
         )
         _monitor_thread.start()
 
-        logger.info(
+        _safe_memory_info(
             "[MEMORY] Periodic memory monitoring started (interval: %ds)",
             int(_interval_seconds),
         )
@@ -221,7 +271,7 @@ def stop_memory_monitoring(timeout: float = 2.0) -> None:
     except Exception:
         pass
 
-    logger.info("[MEMORY] Periodic memory monitoring stopped")
+    _safe_memory_info("[MEMORY] Periodic memory monitoring stopped")
 
 
 def is_running() -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8567,7 +8567,8 @@ class GatewayRunner:
                                     # fresh.
                                     _comp = getattr(_hyg_agent, "context_compressor", None)
                                     if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
-                                        _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
+                                        from agent.context_compressor import _safe_user_warning_detail
+                                        _err = _safe_user_warning_detail(getattr(_comp, "_last_summary_error", None))
                                         _warn_msg = (
                                             "⚠️ Context compression aborted "
                                             f"({_err}). No messages were dropped — "
@@ -8593,7 +8594,8 @@ class GatewayRunner:
                                     # silent recovery would hide it.
                                     elif _comp is not None and getattr(_comp, "_last_aux_model_failure_model", None):
                                         _aux_model = getattr(_comp, "_last_aux_model_failure_model", "")
-                                        _aux_err = getattr(_comp, "_last_aux_model_failure_error", None) or "unknown error"
+                                        from agent.context_compressor import _safe_user_warning_detail
+                                        _aux_err = _safe_user_warning_detail(getattr(_comp, "_last_aux_model_failure_error", None))
                                         _aux_msg = (
                                             f"ℹ️ Configured compression model `{_aux_model}` "
                                             f"failed ({_aux_err}). Recovered using your main "
@@ -12253,12 +12255,13 @@ class GatewayRunner:
                 # unchanged (no drop, no placeholder).  force=True was
                 # passed above so any active cooldown is bypassed.
                 _summary_aborted = bool(getattr(compressor, "_last_compress_aborted", False))
-                _summary_err = getattr(compressor, "_last_summary_error", None)
+                from agent.context_compressor import _safe_user_warning_detail
+                _summary_err = _safe_user_warning_detail(getattr(compressor, "_last_summary_error", None))
                 # Separately: did the user's CONFIGURED aux model fail
                 # and we recovered via main?  Surface that as an info
                 # note so they can fix their config.
                 _aux_fail_model = getattr(compressor, "_last_aux_model_failure_model", None)
-                _aux_fail_err = getattr(compressor, "_last_aux_model_failure_error", None)
+                _aux_fail_err = _safe_user_warning_detail(getattr(compressor, "_last_aux_model_failure_error", None))
             finally:
                 # Evict cached agent so next turn rebuilds system prompt
                 # from current files (SOUL.md, memory, etc.).
@@ -14861,10 +14864,12 @@ class GatewayRunner:
                         _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
                     else:
                         _out = _raw
+                    from tools.process_registry import _redact_command_for_display
+                    _safe_command = _redact_command_for_display(session.command)
                     synth_text = (
                         f"[IMPORTANT: Background process {session_id} completed "
                         f"(exit code {session.exit_code}).\n"
-                        f"Command: {session.command}\n"
+                        f"Command: {_safe_command}\n"
                         f"Output:\n{_out}]"
                     )
                     source = self._build_process_event_source({

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2359,6 +2359,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "PERPLEXITY_API_KEY": {
+        "description": "Perplexity API key for Search API / Sonar web search",
+        "prompt": "Perplexity API key",
+        "url": "https://www.perplexity.ai/settings/api",
+        "tools": ["web_search"],
+        "password": True,
+        "category": "tool",
+    },
     "PARALLEL_API_KEY": {
         "description": "Parallel API key for AI-native web search and extract",
         "prompt": "Parallel API key",
@@ -5186,6 +5194,7 @@ def show_config():
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
         ("EXA_API_KEY", "Exa"),
+        ("PERPLEXITY_API_KEY", "Perplexity"),
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
         ("TAVILY_API_KEY", "Tavily"),
@@ -5380,7 +5389,7 @@ def set_config_value(key: str, value: str):
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
+        'EXA_API_KEY', 'PERPLEXITY_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
         'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -284,6 +284,7 @@ def get_nous_subscription_features(
     direct_firecrawl = bool(get_env_value("FIRECRAWL_API_KEY") or get_env_value("FIRECRAWL_API_URL"))
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
+    direct_perplexity = bool(get_env_value("PERPLEXITY_API_KEY"))
     direct_searxng = bool(get_env_value("SEARXNG_URL"))
     direct_fal = fal_key_is_configured()
     direct_openai_tts = bool(resolve_openai_audio_api_key())
@@ -299,6 +300,7 @@ def get_nous_subscription_features(
         direct_exa = False
         direct_parallel = False
         direct_tavily = False
+        direct_perplexity = False
     if image_use_gateway:
         direct_fal = False
     if tts_use_gateway:
@@ -328,6 +330,7 @@ def get_nous_subscription_features(
             or (web_backend == "firecrawl" and direct_firecrawl)
             or (web_backend == "parallel" and direct_parallel)
             or (web_backend == "tavily" and direct_tavily)
+            or (web_backend == "perplexity" and direct_perplexity)
             or (web_backend == "searxng" and direct_searxng)
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
@@ -336,10 +339,17 @@ def get_nous_subscription_features(
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
             or (web_search_backend == "tavily" and direct_tavily)
+            or (web_search_backend == "perplexity" and direct_perplexity)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available
+        or direct_exa
+        or direct_firecrawl
+        or direct_parallel
+        or direct_tavily
+        or direct_perplexity
+        or direct_searxng
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal

--- a/plugins/web/perplexity/__init__.py
+++ b/plugins/web/perplexity/__init__.py
@@ -1,0 +1,10 @@
+"""Perplexity Search API plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.perplexity.provider import PerplexityWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Perplexity provider with the plugin context."""
+    ctx.register_web_search_provider(PerplexityWebSearchProvider())

--- a/plugins/web/perplexity/plugin.yaml
+++ b/plugins/web/perplexity/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-perplexity
+version: 1.0.0
+description: "Perplexity Search API backend for web_search. Requires PERPLEXITY_API_KEY — sign up at https://www.perplexity.ai/settings/api."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - perplexity

--- a/plugins/web/perplexity/provider.py
+++ b/plugins/web/perplexity/provider.py
@@ -1,0 +1,132 @@
+"""Perplexity Search API web search provider.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "perplexity"     # explicit per-capability
+      backend: "perplexity"            # shared fallback (search-only)
+
+Env vars::
+
+    PERPLEXITY_API_KEY=...             # https://www.perplexity.ai/settings/api
+
+This provider implements Perplexity's structured Search API (``POST /search``),
+not Sonar chat completions. It returns ranked web result metadata only; use a
+separate extract-capable backend for ``web_extract``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+_PERPLEXITY_SEARCH_URL = "https://api.perplexity.ai/search"
+
+
+def _perplexity_request(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """POST to Perplexity Search API and return parsed JSON."""
+    api_key = os.getenv("PERPLEXITY_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError(
+            "PERPLEXITY_API_KEY environment variable not set. "
+            "Get your API key at https://www.perplexity.ai/settings/api"
+        )
+
+    response = httpx.post(
+        _PERPLEXITY_SEARCH_URL,
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _normalize_perplexity_search_results(response: Dict[str, Any]) -> Dict[str, Any]:
+    """Map Perplexity ``/search`` response to Hermes' web_search shape."""
+    web_results: List[Dict[str, Any]] = []
+    for i, result in enumerate(response.get("results", []) or []):
+        if not isinstance(result, dict):
+            continue
+        web_results.append(
+            {
+                "title": result.get("title", "") or "",
+                "url": result.get("url", "") or "",
+                "description": result.get("snippet", "") or "",
+                "position": i + 1,
+            }
+        )
+    return {"success": True, "data": {"web": web_results}}
+
+
+class PerplexityWebSearchProvider(WebSearchProvider):
+    """Perplexity Search API provider for ``web_search``."""
+
+    @property
+    def name(self) -> str:
+        return "perplexity"
+
+    @property
+    def display_name(self) -> str:
+        return "Perplexity Search"
+
+    def is_available(self) -> bool:
+        """Return True when ``PERPLEXITY_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("PERPLEXITY_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def supports_crawl(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a Perplexity Search API query."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            max_results = min(max(int(limit), 1), 20)
+            logger.info("Perplexity search: '%s' (limit=%d)", query, max_results)
+            raw = _perplexity_request(
+                {
+                    "query": query,
+                    "max_results": max_results,
+                }
+            )
+            return _normalize_perplexity_search_results(raw)
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:  # noqa: BLE001 — including httpx errors
+            logger.warning("Perplexity search error: %s", exc)
+            return {"success": False, "error": f"Perplexity search failed: {exc}"}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Perplexity Search",
+            "badge": "paid",
+            "tag": "Structured Search API results from Perplexity; search-only.",
+            "env_vars": [
+                {
+                    "key": "PERPLEXITY_API_KEY",
+                    "prompt": "Perplexity API key",
+                    "url": "https://www.perplexity.ai/settings/api",
+                },
+            ],
+        }

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -49,9 +49,67 @@ fi
 PYTHON="$VENV/bin/python"
 
 
+# ── Hermetic environment ────────────────────────────────────────────────────
+# Mirror what CI does in .github/workflows/tests.yml + what conftest.py does.
+# Unset every credential-shaped var currently in the environment.
+while IFS='=' read -r name _; do
+  case "$name" in
+    *_API_KEY|*_TOKEN|*_SECRET|*_PASSWORD|*_CREDENTIALS|*_ACCESS_KEY| \
+    *_SECRET_ACCESS_KEY|*_PRIVATE_KEY|*_OAUTH_TOKEN|*_WEBHOOK_SECRET| \
+    *_ENCRYPT_KEY|*_APP_SECRET|*_CLIENT_SECRET|*_CORP_SECRET|*_AES_KEY| \
+    AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|FAL_KEY| \
+    GH_TOKEN|GITHUB_TOKEN)
+      unset "$name"
+      ;;
+  esac
+done < <(env)
+
+# Unset HERMES_* behavioral vars too.
+unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
+      HERMES_TOOL_PROGRESS_MODE HERMES_MAX_ITERATIONS HERMES_SESSION_PLATFORM \
+      HERMES_SESSION_CHAT_ID HERMES_SESSION_CHAT_NAME HERMES_SESSION_THREAD_ID \
+      HERMES_SESSION_SOURCE HERMES_SESSION_KEY HERMES_GATEWAY_SESSION \
+      HERMES_CRON_SESSION \
+      HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \
+      HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \
+      HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \
+      HERMES_HOME_MODE 2>/dev/null || true
+
+# Pin deterministic runtime.
+export TZ=UTC
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+export PYTHONHASHSEED=0
+
+# ── File-descriptor budget ───────────────────────────────────────────────────
+# macOS login shells commonly default to 256 open files. The full pytest suite
+# uses subprocess/PTY/socket-heavy tests; at 256 it can cascade into unrelated
+# ``OSError: [Errno 24] Too many open files`` errors. Raising the soft limit is
+# process-local to this test runner and its children.
+_current_nofile="$(ulimit -n 2>/dev/null || echo 0)"
+case "$_current_nofile" in
+  ''|*[!0-9]*) _current_nofile=0 ;;
+esac
+if [ "$_current_nofile" -gt 0 ] && [ "$_current_nofile" -lt 4096 ]; then
+  ulimit -n 4096 2>/dev/null || {
+    _hard_nofile="$(ulimit -Hn 2>/dev/null || echo 0)"
+    case "$_hard_nofile" in
+      ''|*[!0-9]*|0) ;;
+      *) ulimit -n "$_hard_nofile" 2>/dev/null || true ;;
+    esac
+  }
+fi
+
 # ── Live-gateway plugin (computed before we drop env) ───────────────────────
 EXTRA_PYTHONPATH=""
 EXTRA_PYTEST_PLUGINS=""
+
+# ── Live-gateway test guard (developer machines) ────────────────────────────
+# If a system-wide hermes pytest_live_guard plugin is installed at
+# $HOME/.hermes/pytest_live_guard.py, force-load it here so every test run
+# from this script gets the protection regardless of which worktree is
+# checked out (in-tree tests/conftest.py guard may be missing on stale
+# branches). Harmless on CI / fresh machines that don't have the file.
 if [ -f "$HOME/.hermes/pytest_live_guard.py" ]; then
   EXTRA_PYTHONPATH="$HOME/.hermes"
   EXTRA_PYTEST_PLUGINS="pytest_live_guard"

--- a/tests/agent/lsp/test_client_e2e.py
+++ b/tests/agent/lsp/test_client_e2e.py
@@ -19,6 +19,8 @@ from agent.lsp.client import LSPClient
 
 MOCK_SERVER = str(Path(__file__).parent / "_mock_lsp_server.py")
 
+pytestmark = pytest.mark.live_system_guard_bypass
+
 
 def _client(workspace: Path, script: str = "clean") -> LSPClient:
     env = {"MOCK_LSP_SCRIPT": script, "PYTHONPATH": os.environ.get("PYTHONPATH", "")}

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3,7 +3,11 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.context_compressor import (
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    _safe_user_warning_detail,
+)
 
 
 @pytest.fixture()
@@ -785,6 +789,173 @@ class TestSummaryFailureTrackingForGatewayWarning:
         assert c._last_summary_fallback_used is False
         assert c._last_summary_dropped_count == 0
 
+    def test_fallback_drops_stale_protected_head_task_without_system(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        msgs = [
+            {"role": "user", "content": "Resume Kadr real style cards closeout: deploy/restart and live smoke"},
+            {"role": "assistant", "content": "old Kadr acknowledgement"},
+            {"role": "user", "content": "Honcho memory question"},
+            {"role": "assistant", "content": "Honcho answer"},
+            {"role": "user", "content": "more memory discussion"},
+            {"role": "assistant", "content": "memory answer"},
+            {"role": "user", "content": "latest user context"},
+            {"role": "assistant", "content": "latest assistant context"},
+            {"role": "user", "content": "Ответь по человечески"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", side_effect=Exception("summary unavailable")):
+            result = c.compress(msgs)
+
+        joined = "\n".join(str(m.get("content", "")) for m in result)
+        assert result[0]["role"] == "user"
+        assert "Resume Kadr" not in joined
+        assert "deploy/restart" not in joined
+        assert "live smoke" not in joined
+        assert "Ответь по человечески" in joined
+        assert "CONTEXT COMPACTION FALLBACK" in joined
+        assert "contains NO active task" in joined
+        assert "ask the user to confirm" in joined
+        assert "side effects" in joined
+        assert c._last_summary_dropped_count == 6
+        assert c._previous_summary is None
+        for idx in range(1, len(result)):
+            prev_role = result[idx - 1].get("role")
+            role = result[idx].get("role")
+            if prev_role in {"user", "assistant"} and role in {"user", "assistant"}:
+                assert prev_role != role, f"consecutive {role} at indices {idx - 1},{idx}"
+
+    def test_fallback_preserves_system_but_drops_stale_first_user_task(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "Resume Kadr real style cards closeout: deploy/restart and live smoke"},
+            {"role": "assistant", "content": "old Kadr acknowledgement"},
+            {"role": "user", "content": "Honcho memory question"},
+            {"role": "assistant", "content": "Honcho answer"},
+            {"role": "user", "content": "more memory discussion"},
+            {"role": "assistant", "content": "memory answer"},
+            {"role": "user", "content": "Ответь по человечески"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", side_effect=Exception("summary unavailable")):
+            result = c.compress(msgs)
+
+        assert result[0]["role"] == "system"
+        assert result[0]["content"].startswith("sys")
+        joined = "\n".join(str(m.get("content", "")) for m in result)
+        assert "Resume Kadr" not in joined
+        assert "deploy/restart" not in joined
+        assert "live smoke" not in joined
+        assert "Ответь по человечески" in joined
+        assert "CONTEXT COMPACTION FALLBACK" in joined
+
+    def test_summary_error_stored_for_user_warning_is_redacted(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        msgs = [
+            {"role": "user", "content": f"msg {i}"}
+            if i % 2 == 0 else {"role": "assistant", "content": f"msg {i}"}
+            for i in range(8)
+        ]
+        bearer = "sk-" + "warningtokenabcdef7890"
+        env_secret = "sk-" + "envtokenabcdef7890"
+        err = (
+            r"failed opening C:\Program Files\Hermes Agent\cache\token.txt "
+            r"for C:\Users\Jane Doe\.hermes\.env and /Users/Jane Doe/.hermes/config.yaml "
+            f"Authorization: Bearer {bearer} OPENAI_API_KEY={env_secret}"
+        )
+
+        with patch("agent.context_compressor.call_llm", side_effect=Exception(err)):
+            c.compress(msgs)
+
+        detail = c._last_summary_error or ""
+        assert "[local path]" in detail
+        assert "[secret]" in detail
+        assert "Program Files" not in detail
+        assert "Jane Doe" not in detail
+        assert ".hermes" not in detail
+        assert "sk-" not in detail
+        assert "...7890" not in detail
+
+    def test_user_warning_detail_redacts_paths_with_spaces_and_secrets(self):
+        pplx_secret = "pplx-" + "sampletoken123456"
+        env_secret = "sk-" + "envtokenabcdef7890"
+        detail = _safe_user_warning_detail(
+            r"open C:\Program Files\Hermes Agent\cache\x.txt; "
+            r"read C:\Users\Jane Doe\.hermes\auth.json; "
+            "load /Users/Jane Doe/.hermes/config.yaml; "
+            f"Authorization: Bearer {pplx_secret} OPENAI_API_KEY={env_secret}"
+        )
+
+        assert detail.count("[local path]") >= 3
+        assert "[secret]" in detail
+        assert "Program Files" not in detail
+        assert "Jane Doe" not in detail
+        assert ".hermes" not in detail
+        assert "pplx-" not in detail
+        assert "sk-" not in detail
+        assert "...3456" not in detail
+        assert "...7890" not in detail
+
+    def test_user_warning_detail_redacts_basename_paths_with_spaces(self):
+        detail = _safe_user_warning_detail(
+            r"open C:\Users\Jane Doe\My Secret File.txt failed; "
+            "open /Users/Jane Doe/My Secret File.txt failed; "
+            r"open C:\Program Files\Hermes Agent\cache\token file.txt failed"
+        )
+
+        assert detail.count("[local path]") == 3
+        assert "My Secret File.txt" not in detail
+        assert "token file.txt" not in detail
+        assert "Jane Doe" not in detail
+        assert "Program Files" not in detail
+        assert "failed" in detail
+
+    def test_user_warning_detail_redacts_quoted_colon_and_private_var_paths(self):
+        detail = _safe_user_warning_detail(
+            "open '/Users/Jane Doe/My Secret Basename': denied; "
+            "trace /private/var/folders/zz/T/hermes_test: failed; "
+            'read "/Users/Jane Doe/.hermes/config.yaml": failed'
+        )
+
+        assert detail.count("[local path]") == 3
+        assert "My Secret Basename" not in detail
+        assert "/private/var/folders" not in detail
+        assert "hermes_test" not in detail
+        assert "config.yaml" not in detail
+        assert "Jane Doe" not in detail
+        assert "denied" in detail
+
+    def test_user_warning_detail_redacts_unquoted_no_extension_paths_with_spaces(self):
+        detail = _safe_user_warning_detail(
+            r"open C:\Users\Jane Doe\My Secret Basename failed; "
+            "open /Users/Jane Doe/My Secret Basename failed"
+        )
+
+        assert detail.count("[local path]") == 2
+        assert "My Secret Basename" not in detail
+        assert "Jane Doe" not in detail
+        assert "Users" not in detail
+
+    def test_user_warning_detail_fully_redacts_log_masked_token_fragments(self):
+        detail = _safe_user_warning_detail(
+            "provider kept fragments "
+            + "pplx-" + "a...7890"
+            + " and Authorization: Bearer " + "ghs_" + "a...7890"
+            + " plus OPENAI_API_KEY=" + "sk-" + "env...7890"
+        )
+
+        assert detail.count("[secret]") >= 3
+        assert "pplx-" not in detail
+        assert "ghs_" not in detail
+        assert "sk-" not in detail
+        assert "...7890" not in detail
+
 
 class TestAbortOnSummaryFailure:
     """Opt-in behavior (compression.abort_on_summary_failure=True):
@@ -875,6 +1046,35 @@ class TestAbortOnSummaryFailure:
 
 
 class TestSummaryPrefixNormalization:
+    def test_fallback_prefix_is_recognized_as_context_summary(self):
+        fallback = "[CONTEXT COMPACTION FALLBACK — REFERENCE ONLY] no active task"
+
+        assert ContextCompressor._is_context_summary_content(fallback)
+        assert ContextCompressor._strip_summary_prefix(fallback) == "no active task"
+
+    def test_old_context_compaction_marker_is_still_recognized(self):
+        old_summary = (
+            "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted into "
+            "the summary below. Your current task is identified in the '## Active Task' "
+            "section of the summary — resume exactly from there:\n## Active Task\nold body"
+        )
+
+        assert ContextCompressor._is_context_summary_content(old_summary)
+        assert ContextCompressor._strip_summary_prefix(old_summary) == "## Active Task\nold body"
+
+    def test_fallback_summary_does_not_seed_previous_summary_body(self):
+        fallback = "[CONTEXT COMPACTION FALLBACK — REFERENCE ONLY]\ncontains NO active task"
+        messages = [
+            {"role": "user", "content": "before"},
+            {"role": "assistant", "content": fallback},
+            {"role": "user", "content": "after"},
+        ]
+
+        idx, body = ContextCompressor._find_latest_context_summary(messages, 0, len(messages))
+
+        assert idx == 1
+        assert body == ""
+
     def test_legacy_prefix_is_replaced(self):
         summary = ContextCompressor._with_summary_prefix("[CONTEXT SUMMARY]: did work")
         assert summary == f"{SUMMARY_PREFIX}\ndid work"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,6 +372,11 @@ def _hermetic_environment(tmp_path, monkeypatch):
     # tests opt back in by patching the security config directly.
     monkeypatch.setenv("TIRITH_ENABLED", "false")
 
+    # macOS Keychain is outside HOME/HERMES_HOME and can contain real Claude
+    # Code OAuth credentials. Disable keychain probing so provider-auth tests
+    # stay hermetic on developer machines.
+    monkeypatch.setenv("HERMES_DISABLE_MACOS_KEYCHAIN", "1")
+
     # 5. Reset plugin singleton so tests don't leak plugins from
     #    ~/.hermes/plugins/ (which, per step 3, is now empty — but the
     #    singleton might still be cached from a previous test).

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -147,12 +147,16 @@ async def test_compress_command_appends_warning_when_compression_aborts():
     agent_instance.tools = None
     agent_instance.context_compressor.has_content_to_compress.return_value = True
     # Simulate compression aborting (force=True bypassed cooldown but the
-    # aux LLM is genuinely broken).
+    # aux LLM is genuinely broken). Also include provider details that must be
+    # sanitized before the warning is shown to the user.
     agent_instance.context_compressor._last_compress_aborted = True
     agent_instance.context_compressor._last_summary_fallback_used = False
     agent_instance.context_compressor._last_summary_dropped_count = 0
+    warning_secret = "sk-" + "warningdetail1234567890"
     agent_instance.context_compressor._last_summary_error = (
-        "404 model not found: gemini-3-flash-preview"
+        r"404 model not found: gemini-3-flash-preview at C:\Program Files\Hermes Agent\cache\x.txt "
+        r"and C:\Users\Jane Doe\.hermes\.env /Users/Jane Doe/.hermes/config.yaml "
+        f"Authorization: Bearer {warning_secret}"
     )
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
@@ -165,7 +169,7 @@ async def test_compress_command_appends_warning_when_compression_aborts():
         raise AssertionError(f"unexpected transcript: {messages!r}")
 
     with (
-        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "***"}),
+        patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}),
         patch("gateway.run._resolve_gateway_model", return_value="test-model"),
         patch("run_agent.AIAgent", return_value=agent_instance),
         patch("agent.model_metadata.estimate_request_tokens_rough", side_effect=_estimate),
@@ -175,8 +179,15 @@ async def test_compress_command_appends_warning_when_compression_aborts():
     # A clearly-marked warning must be appended.
     assert "⚠️" in result
     assert "Compression aborted" in result
-    # Underlying error must surface so users can fix their config.
+    # Underlying error must surface so users can fix their config, but local
+    # paths and secrets from provider exceptions must not leak to the chat.
     assert "404 model not found" in result
+    assert "[local path]" in result
+    assert "Program Files" not in result
+    assert "Jane Doe" not in result
+    assert ".hermes" not in result
+    assert "sk-" not in result
+    assert "...7890" not in result
     # User must be told nothing was dropped — the whole point of the
     # new behavior is no silent data loss.
     assert "No messages were dropped" in result
@@ -213,8 +224,10 @@ async def test_compress_command_surfaces_aux_model_failure_even_when_recovered()
     agent_instance.context_compressor._last_aux_model_failure_model = (
         "gemini-3-flash-preview"
     )
+    aux_secret = "sk-" + "auxwarning1234567890"
     agent_instance.context_compressor._last_aux_model_failure_error = (
-        "404 model not found: gemini-3-flash-preview"
+        r"404 model not found: gemini-3-flash-preview from C:\Users\Jane Doe\.hermes\config.yaml "
+        f"OPENAI_API_KEY={aux_secret}"
     )
     agent_instance.session_id = "sess-1"
     agent_instance._compress_context.return_value = (compressed, "")
@@ -242,6 +255,11 @@ async def test_compress_command_surfaces_aux_model_failure_even_when_recovered()
     assert "ℹ️" in result
     assert "gemini-3-flash-preview" in result
     assert "404" in result
+    assert "[local path]" in result
+    assert "Jane Doe" not in result
+    assert ".hermes" not in result
+    assert "sk-" not in result
+    assert "...7890" not in result
     assert "auxiliary.compression.model" in result
     # The user's context is explicitly called out as intact
     assert "intact" in result

--- a/tests/gateway/test_memory_monitor.py
+++ b/tests/gateway/test_memory_monitor.py
@@ -7,6 +7,7 @@ leaks show up as a time series in agent.log / gateway.log.
 
 from __future__ import annotations
 
+import io
 import logging
 import time
 
@@ -90,18 +91,39 @@ def test_stop_without_start_is_noop():
 def test_periodic_timer_fires(caplog):
     caplog.set_level(logging.INFO, logger="gateway.memory_monitor")
     # Short interval so we can observe multiple ticks inside the test budget.
-    mm.start_memory_monitoring(interval_seconds=0.1)
-    time.sleep(0.45)
+    mm.start_memory_monitoring(interval_seconds=0.05)
+    deadline = time.time() + 1.5
+    periodic = []
+    while time.time() < deadline:
+        periodic = [
+            r for r in caplog.records
+            if r.getMessage().startswith("[MEMORY] rss=") or r.getMessage().startswith("[MEMORY] rss=unavailable")
+        ]
+        if len(periodic) >= 2:
+            break
+        time.sleep(0.02)
     mm.stop_memory_monitoring(timeout=1.0)
 
-    periodic = [
-        r for r in caplog.records
-        if r.getMessage().startswith("[MEMORY] rss=") or r.getMessage().startswith("[MEMORY] rss=unavailable")
-    ]
-    # baseline + at least 2 periodic + shutdown — but shutdown has the
-    # "shutdown " prefix so it won't match the strict "[MEMORY] rss=" start.
-    # We expect >= 3 bare "[MEMORY] rss=..." lines.
-    assert len(periodic) >= 3, [r.getMessage() for r in caplog.records]
+    # baseline + at least 2 periodic + shutdown — but baseline/shutdown have
+    # prefixes so they won't match the strict "[MEMORY] rss=" start.
+    # The timer contract is "periodic fires more than once"; poll instead of
+    # relying on one fixed sleep so this stays deterministic under xdist load.
+    assert len(periodic) >= 2, [r.getMessage() for r in caplog.records]
+
+
+def test_log_memory_usage_prunes_closed_stream_handlers(capsys):
+    root = logging.getLogger()
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    root.addHandler(handler)
+    stream.close()
+    try:
+        mm.log_memory_usage()
+    finally:
+        root.removeHandler(handler)
+
+    captured = capsys.readouterr()
+    assert "Logging error" not in captured.err
 
 
 def test_thread_is_daemon():

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -23,6 +23,26 @@ def test_get_nous_subscription_features_recognizes_direct_exa_backend(monkeypatc
     assert features.web.current_provider == "exa"
 
 
+def test_get_nous_subscription_features_recognizes_direct_perplexity_search_backend(monkeypatch):
+    env = {"PERPLEXITY_API_KEY": "pplx-test"}
+
+    monkeypatch.setattr(ns, "get_env_value", lambda name: env.get(name, ""))
+    monkeypatch.setattr(ns, "get_nous_auth_status", lambda: {})
+    monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "web")
+    monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
+    monkeypatch.setattr(ns, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(ns, "has_direct_modal_credentials", lambda: False)
+
+    features = ns.get_nous_subscription_features({"web": {"search_backend": "perplexity"}})
+
+    assert features.web.available is True
+    assert features.web.active is True
+    assert features.web.managed_by_nous is False
+    assert features.web.direct_override is True
+    assert features.web.current_provider == "perplexity"
+
+
 def test_get_nous_subscription_features_prefers_managed_modal_in_auto_mode(monkeypatch):
     monkeypatch.setattr("tools.tool_backend_helpers.managed_nous_tools_enabled", lambda: True)
     monkeypatch.setattr(ns, "get_env_value", lambda name: "")

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, perplexity,
+  parallel, tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -40,6 +40,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TAVILY_API_KEY",
         "TAVILY_BASE_URL",
         "EXA_API_KEY",
+        "PERPLEXITY_API_KEY",
         "PARALLEL_API_KEY",
         "PARALLEL_SEARCH_MODE",
         "FIRECRAWL_API_KEY",
@@ -73,7 +74,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestBundledPluginsRegister:
     """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_eight_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -84,6 +85,7 @@ class TestBundledPluginsRegister:
             "exa",
             "firecrawl",
             "parallel",
+            "perplexity",
             "searxng",
             "tavily",
             "xai",
@@ -96,6 +98,7 @@ class TestBundledPluginsRegister:
             ("ddgs", True, False, False),
             ("searxng", True, False, False),
             ("exa", True, True, False),
+            ("perplexity", True, False, False),
             ("parallel", True, True, False),
             ("tavily", True, True, True),
             # firecrawl: search + extract + crawl. Crawl was originally
@@ -124,7 +127,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "perplexity", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -137,7 +140,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "perplexity", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -198,6 +201,16 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False
         monkeypatch.setenv("EXA_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_perplexity_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("perplexity")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("PERPLEXITY_API_KEY", "real")
         assert p.is_available() is True
 
     def test_parallel_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -413,6 +426,17 @@ class TestErrorResponseShapes:
         from agent.web_search_registry import get_provider
 
         p = get_provider("exa")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_perplexity_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("perplexity")
         assert p is not None
         result = p.search("test", limit=5)
         assert isinstance(result, dict)

--- a/tests/scripts/test_run_tests_script.py
+++ b/tests/scripts/test_run_tests_script.py
@@ -1,0 +1,35 @@
+"""Static checks for scripts/run_tests.sh invariants."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+RUN_TESTS = Path(__file__).resolve().parents[2] / "scripts" / "run_tests.sh"
+
+
+def _script() -> str:
+    return RUN_TESTS.read_text(encoding="utf-8")
+
+
+def test_run_tests_raises_file_descriptor_limit_for_full_suite():
+    script = _script()
+    assert "ulimit -n 4096" in script
+    assert "Too many open files" in script
+
+
+def test_run_tests_keeps_hermetic_credential_env_unset():
+    script = _script()
+    assert "*_API_KEY" in script
+    assert "*_TOKEN" in script
+    assert "unset \"$name\"" in script
+
+
+def test_run_tests_no_arg_invocation_is_safe_on_bash_32():
+    script = _script()
+    executable_lines = "\n".join(
+        line for line in script.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "if [ \"$#\" -gt 0 ]; then" in script
+    assert 'PYTEST_CMD+=("$@")' in script
+    assert "ARGS=(" not in executable_lines
+    assert '"${ARGS[@]}"' not in executable_lines

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -6,6 +6,7 @@ gateway /yolo, approvals.mode=off, or cron approve mode.
 
 Inspired by Mercury Agent's permission-hardened blocklist.
 """
+import logging
 import os
 
 import pytest
@@ -15,6 +16,7 @@ from tools.approval import (
     HARDLINE_PATTERNS,
     check_all_command_guards,
     check_dangerous_command,
+    check_unbypassable_command_guards,
     detect_dangerous_command,
     detect_hardline_command,
     disable_session_yolo,
@@ -376,3 +378,716 @@ def test_sudo_stdin_guard_container_bypass(clean_session):
         for cmd in _SUDO_STDIN_BLOCK:
             result = check_all_command_guards(cmd, env)
             assert result["approved"] is True, f"container {env} should bypass sudo guard on {cmd!r}"
+
+
+# =========================================================================
+# Protected Hermes config guard — direct writes must go through config CLI
+# =========================================================================
+
+_PROTECTED_CONFIG_BLOCK = [
+    "echo x > ~/.hermes/config.yaml",
+    "echo TOKEN=x >> ~/.hermes/.env",
+    "printf x | tee $HERMES_HOME/config.yaml",
+    "sed -i 's/a/b/' ${HERMES_HOME}/.env",
+    "python3 -c \"open('~/.hermes/config.yaml','w').write('x')\"",
+    "/usr/bin/python3 -c \"open('~/.hermes/config.yaml','w').write('x')\"",
+    "/usr/bin/node -e \"require('fs').writeFileSync('~/.hermes/config.yaml','x')\"",
+    "/usr/bin/perl -e \"open(my $fh, '>', '~/.hermes/config.yaml')\"",
+    "/usr/bin/ruby -e \"File.write('~/.hermes/config.yaml','x')\"",
+    "cat >| ~/.hermes/config.yaml",
+    "touch ~/.hermes/config.yaml",
+    "/usr/bin/touch ~/.hermes/config.yaml",
+    "dd if=/tmp/config.yaml of=~/.hermes/config.yaml",
+    # dd overwriting protected files must be blocked just like redirection/tee.
+    "dd if=/tmp/x of=~/.hermes/config.yaml",
+    f"dd if=/tmp/x of={os.path.expanduser('~/.hermes/.env')}",
+    f'echo x > "{os.path.expanduser("~")}"/.hermes/config.yaml',
+    f'echo x > "{os.path.expanduser("~/.hermes")}"/config.yaml',
+    "echo x > ~/.hermes/./config.yaml",
+    "echo x > ~/.hermes/../.hermes/config.yaml",
+    "echo x > ~/.hermes//config.yaml",
+    "echo x > ~/.hermes/logs/../config.yaml",
+    "echo x > ~/\\.hermes/con\\fig.yaml",
+    "echo x > ~/\\.hermes/.\\env",
+    f"echo x > ~/../{os.path.basename(os.path.expanduser('~'))}/.hermes/config.yaml",
+    f"echo x > $HOME/../{os.path.basename(os.path.expanduser('~'))}/.hermes/.env",
+    "cd ~/.hermes && echo x > config.yaml",
+    "cd -- ~/.hermes && echo x > config.yaml",
+    "cd ~/.hermes || exit; echo x > config.yaml",
+    "cd ~/.hermes/logs && echo x > ../config.yaml",
+    "cd ~/.hermes && python3 -c \"open('config.yaml','w').write('x')\"",
+    "env python3 -c \"open('~/.hermes/config.yaml','w').write('x')\"",
+    "python3.12 -c \"open('~/.hermes/config.yaml','w').write('x')\"",
+    "cd ~/.hermes && python3 -c \"from pathlib import Path; Path('config.yaml').write_text('x')\"",
+    "cd ~/.hermes && /usr/bin/env node -e \"require('fs').writeFileSync('config.yaml','x')\"",
+    "cd ~/.hermes && /usr/bin/node -e \"require('fs').writeFileSync('config.yaml','x')\"",
+    "cd ~/.hermes && /usr/bin/ruby -e \"File.write('config.yaml','x')\"",
+    "cd ~/.hermes && /usr/bin/perl -e \"open(my $fh, '>', 'config.yaml')\"",
+    "cd ~/.hermes && echo x > config.yaml; cd /tmp && true",
+    "cd -- ~/.hermes && echo x > config.yaml; cd /tmp && true",
+    "cd ~/.hermes || exit; echo x > config.yaml; cd /tmp && true",
+    "cd ~/.hermes && python3 -c \"open('config.yaml','w').write('x')\"; cd /tmp && true",
+    "cd ~/.hermes && python3 -c \"from pathlib import Path; Path('config.yaml').write_text('x')\"; cd /tmp && true",
+    "(cd ~/.hermes && echo x > config.yaml)",
+    "{ cd ~/.hermes && echo x > config.yaml; }",
+    "cd ~/.hermes && (cd /tmp) && echo x > config.yaml",
+    "bash -c 'echo x > ~/.hermes/config.yaml'",
+    "bash -o pipefail -c 'echo x > ~/.hermes/config.yaml'",
+    "bash --rcfile /tmp/r -c 'echo x > ~/.hermes/config.yaml'",
+    "/bin/sh -c 'cd ~/.hermes && echo x > config.yaml'",
+    "cd ~/.hermes && bash -c 'echo x > config.yaml'",
+    "cd ~/.hermes && python3 -c \"p='config.yaml'; open(p,'w').write('x')\"",
+    "cd ~/.hermes && python3 -c \"from pathlib import Path; p=Path('config.yaml'); p.write_text('x')\"",
+    "cd ~/.hermes && ln -s config.yaml /tmp/hermes-review-link && echo x > /tmp/hermes-review-link",
+    "cd ~/.hermes && ln -s config.yaml /tmp/hermes-review-link && printf x | tee /tmp/hermes-review-link",
+    "cd ~/.hermes && ln -s config.yaml /tmp/hermes-review-link && truncate -s0 /tmp/hermes-review-link",
+    "cd ~/.hermes && ln -s config.yaml /tmp/hermes-review-link && cp /tmp/x /tmp/hermes-review-link",
+    "rm ~/.hermes/config.yaml",
+    "mv /tmp/config.yaml ~/.hermes/config.yaml",
+    "/bin/mv /tmp/config.yaml ~/.hermes/config.yaml",
+    "/bin/cp /tmp/config.yaml ~/.hermes/config.yaml",
+    "/bin/cp /tmp/config.yaml ~/.hermes/",
+    "/bin/mv /tmp/.env ~/.hermes/",
+    "/usr/bin/install /tmp/config.yaml ~/.hermes/config.yaml",
+    "/usr/bin/install /tmp/config.yaml ~/.hermes/",
+    "cp -t ~/.hermes /tmp/config.yaml",
+    "cp -t~/.hermes /tmp/config.yaml",
+    "cp -at ~/.hermes /tmp/config.yaml",
+    "install -t ~/.hermes /tmp/.env",
+    "install -t~/.hermes /tmp/.env",
+    "install -Ct ~/.hermes /tmp/.env",
+    "mv -t~/.hermes /tmp/config.yaml",
+    "mv -vt ~/.hermes /tmp/config.yaml",
+    "bash -euxo pipefail -c 'echo x > ~/.hermes/config.yaml'",
+    "cd ~/.hermes && mv config.yaml /tmp/config.yaml.bak",
+    "cd ~/.hermes && /usr/bin/python3 -c \"open('config.yaml','w').write('x')\"",
+    "cd ~/.hermes && mv config.yaml /tmp/config.yaml.bak; cd /tmp && true",
+]
+
+_PROTECTED_CONFIG_ALLOW = [
+    "hermes config set web.search_backend brave-free",
+    "cat ~/.hermes/config.yaml | head -n 1",
+    "grep web ~/.hermes/config.yaml",
+    "touch /tmp/done && grep web ~/.hermes/config.yaml",
+    "rm -rf node_modules && cat ~/.hermes/config.yaml",
+    "cp ~/.hermes/config.yaml /tmp/config.yaml.bak",
+    "echo '~/.hermes/config.yaml'",
+    "echo 'echo x > ~/.hermes/config.yaml'",
+    "echo 'foo && echo x > ~/.hermes/config.yaml'",
+    "printf '%s\\n' 'printf x | tee ~/.hermes/config.yaml'",
+    "echo 'touch ~/.hermes/config.yaml'",
+    "echo 'python3 -c open(~/.hermes/config.yaml,w)'",
+    "python3 -c \"print(1)\" ~/.hermes/config.yaml",
+    "/usr/bin/env python3 -c \"print(1)\" ~/.hermes/config.yaml",
+    "node -e \"console.log(1)\" ~/.hermes/config.yaml",
+    "echo x > /tmp/config.yaml",
+    # Read-only nested shell payloads under find/xargs must stay allowed.
+    "find /tmp -maxdepth 0 -exec sh -c 'cat ~/.hermes/config.yaml' \\;",
+    "xargs -I{} sh -c 'cat ~/.hermes/config.yaml' <<< foo",
+    "find /usr/bin -name sh",
+    # Symlink whose destination is OUTSIDE protected config (source protected,
+    # link lands in /tmp) is not itself a write — stays allowed.
+    "cd ~/.hermes && ln -s config.yaml /tmp/readonly-link",
+]
+
+
+def test_protected_config_guard_detects_direct_writes(clean_session):
+    import tools.approval as approval_mod
+
+    for cmd in _PROTECTED_CONFIG_BLOCK:
+        is_blocked, desc = approval_mod._check_protected_config_write_guard(cmd)
+        assert is_blocked, f"expected protected config guard to block {cmd!r}"
+        assert "protected" in desc.lower()
+
+
+def test_protected_config_guard_detects_literal_active_home(clean_session):
+    from hermes_constants import get_hermes_home
+    import tools.approval as approval_mod
+
+    for name in ("config.yaml", ".env"):
+        cmd = f"echo x > {get_hermes_home() / name}"
+        is_blocked, desc = approval_mod._check_protected_config_write_guard(cmd)
+        assert is_blocked, f"expected protected config guard to block active HERMES_HOME path {name!r}"
+        assert "protected" in desc.lower()
+
+
+def test_protected_config_guard_detects_default_root_in_profile_mode(clean_session, monkeypatch, tmp_path):
+    root = tmp_path / "hermes-root"
+    profile_home = root / "profiles" / "ops" / "home"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(profile_home))
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "ops"))
+
+    for name in ("config.yaml", ".env"):
+        cmd = f"echo x > {root / name}"
+        result = check_all_command_guards(cmd, "local")
+        assert result["approved"] is False, f"expected default Hermes root path to block {name!r}"
+        assert result.get("protected_config") is True
+
+
+def test_protected_config_guard_detects_relative_cwd_with_spaces(clean_session, monkeypatch, tmp_path):
+    import tools.approval as approval_mod
+
+    hermes_home = tmp_path / "hermes home with spaces"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    is_blocked, desc = approval_mod._check_protected_config_write_guard(
+        "echo x > config.yaml",
+        cwd=str(hermes_home),
+    )
+    assert is_blocked
+    assert "protected" in desc.lower()
+
+    absolute_cmd = f'echo x > "{hermes_home / "config.yaml"}"'
+    is_blocked, desc = approval_mod._check_protected_config_write_guard(absolute_cmd)
+    assert is_blocked
+    assert "protected" in desc.lower()
+
+    read_copy_cmd = f'cp "{hermes_home / "config.yaml"}" /tmp/config.yaml.bak'
+    is_blocked, desc = approval_mod._check_protected_config_write_guard(read_copy_cmd)
+    assert not is_blocked, f"protected source read should not be treated as direct write (got {desc})"
+
+    quoted_cd_cmd = f'cd "{hermes_home}" && echo x > config.yaml'
+    is_blocked, desc = approval_mod._check_protected_config_write_guard(quoted_cd_cmd)
+    assert is_blocked
+    assert "protected" in desc.lower()
+
+    for cmd in (
+        f'(cd "{hermes_home}"); echo x > config.yaml',
+        f'(cd "{hermes_home}" && cat config.yaml); echo x > config.yaml',
+    ):
+        is_blocked, desc = approval_mod._check_protected_config_write_guard(cmd, cwd="/tmp")
+        assert not is_blocked, f"subshell cd should not leak to parent cwd for {cmd!r} (got {desc})"
+
+
+def test_protected_config_guard_detects_relative_guard_cwd(clean_session, monkeypatch, tmp_path):
+    import tools.approval as approval_mod
+
+    hermes_home = tmp_path / "hermes-home"
+    repo_dir = hermes_home / "hermes-agent"
+    repo_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(repo_dir)
+
+    is_blocked, desc = approval_mod._check_protected_config_write_guard(
+        "echo x > config.yaml",
+        cwd="..",
+    )
+    assert is_blocked
+    assert "protected" in desc.lower()
+
+
+def test_protected_config_guard_detects_hermes_home_symbolic_parent(clean_session, monkeypatch, tmp_path):
+    import tools.approval as approval_mod
+
+    base = tmp_path / "base"
+    hermes_home = base / "hermes-home"
+    hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    cmd = "echo x > $HERMES_HOME/../hermes-home/config.yaml"
+    is_blocked, desc = approval_mod._check_protected_config_write_guard(cmd)
+    assert is_blocked
+    assert "protected" in desc.lower()
+
+
+def test_protected_config_guard_allows_non_writes(clean_session):
+    import tools.approval as approval_mod
+
+    for cmd in _PROTECTED_CONFIG_ALLOW:
+        is_blocked, desc = approval_mod._check_protected_config_write_guard(cmd)
+        assert not is_blocked, f"expected protected config guard NOT to block {cmd!r} (got {desc})"
+
+
+def test_protected_config_guard_below_yolo_and_off(clean_session, monkeypatch):
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    for cmd in _PROTECTED_CONFIG_BLOCK:
+        r1 = check_dangerous_command(cmd, "local")
+        assert r1["approved"] is False, f"yolo leaked protected config guard on {cmd!r}"
+        assert r1.get("protected_config") is True
+
+        r2 = check_all_command_guards(cmd, "local")
+        assert r2["approved"] is False, f"yolo leaked protected config guard on {cmd!r}"
+        assert r2.get("protected_config") is True
+
+
+def test_protected_config_guard_below_approvals_off(clean_session, monkeypatch):
+    import tools.approval as approval_mod
+
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "off")
+    result = check_all_command_guards("echo x > ~/.hermes/config.yaml", "local")
+    assert result["approved"] is False
+    assert result.get("protected_config") is True
+
+
+def test_unbypassable_guard_blocks_protected_config_direct_write(clean_session):
+    result = check_unbypassable_command_guards("echo x > ~/.hermes/config.yaml", "local")
+    assert result["approved"] is False
+    assert result.get("protected_config") is True
+    assert "Secret values were not inspected" in result["message"]
+
+
+def test_protected_config_guard_log_does_not_leak_raw_command(clean_session, caplog):
+    caplog.set_level(logging.WARNING, logger="tools.approval")
+
+    result = check_unbypassable_command_guards(
+        "echo SECRET_VALUE > ~/.hermes/config.yaml && sudo -S whoami",
+        "local",
+    )
+
+    assert result["approved"] is False
+    assert result.get("protected_config") is True
+    assert "Protected config guard block" in caplog.text
+    assert "SECRET_VALUE" not in caplog.text
+
+
+def test_protected_config_guard_container_bypass(clean_session):
+    for env in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+        result = check_all_command_guards("echo x > ~/.hermes/config.yaml", env)
+        assert result["approved"] is True, f"container {env} should bypass protected config guard"
+
+
+# =========================================================================
+# Independent review regressions — wrapper/stdin/argv bypasses
+# =========================================================================
+
+_REVIEW_SUDO_STDIN_BLOCK = [
+    "sudo -nS whoami",
+    "sudo -Sn whoami",
+    "sudo --stdin whoami",
+    "echo x | sudo -nS whoami",
+    "/usr/bin/env -S 'sudo -S whoami'",
+    "/usr/bin/env -S 'sh -c \"sudo -S whoami\"'",
+    "/usr/bin/env --split-string='sudo --stdin whoami'",
+]
+
+
+def test_sudo_stdin_guard_blocks_combined_and_long_forms(clean_session, monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    for cmd in _REVIEW_SUDO_STDIN_BLOCK:
+        result = check_unbypassable_command_guards(cmd, "local")
+        assert result["approved"] is False, f"expected sudo stdin guard to block {cmd!r}"
+        assert "sudo password guessing" in result["message"]
+
+
+def test_sudo_stdin_guard_log_does_not_leak_raw_command(clean_session, monkeypatch, caplog):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    caplog.set_level(logging.WARNING, logger="tools.approval")
+
+    result = check_unbypassable_command_guards(
+        "printf SECRET_VALUE | sudo -S whoami",
+        "local",
+    )
+
+    assert result["approved"] is False
+    assert "Sudo stdin guard block" in caplog.text
+    assert "SECRET_VALUE" not in caplog.text
+
+
+_REVIEW_PROTECTED_CONFIG_BLOCK = [
+    "nice truncate -s0 ~/.hermes/config.yaml",
+    "time truncate -s0 ~/.hermes/.env",
+    "sudo sh -c 'echo x > ~/.hermes/config.yaml'",
+    "rsync /tmp/config.yaml ~/.hermes/config.yaml",
+    "rsync /tmp/.env ~/.hermes/",
+    "echo x > ~/.hermes/$'config.yaml'",
+    "touch ~/.hermes/{config.yaml}",
+    "python3 -c \"import sys; open(sys.argv[1], 'w').write('x')\" ~/.hermes/config.yaml",
+    "python3 -c \"from pathlib import Path; import sys; Path(sys.argv[1]).write_text('x')\" ~/.hermes/config.yaml",
+    "node -e \"require('fs').writeFileSync(process.argv[1], 'x')\" ~/.hermes/config.yaml",
+    # env -S / --split-string must preserve the split-string flag payload and
+    # recurse into nested shell writes.
+    "/usr/bin/env -S 'sh -c \"echo x > ~/.hermes/config.yaml\"'",
+    "/usr/bin/env --split-string='sh -c \"echo x > ~/.hermes/.env\"'",
+    "env -S 'sh -c \"echo x > ~/.hermes/config.yaml\"'",
+    # Nested shell payloads under xargs / find -exec — the inner `sh -c`
+    # argument is opaque to the outer-command word scan, so the guard must
+    # recurse into it.
+    "find /tmp -maxdepth 0 -exec sh -c 'echo x > ~/.hermes/config.yaml' \\;",
+    "find /tmp -maxdepth 0 -execdir sh -c 'echo x > ~/.hermes/.env' \\;",
+    "xargs -I{} sh -c 'echo x > ~/.hermes/config.yaml' <<< foo",
+    "echo foo | xargs sh -c 'echo x > ~/.hermes/config.yaml'",
+    # Relative symlink whose destination IS the protected config after a cd —
+    # creating the link overwrites config.yaml. The absolute dest form was
+    # already blocked; this closes the relative-cwd gap.
+    "cd ~/.hermes && ln -sf /tmp/x config.yaml",
+    "cd ~/.hermes && ln -f /tmp/x .env",
+    # Directory destinations must be treated like copy/move semantics: the
+    # source basename becomes the link name inside the protected config dir.
+    "ln -sf /tmp/config.yaml ~/.hermes/",
+    "ln -sf /tmp/.env ~/.hermes/",
+    "cd ~/.hermes && ln -sf /tmp/config.yaml .",
+    "cd ~/.hermes && ln -sf /tmp/.env .",
+]
+
+
+def test_protected_config_guard_blocks_review_bypasses(clean_session):
+    import tools.approval as approval_mod
+
+    for cmd in _REVIEW_PROTECTED_CONFIG_BLOCK:
+        is_blocked, desc = approval_mod._check_protected_config_write_guard(cmd)
+        assert is_blocked, f"expected protected config guard to block {cmd!r} (got {desc})"
+
+
+_REVIEW_HARDLINE_BLOCK = [
+    "env -i reboot",
+    "env -i PATH=/sbin reboot",
+    "/usr/bin/env -S 'reboot'",
+    "/usr/bin/env -S 'sh -c reboot'",
+    "env --split-string='sh -c reboot'",
+    "command reboot",
+    "time -p reboot",
+    "bash -c 'reboot'",
+    "rm -rf '$HOME'",
+    'rm -rf "$HOME"',
+    "rm -rf '~'",
+]
+
+
+def test_hardline_guard_blocks_wrapper_forms(clean_session):
+    for cmd in _REVIEW_HARDLINE_BLOCK:
+        result = check_unbypassable_command_guards(cmd, "local")
+        assert result["approved"] is False, f"expected hardline guard to block {cmd!r}"
+        assert result.get("hardline") is True
+
+
+def test_shell_stdin_and_shell_c_payloads_are_unbypassable(clean_session):
+    import tools.approval as approval_mod
+
+    hardline_cases = [
+        "printf 'reboot' | sh",
+        "bash <<< 'reboot'",
+    ]
+    for cmd in hardline_cases:
+        approval = approval_mod.check_unbypassable_command_guards(cmd, "local")
+        assert not approval["approved"], cmd
+
+    protected_cases = [
+        "printf 'echo x > ~/.hermes/config.yaml' | sh",
+        "bash <<< 'echo x > ~/.hermes/config.yaml'",
+    ]
+    for cmd in protected_cases:
+        assert approval_mod._check_protected_config_write_guard(cmd)[0], cmd
+
+    sudo_cases = [
+        "printf x | bash -c 'sudo -S whoami'",
+        "sh -c 'sudo --stdin whoami'",
+    ]
+    for cmd in sudo_cases:
+        approval = approval_mod.check_unbypassable_command_guards(cmd, "local")
+        assert not approval["approved"], cmd
+
+
+def test_export_alias_to_protected_config_is_blocked(clean_session):
+    import tools.approval as approval_mod
+
+    assert approval_mod._check_protected_config_write_guard(
+        "export p=~/.hermes/config.yaml; echo x > $p"
+    )[0]
+    assert approval_mod._check_protected_config_write_guard(
+        "readonly p=~/.hermes/.env; touch $p"
+    )[0]
+
+
+def test_process_stdin_wrapped_shell_and_repl_guards(tmp_path):
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    class FakePty:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, data):
+            self.writes.append(data)
+
+    registry = ProcessRegistry()
+    shell_session = ProcessSession(
+        id="wrapped-shell",
+        command="/usr/bin/env bash",
+        cwd=str(tmp_path),
+        started_at=0,
+    )
+    shell_session._pty = FakePty()
+    registry._running[shell_session.id] = shell_session
+
+    blocked = registry.submit_stdin(shell_session.id, "reboot")
+    assert blocked["status"] == "blocked"
+    assert shell_session._pty.writes == []
+
+    repl_session = ProcessSession(
+        id="py-repl",
+        command="python3",
+        cwd=str(tmp_path),
+        started_at=0,
+    )
+    repl_session._pty = FakePty()
+    registry._running[repl_session.id] = repl_session
+
+    blocked = registry.submit_stdin(
+        repl_session.id,
+        "open('~/.hermes/config.yaml', 'w').write('x')",
+    )
+    assert blocked["status"] == "blocked"
+    assert repl_session._pty.writes == []
+
+
+@pytest.mark.parametrize("command", [
+    "python3.12",
+    "/usr/bin/python3.12",
+    "node20",
+    "nodejs20",
+    "ruby3.2",
+    "perl5.36",
+])
+def test_process_stdin_versioned_repl_names_are_guarded(tmp_path, command):
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    class FakePty:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, data):
+            self.writes.append(data)
+
+    registry = ProcessRegistry()
+    session = ProcessSession(
+        id="versioned-repl-" + command.replace("/", "_"),
+        command=command,
+        cwd=str(tmp_path),
+        started_at=0,
+    )
+    session._pty = FakePty()
+    registry._running[session.id] = session
+
+    blocked = registry.submit_stdin(
+        session.id,
+        "open('~/.hermes/config.yaml', 'w').write('x')",
+    )
+    assert blocked["status"] == "blocked"
+    assert session._pty.writes == []
+
+
+def test_process_stdin_split_writes_are_buffered(tmp_path):
+    """Protected writes split across write_stdin chunks must still block.
+
+    Each chunk is individually benign ("echo x > ~/.hermes/" is an incomplete
+    path; "config.yaml" alone is harmless), but combined they overwrite the
+    protected config. The stateful guard buffer reconstructs the pending line
+    and blocks the completing chunk before its newline reaches the shell.
+    """
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    class FakePty:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, data):
+            self.writes.append(data)
+
+    registry = ProcessRegistry()
+    shell_session = ProcessSession(
+        id="split-shell",
+        command="/usr/bin/env bash",
+        cwd=str(tmp_path),
+        started_at=0,
+    )
+    shell_session._pty = FakePty()
+    registry._running[shell_session.id] = shell_session
+
+    # Benign incomplete prefix — allowed and buffered.
+    ok = registry.write_stdin(shell_session.id, "echo x > ~/.hermes/")
+    assert ok["status"] == "ok"
+    # Completing chunk + newline reconstructs the protected write → blocked,
+    # and the dangerous tail must never reach the shell.
+    blocked = registry.submit_stdin(shell_session.id, "config.yaml")
+    assert blocked["status"] == "blocked"
+    assert all(b"config.yaml" not in w for w in shell_session._pty.writes)
+
+    # REPL variant: split an inline Python write across two chunks.
+    repl_session = ProcessSession(
+        id="split-repl",
+        command="python3",
+        cwd=str(tmp_path),
+        started_at=0,
+    )
+    repl_session._pty = FakePty()
+    registry._running[repl_session.id] = repl_session
+
+    ok = registry.write_stdin(repl_session.id, "open('~/.hermes/")
+    assert ok["status"] == "ok"
+    blocked = registry.submit_stdin(repl_session.id, "config.yaml','w').write('x')")
+    assert blocked["status"] == "blocked"
+    assert all(b"config.yaml" not in w for w in repl_session._pty.writes)
+
+
+def test_process_stdin_buffer_resets_after_newline(tmp_path):
+    """A completed (newline-terminated) benign line must not leave stale state
+    that falsely blocks a later unrelated write."""
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    class FakePty:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, data):
+            self.writes.append(data)
+
+    registry = ProcessRegistry()
+    session = ProcessSession(
+        id="reset-shell",
+        command="/usr/bin/env bash",
+        cwd=str(tmp_path),
+        started_at=0,
+    )
+    session._pty = FakePty()
+    registry._running[session.id] = session
+
+    first = registry.submit_stdin(session.id, "echo hello > /tmp/safe.txt")
+    assert first["status"] == "ok"
+    second = registry.submit_stdin(session.id, "echo world > /tmp/other.txt")
+    assert second["status"] == "ok"
+
+
+def test_eval_and_piped_interpreter_payloads_are_unbypassable(clean_session):
+    import tools.approval as approval_mod
+
+    guard_cases = [
+        "eval reboot",
+        'eval "sudo -S whoami"',
+        'eval "echo x > ~/.hermes/config.yaml"',
+    ]
+    for cmd in guard_cases:
+        approval = approval_mod.check_unbypassable_command_guards(cmd, "local")
+        assert not approval["approved"], cmd
+
+    interpreter_cases = [
+        "printf \"open('~/.hermes/config.yaml','w').write('x')\" | python3",
+        "printf \"import os; os.system('echo x > ~/.hermes/config.yaml')\" | python3",
+        "python3 <<'PY'\nimport os; os.system('echo x > ~/.hermes/config.yaml')\nPY",
+        "printf \"require('fs').writeFileSync('~/.hermes/config.yaml','x')\" | node",
+    ]
+    for cmd in interpreter_cases:
+        assert approval_mod._check_protected_config_write_guard(cmd)[0], cmd
+
+
+def test_process_command_metadata_is_redacted():
+    from tools.process_registry import ProcessRegistry, ProcessSession, format_process_notification
+
+    secret = "sk-" + "A" * 24
+    command = f"python worker.py --api-key {secret} token={secret}"
+    registry = ProcessRegistry()
+    session = ProcessSession(id="redact-proc", command=command, cwd="/tmp", started_at=0)
+    registry._running[session.id] = session
+
+    listed = registry.list_sessions()
+    polled = registry.poll(session.id)
+    notice = format_process_notification({
+        "type": "completion",
+        "session_id": session.id,
+        "command": command,
+        "exit_code": 0,
+        "output": "ok",
+    })
+
+    assert secret not in listed[0]["command"]
+    assert secret not in polled["command"]
+    assert secret not in notice
+    assert "[REDACTED]" in listed[0]["command"]
+    assert "[REDACTED]" in polled["command"]
+    assert "[REDACTED]" in notice
+
+
+def test_static_stdin_parser_handles_unquoted_echo_and_printf_format(clean_session):
+    import tools.approval as approval_mod
+
+    assert not approval_mod.check_unbypassable_command_guards(
+        "echo reboot | sh",
+        "local",
+    )["approved"]
+    assert not approval_mod.check_unbypassable_command_guards(
+        "printf '%s\\n' reboot | sh",
+        "local",
+    )["approved"]
+    assert approval_mod._check_protected_config_write_guard(
+        "printf '%s\\n' \"open('~/.hermes/config.yaml','w').write('x')\" | python3"
+    )[0]
+
+
+def test_process_command_redaction_handles_prefixed_env_secret_names():
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    value = "DUMMY_NOT_A_REAL_SECRET_12345"
+    command = f"OPENAI_API_KEY={value} AWS_SECRET_ACCESS_KEY={value} python worker.py"
+    registry = ProcessRegistry()
+    session = ProcessSession(id="redact-env-proc", command=command, cwd="/tmp", started_at=0)
+    registry._running[session.id] = session
+
+    polled = registry.poll(session.id)["command"]
+    listed = registry.list_sessions()[0]["command"]
+
+    assert value not in polled
+    assert value not in listed
+    assert polled.count("[REDACTED]") >= 2
+
+
+def test_process_command_redaction_handles_bearer_and_perplexity_tokens():
+    from tools.process_registry import ProcessRegistry, ProcessSession, format_process_notification
+
+    bearer = "pplx-" + "A" * 24
+    command = f"curl -H 'Authorization: Bearer {bearer}' https://api.perplexity.ai/search"
+    registry = ProcessRegistry()
+    session = ProcessSession(id="redact-bearer-proc", command=command, cwd="/tmp", started_at=0)
+    registry._running[session.id] = session
+
+    rendered = [
+        registry.poll(session.id)["command"],
+        registry.list_sessions()[0]["command"],
+        format_process_notification({
+            "type": "completion",
+            "session_id": session.id,
+            "command": command,
+            "exit_code": 0,
+            "output": "ok",
+        }),
+    ]
+
+    assert all(bearer not in item for item in rendered)
+    assert all("[REDACTED]" in item for item in rendered)
+
+
+def test_repl_stdin_nested_shell_and_eval_writes_are_guarded(clean_session, tmp_path):
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    class FakePty:
+        def __init__(self):
+            self.writes = []
+
+        def write(self, data):
+            self.writes.append(data)
+
+    cases = [
+        "import os; os.system('echo x > ~/.hermes/config.yaml')",
+        "__import__('os').system('echo x > ~/.hermes/config.yaml')",
+        "import subprocess; subprocess.run('echo x > ~/.hermes/config.yaml', shell=True)",
+        "import subprocess; subprocess.run(['sh','-c','echo x > ~/.hermes/config.yaml'])",
+        "import subprocess; subprocess.run(['/bin/sh','-c','echo x > ~/.hermes/config.yaml'])",
+        "import subprocess; subprocess.run(['bash','-lc','echo x > ~/.hermes/config.yaml'])",
+        "from subprocess import run; run('echo x > ~/.hermes/config.yaml', shell=True)",
+        "import subprocess; subprocess.run(args='echo x > ~/.hermes/config.yaml', shell=True)",
+        "eval(\"open('~/.hermes/config.yaml','w').write('x')\")",
+    ]
+    for idx, command in enumerate(cases):
+        registry = ProcessRegistry()
+        session = ProcessSession(
+            id=f"repl-nested-{idx}",
+            command="python3",
+            cwd=str(tmp_path),
+            started_at=0,
+        )
+        session._pty = FakePty()
+        registry._running[session.id] = session
+
+        blocked = registry.submit_stdin(session.id, command)
+
+        assert blocked["status"] == "blocked", command
+        assert session._pty.writes == []

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,5 +1,7 @@
 """Regression tests for sudo detection and sudo password handling."""
 
+import json
+
 import tools.terminal_tool as terminal_tool
 
 
@@ -155,6 +157,118 @@ def test_passwordless_sudo_probe_is_disabled_for_nonlocal_terminal_env(monkeypat
     assert terminal_tool._sudo_nopasswd_works() is False
 
 
+def test_force_path_still_runs_unbypassable_guards(monkeypatch):
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    result = terminal_tool._check_unbypassable_guards("echo x > ~/.hermes/config.yaml", "local")
+    assert result["approved"] is False
+    assert result.get("protected_config") is True
+
+
+def test_force_terminal_tool_blocks_protected_config_before_execution(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    repo_dir = hermes_home / "hermes-agent"
+    repo_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(repo_dir)
+
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "local",
+            "cwd": str(hermes_home),
+            "timeout": 30,
+        },
+    )
+    executed = []
+
+    class FakeEnv:
+        env = {}
+        cwd = str(hermes_home)
+
+        def execute(self, *_args, **_kwargs):
+            executed.append(True)
+            raise AssertionError("protected config command should not execute")
+
+    old_envs = dict(terminal_tool._active_environments)
+    old_activity = dict(terminal_tool._last_activity)
+    terminal_tool._active_environments.clear()
+    terminal_tool._last_activity.clear()
+    terminal_tool._active_environments["default"] = FakeEnv()
+    try:
+        commands = [
+            ("echo x > ~/.hermes/config.yaml", None),
+            ("echo x > config.yaml", None),
+            ("echo x > config.yaml", str(hermes_home)),
+        ]
+        for command, workdir in commands:
+            if workdir is None:
+                raw = terminal_tool.terminal_tool(command, force=True)
+            else:
+                raw = terminal_tool.terminal_tool(command, force=True, workdir=workdir)
+            result = json.loads(raw)
+            assert result["status"] == "blocked"
+            assert result["exit_code"] == -1
+            assert "protected Hermes config/env" in result["error"]
+    finally:
+        terminal_tool._active_environments.clear()
+        terminal_tool._active_environments.update(old_envs)
+        terminal_tool._last_activity.clear()
+        terminal_tool._last_activity.update(old_activity)
+
+    assert executed == []
+
+
+
+
+def test_force_terminal_tool_resolves_relative_workdir_like_execution(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    repo_dir = hermes_home / "hermes-agent"
+    repo_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "local",
+            "cwd": str(hermes_home),
+            "timeout": 30,
+        },
+    )
+
+    executed = []
+
+    class FakeEnv:
+        env = {}
+        cwd = str(repo_dir)
+
+        def execute(self, *_args, **_kwargs):
+            executed.append(True)
+            raise AssertionError("protected config command should not execute")
+
+    old_envs = dict(terminal_tool._active_environments)
+    old_activity = dict(terminal_tool._last_activity)
+    terminal_tool._active_environments.clear()
+    terminal_tool._last_activity.clear()
+    terminal_tool._active_environments["default"] = FakeEnv()
+    try:
+        raw = terminal_tool.terminal_tool("echo x > config.yaml", force=True, workdir="..")
+        result = json.loads(raw)
+        assert result["status"] == "blocked"
+        assert result["exit_code"] == -1
+        assert "protected Hermes config/env" in result["error"]
+    finally:
+        terminal_tool._active_environments.clear()
+        terminal_tool._active_environments.update(old_envs)
+        terminal_tool._last_activity.clear()
+        terminal_tool._last_activity.update(old_activity)
+
+    assert executed == []
+
 def test_validate_workdir_allows_windows_drive_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project") is None
     assert terminal_tool._validate_workdir("C:/Users/Alice/project") is None
@@ -168,3 +282,28 @@ def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")
     assert terminal_tool._validate_workdir("C:\\Users\\Alice\\project\nwhoami")
+
+
+def test_process_stdin_to_shell_runs_unbypassable_guards(tmp_path):
+    from tools.process_registry import ProcessRegistry, ProcessSession
+
+    registry = ProcessRegistry()
+    session = ProcessSession(
+        id="proc_test",
+        command="bash",
+        cwd=str(tmp_path),
+        started_at=0,
+        env_type="local",
+    )
+
+    class FakePty:
+        def write(self, _data):
+            raise AssertionError("blocked stdin must not be written")
+
+    session._pty = FakePty()
+    registry._running[session.id] = session
+
+    result = registry.submit_stdin(session.id, "echo x > ~/.hermes/config.yaml")
+    assert result["status"] == "blocked"
+    assert result["exit_code"] == -1
+    assert "protected Hermes config/env" in result["error"]

--- a/tests/tools/test_web_providers_perplexity.py
+++ b/tests/tools/test_web_providers_perplexity.py
@@ -1,0 +1,70 @@
+"""Tests for the Perplexity Search web provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from plugins.web.perplexity.provider import (
+    PerplexityWebSearchProvider,
+    _normalize_perplexity_search_results,
+)
+
+
+def test_perplexity_normalizes_search_results() -> None:
+    result = _normalize_perplexity_search_results(
+        {
+            "results": [
+                {
+                    "title": "Example",
+                    "url": "https://example.com",
+                    "snippet": "Example snippet",
+                    "date": "2026-01-01",
+                }
+            ]
+        }
+    )
+
+    assert result == {
+        "success": True,
+        "data": {
+            "web": [
+                {
+                    "title": "Example",
+                    "url": "https://example.com",
+                    "description": "Example snippet",
+                    "position": 1,
+                }
+            ]
+        },
+    }
+
+
+def test_perplexity_search_posts_to_search_api(monkeypatch) -> None:
+    response = MagicMock()
+    response.json.return_value = {"results": []}
+    response.raise_for_status.return_value = None
+    post = MagicMock(return_value=response)
+
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pplx-test")
+    monkeypatch.setattr("plugins.web.perplexity.provider.httpx.post", post)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    provider = PerplexityWebSearchProvider()
+    result = provider.search("docs", limit=500)
+
+    assert result == {"success": True, "data": {"web": []}}
+    post.assert_called_once()
+    kwargs = post.call_args.kwargs
+    assert kwargs["json"] == {"query": "docs", "max_results": 20}
+    assert kwargs["headers"]["Authorization"] == "Bearer pplx-test"
+
+
+def test_perplexity_search_returns_error_without_key(monkeypatch) -> None:
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+    provider = PerplexityWebSearchProvider()
+    result = provider.search("docs", limit=5)
+
+    assert result["success"] is False
+    assert "PERPLEXITY_API_KEY" in result["error"]

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -259,6 +259,7 @@ class TestBackendSelection:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "PERPLEXITY_API_KEY",
     )
 
     def setup_method(self):
@@ -305,6 +306,12 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}):
             assert _get_backend() == "tavily"
 
+    def test_config_perplexity(self):
+        """web.backend=perplexity in config → 'perplexity' regardless of other keys."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "perplexity"}):
+            assert _get_backend() == "perplexity"
+
     def test_config_tavily_overrides_env_keys(self):
         """web.backend=tavily in config → 'tavily' even if Firecrawl key set."""
         from tools.web_tools import _get_backend
@@ -339,6 +346,13 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}):
             assert _get_backend() == "exa"
+
+    def test_fallback_perplexity_only_key(self):
+        """Only PERPLEXITY_API_KEY set → 'perplexity'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"PERPLEXITY_API_KEY": "pplx-test"}):
+            assert _get_backend() == "perplexity"
 
     def test_fallback_parallel_takes_priority_over_exa(self):
         """Exa should only win the fallback path when it is the only configured backend."""
@@ -386,7 +400,13 @@ class TestBackendSelection:
     def test_fallback_no_keys_defaults_to_firecrawl(self):
         """No keys, no config → 'firecrawl' (will fail at client init)."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        # ddgs availability is driven by package presence, not env/config, so
+        # an installed ``ddgs`` in the test environment would otherwise win the
+        # key-based fallback. Force it unavailable to assert the firecrawl
+        # backward-compat default; ddgs fallback behavior is covered elsewhere.
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch.dict(os.environ, {}, clear=True):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
@@ -558,6 +578,7 @@ class TestCheckWebApiKey:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "PERPLEXITY_API_KEY",
     )
 
     def setup_method(self):
@@ -601,9 +622,20 @@ class TestCheckWebApiKey:
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
+    def test_perplexity_key_only(self):
+        with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "pplx-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
     def test_no_keys_returns_false(self):
         from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        # ddgs is importable in the test environment, which would make the
+        # no-key check report an available (free) backend. Force it
+        # unavailable so this asserts the genuine "nothing configured" path;
+        # ddgs availability is exercised in its own provider tests.
+        with patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch.dict(os.environ, {}, clear=True):
+            assert check_web_api_key() is False
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {
@@ -646,3 +678,9 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+def test_web_requires_env_includes_perplexity_key():
+    from tools.web_tools import _web_requires_env
+
+    assert "PERPLEXITY_API_KEY" in _web_requires_env()

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -124,6 +124,19 @@ class TestWriteAllowed:
     def test_project_file(self):
         assert _is_write_denied("/home/user/project/main.py") is False
 
-    def test_hermes_config_not_env(self):
-        path = os.path.join(str(Path.home()), ".hermes", "config.yaml")
-        assert _is_write_denied(path) is False
+    def test_hermes_config_yaml(self):
+        # ``config.yaml`` under active HERMES_HOME must be changed through
+        # `hermes config set`, not direct file writes/patches.
+        from hermes_constants import get_hermes_home
+        path = str(get_hermes_home() / "config.yaml")
+        assert _is_write_denied(path) is True
+
+    def test_default_hermes_root_in_profile_mode(self, monkeypatch, tmp_path):
+        root = tmp_path / "hermes-root"
+        profile_home = root / "profiles" / "ops" / "home"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(profile_home))
+        monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "ops"))
+
+        for name in ("config.yaml", ".env"):
+            assert _is_write_denied(str(root / name)) is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -9,9 +9,11 @@ This module is the single source of truth for the dangerous command system:
 """
 
 import contextvars
+import fnmatch
 import logging
 import os
 import re
+import shlex
 import sys
 import threading
 import time
@@ -248,8 +250,155 @@ HARDLINE_PATTERNS_COMPILED = [
 # reason for the agent to pipe passwords to sudo -S when no password
 # has been configured.
 _SUDO_STDIN_RE = re.compile(
-    r'(?:^|[;&|`\n]|&&|\|\||\$\()\s*sudo\s+-S\b',
+    # Command-position sudo invocation with any stdin-reading form:
+    #   sudo -S, sudo -nS, sudo -Sn, sudo --stdin
+    # Stop at shell separators so a quoted/later mention does not bleed into
+    # the current sudo command. The input is normalized/lowercased before use.
+    r'(?:^|[;&|`\n]|&&|\|\||\$\()\s*sudo\b[^;&|`\n]*?(?:--stdin\b|-[a-z]*s[a-z]*\b)',
     re.IGNORECASE)
+
+
+def _extract_static_shell_stdin_payloads(command: str) -> list[str]:
+    """Return statically visible payloads fed to shell/interpreter stdin.
+
+    Conservative parser for literal echo/printf pipelines plus here-strings and
+    heredocs.  It does not emulate shell expansion; it only unwraps payload text
+    that is already present in the command.
+    """
+    raw = _normalize_command_for_detection(command or "")
+    payloads: list[str] = []
+    stdin_consumers = r"(?:bash|sh|zsh|ksh|dash|python|python3|node|nodejs|ruby|perl)"
+
+    # Generic pipeline parser for: echo payload | sh, printf '%s\n' payload | python3.
+    # Split pipes with quote awareness first; regexes such as [^;&|] miss
+    # semicolons inside quoted interpreter payloads.
+    pipe_segments: list[str] = []
+    buf: list[str] = []
+    quote: str | None = None
+    escaped = False
+    i = 0
+    while i < len(raw):
+        ch = raw[i]
+        if escaped:
+            buf.append(ch)
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\" and quote != "'":
+            buf.append(ch)
+            escaped = True
+            i += 1
+            continue
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in {'"', "'"}:
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+        if ch == "|" and not raw.startswith("||", i) and (i == 0 or raw[i - 1] != ">"):
+            pipe_segments.append("".join(buf).strip())
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    pipe_segments.append("".join(buf).strip())
+
+    for left, right in zip(pipe_segments, pipe_segments[1:]):
+        right_words = _shlex_words(right)
+        if not right_words or not re.fullmatch(stdin_consumers, _command_basename(right_words[0]), _RE_FLAGS):
+            continue
+        words = _shlex_words(left)
+        if not words:
+            continue
+        cmd = _command_basename(words[0]).lower()
+        if cmd == "echo":
+            idx = 1
+            while idx < len(words) and re.fullmatch(r"-[A-Za-z]+", words[idx]):
+                idx += 1
+            if idx < len(words):
+                payloads.append(" ".join(words[idx:]))
+        elif cmd == "printf":
+            idx = 1
+            while idx < len(words) and words[idx].startswith("--"):
+                idx += 1
+            if idx >= len(words):
+                continue
+            fmt = words[idx]
+            args = words[idx + 1:]
+            if args:
+                # For guard purposes, the argument text is the dangerous part in
+                # common `printf '%s\n' payload | sh/python` forms.
+                payloads.append("\n".join(args) if "%" in fmt else " ".join(args))
+            else:
+                payloads.append(fmt)
+
+    for match in re.finditer(
+        rf"\b(?:\S*/)?{stdin_consumers}\b[^;&|`\n]*<<<\s*(?P<q>['\"])(?P<payload>.*?)(?P=q)",
+        raw,
+        _RE_FLAGS,
+    ):
+        payloads.append(match.group("payload"))
+    heredoc_re = re.compile(
+        rf"\b(?:\S*/)?{stdin_consumers}\b[^\n]*<<-?\s*['\"]?(?P<tag>[A-Za-z_][A-Za-z0-9_]*)['\"]?\n(?P<body>.*?)\n(?P=tag)(?:\n|$)",
+        _RE_FLAGS,
+    )
+    payloads.extend(match.group("body") for match in heredoc_re.finditer(raw))
+    return [payload for payload in payloads if payload.strip()]
+
+
+def _shell_c_payloads_from_command(command: str) -> list[str]:
+    """Return statically visible payloads passed to shell -c after wrappers."""
+    payloads: list[str] = []
+    normalized = _normalize_command_for_detection(command or "")
+    for segment in _split_command_segments(normalized):
+        words = _shlex_words(segment)
+        if not words:
+            continue
+        for idx in _command_word_indices(words):
+            if _command_basename(words[idx]).lower() in {"bash", "sh", "zsh", "ksh", "dash"}:
+                payload = _shell_c_payload_from_words(words, idx)
+                if payload:
+                    payloads.append(payload)
+    return payloads
+
+
+def _eval_payloads_from_command(command: str) -> list[str]:
+    """Return simple literal payloads passed to shell eval."""
+    payloads: list[str] = []
+    normalized = _normalize_command_for_detection(command or "")
+    for segment in _split_command_segments(normalized):
+        words = _shlex_words(segment)
+        if not words:
+            continue
+        for idx in _command_word_indices(words):
+            if _command_basename(words[idx]).lower() == "eval" and idx + 1 < len(words):
+                payloads.append(" ".join(words[idx + 1:]))
+    return [payload for payload in payloads if payload.strip()]
+
+
+def _env_split_string_payloads_from_command(command: str) -> list[str]:
+    """Return statically visible `/usr/bin/env -S/--split-string` payloads.
+
+    Keep the original option spelling while matching the `env` command word
+    case-insensitively. This prevents callers that need exact flag case (notably
+    the sudo-stdin guard) from losing `-S` by lowercasing the whole command.
+    """
+    payloads: list[str] = []
+    normalized = _normalize_command_for_detection(command or "")
+    for segment in _split_command_segments(normalized):
+        words = _shlex_words(segment)
+        if not words:
+            continue
+        for idx in _command_word_indices(words):
+            if _command_basename(words[idx]).lower() == "env":
+                payloads.extend(_env_split_string_payloads(words, idx))
+    return [payload for payload in payloads if payload.strip()]
 
 
 def _check_sudo_stdin_guard(command: str) -> tuple:
@@ -265,9 +414,19 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     """
     if "SUDO_PASSWORD" in os.environ:
         return (False, None)
-    normalized = _normalize_command_for_detection(command).lower()
+    normalized_preserving_case = _normalize_command_for_detection(command)
+    normalized = normalized_preserving_case.lower()
     if _SUDO_STDIN_RE.search(normalized):
         return (True, "sudo password guessing via stdin (sudo -S)")
+    for payload in (
+        _shell_c_payloads_from_command(normalized_preserving_case)
+        + _extract_static_shell_stdin_payloads(normalized_preserving_case)
+        + _eval_payloads_from_command(normalized_preserving_case)
+        + _env_split_string_payloads_from_command(normalized_preserving_case)
+    ):
+        is_blocked, desc = _check_sudo_stdin_guard(payload)
+        if is_blocked:
+            return (True, desc)
     return (False, None)
 
 
@@ -277,11 +436,61 @@ def detect_hardline_command(command: str) -> tuple:
     Returns:
         (is_hardline, description) or (False, None)
     """
-    normalized = _normalize_command_for_detection(command).lower()
+    normalized = _normalize_command_for_detection(command)
+    normalized_lower = normalized.lower()
     for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
-        if pattern_re.search(normalized):
+        if pattern_re.search(normalized_lower):
             return (True, description)
+    structural = _detect_hardline_structural(normalized)
+    if structural:
+        return (True, structural)
     return (False, None)
+
+
+
+
+def _detect_hardline_structural(normalized: str) -> Optional[str]:
+    """Detect hardline commands after simple wrapper/shell unwrapping.
+
+    Regexes above intentionally stay fast and broad; this structural pass closes
+    bypasses such as ``env -i reboot``, ``command reboot``, ``time -p reboot``,
+    and ``bash -c 'reboot'`` without trying to execute or expand the command.
+    """
+    shutdown_verbs = {"reboot", "shutdown", "halt", "poweroff", "kexec"}
+    for payload in _extract_static_shell_stdin_payloads(normalized) + _eval_payloads_from_command(normalized):
+        nested = _detect_hardline_structural(_normalize_command_for_detection(payload))
+        if nested:
+            return nested
+    for segment in _split_command_segments(normalized):
+        words = _shlex_words(segment)
+        if not words:
+            continue
+        for idx in _command_word_indices(words):
+            cmd_word = _command_basename(words[idx]).lower()
+            if cmd_word in shutdown_verbs:
+                return f"{cmd_word} command"
+            if cmd_word == "rm":
+                args = words[idx + 1:]
+                has_recursive = any(w.startswith("-") and "r" in w for w in args)
+                if has_recursive:
+                    for arg in args:
+                        if arg.startswith("-"):
+                            continue
+                        expanded = _expand_protected_path_token(arg).lower()
+                        if expanded in {"~", os.path.expanduser("~").lower()}:
+                            return "recursive delete of home directory"
+            if cmd_word in {"bash", "sh", "zsh", "ksh", "dash"}:
+                payload = _shell_c_payload_from_words(words, idx)
+                if payload:
+                    nested = _detect_hardline_structural(_normalize_command_for_detection(payload))
+                    if nested:
+                        return nested
+            if cmd_word == "env":
+                for payload in _env_split_string_payloads(words, idx):
+                    nested = _detect_hardline_structural(_normalize_command_for_detection(payload))
+                    if nested:
+                        return nested
+    return None
 
 
 def _hardline_block_result(description: str) -> dict:
@@ -315,9 +524,1123 @@ def _sudo_stdin_block_result(description: str) -> dict:
 
 
 # =========================================================================
+# Protected Hermes config guard — unbypassable direct-write block
+# =========================================================================
+# The supported mutation path for Hermes configuration is `hermes config set`.
+# Direct shell writes to ~/.hermes/.env or ~/.hermes/config.yaml are blocked
+# below yolo/approvals.mode=off so rules cannot be bypassed by a convenience
+# mode. This guard does not inspect or log secret values; it only detects the
+# command shape and protected path names.
+
+def _protected_hermes_path_pattern() -> str:
+    """Return a regex matching active/default Hermes .env and config.yaml paths."""
+    symbolic_roots = [
+        r'~\/\.hermes',
+        r'\$home\/\.hermes',
+        r'\$\{home\}\/\.hermes',
+        r'\$hermes_home',
+        r'\$\{hermes_home\}',
+    ]
+
+    literal_roots = {os.path.expanduser("~/.hermes")}
+    active_home = os.getenv("HERMES_HOME")
+    if active_home:
+        literal_roots.add(os.path.expanduser(active_home))
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        literal_roots.add(str(get_default_hermes_root()))
+    except Exception:
+        pass
+
+    literal_paths = []
+    for root in literal_roots:
+        root = os.path.realpath(root).lower()
+        literal_paths.extend([
+            re.escape(os.path.join(root, ".env")),
+            re.escape(os.path.join(root, "config.yaml")),
+        ])
+
+    symbolic = rf'(?:{"|".join(symbolic_roots)})\/(?:\.env|config\.yaml)'
+    literal = rf'(?:{"|".join(sorted(set(literal_paths)))})' if literal_paths else r'(?!)'
+    return rf'(?:{symbolic}|{literal})(?=$|[\s"\'`,;&|<>)])'
+
+
+def _normalize_protected_config_command(command: str) -> str:
+    """Normalize shell path variants before protected config matching."""
+    normalized = _normalize_command_for_detection(command).lower()
+    normalized = normalized.replace('"', "").replace("'", "")
+    # Shell backslashes can escape ordinary path characters
+    # (``~/\.hermes/con\fig.yaml`` resolves to ``~/.hermes/config.yaml``).
+    normalized = re.sub(r"\\([^\s])", r"\1", normalized)
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    while "/./" in normalized:
+        normalized = normalized.replace("/./", "/")
+    while re.search(r"/[^/\s;&|<>]+/\.\./", normalized):
+        normalized = re.sub(r"/[^/\s;&|<>]+/\.\./", "/", normalized)
+    return normalized
+
+
+def _protected_config_resolved_paths() -> set[str]:
+    """Return resolved protected Hermes config/env paths for path-token checks."""
+    roots = {os.path.expanduser("~/.hermes")}
+    active_home = os.getenv("HERMES_HOME")
+    if active_home:
+        roots.add(os.path.expanduser(active_home))
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        roots.add(str(get_default_hermes_root()))
+    except Exception:
+        pass
+    protected = set()
+    for root in roots:
+        root = os.path.realpath(root)
+        protected.add(os.path.realpath(os.path.join(root, ".env")).lower())
+        protected.add(os.path.realpath(os.path.join(root, "config.yaml")).lower())
+    return protected
+
+
+def _expand_protected_path_token(token: str) -> str:
+    """Expand shell-ish path tokens enough for protected-path comparison."""
+    token = (token or "").strip().strip("() ").strip('"\'')
+    # Bash ANSI-C quoted path fragments: ~/.hermes/$'config.yaml'
+    token = re.sub(r"\$'([^']*)'", r"\1", token)
+    token = token.replace("/$config.yaml", "/config.yaml").replace("/$.env", "/.env")
+    # Deterministic brace expansion used in write targets such as
+    # ``~/.hermes/{config.yaml}``.  Leave multi-value/glob braces unresolved
+    # so they fail closed through the wildcard guard below rather than being
+    # mistaken for a literal safe path.
+    token = re.sub(r"\{(config\.yaml|\.env)\}", r"\1", token, flags=re.IGNORECASE)
+    token = re.sub(r"\\([^\s])", r"\1", token)
+    home = os.path.expanduser("~")
+    hermes_home = os.path.expanduser(os.getenv("HERMES_HOME") or "~/.hermes")
+    replacements = (
+        (r"\$\{home\}|\$home", home),
+        (r"\$\{hermes_home\}|\$hermes_home", hermes_home),
+    )
+    for pattern, new in replacements:
+        token = re.sub(pattern, new, token, flags=re.IGNORECASE)
+    return os.path.expanduser(token)
+
+
+def _expand_known_shell_vars(token: str, shell_vars: dict[str, str]) -> str:
+    """Expand simple shell variables assigned earlier in the same command."""
+    if not shell_vars:
+        return token
+
+    def replace_braced(match: re.Match) -> str:
+        return shell_vars.get((match.group(1) or "").lower(), match.group(0) or "")
+
+    def replace_plain(match: re.Match) -> str:
+        return shell_vars.get((match.group(1) or "").lower(), match.group(0) or "")
+
+    token = re.sub(r"\$\{([A-Za-z_]\w*)\}", replace_braced, token)
+    token = re.sub(r"\$([A-Za-z_]\w*)", replace_plain, token)
+    return token
+
+
+def _resolve_protected_path_token(token: str, cwd: Optional[str] = None) -> Optional[str]:
+    """Resolve a candidate shell path token without reading the path."""
+    token = _expand_protected_path_token(token)
+    if not token or any(ch in token for ch in "*?[]{}"):
+        return None
+    if not os.path.isabs(token):
+        if not cwd:
+            return None
+        token = os.path.join(cwd, token)
+    return os.path.realpath(token).lower()
+
+
+def _token_glob_matches_protected_path(token: str, cwd: Optional[str]) -> bool:
+    """Return True when a shell glob token can match a protected config path."""
+    expanded = _expand_protected_path_token(token)
+    if not expanded or not any(ch in expanded for ch in "*?[]"):
+        return False
+    if "{" in expanded or "}" in expanded:
+        return False
+    if not os.path.isabs(expanded):
+        if not cwd:
+            return False
+        expanded = os.path.join(cwd, expanded)
+    pattern = os.path.realpath(expanded).lower()
+    return any(fnmatch.fnmatch(path, pattern) for path in _protected_config_resolved_paths())
+
+
+def _infer_cd_cwd(normalized_command: str) -> Optional[str]:
+    """Infer obvious shell cwd changes before relative write checks.
+
+    This intentionally covers only simple, deterministic forms; it is a
+    pre-exec guard, not a full shell interpreter.  Supported separators include
+    `&&`, `;`, and the common defensive `cd PATH || exit; ...` shape.
+    """
+    cwd = None
+    cd_pattern = r"(?:^|[;&|]\s*)cd\s+(?:--\s+)?([^\s;&|]+)\s*(?=&&|;|\|\|\s*exit\s*;)"
+    for match in re.finditer(cd_pattern, normalized_command):
+        cwd = _resolve_protected_path_token(match.group(1))
+    return cwd
+
+
+def _split_command_segments(normalized_command: str) -> list[str]:
+    """Split shell command separators while preserving quoted literals."""
+    segments = []
+    buf: list[str] = []
+    quote: str | None = None
+    escaped = False
+    i = 0
+    while i < len(normalized_command):
+        ch = normalized_command[i]
+        if escaped:
+            buf.append(ch)
+            escaped = False
+            i += 1
+            continue
+        if ch == "\\" and quote != "'":
+            buf.append(ch)
+            escaped = True
+            i += 1
+            continue
+        if quote:
+            buf.append(ch)
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in {'"', "'"}:
+            quote = ch
+            buf.append(ch)
+            i += 1
+            continue
+        if normalized_command.startswith(("&&", "||"), i):
+            cleaned = "".join(buf).strip()
+            if cleaned:
+                segments.append(cleaned)
+            buf = []
+            i += 2
+            continue
+        if ch == ";" or (ch == "|" and (i == 0 or normalized_command[i - 1] != ">")):
+            cleaned = "".join(buf).strip()
+            if cleaned:
+                segments.append(cleaned)
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    cleaned = "".join(buf).strip()
+    if cleaned:
+        segments.append(cleaned)
+    return segments
+
+
+def _shlex_words(segment: str) -> list[str]:
+    try:
+        return shlex.split(segment)
+    except ValueError:
+        return segment.split()
+
+
+def _command_basename(word: str) -> str:
+    """Normalize a shell command word for guard verb comparisons."""
+    return os.path.basename((word or "").lstrip("({"))
+
+
+def _is_inline_script_interpreter(cmd_word: str) -> bool:
+    """Return True for interpreter command names that support inline code."""
+    cmd_word = _command_basename(cmd_word).lower()
+    return bool(
+        re.fullmatch(r"python(?:\d+(?:\.\d+)?)?", cmd_word)
+        or re.fullmatch(r"perl(?:\d+(?:\.\d+)?)?", cmd_word)
+        or re.fullmatch(r"ruby(?:\d+(?:\.\d+)?)?", cmd_word)
+        or re.fullmatch(r"node(?:js)?(?:\d+(?:\.\d+)?)?", cmd_word)
+    )
+
+
+def _is_shell_assignment(word: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z_]\w*=.*", word or ""))
+
+
+def _command_word_indices(words: list[str]) -> list[int]:
+    """Return word indexes that are actual command positions in a simple segment."""
+    indices: list[int] = []
+    idx = 0
+    while idx < len(words) and _is_shell_assignment(words[idx]):
+        idx += 1
+    while idx < len(words):
+        if idx not in indices:
+            indices.append(idx)
+        cmd_word = _command_basename(words[idx]).lower()
+        if cmd_word == "env":
+            j = idx + 1
+            while j < len(words):
+                word = words[j]
+                if word == "--":
+                    j += 1
+                    break
+                if _is_shell_assignment(word):
+                    j += 1
+                    continue
+                # Upstream `.lower()` collapses env's short flags (-S -> -s,
+                # -C -> -c). env defines no lowercase -s/-c of its own, so
+                # matching value-taking flags case-insensitively keeps the
+                # split-string / chdir argument from being mistaken for the
+                # wrapped command word.
+                lower = word.lower()
+                if lower in {"-i", "-0", "--ignore-environment", "--null"}:
+                    j += 1
+                    continue
+                if lower in {"-u", "--unset", "-c", "--chdir", "-s", "--split-string"} and j + 1 < len(words):
+                    j += 2
+                    continue
+                if any(lower.startswith(prefix) for prefix in ("--unset=", "--chdir=", "--split-string=")):
+                    j += 1
+                    continue
+                if word.startswith("-"):
+                    j += 1
+                    continue
+                break
+            if j < len(words):
+                idx = j
+                continue
+        if cmd_word == "sudo":
+            j = idx + 1
+            value_options = {"-u", "--user", "-g", "--group", "-h", "--host", "-p", "--prompt", "-C", "--close-from", "-T", "--command-timeout"}
+            while j < len(words):
+                word = words[j]
+                if word == "--":
+                    j += 1
+                    break
+                if word in value_options and j + 1 < len(words):
+                    j += 2
+                    continue
+                if any(word.startswith(opt + "=") for opt in value_options if opt.startswith("--")):
+                    j += 1
+                    continue
+                if word.startswith("-"):
+                    j += 1
+                    continue
+                break
+            if j < len(words):
+                idx = j
+                continue
+        if cmd_word == "time":
+            j = idx + 1
+            while j < len(words) and words[j].startswith("-"):
+                j += 1
+            if j < len(words):
+                idx = j
+                continue
+        if cmd_word == "nice":
+            j = idx + 1
+            while j < len(words):
+                word = words[j]
+                if word in {"-n", "--adjustment"} and j + 1 < len(words):
+                    j += 2
+                    continue
+                if word.startswith("--adjustment=") or re.fullmatch(r"-\d+", word):
+                    j += 1
+                    continue
+                if word.startswith("-") and word != "-":
+                    j += 1
+                    continue
+                break
+            if j < len(words):
+                idx = j
+                continue
+        if cmd_word == "stdbuf":
+            j = idx + 1
+            while j < len(words):
+                word = words[j]
+                if word in {"-i", "-o", "-e"} and j + 1 < len(words):
+                    j += 2
+                    continue
+                if re.fullmatch(r"-[ioe].+", word) or any(word.startswith(prefix) for prefix in ("--input=", "--output=", "--error=")):
+                    j += 1
+                    continue
+                if word.startswith("-") and word != "-":
+                    j += 1
+                    continue
+                break
+            if j < len(words):
+                idx = j
+                continue
+        if cmd_word in {"command", "builtin", "exec", "nohup", "setsid"} and idx + 1 < len(words):
+            idx += 1
+            continue
+        break
+    return indices
+
+
+def _redirection_targets_from_words(words: list[str]) -> list[str]:
+    """Return shell redirection targets from shlex words without scanning quotes."""
+    targets: list[str] = []
+    redirect_ops = {">", ">>", ">|", "&>", "&>>"}
+    for idx, word in enumerate(words):
+        if word in redirect_ops or re.fullmatch(r"\d*(?:>>?|>\|)", word):
+            if idx + 1 < len(words):
+                targets.append(words[idx + 1])
+            continue
+        match = re.fullmatch(r"(?:\d*(?:>>?|>\|)|&>>?)(.+)", word)
+        if match:
+            targets.append(match.group(1))
+    return targets
+
+
+def _dd_of_targets_from_words(words: list[str]) -> list[str]:
+    """Return dd(1) output-file targets from shlex words."""
+    return [word.split("=", 1)[1] for word in words if word.startswith("of=") and len(word) > 3]
+
+
+def _token_is_protected_path(token: str, cwd: Optional[str]) -> bool:
+    resolved = _resolve_protected_path_token(token, cwd)
+    return bool((resolved and resolved in _protected_config_resolved_paths()) or _token_glob_matches_protected_path(token, cwd))
+
+
+def _token_or_alias_is_protected_path(token: str, cwd: Optional[str], aliases: set[str]) -> bool:
+    resolved = _resolve_protected_path_token(token, cwd)
+    return bool(
+        (resolved and (resolved in aliases or resolved in _protected_config_resolved_paths()))
+        or _token_glob_matches_protected_path(token, cwd)
+    )
+
+
+def _protected_config_root_paths() -> set[str]:
+    roots = {os.path.expanduser("~/.hermes")}
+    active_home = os.getenv("HERMES_HOME")
+    if active_home:
+        roots.add(os.path.expanduser(active_home))
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        roots.add(str(get_default_hermes_root()))
+    except Exception:
+        pass
+    return {os.path.realpath(root).lower() for root in roots}
+
+
+def _token_is_protected_config_root(token: str, cwd: Optional[str]) -> bool:
+    resolved = _resolve_protected_path_token(token, cwd)
+    return bool(resolved and resolved in _protected_config_root_paths())
+
+
+def _source_basename_is_protected_config(token: str) -> bool:
+    return os.path.basename((token or "").strip().strip("{}() ").strip('"\'')).lower() in {"config.yaml", ".env"}
+
+
+def _copy_like_operands(args: list[str]) -> tuple[list[str], Optional[str]]:
+    operands: list[str] = []
+    target_dir: Optional[str] = None
+    options_with_values = {
+        "-t", "--target-directory", "-m", "--mode", "-o", "--owner", "-g", "--group",
+        "-e", "--rsh", "--exclude", "--include", "--filter",
+    }
+    short_options_with_values = {"t", "m", "o", "g", "e"}
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg.startswith("--target-directory="):
+            target_dir = arg.split("=", 1)[1]
+            i += 1
+            continue
+        if arg.startswith("--") and "=" in arg:
+            i += 1
+            continue
+        if arg.startswith("-t") and len(arg) > 2:
+            target_dir = arg[2:]
+            i += 1
+            continue
+        if arg in {"-t", "--target-directory"} and i + 1 < len(args):
+            target_dir = args[i + 1]
+            i += 2
+            continue
+        if arg.startswith("-") and not arg.startswith("--") and len(arg) > 2:
+            consumed_next = False
+            cluster = arg[1:]
+            for pos, opt in enumerate(cluster):
+                if opt not in short_options_with_values:
+                    continue
+                value = cluster[pos + 1:]
+                if opt == "t":
+                    if value:
+                        target_dir = value
+                    elif i + 1 < len(args):
+                        target_dir = args[i + 1]
+                        consumed_next = True
+                elif not value and i + 1 < len(args):
+                    consumed_next = True
+                break
+            i += 2 if consumed_next else 1
+            continue
+        if arg in options_with_values and i + 1 < len(args):
+            i += 2
+            continue
+        if arg.startswith("-"):
+            i += 1
+            continue
+        operands.append(arg)
+        i += 1
+    return operands, target_dir
+
+
+def _copy_like_hits_protected_path(args: list[str], cwd: Optional[str], aliases: set[str] | None = None) -> bool:
+    aliases = aliases or set()
+    operands, target_dir = _copy_like_operands(args)
+    if target_dir:
+        return _token_is_protected_config_root(target_dir, cwd) and any(_source_basename_is_protected_config(src) for src in operands)
+    if not operands:
+        return False
+    dest = operands[-1]
+    sources = operands[:-1]
+    if _token_or_alias_is_protected_path(dest, cwd, aliases):
+        return True
+    return _token_is_protected_config_root(dest, cwd) and any(_source_basename_is_protected_config(src) for src in sources)
+
+
+def _shell_c_payload_from_words(words: list[str], start: int) -> Optional[str]:
+    """Return the payload passed to a shell ``-c`` option, if present."""
+    idx = start + 1
+    value_options = {"-o", "+o", "-O", "+O", "--rcfile", "--init-file"}
+    while idx < len(words):
+        word = words[idx]
+        if word in {"--"}:
+            return None
+        if word in value_options and idx + 1 < len(words):
+            idx += 2
+            continue
+        if word == "-c" and idx + 1 < len(words):
+            if words[idx + 1] == "--" and idx + 2 < len(words):
+                return words[idx + 2]
+            return words[idx + 1]
+        if any(word.startswith(prefix + "=") for prefix in value_options if prefix.startswith("--")):
+            idx += 1
+            continue
+        if word.startswith(("-", "+")) and not word.startswith(("--", "++")) and len(word) > 1:
+            consumed_next = False
+            cluster = word[1:]
+            for pos, opt in enumerate(cluster):
+                rest = cluster[pos + 1:]
+                if word[0] == "-" and opt == "c":
+                    if rest:
+                        return rest
+                    if idx + 1 < len(words) and words[idx + 1] == "--" and idx + 2 < len(words):
+                        return words[idx + 2]
+                    return words[idx + 1] if idx + 1 < len(words) else None
+                if opt in {"o", "O"}:
+                    if not rest and idx + 1 < len(words):
+                        consumed_next = True
+                    break
+            idx += 2 if consumed_next else 1
+            continue
+        if not word.startswith("-"):
+            return None
+        idx += 1
+    return None
+
+
+def _nested_shell_c_payloads_after_command(words: list[str], start: int) -> list[str]:
+    """Return shell ``-c`` payloads nested under xargs / find -exec invocations.
+
+    ``xargs -I{} sh -c '<payload>'`` and ``find ... -exec sh -c '<payload>' \\;``
+    run a fresh shell whose ``-c`` argument is opaque to the outer-command
+    guards (xargs/find are not command positions a shell payload is parsed
+    from). Pull those payloads out so the protected-config / write checks can
+    recurse into them. Read-only nested commands (no shell ``-c`` argument, or
+    no write primitive inside it) yield nothing and stay allowed — quoted
+    literals and read-only operands do not match.
+    """
+    payloads: list[str] = []
+    j = start + 1
+    while j < len(words):
+        if _command_basename(words[j]).lower() in {"bash", "sh", "zsh", "ksh", "dash"}:
+            payload = _shell_c_payload_from_words(words, j)
+            if payload:
+                payloads.append(payload)
+        j += 1
+    return payloads
+
+
+def _env_split_string_payloads(words: list[str], start: int) -> list[str]:
+    """Return `/usr/bin/env -S/--split-string` payloads for recursive inspection.
+
+    Callers should pass tokens with their original option spelling. The matcher
+    also accepts lowercase ``-s`` for older guard paths that normalized before
+    tokenizing; ``env`` has no lowercase ``-s`` split-string alternative in real
+    execution, so this is conservative only for static detection.
+    """
+    payloads: list[str] = []
+    idx = start + 1
+    while idx < len(words):
+        word = words[idx]
+        lower = word.lower()
+        if lower in {"-s", "--split-string"} and idx + 1 < len(words):
+            payloads.append(words[idx + 1])
+            idx += 2
+            continue
+        if lower.startswith("--split-string="):
+            payloads.append(word.split("=", 1)[1])
+            idx += 1
+            continue
+        if word == "--":
+            break
+        idx += 1
+    return payloads
+
+
+def _inline_payload_and_argv_from_words(words: list[str], start: int) -> tuple[Optional[str], list[str]]:
+    """Return inline code passed to interpreter -c/-e plus post-payload argv."""
+    idx = start + 1
+    while idx < len(words):
+        word = words[idx]
+        if word in {"-c", "-e"} and idx + 1 < len(words):
+            return words[idx + 1], words[idx + 2:]
+        if word.startswith(("-c", "-e")) and len(word) > 2:
+            return word[2:], words[idx + 1:]
+        idx += 1
+    return None, []
+
+
+def _inline_payload_from_words(words: list[str], start: int) -> Optional[str]:
+    """Return inline code passed to interpreter -c/-e, if present."""
+    payload, _argv = _inline_payload_and_argv_from_words(words, start)
+    return payload
+
+
+def _inline_payload_argv_writes_protected_path(payload: str, argv: list[str], cwd: Optional[str]) -> bool:
+    """Detect inline code writing to a protected path supplied as argv.
+
+    Read-only argv references such as ``python -c 'print(1)' ~/.hermes/config.yaml``
+    must remain allowed, but write primitives targeting ``sys.argv`` /
+    ``process.argv`` / ``ARGV`` are direct writes to the post-payload operand.
+    """
+    if not argv:
+        return False
+    normalized = payload.lower()
+    has_argv_reference = bool(re.search(r"\b(?:sys\.argv|process\.argv|argv)\b", normalized))
+    if not has_argv_reference:
+        return False
+    # Conservative: once inline code contains a write primitive and references
+    # argv, any protected argv operand is considered a protected write target.
+    for candidate in argv:
+        if _token_is_protected_path(candidate, cwd):
+            return True
+    return False
+
+
+def _inline_script_nested_payloads(payload: str) -> list[str]:
+    """Return literal code/shell strings nested inside inline-language payloads.
+
+    This catches guarded REPL/stdin cases such as ``os.system('echo x >
+    ~/.hermes/config.yaml')`` or ``eval("open(..., 'w')")``.  It is a
+    deliberately small static extractor: only literal quoted first arguments
+    are recursed into, so read-only mentions remain allowed while obvious
+    self-executing payloads cannot hide protected writes.
+    """
+    nested: list[str] = []
+    call_patterns = [
+        r"\b(?:os\.)?system\s*\(\s*(['\"])(?P<system>.*?)(?<!\\)(?:\1)",
+        r"\b(?:subprocess\s*\.\s*)?(?:run|call|check_call|check_output|popen|Popen)\s*\(\s*(['\"])(?P<subprocess>.*?)(?<!\\)(?:\1)",
+        r"\b(?:subprocess\s*\.\s*)?(?:run|call|check_call|check_output|popen|Popen)\s*\(\s*\[\s*['\"][^'\"]*(?:sh|bash|zsh|dash|ksh)['\"]\s*,\s*['\"]-[lc]+['\"]\s*,\s*(['\"])(?P<subprocess_shell_list>.*?)(?<!\\)(?:\1)",
+        r"\b(?:subprocess\s*\.\s*)?(?:run|call|check_call|check_output|popen|Popen)\s*\([^)]*\bargs\s*=\s*(['\"])(?P<subprocess_args>.*?)(?<!\\)(?:\1)[^)]*\bshell\s*=\s*True\b",
+        r"\b(?:subprocess\s*\.\s*)?(?:run|call|check_call|check_output|popen|Popen)\s*\([^)]*\bshell\s*=\s*True\b[^)]*\bargs\s*=\s*(['\"])(?P<subprocess_args_after_shell>.*?)(?<!\\)(?:\1)",
+        r"\b(?:eval|exec)\s*\(\s*(['\"])(?P<eval>.*?)(?<!\\)(?:\1)",
+        r"\b__import__\s*\(\s*(['\"])os(?:\1)\s*\)\s*\.\s*system\s*\(\s*(['\"])(?P<import_os>.*?)(?<!\\)(?:\2)",
+    ]
+    for pattern in call_patterns:
+        for match in re.finditer(pattern, payload, _RE_FLAGS):
+            for value in match.groupdict().values():
+                if value:
+                    nested.append(value)
+                    break
+    return nested
+
+
+def _inline_script_payload_writes_protected_path(payload: Optional[str], cwd: Optional[str],
+                                                 argv: Optional[list[str]] = None,
+                                                 _depth: int = 0) -> bool:
+    """Detect protected writes inside inline Python/Node/Ruby/Perl payloads."""
+    if not payload:
+        return False
+    normalized = payload.lower()
+    if _script_write_target_hits_protected_path(normalized, cwd):
+        return True
+    if _depth < 3:
+        for nested_payload in _inline_script_nested_payloads(payload):
+            nested_normalized = nested_payload.lower()
+            if (
+                _write_target_hits_protected_path_preserving_quotes(nested_payload, cwd)
+                or _relative_write_target_hits_protected_path(nested_normalized, cwd)
+                or _inline_script_payload_writes_protected_path(nested_payload, cwd, _depth=_depth + 1)
+            ):
+                return True
+    has_write_primitive = bool(re.search(
+        r"\b(?:open|write_text|write_bytes|writefilesync|appendfilesync|createwritestream|file\.write|file\.open)\b",
+        normalized,
+        _RE_FLAGS,
+    ))
+    if not has_write_primitive:
+        return False
+    if argv and _inline_payload_argv_writes_protected_path(payload, argv, cwd):
+        return True
+    for quoted in re.findall(r"['\"]([^'\"]+)['\"]", payload):
+        if _token_is_protected_path(quoted, cwd):
+            return True
+    path_pat = _protected_hermes_path_pattern()
+    return bool(re.search(path_pat, _normalize_protected_config_command(payload), _RE_FLAGS))
+
+
+def _strip_shell_quoted_content(command: str) -> str:
+    """Remove quoted literal contents before broad fallback regex checks."""
+    out: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for ch in command:
+        if escaped:
+            if quote is None:
+                out.append(ch)
+            escaped = False
+            continue
+        if ch == "\\" and quote != "'":
+            if quote is None:
+                out.append(ch)
+            escaped = True
+            continue
+        if quote:
+            if ch == quote:
+                quote = None
+                out.append(ch)
+            else:
+                out.append(" ")
+            continue
+        if ch in {'"', "'"}:
+            quote = ch
+            out.append(ch)
+            continue
+        out.append(ch)
+    return "".join(out)
+
+
+def _write_target_hits_protected_path_preserving_quotes(command: str, cwd: Optional[str]) -> bool:
+    """Detect write targets while preserving quoted path tokens with spaces."""
+    raw = _normalize_command_for_detection(command).lower()
+    # Bash ANSI-C quoted fragments can appear in paths before shlex sees them:
+    # ~/.hermes/$'config.yaml' -> ~/.hermes/config.yaml
+    raw = re.sub(r"\$'([^']*)'", r"\1", raw)
+    raw = re.sub(r"\\([^\s])", r"\1", raw)
+    for payload in _extract_static_shell_stdin_payloads(raw) + _eval_payloads_from_command(raw):
+        if (
+            _inline_script_payload_writes_protected_path(payload, cwd)
+            or _write_target_hits_protected_path_preserving_quotes(payload, cwd)
+            or _relative_write_target_hits_protected_path(payload.lower(), cwd)
+        ):
+            return True
+    for segment in _split_command_segments(raw):
+        words = _shlex_words(segment)
+        if not words:
+            continue
+        for target in _redirection_targets_from_words(words):
+            if _token_is_protected_path(target, cwd):
+                return True
+        for idx in _command_word_indices(words):
+            word = words[idx]
+            cmd_word = _command_basename(word)
+            if cmd_word == "env":
+                for payload in _env_split_string_payloads(words, idx):
+                    if (
+                        _write_target_hits_protected_path_preserving_quotes(payload, cwd)
+                        or _relative_write_target_hits_protected_path(payload.lower(), cwd)
+                    ):
+                        return True
+            if cmd_word in {"xargs", "find"}:
+                for payload in _nested_shell_c_payloads_after_command(words, idx):
+                    if (
+                        _write_target_hits_protected_path_preserving_quotes(payload, cwd)
+                        or _relative_write_target_hits_protected_path(payload.lower(), cwd)
+                    ):
+                        return True
+            if _is_inline_script_interpreter(cmd_word):
+                payload, argv = _inline_payload_and_argv_from_words(words, idx)
+                if _inline_script_payload_writes_protected_path(payload, cwd, argv):
+                    return True
+            if cmd_word == "dd":
+                for target in _dd_of_targets_from_words(words[idx + 1:]):
+                    if _token_is_protected_path(target, cwd):
+                        return True
+            if cmd_word == "tee":
+                for candidate in [w for w in words[idx + 1:] if not w.startswith("-")]:
+                    if _token_is_protected_path(candidate, cwd):
+                        return True
+            if cmd_word in {"sed", "perl", "ruby"}:
+                has_in_place = any(w == "--in-place" or (w.startswith("-") and "i" in w) for w in words[idx + 1:])
+                if has_in_place:
+                    for candidate in [w for w in words[idx + 1:] if not w.startswith("-")]:
+                        if _token_is_protected_path(candidate, cwd):
+                            return True
+            if cmd_word in {"rm", "unlink", "truncate", "touch", "nano", "vim", "vi", "nvim", "emacs", "code"}:
+                for candidate in [w for w in words[idx + 1:] if not w.startswith("-")]:
+                    if _token_is_protected_path(candidate, cwd):
+                        return True
+            if cmd_word == "mv":
+                args = words[idx + 1:]
+                for candidate in [w for w in args if not w.startswith("-")]:
+                    if _token_is_protected_path(candidate, cwd):
+                        return True
+                if _copy_like_hits_protected_path(args, cwd):
+                    return True
+            if cmd_word in {"cp", "install", "ln", "rsync"}:
+                args = words[idx + 1:]
+                candidates = [w for w in args if not w.startswith("-")]
+                if candidates and _token_is_protected_path(candidates[-1], cwd):
+                    return True
+                # ln SOURCE... DIR/ with DIR == protected config root and a
+                # source basename of config.yaml/.env overwrites the protected
+                # file via the link created inside DIR (absolute-dest form of
+                # `ln -sf /tmp/config.yaml ~/.hermes/`).
+                if (
+                    cmd_word == "ln"
+                    and len(candidates) >= 2
+                    and _token_is_protected_config_root(candidates[-1], cwd)
+                    and any(_source_basename_is_protected_config(src) for src in candidates[:-1])
+                ):
+                    return True
+                if cmd_word in {"cp", "install", "rsync"} and _copy_like_hits_protected_path(args, cwd):
+                    return True
+            if cmd_word in {"bash", "sh", "zsh", "ksh", "dash"}:
+                payload = _shell_c_payload_from_words(words, idx)
+                if payload and (
+                    _write_target_hits_protected_path_preserving_quotes(payload, cwd)
+                    or _relative_write_target_hits_protected_path(payload.lower(), cwd)
+                ):
+                    return True
+    return False
+
+
+def _script_write_target_hits_protected_path(normalized: str, cwd: Optional[str]) -> bool:
+    """Detect simple inline-language writes to protected paths.
+
+    The command has already had shell quotes removed by
+    `_normalize_protected_config_command`, so match conservative token shapes
+    such as `open(config.yaml,w)` and `Path(config.yaml).write_text(...)`.
+    """
+    script_write_patterns = [
+        r"\bopen\(\s*([^,\s)]+)\s*,\s*['\"]?[r]?['\"]?\s*['\"]?[wxa+]",
+        r"\bpath\(\s*([^,\s)]+)\s*\)\s*\.\s*(?:write_text|write_bytes)",
+        r"\b(?:writefilesync|appendfilesync|createwritestream)\(\s*([^,\s)]+)",
+        r"\bfile\s*\.\s*write\(\s*([^,\s)]+)",
+        r"\bfile\s*\.\s*open\(\s*([^,\s)]+)\s*,\s*['\"]?[wa]",
+        r"\bopen\(\s*[^,]+,\s*['\"]?>{1,2}['\"]?\s*,\s*([^,\s)]+)",
+    ]
+    for pattern in script_write_patterns:
+        for target in re.findall(pattern, normalized, _RE_FLAGS):
+            if _token_is_protected_path(target, cwd):
+                return True
+    return False
+
+
+def _cd_target_from_words(words: list[str]) -> Optional[str]:
+    """Return the path argument from a simple ``cd`` command segment."""
+    if not words:
+        return None
+    command_word = words[0].lstrip("({")
+    args = words[1:]
+    if command_word != "cd" and words[0] in {"{", "("} and len(words) > 1:
+        command_word = words[1]
+        args = words[2:]
+    if command_word != "cd":
+        return None
+    if args and args[0] == "--":
+        args = args[1:]
+    return args[0] if args else "~"
+
+
+def _record_script_protected_vars(segment: str, cwd: Optional[str], vars_: set[str]) -> None:
+    """Remember simple script variables assigned to protected relative paths."""
+    for name, value in re.findall(r"\b([a-z_]\w*)\s*=\s*([^,;\s)]+)", segment, _RE_FLAGS):
+        if _token_is_protected_path(value, cwd):
+            vars_.add(name.lower())
+    for name, value in re.findall(r"\b([a-z_]\w*)\s*=\s*path\(\s*([^,\s)]+)\s*\)", segment, _RE_FLAGS):
+        if _token_is_protected_path(value, cwd):
+            vars_.add(name.lower())
+
+
+def _script_write_uses_protected_var(segment: str, vars_: set[str]) -> bool:
+    """Detect simple script writes whose target is a known protected variable."""
+    if not vars_:
+        return False
+    script_write_patterns = [
+        r"\bopen\(\s*([^,\s)]+)\s*,\s*['\"]?[r]?['\"]?\s*['\"]?[wxa+]",
+        r"\bpath\(\s*([^,\s)]+)\s*\)\s*\.\s*(?:write_text|write_bytes)",
+        r"\b([a-z_]\w*)\s*\.\s*(?:write_text|write_bytes)\s*\(",
+        r"\b(?:writefilesync|appendfilesync|createwritestream)\(\s*([a-z_]\w*)",
+        r"\bfile\s*\.\s*(?:write|open)\(\s*([a-z_]\w*)",
+        r"\bopen\(\s*[^,]+,\s*['\"]?>{1,2}['\"]?\s*,\s*([a-z_]\w*)",
+    ]
+    for pattern in script_write_patterns:
+        for target in re.findall(pattern, segment, _RE_FLAGS):
+            if target.lower() in vars_:
+                return True
+    return False
+
+
+def _relative_write_target_hits_protected_path(normalized: str, cwd: Optional[str]) -> bool:
+    """Resolve write-target tokens relative to shell cwd and compare protected paths.
+
+    This is intentionally a small pre-exec shell model, not a full interpreter:
+    it walks simple command segments left-to-right, carrying forward obvious
+    ``cd`` state so a later harmless ``cd`` cannot hide an earlier relative
+    write to ``config.yaml``/``.env`` under Hermes home.  Subshell ``cd`` state
+    is scoped to the parenthesized command and does not leak back to the parent.
+    """
+    current_cwd = cwd
+    subshell_cwd: Optional[str] = None
+    in_subshell = False
+    script_cwd = None
+    script_protected_vars: set[str] = set()
+    protected_aliases: set[str] = set()
+    shell_vars: dict[str, str] = {}
+    for segment in _split_command_segments(normalized):
+        stripped_segment = segment.strip()
+        starts_subshell = stripped_segment.startswith("(")
+        ends_subshell = stripped_segment.endswith(")")
+        if starts_subshell:
+            in_subshell = True
+            subshell_cwd = current_cwd
+            script_cwd = None
+            script_protected_vars.clear()
+        active_cwd = subshell_cwd if in_subshell else current_cwd
+        words = _shlex_words(segment)
+        if not words:
+            if ends_subshell:
+                in_subshell = False
+                subshell_cwd = None
+            continue
+        for word in words:
+            if not _is_shell_assignment(word):
+                break
+            name, value = word.split("=", 1)
+            shell_vars[name.lower()] = _expand_known_shell_vars(value, shell_vars)
+        words = [_expand_known_shell_vars(word, shell_vars) for word in words]
+
+        for idx in _command_word_indices(words):
+            if _command_basename(words[idx]).lower() not in {"export", "declare", "typeset", "readonly", "local"}:
+                continue
+            for assignment in words[idx + 1:]:
+                if not _is_shell_assignment(assignment):
+                    continue
+                name, value = assignment.split("=", 1)
+                expanded_value = _expand_known_shell_vars(value, shell_vars)
+                shell_vars[name.lower()] = expanded_value
+                resolved_alias = _resolve_protected_path_token(expanded_value, active_cwd)
+                if resolved_alias and resolved_alias in _protected_config_resolved_paths():
+                    protected_aliases.add(resolved_alias)
+
+        cd_target = _cd_target_from_words(words)
+        if cd_target is not None:
+            resolved_cd = _resolve_protected_path_token(cd_target, active_cwd)
+            if resolved_cd:
+                if in_subshell:
+                    subshell_cwd = resolved_cd
+                else:
+                    current_cwd = resolved_cd
+            script_cwd = None
+            script_protected_vars.clear()
+            if ends_subshell:
+                in_subshell = False
+                subshell_cwd = None
+            continue
+
+        if script_cwd is not None:
+            _record_script_protected_vars(segment, script_cwd, script_protected_vars)
+            if (
+                _script_write_target_hits_protected_path(segment, script_cwd)
+                or _script_write_uses_protected_var(segment, script_protected_vars)
+            ):
+                return True
+
+        for target in _redirection_targets_from_words(words):
+            if _token_or_alias_is_protected_path(target, active_cwd, protected_aliases):
+                return True
+
+        for idx in _command_word_indices(words):
+            word = words[idx]
+            cmd_word = _command_basename(word)
+            if cmd_word == "env":
+                for payload in _env_split_string_payloads(words, idx):
+                    if (
+                        _write_target_hits_protected_path_preserving_quotes(payload, active_cwd)
+                        or _relative_write_target_hits_protected_path(payload.lower(), active_cwd)
+                    ):
+                        return True
+            if cmd_word in {"xargs", "find"}:
+                for payload in _nested_shell_c_payloads_after_command(words, idx):
+                    if (
+                        _write_target_hits_protected_path_preserving_quotes(payload, active_cwd)
+                        or _relative_write_target_hits_protected_path(payload.lower(), active_cwd)
+                    ):
+                        return True
+            if _is_inline_script_interpreter(cmd_word):
+                payload, argv = _inline_payload_and_argv_from_words(words, idx)
+                if _inline_script_payload_writes_protected_path(payload, active_cwd, argv):
+                    return True
+            if cmd_word == "dd":
+                for target in _dd_of_targets_from_words(words[idx + 1:]):
+                    if _token_or_alias_is_protected_path(target, active_cwd, protected_aliases):
+                        return True
+            if cmd_word == "tee":
+                for candidate in [w for w in words[idx + 1:] if not w.startswith("-")]:
+                    if _token_or_alias_is_protected_path(candidate, active_cwd, protected_aliases):
+                        return True
+            if cmd_word in {"sed", "perl", "ruby"}:
+                has_in_place = any(w == "--in-place" or (w.startswith("-") and "i" in w) for w in words[idx + 1:])
+                if has_in_place:
+                    for candidate in [w for w in words[idx + 1:] if not w.startswith("-")]:
+                        if _token_or_alias_is_protected_path(candidate, active_cwd, protected_aliases):
+                            return True
+            if cmd_word in {"rm", "unlink"}:
+                for candidate in [w for w in words[idx + 1:] if not w.startswith("-")]:
+                    if _token_is_protected_path(candidate, active_cwd):
+                        return True
+            if cmd_word in {"truncate", "touch", "nano", "vim", "vi", "nvim", "emacs", "code"}:
+                for candidate in [w for w in words[idx + 1:] if not w.startswith("-")]:
+                    if _token_or_alias_is_protected_path(candidate, active_cwd, protected_aliases):
+                        return True
+            if cmd_word == "mv":
+                args = words[idx + 1:]
+                candidates = [w for w in args if not w.startswith("-")]
+                for candidate in candidates[:-1]:
+                    if _token_is_protected_path(candidate, active_cwd):
+                        return True
+                if candidates and _token_or_alias_is_protected_path(candidates[-1], active_cwd, protected_aliases):
+                    return True
+                if _copy_like_hits_protected_path(args, active_cwd, protected_aliases):
+                    return True
+            if cmd_word in {"cp", "install", "ln", "rsync"}:
+                candidates = [w for w in words[idx + 1:] if not w.startswith("-")]
+                if cmd_word == "ln":
+                    # Creating a link AT a protected config path overwrites it
+                    # (cd ~/.hermes && ln -sf /tmp/x config.yaml). The absolute
+                    # form is caught by the quote-preserving pass; this closes
+                    # the relative-cwd gap.
+                    if candidates and _token_or_alias_is_protected_path(candidates[-1], active_cwd, protected_aliases):
+                        return True
+                    # ln SOURCE... DIR/ creates the link inside DIR named after
+                    # the source basename. If DIR is the protected config root
+                    # and a source basename is config.yaml/.env, the resulting
+                    # link overwrites the protected file
+                    # (ln -sf /tmp/config.yaml ~/.hermes/ ;
+                    #  cd ~/.hermes && ln -sf /tmp/config.yaml .).
+                    if (
+                        len(candidates) >= 2
+                        and _token_is_protected_config_root(candidates[-1], active_cwd)
+                        and any(_source_basename_is_protected_config(src) for src in candidates[:-1])
+                    ):
+                        return True
+                    # ln SOURCE LINK where SOURCE is protected: the link name
+                    # becomes an alias for later writes through it.
+                    if len(candidates) >= 2 and _token_is_protected_path(candidates[-2], active_cwd):
+                        alias = _resolve_protected_path_token(candidates[-1], active_cwd)
+                        if alias:
+                            protected_aliases.add(alias)
+                elif _copy_like_hits_protected_path(words[idx + 1:], active_cwd, protected_aliases):
+                    return True
+            if cmd_word in {"bash", "sh", "zsh", "ksh", "dash"}:
+                payload = _shell_c_payload_from_words(words, idx)
+                if payload and (
+                    _write_target_hits_protected_path_preserving_quotes(payload, active_cwd)
+                    or _relative_write_target_hits_protected_path(payload.lower(), active_cwd)
+                ):
+                    return True
+            if cmd_word == "eval" and idx + 1 < len(words):
+                payload = " ".join(words[idx + 1:])
+                if (
+                    _write_target_hits_protected_path_preserving_quotes(payload, active_cwd)
+                    or _relative_write_target_hits_protected_path(payload.lower(), active_cwd)
+                ):
+                    return True
+            if _is_inline_script_interpreter(cmd_word):
+                _record_script_protected_vars(segment, active_cwd, script_protected_vars)
+                if (
+                    _script_write_target_hits_protected_path(segment, active_cwd)
+                    or _script_write_uses_protected_var(segment, script_protected_vars)
+                ):
+                    return True
+                if any(word in {"-c", "-e"} for word in words[idx + 1:]) or "<<" in segment:
+                    script_cwd = active_cwd
+        if _is_inline_script_interpreter(words[0]):
+            _record_script_protected_vars(segment, active_cwd, script_protected_vars)
+            if (
+                _script_write_target_hits_protected_path(segment, active_cwd)
+                or _script_write_uses_protected_var(segment, script_protected_vars)
+            ):
+                return True
+            if any(word in {"-c", "-e"} for word in words[1:]) or "<<" in segment:
+                script_cwd = active_cwd
+        if ends_subshell:
+            in_subshell = False
+            subshell_cwd = None
+            script_cwd = None
+            script_protected_vars.clear()
+    return False
+
+
+def _check_protected_config_write_guard(command: str, cwd: Optional[str] = None) -> tuple:
+    """Detect direct writes/edits to protected Hermes config files.
+
+    Returns:
+        (is_blocked: bool, description: str | None)
+    """
+    effective_cwd = _resolve_protected_path_token(cwd, os.getcwd()) if cwd else None
+    if _write_target_hits_protected_path_preserving_quotes(command, effective_cwd):
+        return (True, "direct write to protected Hermes config/env")
+    quote_preserving_command = _normalize_command_for_detection(command).lower()
+    if _relative_write_target_hits_protected_path(quote_preserving_command, effective_cwd):
+        return (True, "direct write to protected Hermes config/env")
+
+    return (False, None)
+
+
+def _protected_config_block_result(description: str) -> dict:
+    """Build the standard block result for protected config direct writes."""
+    return {
+        "approved": False,
+        "protected_config": True,
+        "message": (
+            f"BLOCKED: {description}. "
+            "Do not edit ~/.hermes/.env or ~/.hermes/config.yaml directly "
+            "from the agent. Use `hermes config set <key> <value>` for "
+            "configuration changes, and do not bypass this guard. Secret "
+            "values were not inspected or printed."
+        ),
+    }
+
+
+def check_unbypassable_command_guards(command: str, env_type: str,
+                                      cwd: Optional[str] = None) -> dict:
+    """Run command guards that must apply even under yolo/force/off modes."""
+    if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+        return {"approved": True, "message": None}
+
+    is_protected_config_write, protected_desc = _check_protected_config_write_guard(command, cwd=cwd)
+    if is_protected_config_write:
+        logger.warning("Protected config guard block: %s", protected_desc)
+        return _protected_config_block_result(protected_desc)
+
+    is_hardline, hardline_desc = detect_hardline_command(command)
+    if is_hardline:
+        logger.warning("Hardline block: %s", hardline_desc)
+        return _hardline_block_result(hardline_desc)
+
+    is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command)
+    if is_sudo_guess:
+        logger.warning("Sudo stdin guard block: %s", sudo_guess_desc)
+        return _sudo_stdin_block_result(sudo_guess_desc)
+
+    return {"approved": True, "message": None}
+
+
+# =========================================================================
 # Dangerous command patterns
 # =========================================================================
-
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
@@ -916,7 +2239,8 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
 
 
 def check_dangerous_command(command: str, env_type: str,
-                            approval_callback=None) -> dict:
+                            approval_callback=None,
+                            cwd: Optional[str] = None) -> dict:
     """Check if a command is dangerous and handle approval.
 
     This is the main entry point called by terminal_tool before executing
@@ -930,20 +2254,13 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
+    unbypassable = check_unbypassable_command_guards(command, env_type, cwd=cwd)
+    if not unbypassable["approved"]:
+        return unbypassable
     if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
         return {"approved": True, "message": None}
 
-    # Hardline floor: commands with no recovery path (rm -rf /, mkfs, dd
-    # to raw device, shutdown/reboot, fork bomb, kill -1) are blocked
-    # unconditionally, BEFORE the yolo bypass.  Opting into yolo is
-    # trusting the agent with your files and services, not trusting it
-    # to wipe the disk or power the box off.
-    is_hardline, hardline_desc = detect_hardline_command(command)
-    if is_hardline:
-        logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
-        return _hardline_block_result(hardline_desc)
-
-    # --yolo: bypass all approval prompts. Gateway /yolo is session-scoped;
+    # --yolo: bypass regular approval prompts. Gateway /yolo is session-scoped;
     # CLI --yolo remains process-scoped via the env var for local use.
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return {"approved": True, "message": None}
@@ -1051,7 +2368,8 @@ def _format_tirith_description(tirith_result: dict) -> str:
 
 
 def check_all_command_guards(command: str, env_type: str,
-                             approval_callback=None) -> dict:
+                             approval_callback=None,
+                             cwd: Optional[str] = None) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -1060,30 +2378,13 @@ def check_all_command_guards(command: str, env_type: str,
     other was shown to the user.
     """
     # Skip containers for both checks
+    unbypassable = check_unbypassable_command_guards(command, env_type, cwd=cwd)
+    if not unbypassable["approved"]:
+        return unbypassable
     if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
         return {"approved": True, "message": None}
 
-    # Hardline floor: unconditional block for catastrophic commands
-    # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
-    # kill -1). Applies BEFORE yolo / mode=off / cron approve-mode so
-    # no session-level setting can bypass it.
-    is_hardline, hardline_desc = detect_hardline_command(command)
-    if is_hardline:
-        logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
-        return _hardline_block_result(hardline_desc)
-
-    # == Sudo stdin guard ==
-    # Like the hardline floor above, this is unconditional: there is never a
-    # legitimate reason for the agent to pipe passwords to sudo -S when no
-    # SUDO_PASSWORD has been configured.  This must fire BEFORE the yolo
-    # check so even yolo/smart approval/mode=off cannot bypass it.
-    is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command)
-    if is_sudo_guess:
-        logger.warning("Sudo stdin guard block: %s (command: %s)",
-                       sudo_guess_desc, command[:200])
-        return _sudo_stdin_block_result(sudo_guess_desc)
-
-    # --yolo or approvals.mode=off: bypass all approval prompts.
+    # --yolo or approvals.mode=off: bypass regular approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
     if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shlex
 import signal
 import subprocess
@@ -73,6 +74,26 @@ WATCH_STRIKE_LIMIT = 3            # Strikes in a row → disable watch + promote
 WATCH_GLOBAL_MAX_PER_WINDOW = 15
 WATCH_GLOBAL_WINDOW_SECONDS = 10
 WATCH_GLOBAL_COOLDOWN_SECONDS = 30
+
+
+def _redact_command_for_display(command: str) -> str:
+    """Redact credential-shaped values before exposing process commands."""
+    text = str(command or "")
+    # Redact bearer headers before generic ``Authorization: ...`` key/value
+    # handling. Otherwise the generic regex replaces only ``Bearer`` and leaves
+    # the actual token behind as a bare word.
+    text = re.sub(r"(?i)(authorization:\s*bearer\s+)[^\s'\"]+", r"\1[REDACTED]", text)
+    # Common provider/GitHub token shapes, including Perplexity's ``pplx-``
+    # Search API tokens and legacy underscore-prefixed service tokens.
+    text = re.sub(r"\b(?:sk|pplx)-[A-Za-z0-9_\-]{12,}\b", "[REDACTED]", text)
+    text = re.sub(r"\b(?:sk|pplx|ghs|ghp)_[A-Za-z0-9_\-]{12,}\b", "[REDACTED]", text)
+    text = re.sub(r"\bgithub_pat_[A-Za-z0-9_\-]{20,}\b", "[REDACTED]", text)
+    # KEY=value / --key value / JSON-ish credential fields.  Match both
+    # exact keys (`token=`) and prefixed env vars (`OPENAI_API_KEY=`).
+    secret_key = r"(?:[A-Za-z0-9_.-]*(?:api[_-]?key|token|secret|password|passwd|authorization|bearer|credential|client[_-]?secret)[A-Za-z0-9_.-]*)"
+    text = re.sub(rf"(?i)(\b{secret_key}\b\s*[=:]\s*)([^\s'\"]+|['\"][^'\"]+['\"])", r"\1[REDACTED]", text)
+    text = re.sub(rf"(?i)(--{secret_key}(?:=|\s+))([^\s'\"]+|['\"][^'\"]+['\"])", r"\1[REDACTED]", text)
+    return text
 
 
 def format_uptime_short(seconds: int) -> str:
@@ -132,6 +153,13 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    env_type: str = "local"                    # Backend type for stdin guard checks
+    # Rolling buffer of stdin written since the last newline, so the stdin
+    # guard sees the full pending shell/REPL line even when a dangerous
+    # command is split across multiple write_stdin() chunks (e.g. "echo x >
+    # ~/.hermes/" then "config.yaml\n"). Only populated for guarded
+    # shells/REPLs; reset once a newline flushes the line to the process.
+    _stdin_guard_buffer: str = field(default="", repr=False)
 
 
 class ProcessRegistry:
@@ -272,7 +300,7 @@ class ProcessRegistry:
                 self.completion_queue.put({
                     "session_id": session.id,
                     "session_key": session.session_key,
-                    "command": session.command,
+                    "command": _redact_command_for_display(session.command),
                     "type": "watch_disabled",
                     "suppressed": session._watch_suppressed,
                     "platform": session.watcher_platform,
@@ -303,7 +331,7 @@ class ProcessRegistry:
         self.completion_queue.put({
             "session_id": session.id,
             "session_key": session.session_key,
-            "command": session.command,
+            "command": _redact_command_for_display(session.command),
             "type": "watch_match",
             "pattern": matched_pattern,
             "output": output,
@@ -538,6 +566,7 @@ class ProcessRegistry:
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
+            env_type="local",
         )
 
         if use_pty:
@@ -677,6 +706,7 @@ class ProcessRegistry:
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
+            env_type=getattr(env, "env_type", getattr(env, "name", "sandbox")),
         )
 
         # Run the command in the sandbox with output capture
@@ -863,7 +893,7 @@ class ProcessRegistry:
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
-                "command": session.command,
+                "command": _redact_command_for_display(session.command),
                 "exit_code": session.exit_code,
                 "output": output_tail,
             })
@@ -989,7 +1019,7 @@ class ProcessRegistry:
 
         result = {
             "session_id": session.id,
-            "command": session.command,
+            "command": _redact_command_for_display(session.command),
             "status": "exited" if session.exited else "running",
             "pid": session.pid,
             "uptime_seconds": int(time.time() - session.started_at),
@@ -1181,6 +1211,96 @@ class ProcessRegistry:
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
+    def _guard_stdin_for_interactive_shell(self, session: ProcessSession, data: str) -> dict | None:
+        """Run unbypassable guards for stdin sent to interactive shells/REPLs."""
+        if not isinstance(data, str) or not data.strip():
+            return None
+        try:
+            words = shlex.split(session.command or "")
+        except Exception:
+            words = (session.command or "").split()
+        if not words:
+            return None
+        try:
+            from tools.approval import (
+                _command_basename,
+                _command_word_indices,
+                _inline_script_payload_writes_protected_path,
+                _is_inline_script_interpreter,
+                check_unbypassable_command_guards,
+            )
+            command_indices = _command_word_indices(words)
+            effective_word = words[command_indices[-1]] if command_indices else words[0]
+            command_name = _command_basename(effective_word).lower()
+        except Exception:
+            command_name = os.path.basename(words[0]).lower()
+            check_unbypassable_command_guards = None
+            _inline_script_payload_writes_protected_path = None
+            _is_inline_script_interpreter = None
+        guarded_shells = {"bash", "sh", "zsh", "ksh", "dash", "fish"}
+        # Match versioned REPL names (python3.12, /usr/bin/python3.12, node20,
+        # nodejs20, ruby3.2, perl5.36, …) via the shared approval interpreter
+        # matcher; the literal set is only a fallback for the degraded-import
+        # path where the helper is unavailable.
+        if _is_inline_script_interpreter is not None:
+            is_repl = _is_inline_script_interpreter(command_name)
+        else:
+            is_repl = command_name in {"python", "python3", "node", "nodejs", "ruby", "perl"}
+        if command_name not in guarded_shells and not is_repl:
+            return None
+        # Stateful buffering: combine with stdin already written but not yet
+        # executed (no newline seen) so a protected write split across chunks
+        # cannot evade the guard by being individually benign. The candidate
+        # reconstructs the full pending line; if blocked we reject WITHOUT
+        # updating the buffer, so the dangerous bytes never gain a newline.
+        with session._lock:
+            pending = session._stdin_guard_buffer
+        candidate = pending + data if pending else data
+        try:
+            if is_repl and _inline_script_payload_writes_protected_path:
+                if _inline_script_payload_writes_protected_path(candidate, session.cwd):
+                    return {
+                        "status": "blocked",
+                        "error": "stdin blocked by protected Hermes config/env guard",
+                        "exit_code": -1,
+                    }
+            if check_unbypassable_command_guards is None:
+                return None
+            approval = check_unbypassable_command_guards(
+                candidate,
+                session.env_type or "local",
+                cwd=session.cwd,
+            )
+        except Exception as exc:
+            logger.warning("Failed to guard process stdin for %s: %s", session.id, exc)
+            return None
+        if approval.get("approved", True):
+            self._remember_stdin_tail(session, candidate)
+            return None
+        return {
+            "status": "blocked",
+            "error": approval.get("message", "stdin blocked by unbypassable command guard"),
+            "exit_code": -1,
+        }
+
+    # Cap on the buffered un-executed stdin line. Generous enough for any
+    # realistic protected-write command; longer pathological single lines
+    # only keep their tail.
+    _STDIN_GUARD_BUFFER_MAX = 16384
+
+    def _remember_stdin_tail(self, session: ProcessSession, candidate: str) -> None:
+        """Retain the still-pending stdin tail (text after the last newline).
+
+        Lines completed by a newline have been flushed to the process and are
+        no longer part of the pending command, so only the trailing fragment
+        is carried forward for the next chunk's guard check.
+        """
+        tail = candidate.rsplit("\n", 1)[-1] if "\n" in candidate else candidate
+        if len(tail) > self._STDIN_GUARD_BUFFER_MAX:
+            tail = tail[-self._STDIN_GUARD_BUFFER_MAX:]
+        with session._lock:
+            session._stdin_guard_buffer = tail
+
     def write_stdin(self, session_id: str, data: str) -> dict:
         """Send raw data to a running process's stdin (no newline appended)."""
         session = self.get(session_id)
@@ -1188,6 +1308,10 @@ class ProcessRegistry:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
         if session.exited:
             return {"status": "already_exited", "error": "Process has already finished"}
+
+        guard_block = self._guard_stdin_for_interactive_shell(session, data)
+        if guard_block:
+            return guard_block
 
         # PTY mode -- write through pty handle (expects bytes)
         if hasattr(session, '_pty') and session._pty:
@@ -1262,7 +1386,7 @@ class ProcessRegistry:
         for s in all_sessions:
             entry = {
                 "session_id": s.id,
-                "command": s.command[:200],
+                "command": _redact_command_for_display(s.command)[:200],
                 "cwd": s.cwd,
                 "pid": s.pid,
                 "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
@@ -1362,7 +1486,7 @@ class ProcessRegistry:
                     if not s.exited:
                         entries.append({
                             "session_id": s.id,
-                            "command": s.command,
+                            "command": _redact_command_for_display(s.command),
                             "pid": s.pid,
                             "pid_scope": s.pid_scope,
                             "cwd": s.cwd,
@@ -1413,7 +1537,7 @@ class ProcessRegistry:
                 # process once the original environment handle is gone.
                 logger.info(
                     "Skipping recovery for non-host process: %s (pid=%s, scope=%s)",
-                    entry.get("command", "unknown")[:60],
+                    _redact_command_for_display(entry.get("command", "unknown"))[:60],
                     pid,
                     pid_scope,
                 )
@@ -1446,7 +1570,7 @@ class ProcessRegistry:
                 with self._lock:
                     self._running[session.id] = session
                 recovered += 1
-                logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
+                logger.info("Recovered detached process: %s (pid=%d)", _redact_command_for_display(session.command)[:60], pid)
 
                 # Re-enqueue watcher so gateway can resume notifications
                 if session.watcher_interval > 0:
@@ -1480,7 +1604,7 @@ def format_process_notification(evt: dict) -> "str | None":
     """
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
-    _cmd = evt.get("command", "unknown")
+    _cmd = _redact_command_for_display(evt.get("command", "unknown"))
 
     if evt_type == "watch_disabled":
         return f"[IMPORTANT: {evt.get('message', '')}]"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -318,18 +318,37 @@ def _reset_cached_sudo_passwords() -> None:
 # Dangerous command detection + approval now consolidated in tools/approval.py
 from tools.approval import (
     check_all_command_guards as _check_all_guards_impl,
+    check_unbypassable_command_guards as _check_unbypassable_guards_impl,
 )
 
 
-def _check_all_guards(command: str, env_type: str) -> dict:
+def _check_all_guards(command: str, env_type: str, cwd: Optional[str] = None) -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
-                                  approval_callback=_get_approval_callback())
+                                  approval_callback=_get_approval_callback(),
+                                  cwd=cwd)
+
+
+def _check_unbypassable_guards(command: str, env_type: str,
+                               cwd: Optional[str] = None) -> dict:
+    """Delegate to guards that must still run when force=True."""
+    return _check_unbypassable_guards_impl(command, env_type, cwd=cwd)
+
+
+def _canonical_guard_cwd(raw_cwd: Optional[str], base_cwd: Optional[str] = None) -> Optional[str]:
+    """Canonicalize cwd/workdir for pre-exec path guards without reading files."""
+    if not raw_cwd:
+        return None
+    expanded = os.path.expanduser(raw_cwd)
+    if not os.path.isabs(expanded):
+        base = os.path.expanduser(base_cwd or os.getcwd())
+        expanded = os.path.join(base, expanded)
+    return os.path.realpath(expanded)
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
-# Covers alphanumeric, path separators, Windows drive/UNC separators, tilde,
-# dot, hyphen, underscore, space, plus, at, equals, and comma.  Everything
+# This includes Unix paths, Windows drive/UNC paths, spaces, and common
+# punctuation used by temp dirs and project names. It intentionally excludes
 # else is rejected.
 _WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/\\:_\-.~ +@=,]+$')
 
@@ -901,6 +920,7 @@ Do NOT use grep/rg/find to search — use search_files instead.
 Do NOT use ls to list directories — use search_files(target='files') instead.
 Do NOT use sed/awk to edit files — use patch instead.
 Do NOT use echo/cat heredoc to create files — use write_file instead.
+Do NOT edit protected Hermes config directly (~/.hermes/.env or ~/.hermes/config.yaml) or bypass its guard — use `hermes config set <key> <value>`.
 Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
 
 Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands.
@@ -1856,45 +1876,7 @@ def terminal_tool(
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
-        # Pre-exec security checks (tirith + dangerous command detection)
-        # Skip check if force=True (user has confirmed they want to run it)
-        approval_note = None
-        if not force:
-            approval = _check_all_guards(command, env_type)
-            if not approval["approved"]:
-                # Check if this is an approval_required (gateway ask mode)
-                if approval.get("status") == "pending_approval":
-                    return json.dumps({
-                        "output": "",
-                        "exit_code": -1,
-                        "error": "",
-                        "status": "pending_approval",
-                        "approval_pending": True,
-                        "command": approval.get("command", command),
-                        "description": approval.get("description", "command flagged"),
-                        "pattern_key": approval.get("pattern_key", ""),
-                    }, ensure_ascii=False)
-                # Command was blocked
-                desc = approval.get("description", "command flagged")
-                fallback_msg = (
-                    f"Command denied: {desc}. "
-                    "Use the approval prompt to allow it, or rephrase the command."
-                )
-                return json.dumps({
-                    "output": "",
-                    "exit_code": -1,
-                    "error": approval.get("message", fallback_msg),
-                    "status": "blocked"
-                }, ensure_ascii=False)
-            # Track whether approval was explicitly granted by the user
-            if approval.get("user_approved"):
-                desc = approval.get("description", "flagged as dangerous")
-                approval_note = f"Command required approval ({desc}) and was approved by the user."
-            elif approval.get("smart_approved"):
-                desc = approval.get("description", "flagged as dangerous")
-                approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
-
-        # Validate workdir against shell injection
+        # Validate workdir against shell injection before using it for guards or execution.
         if workdir:
             workdir_error = _validate_workdir(workdir)
             if workdir_error:
@@ -1906,6 +1888,56 @@ def terminal_tool(
                     "error": workdir_error,
                     "status": "blocked"
                 }, ensure_ascii=False)
+
+        # Pre-exec security checks (tirith + dangerous command detection).
+        # `force=True` skips regular approval prompts after user confirmation,
+        # but never skips hardline/sudo/protected-config guards.
+        approval_note = None
+        # Resolve cwd exactly once and reuse it for both guard checks and
+        # execution.  BaseEnvironment resolves relative cwd/workdir from the
+        # session cwd, so guard resolution must use the same base; otherwise
+        # force=True could approve a relative workdir that executes elsewhere.
+        guard_base_cwd = getattr(locals().get("env"), "cwd", None) or cwd or os.getcwd()
+        guard_cwd = _canonical_guard_cwd(workdir or cwd, base_cwd=guard_base_cwd)
+        execution_cwd = guard_cwd or workdir or cwd
+        if force:
+            approval = _check_unbypassable_guards(command, env_type, cwd=guard_cwd)
+        else:
+            approval = _check_unbypassable_guards(command, env_type, cwd=guard_cwd)
+            if approval["approved"]:
+                approval = _check_all_guards(command, env_type, cwd=guard_cwd)
+        if not approval["approved"]:
+            # Check if this is an approval_required (gateway ask mode)
+            if approval.get("status") == "approval_required":
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": approval.get("message", "Waiting for user approval"),
+                    "status": "approval_required",
+                    "command": approval.get("command", command),
+                    "description": approval.get("description", "command flagged"),
+                    "pattern_key": approval.get("pattern_key", ""),
+                }, ensure_ascii=False)
+            # Command was blocked
+            desc = approval.get("description", "command flagged")
+            fallback_msg = (
+                f"Command denied: {desc}. "
+                "Use the approval prompt to allow it, or rephrase the command."
+            )
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": approval.get("message", fallback_msg),
+                "status": "blocked"
+            }, ensure_ascii=False)
+        if not force:
+            # Track whether approval was explicitly granted by the user
+            if approval.get("user_approved"):
+                desc = approval.get("description", "flagged as dangerous")
+                approval_note = f"Command required approval ({desc}) and was approved by the user."
+            elif approval.get("smart_approved"):
+                desc = approval.get("description", "flagged as dangerous")
+                approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
 
         # Prepare command for execution
         pty_disabled_reason = None
@@ -1927,7 +1959,7 @@ def terminal_tool(
             from tools.process_registry import process_registry
 
             session_key = get_current_session_key(default="")
-            effective_cwd = workdir or cwd
+            effective_cwd = execution_cwd
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -2065,7 +2097,7 @@ def terminal_tool(
                 try:
                     execute_kwargs = {
                         "timeout": effective_timeout,
-                        "cwd": workdir or cwd,
+                        "cwd": execution_cwd,
                     }
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -140,7 +140,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "perplexity", "searxng", "brave-free", "ddgs", "xai"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -153,6 +153,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("perplexity", _has_env("PERPLEXITY_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -206,6 +207,8 @@ def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
     if backend == "exa":
         return _has_env("EXA_API_KEY")
+    if backend == "perplexity":
+        return _has_env("PERPLEXITY_API_KEY")
     if backend == "parallel":
         return _has_env("PARALLEL_API_KEY")
     if backend == "firecrawl":
@@ -269,6 +272,7 @@ def _web_requires_env() -> list[str]:
     """
     return [
         "EXA_API_KEY",
+        "PERPLEXITY_API_KEY",
         "PARALLEL_API_KEY",
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
@@ -799,8 +803,9 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
+        # Dispatch through the web search registry. All built-in providers
+        # (brave-free, ddgs, searxng, exa, perplexity, parallel, tavily,
+        # firecrawl)
         # now live as plugins; the dispatcher is just a registry lookup +
         # delegation. Sync only — every provider's search() is sync.
         from agent.web_search_registry import (
@@ -1367,11 +1372,11 @@ async def web_crawl_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    if configured in {"exa", "perplexity", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "perplexity", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
     )
 
 
@@ -1403,6 +1408,8 @@ if __name__ == "__main__":
         print(f"✅ Web backend: {backend}")
         if backend == "exa":
             print("   Using Exa API (https://exa.ai)")
+        elif backend == "perplexity":
+            print("   Using Perplexity Search API (search only)")
         elif backend == "parallel":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
@@ -1424,7 +1431,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PERPLEXITY_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 


### PR DESCRIPTION
## Summary
- add Perplexity web provider/config coverage and related web tooling tests
- harden process command redaction and background completion command display
- tighten protected-config guards for inline stdin/REPL/subprocess payloads
- ignore repo-local .hermes workspace artifacts

## Test Plan
- venv/bin/python -m pytest -q -o addopts='' tests/tools/test_web_tools_config.py
- venv/bin/python -m pytest -q -o addopts='' tests/tools/test_hardline_blocklist.py tests/tools/test_terminal_tool.py tests/gateway/test_background_process_notifications.py tests/tools/test_web_tools_config.py
- targeted suite previously passed: 423 passed

No restart/deploy/reset/stash.