### PR TITLE
fix: show current session in session_search + rebuild prompt on model switch

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -127,6 +127,29 @@ def _ra():
     return run_agent
 
 
+def _extract_system_prompt_field(system_prompt: str, field: str) -> str:
+    """Extract a timestamp-line field value from a stored system prompt.
+
+    The system prompt's volatile section contains lines like::
+
+        Model: deepseek-v4-pro
+        Provider: deepseek
+
+    This helper parses the stored prompt and returns the value for a
+    given field name, or an empty string if not found.
+    """
+    import re
+
+    if not system_prompt or not field:
+        return ""
+    pattern = rf"^{re.escape(field)}:\s*(.+)$"
+    for line in system_prompt.splitlines():
+        m = re.match(pattern, line.strip())
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
 def _restore_or_build_system_prompt(agent, system_message, conversation_history):
     """Restore the cached system prompt from the session DB or build it fresh.
 
@@ -178,9 +201,30 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     if stored_prompt:
         # Continuing session — reuse the exact system prompt from the
-        # previous turn so the Anthropic cache prefix matches.
-        agent._cached_system_prompt = stored_prompt
-        return
+        # previous turn so the Anthropic cache prefix matches, BUT only
+        # when the model/provider haven't changed.  A model switch (e.g.
+        # config update + gateway retry) can leave the stored prompt
+        # advertising a different model than the one the agent now uses,
+        # which confuses both the user and the model.
+        _stored_model = _extract_system_prompt_field(stored_prompt, "Model")
+        _stored_provider = _extract_system_prompt_field(stored_prompt, "Provider")
+        _model_mismatch = (
+            _stored_model
+            and agent.model
+            and _stored_model != agent.model
+        ) or (
+            _stored_provider
+            and agent.provider
+            and _stored_provider != agent.provider
+        )
+        if not _model_mismatch:
+            agent._cached_system_prompt = stored_prompt
+            return
+        logger.info(
+            "Stored system prompt model/provider (%s/%s) does not match "
+            "current agent (%s/%s) — rebuilding.",
+            _stored_model, _stored_provider, agent.model, agent.provider,
+        )
 
     if conversation_history and stored_state in ("null", "empty"):
         # Continuing session whose stored prompt is unusable.  The

--- a/cli.py
+++ b/cli.py
@@ -6288,7 +6288,19 @@ class HermesCLI:
             )
         except Exception:
             return []
-        return [s for s in sessions if s.get("id") != self.session_id]
+        # Put the current session first if it exists
+        current = None
+        others = []
+        for s in sessions:
+            if s.get("id") == self.session_id:
+                current = s
+            else:
+                others.append(s)
+        result = []
+        if current:
+            result.append(current)
+        result.extend(others)
+        return result
 
     def _show_recent_sessions(self, *, reason: str = "history", limit: int = 10) -> bool:
         """Render recent sessions inline from the active chat TUI.

--- a/cli.py
+++ b/cli.py
@@ -6319,13 +6319,14 @@ class HermesCLI:
         else:
             print("  Recent sessions:")
         print()
-        print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+        print(f"  {'#':<3} {'Title':<32} {'Status':<12} {'Preview':<38} {'Last Active':<13} {'ID'}")
+        print(f"  {'─' * 3} {'─' * 32} {'─' * 12} {'─' * 38} {'─' * 13} {'─' * 24}")
         for idx, session in enumerate(sessions, start=1):
             title = session.get("title") or "—"
+            active_flag = " ← active" if session.get("id") == self.session_id else ""
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
-            print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+            print(f"  {idx:<3} {title:<32}{active_flag:<12} {preview:<38} {last_active:<13} {session['id']}")
         print()
         print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
         print("  Example: /resume 2")

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -188,6 +188,72 @@ class TestSilentFailureWarnings:
 
 
 # ---------------------------------------------------------------------------
