### PR TITLE
fix: keep cron ticker failures visible

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18003,6 +18003,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     """
     from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.status import write_cron_ticker_status
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -18012,74 +18013,90 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
-    while not stop_event.is_set():
-        try:
-            cron_tick(verbose=False, adapters=adapters, loop=loop)
-        except Exception as e:
-            logger.debug("Cron tick error: %s", e)
-
-        tick_count += 1
-
-        if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
+    write_cron_ticker_status(state="running", interval_seconds=interval, tick_count=tick_count, last_error=None)
+    try:
+        while not stop_event.is_set():
             try:
-                from gateway.channel_directory import build_channel_directory
-                if loop is not None:
-                    # build_channel_directory is async (Slack web calls), and
-                    # this ticker runs in a background thread. Schedule onto
-                    # the gateway event loop and wait briefly for completion
-                    # so refresh failures are still logged via the except.
-                    fut = safe_schedule_threadsafe(
-                        build_channel_directory(adapters), loop,
-                        logger=logger,
-                        log_message="Channel directory refresh scheduling error",
-                    )
-                    if fut is not None:
-                        fut.result(timeout=30)
-            except Exception as e:
-                logger.debug("Channel directory refresh error: %s", e)
-
-        if tick_count % IMAGE_CACHE_EVERY == 0:
-            try:
-                removed = cleanup_image_cache(max_age_hours=24)
-                if removed:
-                    logger.info("Image cache cleanup: removed %d stale file(s)", removed)
-            except Exception as e:
-                logger.debug("Image cache cleanup error: %s", e)
-            try:
-                removed = cleanup_document_cache(max_age_hours=24)
-                if removed:
-                    logger.info("Document cache cleanup: removed %d stale file(s)", removed)
-            except Exception as e:
-                logger.debug("Document cache cleanup error: %s", e)
-
-        if tick_count % PASTE_SWEEP_EVERY == 0:
-            try:
-                deleted, remaining = _sweep_expired_pastes()
-                if deleted:
-                    logger.info(
-                        "Paste sweep: deleted %d expired paste(s), %d pending",
-                        deleted, remaining,
-                    )
-            except Exception as e:
-                logger.debug("Paste sweep error: %s", e)
-
-        # Curator — piggy-back on the existing cron ticker so long-running
-        # gateways get weekly skill maintenance without needing restarts.
-        # maybe_run_curator() is internally gated by config.interval_hours
-        # (7 days by default), so CURATOR_EVERY is just the poll rate — the
-        # real work only fires once per config interval.
-        if tick_count % CURATOR_EVERY == 0:
-            try:
-                from agent.curator import maybe_run_curator
-                maybe_run_curator(
-                    idle_for_seconds=float("inf"),
-                    on_summary=lambda msg: logger.info("curator: %s", msg),
+                cron_tick(verbose=False, adapters=adapters, loop=loop)
+                write_cron_ticker_status(
+                    state="running",
+                    interval_seconds=interval,
+                    tick_count=tick_count,
+                    last_error=None,
                 )
-            except Exception as e:
-                logger.debug("Curator tick error: %s", e)
+            except BaseException as e:
+                logger.exception("Cron tick error: %s", e)
+                write_cron_ticker_status(
+                    state="running",
+                    interval_seconds=interval,
+                    tick_count=tick_count,
+                    last_error=f"{type(e).__name__}: {e}",
+                )
 
-        stop_event.wait(timeout=interval)
-    logger.info("Cron ticker stopped")
+            tick_count += 1
+
+            if tick_count % CHANNEL_DIR_EVERY == 0 and adapters:
+                try:
+                    from gateway.channel_directory import build_channel_directory
+                    if loop is not None:
+                        # build_channel_directory is async (Slack web calls), and
+                        # this ticker runs in a background thread. Schedule onto
+                        # the gateway event loop and wait briefly for completion
+                        # so refresh failures are still logged via the except.
+                        fut = safe_schedule_threadsafe(
+                            build_channel_directory(adapters), loop,
+                            logger=logger,
+                            log_message="Channel directory refresh scheduling error",
+                        )
+                        if fut is not None:
+                            fut.result(timeout=30)
+                except Exception as e:
+                    logger.debug("Channel directory refresh error: %s", e)
+
+            if tick_count % IMAGE_CACHE_EVERY == 0:
+                try:
+                    removed = cleanup_image_cache(max_age_hours=24)
+                    if removed:
+                        logger.info("Image cache cleanup: removed %d stale file(s)", removed)
+                except Exception as e:
+                    logger.debug("Image cache cleanup error: %s", e)
+                try:
+                    removed = cleanup_document_cache(max_age_hours=24)
+                    if removed:
+                        logger.info("Document cache cleanup: removed %d stale file(s)", removed)
+                except Exception as e:
+                    logger.debug("Document cache cleanup error: %s", e)
+
+            if tick_count % PASTE_SWEEP_EVERY == 0:
+                try:
+                    deleted, remaining = _sweep_expired_pastes()
+                    if deleted:
+                        logger.info(
+                            "Paste sweep: deleted %d expired paste(s), %d pending",
+                            deleted, remaining,
+                        )
+                except Exception as e:
+                    logger.debug("Paste sweep error: %s", e)
+
+            # Curator — piggy-back on the existing cron ticker so long-running
+            # gateways get weekly skill maintenance without needing restarts.
+            # maybe_run_curator() is internally gated by config.interval_hours
+            # (7 days by default), so CURATOR_EVERY is just the poll rate — the
+            # real work only fires once per config interval.
+            if tick_count % CURATOR_EVERY == 0:
+                try:
+                    from agent.curator import maybe_run_curator
+                    maybe_run_curator(
+                        idle_for_seconds=float("inf"),
+                        on_summary=lambda msg: logger.info("curator: %s", msg),
+                    )
+                except Exception as e:
+                    logger.debug("Curator tick error: %s", e)
+
+            stop_event.wait(timeout=interval)
+    finally:
+        write_cron_ticker_status(state="stopped", interval_seconds=interval, tick_count=tick_count)
+        logger.info("Cron ticker stopped")
 
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -546,6 +546,37 @@ def write_runtime_status(
     _write_json_file(path, payload)
 
 
+def write_cron_ticker_status(
+    *,
+    state: str,
+    interval_seconds: Any = _UNSET,
+    tick_count: Any = _UNSET,
+    last_error: Any = _UNSET,
+) -> None:
+    """Persist cron ticker heartbeat/liveness information for diagnostics."""
+    path = _get_runtime_status_path()
+    payload = _read_json_file(path) or _build_runtime_status_record()
+    current_record = _build_pid_record()
+    payload["kind"] = current_record["kind"]
+    payload["pid"] = current_record["pid"]
+    payload["argv"] = current_record["argv"]
+    payload["start_time"] = current_record["start_time"]
+    payload["updated_at"] = _utc_now_iso()
+
+    ticker_payload = dict(payload.get("cron_ticker") or {})
+    ticker_payload["state"] = state
+    ticker_payload["updated_at"] = _utc_now_iso()
+    if interval_seconds is not _UNSET:
+        ticker_payload["interval_seconds"] = float(interval_seconds)
+    if tick_count is not _UNSET:
+        ticker_payload["tick_count"] = max(0, int(tick_count))
+    if last_error is not _UNSET:
+        ticker_payload["last_error"] = last_error
+    payload["cron_ticker"] = ticker_payload
+
+    _write_json_file(path, payload)
+
+
 def read_runtime_status() -> Optional[dict[str, Any]]:
     """Read the persisted gateway runtime health/status information."""
     return _read_json_file(_get_runtime_status_path())

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -7,6 +7,7 @@ pause/resume/run/remove, status, and tick.
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, List, Optional
 
@@ -132,6 +133,41 @@ def cron_tick():
     tick(verbose=True)
 
 
+def _describe_cron_ticker_health(runtime_status: Optional[dict], *, now: Optional[datetime] = None) -> tuple[str, str]:
+    """Return (state, message) for persisted gateway cron ticker liveness."""
+    ticker = (runtime_status or {}).get("cron_ticker")
+    if not isinstance(ticker, dict):
+        return "unknown", "⚠ Cron ticker health unknown — restart gateway if jobs do not fire"
+
+    state = str(ticker.get("state") or "unknown").lower()
+    if state != "running":
+        return "unhealthy", f"⚠ Cron ticker is {state or 'not running'} — jobs may not fire automatically"
+
+    updated_raw = ticker.get("updated_at")
+    if not updated_raw:
+        return "unknown", "⚠ Cron ticker health unknown — missing heartbeat timestamp"
+
+    try:
+        updated_at = datetime.fromisoformat(str(updated_raw).replace("Z", "+00:00"))
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return "unknown", "⚠ Cron ticker health unknown — invalid heartbeat timestamp"
+
+    now = now or datetime.now(timezone.utc)
+    interval = ticker.get("interval_seconds", 60)
+    try:
+        interval_seconds = float(interval)
+    except (TypeError, ValueError):
+        interval_seconds = 60.0
+    stale_after = max(180.0, interval_seconds * 3.0)
+    age_seconds = (now - updated_at).total_seconds()
+    if age_seconds > stale_after:
+        return "unhealthy", "⚠ Cron ticker heartbeat is stale — jobs may not fire automatically"
+
+    return "healthy", "✓ Cron ticker healthy"
+
+
 def cron_status():
     """Show cron execution status."""
     from cron.jobs import list_jobs
@@ -141,8 +177,15 @@ def cron_status():
 
     pids = find_gateway_pids()
     if pids:
-        print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+        print(color("✓ Gateway is running", Colors.GREEN))
         print(f"  PID: {', '.join(map(str, pids))}")
+        try:
+            from gateway.status import read_runtime_status
+            health, message = _describe_cron_ticker_health(read_runtime_status())
+        except Exception:
+            health, message = "unknown", "⚠ Cron ticker health unknown — restart gateway if jobs do not fire"
+        health_color = Colors.GREEN if health == "healthy" else Colors.YELLOW
+        print(color(f"  {message}", health_color))
     else:
         print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))
         print()

--- a/tests/gateway/test_cron_ticker.py
+++ b/tests/gateway/test_cron_ticker.py
@@ -1,0 +1,50 @@
+"""Regression tests for gateway cron ticker liveness."""
+
+import logging
+import threading
+
+from gateway.run import _start_cron_ticker
+
+
+def test_cron_ticker_logs_tick_exception_at_error(monkeypatch, caplog):
+    import cron.scheduler
+
+    stop = threading.Event()
+    calls = {"count": 0}
+
+    def fake_tick(*args, **kwargs):
+        calls["count"] += 1
+        stop.set()
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cron.scheduler, "tick", fake_tick)
+
+    with caplog.at_level(logging.ERROR):
+        _start_cron_ticker(stop, interval=0)
+
+    assert calls["count"] == 1
+    assert any("Cron tick error" in record.message for record in caplog.records)
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+def test_cron_ticker_catches_baseexception_logs_error_and_continues(monkeypatch, caplog):
+    import cron.scheduler
+
+    stop = threading.Event()
+    calls = {"count": 0}
+
+    def fake_tick(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise SystemExit("simulated fatal cron tick failure")
+        stop.set()
+        return 0
+
+    monkeypatch.setattr(cron.scheduler, "tick", fake_tick)
+
+    with caplog.at_level(logging.ERROR):
+        _start_cron_ticker(stop, interval=0)
+
+    assert calls["count"] == 2
+    assert any("Cron tick error" in record.message for record in caplog.records)
+    assert any(record.levelno >= logging.ERROR for record in caplog.records)

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.cron command handling."""
 
 from argparse import Namespace
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -111,3 +112,48 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+    def test_status_reports_healthy_cron_ticker(self, tmp_cron_dir, monkeypatch, capsys):
+        fresh = datetime.now(timezone.utc)
+
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [123])
+        monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+        monkeypatch.setattr(
+            "gateway.status.read_runtime_status",
+            lambda: {
+                "cron_ticker": {
+                    "state": "running",
+                    "updated_at": fresh.isoformat(),
+                    "interval_seconds": 60,
+                }
+            },
+        )
+
+        cron_command(Namespace(cron_command="status"))
+
+        out = capsys.readouterr().out
+        assert "Gateway is running" in out
+        assert "Cron ticker healthy" in out
+
+    def test_status_warns_when_cron_ticker_heartbeat_is_stale(self, tmp_cron_dir, monkeypatch, capsys):
+        stale = datetime.now(timezone.utc) - timedelta(minutes=10)
+
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [123])
+        monkeypatch.setattr("cron.jobs.list_jobs", lambda include_disabled=False: [])
+        monkeypatch.setattr(
+            "gateway.status.read_runtime_status",
+            lambda: {
+                "cron_ticker": {
+                    "state": "running",
+                    "updated_at": stale.isoformat(),
+                    "interval_seconds": 60,
+                }
+            },
+        )
+
+        cron_command(Namespace(cron_command="status"))
+
+        out = capsys.readouterr().out
+        assert "Gateway is running" in out
+        assert "Cron ticker heartbeat is stale" in out
+        assert "jobs may not fire automatically" in out


### PR DESCRIPTION
## Summary
- log cron tick failures at ERROR with tracebacks instead of DEBUG
- catch BaseException inside the gateway cron ticker loop so one fatal tick cannot silently kill scheduling
- persist cron ticker heartbeat/liveness in gateway_state.json
- make hermes cron status warn when the ticker heartbeat is stale/unhealthy instead of only checking the gateway PID

Fixes #32612

## Test Plan
- python -m pytest tests/gateway/test_cron_ticker.py tests/hermes_cli/test_cron.py -q
- python -m pytest tests/hermes_cli/test_cron.py tests/gateway/test_cron_ticker.py tests/gateway/test_runner_startup_failures.py -q
