### PR TITLE
fix(dingtalk): route proactive send_message to any group via OrgGroupSend OpenAPI

### DIFF
--- a/tests/tools/test_send_message_dingtalk.py
+++ b/tests/tools/test_send_message_dingtalk.py
@@ -1,0 +1,252 @@
+"""Tests for DingTalk delivery in tools/send_message_tool.py.
+
+Covers the OrgGroupSend OpenAPI path (proactive send to any group by
+openConversationId) and the static custom-robot webhook fallback. Kept in a
+separate module from test_send_message_tool.py so it does not inherit that
+file's `pytest.importorskip("telegram")` skip — none of these tests need
+python-telegram-bot.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from tools.send_message_tool import (
+    _is_dingtalk_group_conversation,
+    _parse_target_ref,
+    _send_dingtalk,
+)
+
+
+# ---------------------------------------------------------------------------
+# _parse_target_ref / _is_dingtalk_group_conversation
+# ---------------------------------------------------------------------------
+
+
+class TestParseTargetRefDingtalk:
+    """A DingTalk openConversationId is recognized as an explicit target."""
+
+    def test_group_conversation_id_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "dingtalk", "cidM1xck538oLOh0Qod1YUVlA=="
+        )
+        assert chat_id == "cidM1xck538oLOh0Qod1YUVlA=="
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_conversation_id_with_plus_and_single_pad(self):
+        chat_id, _thread_id, is_explicit = _parse_target_ref(
+            "dingtalk", "cidFk62nfRicihGYoueJdbv+nmUCsZhYgc6MURB1F4gIeg="
+        )
+        assert chat_id == "cidFk62nfRicihGYoueJdbv+nmUCsZhYgc6MURB1F4gIeg="
+        assert is_explicit is True
+
+    def test_whitespace_is_stripped(self):
+        chat_id, _thread_id, is_explicit = _parse_target_ref(
+            "dingtalk", "  cidunHQNUauVrulszxrY5naeA==  "
+        )
+        assert chat_id == "cidunHQNUauVrulszxrY5naeA=="
+        assert is_explicit is True
+
+    def test_non_conversation_name_is_not_explicit(self):
+        # A human-friendly name must still flow through directory resolution.
+        chat_id, _thread_id, is_explicit = _parse_target_ref("dingtalk", "SEO group")
+        assert is_explicit is False
+        assert chat_id is None
+
+    def test_webhook_url_is_not_a_conversation_id(self):
+        assert not _is_dingtalk_group_conversation(
+            "https://oapi.dingtalk.com/robot/send?access_token=abc"
+        )
+
+    def test_is_group_conversation_helper(self):
+        assert _is_dingtalk_group_conversation("cidM1xck538oLOh0Qod1YUVlA==")
+        assert not _is_dingtalk_group_conversation("")
+        assert not _is_dingtalk_group_conversation(None)
+        assert not _is_dingtalk_group_conversation("12345")
+
+
+# ---------------------------------------------------------------------------
+# httpx stand-in
+# ---------------------------------------------------------------------------
+
+
+class _FakeHttp:
+    """Async-context-manager stand-in for httpx.AsyncClient.
+
+    Returns a response per `post` call, matched by URL substring against
+    `responses` (a dict of {url_substring: payload}). Captures every call's
+    url / payload / headers for assertions.
+    """
+
+    def __init__(self, responses, status_code=200):
+        self.responses = responses
+        self.status_code = status_code
+        self.calls = []
+
+    def __call__(self, *_a, **_kw):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append({"url": url, "payload": json, "headers": headers})
+        payload = None
+        for key, value in self.responses.items():
+            if key in url:
+                payload = value
+                break
+        if payload is None:
+            raise AssertionError(f"Unexpected POST to {url}")
+        body = json_dumps(payload)
+        return SimpleNamespace(
+            status_code=self.status_code,
+            content=body.encode("utf-8"),
+            text=body,
+            raise_for_status=lambda: None,
+            json=lambda data=payload: data,
+        )
+
+
+def json_dumps(obj):
+    return json.dumps(obj)
+
+
+def _install_http(monkeypatch, fake):
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", fake)
+
+
+# ---------------------------------------------------------------------------
+# _send_dingtalk — OpenAPI group send
+# ---------------------------------------------------------------------------
+
+
+class TestSendDingtalkOpenAPI:
+    def test_group_cid_with_credentials_uses_openapi(self, monkeypatch):
+        fake = _FakeHttp(
+            {
+                "oauth2/accessToken": {"accessToken": "tok-123"},
+                "robot/groupMessages/send": {"processQueryKey": "pqk-456"},
+            }
+        )
+        _install_http(monkeypatch, fake)
+
+        extra = {"client_id": "appkey", "client_secret": "appsecret"}
+        result = asyncio.run(
+            _send_dingtalk(extra, "cidM1xck538oLOh0Qod1YUVlA==", "hello group")
+        )
+
+        assert result["success"] is True
+        assert result["chat_id"] == "cidM1xck538oLOh0Qod1YUVlA=="
+        assert result["message_id"] == "pqk-456"
+
+        # Two calls: token fetch, then group send.
+        assert len(fake.calls) == 2
+        token_call, send_call = fake.calls
+        assert "oauth2/accessToken" in token_call["url"]
+        assert token_call["payload"] == {"appKey": "appkey", "appSecret": "appsecret"}
+
+        assert "robot/groupMessages/send" in send_call["url"]
+        assert send_call["headers"]["x-acs-dingtalk-access-token"] == "tok-123"
+        body = send_call["payload"]
+        assert body["robotCode"] == "appkey"  # defaults to client_id
+        assert body["openConversationId"] == "cidM1xck538oLOh0Qod1YUVlA=="
+        assert body["msgKey"] == "sampleText"
+        assert json.loads(body["msgParam"]) == {"content": "hello group"}
+
+    def test_explicit_robot_code_is_used(self, monkeypatch):
+        fake = _FakeHttp(
+            {
+                "oauth2/accessToken": {"accessToken": "tok"},
+                "robot/groupMessages/send": {"processQueryKey": "k"},
+            }
+        )
+        _install_http(monkeypatch, fake)
+
+        extra = {
+            "client_id": "appkey",
+            "client_secret": "appsecret",
+            "robot_code": "custom-robot",
+        }
+        asyncio.run(_send_dingtalk(extra, "cidAAAA==", "hi"))
+        assert fake.calls[1]["payload"]["robotCode"] == "custom-robot"
+
+    def test_openapi_http_error_is_surfaced(self, monkeypatch):
+        fake = _FakeHttp(
+            {
+                "oauth2/accessToken": {"accessToken": "tok"},
+                "robot/groupMessages/send": {"code": "Forbidden", "message": "no perm"},
+            },
+            status_code=403,
+        )
+        _install_http(monkeypatch, fake)
+
+        extra = {"client_id": "appkey", "client_secret": "appsecret"}
+        result = asyncio.run(_send_dingtalk(extra, "cidAAAA==", "hi"))
+        assert "error" in result
+        assert "403" in result["error"]
+        assert "no perm" in result["error"]
+
+    def test_missing_token_is_reported(self, monkeypatch):
+        fake = _FakeHttp({"oauth2/accessToken": {}})  # no accessToken in body
+        _install_http(monkeypatch, fake)
+
+        extra = {"client_id": "appkey", "client_secret": "appsecret"}
+        result = asyncio.run(_send_dingtalk(extra, "cidAAAA==", "hi"))
+        assert "error" in result
+        assert "access token" in result["error"].lower()
+        # Never attempted the group send.
+        assert len(fake.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# _send_dingtalk — static webhook fallback
+# ---------------------------------------------------------------------------
+
+
+class TestSendDingtalkWebhookFallback:
+    def test_no_credentials_falls_back_to_webhook(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        fake = _FakeHttp({"oapi.dingtalk.com/robot/send": {"errcode": 0}})
+        _install_http(monkeypatch, fake)
+
+        extra = {"webhook_url": "https://oapi.dingtalk.com/robot/send?access_token=x"}
+        result = asyncio.run(
+            _send_dingtalk(extra, "cidM1xck538oLOh0Qod1YUVlA==", "hi")
+        )
+        assert result["success"] is True
+        assert len(fake.calls) == 1
+        assert "oapi.dingtalk.com/robot/send" in fake.calls[0]["url"]
+        assert fake.calls[0]["payload"] == {
+            "msgtype": "text",
+            "text": {"content": "hi"},
+        }
+
+    def test_non_conversation_target_falls_back_even_with_credentials(self, monkeypatch):
+        # A non-cid chat_id with creds present must NOT hit the OpenAPI path.
+        fake = _FakeHttp({"oapi.dingtalk.com/robot/send": {"errcode": 0}})
+        _install_http(monkeypatch, fake)
+
+        extra = {
+            "client_id": "appkey",
+            "client_secret": "appsecret",
+            "webhook_url": "https://oapi.dingtalk.com/robot/send?access_token=x",
+        }
+        result = asyncio.run(_send_dingtalk(extra, "not-a-cid", "hi"))
+        assert result["success"] is True
+        assert "oapi.dingtalk.com/robot/send" in fake.calls[0]["url"]
+
+    def test_no_webhook_and_no_credentials_returns_error(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("DINGTALK_WEBHOOK_URL", raising=False)
+        result = asyncio.run(_send_dingtalk({}, "cidAAAA==", "hi"))
+        assert "error" in result
+        assert "DingTalk not configured" in result["error"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -41,6 +41,11 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+# DingTalk openConversationId — the base64-ish "cid...==" value carried on
+# incoming stream messages and surfaced by send_message(action='list'). Marking
+# it explicit lets the OpenAPI group-send path (_send_dingtalk) route to ANY
+# group the robot belongs to, without depending on the channel directory cache.
+_DINGTALK_CONVERSATION_RE = re.compile(r"^\s*(cid[A-Za-z0-9+/]+={0,2})\s*$")
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
@@ -375,6 +380,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return trimmed[:split_idx], trimmed[split_idx + 1 :], True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
+    if platform_name == "dingtalk":
+        match = _DINGTALK_CONVERSATION_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
     if platform_name == "yuanbao":
@@ -1484,22 +1493,54 @@ async def _send_homeassistant(token, extra, chat_id, message):
 
 
 async def _send_dingtalk(extra, chat_id, message):
-    """Send via DingTalk robot webhook.
+    """Send via DingTalk, choosing between two delivery modes.
 
-    Note: The gateway's DingTalk adapter uses per-session webhook URLs from
-    incoming messages (dingtalk-stream SDK).  For cross-platform send_message
-    delivery we use a static robot webhook URL instead, which must be
-    configured via ``DINGTALK_WEBHOOK_URL`` env var or ``webhook_url`` in the
-    platform's extra config.
+    1. **OpenAPI group send (preferred).** When the target is a group
+       ``openConversationId`` (the ``cid...`` value carried on incoming stream
+       messages and shown by ``send_message(action='list')``) and app
+       credentials are configured, deliver via the robot ``OrgGroupSend`` API
+       (``POST /v1.0/robot/groupMessages/send``). This routes the message to
+       *any* group the robot belongs to — solving the long-standing limitation
+       that a custom-robot webhook only reaches one hard-wired group. Requires
+       ``client_id``/``client_secret`` (AppKey/AppSecret); ``robot_code``
+       defaults to the AppKey, matching the gateway's DingTalk adapter.
+
+    2. **Static custom-robot webhook (fallback).** The legacy behavior, used
+       when no app credentials are set, or when the target isn't a recognizable
+       group conversation id. A custom-robot webhook is bound to a single group,
+       so it ignores ``chat_id``. Configured via ``DINGTALK_WEBHOOK_URL`` env
+       var or ``webhook_url`` in the platform's extra config.
+
+    Note: the gateway's DingTalk adapter replies to *incoming* messages via the
+    per-session webhook URL (dingtalk-stream SDK); that path is unavailable for
+    proactive ``send_message`` delivery, which is what this function covers.
     """
     try:
         import httpx
     except ImportError:
         return {"error": "httpx not installed"}
