### PR TITLE
fix(agent): surface silent pre-tool-call hook stalls (#32460)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1554,11 +1554,16 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     its own inline invocation for backward-compatible display handling.
     """
     # Check plugin hooks for a block directive before executing anything.
+    # Routed through the latency-aware wrapper so a slow pre_tool_call
+    # hook surfaces a WARNING in agent.log instead of producing a silent
+    # multi-second wall-clock gap (#32460).
     block_message: Optional[str] = None
     if not pre_tool_block_checked:
         try:
-            from hermes_cli.plugins import get_pre_tool_call_block_message
-            block_message = get_pre_tool_call_block_message(
+            from agent.tool_dispatch_helpers import (
+                pre_tool_call_block_message_with_latency,
+            )
+            block_message = pre_tool_call_block_message_with_latency(
                 function_name, function_args, task_id=effective_task_id or "",
             )
         except Exception:

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -85,6 +85,18 @@ MAX_TIMEOUT_SECONDS = 300
 ALLOWLIST_FILENAME = "shell-hooks-allowlist.json"
 _DEFAULT_BLOCK_MESSAGE = "Blocked by shell hook."
 
+# Slow-hook watchdog (#32460).  A ``pre_tool_call`` hook is on the hot
+# path between an LLM response and tool execution, so a hook that hangs
+# for the full ``DEFAULT_TIMEOUT_SECONDS = 60`` window manifests to the
+# user as a silent 50-65s wall-clock gap with no log line at all — only
+# a single ``shell hook timed out`` WARNING fires after the timer
+# expires.  These thresholds make the hang visible immediately: a
+# WARNING is emitted while the hook is *still running* once it crosses
+# the threshold, then repeated at the interval so the user can identify
+# the offending script without waiting for the full timeout.
+_SLOW_HOOK_THRESHOLD_SECONDS = 5.0
+_SLOW_HOOK_REPEAT_SECONDS = 10.0
+
 # (event, matcher, command) triples that have been wired to the plugin
 # manager in the current process.  Matcher is part of the key because
 # the same script can legitimately register for different matchers under
@@ -361,6 +373,43 @@ def _parse_single_entry(
 _TOP_LEVEL_PAYLOAD_KEYS = {"tool_name", "args", "session_id", "parent_session_id"}
 
 
+def _watch_slow_hook(
+    spec: ShellHookSpec,
+    started_at: float,
+    stop_event: threading.Event,
+) -> None:
+    """Emit a WARNING while a shell hook is still running past the threshold.
+
+    Runs in a daemon thread spawned by :func:`_spawn`.  The first warning
+    fires once the hook has been running for ``_SLOW_HOOK_THRESHOLD_SECONDS``
+    and is repeated every ``_SLOW_HOOK_REPEAT_SECONDS`` until the hook
+    returns or its own timeout elapses.  Without this, a hook that hangs
+    for the full ``spec.timeout`` window manifests as a silent ~60s wall
+    clock gap between an LLM response and the resulting tool execution —
+    the symptom reported in #32460.
+    """
+    if not stop_event.wait(_SLOW_HOOK_THRESHOLD_SECONDS):
+        # Hook still hasn't returned at the threshold — log once.
+        logger.warning(
+            "shell hook still running after %.1fs "
+            "(event=%s command=%s timeout=%ss); "
+            "this stalls every tool call dispatch until the hook returns",
+            time.monotonic() - started_at,
+            spec.event,
+            spec.command,
+            spec.timeout,
+        )
+    while not stop_event.wait(_SLOW_HOOK_REPEAT_SECONDS):
+        logger.warning(
+            "shell hook still running after %.1fs "
+            "(event=%s command=%s timeout=%ss)",
+            time.monotonic() - started_at,
+            spec.event,
+            spec.command,
+            spec.timeout,
+        )
+
+
 def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     """Run ``spec.command`` as a subprocess with ``stdin_json`` on stdin.
 
@@ -370,6 +419,11 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     subprocess is actually invoked — both the live callback path
     (:func:`_make_callback`) and the CLI test helper (:func:`run_once`)
     go through it.
+
+    While the subprocess is running, a watchdog thread emits a WARNING
+    if the hook crosses ``_SLOW_HOOK_THRESHOLD_SECONDS`` so a hanging
+    script becomes visible immediately instead of after the full
+    ``spec.timeout`` window (see #32460).
     """
     result: Dict[str, Any] = {
         "returncode": None,
@@ -389,34 +443,51 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
         return result
 
     t0 = time.monotonic()
+    # Slow-hook watchdog (#32460) — fire a WARNING while the hook is
+    # still running once it crosses ``_SLOW_HOOK_THRESHOLD_SECONDS``, so
+    # a hanging script is surfaced immediately instead of after the full
+    # ``spec.timeout`` window.  The watchdog is a daemon thread that
+    # stops as soon as the subprocess returns (success, timeout, or
+    # spawn error — all paths go through ``finally``).
+    _watchdog_stop = threading.Event()
+    _watchdog = threading.Thread(
+        target=_watch_slow_hook,
+        args=(spec, t0, _watchdog_stop),
+        daemon=True,
+        name=f"shell-hook-watchdog[{spec.event}]",
+    )
+    _watchdog.start()
     try:
-        proc = subprocess.run(
-            argv,
-            input=stdin_json,
-            capture_output=True,
-            timeout=spec.timeout,
-            text=True,
-            shell=False,
-        )
-    except subprocess.TimeoutExpired:
-        result["timed_out"] = True
+        try:
+            proc = subprocess.run(
+                argv,
+                input=stdin_json,
+                capture_output=True,
+                timeout=spec.timeout,
+                text=True,
+                shell=False,
+            )
+        except subprocess.TimeoutExpired:
+            result["timed_out"] = True
+            result["elapsed_seconds"] = round(time.monotonic() - t0, 3)
+            return result
+        except FileNotFoundError:
+            result["error"] = "command not found"
+            return result
+        except PermissionError:
+            result["error"] = "command not executable"
+            return result
+        except Exception as exc:  # pragma: no cover — defensive
+            result["error"] = str(exc)
+            return result
+
+        result["returncode"] = proc.returncode
+        result["stdout"] = proc.stdout or ""
+        result["stderr"] = proc.stderr or ""
         result["elapsed_seconds"] = round(time.monotonic() - t0, 3)
         return result
-    except FileNotFoundError:
-        result["error"] = "command not found"
-        return result
-    except PermissionError:
-        result["error"] = "command not executable"
-        return result
-    except Exception as exc:  # pragma: no cover — defensive
-        result["error"] = str(exc)
-        return result
-
-    result["returncode"] = proc.returncode
-    result["stdout"] = proc.stdout or ""
-    result["stderr"] = proc.stderr or ""
-    result["elapsed_seconds"] = round(time.monotonic() - t0, 3)
-    return result
+    finally:
+        _watchdog_stop.set()
 
 
 def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]]]:

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -27,6 +27,7 @@ import json
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -35,6 +36,63 @@ from agent.tool_result_classification import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Pre-tool dispatch latency threshold (#32460).  The agent loop calls
+# ``get_pre_tool_call_block_message()`` for every tool call before the
+# tool starts measuring its own duration, so a slow plugin / shell hook
+# here produces a silent wall-clock gap between an LLM response and the
+# resulting tool execution.  When the call exceeds this threshold, emit
+# a single WARNING that names the tool — the operator no longer has to
+# guess whether the agent was idle or one of their hooks was hung.
+_PRE_TOOL_DISPATCH_SLOW_THRESHOLD_SECONDS = 2.0
+
+
+def pre_tool_call_block_message_with_latency(
+    tool_name: str,
+    function_args: Optional[Dict[str, Any]],
+    *,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+) -> Optional[str]:
+    """Call ``get_pre_tool_call_block_message`` and warn on slow dispatch.
+
+    Equivalent to invoking
+    :func:`hermes_cli.plugins.get_pre_tool_call_block_message` directly,
+    but wraps the call in a ``time.monotonic`` window so dispatch latency
+    above ``_PRE_TOOL_DISPATCH_SLOW_THRESHOLD_SECONDS`` is reported via a
+    WARNING that names the offending tool.
+
+    The pre-tool dispatch path is silent in the agent log under normal
+    conditions, so a hook or plugin that blocks here for tens of seconds
+    appears to the user as the agent "freezing" between an LLM response
+    and the next tool execution — exactly the symptom reported in
+    #32460.  Surfacing the latency immediately lets the operator chase
+    down the responsible hook / plugin without having to enable debug
+    logging or instrument by hand.
+    """
+    from hermes_cli.plugins import get_pre_tool_call_block_message
+
+    t0 = time.monotonic()
+    try:
+        return get_pre_tool_call_block_message(
+            tool_name,
+            function_args,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+        )
+    finally:
+        elapsed = time.monotonic() - t0
+        if elapsed >= _PRE_TOOL_DISPATCH_SLOW_THRESHOLD_SECONDS:
+            logger.warning(
+                "pre_tool_call dispatch took %.1fs for tool %r — a slow "
+                "shell hook or plugin is stalling the agent loop. "
+                "Check ~/.hermes/config.yaml 'hooks.pre_tool_call' "
+                "entries and recently installed plugins.",
+                elapsed,
+                tool_name,
+            )
 
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -36,6 +36,7 @@ from agent.tool_dispatch_helpers import (
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
     make_tool_result_message,
+    pre_tool_call_block_message_with_latency,
 )
 from tools.terminal_tool import (
     _get_approval_callback,
@@ -125,8 +126,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         block_result = None
         blocked_by_guardrail = False
         try:
-            from hermes_cli.plugins import get_pre_tool_call_block_message
-            block_message = get_pre_tool_call_block_message(
+            block_message = pre_tool_call_block_message_with_latency(
                 function_name, function_args, task_id=effective_task_id or "",
             )
         except Exception:
@@ -500,8 +500,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None
         try:
-            from hermes_cli.plugins import get_pre_tool_call_block_message
-            _block_msg = get_pre_tool_call_block_message(
+            _block_msg = pre_tool_call_block_message_with_latency(
                 function_name, function_args, task_id=effective_task_id or "",
             )
         except Exception:

--- a/model_tools.py
+++ b/model_tools.py
@@ -784,8 +784,13 @@ def handle_function_call(
         if not skip_pre_tool_call_hook:
             block_message: Optional[str] = None
             try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
-                block_message = get_pre_tool_call_block_message(
+                # Routed through the latency-aware wrapper so a slow
+                # pre_tool_call hook surfaces a WARNING in agent.log
+                # instead of a silent wall-clock gap (#32460).
+                from agent.tool_dispatch_helpers import (
+                    pre_tool_call_block_message_with_latency,
+                )
+                block_message = pre_tool_call_block_message_with_latency(
                     function_name,
                     function_args,
                     task_id=task_id or "",

--- a/tests/agent/test_pre_tool_dispatch_latency.py
+++ b/tests/agent/test_pre_tool_dispatch_latency.py
@@ -1,0 +1,171 @@
+"""Regression tests for pre-tool dispatch latency observability (#32460).
+
+The agent loop calls ``get_pre_tool_call_block_message()`` for every
+tool invocation before the tool starts measuring its own duration, so a
+slow plugin or shell hook here produces a silent wall-clock gap with no
+indication of where time was spent.  The
+:func:`agent.tool_dispatch_helpers.pre_tool_call_block_message_with_latency`
+wrapper measures that window and logs a WARNING when it exceeds
+``_PRE_TOOL_DISPATCH_SLOW_THRESHOLD_SECONDS`` — turning the previously-
+silent stall into an actionable log line that names the offending tool.
+
+These tests pin three invariants:
+
+* Fast dispatch is silent — the warning must not fire on every tool
+  call or the log noise would be intolerable.
+* Slow dispatch logs a WARNING that names the tool and the elapsed
+  time so the operator can correlate the latency with a specific tool
+  invocation.
+* The return value of the wrapper is the same as the underlying call —
+  the wrapper is purely observational and must never mutate the block
+  decision.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from unittest.mock import patch
+
+import pytest
+
+from agent import tool_dispatch_helpers
+
+
+@pytest.fixture
+def low_threshold(monkeypatch):
+    """Shrink the slow-dispatch threshold for fast, deterministic tests."""
+    monkeypatch.setattr(
+        tool_dispatch_helpers,
+        "_PRE_TOOL_DISPATCH_SLOW_THRESHOLD_SECONDS",
+        0.1,
+    )
+
+
+def _latency_warnings(caplog) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if "pre_tool_call dispatch took" in r.getMessage()
+    ]
+
+
+class TestPreToolDispatchLatency:
+    def test_fast_dispatch_emits_no_warning(self, caplog, low_threshold):
+        """Sub-threshold dispatch must stay silent.
+
+        A naked pre-tool check on every single tool invocation would
+        flood the log if the wrapper warned unconditionally, so we
+        guard against accidental "always warn" regressions here.
+        """
+        with patch(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            return_value=None,
+        ):
+            with caplog.at_level("WARNING", logger="agent.tool_dispatch_helpers"):
+                result = tool_dispatch_helpers.pre_tool_call_block_message_with_latency(
+                    "terminal", {"command": "echo ok"},
+                )
+
+        assert result is None
+        assert _latency_warnings(caplog) == []
+
+    def test_slow_dispatch_warns_with_tool_name_and_elapsed(
+        self, caplog, low_threshold
+    ):
+        """Above-threshold dispatch must log a WARNING that names the tool.
+
+        The warning text is the operator-facing diagnostic for the
+        symptom in #32460 — the line must include both the tool name
+        (so the user can pinpoint which call stalled) and the elapsed
+        time (so they can correlate with the magnitude of the gap).
+        """
+        def _slow_hook(*_args, **_kwargs):
+            time.sleep(0.2)
+            return None
+
+        with patch(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            side_effect=_slow_hook,
+        ):
+            with caplog.at_level("WARNING", logger="agent.tool_dispatch_helpers"):
+                tool_dispatch_helpers.pre_tool_call_block_message_with_latency(
+                    "terminal", {"command": "echo slow"},
+                )
+
+        warnings = _latency_warnings(caplog)
+        assert warnings, "wrapper must warn when dispatch exceeds threshold"
+        msg = warnings[0]
+        assert "terminal" in msg, "warning must name the offending tool"
+        # Elapsed-time format is "%.1fs"; just check it's a plausible
+        # decimal value near our sleep duration.  Allow generous slack
+        # for slow CI hosts.
+        assert "0.2s" in msg or "0.3s" in msg or "0.4s" in msg, (
+            f"warning should report elapsed time ≈0.2s, got: {msg}"
+        )
+
+    def test_block_message_passes_through(self, caplog, low_threshold):
+        """The wrapper must return the underlying block decision unchanged.
+
+        Regression guard: an early implementation could mask block
+        directives by accidentally swallowing the return value while
+        timing the call.  We assert here that the wrapper is purely
+        observational — when the upstream hook returns a block message,
+        the wrapper returns the same string verbatim.
+        """
+        with patch(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            return_value="blocked by plugin policy",
+        ):
+            with caplog.at_level("WARNING", logger="agent.tool_dispatch_helpers"):
+                result = tool_dispatch_helpers.pre_tool_call_block_message_with_latency(
+                    "terminal", {"command": "rm -rf /"},
+                )
+
+        assert result == "blocked by plugin policy"
+
+    def test_exception_propagates_and_still_logs_latency(
+        self, caplog, low_threshold
+    ):
+        """Even if the underlying call raises, the latency check still runs.
+
+        The wrapper uses ``try/finally`` so the timing path executes on
+        every dispatch regardless of how the underlying call exits.
+        A slow hook that raises after stalling must still produce the
+        WARNING so the operator can locate the offending plugin.
+        """
+        def _slow_then_raise(*_args, **_kwargs):
+            time.sleep(0.2)
+            raise RuntimeError("plugin exploded")
+
+        with patch(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            side_effect=_slow_then_raise,
+        ):
+            with caplog.at_level("WARNING", logger="agent.tool_dispatch_helpers"):
+                with pytest.raises(RuntimeError, match="plugin exploded"):
+                    tool_dispatch_helpers.pre_tool_call_block_message_with_latency(
+                        "terminal", {"command": "echo boom"},
+                    )
+
+        # The warning still fires even though the call raised.
+        assert _latency_warnings(caplog), (
+            "latency warning must fire even when the hook raises"
+        )
+
+    def test_default_threshold_is_production_sane(self):
+        """Production threshold should be high enough not to flood the log
+        but low enough that a stuck hook surfaces well before the 60-second
+        ``DEFAULT_TIMEOUT_SECONDS`` window in ``agent.shell_hooks``.
+
+        This is a behavioural pin — the constant exists precisely
+        because lowering it to satisfy tests (and forgetting to restore
+        it) would silently re-introduce the #32460 symptom.
+        """
+        # Reference the un-patched module-level default explicitly.
+        assert (
+            0.5 <= tool_dispatch_helpers._PRE_TOOL_DISPATCH_SLOW_THRESHOLD_SECONDS <= 10.0
+        ), (
+            "production threshold must be a small-but-not-tiny value so "
+            "real hangs surface fast while routine dispatch stays quiet"
+        )

--- a/tests/agent/test_shell_hooks_slow_watchdog.py
+++ b/tests/agent/test_shell_hooks_slow_watchdog.py
@@ -1,0 +1,226 @@
+"""Regression tests for the slow-hook watchdog (#32460).
+
+The watchdog runs in a daemon thread alongside every shell-hook
+subprocess and emits a WARNING once the hook crosses the configured
+threshold without returning.  Without it, a hook that hangs for the
+full ``DEFAULT_TIMEOUT_SECONDS = 60`` window manifests as a silent
+50-65s wall-clock gap between an LLM response and the resulting tool
+execution — the symptom reported in the bug.
+
+These tests pin three invariants:
+
+* A hook that returns before the threshold emits **no** "still running"
+  warning, so well-behaved scripts stay silent.
+* A hook that runs **past** the threshold emits at least one
+  "still running" warning while it is still in flight (i.e. before the
+  subprocess returns), with the offending command in the message so the
+  user can identify which script is hanging.
+* The watchdog stops once the hook returns and does not leak repeated
+  warnings indefinitely.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent import shell_hooks
+
+
+def _write_script(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body)
+    path.chmod(0o755)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _reset_registration_state():
+    shell_hooks.reset_for_tests()
+    yield
+    shell_hooks.reset_for_tests()
+
+
+@pytest.fixture
+def fast_watchdog(monkeypatch):
+    """Shrink the watchdog thresholds so tests can exercise them in <2s.
+
+    The production defaults (5s / 10s) are tuned for human-visible logs
+    and would make every test on this file ~10s long.  We collapse both
+    knobs to small but realistic values.  Threshold stays high enough
+    that a single ``bash`` cold start on a loaded test host (~0.3s on
+    macOS under contention) doesn't trip the watchdog — otherwise the
+    "fast hook stays silent" invariant becomes flaky on shared CI.
+    """
+    monkeypatch.setattr(shell_hooks, "_SLOW_HOOK_THRESHOLD_SECONDS", 1.0)
+    monkeypatch.setattr(shell_hooks, "_SLOW_HOOK_REPEAT_SECONDS", 0.2)
+
+
+def _slow_hook_warnings(caplog) -> list[str]:
+    """Return the messages logged by the watchdog (filter out other lines)."""
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if "shell hook still running" in r.getMessage()
+    ]
+
+
+class TestSlowHookWatchdog:
+    def test_fast_hook_emits_no_warning(self, tmp_path, caplog, fast_watchdog):
+        """Hooks that return below the threshold stay silent.
+
+        Even a script that prints a no-op JSON object and exits must not
+        trigger the watchdog warning — otherwise the log line would fire
+        on every successful tool dispatch.
+        """
+        script = _write_script(
+            tmp_path,
+            "fast.sh",
+            "#!/usr/bin/env bash\nprintf '{}\\n'\n",
+        )
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call", command=str(script), timeout=5,
+        )
+
+        with caplog.at_level("WARNING", logger="agent.shell_hooks"):
+            result = shell_hooks._spawn(spec, "{}")
+
+        assert result["error"] is None
+        assert result["timed_out"] is False
+        assert _slow_hook_warnings(caplog) == []
+
+    def test_slow_hook_emits_warning_with_command_and_event(
+        self, tmp_path, caplog, fast_watchdog
+    ):
+        """A hook that runs past the threshold must log a visible warning.
+
+        The warning text must name both the event and the command so the
+        operator can find the offending script without having to enable
+        debug logging or guess at process ancestry.
+        """
+        script = _write_script(
+            tmp_path,
+            "slow.sh",
+            "#!/usr/bin/env bash\nsleep 1.5\nprintf '{}\\n'\n",
+        )
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call", command=str(script), timeout=10,
+        )
+
+        with caplog.at_level("WARNING", logger="agent.shell_hooks"):
+            result = shell_hooks._spawn(spec, "{}")
+
+        warnings = _slow_hook_warnings(caplog)
+        assert warnings, "watchdog must emit at least one warning for slow hook"
+        # The first warning is the threshold notice; it must name the event
+        # and the command so the user can identify the offending script.
+        first = warnings[0]
+        assert "pre_tool_call" in first
+        assert str(script) in first
+        # The hook still succeeded once it finished, so the spawn result
+        # is clean — the warning is purely informational.
+        assert result["error"] is None
+        assert result["timed_out"] is False
+
+    def test_watchdog_stops_after_hook_returns(
+        self, tmp_path, caplog, fast_watchdog
+    ):
+        """Once the hook returns, the watchdog must stop logging.
+
+        Regression guard: the watchdog uses ``Event.wait()`` with a
+        short interval, so a missing ``stop_event.set()`` in the
+        subprocess-return path would cause the daemon thread to keep
+        warning forever.  We verify the count stabilises within a
+        bounded window after the hook returns.
+        """
+        import time
+
+        script = _write_script(
+            tmp_path,
+            "slow.sh",
+            "#!/usr/bin/env bash\nsleep 1.3\nprintf '{}\\n'\n",
+        )
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call", command=str(script), timeout=10,
+        )
+
+        with caplog.at_level("WARNING", logger="agent.shell_hooks"):
+            shell_hooks._spawn(spec, "{}")
+            count_immediately_after = len(_slow_hook_warnings(caplog))
+            # Give the watchdog several extra intervals to (incorrectly)
+            # log more warnings if its stop signal wasn't honored.
+            time.sleep(0.6)
+            count_after_wait = len(_slow_hook_warnings(caplog))
+
+        assert count_after_wait == count_immediately_after, (
+            "watchdog must stop firing once the hook subprocess returns"
+        )
+
+    def test_hook_timeout_path_also_stops_watchdog(
+        self, tmp_path, caplog, fast_watchdog, monkeypatch
+    ):
+        """When the hook hits ``spec.timeout``, the watchdog must also stop.
+
+        The subprocess ``timeout`` branch is a separate exit path from
+        the success branch.  Both must trigger the ``finally: stop``
+        in :func:`_spawn`, otherwise a hung hook would leave behind a
+        zombie watchdog thread that keeps logging after the timeout
+        message has already fired.
+
+        We mock ``subprocess.run`` directly rather than use a real
+        ``sleep`` script: subprocess teardown on POSIX can hang
+        unbounded inside ``communicate()`` waiting for grandchild
+        stdout-pipe EOF (the same footgun documented in
+        :func:`_wait_for_process`), which would prevent us from
+        observing the watchdog state at the *moment* the timeout fires.
+        Mocking lets the assertion focus on the watchdog stop signal.
+        """
+        import subprocess
+        import time
+
+        def _fake_run(*_args, **_kwargs):
+            # Simulate a hook that exceeds spec.timeout — sleep long enough
+            # that the watchdog warns at least once, then raise.
+            time.sleep(1.3)
+            raise subprocess.TimeoutExpired(cmd="fake-hook", timeout=1.3)
+
+        monkeypatch.setattr(shell_hooks.subprocess, "run", _fake_run)
+
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call", command="/bin/true", timeout=2,
+        )
+
+        with caplog.at_level("WARNING", logger="agent.shell_hooks"):
+            result = shell_hooks._spawn(spec, "{}")
+            # Capture the warning count right after the timeout fires…
+            count_at_timeout = len(_slow_hook_warnings(caplog))
+            # …then wait several extra repeat intervals and confirm the
+            # watchdog stopped emitting once subprocess.run raised.
+            time.sleep(0.6)
+            count_after_wait = len(_slow_hook_warnings(caplog))
+
+        assert result["timed_out"] is True
+        assert count_after_wait == count_at_timeout, (
+            "watchdog must stop firing once the hook subprocess raises "
+            "TimeoutExpired (otherwise zombie warnings keep appearing)"
+        )
+
+    def test_spawn_failure_does_not_warn(self, tmp_path, caplog, fast_watchdog):
+        """Spawn-time failures (command not found) return immediately, so
+        the watchdog must not fire even with a tiny threshold.
+
+        The watchdog only makes sense for hooks that actually started
+        but won't return.  An ``argv``-validation error never reaches
+        the subprocess and should look the same in the log as a
+        no-hook setup.
+        """
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call", command="", timeout=5,
+        )
+
+        with caplog.at_level("WARNING", logger="agent.shell_hooks"):
+            result = shell_hooks._spawn(spec, "{}")
+
+        assert result["error"] == "empty command"
+        assert _slow_hook_warnings(caplog) == []


### PR DESCRIPTION
## What does this PR do?

Makes the silent 50-65s wall-clock gap reported in #32460 visible in `agent.log` instead of looking like the agent froze.

The bug surfaces as a terminal-tool hang on every subsequent call after the first in a CLI/TUI session, while Feishu / gateway sessions run fast. Tool durations in the log show ≤0.5s for trivial commands like `ping` / `echo`, but the wall-clock gap between *API call #N completed* and *tool terminal completed* clusters tightly around 50-65s — a textbook fixed-timeout pattern.

**Root cause:** `agent/shell_hooks.py` runs every configured `pre_tool_call` hook synchronously on the path between the LLM response and tool execution with `DEFAULT_TIMEOUT_SECONDS = 60`. When a hook stalls for the full window, `subprocess.run` waits silently and the bridge only logs a single *shell hook timed out* WARNING **after** the timer expires. The matching tool execution then completes in milliseconds, so the user-visible `tool ... completed (Xs)` line under-reports the stall and there is nothing in the log that names the offending hook. CLI registers shell hooks by default; the gateway side does not unless they are allow-listed — which explains the CLI-only / Feishu-fast split.

Three small additions wired together turn the stall from silent into actionable:

1. **`agent/shell_hooks.py`** — spawn each hook subprocess alongside a daemon watchdog thread. Once the hook has been running for 5 seconds the watchdog emits a WARNING naming the event and command, repeated every 10s until the hook returns. The threshold is well under `DEFAULT_TIMEOUT_SECONDS`, so a hung hook surfaces immediately instead of after the full 60s window. The watchdog stop signal is wired through `finally` so success, timeout, and spawn-error paths all clean it up.
2. **`agent/tool_dispatch_helpers.py`** — new `pre_tool_call_block_message_with_latency` wraps `get_pre_tool_call_block_message` in a `time.monotonic` window and logs a WARNING when dispatch exceeds 2s. The warning names the tool so the operator can correlate the stall with a specific invocation regardless of what's blocking (hook, plugin, MCP probe, etc.). The wrapper is purely observational — return value passes through verbatim and exceptions re-raise.
3. **Call-site routing** — sequential + concurrent paths in `agent/tool_executor.py`, `invoke_tool` in `agent/agent_runtime_helpers.py`, and the non-skip path in `model_tools.handle_function_call` all swap to the new wrapper. Every `pre_tool_call` invocation now contributes to the slow-dispatch warning.

## Related Issue

Fixes #32460

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that surfaces a previously-silent stall)

## Changes Made

- `agent/shell_hooks.py` — add `_SLOW_HOOK_THRESHOLD_SECONDS=5` / `_SLOW_HOOK_REPEAT_SECONDS=10`, new `_watch_slow_hook` daemon, wire watchdog around `subprocess.run` in `_spawn` with `try/finally` cleanup so the success / `TimeoutExpired` / spawn-error paths all stop it.
- `agent/tool_dispatch_helpers.py` — new `pre_tool_call_block_message_with_latency` wrapper + `_PRE_TOOL_DISPATCH_SLOW_THRESHOLD_SECONDS=2`.
- `agent/tool_executor.py` — sequential + concurrent paths route through the wrapper.
- `agent/agent_runtime_helpers.py::invoke_tool` — routes through the wrapper.
- `model_tools.py::handle_function_call` — non-skip path routes through the wrapper.
- `tests/agent/test_shell_hooks_slow_watchdog.py` — **5 new tests** pinning fast-hook silence, slow-hook warning content, watchdog stop on success, watchdog stop on `TimeoutExpired`, and spawn-failure silence.
- `tests/agent/test_pre_tool_dispatch_latency.py` — **5 new tests** pinning fast-dispatch silence, slow-dispatch warning with tool name + elapsed time, block-message pass-through, exception propagation while still logging, and a production-threshold behavioural pin.

Backwards compatible: no public API removed, no schema migration, no new config keys. Hooks that already returned promptly keep behaving identically; the only user-visible change is a WARNING that names the offending hook when it stalls.

## How to Test

```bash
# New regression suites (10 tests total, ~7s)
.venv/bin/python -m pytest tests/agent/test_shell_hooks_slow_watchdog.py tests/agent/test_pre_tool_dispatch_latency.py -v

# Related areas exercised by the change (131 tests, ~7s)
.venv/bin/python -m pytest tests/agent/test_shell_hooks_consent.py \
    tests/hermes_cli/test_plugins.py \
    tests/test_model_tools.py \
    tests/run_agent/test_tool_call_guardrail_runtime.py \
    tests/run_agent/test_background_review_toolset_restriction.py -q
```

Behaviour after the fix — agent.log on a hook that stalls 60s:

```
2026-05-26 14:26:04,070 agent.conversation_loop: API call #3 completed
2026-05-26 14:26:09,073 agent.shell_hooks: shell hook still running after 5.0s
    (event=pre_tool_call command=/home/me/pre-tool-scan.sh timeout=60s); this
    stalls every tool call dispatch until the hook returns
2026-05-26 14:26:19,074 agent.shell_hooks: shell hook still running after 15.0s
    (event=pre_tool_call command=/home/me/pre-tool-scan.sh timeout=60s)
2026-05-26 14:26:29,074 agent.shell_hooks: shell hook still running after 25.0s
    (event=pre_tool_call command=/home/me/pre-tool-scan.sh timeout=60s)
…
2026-05-26 14:27:04,071 agent.shell_hooks: shell hook timed out after 60.00s
    (event=pre_tool_call command=/home/me/pre-tool-scan.sh)
2026-05-26 14:27:04,072 agent.tool_dispatch_helpers: pre_tool_call dispatch
    took 60.0s for tool 'terminal' — a slow shell hook or plugin is stalling
    the agent loop. Check ~/.hermes/config.yaml 'hooks.pre_tool_call' entries
    and recently installed plugins.
2026-05-26 14:27:04,219 agent.tool_executor: tool terminal completed (0.15s, 42 chars)
```

The 50-65s wall-clock gap is now named, timestamped, attributed to a specific tool, and traceable to a specific hook command — operator can act on it instead of guessing.

## Checklist

- [x] Conventional Commits (`feat(shell_hooks):`, `feat(agent):`, `refactor(dispatch):`)
- [x] 3 focused commits, single author (`xxxigm`)
- [x] 10 new tests pass; 131 related existing tests pass; pre-existing macOS flakes (`test_anthropic_adapter.py::TestRunOauthSetupToken`, `test_shell_hooks.py::TestCallbackSubprocess::test_timeout_returns_none`, `test_vision_routing_31179.py` under contention) confirmed unchanged on `upstream/main`
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12.5
- [x] No new config keys, no architecture change, no platform-specific calls
- [x] Backwards compatible — well-behaved hooks stay silent