### PR TITLE
fix(gateway): expand MEDIA: tag regex to support all file extensions

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|bmp|tiff|svg|mp4|mov|avi|mkv|webm|mp3|wav|ogg|opus|m4a|flac|pdf|docx?|odt|rtf|txt|md|xlsx?|ods|csv|tsv|json|xml|ya?ml|pptx?|odp|key|zip|tar|gz|tgz|bz2|xz|7z|rar|html?|epub|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Summary

The `MEDIA:<path>` tag regex in `gateway/platforms/base.py` had a smaller, hardcoded set of file extensions (png, jpg, gif, webp, mp4, mov, avi, mkv, webm, ogg, opus, mp3, wav, m4a, flac, epub, pdf, zip, rar, 7z, doc, docx, xls, xlsx, ppt, pptx, txt, csv, apk, ipa) compared to the full `_LOCAL_MEDIA_EXTS` tuple defined just a few lines below.

This meant that valid file types like `.xml`, `.json`, `.yaml`, `.md`, `.html`, `.svg`, `.odt`, and many others would be silently ignored when included in `MEDIA:` tags — even though the file delivery logic already supported them.

## Fix

Sync the `media_pattern` regex with the full `_LOCAL_MEDIA_EXTS` list, adding:
- **Images:** bmp, tiff, svg
- **Documents:** odt, rtf, md
- **Data:** ods, tsv, json, xml, yaml/yml
- **Presentations:** odp, key
- **Archives:** tar, gz, tgz, bz2, xz
- **Web:** html/htm

## Testing

Verified locally: sending `MEDIA:/path/to/file.xml` now correctly delivers the file as a document attachment via Telegram gateway.

## Impact

Single-line regex change in `gateway/platforms/base.py`. No behavioral change for already-supported extensions.