+
+    client_id = extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID", "")
+    client_secret = extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET", "")
+    robot_code = extra.get("robot_code") or os.getenv("DINGTALK_ROBOT_CODE", "") or client_id
+
+    # Mode 1: OpenAPI group send when we have app credentials and a group cid.
+    if client_id and client_secret and _is_dingtalk_group_conversation(chat_id):
+        return await _send_dingtalk_group_openapi(
+            httpx, client_id, client_secret, robot_code, chat_id, message
+        )
+
+    # Mode 2: static custom-robot webhook (single group, ignores chat_id).
     try:
         webhook_url = extra.get("webhook_url") or os.getenv("DINGTALK_WEBHOOK_URL", "")
         if not webhook_url:
-            return {"error": "DingTalk not configured. Set DINGTALK_WEBHOOK_URL env var or webhook_url in dingtalk platform extra config."}
+            return {"error": (
+                "DingTalk not configured. To send to a specific group, set app "
+                "credentials (DINGTALK_CLIENT_ID/DINGTALK_CLIENT_SECRET) and target "
+                "the group's openConversationId. Otherwise set DINGTALK_WEBHOOK_URL "
+                "(or webhook_url in the dingtalk platform extra config) for "
+                "single-group custom-robot delivery."
+            )}
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 webhook_url,
@@ -1512,6 +1553,58 @@ async def _send_dingtalk(extra, chat_id, message):
         return {"success": True, "platform": "dingtalk", "chat_id": chat_id}
     except Exception as e:
         return _error(f"DingTalk send failed: {e}")
