### PR TITLE
fix: add .md to MEDIA directive regex supported extensions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2268,7 +2268,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|md|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Problem

The MEDIA: path regex in `extract_media_tags()` (`gateway/platforms/base.py`, line 2271) is missing `.md` in its extension alternation. The parallel `_LOCAL_MEDIA_EXTS` list in `extract_local_files()` already includes `.md`, creating an inconsistency.

**Result:** `MEDIA:/path/to/file.md` is silently stripped from agent responses instead of being delivered as a native attachment. The gateway log shows the content length drops (the MEDIA line is removed) but no file is sent.

## Fix

Add `md` to the regex extension group so markdown files can be delivered via MEDIA: directives.

## Testing

Tested on a self-hosted Hermes instance running in Docker with WhatsApp gateway. After applying the fix and restarting the gateway, `MEDIA:/path/to/document.md` was successfully delivered as a native attachment.

---

*This PR was prepared by Hermes AI agent under my direction and review. All changes were verified and approved by me before submission.*