### PR TITLE
Fix gateway cleanup, Feishu cron cards, and Codex MCP memory bridge

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -453,6 +453,7 @@ def init_agent(
     # Store toolset filtering options
     agent.enabled_toolsets = enabled_toolsets
     agent.disabled_toolsets = disabled_toolsets
+    agent.skip_memory = skip_memory
     
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,35 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _codex_memory_tool_hint(agent, user_message: str) -> str:
+    """Tell Codex app-server how Hermes memory tools map onto MCP tools.
+
+    The app-server runtime owns its own tool loop. Hermes exposes provider
+    tools like memos_search through the hermes-tools MCP server, not as native
+    OpenAI function names. Without a short bridge note, the model can list MCP
+    tools but still conclude that an exact `memos_search` function is absent.
+    """
+    memory_manager = getattr(agent, "_memory_manager", None)
+    if not memory_manager:
+        return user_message
+    try:
+        tool_names = sorted(str(name) for name in memory_manager.get_all_tool_names())
+    except Exception:
+        return user_message
+    if not tool_names:
+        return user_message
+
+    tool_list = ", ".join(tool_names)
+    return (
+        "[Hermes system note for Codex runtime: Active Hermes memory-provider "
+        f"tools are exposed through the MCP server `hermes-tools`: {tool_list}. "
+        "When the user asks to call one of these tools, call the corresponding "
+        "`hermes-tools` MCP tool. Do not say the tool is unavailable merely "
+        "because it is exposed through MCP.]\n\n"
+        f"{user_message}"
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -57,9 +86,56 @@ def run_codex_app_server_turn(
             approval_callback = _get_approval_callback()
         except Exception:
             approval_callback = None
+        codex_env: dict[str, str] = {}
+        if getattr(agent, "session_id", None):
+            codex_env["HERMES_SESSION_ID"] = str(agent.session_id)
+            codex_env["HERMES_CODEX_SESSION_ID"] = str(agent.session_id)
+        if getattr(agent, "platform", None):
+            codex_env["HERMES_PLATFORM"] = str(agent.platform)
+        if getattr(agent, "enabled_toolsets", None) is not None:
+            codex_env["HERMES_ENABLED_TOOLSETS"] = ",".join(
+                str(item) for item in (agent.enabled_toolsets or [])
+            )
+        if getattr(agent, "disabled_toolsets", None) is not None:
+            codex_env["HERMES_DISABLED_TOOLSETS"] = ",".join(
+                str(item) for item in (agent.disabled_toolsets or [])
+            )
+        if getattr(agent, "skip_memory", False):
+            codex_env["HERMES_SKIP_MEMORY"] = "1"
+        # Give hermes-tools MCP callbacks enough identity context to initialize
+        # the active memory provider with the same scoping as the parent agent.
+        optional_agent_env = {
+            "HERMES_USER_ID": "_user_id",
+            "HERMES_USER_NAME": "_user_name",
+            "HERMES_CHAT_ID": "_chat_id",
+            "HERMES_CHAT_NAME": "_chat_name",
+            "HERMES_CHAT_TYPE": "_chat_type",
+            "HERMES_THREAD_ID": "_thread_id",
+            "HERMES_GATEWAY_SESSION_KEY": "_gateway_session_key",
+        }
+        for env_name, attr_name in optional_agent_env.items():
+            value = getattr(agent, attr_name, None)
+            if value:
+                codex_env[env_name] = str(value)
+        if getattr(agent, "_session_db", None) and getattr(agent, "session_id", None):
+            try:
+                session_title = agent._session_db.get_session_title(agent.session_id)
+                if session_title:
+                    codex_env["HERMES_SESSION_TITLE"] = str(session_title)
+            except Exception:
+                pass
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            profile_name = get_active_profile_name()
+            if profile_name:
+                codex_env["HERMES_AGENT_IDENTITY"] = str(profile_name)
+                codex_env["HERMES_AGENT_WORKSPACE"] = "hermes"
+        except Exception:
+            pass
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            env=codex_env,
         )
 
     # NOTE: the user message is ALREADY appended to messages by the
@@ -67,7 +143,9 @@ def run_codex_app_server_turn(
     # return reaches us. Do NOT append again — that would duplicate.
 
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        turn = agent._codex_session.run_turn(
+            user_input=_codex_memory_tool_hint(agent, user_message)
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -204,6 +204,7 @@ class CodexAppServerSession:
         on_event: Optional[Callable[[dict], None]] = None,
         request_routing: Optional[_ServerRequestRouting] = None,
         client_factory: Optional[Callable[..., CodexAppServerClient]] = None,
+        env: Optional[dict[str, str]] = None,
     ) -> None:
         self._cwd = cwd or os.getcwd()
         self._codex_bin = codex_bin
@@ -218,6 +219,7 @@ class CodexAppServerSession:
         self._on_event = on_event  # Display hook (kawaii spinner ticks etc.)
         self._routing = request_routing or _ServerRequestRouting()
         self._client_factory = client_factory or CodexAppServerClient
+        self._env = dict(env or {})
 
         self._client: Optional[CodexAppServerClient] = None
         self._thread_id: Optional[str] = None
@@ -240,7 +242,9 @@ class CodexAppServerSession:
             return self._thread_id
         if self._client is None:
             self._client = self._client_factory(
-                codex_bin=self._codex_bin, codex_home=self._codex_home
+                codex_bin=self._codex_bin,
+                codex_home=self._codex_home,
+                env=self._env or None,
             )
         self._client.initialize(
             client_name="hermes",

--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -20,6 +20,7 @@ Scope (what we expose):
   - image_generate                       — image generation
   - skill_view, skills_list              — Hermes' skill library
   - text_to_speech                       — TTS
+  - active memory-provider tools         — e.g. memos_search/memos_skill_list
   - kanban_* (complete/block/comment/    — kanban worker + orchestrator
     heartbeat/show/list/create/            handoff (stateless: read env var,
     unblock/link)                          write ~/.hermes/kanban.db)
@@ -29,7 +30,7 @@ What we DO NOT expose:
   - read_file / write_file / patch       — codex's apply_patch + shell
   - search_files / process               — codex's shell
   - clarify                              — codex's own UX
-  - delegate_task / memory /             — `_AGENT_LOOP_TOOLS` in Hermes
+  - delegate_task / builtin memory /     — `_AGENT_LOOP_TOOLS` in Hermes
     session_search / todo                  (model_tools.py). They require
                                            the running AIAgent context to
                                            dispatch (mid-loop state), so a
@@ -44,13 +45,240 @@ Spawned by: CodexAppServerSession.ensure_started() when the runtime is
 
 from __future__ import annotations
 
+import atexit
+import inspect
 import json
+import keyword
 import logging
 import os
 import sys
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _current_session_id() -> str:
+    """Return the Hermes session id visible to the MCP subprocess."""
+    return (
+        os.environ.get("HERMES_SESSION_ID")
+        or os.environ.get("HERMES_CODEX_SESSION_ID")
+        or "codex_app_server_mcp"
+    )
+
+
+def _env_toolset_list(env_name: str) -> Optional[list[str]]:
+    """Parse an exported toolset filter.
+
+    ``None`` means the parent did not apply a filter.  An empty string is a real
+    empty filter (for example ``enabled_toolsets=[]``), so return ``[]`` rather
+    than falling back to "all".
+    """
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return None
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _memory_enabled(config: dict[str, Any]) -> bool:
+    memory_cfg = config.get("memory") if isinstance(config, dict) else {}
+    if not isinstance(memory_cfg, dict):
+        return False
+    if os.environ.get("HERMES_SKIP_MEMORY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return False
+    enabled_toolsets = _env_toolset_list("HERMES_ENABLED_TOOLSETS")
+    if enabled_toolsets is not None:
+        enabled = set(enabled_toolsets)
+        if not enabled.intersection({"memory", "all", "*"}):
+            return False
+    disabled_toolsets = _env_toolset_list("HERMES_DISABLED_TOOLSETS")
+    if disabled_toolsets is not None:
+        disabled = set(disabled_toolsets)
+        if disabled.intersection({"memory", "all", "*"}):
+            return False
+    if memory_cfg.get("enabled") is False:
+        return False
+    if memory_cfg.get("memory_enabled") is False:
+        return False
+    return bool(str(memory_cfg.get("provider") or "").strip())
+
+
+def _build_memory_manager_for_mcp() -> Any:
+    """Initialize the active MemoryProvider for codex's hermes-tools MCP bridge.
+
+    Memory provider tools are dynamic: they are not registered in
+    model_tools.get_tool_definitions(), because the normal AIAgent path injects
+    them after reading the user's memory.provider config. The codex app-server
+    runtime bypasses that path, so the MCP callback has to repeat the provider
+    bootstrap locally.
+    """
+    try:
+        from agent.memory_manager import MemoryManager
+        from hermes_cli.config import load_config
+        from hermes_constants import get_hermes_home
+        from plugins.memory import load_memory_provider
+    except Exception as exc:
+        logger.debug("memory provider MCP bootstrap unavailable: %s", exc)
+        return None
+
+    try:
+        config = load_config()
+    except Exception as exc:
+        logger.debug("memory provider MCP config load failed: %s", exc)
+        return None
+
+    memory_cfg = config.get("memory") if isinstance(config, dict) else {}
+    if not isinstance(memory_cfg, dict) or not _memory_enabled(config):
+        return None
+
+    provider_name = str(memory_cfg.get("provider") or "").strip()
+    try:
+        provider = load_memory_provider(provider_name)
+        if not provider or not provider.is_available():
+            logger.debug("memory provider %r unavailable for MCP bridge", provider_name)
+            return None
+        manager = MemoryManager()
+        manager.add_provider(provider)
+        init_kwargs: dict[str, Any] = {
+            "hermes_home": str(get_hermes_home()),
+            "platform": os.environ.get("HERMES_PLATFORM") or "cli",
+            "agent_context": os.environ.get("HERMES_AGENT_CONTEXT") or "primary",
+        }
+        # Preserve identity/scoping metadata when the parent agent exported it.
+        optional_env = {
+            "user_id": "HERMES_USER_ID",
+            "user_name": "HERMES_USER_NAME",
+            "chat_id": "HERMES_CHAT_ID",
+            "chat_name": "HERMES_CHAT_NAME",
+            "chat_type": "HERMES_CHAT_TYPE",
+            "thread_id": "HERMES_THREAD_ID",
+            "gateway_session_key": "HERMES_GATEWAY_SESSION_KEY",
+            "session_title": "HERMES_SESSION_TITLE",
+            "agent_identity": "HERMES_AGENT_IDENTITY",
+            "agent_workspace": "HERMES_AGENT_WORKSPACE",
+        }
+        for key, env_name in optional_env.items():
+            value = os.environ.get(env_name)
+            if value:
+                init_kwargs[key] = value
+        if "agent_workspace" not in init_kwargs:
+            init_kwargs["agent_workspace"] = "hermes"
+        manager.initialize_all(_current_session_id(), **init_kwargs)
+        return manager
+    except Exception as exc:
+        logger.warning("memory provider %r MCP bootstrap failed: %s", provider_name, exc)
+        return None
+
+
+def _memory_tool_specs(memory_manager: Any) -> dict[str, dict[str, Any]]:
+    """Return OpenAI-style function specs for active memory provider tools."""
+    if memory_manager is None:
+        return {}
+    try:
+        schemas = memory_manager.get_all_tool_schemas() or []
+    except Exception as exc:
+        logger.warning("memory provider MCP get_tool_schemas failed: %s", exc)
+        return {}
+    specs: dict[str, dict[str, Any]] = {}
+    for schema in schemas:
+        if not isinstance(schema, dict):
+            continue
+        name = str(schema.get("name") or "").strip()
+        if not name:
+            continue
+        specs[name] = {
+            "name": name,
+            "description": schema.get("description") or f"Hermes memory {name} tool",
+            "parameters": schema.get("parameters")
+            or {"type": "object", "properties": {}},
+        }
+    return specs
+
+
+def _annotation_for_json_schema(schema: dict[str, Any]) -> Any:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    return {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }.get(schema_type, Any)
+
+
+def _signature_from_json_schema(parameters_schema: dict[str, Any]) -> inspect.Signature:
+    properties = parameters_schema.get("properties") or {}
+    if not isinstance(properties, dict):
+        properties = {}
+    required = parameters_schema.get("required") or []
+    if not isinstance(required, list):
+        required = []
+    required_names = [str(name) for name in required]
+    property_names = [
+        name for name in required_names if name in properties
+    ] + [
+        name for name in properties if name not in required_names
+    ]
+
+    params: list[inspect.Parameter] = []
+    for name in property_names:
+        if not name.isidentifier() or keyword.iskeyword(name):
+            logger.debug("skipping non-identifier MCP parameter %r", name)
+            continue
+        prop_schema = properties.get(name) or {}
+        if not isinstance(prop_schema, dict):
+            prop_schema = {}
+        default = (
+            inspect.Parameter.empty
+            if name in required_names
+            else prop_schema.get("default", None)
+        )
+        params.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=default,
+                annotation=_annotation_for_json_schema(prop_schema),
+            )
+        )
+    return inspect.Signature(params)
+
+
+def _make_mcp_handler(
+    *,
+    tool_name: str,
+    description: str,
+    parameters_schema: dict[str, Any],
+    dispatcher: Callable[[dict[str, Any]], str],
+) -> Callable[..., str]:
+    """Build a FastMCP handler whose signature matches the JSON schema.
+
+    FastMCP derives tool argument validation from inspect.signature(). A plain
+    ``def handler(**kwargs)`` becomes a schema with one required ``kwargs``
+    field, so clients cannot call ``memos_search(query="...")``. Setting an
+    explicit keyword-only signature preserves the Hermes/OpenAI tool schema at
+    the MCP boundary while still dispatching through one generic function.
+    """
+    def _dispatch(**kwargs: Any) -> str:
+        try:
+            return dispatcher(kwargs or {})
+        except Exception as exc:
+            logger.exception("tool %s raised", tool_name)
+            return json.dumps({"error": str(exc), "tool": tool_name})
+
+    _dispatch.__name__ = tool_name
+    _dispatch.__doc__ = description
+    _dispatch.__signature__ = _signature_from_json_schema(  # type: ignore[attr-defined]
+        parameters_schema
+    )
+    return _dispatch
 
 
 # Tools we expose. Each name MUST match a registered Hermes tool that
@@ -60,7 +288,7 @@ logger = logging.getLogger(__name__)
 #   - terminal / shell / read_file / write_file / patch / search_files /
 #     process — codex's built-ins cover these and approval routes through
 #     codex's own UI.
-#   - delegate_task / memory / session_search / todo — these are
+#   - delegate_task / builtin memory / session_search / todo — these are
 #     `_AGENT_LOOP_TOOLS` in Hermes (model_tools.py:493). They require
 #     the running AIAgent context to dispatch (mid-loop state), so a
 #     stateless MCP callback can't drive them. Hermes' default runtime
@@ -133,13 +361,34 @@ def _build_server() -> Any:
         ),
     )
 
-    # Pull authoritative Hermes tool schemas for the ones we expose, so
-    # MCP clients see the same parameter docs Hermes gives the model.
-    all_defs = {
+    # Pull authoritative Hermes tool schemas for the static tools we expose,
+    # so MCP clients see the same parameter docs Hermes gives the model.
+    enabled_toolsets = _env_toolset_list("HERMES_ENABLED_TOOLSETS")
+    disabled_toolsets = _env_toolset_list("HERMES_DISABLED_TOOLSETS")
+    all_defs: dict[str, dict[str, Any]] = {
         td["function"]["name"]: td["function"]
-        for td in (get_tool_definitions(quiet_mode=True) or [])
+        for td in (
+            get_tool_definitions(
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=disabled_toolsets,
+                quiet_mode=True,
+            )
+            or []
+        )
         if isinstance(td, dict) and td.get("type") == "function"
     }
+
+    # Memory provider tools are injected dynamically in the normal AIAgent
+    # path and therefore are absent from get_tool_definitions(). Bootstrap the
+    # active provider here so codex_app_server can see memos_search,
+    # memos_skill_list, honcho_search, etc. through the hermes-tools MCP
+    # callback.
+    memory_manager = _build_memory_manager_for_mcp()
+    memory_defs = _memory_tool_specs(memory_manager)
+    if memory_manager is not None:
+        atexit.register(memory_manager.shutdown_all)
+
+    dispatchers: dict[str, Callable[[dict[str, Any]], str]] = {}
 
     exposed_count = 0
 
@@ -150,46 +399,58 @@ def _build_server() -> Any:
                 "skipping %s — not registered in this Hermes process", name
             )
             continue
+        dispatchers[name] = (
+            lambda kwargs, tool_name=name: handle_function_call(
+                tool_name, kwargs or {}
+            )
+        )
+        exposed_count += 1
 
+    for name, spec in memory_defs.items():
+        if name in all_defs:
+            logger.debug("skipping memory tool %s — static tool already exists", name)
+            continue
+        if memory_manager is None:
+            continue
+        all_defs[name] = spec
+        dispatchers[name] = (
+            lambda kwargs, tool_name=name: memory_manager.handle_tool_call(
+                tool_name, kwargs or {}
+            )
+        )
+        exposed_count += 1
+
+    for name, spec in all_defs.items():
+        if name not in dispatchers:
+            continue
         description = spec.get("description") or f"Hermes {name} tool"
-        params_schema = spec.get("parameters") or {"type": "object", "properties": {}}
+        params_schema = spec.get("parameters") or {
+            "type": "object",
+            "properties": {},
+        }
 
-        # FastMCP wants a Python callable. Build a closure that takes the
-        # arguments dict, dispatches via handle_function_call, and returns
-        # the result string. We use add_tool() for full control over the
-        # input schema (FastMCP's @tool() decorator inspects type hints,
-        # which we can't get from a JSON schema at runtime).
-        def _make_handler(tool_name: str):
-            def _dispatch(**kwargs: Any) -> str:
-                try:
-                    return handle_function_call(tool_name, kwargs or {})
-                except Exception as exc:
-                    logger.exception("tool %s raised", tool_name)
-                    return json.dumps({"error": str(exc), "tool": tool_name})
-            _dispatch.__name__ = tool_name
-            _dispatch.__doc__ = description
-            return _dispatch
+        handler = _make_mcp_handler(
+            tool_name=name,
+            description=description,
+            parameters_schema=params_schema,
+            dispatcher=dispatchers[name],
+        )
 
         try:
             mcp.add_tool(
-                _make_handler(name),
+                handler,
                 name=name,
                 description=description,
-                # FastMCP accepts JSON schema directly via the
-                # input_schema parameter on newer versions; older
-                # versions use parameters_schema. Try both for compat.
             )
         except TypeError:
             # Older mcp SDK signature — fall back to decorator-style.
-            handler = _make_handler(name)
             handler = mcp.tool(name=name, description=description)(handler)
 
-        exposed_count += 1
-
     logger.info(
-        "hermes-tools MCP server registered %d/%d tools",
+        "hermes-tools MCP server registered %d tools (%d static candidates, %d memory tools)",
         exposed_count,
         len(EXPOSED_TOOLS),
+        len(memory_defs),
     )
     return mcp
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -644,6 +644,18 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _load_cron_delivery_dotenv(job_id: str) -> None:
+    """Load Hermes dotenv before delivery target/config resolution."""
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv(
+            hermes_home=_get_hermes_home(),
+            project_env=Path(__file__).resolve().parents[1] / ".env",
+        )
+    except Exception as env_exc:
+        logger.debug("Job '%s': dotenv load before delivery failed: %s", job_id, env_exc)
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -655,6 +667,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    # Standalone cron ticks (especially no_agent script jobs) do not pass
+    # through the agent setup path that reloads ~/.hermes/.env. Load it before
+    # target resolution so bare targets like ``deliver: feishu`` can resolve
+    # FEISHU_HOME_CHANNEL from dotenv.
+    _load_cron_delivery_dotenv(str(job.get("id", "?")))
+
     targets = _resolve_delivery_targets(job)
     if not targets:
         if job.get("deliver", "local") != "local":
@@ -694,19 +712,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from gateway.platforms.base import BasePlatformAdapter
 
     try:
-        # Standalone cron ticks (especially no_agent script jobs) do not pass
-        # through the agent setup path that reloads ~/.hermes/.env. Load it here
-        # before resolving gateway platform config so direct delivery has the
-        # same credentials as gateway-hosted delivery.
-        try:
-            from hermes_cli.env_loader import load_hermes_dotenv
-            load_hermes_dotenv(
-                hermes_home=_get_hermes_home(),
-                project_env=Path(__file__).resolve().parents[1] / ".env",
-            )
-        except Exception as env_exc:
-            logger.debug("Job '%s': dotenv load before delivery failed: %s", job["id"], env_exc)
-
         config = load_gateway_config()
     except Exception as e:
         msg = f"failed to load gateway config: {e}"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -489,6 +489,35 @@ def _normalize_deliver_value(deliver) -> str:
     return str(deliver)
 
 
+def _format_card_title_template(raw_title: str) -> str:
+    """Format a user-provided Feishu card title template.
+
+    Supports ``{date}`` and ``{datetime}`` placeholders. Invalid templates are
+    delivered literally so a bad title cannot break cron delivery.
+    """
+    title = str(raw_title or "").strip()
+    if not title:
+        return ""
+    try:
+        return title.format(
+            date=_hermes_now().strftime("%Y-%m-%d"),
+            datetime=_hermes_now().strftime("%Y-%m-%d %H:%M"),
+        )
+    except Exception:
+        return title
+
+
+def _resolve_feishu_card_metadata(job: dict) -> dict:
+    title = _format_card_title_template(job.get("feishu_card_title", ""))
+    if not title:
+        return {}
+    template = str(job.get("feishu_card_template") or "blue").strip() or "blue"
+    return {
+        "feishu_card_title": title,
+        "feishu_card_template": template,
+    }
+
+
 # Routing intent tokens — resolved at fire time, not create time, so a
 # job created before Telegram was wired up will pick up Telegram once it
 # comes online.  ``all`` expands into the set of connected platforms
@@ -647,10 +676,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     except Exception:
         pass
 
+    card_metadata = _resolve_feishu_card_metadata(job)
+
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
-        delivery_content = (
+        wrapped_delivery_content = (
             f"Cronjob Response: {task_name}\n"
             f"(job_id: {job_id})\n"
             f"-------------\n\n"
@@ -658,14 +689,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
         )
     else:
-        delivery_content = content
+        wrapped_delivery_content = content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
     from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
 
     try:
+        # Standalone cron ticks (especially no_agent script jobs) do not pass
+        # through the agent setup path that reloads ~/.hermes/.env. Load it here
+        # before resolving gateway platform config so direct delivery has the
+        # same credentials as gateway-hosted delivery.
+        try:
+            from hermes_cli.env_loader import load_hermes_dotenv
+            load_hermes_dotenv(
+                hermes_home=_get_hermes_home(),
+                project_env=Path(__file__).resolve().parents[1] / ".env",
+            )
+        except Exception as env_exc:
+            logger.debug("Job '%s': dotenv load before delivery failed: %s", job["id"], env_exc)
+
         config = load_gateway_config()
     except Exception as e:
         msg = f"failed to load gateway config: {e}"
@@ -704,6 +745,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             delivery_errors.append(msg)
             continue
 
+        target_card_metadata = card_metadata if platform_name.lower() == "feishu" else {}
+        target_delivery_content = content if target_card_metadata else wrapped_delivery_content
+        # Extract MEDIA: tags so attachments are forwarded as files, not raw text.
+        media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(target_delivery_content)
+        media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+
         pconfig = config.platforms.get(platform)
         if not pconfig or not pconfig.enabled:
             msg = f"platform '{platform_name}' not configured/enabled"
@@ -723,6 +770,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 adapter_ok = True
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
+                    send_metadata = {"thread_id": thread_id} if thread_id else {}
+                    if target_card_metadata:
+                        send_metadata.update(target_card_metadata)
+                    send_metadata = send_metadata or None
                     future = safe_schedule_threadsafe(
                         runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
                         loop,
@@ -779,7 +830,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            send_metadata = {}
+            if target_card_metadata:
+                send_metadata.update(target_card_metadata)
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                thread_id=thread_id,
+                media_files=media_files,
+                metadata=send_metadata or None,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -789,7 +851,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            cleaned_delivery_content,
+                            thread_id=thread_id,
+                            media_files=media_files,
+                            metadata=send_metadata or None,
+                        ),
+                    )
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3265,12 +3265,18 @@ class BasePlatformAdapter(ABC):
             )
         except Exception:
             # On failure, restore the original guard if one still exists so
