### PR TITLE
feat: add agent_profiles support for delegate_task (closes #9459)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1336,6 +1336,8 @@ DEFAULT_CONFIG = {
         "subagent_auto_approve": False,
     },
 
+    "agent_profiles": {},   # named child agent profile definitions
+
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.
     # Never saved to sessions, logs, or trajectories.
@@ -3448,6 +3450,7 @@ _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
+    "agent_profiles",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",
 }

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -12,9 +12,11 @@ Run with:  python -m pytest tests/test_delegate.py -v
 import json
 import os
 import sys
+import tempfile
 import threading
 import time
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -29,6 +31,8 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _load_profiles,
+    _resolve_profile,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -2665,6 +2669,179 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+class TestAgentProfiles(unittest.TestCase):
+    """Tests for named agent_profiles resolution (#9459)."""
+
+    def test_unknown_profile_raises_value_error(self):
+        """_resolve_profile raises ValueError for unknown profile name."""
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_profile("nope", {"researcher": {"model": "x"}})
+        self.assertIn("Unknown agent profile", str(ctx.exception))
+        self.assertIn("researcher", str(ctx.exception))
+
+    def test_resolve_profile_returns_model(self):
+        """Profile model field is returned."""
+        out = _resolve_profile(
+            "researcher", {"researcher": {"model": "anthropic/claude-haiku"}}
+        )
+        self.assertEqual(out["model"], "anthropic/claude-haiku")
+
+    def test_resolve_profile_returns_toolsets(self):
+        """Profile toolsets field is returned."""
+        out = _resolve_profile(
+            "coder", {"coder": {"toolsets": ["terminal", "file"]}}
+        )
+        self.assertEqual(out["toolsets"], ["terminal", "file"])
+
+    def test_resolve_profile_inline_system_prompt(self):
+        """system_prompt: inline string becomes system_prompt_text."""
+        out = _resolve_profile(
+            "p", {"p": {"system_prompt": "You are a focused worker."}}
+        )
+        self.assertEqual(out["system_prompt_text"], "You are a focused worker.")
+        # The raw 'system_prompt' key is consumed, not leaked.
+        self.assertNotIn("system_prompt", out)
+
+    def test_resolve_profile_system_prompt_file(self):
+        """system_prompt_file: path is read into system_prompt_text."""
+        with tempfile.TemporaryDirectory() as tmp:
+            spf = Path(tmp) / "prompt.txt"
+            spf.write_text("Prompt from file.", encoding="utf-8")
+            out = _resolve_profile(
+                "p", {"p": {"system_prompt_file": str(spf)}}
+            )
+            self.assertEqual(out["system_prompt_text"], "Prompt from file.")
+            # system_prompt_file is consumed during resolution.
+            self.assertNotIn("system_prompt_file", out)
+
+    def test_resolve_profile_missing_file_raises(self):
+        """system_prompt_file pointing to nonexistent file raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does_not_exist.txt"
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_profile(
+                    "p", {"p": {"system_prompt_file": str(missing)}}
+                )
+            self.assertIn("Cannot read system_prompt_file", str(ctx.exception))
+
+    def test_resolve_profile_max_iterations(self):
+        """Profile max_iterations field is returned."""
+        out = _resolve_profile("p", {"p": {"max_iterations": 25}})
+        self.assertEqual(out["max_iterations"], 25)
+
+    def test_profile_in_schema_properties(self):
+        """DELEGATE_TASK_SCHEMA contains 'profile' property."""
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("profile", props)
+        self.assertEqual(props["profile"]["type"], "string")
+
+    def test_load_profiles_returns_empty_on_error(self):
+        """_load_profiles returns {} if config load fails."""
+        with patch(
+            "hermes_cli.config.load_config", side_effect=RuntimeError("boom")
+        ):
+            self.assertEqual(_load_profiles(), {})
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_profile_drives_child_model_and_prompt(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """profile= sets the child's model and ephemeral system prompt end-to-end."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        # No delegation.model configured → profile model is the baseline.
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {
+            "fast": {
+                "model": "anthropic/claude-haiku",
+                "system_prompt": "You are the fast profile worker.",
+            }
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                result = json.loads(
+                    delegate_task(goal="do it", profile="fast", parent_agent=parent)
+                )
+
+            self.assertIn("results", result)
+            _, kwargs = MockAgent.call_args
+            # Profile model is used as the baseline when config sets none.
+            self.assertEqual(kwargs["model"], "anthropic/claude-haiku")
+            # Inline system_prompt overrides the generated child prompt.
+            self.assertEqual(
+                mock_child.ephemeral_system_prompt,
+                "You are the fast profile worker.",
+            )
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_explicit_toolsets_override_profile(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """Explicit toolsets= wins over the profile's toolsets baseline."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {"p": {"toolsets": ["web"]}}
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.return_value = MagicMock()
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                delegate_task(
+                    goal="g",
+                    toolsets=["terminal"],
+                    profile="p",
+                    parent_agent=parent,
+                )
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["toolsets"], ["terminal"])
+
+    def test_unknown_profile_returns_error_json(self):
+        """delegate_task with an unknown profile returns a clean error, not a crash."""
+        parent = _make_mock_parent(depth=0)
+        with patch(
+            "tools.delegate_tool._load_profiles", return_value={"known": {}}
+        ):
+            result = json.loads(
+                delegate_task(goal="g", profile="missing", parent_agent=parent)
+            )
+        self.assertIn("error", result)
+        self.assertIn("Unknown agent profile", result["error"])
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2731,6 +2731,26 @@ class TestAgentProfiles(unittest.TestCase):
         out = _resolve_profile("p", {"p": {"max_iterations": 25}})
         self.assertEqual(out["max_iterations"], 25)
 
+    def test_resolve_profile_max_iterations_coerces_numeric_string(self):
+        """A numeric-string max_iterations (e.g. from YAML) is coerced to int."""
+        out = _resolve_profile("p", {"p": {"max_iterations": "30"}})
+        self.assertEqual(out["max_iterations"], 30)
+        self.assertIsInstance(out["max_iterations"], int)
+
+    def test_resolve_profile_max_iterations_invalid_raises(self):
+        """A non-integer max_iterations raises a clear ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_profile("p", {"p": {"max_iterations": "lots"}})
+        self.assertIn("max_iterations must be an integer", str(ctx.exception))
+        self.assertIn("'p'", str(ctx.exception))
+
+    def test_resolve_profile_does_not_mutate_source(self):
+        """_resolve_profile deep-copies; mutating the result leaves the source intact."""
+        source = {"p": {"toolsets": ["web"]}}
+        out = _resolve_profile("p", source)
+        out["toolsets"].append("terminal")
+        self.assertEqual(source["p"]["toolsets"], ["web"])
+
     def test_profile_in_schema_properties(self):
         """DELEGATE_TASK_SCHEMA contains 'profile' property."""
         props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
@@ -2830,6 +2850,84 @@ class TestAgentProfiles(unittest.TestCase):
 
             _, kwargs = mock_build.call_args
             self.assertEqual(kwargs["toolsets"], ["terminal"])
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_profile_max_iterations_applied_single_task(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """A top-level profile's max_iterations reaches the child on a single-task call.
+
+        Regression: the value was read into a local then discarded by
+        effective_max_iter = default_max_iter, so single-task profile budgets
+        were silently dropped (the per-task batch path applied it correctly).
+        """
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {"p": {"max_iterations": 30}}
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.return_value = MagicMock()
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                delegate_task(goal="g", profile="p", parent_agent=parent)
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["max_iterations"], 30)
+
+    @patch("tools.delegate_tool._load_profiles")
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_profile_max_iterations_beats_top_level(
+        self, mock_creds, mock_cfg, mock_profiles
+    ):
+        """A per-task profile's max_iterations still overrides the top-level profile."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_profiles.return_value = {
+            "top": {"max_iterations": 30},
+            "task": {"max_iterations": 12},
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build:
+            mock_build.return_value = MagicMock()
+            with patch("tools.delegate_tool._run_single_child") as mock_run:
+                mock_run.return_value = {
+                    "task_index": 0,
+                    "status": "completed",
+                    "summary": "ok",
+                    "api_calls": 1,
+                    "duration_seconds": 1.0,
+                }
+                delegate_task(
+                    tasks=[{"goal": "g", "profile": "task"}],
+                    profile="top",
+                    parent_agent=parent,
+                )
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs["max_iterations"], 12)
 
     def test_unknown_profile_returns_error_json(self):
         """delegate_task with an unknown profile returns a clean error, not a crash."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1924,6 +1924,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1971,6 +1972,21 @@ def delegate_task(
             }
         )
 
