### PR TITLE
feat(skills): add Webwright browser automation skill

### DIFF
--- a/skills/software-development/webwright/SKILL.md
+++ b/skills/software-development/webwright/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: webwright
+description: Use when automating browser tasks that should leave behind a reusable, auditable Playwright program rather than a one-shot browser session — search/filter/form-fill flows, probing browser-gated or WAF-sensitive sites, dynamic extraction, regression harnesses for JurisNet legal-source adapters. Drives a local headless Playwright (Firefox preferred), writes `final_script.py` + `final_runs/run_<id>_<tag>/` with screenshots, action log, and `results.json`, and self-verifies against a `plan.md` critical-points checklist.
+version: 1.0.0
+author: Hermes Agent (adapted from Microsoft Webwright)
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [browser-automation, playwright, webwright, scraping, qa, browser-gated, jurisnet]
+    homepage: https://github.com/microsoft/Webwright
+    related_skills: [systematic-debugging, spike, requesting-code-review]
+---
+
+# Webwright — Terminal-Native Browser Automation
+
+## Overview
+
+Webwright is the preferred Hermes workflow for browser tasks that should leave behind a reusable, auditable program instead of a fragile manual click path. The pattern is: write Playwright code, run it from the terminal, save screenshots / action log / JSON results into a numbered run folder, inspect failures, iterate, then preserve a `final_script.py` that can be rerun from a clean workspace.
+
+This skill is adapted from Microsoft Webwright (https://github.com/microsoft/Webwright). The upstream loop relied on `webwright.tools.image_qa` / `self_reflection` for OpenAI-backed visual QA; here those are replaced by the agent's own `Read` on PNG files plus reasoning against `plan.md`. No `OPENAI_API_KEY` or other external model API is required — the workflow is terminal + Playwright + this agent.
+
+Treat Webwright as a **workflow / tooling skill**, not as a separate runtime service. Hermes can drive it directly with `Bash` + file tools, and can delegate the heavier scripting loop to Claude Code when the task is non-trivial (see `Delegating to Claude Code`).
+
+## When to Use
+
+Use Webwright when the user asks to:
+
+- Automate a live website task: search, filter, form-fill, checkout-like flow, upload/download, compare results.
+- Probe browser-gated or WAF-sensitive sources where plain HTTP is insufficient (typical for JurisNet legal-source adapter spikes — SAIJ, CSJN, JUBA, provincial portals).
+- Extract data from dynamic pages that require JS, scrolling, waiting, or human-like navigation.
+- Produce durable evidence: screenshots, action log, `results.json`, and a rerunnable script.
+- Turn a successful one-shot flow into a reusable parameterized CLI tool (see `references/cli_tool_mode.md`).
+- Build a regression harness for a flaky UI path or a site whose markup drifts.
+
+Do **not** use it for:
+
+- Static HTTP fetches where `curl` / `httpx` / an official API works. Use the API.
+- Tasks that would require bypassing access controls or violating ToS. Stay on public/authorized surfaces, keep rate low, and surface the legal/ToS concern back to Hermes if in doubt.
+- Quick visual inspection where a single browser snapshot is enough and no reusable artifact is needed.
+
+## Prerequisites
+
+```bash
+python3 -m pip show playwright >/dev/null 2>&1 || python3 -m pip install playwright
+python3 -m playwright install firefox chromium
+```
+
+If the project provides a venv or `uv`, prefer the project runtime:
+
+```bash
+uv run python -c "from playwright.async_api import async_playwright; print('playwright ok')"
+uv run playwright install firefox chromium
+```
+
+Firefox is the default engine — some sites (cars.com, Akamai-protected portals, parts of SAIJ/JUBA) reject Playwright Chromium with `ERR_HTTP2_PROTOCOL_ERROR` due to TLS/H2 fingerprinting but load cleanly under Firefox. Keep Chromium installed for CDP / compatibility comparisons.
+
+## Workspace Contract
+
+Pick a bounded workspace per task. Typical layouts:
+
+```text
+spikes/<task-id>/webwright/
+outputs/<task-id>/webwright/
+```
+
+Layout inside the workspace:
+
+```text
+plan.md
+final_script.py
+final_runs/run_<id>_<tag>/
+  final_script.py            # snapshot of the script that produced this run
+  final_script_log.txt
+  results.json
+  screenshots/final_execution_<step>_<action>.png
+scratch/                      # exploration scripts and PNGs, separate from final_runs/
+```
+
+Rules:
+
+- `plan.md` lists every critical point that must be proven by a screenshot or a log line.
+- `final_script.py` must be rerunnable from scratch — no hidden state, no shell-side mutations required.
+- Every clean execution creates a **new** `final_runs/run_<id>_<tag>/` (next integer above any existing `run_*`).
+- Each constraint-relevant interaction writes `step <n> action: ...` to `final_script_log.txt`. The first line after reset is `step 0 params: ...` when running in CLI tool mode.
+- One screenshot per critical point, named `final_execution_<step>_<action>.png`. **Never** use `full_page=True` — for exploration, debugging, or final runs alike.
+- Viewport is `{"width": 1280, "height": 1800}`. Don't change it without a reason recorded in `plan.md`.
+- Persist concise snippets and structured facts, not giant raw HTML bodies.
+- **Never** persist local IPs, proxy credentials, cookies, tokens, session storage, or anything that could leak the runner's identity / network.
+
+## Workflow
+
+1. **Plan critical points.** Write `plan.md`:
+
+   ```markdown
+   # Task
+   <verbatim task description>
+
+   # Critical Points
+   - [ ] CP1: <exact constraint / target URL / expected result>
+   - [ ] CP2: <filter, sort, selection, or required datum that must be proven>
+   ```
+
+   One CP per independently verifiable requirement. Numeric/date/quantity/unit CPs must be exact. Ranking CPs ("cheapest", "most cited", "latest") must reference the site's actual sort/filter control, not your own ordering of the results. If the task asks for a final datum, make it its own CP.
+
+2. **Explore with scratch scripts.** Short Playwright heredocs (see `references/playwright_patterns.md`) to inspect titles, URLs, response status, visible labels, `aria_snapshot()`, selectors, network events, and screenshots. Save scratch PNGs under `scratch/`, not `final_runs/`.
+
+3. **Author `final_script.py`.** Deterministic, parameterized where useful. Include:
+   - `argparse` flags for task inputs, proxy, headless mode, engine, output tag.
+   - A run-dir allocator (`allocate_run_dir`) so each invocation goes to a fresh `final_runs/run_<id>_<tag>/`.
+   - Structured `log(step, msg)` writing to `final_script_log.txt`.
+   - `results.json` output with status, URLs, captured data, timestamps.
+   - A screenshot at each critical point, mapped 1-to-1 to a CP in `plan.md`.
+
+   The skeleton is in this file (`Playwright Skeleton`); detailed patterns (role/name selectors, interactive form filling, ARIA snapshots, paired-field modals) are in `references/playwright_patterns.md`.
+
+4. **Run cleanly.** Execute once direct, then with alternate engine or proxy if relevant:
+
+   ```bash
+   python final_script.py --tag direct
+   python final_script.py --engine chromium --tag chromium
+   JURISNET_BROWSER_PROXY=socks5://127.0.0.1:18080 python final_script.py --tag socks
+   ```
+
+5. **Self-verify.** For each CP in `plan.md`: identify the screenshot(s) and/or log line that prove it, `Read` each cited PNG, confirm the evidence is unambiguous (filter chip visible, value exact, sort applied via the site control, final datum legible). Be harsh with partial, occluded, or ambiguous states. If a CP fails, diagnose the *specific* issue, fix `final_script.py`, re-run inside `run_<id+1>_<tag>/`, and re-verify. Empty result sets are acceptable when the correct filters were demonstrably applied.
+
+6. **Report and preserve.** Report the final datum verbatim and the artifact paths. Commit the script + results only when the repo expects spike evidence (e.g. `spikes/<task-id>/`); otherwise keep generated outputs local and `.gitignore`'d.
+
+Full step-by-step guidance — including CP rules, exploration heuristics, and the completion checklist — lives in `references/workflow.md`. Load it for non-trivial tasks; the summary above is the minimum.
+
+## Playwright Skeleton
+
+```python
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+
+VIEWPORT = {"width": 1280, "height": 1800}
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def allocate_run_dir(workspace: Path, tag: str) -> Path:
+    runs = workspace / "final_runs"
+    runs.mkdir(parents=True, exist_ok=True)
+    nums = []
+    for p in runs.glob("run_*"):
+        try:
+            nums.append(int(p.name.split("_")[1]))
+        except (IndexError, ValueError):
+            pass
+    run_id = max(nums, default=0) + 1
+    out = runs / f"run_{run_id}_{tag}"
+    (out / "screenshots").mkdir(parents=True, exist_ok=True)
+    return out
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--tag", default="direct")
+    parser.add_argument("--proxy", default=os.getenv("JURISNET_BROWSER_PROXY"))
+    parser.add_argument("--engine", choices=["firefox", "chromium"], default="firefox")
+    args = parser.parse_args()
+
+    workspace = Path(__file__).resolve().parent
+    run_dir = allocate_run_dir(workspace, args.tag)
+    log_path = run_dir / "final_script_log.txt"
+    log_path.write_text("")
+
+    def log(step: int, msg: str) -> None:
+        line = f"step {step} action: {msg}"
+        print(line)
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+    async with async_playwright() as pw:
+        browser_type = getattr(pw, args.engine)
+        launch_kwargs = {"headless": True}
+        if args.proxy:
+            launch_kwargs["proxy"] = {"server": args.proxy}
+        browser = await browser_type.launch(**launch_kwargs)
+        context = await browser.new_context(viewport=VIEWPORT)
+        page = await context.new_page()
+
+        log(1, f"goto {args.url}")
+        response = await page.goto(args.url, wait_until="domcontentloaded", timeout=45_000)
+        await page.screenshot(path=str(run_dir / "screenshots" / "final_execution_01_loaded.png"))
+
+        result = {
+            "url": page.url,
+            "status": response.status if response else None,
+            "title": await page.title(),
+            "captured_at": now(),
+        }
+        (run_dir / "results.json").write_text(
+            json.dumps(result, indent=2, ensure_ascii=False)
+        )
+        log(2, f"result: {json.dumps(result, ensure_ascii=False)}")
+        await browser.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+For role/name selectors, ARIA snapshots, interactive form filling, paired-field modal patterns, and final-script instrumentation, see `references/playwright_patterns.md`.
+
+## Browser-Gated Source Pattern (JurisNet)
+
+For legal-source probes and adapter spikes (SAIJ, CSJN, JUBA, provincial portals, FalloBot data sources):
+
+- **Try the official API / static endpoint first.** If it works, build the production adapter on the API and skip the browser.
+- **Use Webwright as a spike or regression harness** when HTTP returns 403/WAF/JS-only pages, or when a site exposes data only through interactive controls.
+- Keep rate low: one browser, one page, bounded target list. Do not loop scrape until legality / robots / ToS are clear; surface concerns to Hermes.
+- Comparison ladder: direct Firefox → direct Chromium → Firefox with `JURISNET_BROWSER_PROXY` (SOCKS/HTTP proxy) → Chromium with proxy. Tag each run accordingly so screenshots and logs are comparable.
+- Preserve evidence (`results.json` + screenshots), not full HTML dumps.
+- If browser probes still hit WAF/403 while an official open-data API works, design the production adapter around the API and keep the Webwright spike only as a diagnostic harness in the repo.
+
+## CLI Tool Mode
+
+Default Webwright runs produce a one-shot `final_script.py` solving the task for the literal values the user provided. **CLI tool mode** instead produces a reusable parameterized tool: one function with a Google-style `Args:` docstring + an `argparse` wrapper whose flags default to the concrete task values, so the user can re-run it later with different inputs.
+
+Trigger CLI tool mode when the user says "make it reusable", "parameterize", "turn this into a CLI", "I want to call this again with different X", or similar. Defaults must reproduce the original task exactly — `python final_script.py` with no arguments equals the original run.
+
+Full contract (the `# Parameters` table, reusable-function shape, `step 0 params:` line, import-safety smoke test, completion gate) is in `references/cli_tool_mode.md`. Load it whenever the user asks for a reusable tool.
+
+## Delegating to Claude Code
+
+For non-trivial automation (long flows, fragile selectors, multi-engine comparison) delegate the script-authoring loop to Claude Code and tell it to follow this skill / workspace contract. Hermes retains final verification.
+
+```bash
+HOME=/root/.hermes/profiles/default/home claude -p \
+  "Use the Webwright skill at skills/software-development/webwright/. \
+   Build a bounded Playwright script for <task>. \
+   Workspace: <workspace>. Produce plan.md, final_script.py, \
+   final_runs/run_<id>_<tag>/ with screenshots, final_script_log.txt, \
+   results.json. Verify every CP. Do not persist secrets/cookies/IPs." \
+  --allowedTools 'Read,Write,Edit,MultiEdit,Bash(python3 *),Bash(uv *),Bash(playwright *),Bash(git *)' \
+  --permission-mode acceptEdits \
+  --max-turns 40
+```
+
+Hermes is then responsible for:
+
+- Reading the final `plan.md`, `final_script.py`, `results.json`, and key screenshots.
+- Confirming every CP is ticked with cited evidence.
+- Running `git diff --stat` if the spike committed anything and confirming bounds.
+- Reporting the final datum + artifact paths back to the user.
+
+Do not skip these checks — the delegated agent only describes what it *intended* to do, not necessarily what landed on disk.
+
+## Hard Rules
+
+- One bash command per exploration step; observe its output before issuing the next.
+- Use stable selectors (role + accessible name, `aria-label`) and current-run evidence — never guess UI state.
+- If a site exposes a dedicated control for a requirement, **use that control**. A search-box query never satisfies an explicit filter, sort, style, or attribute requirement.
+- Ranking language must be grounded in the site's actual sort/filter, not in your own ordering of the results.
+- Numeric / date / quantity / unit constraints are **exact**. Wider buckets are failures unless the site offers no exacter control (record that in `plan.md`).
+- If a selected state becomes hidden after a drawer / modal / dropdown closes, reopen it or capture a visible chip/summary before treating the state as verified.
+- For blocker claims (Access Denied, 403, "control unavailable"), require repeated evidence from the actual UI — not a single timeout.
+- Never hardcode proxy endpoints or credentials. Accept `--proxy` and `JURISNET_BROWSER_PROXY`.
+- Do not install extra packages unless the project's runtime is missing one. `playwright`, `httpx`, `pydantic` are typically already installed.
+- Once `final_script.py` exists, prefer incremental `Edit` over rewriting the whole file.
+
+## Common Pitfalls
+
+1. **Reporting success from live browser state alone.** The deliverable is the reusable script + cited evidence, not a manual click path that happened to work once.
+2. **No critical-point plan.** Without `plan.md`, verification becomes vibes-based. Write CPs *before* coding.
+3. **Saving huge HTML dumps, cookies, or secrets.** Persist `results.json` + structured snippets only. Never persist proxy creds or local IPs.
+4. **One engine only.** For WAF / TLS / H2-fingerprint issues, compare Firefox and Chromium before concluding the site is unreachable.
+5. **Deep-link URLs as the primary path.** Sites silently drop unparseable query params. Drive the on-page form interactively; treat deep links as an opportunistic shortcut and verify form state afterwards.
+6. **Declaring filters applied from URL or search text alone.** Verify with visible chips, selected controls, or a result-summary banner — not the URL bar.
+7. **`full_page=True` screenshots.** Banned everywhere. Use the 1280×1800 viewport.
+8. **Committing generated bulk by default.** Commit spike evidence only when the repo expects it (`spikes/<task-id>/`); otherwise add `final_runs/`, `scratch/`, `outputs/` to `.gitignore`.
+9. **Reusing a run folder after a partial / crashed execution.** Either delete the partial PNGs or allocate `run_<id+1>_<tag>/`. Mixed evidence inside one run folder breaks verification.
+10. **Skipping the import-safety check in CLI tool mode.** A `final_script.py` that launches a browser at import time is not a reusable tool. See `references/cli_tool_mode.md`.
+
+## Verification Checklist
+
+- [ ] `plan.md` exists and lists every CP as a checklist item.
+- [ ] `final_script.py` runs from a clean workspace with no manual setup.
+- [ ] A fresh `final_runs/run_<id>_<tag>/` was produced for the reported run.
+- [ ] `results.json` captures status / URLs / captured data / timestamps.
+- [ ] `final_script_log.txt` has a `step <n> action: ...` line for every constraint-relevant interaction (and `step 0 params: ...` in CLI tool mode).
+- [ ] One screenshot per CP under `screenshots/`, named `final_execution_<step>_<action>.png`. No `full_page=True`. Viewport 1280×1800.
+- [ ] Every CP in `plan.md` is ticked with a cited screenshot and/or log line; the agent has `Read` each cited PNG.
+- [ ] The final datum (if the task asked for one) is reported verbatim and is also present in `final_script_log.txt` / `results.json`.
+- [ ] No secrets, cookies, session storage, local IPs, or proxy credentials are persisted.
+- [ ] If committed, `git diff --stat` is bounded and matches the spike's stated scope.
+- [ ] If delegated to Claude Code, Hermes has independently verified plan.md, script, results, and key screenshots before reporting success.

--- a/skills/software-development/webwright/references/cli_tool_mode.md
+++ b/skills/software-development/webwright/references/cli_tool_mode.md
@@ -1,0 +1,149 @@
+# CLI Tool Mode
+
+Default Webwright runs produce a one-shot `final_script.py` that solves the task for the literal values the user provided. **CLI tool mode** instead produces a **reusable, parameterized CLI tool**: the same script can be re-run later with different argument values to perform the same kind of task.
+
+This mode is adapted from `webwright/config/crafted_cli.yaml`'s "Final-Script Shape (CLI Tool, MANDATORY)" contract from the upstream Microsoft Webwright repo. The OpenAI-backed `self_reflection` gate is replaced by the agent's own self-verification against `plan.md`.
+
+## When to use
+
+Trigger CLI tool mode when:
+
+- the user says "make it reusable", "parameterize", "turn this into a CLI", "I want to call this again with different X", or similar; or
+- the spike is meant to become a JurisNet adapter regression harness that another script will import and call with different fallo ids, jurisdictions, or date ranges.
+
+Otherwise, stay in default one-shot mode.
+
+## `plan.md` — add a `# Parameters` section
+
+Before writing the script, identify every requirement the user could plausibly vary and list them in `plan.md` **in addition to** the usual `# Critical Points` checklist:
+
+```markdown
+# Task
+<verbatim task description>
+
+# Parameters
+| name    | type | source phrase from task | default     | allowed / format        |
+|---------|------|-------------------------|-------------|-------------------------|
+| <arg_a> | str  | "..."                   | "<value>"   | <format / allowed set>  |
+| <arg_b> | int  | "..."                   | <value>     | <range or units>        |
+| <arg_c> | str  | "..."                   | "<value>"   | <format>                |
+
+# Critical Points
+- [ ] CP1: ...
+- [ ] CP2: ...
+```
+
+Rules:
+
+- Every entry in `# Parameters` must (a) become a function argument and (b) become an `argparse --flag` with the listed default.
+- Items that are truly fixed for the site (start URL, site name, selector strategy, proxy env var name) are NOT parameters — keep them hard-coded.
+- Defaults reproduce the original task exactly. Running `python final_script.py` with no arguments must reproduce the task.
+- Critical Points are still required; they are the verification contract.
+
+## `final_script.py` — required shape
+
+1. **One reusable function** named after the task domain. Examples:
+   - `def search_<domain>(arg_a, arg_b, ...): ...`
+   - `def lookup_<entity>(query, filters): ...`
+   - `def fetch_fallo(fallo_id: str, jurisdiction: str): ...`
+
+2. **Google-style docstring** with summary, full `Args:` block, and `Returns:`. Each `Args:` entry documents:
+   - the argument name and type,
+   - what it represents in the task domain,
+   - accepted format / units / allowed values,
+   - the default (mirroring the `# Parameters` table).
+
+   ```python
+   def search_<domain>(arg_a: str, arg_b: int, arg_c: str) -> dict:
+       """<One-line summary of what this tool does on the target site>.
+
+       Args:
+           arg_a: <what it represents>; <format / allowed values>.
+               Default: "<value>".
+           arg_b: <what it represents>; <range / units>.
+               Default: <value>.
+           arg_c: <what it represents>; <format>.
+               Default: "<value>".
+
+       Returns:
+           dict with keys ``<key1>`` (<type>), ``<key2>`` (<type>), ...
+       """
+   ```
+
+3. **`argparse` CLI** under `if __name__ == "__main__":`. Every function argument has a matching `--<arg>` flag with `type=`, `help=` (copied from the docstring), and `default=` equal to the concrete task value:
+
+   ```python
+   if __name__ == "__main__":
+       import argparse
+       parser = argparse.ArgumentParser(
+           description=search_<domain>.__doc__.splitlines()[0])
+       parser.add_argument("--arg-a", dest="arg_a", type=str,
+                           default="<value>",
+                           help="<copied from docstring>")
+       parser.add_argument("--arg-b", dest="arg_b", type=int,
+                           default=<value>,
+                           help="<copied from docstring>")
+       parser.add_argument("--arg-c", dest="arg_c", type=str,
+                           default="<value>",
+                           help="<copied from docstring>")
+       args = parser.parse_args()
+       result = asyncio.run(_run(**vars(args)))
+       print(result)
+   ```
+
+4. **Side-effect-free at import time.** No browser launch, no network call, no file write at module top-level. The reusable function must be importable from another Python process without triggering a run.
+
+5. **Action-log parameter echo.** The first line written to `final_script_log.txt` after reset MUST be a `step 0 params: ...` line listing every resolved argument as `name=value` pairs, e.g.:
+
+   ```
+   step 0 params: arg_a=<value> arg_b=<value> arg_c=<value>
+   ```
+
+   so the resolved inputs are visible in any verification pass.
+
+6. Same instrumentation as default mode: viewport 1280×1800, headless local Firefox by default, no `full_page=True`, screenshots saved as `final_runs/run_<id>_<tag>/screenshots/final_execution_<step>_<action>.png`, final datum appended to `final_script_log.txt`, `results.json` written at the end.
+
+## Verification (replaces `self_reflection`)
+
+In addition to the default self-verification (every CP in `plan.md` ticked with cited screenshot/log evidence), CLI mode requires:
+
+1. **Reproduce the task with no arguments.** Inside a fresh `final_runs/run_<id>_<tag>/`:
+
+   ```bash
+   cd final_runs/run_<id>_<tag> && python final_script.py
+   ```
+
+   The run must succeed end-to-end and produce the expected screenshots and `step 0 params: ...` log line.
+
+2. **Import-safety smoke test.** From any other directory:
+
+   ```bash
+   python -c "import importlib.util, pathlib; \
+     spec = importlib.util.spec_from_file_location('fs', 'final_runs/run_<id>_<tag>/final_script.py'); \
+     m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); \
+     print([n for n in dir(m) if not n.startswith('_')])"
+   ```
+
+   This must complete instantly with no browser launch and print the reusable function's name.
+
+3. **Optional second run with a different argument value.** Demonstrates parameterization actually works. Run inside `final_runs/run_<id+1>_alt/` (or save its log/screenshot folder there). Skip only if the alternate value would clearly fail (e.g. an unsupported value on the target site).
+
+4. **Print `--help`.** End by showing the user:
+
+   ```bash
+   python final_runs/run_<id>_<tag>/final_script.py --help
+   ```
+
+## Completion gate (CLI mode)
+
+Set the task complete only when **all** are true:
+
+1. `plan.md` contains both `# Parameters` (with name, type, source phrase, default, allowed/format) and `# Critical Points` checklists.
+2. `final_script.py` defines exactly one reusable function with a Google-style `Args:` docstring covering every parameter.
+3. Every `# Parameters` entry maps 1-to-1 to a function argument **and** an argparse `--flag` whose default equals the concrete task value.
+4. The script is import-safe (smoke test passes — no browser launch, no I/O on import).
+5. `python final_script.py` (no args) inside `final_runs/run_<id>_<tag>/` reproduced the task; all CPs verified against saved screenshots and the action log.
+6. `step 0 params: ...` line is present in `final_script_log.txt`.
+7. The user has seen the final datum **and** the `--help` output so they know how to call the tool again with different arguments.
+
+If any of those is false, do not declare done — diagnose, fix the script (preserving the CLI shape), re-run inside the next `run_<id+1>_<tag>/`, and re-verify.

--- a/skills/software-development/webwright/references/playwright_patterns.md
+++ b/skills/software-development/webwright/references/playwright_patterns.md
@@ -1,0 +1,185 @@
+# Playwright Patterns
+
+The canonical patterns the Webwright workflow uses. Run them via `Bash` — no JSON wrapping, one bash command per turn.
+
+## Browser launch skeleton (exploration)
+
+Webwright uses **Playwright Firefox** as its default engine. Some sites (cars.com, Akamai-protected portals, parts of SAIJ/JUBA) reject Playwright Chromium with `ERR_HTTP2_PROTOCOL_ERROR` due to TLS/H2 fingerprinting but load cleanly under Firefox. Run `playwright install firefox chromium` once before the first task.
+
+```bash
+python - <<'PY'
+import asyncio
+import os
+from pathlib import Path
+
+from playwright.async_api import async_playwright
+
+WORKSPACE = Path(os.environ.get("WORKSPACE_DIR", "."))
+SCREENSHOTS = WORKSPACE / "scratch" / "screenshots"
+SCREENSHOTS.mkdir(parents=True, exist_ok=True)
+
+async def main():
+    async with async_playwright() as playwright:
+        browser = await playwright.firefox.launch(headless=True)
+        context = await browser.new_context(viewport={"width": 1280, "height": 1800})
+        page = await context.new_page()
+
+        await page.goto("<START_URL>", wait_until="domcontentloaded")
+        await page.screenshot(path=str(SCREENSHOTS / "explore_1_start.png"))
+
+        print("URL:", page.url)
+        print("TITLE:", await page.title())
+
+        # Inspect the region you care about with an ARIA snapshot
+        snapshot = await page.locator("body").aria_snapshot()
+        print("ARIA:", snapshot)
+
+        await browser.close()
+
+asyncio.run(main())
+PY
+```
+
+Rules:
+
+- **Always** set `viewport={"width": 1280, "height": 1800}`.
+- **Never** call `page.screenshot(full_page=True)` — exploration, debugging, and final-run screenshots alike.
+- Each Playwright run is fresh: navigate from the start URL, reapply filters, reconstruct state in code. There is no persistent session.
+
+## Proxy injection (JurisNet sources)
+
+```bash
+JURISNET_BROWSER_PROXY=socks5://127.0.0.1:18080 python - <<'PY'
+import asyncio, os
+from playwright.async_api import async_playwright
+
+proxy = os.environ.get("JURISNET_BROWSER_PROXY")
+
+async def main():
+    async with async_playwright() as pw:
+        launch_kwargs = {"headless": True}
+        if proxy:
+            launch_kwargs["proxy"] = {"server": proxy}
+        browser = await pw.firefox.launch(**launch_kwargs)
+        # ...
+        await browser.close()
+
+asyncio.run(main())
+PY
+```
+
+Never hardcode proxy hosts or credentials. Read from `JURISNET_BROWSER_PROXY` (or an explicit `--proxy` CLI flag).
+
+## Targeting elements with role + name
+
+```python
+await page.get_by_role("button", name="Filters").click()
+await asyncio.sleep(1)
+
+# Snapshot the *parent* of the control to see siblings/options
+panel = page.get_by_role("button", name="Filters").first.locator("..")
+print(await panel.aria_snapshot())
+
+await page.get_by_role("checkbox", name="BMW").check()
+await asyncio.sleep(1)
+```
+
+If a selected state becomes hidden after a drawer/dropdown closes, reopen it before capturing the verification screenshot.
+
+## Prefer interactive form filling over deep-link URLs
+
+When a task requires parameterizing a search (locations, dates, filters, query strings), **drive the on-page form interactively** rather than constructing a deep-link URL with the parameters baked into the query string. Deep links are convenient for the one specific case the agent explored, but they are brittle as a CLI surface:
+
+- Sites silently drop parameters they cannot parse, leaving downstream fields blank.
+- URL parsers vary by locale, A/B bucket, and signed-in state.
+- A working deep link for one input set tells you nothing about whether another set will populate.
+
+Interactive filling using the same controls a human would click is the most reliable strategy across input variations. Make it the **primary** path in the final script; only use a deep link as an opportunistic shortcut, and always verify the form state afterwards and fall back to interactive filling when any field is empty or wrong.
+
+```python
+# After navigating, read the visible form state and decide.
+form_state = await page.locator("input[aria-label]").evaluate_all(
+    "els => els.map(e => ({label: e.getAttribute('aria-label'), "
+    "value: e.value, hidden: e.offsetParent === null}))"
+)
+if not form_is_fully_populated(form_state, expected):
+    # Type into each field, pick from the suggestion list, fill grouped
+    # inputs via their shared modal (Tab between siblings to keep one
+    # modal open), then click the submit control.
+    await fill_form_interactively(page, expected)
+```
+
+Guidelines for the interactive path:
+
+- Use `get_by_role` / `aria-label` selectors, not brittle CSS classes.
+- Type the value, wait for the suggestion listbox, then click the option whose text contains the canonical token for the input.
+- For paired fields rendered inside a single modal (date range pickers, stepper groups, etc.), open the modal **once** and `Tab` between fields instead of clicking each input separately — clicking the second input while the modal is open often gets blocked by the modal's own overlay.
+- After filling, click the explicit submit control rather than relying on auto-submit.
+- Re-read the form state and assert each checkpoint (CP1..CPn) before proceeding to results extraction.
+
+## Final-script instrumentation
+
+`final_runs/run_<id>_<tag>/final_script.py` must:
+
+- write screenshots to `final_runs/run_<id>_<tag>/screenshots/final_execution_<step>_<action>.png`,
+- reset and append to `final_runs/run_<id>_<tag>/final_script_log.txt`,
+- write structured results to `final_runs/run_<id>_<tag>/results.json`,
+- print the final datum at the end of the log.
+
+```python
+import asyncio, json, os
+from datetime import datetime, timezone
+from pathlib import Path
+from playwright.async_api import async_playwright
+
+RUN_DIR = Path(__file__).parent
+SCREENSHOTS = RUN_DIR / "screenshots"
+SCREENSHOTS.mkdir(parents=True, exist_ok=True)
+LOG = RUN_DIR / "final_script_log.txt"
+LOG.write_text("")  # reset
+
+def log(step: int, msg: str) -> None:
+    line = f"step {step} action: {msg}\n"
+    LOG.open("a").write(line)
+    print(line, end="")
+
+async def main():
+    async with async_playwright() as playwright:
+        browser = await playwright.firefox.launch(headless=True)
+        context = await browser.new_context(viewport={"width": 1280, "height": 1800})
+        page = await context.new_page()
+
+        await page.goto("<START_URL>", wait_until="domcontentloaded")
+        await page.screenshot(path=str(SCREENSHOTS / "final_execution_1_open_start_page.png"))
+        log(1, "open start page")
+
+        # ... apply CP1, screenshot, log ...
+        # ... apply CP2, screenshot, log ...
+
+        final_value = "<extracted price / code / winner>"
+        results = {
+            "final_value": final_value,
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+        }
+        (RUN_DIR / "results.json").write_text(json.dumps(results, indent=2, ensure_ascii=False))
+        with LOG.open("a") as f:
+            f.write(f"\nFINAL_RESPONSE: {final_value}\n")
+
+        await browser.close()
+
+asyncio.run(main())
+```
+
+## Inspection commands
+
+```bash
+# Latest run tree + log
+ls -R final_runs/run_<id>_<tag>
+cat final_runs/run_<id>_<tag>/final_script_log.txt
+cat final_runs/run_<id>_<tag>/results.json
+
+# Quick file read
+sed -n '1,220p' final_runs/run_<id>_<tag>/final_script.py
+```
+
+For visual checks, use `Read` on individual PNG files inside `final_runs/run_<id>_<tag>/screenshots/` rather than calling an external image-QA service.

--- a/skills/software-development/webwright/references/workflow.md
+++ b/skills/software-development/webwright/references/workflow.md
@@ -1,0 +1,90 @@
+# Workflow
+
+Detailed expansion of the six-step Webwright loop, adapted for terminal-native agents (Hermes / Claude Code). The original Microsoft Webwright loop relied on `webwright.tools.image_qa` for visual QA and `webwright.tools.self_reflection` for the final verdict. Both are replaced here by the agent's native abilities (`Read` on PNG files + reasoning against `plan.md`). No `OPENAI_API_KEY` is required.
+
+## 1. Plan
+
+Parse the task into critical points (CPs) and write `WORKSPACE_DIR/plan.md`:
+
+```markdown
+# Task
+<verbatim task description>
+
+# Critical Points
+- [ ] CP1: <constraint / filter / sort / selection / required datum>
+- [ ] CP2: ...
+```
+
+Rules for CPs:
+
+- One CP per independently verifiable requirement.
+- Numeric, date, quantity, and unit CPs must be exact. Wider buckets are failures unless the site genuinely offers no exacter control (record that exception in `plan.md`).
+- Ranking CPs ("cheapest", "best-selling", "highest-rated", "most cited", "latest", …) must reference the site's actual sort/filter control, not the order results happen to come back in.
+- If the task asks for a final datum (price, code, winner, fallo id, holding, quote), make it its own CP (e.g. `CP5: Record the displayed cheapest economy fare`).
+- For browser-gated source spikes, include a CP for the access verdict itself (e.g. `CP1: Direct Firefox loads result list without 403/WAF interstitial`).
+
+## 2. Explore
+
+Goal: discover stable selectors, confirm every required filter control exists, and identify how to capture evidence for each CP.
+
+- Run scratch Playwright scripts (see `playwright_patterns.md`) inside `WORKSPACE_DIR/scratch/`. Save scratch PNGs there — keep `final_runs/` clean.
+- Print URL, title, and `aria_snapshot()` for the region of interest at every step.
+- Use `Read` on saved PNGs to confirm UI state when ARIA evidence is ambiguous.
+- If a filter looks unavailable, expand drawers / accordions / mobile filter panels and inspect again before concluding it doesn't exist.
+- A search-box query never substitutes for a dedicated filter control — if the site has a "Year" facet, use it, don't append "year:2024" to the search.
+- For WAF/TLS issues, try the same exploration step under Chromium *and* Firefox before concluding the site rejects all clients.
+
+## 3. Author `final_script.py`
+
+Create a fresh `final_runs/run_<id>_<tag>/` (use the next integer above any existing `run_*`, and a short `<tag>` like `direct`, `chromium`, `socks`) and place `final_script.py` inside it. Instrument per `playwright_patterns.md`:
+
+- viewport 1280×1800, headless local Firefox by default, no `full_page=True`;
+- one `final_execution_<step>_<action>.png` per CP;
+- one `step <n> action: <reason and action>` log line per constraint-relevant interaction;
+- the final datum printed into `final_script_log.txt` at the end (e.g. `FINAL_RESPONSE: <value>`);
+- `results.json` with status, URLs, captured data, and timestamps.
+
+Each screenshot should map to a CP from `plan.md` so verification is mechanical.
+
+## 4. Execute
+
+Run the script once. Compare engines / proxy modes when relevant:
+
+```bash
+python final_script.py --tag direct
+python final_script.py --engine chromium --tag chromium
+JURISNET_BROWSER_PROXY=socks5://127.0.0.1:18080 python final_script.py --tag socks
+```
+
+If a run crashes mid-flight and produces partial screenshots that don't match the fixed flow, delete the partial run folder before re-executing — mixed evidence inside one run folder breaks the verification step.
+
+## 5. Self-verify (replaces `self_reflection`)
+
+For every CP in `plan.md`:
+
+1. Identify the screenshot(s) and/or log line that provide evidence.
+2. `Read` each cited PNG.
+3. Confirm the evidence is **unambiguous**:
+   - Filter chip / selected state visibly applied (not hidden behind a closed drawer);
+   - Numeric / date values match exactly (not broadened or "close enough");
+   - Sort applied via the site's control (not implied by result order);
+   - Required submit / search / apply action visibly taken;
+   - Final datum legibly displayed.
+4. Tick the CP only when the evidence is concrete. Be harsh on partial, occluded, or ambiguous states.
+
+If any CP fails, diagnose the *specific* issue — wrong filter value, missing control, hidden chip, broadened range, missing confirmation, missing screenshot, etc. Fix `final_script.py`, run it again inside `final_runs/run_<id+1>_<tag>/`, and re-verify against `plan.md`.
+
+Empty result sets are acceptable when the correct filters were demonstrably applied and the screenshot shows the empty state with the filter chips visible.
+
+## 6. Done
+
+Stop only when **all** of the following are true:
+
+1. `plan.md` exists with every CP enumerated as a checklist item.
+2. `final_runs/run_<id>_<tag>/final_script.py` ran cleanly from scratch and produced `final_script_log.txt`, `results.json`, and all CP screenshots.
+3. Every CP is checked off with a cited screenshot and/or log line, and the agent has actually `Read` each cited PNG.
+4. The final datum (if the task asked for one) is reported to the user verbatim and is also present in `final_script_log.txt` / `results.json`.
+5. `ls -R final_runs/run_<id>_<tag>` and `cat final_runs/run_<id>_<tag>/final_script_log.txt` show the expected artifacts.
+6. No secrets, cookies, local IPs, or proxy credentials persisted.
+
+If any of those is false, do not declare done — diagnose, fix, and re-run in a new `run_<id+1>_<tag>/`.


### PR DESCRIPTION
## Summary
- add bundled Webwright skill for terminal-native Playwright browser automation
- document final_script/final_runs workspace contract, screenshots/logs/results evidence, and critical-point verification
- include reference docs adapted from Microsoft Webwright for workflow, Playwright patterns, and CLI tool mode

## Validation
- python frontmatter/link validation
- sensitive grep clean
- git diff --check
- hermes --version smoke