-            # we don't leave the session in a half-reset state.
+            # we don't leave the session in a half-reset state. If the original
+            # task already finished while the command guard was installed,
+            # there is no owner left to drain queued text, so the command guard
+            # must perform the same pending handoff before the error is logged.
             if self._active_sessions.get(session_key) is command_guard:
                 if session_key in self._session_tasks and current_guard is not None:
                     self._active_sessions[session_key] = current_guard
                 else:
-                    self._release_session_guard(session_key, guard=command_guard)
+                    await self._drain_pending_after_session_command(
+                        session_key,
+                        command_guard,
+                    )
             raise
 
         await self._drain_pending_after_session_command(session_key, command_guard)
@@ -3809,8 +3815,15 @@ class BasePlatformAdapter(ABC):
             # this task hand off the follow-up.
             await self._flush_text_debounce_now(session_key)
 
-            # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
+            # Check if there's a pending message that was queued during our processing.
+            # Only the task that still owns the adapter guard may drain it.  Reset-like
+            # commands (/stop, /new, /reset) replace the guard while they run; if this
+            # old task stole pending text during that window, the follow-up would run
+            # before the command finished cleaning up the interrupted turn.
+            if (
+                self._active_sessions.get(session_key) is interrupt_event
+                and session_key in self._pending_messages
+            ):
                 pending_event = self._pending_messages.pop(session_key)
                 logger.debug("[%s] Processing queued follow-up message", self.name)
                 # Keep the _active_sessions entry live across the turn chain