+
+
+def _is_dingtalk_group_conversation(chat_id) -> bool:
+    """True when *chat_id* looks like a DingTalk group openConversationId."""
+    return bool(chat_id) and bool(_DINGTALK_CONVERSATION_RE.fullmatch(str(chat_id)))
+
+
+async def _dingtalk_access_token(httpx, client_id, client_secret):
+    """Fetch an app access token via the DingTalk OAuth2 endpoint."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            "https://api.dingtalk.com/v1.0/oauth2/accessToken",
+            json={"appKey": client_id, "appSecret": client_secret},
+        )
+        resp.raise_for_status()
+        return resp.json().get("accessToken", "")
+
+
+async def _send_dingtalk_group_openapi(httpx, client_id, client_secret, robot_code, conversation_id, message):
+    """Send a text message to a group via the robot OrgGroupSend OpenAPI."""
+    try:
+        token = await _dingtalk_access_token(httpx, client_id, client_secret)
+        if not token:
+            return _error("DingTalk: failed to obtain access token (check DINGTALK_CLIENT_ID/SECRET).")
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                "https://api.dingtalk.com/v1.0/robot/groupMessages/send",
+                headers={"x-acs-dingtalk-access-token": token},
+                json={
+                    "robotCode": robot_code,
+                    "openConversationId": conversation_id,
+                    "msgKey": "sampleText",
+                    "msgParam": json.dumps({"content": message}),
+                },
+            )
+            if resp.status_code >= 400:
+                # DingTalk returns a JSON error body ({code, message}) on 4xx/5xx.
+                try:
+                    err = resp.json()
+                    detail = err.get("message") or err.get("errmsg") or resp.text
+                except Exception:
+                    detail = resp.text
+                return _error(f"DingTalk group send failed ({resp.status_code}): {detail}")
+            data = resp.json() if resp.content else {}
+        return {
+            "success": True,
+            "platform": "dingtalk",
+            "chat_id": conversation_id,
+            "message_id": data.get("processQueryKey"),
+        }
+    except Exception as e:
+        return _error(f"DingTalk group send failed: {e}")
 
 
 async def _send_wecom(extra, chat_id, message):


### PR DESCRIPTION
## Problem

`_send_dingtalk` (in `tools/send_message_tool.py`) only ever posts to a single static `DINGTALK_WEBHOOK_URL` — a custom-robot webhook that is bound to **one** group — and it ignores `chat_id` entirely. So a proactive `send_message` to any other DingTalk group either fails to resolve or silently lands in the one wired-up group, regardless of the target the model picked.

In-group replies work because the gateway adapter reuses the incoming message's per-session webhook (`session_webhook`). Proactive sends have no such webhook, which is the gap this fixes.

## Fix

Add a preferred delivery mode to `_send_dingtalk`:

- When app credentials (`client_id`/`client_secret`, i.e. AppKey/AppSecret) are configured **and** the target is a group `openConversationId` (the `cid...` value carried on incoming stream messages and shown by `send_message(action='list')`), send via the robot **OrgGroupSend** OpenAPI (`POST /v1.0/robot/groupMessages/send`) using `robot_code` + `openConversationId`. This reaches **any** group the robot belongs to.
- `robot_code` defaults to the AppKey, matching the gateway's DingTalk adapter (`_robot_code = extra.get("robot_code") or self._client_id`).
- When credentials are absent, or the target is not a group conversation id, behavior is unchanged — it falls back to the static webhook.

Also recognize `cid...==` as an explicit target in `_parse_target_ref`, so it routes without depending on the channel directory cache being populated yet.

## Tests

New `tests/tools/test_send_message_dingtalk.py` (kept separate so it doesn't inherit the telegram `importorskip` in the existing suite):

- `_parse_target_ref` / `_is_dingtalk_group_conversation` recognition of conversation ids vs names vs webhook URLs
- OpenAPI group-send path: payload, headers, `robot_code` default + override, HTTP error surfacing, missing-token handling
- webhook fallback for missing credentials and non-conversation targets

```
tests/tools/test_send_message_dingtalk.py  13 passed
tests/tools/test_send_message_tool.py     111 passed   (no regressions)
```

## Verification

Verified live against the DingTalk API: `POST /v1.0/oauth2/accessToken` followed by `POST /v1.0/robot/groupMessages/send` both return 200, and the message is delivered to the targeted group by `openConversationId`.