### PR TITLE
fix(dashboard): allow websocket clients for public binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3330,8 +3330,15 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
-    Allows loopback clients only.
+    Defaults to loopback-only. When the operator explicitly binds the
+    dashboard to a non-loopback interface (which start_server only permits
+    with ``--insecure``), allow remote WebSocket clients too; HTTP access is
+    already public in that mode and the WebSocket guard should match it.
     """
+    bound_host = getattr(app.state, "bound_host", None)
+    if bound_host and bound_host.lower() not in _LOOPBACK_HOST_VALUES:
+        return True
+
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return True

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -215,3 +215,27 @@ class TestWebSocketHostOriginGuard:
             },
         ):
             pass
+
+    def test_remote_websocket_client_allowed_for_public_bind(self, monkeypatch):
+        """Binding to 0.0.0.0 with --insecure makes HTTP public, so the
+        companion WebSocket endpoints must not stay loopback-only."""
+        from typing import Any, cast
+        from types import SimpleNamespace
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "0.0.0.0", raising=False)
+
+        fake_ws = cast(Any, SimpleNamespace(client=SimpleNamespace(host="10.0.0.42")))
+        assert ws._ws_client_is_allowed(fake_ws)
+
+    def test_remote_websocket_client_rejected_for_loopback_bind(self, monkeypatch):
+        from typing import Any, cast
+        from types import SimpleNamespace
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws.app.state, "bound_host", "127.0.0.1", raising=False)
+
+        fake_ws = cast(Any, SimpleNamespace(client=SimpleNamespace(host="10.0.0.42")))
+        assert not ws._ws_client_is_allowed(fake_ws)


### PR DESCRIPTION
## Summary
- allow dashboard WebSocket clients from non-loopback peers when the dashboard is explicitly bound to a non-loopback interface
- keep loopback-bound dashboards restricted to loopback WebSocket clients
- add regression coverage for public-bind vs loopback-bind client checks

## Why
A recent hardening change made dashboard WebSockets loopback-only. That is correct for the default localhost bind, but it breaks the existing LAN dashboard use case when the operator explicitly starts the dashboard with e.g. `hermes dashboard --host 0.0.0.0 --insecure --tui`: the HTTP UI loads remotely, but `/api/events`, `/api/ws`, and `/api/pty` are rejected, causing the chat sidebar to show `events feed disconnected`.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_web_server_host_header.py -q`
- [x] manually verified `/api/events` connects from `127.0.0.1:9119` and LAN addresses after restarting the dashboard