@@ -3924,7 +3937,10 @@ class BasePlatformAdapter(ABC):
             # busy-handler path.  Without this block, we would delete the
             # active-session entry and the queued message would be silently
             # dropped (user never gets a reply).
-            late_pending = self._pending_messages.pop(session_key, None)
+            if self._active_sessions.get(session_key) is interrupt_event:
+                late_pending = self._pending_messages.pop(session_key, None)
+            else:
+                late_pending = None
             if late_pending is not None:
                 current_task = asyncio.current_task()
                 existing_task = self._session_tasks.get(session_key)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1778,7 +1778,16 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
+                card_title = self._metadata_card_title(metadata)
+                if card_title:
+                    msg_type = "interactive"
+                    payload = self._build_markdown_card_payload(
+                        title=card_title,
+                        content=chunk,
+                        template=self._metadata_card_template(metadata),
+                    )
+                else:
+                    msg_type, payload = self._build_outbound_payload(chunk)
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
@@ -4294,6 +4303,93 @@ class FeishuAdapter(BasePlatformAdapter):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
+
+    @staticmethod
+    def _metadata_card_title(metadata: Optional[Dict[str, Any]]) -> str:
+        if not isinstance(metadata, dict):
+            return ""
+        title = metadata.get("feishu_card_title") or metadata.get("card_title")
+        return str(title or "").strip()
+
+    @staticmethod
+    def _metadata_card_template(metadata: Optional[Dict[str, Any]]) -> str:
+        if not isinstance(metadata, dict):
+            return "blue"
+        template = str(
+            metadata.get("feishu_card_template")
+            or metadata.get("card_template")
+            or "blue"
+        ).strip()
+        return template or "blue"
+
+    @staticmethod
+    def _build_markdown_card_payload(*, title: str, content: str, template: str = "blue") -> str:
+        elements = [
+            {"tag": "markdown", "content": chunk}
+            for chunk in FeishuAdapter._split_markdown_card_content(content)
+        ]
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"tag": "plain_text", "content": str(title).strip()[:120] or "Hermes"},
+                "template": str(template).strip() or "blue",
+            },
+            "elements": elements,
+        }
+        return json.dumps(card, ensure_ascii=False)
+
+    @staticmethod
+    def _split_markdown_card_content(content: str, limit: int = 3000) -> List[str]:
+        """Split long card markdown into smaller elements for stable rendering."""
+        cleaned = str(content or "").strip()
+        if not cleaned:
+            return [" "]
+
+        chunks: List[str] = []
+        current = ""
+
+        def flush() -> None:
+            nonlocal current
+            if current.strip():
+                chunks.append(current.strip())
+            current = ""
+
+        for paragraph in re.split(r"\n{2,}", cleaned):
+            paragraph = paragraph.strip()
+            if not paragraph:
+                continue
+            if len(paragraph) > limit:
+                flush()
+                lines = paragraph.splitlines() or [paragraph]
+                partial = ""
+                for line in lines:
+                    line = line.rstrip()
+                    if len(line) > limit:
+                        if partial:
+                            chunks.append(partial.strip())
+                            partial = ""
+                        for start in range(0, len(line), limit):
+                            chunks.append(line[start:start + limit])
+                        continue
+                    candidate = f"{partial}\n{line}".strip() if partial else line
+                    if len(candidate) > limit:
+                        chunks.append(partial.strip())
+                        partial = line
+                    else:
+                        partial = candidate
+                if partial:
+                    chunks.append(partial.strip())
+                continue
+
+            candidate = f"{current}\n\n{paragraph}".strip() if current else paragraph
+            if len(candidate) > limit:
+                flush()
+                current = paragraph
+            else:
+                current = candidate
+
+        flush()
+        return chunks or [" "]
 
     async def _send_uploaded_file_message(
         self,

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -163,6 +163,23 @@ class TestLifecycle:
         assert params["cwd"] == "/tmp"
         assert "permissions" not in params  # see session.ensure_started() comment
 
+    def test_ensure_started_passes_env_to_client_factory(self):
+        captured = {}
+        client = FakeClient()
+
+        def factory(**kwargs):
+            captured.update(kwargs)
+            return client
+
+        s = CodexAppServerSession(
+            cwd="/tmp",
+            client_factory=factory,
+            env={"HERMES_SESSION_ID": "sess-123"},
+        )
+        s.ensure_started()
+
+        assert captured["env"] == {"HERMES_SESSION_ID": "sess-123"}
+
     def test_close_idempotent(self):
         client = FakeClient()
         s = make_session(client)

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -8,6 +8,8 @@ build helper assembles a server when the SDK is present.
 
 from __future__ import annotations
 
+import asyncio
+import json
 from unittest.mock import patch
 
 import pytest
@@ -97,6 +99,238 @@ class TestModuleSurface:
             assert orch_tool in EXPOSED_TOOLS, (
                 f"{orch_tool!r} missing from codex callback"
             )
+
+    def test_memory_tool_specs_from_dynamic_provider(self):
+        """Memory-provider tools are dynamic and do not live in the static
+        Hermes registry. The codex MCP bridge must still be able to surface
+        them, otherwise providers like MemOS are invisible on codex runtime."""
+        from agent.transports import hermes_tools_mcp_server as m
+
+        class FakeMemoryManager:
+            def get_all_tool_schemas(self):
+                return [
+                    {
+                        "name": "memos_search",
+                        "description": "Search MemOS",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                        },
+                    }
+                ]
+
+        specs = m._memory_tool_specs(FakeMemoryManager())
+        assert "memos_search" in specs
+        assert specs["memos_search"]["parameters"]["required"] == ["query"]
+
+    def test_memory_enabled_respects_toolset_filter(self, monkeypatch):
+        from agent.transports import hermes_tools_mcp_server as m
+
+        cfg = {
+            "memory": {
+                "enabled": True,
+                "memory_enabled": True,
+                "provider": "memtensor",
+            }
+        }
+
+        monkeypatch.setenv("HERMES_ENABLED_TOOLSETS", "development")
+        assert not m._memory_enabled(cfg)
+
+        monkeypatch.setenv("HERMES_ENABLED_TOOLSETS", "development,memory")
+        assert m._memory_enabled(cfg)
+
+        monkeypatch.setenv("HERMES_ENABLED_TOOLSETS", "all")
+        assert m._memory_enabled(cfg)
+
+        monkeypatch.setenv("HERMES_ENABLED_TOOLSETS", "*")
+        assert m._memory_enabled(cfg)
+
+        monkeypatch.setenv("HERMES_DISABLED_TOOLSETS", "memory")
+        assert not m._memory_enabled(cfg)
+
+        monkeypatch.setenv("HERMES_DISABLED_TOOLSETS", "all")
+        assert not m._memory_enabled(cfg)
+
+        monkeypatch.setenv("HERMES_DISABLED_TOOLSETS", "*")
+        assert not m._memory_enabled(cfg)
+
+        monkeypatch.delenv("HERMES_ENABLED_TOOLSETS", raising=False)
+        monkeypatch.delenv("HERMES_DISABLED_TOOLSETS", raising=False)
+        monkeypatch.setenv("HERMES_SKIP_MEMORY", "1")
+        assert not m._memory_enabled(cfg)
+
+    def test_build_server_applies_parent_toolset_filters(self, monkeypatch):
+        """Static Hermes tools must respect the parent agent's toolset filter.
+
+        Otherwise a codex_app_server session with enabled_toolsets=["memory"]
+        can still see web/browser tools through the MCP callback.
+        """
+        from agent.transports import hermes_tools_mcp_server as m
+        import mcp.server.fastmcp as fastmcp_mod
+        import model_tools
+
+        captured = {}
+
+        class FakeFastMCP:
+            def __init__(self, *args, **kwargs):
+                self.tools = {}
+
+            def add_tool(self, fn, *, name, description):
+                self.tools[name] = fn
+
+        def fake_get_tool_definitions(**kwargs):
+            captured.update(kwargs)
+            if kwargs.get("enabled_toolsets") == ["memory"]:
+                return []
+            return [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "description": "Search web",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+
+        monkeypatch.setenv("HERMES_ENABLED_TOOLSETS", "memory")
+        monkeypatch.setenv("HERMES_DISABLED_TOOLSETS", "browser")
+        monkeypatch.setattr(fastmcp_mod, "FastMCP", FakeFastMCP)
+        monkeypatch.setattr(model_tools, "get_tool_definitions", fake_get_tool_definitions)
+        monkeypatch.setattr(m, "_build_memory_manager_for_mcp", lambda: None)
+
+        server = m._build_server()
+
+        assert captured["enabled_toolsets"] == ["memory"]
+        assert captured["disabled_toolsets"] == ["browser"]
+        assert "web_search" not in server.tools
+
+    def test_build_server_registers_dynamic_memory_tools(self, monkeypatch):
+        """Regression guard for MemOS under codex_app_server: memos_search is
+        not in get_tool_definitions(), so _build_server must merge the active
+        MemoryManager schemas explicitly."""
+        from agent.transports import hermes_tools_mcp_server as m
+        import mcp.server.fastmcp as fastmcp_mod
+        import model_tools
+
+        class FakeMemoryManager:
+            def __init__(self):
+                self.shutdown_called = False
+
+            def get_all_tool_schemas(self):
+                return [
+                    {
+                        "name": "memos_search",
+                        "description": "Search MemOS",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ]
+
+            def handle_tool_call(self, tool_name, args):
+                return '{"ok": true}'
+
+            def shutdown_all(self):
+                self.shutdown_called = True
+
+        class FakeFastMCP:
+            def __init__(self, *args, **kwargs):
+                self.tools = {}
+
+            def add_tool(self, fn, *, name, description):
+                self.tools[name] = {
+                    "fn": fn,
+                    "description": description,
+                }
+
+        fake_manager = FakeMemoryManager()
+        monkeypatch.setattr(fastmcp_mod, "FastMCP", FakeFastMCP)
+        monkeypatch.setattr(
+            model_tools,
+            "get_tool_definitions",
+            lambda **kwargs: [],
+        )
+        monkeypatch.setattr(m, "_build_memory_manager_for_mcp", lambda: fake_manager)
+
+        server = m._build_server()
+
+        assert "memos_search" in server.tools
+        assert server.tools["memos_search"]["fn"](query="abc") == '{"ok": true}'
+
+    def test_memory_manager_bootstrap_passes_session_title(self, monkeypatch, tmp_path):
+        """MCP memory tools must resolve provider scope like the parent agent."""
+        from agent.transports import hermes_tools_mcp_server as m
+        import agent.memory_manager as memory_manager_mod
+        import hermes_cli.config as config_mod
+        import hermes_constants as constants_mod
+        import plugins.memory as memory_plugins_mod
+
+        captured = {}
+
+        class FakeProvider:
+            name = "memtensor"
+
+            def is_available(self):
+                return True
+
+        class FakeMemoryManager:
+            def add_provider(self, provider):
+                captured["provider"] = provider.name
+
+            def initialize_all(self, session_id, **kwargs):
+                captured["session_id"] = session_id
+                captured.update(kwargs)
+
+        monkeypatch.setattr(
+            config_mod,
+            "load_config",
+            lambda: {
+                "memory": {
+                    "enabled": True,
+                    "memory_enabled": True,
+                    "provider": "memtensor",
+                }
+            },
+        )
+        monkeypatch.setattr(memory_plugins_mod, "load_memory_provider", lambda name: FakeProvider())
+        monkeypatch.setattr(memory_manager_mod, "MemoryManager", FakeMemoryManager)
+        monkeypatch.setattr(constants_mod, "get_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_SESSION_ID", "sess-123")
+        monkeypatch.setenv("HERMES_SESSION_TITLE", "Project Alpha")
+
+        assert m._build_memory_manager_for_mcp() is not None
+        assert captured["session_id"] == "sess-123"
+        assert captured["session_title"] == "Project Alpha"
+
+    def test_generated_handler_uses_schema_args_not_kwargs(self):
+        """FastMCP must see `query`, not a synthetic `kwargs` argument."""
+        from agent.transports import hermes_tools_mcp_server as m
+        from mcp.server.fastmcp.tools import Tool
+
+        handler = m._make_mcp_handler(
+            tool_name="memos_search",
+            description="Search MemOS",
+            parameters_schema={
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "maxResults": {"type": "integer", "default": 10},
+                },
+                "required": ["query"],
+            },
+            dispatcher=lambda kwargs: json.dumps(kwargs),
+        )
+        tool = Tool.from_function(
+            handler,
+            name="memos_search",
+            description="Search MemOS",
+        )
+
+        assert "query" in tool.parameters["properties"]
+        assert "kwargs" not in tool.parameters["properties"]
+        result = asyncio.run(tool.run({"query": "abc", "maxResults": 3}))
+        assert json.loads(result) == {"query": "abc", "maxResults": 3}
 
 
 class TestMain:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -604,6 +604,41 @@ class TestDeliverResultWrapping:
         assert metadata["feishu_card_title"].startswith("AI 情报雷达 · ")
         assert metadata["feishu_card_template"] == "blue"
 
+    def test_delivery_loads_dotenv_before_resolving_bare_feishu_target(self, monkeypatch):
+        """Standalone cron delivery should resolve FEISHU_HOME_CHANNEL from dotenv."""
+        from gateway.config import Platform
+
+        monkeypatch.delenv("FEISHU_HOME_CHANNEL", raising=False)
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.FEISHU: pconfig}
+
+        def fake_load_dotenv(**kwargs):
+            monkeypatch.setenv("FEISHU_HOME_CHANNEL", "oc_from_dotenv")
+            return []
+
+        with patch("hermes_cli.env_loader.load_hermes_dotenv", side_effect=fake_load_dotenv), \
+             patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            err = _deliver_result(
+                {
+                    "id": "dotenv-feishu",
+                    "name": "daily-ai-intel-briefing",
+                    "deliver": "feishu",
+                    "feishu_card_title": "AI 情报雷达 · {date}",
+                },
+                "**Body**",
+            )
+
+        assert err is None
+        send_mock.assert_called_once()
+        assert send_mock.call_args.args[0] == Platform.FEISHU
+        assert send_mock.call_args.args[2] == "oc_from_dotenv"
+        assert send_mock.call_args.args[3] == "**Body**"
+        assert send_mock.call_args.kwargs["metadata"]["feishu_card_title"]
+
     def test_feishu_card_metadata_only_skips_wrapper_for_feishu_targets(self):
         """Mixed delivery keeps cron context for non-Feishu targets."""
         from gateway.config import Platform

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -575,6 +575,71 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
 
