### PR TITLE
fix(codex): prevent device-login auth desync

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3191,9 +3191,14 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     if _lock:
         with _auth_store_lock():
             auth_store = _load_auth_store()
+            state = _load_provider_state(auth_store, "openai-codex")
+            if not state:
+                state = _recover_codex_provider_state_from_pool(auth_store)
     else:
         auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
+        state = _load_provider_state(auth_store, "openai-codex")
+        if not state:
+            state = _recover_codex_provider_state_from_pool(auth_store)
     if not state:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
@@ -3231,7 +3236,66 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     }
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
+def _recover_codex_provider_state_from_pool(auth_store: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Repair providers.openai-codex from a pool-only OAuth credential.
+
+    `hermes auth add openai-codex` and the dashboard device-code flow used
+    to write only credential_pool.openai-codex. That worked until the pool
+    entry was marked exhausted, then runtime resolution fell back to the
+    missing provider state and reported "No Codex credentials stored." Keep
+    this recovery path so old auth stores self-heal instead of stranding the
+    user.
+    """
+    pool = auth_store.get("credential_pool")
+    entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+    if not isinstance(entries, list):
+        return None
+
+    allowed_sources = {
+        "device_code",
+        "manual:device_code",
+        "manual:dashboard_device_code",
+    }
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("auth_type") != "oauth":
+            continue
+        if entry.get("source") not in allowed_sources:
+            continue
+        access_token = str(entry.get("access_token") or "").strip()
+        refresh_token = str(entry.get("refresh_token") or "").strip()
+        if not access_token or not refresh_token:
+            continue
+        state: Dict[str, Any] = {
+            "tokens": {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            },
+            "auth_mode": "chatgpt",
+            "source": "credential_pool_recovery",
+        }
+        if entry.get("last_refresh"):
+            state["last_refresh"] = entry["last_refresh"]
+        if entry.get("base_url"):
+            state["base_url"] = entry["base_url"]
+        _store_provider_state(auth_store, "openai-codex", state, set_active=False)
+        _save_auth_store(auth_store)
+        logger.warning(
+            "Recovered providers.openai-codex from credential_pool.openai-codex "
+            "entry %s",
+            entry.get("id") or "<unknown>",
+        )
+        return state
+    return None
+
+
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: str = None,
+    *,
+    set_active: bool = True,
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -3241,7 +3305,7 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
-        _save_provider_state(auth_store, "openai-codex", state)
+        _store_provider_state(auth_store, "openai-codex", state, set_active=set_active)
         _save_auth_store(auth_store)
 
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -319,6 +319,11 @@ def auth_add_command(args) -> None:
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
         )
+        auth_mod._save_codex_tokens(
+            creds["tokens"],
+            creds.get("last_refresh"),
+            set_active=False,
+        )
         entry = PooledCredential(
             provider=provider,
             id=uuid.uuid4().hex[:6],

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2185,6 +2185,7 @@ def _codex_full_login_worker(session_id: str) -> None:
             CODEX_OAUTH_CLIENT_ID,
             CODEX_OAUTH_TOKEN_URL,
             DEFAULT_CODEX_BASE_URL,
+            _save_codex_tokens,
         )
         issuer = "https://auth.openai.com"
 
@@ -2287,6 +2288,13 @@ def _codex_full_login_worker(session_id: str) -> None:
             access_token=access_token,
             refresh_token=refresh_token,
             base_url=base_url,
+        )
+        _save_codex_tokens(
+            {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+            },
+            set_active=False,
         )
         pool.add_entry(entry)
         with _oauth_sessions_lock:

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -75,6 +75,44 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
+def test_read_codex_tokens_recovers_pool_only_login(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    auth_file = hermes_home / "auth.json"
+    auth_file.write_text(json.dumps({
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "pool-1",
+                    "label": "dashboard login",
+                    "auth_type": "oauth",
+                    "source": "manual:dashboard_device_code",
+                    "access_token": "pool-access",
+                    "refresh_token": "pool-refresh",
+                    "base_url": DEFAULT_CODEX_BASE_URL,
+                    "last_refresh": "2026-05-20T04:42:19Z",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                }
+            ]
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == "pool-access"
+    assert data["tokens"]["refresh_token"] == "pool-refresh"
+    assert data["last_refresh"] == "2026-05-20T04:42:19Z"
+    repaired = json.loads(auth_file.read_text())
+    provider_state = repaired["providers"]["openai-codex"]
+    assert provider_state["tokens"]["access_token"] == "pool-access"
+    assert provider_state["tokens"]["refresh_token"] == "pool-refresh"
+    assert provider_state["source"] == "credential_pool_recovery"
+
+
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -308,6 +308,10 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["source"] == "manual:device_code"
     assert entry["refresh_token"] == "refresh-token"
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
+    provider_state = payload["providers"]["openai-codex"]
+    assert provider_state["tokens"]["access_token"] == token
+    assert provider_state["tokens"]["refresh_token"] == "refresh-token"
+    assert provider_state["last_refresh"] == "2026-03-23T10:00:00Z"
 
 
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- recover missing `providers.openai-codex` auth state from valid Codex OAuth credential-pool entries
- persist Codex device-code logins to provider state as well as the credential pool from both CLI and dashboard flows
- cover the pool-only/desynced login case with regression tests

## Why
`hermes auth add openai-codex` and the dashboard device-code flow could write only `credential_pool.openai-codex`. Runtime token resolution reads `providers.openai-codex`, so once the pool entry was exhausted/rotated the install could report `No Codex credentials stored` even though valid OAuth material was still present in `auth.json`.

## Tests
- `PYTHONPATH="$PWD" /home/mitch/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_commands.py tests/agent/test_credential_pool.py tests/hermes_cli/test_runtime_provider_resolution.py -k codex`
