### PR TITLE
fix(feishu): render markdown tables as aligned code blocks instead of raw text

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -154,8 +154,10 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
+_TABLE_SEPARATOR_LINE_RE = re.compile(
+    r"^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$"
+)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -449,6 +451,94 @@ def _sender_identity(sender: Any) -> frozenset:
 # ---------------------------------------------------------------------------
 # Markdown rendering helpers
 # ---------------------------------------------------------------------------
+
+
+def _split_table_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _render_table_as_code_block(table_lines: list[str]) -> str:
+    """Render a GFM pipe table as an aligned plain-text code block.
+
+    Feishu's post-type ``md`` elements cannot render markdown tables, so we
+    convert them to monospaced code blocks with padded columns.  This keeps
+    tables readable without forcing the entire message to plain text.
+    """
+    if len(table_lines) < 3:
+        return "\n".join(table_lines)
+
+    header_cells = _split_table_row(table_lines[0])
+    data_rows = [_split_table_row(line) for line in table_lines[2:]]
+    num_cols = len(header_cells)
+
+    col_widths = [len(h) for h in header_cells]
+    for row in data_rows:
+        for i, cell in enumerate(row[:num_cols]):
+            if i < len(col_widths):
+                col_widths[i] = max(col_widths[i], len(cell))
+
+    def _format_row(cells: list[str]) -> str:
+        padded = []
+        for i in range(num_cols):
+            val = cells[i] if i < len(cells) else ""
+            padded.append(val.ljust(col_widths[i]))
+        return "  ".join(padded)
+
+    lines = [_format_row(header_cells)]
+    lines.append("  ".join("─" * w for w in col_widths))
+    for row in data_rows:
+        lines.append(_format_row(row))
+
+    return "```\n" + "\n".join(lines) + "\n```"
+
+
+def _convert_tables_to_code_blocks(content: str) -> str:
+    """Replace GFM pipe tables in *content* with aligned code blocks.
+
+    Tables inside existing fenced code blocks are left untouched.
+    """
+    if "|" not in content or "-" not in content:
+        return content
+
+    lines = content.split("\n")
+    out: list[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+
+        if (
+            "|" in line
+            and i + 1 < len(lines)
+            and _TABLE_SEPARATOR_LINE_RE.match(lines[i + 1])
+        ):
+            table_block = [line, lines[i + 1]]
+            j = i + 2
+            while j < len(lines) and "|" in lines[j] and lines[j].strip():
+                table_block.append(lines[j])
+                j += 1
+            out.append(_render_table_as_code_block(table_block))
+            i = j
+            continue
+
+        out.append(line)
+        i += 1
+
+    return "\n".join(out)
 
 
 def _escape_markdown_text(text: str) -> str:
@@ -4284,12 +4374,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Feishu post-type 'md' elements do not render markdown tables.
+        # Convert them to aligned code blocks so the rest of the message
+        # keeps its markdown formatting instead of falling back to raw text.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            content = _convert_tables_to_code_blocks(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4885,3 +4885,43 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         # Body: leading @Hermes stripped, Alice preserved, trailing text intact.
         self.assertIn("@Alice review the spec with Alice", event.text)
         self.assertNotIn("@Hermes @Alice", event.text)
+
+
+class TestFeishuTableConversion(unittest.TestCase):
+    """Verify markdown tables are converted to code blocks for Feishu (#32607)."""
+
+    def test_simple_table_converted_to_code_block(self):
+        from gateway.platforms.feishu import _convert_tables_to_code_blocks
+
+        content = (
+            "Here are the results:\n\n"
+            "| Name | Score |\n"
+            "|------|-------|\n"
+            "| Alice | 95 |\n"
+            "| Bob | 87 |\n"
+        )
+        result = _convert_tables_to_code_blocks(content)
+        self.assertIn("```", result)
+        self.assertIn("Alice", result)
+        self.assertNotIn("|", result.split("```")[1])
+
+    def test_non_table_content_unchanged(self):
+        from gateway.platforms.feishu import _convert_tables_to_code_blocks
+
+        content = "Just a **bold** paragraph with no tables."
+        self.assertEqual(_convert_tables_to_code_blocks(content), content)
+
+    def test_table_inside_code_block_left_alone(self):
+        from gateway.platforms.feishu import _convert_tables_to_code_blocks
+
+        content = "```\n| A | B |\n|---|---|\n| 1 | 2 |\n```"
+        self.assertEqual(_convert_tables_to_code_blocks(content), content)
+
+    def test_outbound_payload_uses_post_with_tables(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "Summary:\n| Col | Val |\n|-----|-----|\n| a | 1 |"
+        msg_type, _ = adapter._build_outbound_payload(content)
+        self.assertEqual(msg_type, "post")


### PR DESCRIPTION
## What does this PR do?

Closes #32607.

Feishu's post-type `md` elements cannot render GFM pipe tables. The adapter previously fell back to plain **text** mode for the entire message when any markdown table was detected, losing all other markdown formatting (bold, italic, code blocks, lists, links).

This PR converts markdown tables to aligned monospaced code blocks in-place, so:
- Tables are readable (padded columns, Unicode separator line)
- Surrounding markdown formatting is preserved (sent as `post`, not `text`)
- Tables inside existing fenced code blocks are left untouched

### Before (raw text fallback)
```
| Column A | Column B | Column C |
|----------|----------|----------|
| Value 1  | Value 2  | Value 3  |
```

### After (aligned code block)
```
Column A  Column B  Column C
────────  ────────  ────────
Value 1   Value 2   Value 3
```

## Related Issue

Closes #32607.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding test coverage)

## Changes Made

- **`gateway/platforms/feishu.py`**:
  - New `_split_table_row()`, `_render_table_as_code_block()`, and `_convert_tables_to_code_blocks()` helpers (same pattern as Telegram's `_wrap_markdown_tables`)
  - `_build_outbound_payload()` now converts tables to code blocks instead of falling back to `"text"` type
- **`tests/gateway/test_feishu.py`** — 4 new tests (`TestFeishuTableConversion`): simple table conversion, non-table passthrough, code-block-guarded tables, and outbound payload type check.

## How to Test

```bash
pytest tests/gateway/test_feishu.py::TestFeishuTableConversion -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(feishu):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this bug fix
- [x] I've added tests for my changes (4 new tests)
- [x] Follows the same pattern used by the Telegram adapter (`_wrap_markdown_tables`)