+    # Resolve named profile (baseline values; explicit call params override profile)
+    _profile_overrides: dict = {}
+    if profile:
+        _all_profiles = _load_profiles()
+        try:
+            _profile_overrides = _resolve_profile(profile, _all_profiles)
+        except ValueError as exc:
+            return tool_error(str(exc))
+
+    # Apply profile baselines (explicit call params override profile values).
+    # toolsets baseline from profile when the caller didn't pass any.
+    toolsets = toolsets or _profile_overrides.get("toolsets")
+    # max_iterations baseline from profile when the caller didn't pass one.
+    max_iterations = max_iterations or _profile_overrides.get("max_iterations")
+
     # Load config
     cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
@@ -1996,6 +2012,12 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Profile model is a baseline: used only when delegation config did not
+    # set an explicit model (creds["model"]). The child still inherits the
+    # parent model when neither config nor profile specify one.
+    if not creds.get("model") and _profile_overrides.get("model"):
+        creds["model"] = _profile_overrides["model"]
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2034,6 +2056,26 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    # Pre-resolve per-task profiles so an unknown profile name surfaces as a
+    # clean tool_error before any child is constructed (and we only load the
+    # profiles block once for the whole batch). Per-task profile beats the
+    # top-level profile; tasks without one inherit the top-level overrides.
+    _task_profile_overrides: List[dict] = []
+    _profiles_cache: Optional[dict] = None
+    for t in task_list:
+        task_profile = t.get("profile")
+        if not task_profile:
+            _task_profile_overrides.append(_profile_overrides)
+            continue
+        if _profiles_cache is None:
+            _profiles_cache = _load_profiles()
+        try:
+            _task_profile_overrides.append(
+                _resolve_profile(task_profile, _profiles_cache)
+            )
+        except ValueError as exc:
+            return tool_error(str(exc))
+
     overall_start = time.monotonic()
     results = []
 
