### PR TITLE
fix(kanban): make dashboard columns swipeable on phones

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -349,23 +349,70 @@
   // -------------------------------------------------------------------------
   // Touch drag-drop helper.
   //
-  // HTML5 DnD is desktop-only. On touch devices we attach a pointerdown
-  // handler that simulates a drag proxy and fires a custom event on the
-  // column under the finger when released. Columns listen for both the
-  // standard `drop` event and our `hermes-kanban:drop` event.
+  // HTML5 DnD is desktop-only. On touch devices we attach a delayed
+  // pointerdown handler that simulates a drag proxy and fires a custom
+  // event on the column under the finger when released. The delay is
+  // intentional: horizontal board swipes and vertical card-list scrolling
+  // must keep their native browser handling unless the user holds on a card.
   // -------------------------------------------------------------------------
+
+  const TOUCH_DRAG_HOLD_MS = 300;
+  const TOUCH_DRAG_MOVE_CANCEL_PX = 10;
 
   function attachTouchDrag(el, taskId) {
     if (!el) return;
     function onDown(e) {
       if (e.pointerType !== "touch") return;
-      e.preventDefault();
-      const proxy = el.cloneNode(true);
-      proxy.classList.add("hermes-kanban-touch-proxy");
-      document.body.appendChild(proxy);
+      if (e.target && e.target.closest && e.target.closest("input, button, textarea, select, a, label")) {
+        return;
+      }
+      const startX = e.clientX;
+      const startY = e.clientY;
+      let proxy = null;
       let lastTarget = null;
+      let dragging = false;
+      let cancelled = false;
+      let holdTimer = window.setTimeout(function () {
+        if (cancelled || dragging) return;
+        dragging = true;
+        proxy = el.cloneNode(true);
+        proxy.classList.add("hermes-kanban-touch-proxy");
+        document.body.appendChild(proxy);
+        proxy.style.position = "fixed";
+        proxy.style.pointerEvents = "none";
+        proxy.style.opacity = "0.85";
+        proxy.style.zIndex = "9999";
+        proxy.style.width = `${el.offsetWidth}px`;
+        proxy.style.left = `${startX - el.offsetWidth / 2}px`;
+        proxy.style.top = `${startY - 24}px`;
+        try { el.setPointerCapture && el.setPointerCapture(e.pointerId); } catch (_err) { /* noop */ }
+      }, TOUCH_DRAG_HOLD_MS);
+
+      function suppressNextClick() {
+        const suppressClick = function (ev) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          el.removeEventListener("click", suppressClick, true);
+        };
+        el.addEventListener("click", suppressClick, true);
+        window.setTimeout(function () {
+          el.removeEventListener("click", suppressClick, true);
+        }, 1200);
+      }
 
       function move(ev) {
+        if (!dragging) {
+          const dx = ev.clientX - startX;
+          const dy = ev.clientY - startY;
+          if (Math.sqrt(dx * dx + dy * dy) > TOUCH_DRAG_MOVE_CANCEL_PX) {
+            cancelled = true;
+            clearTimeout(holdTimer);
+            suppressNextClick();
+            cleanup(false);
+          }
+          return;
+        }
+        ev.preventDefault();
         proxy.style.left = `${ev.clientX - proxy.offsetWidth / 2}px`;
         proxy.style.top = `${ev.clientY - 24}px`;
         proxy.style.display = "none";
@@ -380,11 +427,13 @@
           lastTarget = target;
         }
       }
-      function up() {
+      function cleanup(shouldDrop) {
         document.removeEventListener("pointermove", move);
         document.removeEventListener("pointerup", up);
-        document.removeEventListener("pointercancel", up);
-        if (lastTarget) {
+        document.removeEventListener("pointercancel", cancel);
+        clearTimeout(holdTimer);
+        if (lastTarget) lastTarget.classList.remove("hermes-kanban-column--drop");
+        if (dragging && shouldDrop && lastTarget) {
           lastTarget.classList.remove("hermes-kanban-column--drop");
           const status = lastTarget.getAttribute("data-kanban-column");
           const isTrash = lastTarget.hasAttribute("data-kanban-trash");
@@ -400,19 +449,21 @@
             }));
           }
         }
-        proxy.remove();
+        if (proxy) proxy.remove();
+        if (dragging) {
+          suppressNextClick();
+        }
+        try { el.releasePointerCapture && el.releasePointerCapture(e.pointerId); } catch (_err) { /* noop */ }
       }
