### PR TITLE
fix(tools): register web_crawl as a model-callable tool

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -45,7 +45,7 @@ class TestGetToolset:
 
         ts = get_toolset("web")
         assert ts is not None
-        assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
+        assert set(ts["tools"]) == {"web_search", "web_extract", "web_crawl", "web_search_plus"}
 
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None
@@ -54,7 +54,7 @@ class TestGetToolset:
 class TestResolveToolset:
     def test_leaf_toolset(self):
         tools = resolve_toolset("web")
-        assert set(tools) == {"web_search", "web_extract"}
+        assert set(tools) == {"web_search", "web_extract", "web_crawl"}
 
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
@@ -153,7 +153,7 @@ class TestGetToolsetInfo:
         info = get_toolset_info("web")
         assert info["name"] == "web"
         assert info["is_composite"] is False
-        assert info["tool_count"] == 2
+        assert info["tool_count"] == 3
 
     def test_composite(self):
         info = get_toolset_info("debugging")

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -469,7 +469,7 @@ class TestStubSchemaDrift(unittest.TestCase):
         # Import the registry and trigger tool registration
         from tools.registry import registry
         import tools.file_tools  # noqa: F401 - registers read_file, write_file, patch, search_files
-        import tools.web_tools  # noqa: F401 - registers web_search, web_extract
+        import tools.web_tools  # noqa: F401 - registers web_search, web_extract, web_crawl
 
         for tool_name, (func_name, sig, doc, args_expr) in _TOOL_STUBS.items():
             entry = registry._tools.get(tool_name)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1559,3 +1559,51 @@ registry.register(
     emoji="📄",
     max_result_size_chars=100_000,
 )
+
+WEB_CRAWL_SCHEMA = {
+    "name": "web_crawl",
+    "description": (
+        "Crawl a website starting from a seed URL with optional natural-language "
+        "instructions for what content to extract from each crawled page. "
+        "Returns one entry per crawled page with url, title, and content "
+        "(markdown). Requires a crawl-capable backend (Firecrawl or Tavily). "
+        "Use this for multi-page traversal of a single site "
+        "(catalog/docs/blog); for single-URL extraction use web_extract."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": (
+                    "Seed URL to crawl from. The crawler will follow "
+                    "links from this page."
+                ),
+            },
+            "instructions": {
+                "type": "string",
+                "description": (
+                    "Natural-language description of what to extract "
+                    "from each crawled page (e.g. 'list all product "
+                    "pages with name and price')."
+                ),
+            },
+        },
+        "required": ["url"],
+    },
+}
+
+registry.register(
+    name="web_crawl",
+    toolset="web",
+    schema=WEB_CRAWL_SCHEMA,
+    handler=lambda args, **kw: web_crawl_tool(
+        args.get("url", ""),
+        instructions=args.get("instructions"),
+    ),
+    check_fn=check_web_api_key,
+    requires_env=_web_requires_env(),
+    is_async=True,
+    emoji="🕸️",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -30,7 +30,7 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search", "web_extract", "web_crawl",
     # Terminal + process management
     "terminal", "process",
     # File manipulation
@@ -89,7 +89,7 @@ TOOLSETS = {
     # Basic toolsets - individual tool categories
     "web": {
         "description": "Web research and content extraction tools",
-        "tools": ["web_search", "web_extract"],
+        "tools": ["web_search", "web_extract", "web_crawl"],
         "includes": []  # No other toolsets included
     },
     
@@ -341,7 +341,7 @@ TOOLSETS = {
     "hermes-acp": {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_crawl",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
             "vision_analyze",
@@ -361,7 +361,7 @@ TOOLSETS = {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
             # Web
-            "web_search", "web_extract",
+            "web_search", "web_extract", "web_crawl",
             # Terminal + process management
             "terminal", "process",
             # File manipulation


### PR DESCRIPTION
## Summary

- `web_crawl_tool()` is fully implemented in `tools/web_tools.py` and the provider dispatch infrastructure works correctly via `agent.web_search_registry`, but no `registry.register(name="web_crawl", ...)` call existed — making the tool unreachable from the model.
- Added `WEB_CRAWL_SCHEMA` and `registry.register()` alongside the existing `web_search` and `web_extract` registrations.
- Added `"web_crawl"` to `_HERMES_CORE_TOOLS` and the `web`, `hermes-acp`, and `hermes-api-server` toolsets in `toolsets.py`.
- Updated affected test assertions in `tests/test_toolsets.py`.
- Intentionally **not** added to `_HERMES_WEBHOOK_SAFE_TOOLS` — crawling arbitrary sites from untrusted webhook payloads is a prompt-injection risk.

## Schema design

Exposes only `url` (required) and `instructions` (optional) to the model. Internal parameters (`depth`, `use_llm_processing`, `model`, `min_length`) have sensible defaults and stay hidden — matching how `WEB_EXTRACT_SCHEMA` hides its post-processing toggles.

## Test plan

- [x] `tests/test_toolsets.py` — 27/27 pass (updated 3 assertions for new tool count)
- [x] `tests/tools/test_web_providers.py` — 14/14 pass
- [x] `tests/tools/test_web_providers_searxng.py` — 18/18 pass
- [x] `tests/tools/test_web_providers_brave_free.py` — 12/12 pass
- [x] `tests/tools/test_web_providers_ddgs.py` — 35/35 pass
- [x] `tests/tools/test_website_policy.py` — 22/22 pass
- [x] `tests/tools/test_web_tools_config.py` — 49/49 pass

Closes #32598