### PR TITLE
fix(T1): eliminate shell=True command injection in local STT transcription

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1203,12 +1203,10 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 language=shlex.quote(language),
                 model=shlex.quote(normalized_model),
             )
-            # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
-            use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
-            if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
-            else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+            # Always use list-form args (shell=False) to prevent command injection.
+            # shlex.split() handles both user-provided templates and auto-detected commands;
+            # users who need shell features (pipes, redirects) must wrap explicitly.
+            subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))


### PR DESCRIPTION
## Summary

Fixes **T1 — HIGH** from the exhaustive audit: shell=True command injection in .

## Pain Before

The  function supported a user-configurable  environment variable as an escape hatch for custom transcription backends. When this env var was set, the rendered template string was executed via .

While  was used on individual template placeholders (, , , ), the **template string itself** was under user control. A malicious user could set  to:



or:



This is a classic command injection vulnerability. The attack surface is controlling  (or any influence over the rendered template), and the consequence is **arbitrary RCE** as the process user.

## What Was Fixed

Removed  execution entirely. The user-provided command template is now **always** parsed via  and executed as a list with . Shell metacharacters in the template are treated as literal command arguments, not shell syntax.

Users who genuinely need pipes or redirects must wrap explicitly in their template — appropriate for an advanced escape hatch.

## Changes

- **File**: 
- **Lines**: ~1212 (was 1207-1215)
- **Net change**: -5 lines, +1 line
- **Before**: conditional  when env var set
- **After**: unconditionally  with 

## Found By

Exhaustive multi-pass audit: 10 strategies, 1,901 files, 913,487 lines. Full findings documented at [findings.md](./findings.md).