### PR TITLE
fix(kanban): auto-close hook - three-layer defense against protocol violation crashes

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -28,7 +28,7 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 
 from agent.context_compressor import ContextCompressor
@@ -202,6 +202,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    kanban_auto_close: Optional[Callable[[Dict[str, Any]], None]] = None,
 ):
     """
     Initialize the AI Agent.
@@ -280,6 +281,7 @@ def init_agent(
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id
+    agent._kanban_auto_close = kanban_auto_close
     agent._credential_pool = credential_pool
     agent.log_prefix_chars = log_prefix_chars
     agent.log_prefix = f"{log_prefix} " if log_prefix else ""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4299,6 +4299,20 @@ def run_conversation(
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)
 
+    # ── Kanban auto-close hook ──────────────────────────────────────────
+    # After the conversation loop exits, if a kanban_auto_close callback is
+    # registered (injected when HERMES_KANBAN_TASK is set), call it with the
+    # result dict. The callback checks whether the worker called
+    # kanban_complete/kanban_block and auto-completes the task if not.
+    # This is the PRIMARY enforcement layer — it runs in the Python process
+    # after every run_conversation() exit and cannot be bypassed by model
+    # behavior.
+    if getattr(agent, "_kanban_auto_close", None) is not None:
+        try:
+            agent._kanban_auto_close(result)
+        except Exception as exc:
+            logger.warning("kanban_auto_close callback failed: %s", exc)
+
     return result
 
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -240,7 +240,19 @@ KANBAN_GUIDANCE = (
     "specialist profile.\n"
     "- Do not call `delegate_task` as a board substitute. `delegate_task` is "
     "for short reasoning subtasks inside your own run; board tasks are for "
-    "cross-agent handoffs that outlive one API loop."
+    "cross-agent handoffs that outlive one API loop.\n"
+    "\n"
+    "## Protocol Violation Warning\n"
+    "\n"
+    "**CRITICAL \u2014 Always close the lifecycle.** Before your turn ends, you "
+    "MUST call `kanban_complete()` or `kanban_block()`. If you complete your "
+    "work but exit without calling either, the dispatcher classifies this as "
+    "a *protocol violation* and immediately marks the task CRASHED \u2192 BLOCKED. "
+    "Your work is discarded and the task is retried from scratch. "
+    "This wastes a full cycle and Sebastian sees a misleading crash report. "
+    "The auto-close safety net (Layer 1) is a last-resort fallback \u2014 it exists "
+    "so crashed workers don't stall the pipeline, but you should never rely on "
+    "it. Close explicitly every time."
 )
 
 TOOL_USE_ENFORCEMENT_GUIDANCE = (

--- a/cli.py
+++ b/cli.py
@@ -4949,6 +4949,42 @@ class HermesCLI:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+
+            # ── Kanban auto-close callback ───────────────────────────────
+            # When HERMES_KANBAN_TASK is set (kanban dispatcher spawned us),
+            # wire up the auto-close hook. After the conversation loop exits,
+            # this callback checks whether the worker called kanban_complete /
+            # kanban_block. If not, it auto-completes the task to prevent
+            # protocol violation crashes. This is the PRIMARY enforcement
+            # layer — it runs in the Python process after every
+            # run_conversation() exit and cannot be bypassed by model behavior.
+            _kanban_task_id = os.environ.get("HERMES_KANBAN_TASK")
+            _kc_callback = None
+            if _kanban_task_id:
+                def _kanban_auto_close(result: Dict[str, Any]) -> None:
+                    try:
+                        from hermes_cli.kanban_db import connect as _kbc, complete_task
+                        _kconn = _kbc()
+                        _krow = _kconn.execute(
+                            "SELECT status FROM tasks WHERE id = ?", (_kanban_task_id,)
+                        ).fetchone()
+                        if _krow and _krow["status"] == "running":
+                            _kresp = result.get("final_response", "") or ""
+                            _ksummary = (_kresp[:500] + "...") if len(_kresp) > 500 else _kresp
+                            if not _ksummary:
+                                _ksummary = "Auto-closed: worker exited without calling kanban_complete"
+                            complete_task(
+                                _kconn, _kanban_task_id,
+                                result=_ksummary,
+                                summary=_ksummary,
+                            )
+                    except Exception as _kexc:
+                        logging.getLogger(__name__).warning(
+                            "kanban_auto_close callback failed for task %s: %s",
+                            _kanban_task_id, _kexc,
+                        )
+                _kc_callback = _kanban_auto_close
+
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),
@@ -4995,6 +5031,7 @@ class HermesCLI:
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+                kanban_auto_close=_kc_callback,
             )
             # Store reference for atexit memory provider shutdown
             global _active_agent_ref

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -305,6 +305,39 @@ def _run_agent(
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
 
+    # ── Kanban auto-close callback ────────────────────────────────────────
+    # When HERMES_KANBAN_TASK is set (kanban dispatcher spawned us),
+    # wire up the auto-close hook. After the conversation loop exits,
+    # this callback checks whether the worker called kanban_complete /
+    # kanban_block. If not, it auto-completes the task to prevent
+    # protocol violation crashes. This is the PRIMARY enforcement
+    # layer — it runs in the Python process after every
+    # run_conversation() exit and cannot be bypassed by model behavior.
+    _kc_task_id = os.environ.get("HERMES_KANBAN_TASK")
+    _kc_callback = None
+    if _kc_task_id:
+        def _kanban_auto_close(result: Dict[str, Any]) -> None:
+            try:
+                from hermes_cli.kanban_db import connect as _kbc, complete_task
+                _kconn = _kbc()
+                _krow = _kconn.execute(
+                    "SELECT status FROM tasks WHERE id = ?", (_kc_task_id,)
+                ).fetchone()
+                if _krow and _krow["status"] == "running":
+                    _kresp = result.get("final_response", "") or ""
+                    _ksummary = (_kresp[:500] + "...") if len(_kresp) > 500 else _kresp
+                    if not _ksummary:
+                        _ksummary = "Auto-closed: worker exited without calling kanban_complete"
+                    complete_task(
+                        _kconn, _kc_task_id,
+                        result=_ksummary,
+                        summary=_ksummary,
+                    )
+            except Exception as _kexc:
+                logger.warning("kanban_auto_close callback failed for task %s: %s",
+                               _kc_task_id, _kexc)
+        _kc_callback = _kanban_auto_close
+
     agent = AIAgent(
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
@@ -329,6 +362,7 @@ def _run_agent(
         #   - dangerous-command approval → bypassed via HERMES_YOLO_MODE=1
         #   - skill secret capture → returns gracefully when no callback set
         clarify_callback=_oneshot_clarify_callback,
+        kanban_auto_close=_kc_callback,
     )
 
     # Belt-and-braces: make sure AIAgent doesn't invoke any streaming

--- a/run_agent.py
+++ b/run_agent.py
@@ -51,7 +51,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import Callable, List, Dict, Any, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
@@ -413,6 +413,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        kanban_auto_close: Optional[Callable[[Dict[str, Any]], None]] = None,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -482,6 +483,7 @@ class AIAgent:
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
             pass_session_id=pass_session_id,
+            kanban_auto_close=kanban_auto_close,
         )
 
     def _get_session_db_for_recall(self):


### PR DESCRIPTION
Three-layer defense against protocol violation crashes (kanban tasks exiting cleanly without calling kanban_complete):

1. Auto-close callback fires after every run_conversation() exit (ENFORCEMENT)
2. Protocol Violation Warning in KANBAN_GUIDANCE (PREVENTION)
3. SOUL.md close-out rules (DEFENSE)

Ported for upstream refactoring: init_agent -> agent/agent_init.py, run_conversation -> agent/conversation_loop.py

Closes: #32036