### PR TITLE
fix: clean unused imports and stale noqa in scripts/contributor_audit.py

### DIFF
--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -17,7 +17,6 @@ Usage:
 
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys
@@ -30,7 +29,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
-from release import AUTHOR_MAP, resolve_author  # noqa: E402
+from release import resolve_author
 
 REPO_ROOT = SCRIPT_DIR.parent
 
@@ -262,9 +261,7 @@ def collect_salvaged_contributors(since_tag, until="HEAD"):
         body = pr.get("body") or ""
         pr_number = pr.get("number", "?")
 
-        # Also credit the PR author
-        pr_author = pr.get("author", {})
-        pr_author_login = pr_author.get("login", "") if isinstance(pr_author, dict) else ""
+
 
         for pattern in SALVAGE_PATTERNS:
             for match in pattern.finditer(body):

--- a/tests/scripts/test_contributor_audit_lint.py
+++ b/tests/scripts/test_contributor_audit_lint.py
@@ -1,0 +1,47 @@
+"""Lint regression tests for scripts/contributor_audit.py.
+
+These tests assert that the file stays clean of specific lint rule classes
+that the project's default ruff config does not enable. Without these guards,
+violations can silently accumulate over time.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TARGET = "scripts/contributor_audit.py"
+
+
+def _ruff_check(select: str) -> subprocess.CompletedProcess:
+    """Run ruff check with a specific --select filter on the target file."""
+    return subprocess.run(
+        [sys.executable, "-m", "ruff", "check", TARGET, "--select", select,
+         "--output-format=concise"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_contributor_audit_has_zero_f_class_violations() -> None:
+    """scripts/contributor_audit.py must have zero F-class violations.
+
+    Covers: F401 (unused imports), F841 (unused variables), and all other
+    F-class rules (F811 redefinitions, F821 undefined names, etc.).
+    """
+    result = _ruff_check("F")
+    assert result.returncode == 0, (
+        f"{TARGET} has F-class violations:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_contributor_audit_has_zero_ruf100_violations() -> None:
+    """scripts/contributor_audit.py must have zero RUF100 (unused noqa) violations."""
+    result = _ruff_check("RUF100")
+    assert result.returncode == 0, (
+        f"{TARGET} has RUF100 violations:\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Remove unused imports, unused variables, and a stale `# noqa` directive in `scripts/contributor_audit.py`, and add a regression test to guard against re-introduction.

### Changes

- Remove unused `import os` (F401)
- Remove unused `AUTHOR_MAP` import, drop stale `# noqa: E402` (F401 + RUF100)
- Remove unused `pr_author` and `pr_author_login` variables (F841)
- Add regression test `tests/scripts/test_contributor_audit_lint.py` asserting zero F-class and RUF100 violations

### Test Plan

- `pytest tests/scripts/test_contributor_audit_lint.py -v` → 2 passed
- `ruff check scripts/contributor_audit.py --select=F,RUF100` → clean (exit 0)

Closes: Part of the broader lint cleanup initiative (~400+ violations across the repo).