### PR TITLE
feat(gateway): 3-layer zombie-state detection for sandboxed Hermes-N instances

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7129,6 +7129,9 @@ class GatewayRunner:
             source.chat_id or "unknown", _msg_preview,
         )
 
+        # Heartbeat: record this event so healthcheck.py knows the gateway is alive.
+        _touch_heartbeat()
+
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
@@ -16569,6 +16572,26 @@ class GatewayRunner:
         return response
 
 
+def _touch_heartbeat() -> None:
+    """Touch the gateway heartbeat file so health checks can detect zombie sessions.
+
+    Written on every inbound message AND every cron tick so the file is always
+    fresh on a live gateway.  The healthcheck.py HEALTHCHECK_STALE_SECONDS
+    threshold (300 s / 5 min) should be comfortably larger than the cron
+    interval (60 s) so idle-but-healthy gateways never false-alarm.
+
+    Path is configurable via the HERMES_HEARTBEAT_FILE env var; defaults to
+    /tmp/hermes-heartbeat so it works inside Docker containers without any
+    host-side setup.
+    """
+    heartbeat_path = os.environ.get("HERMES_HEARTBEAT_FILE", "/tmp/hermes-heartbeat")
+    try:
+        with open(heartbeat_path, "w") as fh:
+            fh.write(str(time.time()))
+    except Exception:
+        pass  # Never let heartbeat writes crash the gateway
+
+
 def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
     """
     Background thread that ticks the cron scheduler at a regular interval.
@@ -16599,6 +16622,11 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
             cron_tick(verbose=False, adapters=adapters, loop=loop)
         except Exception as e:
             logger.debug("Cron tick error: %s", e)
+
+        # Heartbeat: keep the file fresh so healthcheck.py can detect zombie sessions.
+        # This fires every 60 s so idle gateways (no inbound messages) don't
+        # false-alarm the 5-min staleness check.
+        _touch_heartbeat()
 
         tick_count += 1
 


### PR DESCRIPTION
## Summary

Adds a 3-layer zombie-state detection system to the hermes-agent gateway, closing a detection gap where sandboxed Hermes-N instances could operate in a zombie state indefinitely without triggering health-check failures.

---

## Motivation: The Atlas 9-Hour Zombie Incident

**2026-05-25 ~22:25 UTC** — Atlas (a sandboxed Docker-based Hermes-N instance) entered a zombie Bolt session. The Slack Socket Mode TCP connection remained ESTABLISHED (Slack's WSS keepalive pings maintain the connection), but the Bolt event dispatch loop stopped processing events entirely. Goals received an ACK from the Slack socket layer but no LLM responses were generated.

**2026-05-26 00:05–09:20 UTC** (~9h) — The zombie persisted undetected through the night. At every 30s healthcheck interval, the container reported `HEALTHY: hermes process alive, 1 ESTABLISHED port-443 connection(s)`. The watchdog only acted on `container_status == exited/dead/missing` — never triggered on `health=unhealthy`.

**Root cause of the detection gap (3 layers):**
1. `healthcheck.py` verified socket *existence* (ESTABLISHED TCP), not event *flow*. Slack keepalive keeps the socket warm indefinitely after Bolt dies.
2. `atlas-watchdog.sh` `health=unhealthy` branch was `warn()` + log-only — no restart action.
3. Combined: effective detection window = **unbounded**.

---

## The Fix

Three files, all three required (any two without the third leaves a gap):

### 1. `gateway/run.py` — `_touch_heartbeat()` (this commit)

Adds a module-level `_touch_heartbeat()` function that writes the current Unix timestamp to a heartbeat file (`/tmp/hermes-heartbeat` by default, configurable via `HERMES_HEARTBEAT_FILE` env var). Called from:

- `_handle_message_with_agent()` — on every inbound message
- `_start_cron_ticker()` — every 60s on the cron tick

A live, non-zombie gateway always refreshes this file at least once per cron interval. A zombie gateway stops ticking — the file goes stale.

### 2. `healthcheck.py` — Check 3: heartbeat mtime (deployed to Atlas + template)

Adds `check_heartbeat()`: stats the heartbeat file and fails if mtime is older than `HEALTHCHECK_STALE_SECONDS` (default 300s / 5 min). The 5-min threshold provides comfortable headroom above the 60s cron interval so idle-but-healthy gateways never false-alarm.

```
UNHEALTHY: heartbeat stale — last touch 380s ago (threshold 300s).
Gateway process alive and socket open but Bolt may be in zombie state.
```

Healthy output now includes heartbeat age: `HEALTHY: hermes process alive, 1 ESTABLISHED port-443 connection(s), heartbeat 13s ago`

### 3. `watchdog.sh` — restart-on-unhealthy (deployed to Atlas + template)

Changes the `health=unhealthy` branch from `warn()` (log-only) to `launchctl kickstart`. Closes the detection-to-restart loop:

```
heartbeat stale -> healthcheck exits 1 -> Docker marks unhealthy
    -> watchdog sees health=unhealthy -> kickstart -> clean Bolt session
```

---

## Deployed State

This fix was deployed to a production Atlas instance on 2026-05-26 and verified live:

```
docker ps:    atlas   Up 2 minutes (healthy)   hermes-agent:atlas
healthcheck:  HEALTHY: hermes process alive, 1 ESTABLISHED port-443 connection(s), heartbeat 13s ago
heartbeat:    /tmp/hermes-heartbeat
              T+0:   14:34:31Z (gateway startup)
              T+60:  14:35:31Z (first cron tick)
```

**Detection latency:** ~5 min (was: unbounded).

---

## Notes

- `healthcheck.py` and `watchdog.sh` are instance-specific files (bind-mounted into Docker containers for sandboxed Hermes-N instances). The `hermes-n-template/` bundle copies have been updated to match.
- `HERMES_HEARTBEAT_FILE` env var allows per-instance path override.
- `HEALTHCHECK_STALE_SECONDS` env var allows per-instance threshold override.
- The heartbeat write is wrapped in a bare `except Exception: pass` — it must never crash the gateway.
- This commit only contains the `gateway/run.py` change. `healthcheck.py` and `watchdog.sh` are instance-level files outside this repo.