@@ -2058,13 +2100,29 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Per-task profile (pre-resolved above) beats the top-level profile;
+            # tasks without one carry the top-level overrides.
+            task_overrides = _task_profile_overrides[i]
+
+            # Explicit per-task value > task profile > top-level toolsets baseline.
+            task_toolsets = t.get("toolsets") or task_overrides.get("toolsets") or toolsets
+            # Config delegation.model wins; otherwise fall back to the task profile model.
+            task_model = creds["model"] or task_overrides.get("model")
+            # Config max_iterations is authoritative; the task profile only
+            # supplies a baseline when the config default is in effect.
+            task_max_iter = effective_max_iter
+            _profile_max_iter = task_overrides.get("max_iterations")
+            if _profile_max_iter and effective_max_iter == default_max_iter:
+                task_max_iter = _profile_max_iter
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
+                toolsets=task_toolsets,
+                model=task_model,
+                max_iterations=task_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
                 override_provider=creds["provider"],
@@ -2081,6 +2139,13 @@ def delegate_task(
                 ),
                 role=effective_role,
             )
+            # Profile system prompt override: replace the child's ephemeral
+            # system prompt (read at runtime by the conversation loop) when the
+            # resolved profile supplies one. _build_child_agent's signature is
+            # intentionally left untouched — the override is applied here.
+            _profile_prompt = task_overrides.get("system_prompt_text")
+            if _profile_prompt:
+                child.ephemeral_system_prompt = _profile_prompt
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))
@@ -2481,6 +2546,46 @@ def _load_config() -> dict:
         return {}
 
 
