### PR TITLE
fix(agent): guard _extract_pricing against unhashable list-typed values

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -593,7 +593,7 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         pricing: Dict[str, Any] = {}
         for target, aliases in alias_map.items():
             for alias in aliases:
-                if alias in normalized and normalized[alias] not in {None, ""}:
+                if alias in normalized and isinstance(normalized[alias], (int, float, str)) and normalized[alias] not in {None, ""}:
                     pricing[target] = normalized[alias]
                     break
         if pricing:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1210,6 +1210,17 @@ class TestNovitaProvider:
         assert float(result["prompt"]) == 2690 / 10_000 / 1_000_000
         assert float(result["completion"]) == 4000 / 10_000 / 1_000_000
 
+    def test_extract_pricing_skips_list_typed_values(self):
+        """Providers like zenmux return pricing as lists of objects (#32618)."""
+        from agent.model_metadata import _extract_pricing
+        payload = {
+            "id": "deepseek/deepseek-v4-pro",
+            "prompt": [{"value": 1, "unit": "perMTokens"}],
+            "completion": [{"value": 2, "unit": "perMTokens"}],
+        }
+        result = _extract_pricing(payload)
+        assert result == {}
+
     def test_novita_pricing_cache(self, monkeypatch):
         """_fetch_novita_pricing should cache results in _pricing_cache."""
         from hermes_cli import models as models_mod


### PR DESCRIPTION
## What does this PR do?

Closes #32618.

Some providers (e.g. zenmux.ai) return pricing fields as lists of objects instead of scalar values:

```json
{"prompt": [{"value": 1, "unit": "perMTokens"}], "completion": [{"value": 2, "unit": "perMTokens"}]}
```

The `not in {None, ""}` membership check in `_extract_pricing()` raises `TypeError: unhashable type: 'list'` on these values. The exception is caught by the outer `except Exception` in the candidate loop, silently discarding all model metadata — including `context_length` — and falling back to `DEFAULT_FALLBACK_CONTEXT` (256K) even when the endpoint reports the correct value.

## Related Issue

Closes #32618.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding test coverage)

## Changes Made

- **`agent/model_metadata.py`** — add `isinstance(normalized[alias], (int, float, str))` guard before the `not in {None, ""}` check so list/dict values are skipped instead of crashing.
- **`tests/hermes_cli/test_api_key_providers.py`** — new test `test_extract_pricing_skips_list_typed_values` verifying that list-typed pricing values produce an empty dict instead of a `TypeError`.

## How to Test

```bash
pytest tests/hermes_cli/test_api_key_providers.py::TestNovitaProvider::test_extract_pricing_skips_list_typed_values -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this bug fix
- [x] I've added tests for my changes
- [x] No platform-specific code