+    def test_feishu_card_delivery_skips_wrapper_and_passes_card_metadata(self):
+        """Cron jobs with Feishu card metadata should render as cards, not wrapped text."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.FEISHU: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            job = {
+                "id": "ai-digest",
+                "name": "daily-ai-intel-briefing",
+                "deliver": "feishu:oc_123",
+                "feishu_card_title": "AI 情报雷达 · {date}",
+                "feishu_card_template": "blue",
+            }
+            _deliver_result(job, "**Body**")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args[0][3]
+        metadata = send_mock.call_args.kwargs.get("metadata")
+        assert sent_content == "**Body**"
+        assert "Cronjob Response" not in sent_content
+        assert metadata["feishu_card_title"].startswith("AI 情报雷达 · ")
+        assert metadata["feishu_card_template"] == "blue"
+
+    def test_feishu_card_metadata_only_skips_wrapper_for_feishu_targets(self):
+        """Mixed delivery keeps cron context for non-Feishu targets."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {
+            Platform.FEISHU: pconfig,
+            Platform.TELEGRAM: pconfig,
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": True}}):
+            job = {
+                "id": "mixed-card",
+                "name": "daily-ai-intel-briefing",
+                "deliver": "feishu:oc_123,telegram:tg_123",
+                "feishu_card_title": "AI 情报雷达 · {date}",
+                "feishu_card_template": "blue",
+            }
+            _deliver_result(job, "**Body**")
+
+        assert send_mock.await_count == 2
+        feishu_call, telegram_call = send_mock.await_args_list
+
+        assert feishu_call.args[0] == Platform.FEISHU
+        assert feishu_call.args[3] == "**Body**"
+        assert feishu_call.kwargs["metadata"]["feishu_card_template"] == "blue"
+
+        assert telegram_call.args[0] == Platform.TELEGRAM
+        assert "Cronjob Response: daily-ai-intel-briefing" in telegram_call.args[3]
+        assert "**Body**" in telegram_call.args[3]
+        assert telegram_call.kwargs.get("metadata") is None
+
     def test_delivery_extracts_media_tags_before_send(self, tmp_path, monkeypatch):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
         from gateway.config import Platform

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -160,6 +160,100 @@ class TestFeishuMessageNormalization(unittest.TestCase):
 
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
+    def test_send_uses_interactive_markdown_card_when_metadata_title_is_set(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import SendResult
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = object()
+        response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="om_card"),
+        )
+        adapter._feishu_send_with_retry = AsyncMock(return_value=response)
+
+        result = asyncio.run(
+            adapter.send(
+                "oc_123",
+                "**TL;DR**\n- first item",
+                metadata={
+                    "feishu_card_title": "AI 情报雷达 · 2026-05-27",
+                    "feishu_card_template": "blue",
+                },
+            )
+        )
+
+        self.assertIsInstance(result, SendResult)
+        self.assertTrue(result.success)
+        kwargs = adapter._feishu_send_with_retry.await_args.kwargs
+        self.assertEqual(kwargs["msg_type"], "interactive")
+        payload = json.loads(kwargs["payload"])
+        self.assertEqual(payload["header"]["title"]["content"], "AI 情报雷达 · 2026-05-27")
+        self.assertEqual(payload["header"]["template"], "blue")
+        self.assertEqual(payload["elements"][0]["tag"], "markdown")
+        self.assertIn("**TL;DR**", payload["elements"][0]["content"])
+
+    def test_standalone_send_to_platform_preserves_card_metadata(self):
+        from gateway.config import Platform
+        from tools.send_message_tool import _send_to_platform
+
+        calls = []
+
+        class FakeFeishuAdapter:
+            MAX_MESSAGE_LENGTH = 8000
+
+            def __init__(self, _config):
+                self._domain_name = "feishu"
+                self._client = None
+
+            def _build_lark_client(self, domain):
+                calls.append(("build_client", domain))
+                return object()
+
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send", chat_id, message, metadata))
+                return SimpleNamespace(success=True, message_id="om_card")
+
+        with patch("gateway.platforms.feishu.FEISHU_AVAILABLE", True), \
+             patch("gateway.platforms.feishu.FeishuAdapter", FakeFeishuAdapter):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.FEISHU,
+                    SimpleNamespace(enabled=True, token="", extra={}),
+                    "oc_123",
+                    "**Body**",
+                    metadata={
+                        "feishu_card_title": "AI 情报雷达",
+                        "feishu_card_template": "blue",
+                    },
+                )
+            )
+
+        self.assertTrue(result["success"])
+        send_call = next(call for call in calls if call[0] == "send")
+        self.assertEqual(send_call[1], "oc_123")
+        self.assertEqual(send_call[2], "**Body**")
+        self.assertEqual(send_call[3]["feishu_card_title"], "AI 情报雷达")
+        self.assertEqual(send_call[3]["feishu_card_template"], "blue")
+
+    def test_markdown_card_payload_splits_long_content(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        content = "\n\n".join([f"**Section {i}**\n" + ("line\n" * 250) for i in range(4)])
+
+        payload = json.loads(
+            FeishuAdapter._build_markdown_card_payload(
+                title="AI 情报雷达",
+                content=content,
+                template="blue",
+            )
+        )
+
+        self.assertGreater(len(payload["elements"]), 1)
+        self.assertTrue(all(element["tag"] == "markdown" for element in payload["elements"]))
+        self.assertTrue(all(len(element["content"]) <= 3000 for element in payload["elements"]))
+
     @patch.dict(os.environ, {
         "FEISHU_APP_ID": "cli_app",
         "FEISHU_APP_SECRET": "secret_app",

--- a/tests/gateway/test_session_split_brain_11016.py
+++ b/tests/gateway/test_session_split_brain_11016.py
@@ -225,6 +225,136 @@ class TestAdapterSessionCancellation:
         assert call_order.index("original:cancelled") < call_order.index("followup:processed")
         assert sk not in adapter._pending_messages
 
+    @pytest.mark.asyncio
+    async def test_stop_follow_up_waits_when_original_finishes_during_command(self):
+        """/stop owns queued follow-ups even if the old task finishes naturally.
+
+        Regression for #31884: while /stop is still running, the old
+        _process_message_background task can reach its pending-drain block.
+        It must not steal the post-/stop user message and start a follow-up
+        turn before the command handler has finished and cancelled/handed off
+        the old task.
+        """
+        adapter = _make_adapter()
+        sk = _session_key()
+        processing_started = asyncio.Event()
+        command_started = asyncio.Event()
+        allow_original_finish = asyncio.Event()
+        allow_command_finish = asyncio.Event()
+        follow_up_processed = asyncio.Event()
+        call_order = []
+
+        async def _handler(event):
+            cmd = event.get_command()
+            if cmd == "stop":
+                call_order.append("command:start")
+                command_started.set()
+                await allow_command_finish.wait()
+                call_order.append("command:end")
+                return "handled:stop"
+
+            if event.text == "hello world":
+                processing_started.set()
+                await allow_original_finish.wait()
+                call_order.append("original:end")
+                return "handled:text:hello"
+
+            if event.text == "after stop":
+                call_order.append("followup:processed")
+                follow_up_processed.set()
+                return "handled:text:after"
+
+            return f"handled:text:{event.text}"
+
+        adapter._message_handler = _handler
+
+        await adapter.handle_message(_make_event("hello world"))
+        await processing_started.wait()
+        original_task = adapter._session_tasks[sk]
+
+        command_task = asyncio.create_task(adapter.handle_message(_make_event("/stop")))
+        await command_started.wait()
+        await asyncio.sleep(0)
+
+        await adapter.handle_message(_make_event("after stop"))
+        await asyncio.sleep(0)
+
+        assert sk in adapter._pending_messages
+        assert not follow_up_processed.is_set()
+
+        allow_original_finish.set()
+        await asyncio.wait_for(asyncio.shield(original_task), timeout=1.0)
+
+        assert not follow_up_processed.is_set(), (
+            "old processing task stole the queued post-/stop follow-up before "
+            "the /stop command completed"
+        )
+
+        allow_command_finish.set()
+        await command_task
+        await asyncio.wait_for(follow_up_processed.wait(), timeout=1.0)
+
+        assert call_order.index("command:end") < call_order.index("followup:processed")
+        assert sk not in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_stop_failure_drains_follow_up_after_original_finishes(self):
+        """/stop failure must not strand queued follow-ups after the old task exits."""
+        adapter = _make_adapter()
+        sk = _session_key()
+        processing_started = asyncio.Event()
+        command_started = asyncio.Event()
+        allow_original_finish = asyncio.Event()
+        allow_command_raise = asyncio.Event()
+        follow_up_processed = asyncio.Event()
+        call_order = []
+
+        async def _handler(event):
+            cmd = event.get_command()
+            if cmd == "stop":
+                call_order.append("command:start")
+                command_started.set()
+                await allow_command_raise.wait()
+                call_order.append("command:raise")
+                raise RuntimeError("boom")
+
+            if event.text == "hello world":
+                processing_started.set()
+                await allow_original_finish.wait()
+                call_order.append("original:end")
+                return "handled:text:hello"
+
+            if event.text == "after stop":
+                call_order.append("followup:processed")
+                follow_up_processed.set()
+                return "handled:text:after"
+
+            return f"handled:text:{event.text}"
+
+        adapter._message_handler = _handler
+
+        await adapter.handle_message(_make_event("hello world"))
+        await processing_started.wait()
+        original_task = adapter._session_tasks[sk]
+
+        command_task = asyncio.create_task(adapter.handle_message(_make_event("/stop")))
+        await command_started.wait()
+
+        await adapter.handle_message(_make_event("after stop"))
+        assert sk in adapter._pending_messages
+
+        allow_original_finish.set()
+        await asyncio.wait_for(asyncio.shield(original_task), timeout=1.0)
+
+        assert not follow_up_processed.is_set()
+
+        allow_command_raise.set()
+        await command_task
+        await asyncio.wait_for(follow_up_processed.wait(), timeout=1.0)
+
+        assert call_order.index("command:raise") < call_order.index("followup:processed")
+        assert sk not in adapter._pending_messages
+
 
 # ===========================================================================
 # Layer 2: Adapter-side on-entry self-heal for stale session locks

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -13,10 +13,12 @@ Verifies that:
 from __future__ import annotations
 
 from unittest.mock import patch
+from types import SimpleNamespace
 
 import pytest
 
 import run_agent
+from agent.codex_runtime import _codex_memory_tool_hint
 from agent.transports.codex_app_server_session import CodexAppServerSession, TurnResult
 
 
@@ -231,6 +233,46 @@ class TestRunConversationCodexPath:
         ):
             agent.run_conversation("hi")
         assert not client_mock.chat.completions.create.called
+
+    def test_session_title_reaches_codex_mcp_env(self, fake_session, monkeypatch):
+        captured = {}
+
+        def fake_init(self, **kwargs):
+            captured.update(kwargs)
+
+        agent = _make_codex_agent()
+        agent.session_id = "sess-123"
+        agent._session_db = SimpleNamespace(
+            get_session_title=lambda session_id: (
+                "Project Alpha" if session_id == "sess-123" else ""
+            )
+        )
+        monkeypatch.setattr(CodexAppServerSession, "__init__", fake_init)
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("hi")
+
+        assert captured["env"]["HERMES_SESSION_TITLE"] == "Project Alpha"
+        assert captured["env"]["HERMES_SKIP_MEMORY"] == "1"
+
+
+class TestCodexMemoryToolHint:
+    def test_no_memory_manager_leaves_message_unchanged(self):
+        agent = SimpleNamespace(_memory_manager=None)
+        assert _codex_memory_tool_hint(agent, "hello") == "hello"
+
+    def test_memory_tools_are_mapped_to_hermes_tools_mcp(self):
+        class FakeMemoryManager:
+            def get_all_tool_names(self):
+                return {"memos_search", "memos_skill_list"}
+
+        agent = SimpleNamespace(_memory_manager=FakeMemoryManager())
+        out = _codex_memory_tool_hint(agent, "请调用 memos_search")
+
+        assert "hermes-tools" in out
+        assert "memos_search" in out
+        assert "memos_skill_list" in out
+        assert out.endswith("请调用 memos_search")
 
 
 class TestReviewForkApiModeDowngrade:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -555,7 +555,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, metadata=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -728,6 +728,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chunk,
                 media_files=media_files if is_last else None,
                 thread_id=thread_id,
+                metadata=metadata,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -768,7 +769,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id, metadata=metadata)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:
@@ -1589,7 +1590,7 @@ async def _send_bluebubbles(extra, chat_id, message):
         return _error(f"BlueBubbles send failed: {e}")
 
 
-async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None):
+async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None, metadata=None):
     """Send via Feishu/Lark using the adapter's send pipeline."""
     try:
         from gateway.platforms.feishu import FeishuAdapter, FEISHU_AVAILABLE
