### PR TITLE
fix(kanban): auto-close hook - three-layer defense against protocol violation crashes

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -237,7 +237,19 @@ KANBAN_GUIDANCE = (
     "specialist profile.\n"
     "- Do not call `delegate_task` as a board substitute. `delegate_task` is "
     "for short reasoning subtasks inside your own run; board tasks are for "
-    "cross-agent handoffs that outlive one API loop."
+    "cross-agent handoffs that outlive one API loop.\n"
+    "\n"
+    "## Protocol Violation Warning\n"
+    "\n"
+    "**CRITICAL \u2014 Always close the lifecycle.** Before your turn ends, you "
+    "MUST call `kanban_complete()` or `kanban_block()`. If you complete your "
+    "work but exit without calling either, the dispatcher classifies this as "
+    "a *protocol violation* and immediately marks the task CRASHED \u2192 BLOCKED. "
+    "Your work is discarded and the task is retried from scratch. "
+    "This wastes a full cycle and Sebastian sees a misleading crash report. "
+    "The auto-close safety net (Layer 1) is a last-resort fallback \u2014 it exists "
+    "so crashed workers don't stall the pipeline, but you should never rely on "
+    "it. Close explicitly every time."
 )
 
 TOOL_USE_ENFORCEMENT_GUIDANCE = (

--- a/cli.py
+++ b/cli.py
@@ -3879,6 +3879,42 @@ class HermesCLI:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+
+            # ── Kanban auto-close callback ───────────────────────────────
+            # When HERMES_KANBAN_TASK is set (kanban dispatcher spawned us),
+            # wire up the auto-close hook. After the conversation loop exits,
+            # this callback checks whether the worker called kanban_complete /
+            # kanban_block. If not, it auto-completes the task to prevent
+            # protocol violation crashes. This is the PRIMARY enforcement
+            # layer — it runs in the Python process after every
+            # run_conversation() exit and cannot be bypassed by model behavior.
+            _kanban_task_id = os.environ.get("HERMES_KANBAN_TASK")
+            _kc_callback = None
+            if _kanban_task_id:
+                def _kanban_auto_close(result: Dict[str, Any]) -> None:
+                    try:
+                        from hermes_cli.kanban_db import connect as _kbc, complete_task
+                        _kconn = _kbc()
+                        _krow = _kconn.execute(
+                            "SELECT status FROM tasks WHERE id = ?", (_kanban_task_id,)
+                        ).fetchone()
+                        if _krow and _krow["status"] == "running":
+                            _kresp = result.get("final_response", "") or ""
+                            _ksummary = (_kresp[:500] + "...") if len(_kresp) > 500 else _kresp
+                            if not _ksummary:
+                                _ksummary = "Auto-closed: worker exited without calling kanban_complete"
+                            complete_task(
+                                _kconn, _kanban_task_id,
+                                result=_ksummary,
+                                summary=_ksummary,
+                            )
+                    except Exception as _kexc:
+                        logging.getLogger(__name__).warning(
+                            "kanban_auto_close callback failed for task %s: %s",
+                            _kanban_task_id, _kexc,
+                        )
+                _kc_callback = _kanban_auto_close
+
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -3924,6 +3960,7 @@ class HermesCLI:
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+                kanban_auto_close=_kc_callback,
             )
             # Store reference for atexit memory provider shutdown
             global _active_agent_ref

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -26,7 +26,7 @@ import logging
 import os
 import sys
 from contextlib import redirect_stderr, redirect_stdout
-from typing import Optional
+from typing import Dict, Any, Optional
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -284,6 +284,39 @@ def _run_agent(
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 
+    # ── Kanban auto-close callback ────────────────────────────────────────
+    # When HERMES_KANBAN_TASK is set (kanban dispatcher spawned us),
+    # wire up the auto-close hook. After the conversation loop exits,
+    # this callback checks whether the worker called kanban_complete /
+    # kanban_block. If not, it auto-completes the task to prevent
+    # protocol violation crashes. This is the PRIMARY enforcement
+    # layer — it runs in the Python process after every
+    # run_conversation() exit and cannot be bypassed by model behavior.
+    _kc_task_id = os.environ.get("HERMES_KANBAN_TASK")
+    _kc_callback = None
+    if _kc_task_id:
+        def _kanban_auto_close(result: Dict[str, Any]) -> None:
+            try:
+                from hermes_cli.kanban_db import connect as _kbc, complete_task
+                _kconn = _kbc()
+                _krow = _kconn.execute(
+                    "SELECT status FROM tasks WHERE id = ?", (_kc_task_id,)
+                ).fetchone()
+                if _krow and _krow["status"] == "running":
+                    _kresp = result.get("final_response", "") or ""
+                    _ksummary = (_kresp[:500] + "...") if len(_kresp) > 500 else _kresp
+                    if not _ksummary:
+                        _ksummary = "Auto-closed: worker exited without calling kanban_complete"
+                    complete_task(
+                        _kconn, _kc_task_id,
+                        result=_ksummary,
+                        summary=_ksummary,
+                    )
+            except Exception as _kexc:
+                logger.warning("kanban_auto_close callback failed for task %s: %s",
+                               _kc_task_id, _kexc)
+        _kc_callback = _kanban_auto_close
+
     agent = AIAgent(
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
@@ -305,6 +338,7 @@ def _run_agent(
         #                (set above); also falls back to deny on non-tty
         #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
         #   - skill secret capture → returns gracefully when no callback set
+        kanban_auto_close=_kc_callback,
         clarify_callback=_oneshot_clarify_callback,
     )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -40,7 +40,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import Callable, List, Dict, Any, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
@@ -1102,6 +1102,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        kanban_auto_close: Optional[Callable[[Dict[str, Any]], None]] = None,
     ):
         """
         Initialize the AI Agent.
@@ -1174,6 +1175,7 @@ class AIAgent:
         # would mangle the escape sequences.  None = use builtins.print.
         self._print_fn = None
         self.background_review_callback = None  # Optional sync callback for gateway delivery
+        self._kanban_auto_close = kanban_auto_close  # Kanban worker auto-close hook
         self.skip_context_files = skip_context_files
         self.load_soul_identity = load_soul_identity
         self.pass_session_id = pass_session_id
@@ -14645,6 +14647,21 @@ class AIAgent:
 
         # Clear stream callback so it doesn't leak into future calls
         self._stream_callback = None
+
+        # ── Kanban auto-close hook ──────────────────────────────────────
+        # After the conversation loop exits, if a kanban_auto_close callback
+        # is registered (injected by the CLI layer when HERMES_KANBAN_TASK
+        # is set), call it with the result dict. The callback checks whether
+        # the worker called kanban_complete/kanban_block and auto-completes
+        # the task if not. This is the PRIMARY layer of defense — it runs in
+        # the Python process after every run_conversation() exit, regardless
+        # of model behavior, and cannot be bypassed by the model failing to
+        # call the kanban_complete tool.
+        if self._kanban_auto_close is not None:
+            try:
+                self._kanban_auto_close(result)
+            except Exception as exc:
+                logger.warning("kanban_auto_close callback failed: %s", exc)
 
         # Check skill trigger NOW — based on how many tool iterations THIS turn used.
         _should_review_skills = False


### PR DESCRIPTION
Three-layer defense against protocol violation crashes (kanban tasks exiting cleanly without calling kanban_complete):

1. Auto-close callback fires after every run_conversation() exit
2. Protocol Violation Warning in KANBAN_GUIDANCE
3. SOUL.md close-out rules

Closes: #32036