### PR TITLE
fix(discord): report bot task exits as fatal

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -583,6 +583,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
+        self._disconnecting = False
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
@@ -850,8 +851,12 @@ class DiscordAdapter(BasePlatformAdapter):
             if self._slash_commands:
                 self._register_slash_commands()
 
-            # Start the bot in background
+            # Start the bot in background. Monitor the task so discord.py
+            # reconnect exhaustion cannot leave the gateway process alive with
+            # a dead adapter and no fatal-error notification.
+            self._disconnecting = False
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))
+            self._bot_task.add_done_callback(self._handle_bot_task_done)
 
             # Wait for ready
             await asyncio.wait_for(self._ready_event.wait(), timeout=30)
@@ -868,8 +873,40 @@ class DiscordAdapter(BasePlatformAdapter):
             self._release_platform_lock()
             return False
 
+    def _handle_bot_task_done(self, task: asyncio.Task) -> None:
+        """Notify the gateway when discord.py's long-running task exits.
+
+        ``commands.Bot.start()`` normally runs until the adapter is explicitly
+        disconnected. If it returns while the adapter is running, discord.py has
+        stopped receiving events (for example after reconnect backoff
+        exhaustion), so surface a retryable fatal error to the gateway runner.
+        """
+        if self._disconnecting or not self._running or task.cancelled():
+            return
+
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+
+        if exc is None:
+            message = "Discord bot task stopped unexpectedly"
+            logger.error("[%s] %s", self.name, message)
+        else:
+            message = f"Discord bot task stopped unexpectedly: {exc}"
+            logger.error(
+                "[%s] %s",
+                self.name,
+                message,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
+        self._set_fatal_error("discord_bot_task_stopped", message, retryable=True)
+        asyncio.create_task(self._notify_fatal_error())
+
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        self._disconnecting = True
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -246,6 +246,99 @@ async def test_reconnect_closes_previous_client_to_prevent_zombie_websocket(monk
 
 
 @pytest.mark.asyncio
+async def test_bot_task_exit_notifies_gateway_fatal_handler(monkeypatch):
+    """Regression for #32574/#26656: if discord.py gives up reconnecting
+    after the adapter is already marked running, the gateway must be notified
+    instead of leaving a zombie process that still appears active.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False, dm_messages=False, guild_messages=False,
+        members=False, voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    class ExitingBot(FakeBot):
+        def __init__(self, *, intents, proxy=None, allowed_mentions=None, **_):
+            super().__init__(intents=intents, proxy=proxy, allowed_mentions=allowed_mentions)
+            self.stop = asyncio.Event()
+
+        async def start(self, token):
+            if "on_ready" in self._events:
+                await self._events["on_ready"]()
+            await self.stop.wait()
+
+        async def close(self):
+            self.stop.set()
+
+    created = {}
+
+    def fake_bot_factory(*, command_prefix, intents, proxy=None, allowed_mentions=None, **_):
+        bot = ExitingBot(intents=intents, proxy=proxy, allowed_mentions=allowed_mentions)
+        created["bot"] = bot
+        return bot
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", fake_bot_factory)
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    assert await adapter.connect() is True
+
+    assert adapter._bot_task is not None
+    created["bot"].stop.set()
+    await asyncio.wait_for(adapter._bot_task, timeout=1.0)
+    await asyncio.sleep(0)
+
+    assert adapter.fatal_error_code == "discord_bot_task_stopped"
+    assert adapter.fatal_error_retryable is True
+    fatal_handler.assert_awaited_once_with(adapter)
+
+
+@pytest.mark.asyncio
+async def test_bot_task_exit_during_disconnect_does_not_report_fatal(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False, dm_messages=False, guild_messages=False,
+        members=False, voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    class ClosingBot(FakeBot):
+        def __init__(self, *, intents, proxy=None, allowed_mentions=None, **_):
+            super().__init__(intents=intents, proxy=proxy, allowed_mentions=allowed_mentions)
+            self.stop = asyncio.Event()
+
+        async def start(self, token):
+            if "on_ready" in self._events:
+                await self._events["on_ready"]()
+            await self.stop.wait()
+
+        async def close(self):
+            self.stop.set()
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", lambda **kwargs: ClosingBot(**kwargs))
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    assert await adapter.connect() is True
+    await adapter.disconnect()
+    await asyncio.sleep(0)
+
+    assert adapter.has_fatal_error is False
+    fatal_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_connect_releases_token_lock_on_timeout(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 


### PR DESCRIPTION
## Summary
- Adds a Discord adapter task monitor so an unexpected `commands.Bot.start()` exit is reported as a retryable fatal adapter error.
- Refs #32574 and #26656.

## Why
- #32574 describes Discord gateways becoming zombie processes after discord.py exhausts reconnect backoff: the process stays alive, but the bot task has stopped and the gateway runner is never notified.
- The watchdog design in #32574 lists a Discord `_bot_task` done-callback as an independently shippable quick win for the May 25-26 incident class.

## Changes
- `plugins/platforms/discord/adapter.py`: attaches a done-callback to the Discord bot task, marks unexpected exits with `discord_bot_task_stopped`, and invokes the existing fatal-error handler path for gateway reconnect handling.
- `tests/gateway/test_discord_connect.py`: covers unexpected bot-task exits after connect and verifies planned disconnects do not report false fatal errors.

## Validation
- `python -m pytest tests/gateway/test_discord_connect.py -o 'addopts=' -q`
- `git diff --check`

## Scope
- In scope: Discord-only quick win for detecting a stopped bot task and routing it through existing fatal-error/retry machinery.
- Out of scope: the broader cross-platform liveness watchdog, per-adapter `is_alive()` methods, and making `_set_fatal_error()` auto-notify for all adapters.