### PR TITLE
fix: remove unused `import re` from test_lint_config.py (F401)

### DIFF
--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -82,7 +82,6 @@ class TestLintWorkflow:
         # Look for the blocking step's named line + its command.  We want
         # at least one ``ruff check .`` that does NOT have ``--exit-zero``
         # nearby.
-        import re
         # Split into lines and find ruff check invocations
         lines = content.splitlines()
         found_blocking = False
@@ -113,3 +112,26 @@ class TestLintWorkflow:
             pytest.fail(f"lint.yml is not valid YAML: {exc}")
         assert isinstance(parsed, dict)
         assert "jobs" in parsed
+
+
+class TestF401UnusedImports:
+    """tests/test_lint_config.py must have zero F401 violations."""
+
+    TARGET = REPO_ROOT / "tests" / "test_lint_config.py"
+
+    def test_lint_config_has_zero_f401(self):
+        import subprocess as _subprocess
+        import sys as _sys
+
+        result = _subprocess.run(
+            [_sys.executable, "-m", "ruff", "check", "--select=F401",
+             "--output-format=concise", str(self.TARGET)],
+            cwd=str(REPO_ROOT), capture_output=True, text=True,
+        )
+
+        assert result.returncode == 0, (
+            f"tests/test_lint_config.py has F401 violation(s):\n"
+            f"{result.stdout}\n{result.stderr}\n"
+        )
+
+


### PR DESCRIPTION
## Summary
- Removes unused `import re` from `test_lint_config.py` (F401 violation)
- Adds a regression test asserting zero F401 violations in the test file

## Changes
1. **F401 fix**: Removed `import re` inside `test_workflow_has_blocking_ruff_step` — `re` was never used in the method body
2. **Regression test**: Added `TestF401UnusedImports.test_lint_config_has_zero_f401()` that runs `ruff check --select=F401` on the test file

## Test Plan
- [x] TDD cycle: RED (test failed with 1 F401 violation) → GREEN (removed unused import)
- [x] FULL: 6/6 tests pass in test_lint_config.py
- [x] ruff --select=F tests/test_lint_config.py: clean
- [x] ruff --select=RUF100 tests/test_lint_config.py: clean
- [ ] Independent code review: passed

Closes ongoing F401 lint decay in test_lint_config.py

---
## CI / Review Note
> `needs-review` label could not be added automatically — the authenticated token lacks admin rights to the upstream repository (expected; see github-pr-workflow Pitfall #42).
> A human reviewer should add the label manually, or simply review via the PR.