@@ -1606,7 +1607,10 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
         domain_name = getattr(adapter, "_domain_name", "feishu")
         domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
         adapter._client = adapter._build_lark_client(domain)
-        metadata = {"thread_id": thread_id} if thread_id else None
+        metadata_payload = dict(metadata or {})
+        if thread_id:
+            metadata_payload["thread_id"] = thread_id
+        metadata = metadata_payload or None
 
         last_result = None
         if message.strip():


### PR DESCRIPTION
## Summary
- Serialize gateway post-stop follow-up draining.
- Add Feishu/Lark interactive card delivery for cron results.
- Harden the Codex app-server `hermes-tools` MCP memory bridge by passing parent session/toolset/identity env, exposing active memory-provider tools, respecting toolset and `skip_memory` filters, and preserving memory scoping metadata.

## Tests
- `uv run --extra dev python -m pytest tests/agent/transports/test_hermes_tools_mcp_server.py tests/run_agent/test_codex_app_server_integration.py tests/agent/transports/test_codex_app_server_session.py tests/cron/test_scheduler.py tests/gateway/test_feishu.py -q`
- `uv run --extra dev ruff check agent/agent_init.py agent/codex_runtime.py agent/transports/codex_app_server_session.py agent/transports/hermes_tools_mcp_server.py cron/scheduler.py gateway/platforms/feishu.py tools/send_message_tool.py tests/agent/transports/test_codex_app_server_session.py tests/agent/transports/test_hermes_tools_mcp_server.py tests/run_agent/test_codex_app_server_integration.py tests/cron/test_scheduler.py tests/gateway/test_feishu.py`
- `git diff --check`

## Review
- `$dual-review` final gate completed with no P0/P1/P2 findings.