### PR TITLE
fix(docker): re-bridge terminal config after per-turn .env reload

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -761,8 +761,8 @@ def _reload_runtime_env_preserving_config_authority() -> None:
 
     Gateway processes are long-lived, so per-turn code reloads ~/.hermes/.env to
     pick up rotated API keys. config.yaml remains authoritative for agent budget
-    settings such as agent.max_turns; otherwise a stale HERMES_MAX_ITERATIONS in
-    .env can replace the startup bridge on later turns.
+    settings such as agent.max_turns and ALL terminal settings; otherwise stale
+    .env values (loaded with override=True) silently replace the startup bridge.
     """
     load_hermes_dotenv(
         hermes_home=_hermes_home,
@@ -785,9 +785,66 @@ def _reload_runtime_env_preserving_config_authority() -> None:
     if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
         os.environ["HERMES_MAX_ITERATIONS"] = str(agent_cfg["max_turns"])
 
+    _bridge_terminal_config(cfg)
+
 
 _DOCKER_VOLUME_SPEC_RE = re.compile(r"^(?P<host>.+):(?P<container>/[^:]+?)(?::(?P<options>[^:]+))?$")
 _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
+
+# Canonical mapping from terminal config keys → TERMINAL_* env vars.
+# Shared by the module-load bridge AND the per-turn reload so that
+# config.yaml stays authoritative even after .env is re-read.
+_terminal_env_map = {
+    "backend": "TERMINAL_ENV",
+    "cwd": "TERMINAL_CWD",
+    "timeout": "TERMINAL_TIMEOUT",
+    "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
+    "docker_image": "TERMINAL_DOCKER_IMAGE",
+    "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
+    "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
+    "modal_image": "TERMINAL_MODAL_IMAGE",
+    "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+    "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
+    "ssh_host": "TERMINAL_SSH_HOST",
+    "ssh_user": "TERMINAL_SSH_USER",
+    "ssh_port": "TERMINAL_SSH_PORT",
+    "ssh_key": "TERMINAL_SSH_KEY",
+    "container_cpu": "TERMINAL_CONTAINER_CPU",
+    "container_memory": "TERMINAL_CONTAINER_MEMORY",
+    "container_disk": "TERMINAL_CONTAINER_DISK",
+    "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+    "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+    "docker_env": "TERMINAL_DOCKER_ENV",
+    "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+    "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+    "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+    "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+}
+
+
+def _bridge_terminal_config(cfg: dict) -> None:
+    """Bridge ``terminal.*`` config values into ``TERMINAL_*`` env vars.
+
+    Called both at module load and on every per-turn ``.env`` reload so that
+    ``config.yaml`` stays authoritative for terminal settings even when
+    ``load_hermes_dotenv(override=True)`` clobbers previously-bridged values.
+    """
+    terminal_cfg = cfg.get("terminal", {})
+    if not terminal_cfg or not isinstance(terminal_cfg, dict):
+        return
+    for cfg_key, env_var in _terminal_env_map.items():
+        if cfg_key not in terminal_cfg:
+            continue
+        val = terminal_cfg[cfg_key]
+        if cfg_key == "cwd" and str(val) in {".", "auto", "cwd"}:
+            continue
+        if cfg_key == "cwd" and isinstance(val, str):
+            val = os.path.expanduser(val)
+        if isinstance(val, (list, dict)):
+            os.environ[env_var] = json.dumps(val)
+        else:
+            os.environ[env_var] = str(val)
+
 
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
@@ -806,51 +863,7 @@ if _config_path.exists():
                 os.environ[_key] = str(_val)
         # Terminal config is nested — bridge to TERMINAL_* env vars.
         # config.yaml overrides .env for these since it's the documented config path.
-        _terminal_cfg = _cfg.get("terminal", {})
-        if _terminal_cfg and isinstance(_terminal_cfg, dict):
-            _terminal_env_map = {
-                "backend": "TERMINAL_ENV",
-                "cwd": "TERMINAL_CWD",
-                "timeout": "TERMINAL_TIMEOUT",
-                "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
-                "docker_image": "TERMINAL_DOCKER_IMAGE",
-                "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
-                "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
-                "modal_image": "TERMINAL_MODAL_IMAGE",
-                "daytona_image": "TERMINAL_DAYTONA_IMAGE",
-                "vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
-                "ssh_host": "TERMINAL_SSH_HOST",
-                "ssh_user": "TERMINAL_SSH_USER",
-                "ssh_port": "TERMINAL_SSH_PORT",
-                "ssh_key": "TERMINAL_SSH_KEY",
-                "container_cpu": "TERMINAL_CONTAINER_CPU",
-                "container_memory": "TERMINAL_CONTAINER_MEMORY",
-                "container_disk": "TERMINAL_CONTAINER_DISK",
-                "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
-                "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
-                "docker_env": "TERMINAL_DOCKER_ENV",
-                "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
-                "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
-                "sandbox_dir": "TERMINAL_SANDBOX_DIR",
-                "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
-            }
-            for _cfg_key, _env_var in _terminal_env_map.items():
-                if _cfg_key in _terminal_cfg:
-                    _val = _terminal_cfg[_cfg_key]
-                    # Skip cwd placeholder values (".", "auto", "cwd") — the
-                    # gateway resolves these to Path.home() later (line ~255).
-                    # Writing the raw placeholder here would just be noise.
-                    # Only bridge explicit absolute paths from config.yaml.
-                    if _cfg_key == "cwd" and str(_val) in {".", "auto", "cwd"}:
-                        continue
-                    # Expand shell tilde in cwd so subprocess.Popen never
-                    # receives a literal "~/" which the kernel rejects.
-                    if _cfg_key == "cwd" and isinstance(_val, str):
-                        _val = os.path.expanduser(_val)
-                    if isinstance(_val, (list, dict)):
-                        os.environ[_env_var] = json.dumps(_val)
-                    else:
-                        os.environ[_env_var] = str(_val)
+        _bridge_terminal_config(_cfg)
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract,

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -514,3 +514,37 @@ def test_run_as_host_user_warns_and_skips_when_no_posix_ids(monkeypatch, caplog)
         "does not expose POSIX uid/gid" in rec.getMessage()
         for rec in caplog.records
     ), "expected a warning when POSIX ids are unavailable"
+
+
+class TestValidateDockerImage:
+    """Guard against corrupted image names reaching ``docker run`` (#32588)."""
+
+    def test_valid_images_pass(self):
+        for img in [
+            "ubuntu:24.04",
+            "python:3.11",
+            "nikolaik/python-nodejs:python3.11-nodejs20",
+            "ghcr.io/nousresearch/hermes-agent:latest",
+            "registry.example.com:5000/myimage:v1",
+            "alpine",
+            "myimage@sha256:" + "a" * 64,
+        ]:
+            docker_env._validate_docker_image(img)
+
+    def test_shell_command_rejected(self):
+        with pytest.raises(ValueError, match="Invalid Docker image reference"):
+            docker_env._validate_docker_image(
+                'export PATH="/Applications/Docker.app/Contents/Resources/bin:$PATH"'
+            )
+
+    def test_empty_image_rejected(self):
+        with pytest.raises(ValueError, match="Docker image is empty"):
+            docker_env._validate_docker_image("")
+
+    def test_whitespace_only_rejected(self):
+        with pytest.raises(ValueError, match="Docker image is empty"):
+            docker_env._validate_docker_image("   ")
+
+    def test_path_string_rejected(self):
+        with pytest.raises(ValueError, match="Invalid Docker image reference"):
+            docker_env._validate_docker_image("/usr/local/bin/docker")

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -224,3 +224,22 @@ def test_docker_env_is_bridged_everywhere():
     assert "docker_env" in _gateway_env_map_keys()
     assert "docker_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_ENV" in _terminal_tool_env_var_names()
+
+
+def test_per_turn_reload_rebridges_terminal_config():
+    """``_reload_runtime_env_preserving_config_authority`` must re-bridge
+    terminal config after reloading ``.env``, otherwise
+    ``load_hermes_dotenv(override=True)`` can clobber config-bridged
+    ``TERMINAL_*`` vars with stale ``.env`` values (#32588).
+
+    Verify by source inspection that ``_bridge_terminal_config`` is called
+    inside the reload function.
+    """
+    import gateway.run as gr
+    source = inspect.getsource(gr._reload_runtime_env_preserving_config_authority)
+    assert "_bridge_terminal_config" in source, (
+        "_reload_runtime_env_preserving_config_authority must call "
+        "_bridge_terminal_config to re-bridge terminal config after "
+        ".env reload — otherwise stale .env values override config.yaml "
+        "(see #32588)."
+    )

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -98,6 +98,32 @@ def _load_hermes_env_vars() -> dict[str, str]:
         return {}
 
 
+_DOCKER_IMAGE_RE = re.compile(
+    r"^(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?(?::[0-9]+)?/)?)"
+    r"[a-z0-9](?:[a-z0-9._/-]*[a-z0-9])?(?::[a-zA-Z0-9._-]+)?(?:@sha256:[0-9a-f]{64})?$"
+)
+
+
+def _validate_docker_image(image: str) -> None:
+    """Reject obviously invalid Docker image references before ``docker run``.
+
+    Catches corruption where a shell command (e.g. ``export PATH=...``) or
+    other non-image string ends up in the image variable — see #32588.
+    """
+    if not image or not image.strip():
+        raise ValueError(
+            "Docker image is empty. Set terminal.docker_image in config.yaml "
+            "or the TERMINAL_DOCKER_IMAGE environment variable."
+        )
+    if not _DOCKER_IMAGE_RE.match(image):
+        raise ValueError(
+            f"Invalid Docker image reference: {image!r}. "
+            f"Expected a Docker image name (e.g. 'ubuntu:24.04'). "
+            f"Check terminal.docker_image in config.yaml and ensure "
+            f"TERMINAL_DOCKER_IMAGE is not set to a non-image value in .env."
+        )
+
+
 def find_docker() -> Optional[str]:
     """Locate the docker (or podman) CLI binary.
 
@@ -305,6 +331,7 @@ class DockerEnvironment(BaseEnvironment):
         run_as_host_user: bool = False,
         extra_args: list = None,
     ):
+        _validate_docker_image(image)
         if cwd == "~":
             cwd = "/root"
         super().__init__(cwd=cwd, timeout=timeout)


### PR DESCRIPTION
## What does this PR do?

Closes #32588.

The gateway's per-turn `.env` reload (`load_hermes_dotenv` with `override=True`) was clobbering config-bridged `TERMINAL_*` env vars but only re-bridging `agent.max_turns` — terminal settings like `TERMINAL_DOCKER_IMAGE` were left with whatever stale value `.env` produced.  On macOS this manifested as a corrupted image name (a literal `export PATH="..."` shell string) reaching `docker run`, causing exit 125.

### Root cause

`_reload_runtime_env_preserving_config_authority()` calls `load_hermes_dotenv(override=True)` which re-reads `~/.hermes/.env` into `os.environ`, overwriting previously-bridged `TERMINAL_*` values from `config.yaml`. The function then re-bridges `HERMES_MAX_ITERATIONS` from `config.yaml` but does **not** re-bridge any terminal config — so `TERMINAL_DOCKER_IMAGE` (and all other `TERMINAL_*` vars) stays at whatever the `.env` reload produced.

### Fix

1. **Extract terminal config bridging** into a reusable `_bridge_terminal_config(cfg)` function (the `_terminal_env_map` dict is promoted to module level).  Called both at module load and in the per-turn reload, so `config.yaml` stays authoritative for terminal settings after every `.env` reload.
2. **Add `_validate_docker_image()`** in `DockerEnvironment.__init__()` as defense-in-depth — rejects obviously invalid image references (shell commands, empty strings, paths) before they reach `docker run`, producing a clear `ValueError` instead of an opaque exit 125.

## Related Issue

Closes #32588.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding test coverage)

## Changes Made

- **`gateway/run.py`** — `_terminal_env_map` promoted to module-level dict; new `_bridge_terminal_config()` function replaces the inline bridging loop and is called in `_reload_runtime_env_preserving_config_authority()` after the `.env` reload.
- **`tools/environments/docker.py`** — new `_validate_docker_image()` with a regex check, called at the top of `DockerEnvironment.__init__()`.
- **`tests/tools/test_docker_environment.py`** — 5 new tests (`TestValidateDockerImage`) covering valid images, shell commands, empty strings, whitespace, and path strings.
- **`tests/tools/test_terminal_config_env_sync.py`** — 1 new regression test verifying `_bridge_terminal_config` is called inside the reload function.

## How to Test

```bash
pytest tests/tools/test_docker_environment.py::TestValidateDockerImage -v
pytest tests/tools/test_terminal_config_env_sync.py::test_per_turn_reload_rebridges_terminal_config -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(docker):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this bug fix
- [x] I've added tests for my changes (6 new tests)
- [x] No platform-specific code; all platforms benefit from the fix

### Documentation & Housekeeping

- [x] N/A — no config key changes
- [x] N/A — no architectural changes
- [x] N/A — no tool schema changes