+# Model/provider mismatch — prompt rebuild
+# ---------------------------------------------------------------------------
+
+
+class TestModelProviderMismatch:
+    # Stored prompt says Model: X but agent uses Y -> rebuild
+    def test_mismatch_triggers_rebuild(self, caplog):
+        stored = (
+            "You are Hermes Agent.\n"
+            "Model: old-model\n"
+            "Provider: old-provider\n"
+            "Conversation started: Sunday\n"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.model = "new-model"  # mismatch!
+
+        with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        # Rebuilt fresh instead of reusing stale prompt
+        agent._build_system_prompt.assert_called_once()
+        assert agent._cached_system_prompt == "BUILT_PROMPT"
+        # Log says mismatch detected
+        infos = [r.getMessage() for r in caplog.records if r.levelno >= logging.INFO]
+        assert any("does not match" in m for m in infos), \
+            f"Expected mismatch log, got: {infos}"
+
+    # Stored prompt matches agent model -> reuse
+    def test_match_reuses_stored_prompt(self, caplog):
+        stored = (
+            "You are Hermes Agent.\n"
+            "Model: test-model\n"
+            "Provider: deepseek\n"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+        agent.provider = "deepseek"  # match!
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        # Reused verbatim - no rebuild
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+        # No warnings on the happy path
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    # Stored prompt without Model: line -> reuse (backward compat)
+    def test_no_model_in_stored_prompt_reuses(self, caplog):
+        stored = "You are Hermes Agent.\nNo model header here.\n"
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db)
+
+        with caplog.at_level(logging.WARNING, logger="agent.conversation_loop"):
+            _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
+
+        # Reused - no mismatch because stored prompt doesn't have model info
+        assert agent._cached_system_prompt == stored
+        agent._build_system_prompt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Byte-stability invariant
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -129,11 +129,12 @@ class TestBrowseShape:
         assert result["mode"] == "browse"
         assert result["count"] >= 3
 
-    def test_browse_excludes_current_session(self, db):
+    def test_browse_includes_current_session_at_top(self, db):
         _seed_modpack_sessions(db)
         result = json.loads(session_search(db=db, current_session_id="s_newest"))
         sids = [r["session_id"] for r in result["results"]]
-        assert "s_newest" not in sids
+        assert "s_newest" in sids
+        assert sids[0] == "s_newest"
 
     def test_browse_returns_titles(self, db):
         _seed_modpack_sessions(db)
@@ -198,11 +199,11 @@ class TestDiscoveryShape:
         result = json.loads(session_search(query="modpack", limit="bogus", db=db))
         assert result["success"] is True
 
-    def test_current_session_filtered_out(self, db):
+    def test_current_session_included_in_discovery(self, db):
         _seed_modpack_sessions(db)
         result = json.loads(session_search(query="modpack", db=db, current_session_id="s_newest"))
         sids = [r["session_id"] for r in result["results"]]
-        assert "s_newest" not in sids
+        assert "s_newest" in sids
 
 
 class TestDiscoverySort:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -119,9 +119,28 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
         current_root = _resolve_to_parent(db, current_session_id) if current_session_id else None
 
         results = []
+        if current_session_id:
+            cur = db.get_session(current_session_id)
+            if cur:
+                cur_msgs = db.get_messages(current_session_id)
+                cur_preview = ""
+                if cur_msgs:
+                    cur_preview = (cur_msgs[0].get("content") or "")[:63].replace("\n", " ").replace("\r", " ")
+                results.append({
+                    "session_id": current_session_id,
+                    "title": cur.get("title") or None,
+                    "source": cur.get("source", ""),
+                    "started_at": cur.get("started_at", ""),
+                    "last_active": cur.get("last_active", ""),
+                    "message_count": cur.get("message_count", 0),
+                    "preview": cur_preview,
+                })
+
         for s in sessions:
             sid = s.get("id", "")
-            if current_root and (sid == current_root or sid == current_session_id):
+            if sid == current_session_id:
+                continue
+            if current_root and sid == current_root:
                 continue
             # Skip child / delegation sessions
             if s.get("parent_session_id"):
@@ -317,11 +336,6 @@ def _discover(
     for r in raw_results:
         raw_sid = r["session_id"]
         resolved_sid = _resolve_to_parent(db, raw_sid)
-        # Skip the current session lineage
-        if current_lineage_root and resolved_sid == current_lineage_root:
-            continue
-        if current_session_id and raw_sid == current_session_id:
-            continue
         if resolved_sid not in seen_sessions:
             row = dict(r)
             row["_lineage_root"] = resolved_sid


### PR DESCRIPTION
Fixes session_search and /sessions to show the current session, plus a prompt restore fix:

- session_search browse/discovery now includes the current session at the top (was being filtered out)
- /sessions command now shows the current session first, marked with "← active"
- conversation_loop now detects when model/provider changed and rebuilds the prompt instead of using stale cached version
- Tests updated to match the new behavior