-      // Kick off proxy at the pointer origin.
-      proxy.style.position = "fixed";
-      proxy.style.pointerEvents = "none";
-      proxy.style.opacity = "0.85";
-      proxy.style.zIndex = "9999";
-      proxy.style.width = `${el.offsetWidth}px`;
-      proxy.style.left = `${e.clientX - el.offsetWidth / 2}px`;
-      proxy.style.top = `${e.clientY - 24}px`;
-      document.addEventListener("pointermove", move);
+      function up() {
+        cleanup(true);
+      }
+      function cancel() {
+        cleanup(false);
+      }
+      document.addEventListener("pointermove", move, { passive: false });
       document.addEventListener("pointerup", up);
-      document.addEventListener("pointercancel", up);
+      document.addEventListener("pointercancel", cancel);
     }
     el.addEventListener("pointerdown", onDown);
     return function () { el.removeEventListener("pointerdown", onDown); };

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -67,6 +67,8 @@
   gap: 0.75rem;
   align-items: start;
   overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
 }
 .hermes-kanban-columns::-webkit-scrollbar {
@@ -75,6 +77,7 @@
 
 .hermes-kanban-column {
   flex: 0 0 280px;
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--color-card) 85%, transparent);
@@ -227,6 +230,7 @@
 
 .hermes-kanban-card {
   cursor: grab;
+  touch-action: pan-x pan-y pinch-zoom;
   transition: transform 100ms ease, box-shadow 100ms ease;
 }
 .hermes-kanban-card:hover {
@@ -1503,6 +1507,7 @@
 
 .hermes-kanban-trash {
   display: flex;
+  box-sizing: border-box;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -1538,4 +1543,33 @@
 
 .hermes-kanban-trash-label {
   font-weight: 500;
+}
+
+/* ---- Mobile column swipe mode --------------------------------------- */
+
+@media (max-width: 767px) {
+  .hermes-kanban {
+    overflow-x: hidden;
+  }
+
+  .hermes-kanban-columns {
+    scroll-snap-type: x mandatory;
+  }
+
+  .hermes-kanban-column,
+  .hermes-kanban-trash {
+    flex-basis: 100%;
+    min-width: 100%;
+    max-width: 100%;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+  }
+
+  .hermes-kanban-column {
+    max-height: calc(100dvh - 220px);
+  }
+
+  .hermes-kanban-trash:not(.hermes-kanban-trash--active) {
+    display: none;
+  }
 }

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2195,3 +2195,44 @@ def test_dashboard_failed_card_highlight_class_exists():
     assert "hermes-kanban-card--failed" in js
     assert "hermes-kanban-card--failed" in css
     assert "failedIds" in js
+
+
+def test_dashboard_mobile_columns_snap_one_bucket_per_swipe():
+    """Phone-sized screens should snap to one full-width bucket at a time."""
+    repo_root = Path(__file__).resolve().parents[2]
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "scroll-snap-type: x proximity" not in css
+    assert "@media (max-width: 767px)" in css
+    assert "scroll-snap-type: x mandatory" in css
+    assert ".hermes-kanban-column,\n  .hermes-kanban-trash" in css
+    assert "flex-basis: 100%" in css
+    assert "min-width: 100%" in css
+    assert "scroll-snap-align: start" in css
+    assert "scroll-snap-stop: always" in css
+    assert "-webkit-overflow-scrolling: touch" in css
+    assert (
+        ".hermes-kanban-trash:not(.hermes-kanban-trash--active) {\n"
+        "    display: none;\n"
+        "  }"
+    ) in css
+
+
+def test_dashboard_touch_drag_does_not_hijack_swipes():
+    """Touch card dragging must wait for a hold so board swipes stay native."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "const TOUCH_DRAG_HOLD_MS = 300;" in js
+    assert "const TOUCH_DRAG_MOVE_CANCEL_PX = 10;" in js
+    assert "let holdTimer = window.setTimeout(function ()" in js
+    assert "Math.sqrt(dx * dx + dy * dy) > TOUCH_DRAG_MOVE_CANCEL_PX" in js
+    assert "function suppressNextClick()" in js
+    assert "suppressNextClick();\n            cleanup(false);" in js
+    assert "document.addEventListener(\"pointermove\", move, { passive: false });" in js
+    assert "document.addEventListener(\"pointercancel\", cancel);" in js
+    assert "function cancel() {\n        cleanup(false);" in js
+    assert "}, 1200);" in js
+    assert ".hermes-kanban-card" in css
+    assert "touch-action: pan-x pan-y pinch-zoom" in css


### PR DESCRIPTION
## What does this PR do?

Makes the Kanban dashboard usable on phone-sized screens by letting the board snap to one full-width bucket per horizontal swipe while preserving the normal multi-column board on tablet and desktop widths.

This also changes touch card dragging to wait for a short hold before starting the drag proxy. Native vertical scrolling and horizontal board swipes are no longer hijacked by the drag/drop helper, and touch movement suppresses the follow-up synthetic click so scrolling a card list does not accidentally open the task dialog.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/dist/style.css`: add phone-only column snap mode below `768px`, keep tablet/desktop on the existing multi-column layout, and allow native touch scrolling/swiping on cards.
- `plugins/kanban/dashboard/dist/index.js`: delay touch drag/drop until a 300ms hold, cancel drag setup when the finger moves, keep drag pointermove non-passive only after drag starts, and suppress the synthetic click after touch scroll/drag gestures.
- `tests/plugins/test_kanban_dashboard_plugin.py`: add static regression coverage for phone-only snap behavior and touch-drag gesture handling.

## Duplicate PR Check

Searched open PRs before opening and again during sign-off:

- `kanban mobile` - no duplicate results
- `kanban swipe` - no duplicate results
- `kanban touch mobile swipe scroll` - no duplicate results
- `kanban dashboard mobile columns` - no duplicate results
- GitHub search for `"mobile" "kanban"`, `"swipe" "kanban"`, and `"touch" "kanban"` returned this PR for the first two targeted queries and no duplicate mobile swipe PR.

Adjacent open PRs reviewed and not duplicates:

- #29173 shows hidden overflow columns via scrollbar and adds missing column metadata; it does not implement phone-sized one-bucket swipe behavior.
- #29233 wraps columns into rows; this PR intentionally keeps tablet/desktop multi-column behavior and uses phone-only horizontal snapping.
- #29251 changes Kanban typography/casing inheritance; this PR does not change font or text-transform styling.

## How to Test

1. Open `/kanban` on a phone-sized viewport.
2. Swipe horizontally across the board and confirm one bucket is focused at a time.
3. Scroll vertically inside a bucket by dragging on a card and confirm the task dialog does not open from the scroll gesture.
4. Open `/kanban` at tablet/desktop width and confirm the existing multi-column board layout remains.
5. Long-press a card on touch and confirm drag/drop behavior still starts after the hold.

Validation run locally:

```text
node --check plugins/kanban/dashboard/dist/index.js
# passed

node -e "const fs=require('fs'); const {transform}=require('./web/node_modules/lightningcss'); transform({filename:'plugins/kanban/dashboard/dist/style.css', code:fs.readFileSync('plugins/kanban/dashboard/dist/style.css')}); console.log('css ok')"
# css ok

uv run --extra dev ruff check tests/plugins/test_kanban_dashboard_plugin.py
# All checks passed!

uv run --extra dev --extra web python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q -o addopts= --tb=short
# 96 passed, 1 warning

scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py
# 96 tests passed, 0 failed

git diff --check
# passed

uv run --extra dev python scripts/check-windows-footguns.py --diff FETCH_HEAD
# No Windows footguns found
```

Full-suite status:

```text
scripts/run_tests.sh
# First run: 1202 files, 26248 tests passed, 9 failed
# Second run after installing optional WeCom/PTY extras: 1202 files, 26268 tests passed, 1 failed
```

The first full-suite run exposed missing optional local test extras for WeCom XML parsing and PTY-backed tests. After installing the optional extras, the WeCom, web-server PTY, and process-registry failures cleared. The single remaining failure is `tests/test_mcp_serve.py::TestEventBridgePollE2E::test_poll_detects_new_message_after_db_write`. It reproduces on untouched upstream `main` with the same assertion, so it is not caused by this Kanban change.

This PR does not touch MCP, WeCom, PTY, gateway, process registry, dependencies, or test harness code. The changed Kanban dashboard test file passed both directly and under the repository test wrapper.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  Full-suite testing was run twice. Missing optional local extras caused the first unrelated WeCom/PTY failures; those cleared after installing the extras. The only remaining failure reproduces on untouched upstream `main`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container; phone-sized dashboard behavior verified on live device

### Documentation & Housekeeping

- [x] No README, `docs/`, or docstring changes were needed for this dashboard behavior fix
- [x] No `cli-config.yaml.example` changes were needed because no config keys changed
- [x] No `CONTRIBUTING.md` or `AGENTS.md` changes were needed because no architecture or workflow changed
- [x] Cross-platform impact considered per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): browser CSS and pointer-event behavior only
- [x] No tool descriptions or schemas changed

## For New Skills

This PR does not add or modify skills.

## Screenshots / Logs

No screenshot captured in this headless environment. Phone behavior was tested successfully against the live dashboard before opening the PR.

