### PR TITLE
Improve media safety, logging, and Telegram formatting

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,6 +15,7 @@ import re
 import socket as _socket
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -840,6 +841,15 @@ MEDIA_DELIVERY_SAFE_ROOTS = (
     _HERMES_HOME / "video_cache",
     _HERMES_HOME / "document_cache",
     _HERMES_HOME / "browser_screenshots",
+    # Agents frequently write deliverables to temp dirs and the user's home
+    # via write_file / execute_code. On macOS tempfile.gettempdir() returns
+    # the per-user sandbox under /var/folders/.../T while /tmp symlinks to
+    # /private/tmp — a separate path — so include both. Path.home() and
+    # project dirs are also common write targets for tools.
+    Path(tempfile.gettempdir()),
+    Path("/tmp"),
+    Path("/private/tmp"),
+    Path.home(),
 )
 
 # Default recency window for trusting freshly-produced files (seconds).
@@ -2358,7 +2368,10 @@ class BasePlatformAdapter(ABC):
             if safe_path:
                 safe_media.append((safe_path, bool(is_voice)))
             else:
-                logger.warning("Skipping unsafe MEDIA directive path outside allowed roots")
+                logger.warning(
+                    "Skipping unsafe MEDIA directive path outside allowed roots: %s",
+                    media_path,
+                )
         return safe_media
 
     @staticmethod
@@ -2370,7 +2383,10 @@ class BasePlatformAdapter(ABC):
             if safe_path:
                 safe_paths.append(safe_path)
             else:
-                logger.warning("Skipping unsafe local file path outside allowed roots")
+                logger.warning(
+                    "Skipping unsafe local file path outside allowed roots: %s",
+                    file_path,
+                )
         return safe_paths
 
     @staticmethod

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2477,10 +2477,15 @@ class TelegramAdapter(BasePlatformAdapter):
         text = content if len(content) <= self.MAX_MESSAGE_LENGTH else \
             self.truncate_message(content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len)[0]
 
+        # Format here so streaming styling matches the final sendMessage path —
+        # without parse_mode + MarkdownV2 conversion, users see raw markdown
+        # syntax (e.g. **bold**) in the draft preview during streaming.
+        formatted = self.format_message(text)
         kwargs: Dict[str, Any] = {
             "chat_id": int(chat_id),
             "draft_id": int(draft_id),
-            "text": text,
+            "text": formatted,
+            "parse_mode": ParseMode.MARKDOWN_V2,
         }
         thread_id = self._metadata_thread_id(metadata)
         if thread_id is not None:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -523,7 +523,11 @@ class GatewayStreamConsumer:
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
-                        ok = await self._send_or_edit(chunk)
+                        # finalize=True so the adapter applies platform-specific
+                        # rich-text markup. This message will never be edited
+                        # again (_message_id is reset to None right below), so
+                        # it must receive its final formatting now.
+                        ok = await self._send_or_edit(chunk, finalize=True)
                         if self._fallback_final_send or not ok:
                             # Edit failed (or backed off due to flood control)
                             # while attempting to split an oversized message.


### PR DESCRIPTION
## Summary

Three independent gateway fixes — all small and surgical, no new tests required.

### 1. `gateway/platforms/base.py` — broaden `MEDIA_DELIVERY_SAFE_ROOTS`

Agents frequently write deliverables to `/tmp`, the macOS per-user temp sandbox (`/var/folders/.../T`), or under `~/` via `write_file` / `execute_code`. Today those paths are silently dropped by `validate_media_delivery_path` with a context-free `"Skipping unsafe MEDIA directive path outside allowed roots"` log line — the user never sees the file the agent just produced.

- Added `import tempfile` to the stdlib block (alphabetical, between `sys` and `time`).
- Extended `MEDIA_DELIVERY_SAFE_ROOTS` with `Path(tempfile.gettempdir())`, `Path("/tmp")`, `Path("/private/tmp")`, and `Path.home()`. On macOS `tempfile.gettempdir()` resolves to the per-user sandbox while `/tmp` symlinks to `/private/tmp` — different real paths, so both are needed.
- The denied-prefix list in `_media_delivery_denied_paths()` (`~/.ssh`, `~/.aws`, etc.) still wins over the allow-list, so widening doesn't expose secrets.
- Both "Skipping unsafe ..." warnings now include the offending path via `%s` so future skips are debuggable.

### 2. `gateway/platforms/telegram.py` — apply MarkdownV2 to draft streaming

`TelegramAdapter.send_draft` was sending raw text to `send_message_draft` with no `parse_mode`, so during streaming the user saw raw `**bold**` / `_italic_` until the final `sendMessage` replaced the preview. The matching `send` and `edit_message` paths already call `self.format_message()` and set `parse_mode=ParseMode.MARKDOWN_V2`.

- Added `formatted = self.format_message(text)` before the kwargs dict.
- Switched `"text": text` → `"text": formatted` and added `"parse_mode": ParseMode.MARKDOWN_V2` to the kwargs.

### 3. `gateway/stream_consumer.py` — finalize=True on split-on-oversize first chunk

When the accumulated stream chunk exceeds the platform safe limit, the first half is sent via `_send_or_edit(chunk)` (default `finalize=False`) and then `_message_id` is reset to `None` so the chunk can never be edited again. The Telegram adapter explicitly documents (`REQUIRES_EDIT_FINALIZE = True`) that `finalize=False` skips its MarkdownV2 conversion — so that first chunk is permanently stuck with raw markdown.

- Changed `ok = await self._send_or_edit(chunk)` → `ok = await self._send_or_edit(chunk, finalize=True)`. The message is being surrendered immediately afterward, so it needs its final platform formatting now.