+def _load_profiles() -> dict:
+    """Read agent_profiles block from full config."""
+    try:
+        from hermes_cli.config import load_config
+        full_config = load_config()
+        return full_config.get("agent_profiles", {})
+    except Exception:
+        return {}
+
+
+def _resolve_profile(name: str, profiles: dict) -> dict:
+    """Validate profile name and resolve system_prompt_file -> system_prompt_text.
+
+    Returns a dict with zero or more of: model, toolsets, max_iterations,
+    system_prompt_text. Unknown keys are preserved for forward-compatibility.
+    """
+    if name not in profiles:
+        available = list(profiles)
+        raise ValueError(
+            f"Unknown agent profile {name!r}. "
+            f"Available profiles: {available if available else '(none configured)'}"
+        )
+    raw = dict(profiles[name])
+    # Resolve system_prompt_file -> system_prompt_text
+    spf = raw.pop("system_prompt_file", None)
+    if spf:
+        import os
+        from pathlib import Path
+        path = Path(os.path.expanduser(os.path.expandvars(str(spf))))
+        try:
+            raw["system_prompt_text"] = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ValueError(
+                f"Cannot read system_prompt_file {spf!r} for profile {name!r}: {exc}"
+            ) from exc
+    elif "system_prompt" in raw:
+        raw["system_prompt_text"] = raw.pop("system_prompt")
+    return raw
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -2736,6 +2841,13 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "profile": {
+                            "type": "string",
+                            "description": (
+                                "Per-task profile override. Beats the top-level 'profile'. "
+                                "See top-level 'profile' for semantics."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2748,6 +2860,14 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Name of a profile defined in agent_profiles config. "
+                    "Sets default model, toolsets, max_iterations, and system prompt "
+                    "for this delegation. Explicit call parameters override profile values."
+                ),
             },
             "acp_command": {
                 "type": "string",
@@ -2793,6 +2913,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        profile=args.get("profile"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2145,7 +2145,7 @@ def delegate_task(
             # intentionally left untouched — the override is applied here.
             _profile_prompt = task_overrides.get("system_prompt_text")
             if _profile_prompt:
-                child.ephemeral_system_prompt = _profile_prompt
+                setattr(child, "ephemeral_system_prompt", _profile_prompt)
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
             children.append((i, t, child))

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -16,6 +16,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import copy
 import enum
 import json
 import logging
@@ -1984,8 +1985,6 @@ def delegate_task(
     # Apply profile baselines (explicit call params override profile values).
     # toolsets baseline from profile when the caller didn't pass any.
     toolsets = toolsets or _profile_overrides.get("toolsets")
-    # max_iterations baseline from profile when the caller didn't pass one.
-    max_iterations = max_iterations or _profile_overrides.get("max_iterations")
 
     # Load config
     cfg = _load_config()
@@ -2002,6 +2001,13 @@ def delegate_task(
             max_iterations, default_max_iter,
         )
     effective_max_iter = default_max_iter
+    # Config max_iterations is authoritative; a top-level profile only supplies a
+    # baseline when the config default is still in effect. This mirrors the
+    # per-task path below (see task_max_iter / _profile_max_iter) so single-task
+    # calls honor a profile's max_iterations instead of silently discarding it.
+    _top_profile_max_iter = _profile_overrides.get("max_iterations")
+    if _top_profile_max_iter and effective_max_iter == default_max_iter:
+        effective_max_iter = _top_profile_max_iter
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -2109,11 +2115,12 @@ def delegate_task(
             task_toolsets = t.get("toolsets") or task_overrides.get("toolsets") or toolsets
             # Config delegation.model wins; otherwise fall back to the task profile model.
             task_model = creds["model"] or task_overrides.get("model")
-            # Config max_iterations is authoritative; the task profile only
-            # supplies a baseline when the config default is in effect.
+            # effective_max_iter already folds in any top-level profile baseline
+            # above (or the config default when no top-level profile applied). A
+            # per-task profile's max_iterations beats that inherited baseline.
             task_max_iter = effective_max_iter
             _profile_max_iter = task_overrides.get("max_iterations")
-            if _profile_max_iter and effective_max_iter == default_max_iter:
+            if _profile_max_iter:
                 task_max_iter = _profile_max_iter
 
             child = _build_child_agent(
@@ -2568,7 +2575,9 @@ def _resolve_profile(name: str, profiles: dict) -> dict:
             f"Unknown agent profile {name!r}. "
             f"Available profiles: {available if available else '(none configured)'}"
         )
-    raw = dict(profiles[name])
+    # Deep copy so nested lists/dicts (e.g. toolsets) can never be mutated back
+    # into the cached profiles block by downstream callers.
+    raw = copy.deepcopy(profiles[name])
     # Resolve system_prompt_file -> system_prompt_text
     spf = raw.pop("system_prompt_file", None)
     if spf:
@@ -2583,6 +2592,16 @@ def _resolve_profile(name: str, profiles: dict) -> dict:
             ) from exc
     elif "system_prompt" in raw:
         raw["system_prompt_text"] = raw.pop("system_prompt")
+    # Coerce max_iterations to int so a YAML string (e.g. "30") or other
+    # non-int value fails fast here instead of corrupting the child budget.
+    if "max_iterations" in raw:
+        try:
+            raw["max_iterations"] = int(raw["max_iterations"])
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                f"Profile {name!r}: max_iterations must be an integer, "
+                f"got {raw['max_iterations']!r}"
+            ) from exc
     return raw
 
 
@@ -2845,7 +2864,9 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "description": (
                                 "Per-task profile override. Beats the top-level 'profile'. "
-                                "See top-level 'profile' for semantics."
+                                "See top-level 'profile' for semantics, including the warning "
+                                "that a profile's system_prompt fully replaces the child's "
+                                "default prompt (dropping orchestrator delegation instructions)."
                             ),
                         },
                     },
@@ -2866,7 +2887,13 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Name of a profile defined in agent_profiles config. "
                     "Sets default model, toolsets, max_iterations, and system prompt "
-                    "for this delegation. Explicit call parameters override profile values."
+                    "for this delegation. Explicit call parameters override profile values. "
+                    "WARNING: a profile's system_prompt REPLACES the child's entire default "
+                    "system prompt (it does NOT append). This drops the orchestrator "
+                    "delegation instructions, so a child run under such a profile cannot "
+                    "spawn its own subagents unless its system_prompt re-includes those "
+                    "instructions. Use a system_prompt profile only for leaf workers, or "
+                    "include the delegation guidance yourself."
                 ),
             },
             "acp_command": {


### PR DESCRIPTION
## Summary

Implements named agent profile presets for `delegate_task()`, resolving Issue #9459.

Profiles are defined in `config.yaml` under `agent_profiles:` and can be referenced per-delegation or per-task. Each profile supports:

- `model` — override the child agent model
- `toolsets` — restrict the child agent's available tools (MCP scoping)
- `max_iterations` — cap the child agent's turn depth
- `system_prompt` / `system_prompt_file` — replace the child's default prompt (leaf workers)

### Usage

```yaml
# config.yaml
agent_profiles:
  email_checker:
    model: openai/gpt-4o-mini
    toolsets: ["mcp-gmail"]
    max_iterations: 5
  web_researcher:
    model: anthropic/claude-3-5-sonnet
    toolsets: ["mcp-search", "mcp-exa"]
```

```python
# In a tool call or agent config
delegate_task(goal="check my inbox", profile="email_checker", parent_agent=agent)
```

### Implementation Notes

- `_load_profiles()` reads from `load_config()` — no new config file, just a new root key
- `_resolve_profile()` handles `system_prompt_file` expansion, `max_iterations` int coercion, and deep-copies the profile dict to prevent mutation
- Profile `max_iterations` is applied at both top-level and per-task call sites (top-level was a dead assignment in the naive implementation — fixed)
- `system_prompt` in a profile **replaces** the entire child prompt (including orchestrator delegation instructions); documented in schema with WARNING; intended for leaf workers only
- `setattr(child, "ephemeral_system_prompt", ...)` used consistently with the existing pattern at line ~1265

## Tests

152 tests passing (147 original + 5 regression tests for the Code Critic findings).

New test class: `TestAgentProfiles` with 17 tests covering:
- Profile resolution (model, toolsets, max_iterations, system_prompt, system_prompt_file)
- Error paths (unknown profile, missing file, invalid max_iterations type)
- Integration (profile drives child; explicit params override profile; unknown profile returns error JSON)
- Regression guards (top-level max_iterations applied; per-task beats top-level; deepcopy isolation; int coercion)

## Checklist

- [x] ruff: `All checks passed!`
- [x] 152/152 tests passing
- [x] 0 net-new Pyright errors (baseline had 38 pre-existing errors in delegate_tool.py)
- [x] Schema updated with profile parameter documentation and system_prompt replacement warning

Closes #9459

## Packaging Note

During production testing on 0.14.0 (installed via PyPI), `hermes_cli/secret_prompt.py` was found to be absent from the installed package. This caused an `ImportError` when the `tools → config` import chain was triggered after deploying the modified `config.py`. The file exists in the repository but was not included in the PyPI distribution.

If a related issue exists, this PR's testing surfaced the same root cause. If not, it may be worth filing separately against the 0.14.0 release packaging.
