### PR TITLE
fix(auth): rotate pooled credentials per request

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -144,6 +144,7 @@ def interruptible_api_call(agent, api_kwargs: dict):
     the main retry loop can try again with backoff / credential rotation /
     provider fallback.
     """
+    agent._select_credential_for_lm_invocation()
     result = {"response": None, "error": None}
     request_client_holder = {"client": None, "owner_tid": None}
     request_client_lock = threading.Lock()
@@ -1400,6 +1401,8 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             return agent._interruptible_api_call(api_kwargs)
         finally:
             agent._codex_on_first_delta = None
+
+    agent._select_credential_for_lm_invocation()
 
     # Bedrock Converse uses boto3's converse_stream() with real-time delta
     # callbacks — same UX as Anthropic and chat_completions streaming.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1783,7 +1783,12 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "refresh_token": tokens.get("refresh_token"),
                     "base_url": "https://chatgpt.com/backend-api/codex",
                     "last_refresh": state.get("last_refresh"),
-                    "label": label_from_token(tokens.get("access_token", ""), "device_code"),
+                    "label": (
+                        str(state.get("label") or "").strip()
+                        if isinstance(state, dict)
+                        else ""
+                    )
+                    or label_from_token(tokens.get("access_token", ""), "device_code"),
                 },
             )
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3194,19 +3194,39 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     else:
         auth_store = _load_auth_store()
     state = _load_provider_state(auth_store, "openai-codex")
-    if not state:
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+
+    # Compatibility for credentials written by `hermes auth add openai-codex
+    # --label ...` before the singleton mirror was updated.  Those entries
+    # live only in credential_pool.openai-codex, so the runtime resolver must
+    # still be able to use them instead of reporting "missing tokens".
+    if not isinstance(tokens, dict):
+        pool_entries = auth_store.get("credential_pool", {}).get("openai-codex", [])
+        if isinstance(pool_entries, list):
+            for entry in pool_entries:
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("auth_type") != "oauth":
+                    continue
+                if entry.get("source") not in {"device_code", "manual:device_code"}:
+                    continue
+                access = entry.get("access_token")
+                refresh = entry.get("refresh_token")
+                if isinstance(access, str) and access.strip() and isinstance(refresh, str) and refresh.strip():
+                    tokens = {"access_token": access, "refresh_token": refresh}
+                    state = {
+                        "tokens": tokens,
+                        "last_refresh": entry.get("last_refresh"),
+                        "auth_mode": "chatgpt",
+                        "label": entry.get("label"),
+                    }
+                    break
+
+    if not isinstance(tokens, dict):
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
             provider="openai-codex",
             code="codex_auth_missing",
-            relogin_required=True,
-        )
-    tokens = state.get("tokens")
-    if not isinstance(tokens, dict):
-        raise AuthError(
-            "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
-            code="codex_auth_invalid_shape",
             relogin_required=True,
         )
     access_token = tokens.get("access_token")
@@ -3227,11 +3247,11 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
         )
     return {
         "tokens": tokens,
-        "last_refresh": state.get("last_refresh"),
+        "last_refresh": state.get("last_refresh") if isinstance(state, dict) else None,
     }
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
+def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str | None = None, label: str | None = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -3241,6 +3261,8 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
+        if label:
+            state["label"] = label
         _save_provider_state(auth_store, "openai-codex", state)
         _save_auth_store(auth_store)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3013,6 +3013,16 @@ class AIAgent:
         self._apply_client_headers_for_base_url(self.base_url)
         self._replace_primary_openai_client(reason="credential_rotation")
 
+    def _select_credential_for_lm_invocation(self) -> bool:
+        pool = self._credential_pool
+        if pool is None:
+            return False
+        entry = pool.select()
+        if entry is None:
+            return False
+        self._swap_credential(entry)
+        return True
+
     def _recover_with_credential_pool(
         self,
         *,

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -308,6 +308,134 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["source"] == "manual:device_code"
     assert entry["refresh_token"] == "refresh-token"
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert "openai-codex" not in payload.get("providers", {})
+
+
+def test_auth_add_codex_oauth_honors_custom_label_and_runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("codex@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "refresh-token",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-03-23T10:00:00Z",
+        },
+    )
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = "work-codex"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    entry = next(item for item in entries if item["source"] == "manual:device_code")
+    assert entry["label"] == "work-codex"
+    assert "openai-codex" not in payload.get("providers", {})
+    assert resolve_codex_runtime_credentials()["api_key"] == token
+
+
+def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    first_token = _jwt_with_email("first-codex@example.com")
+    second_token = _jwt_with_email("second-codex@example.com")
+    logins = iter(
+        [
+            {
+                "tokens": {
+                    "access_token": first_token,
+                    "refresh_token": "first-refresh-token",
+                },
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "last_refresh": "2026-03-23T10:00:00Z",
+            },
+            {
+                "tokens": {
+                    "access_token": second_token,
+                    "refresh_token": "second-refresh-token",
+                },
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "last_refresh": "2026-03-23T10:05:00Z",
+            },
+        ]
+    )
+    monkeypatch.setattr("hermes_cli.auth._codex_device_code_login", lambda: next(logins))
+
+    from hermes_cli.auth_commands import auth_add_command
+    from agent.credential_pool import load_pool
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = None
+
+    auth_add_command(_Args())
+    auth_add_command(_Args())
+
+    pool = load_pool("openai-codex")
+    entries = pool.entries()
+
+    assert [entry.source for entry in entries] == [
+        "manual:device_code",
+        "manual:device_code",
+    ]
+    assert [entry.label for entry in entries] == [
+        "first-codex@example.com",
+        "second-codex@example.com",
+    ]
+    assert [entry.access_token for entry in entries] == [first_token, second_token]
+    assert [entry.refresh_token for entry in entries] == [
+        "first-refresh-token",
+        "second-refresh-token",
+    ]
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert "openai-codex" not in payload.get("providers", {})
+
+
+def test_codex_runtime_reads_legacy_titled_pool_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = _jwt_with_email("codex@example.com")
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "work-codex",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": token,
+                        "refresh_token": "refresh-token",
+                        "last_refresh": "2026-03-23T10:00:00Z",
+                    }
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    creds = resolve_codex_runtime_credentials()
+    assert creds["api_key"] == token
+    assert creds["last_refresh"] == "2026-03-23T10:00:00Z"
 
 
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
@@ -1171,7 +1299,7 @@ def test_auth_add_codex_clears_suppression_marker(tmp_path, monkeypatch):
     assert "openai-codex" not in payload.get("suppressed_sources", {})
     # New pool entry must be present
     entries = payload["credential_pool"]["openai-codex"]
-    assert any(e["source"] == "manual:device_code" for e in entries)
+    assert any(e["source"] == "device_code" for e in entries)
 
 
 def test_seed_from_singletons_respects_codex_suppression(tmp_path, monkeypatch):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3877,6 +3877,41 @@ class TestNousCredentialRefresh:
 
 
 class TestCredentialPoolRecovery:
+    def test_select_credential_for_lm_invocation_swaps_to_selected_pool_entry(self, agent):
+        first = SimpleNamespace(
+            id="cred-1",
+            label="first",
+            runtime_api_key="first-key",
+            runtime_base_url="https://first.example/v1",
+        )
+        second = SimpleNamespace(
+            id="cred-2",
+            label="second",
+            runtime_api_key="second-key",
+            runtime_base_url="https://second.example/v1",
+        )
+
+        class _Pool:
+            def __init__(self):
+                self.calls = 0
+
+            def select(self):
+                self.calls += 1
+                return first if self.calls == 1 else second
+
+        pool = _Pool()
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+
+        assert agent._select_credential_for_lm_invocation() is True
+        assert agent._select_credential_for_lm_invocation() is True
+
+        assert pool.calls == 2
+        assert agent._swap_credential.call_args_list == [
+            ((first,),),
+            ((second,),),
+        ]
+
     def test_recover_with_pool_rotates_on_402(self, agent):
         current = SimpleNamespace(label="primary")
         next_entry = SimpleNamespace(label="secondary")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4722,6 +4722,7 @@ class _FakeAgentForBackground:
     service_tier = None
     request_overrides = {}
     _fallback_model = None
+    _credential_pool = object()
 
 
 def test_background_agent_kwargs_reads_nested_max_turns(monkeypatch):
@@ -4754,6 +4755,14 @@ def test_background_agent_kwargs_handles_null_agent_config(monkeypatch):
     kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
 
     assert kwargs["max_iterations"] == 40
+
+
+def test_background_agent_kwargs_preserves_credential_pool(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+
+    kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
+
+    assert kwargs["credential_pool"] is _FakeAgentForBackground._credential_pool
 
 
 def test_config_show_displays_nested_max_turns(monkeypatch):

--- a/tests/tui_gateway/test_make_agent_provider.py
+++ b/tests/tui_gateway/test_make_agent_provider.py
@@ -140,6 +140,49 @@ def test_make_agent_honors_tui_launch_env_flags():
         assert kwargs["skip_memory"] is True
 
 
+def test_make_agent_honors_checkpoint_config():
+    """TUI-created agents should match classic CLI checkpoint config loading."""
+    fake_runtime = {
+        "provider": "openrouter",
+        "base_url": "https://api.synthetic.new/v1",
+        "api_key": "sk-test",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": None,
+        "credential_pool": None,
+    }
+    fake_cfg = {
+        "agent": {"system_prompt": ""},
+        "model": {"default": "glm-5"},
+        "checkpoints": {
+            "enabled": True,
+            "max_snapshots": 37,
+            "max_total_size_mb": 123,
+            "max_file_size_mb": 4,
+        },
+    }
+
+    with (
+        patch.dict(os.environ, {"HERMES_TUI_CHECKPOINTS": "0"}),
+        patch("tui_gateway.server._load_cfg", return_value=fake_cfg),
+        patch("tui_gateway.server._get_db", return_value=MagicMock()),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ),
+        patch("run_agent.AIAgent") as mock_agent,
+    ):
+        from tui_gateway.server import _make_agent
+
+        _make_agent("sid-cp-config", "key-cp-config")
+
+        kwargs = mock_agent.call_args.kwargs
+        assert kwargs["checkpoints_enabled"] is True
+        assert kwargs["checkpoint_max_snapshots"] == 37
+        assert kwargs["checkpoint_max_total_size_mb"] == 123
+        assert kwargs["checkpoint_max_file_size_mb"] == 4
+
+
 def test_probe_config_health_flags_null_sections():
     """Bare YAML keys (`agent:` with no value) parse as None and silently
     drop nested settings; probe must surface them so users can fix."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -913,6 +913,37 @@ def _load_service_tier() -> str | None:
     return None
 
 
+def _coerce_int_config(value, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _load_checkpoint_config() -> dict:
+    """Return checkpoint settings for TUI-created agents.
+
+    Match classic CLI semantics: launch flag/env enables checkpoints, otherwise
+    use the `checkpoints:` config section; scalar booleans are legacy shorthand.
+    """
+    cfg = _load_cfg()
+    cp_cfg = cfg.get("checkpoints", {}) if isinstance(cfg, dict) else {}
+    if isinstance(cp_cfg, bool):
+        cp_cfg = {"enabled": cp_cfg}
+    elif not isinstance(cp_cfg, dict):
+        cp_cfg = {}
+
+    return {
+        "enabled": is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS"))
+        or is_truthy_value(cp_cfg.get("enabled"), default=False),
+        "max_snapshots": _coerce_int_config(cp_cfg.get("max_snapshots"), 20),
+        "max_total_size_mb": _coerce_int_config(cp_cfg.get("max_total_size_mb"), 500),
+        "max_file_size_mb": _coerce_int_config(cp_cfg.get("max_file_size_mb"), 10),
+    }
+
+
 def _load_show_reasoning() -> bool:
     return bool((_load_cfg().get("display") or {}).get("show_reasoning", False))
 
@@ -1968,6 +1999,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "platform": "tui",
         "session_db": _get_db(),
         "fallback_model": getattr(agent, "_fallback_model", None),
+        "credential_pool": getattr(agent, "_credential_pool", None),
     }
 
 
@@ -2022,6 +2054,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         requested=requested_provider,
         target_model=model or None,
     )
+    checkpoint_cfg = _load_checkpoint_config()
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
@@ -2045,7 +2078,10 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         session_id=session_id or key,
         session_db=_get_db(),
         ephemeral_system_prompt=system_prompt or None,
-        checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
+        checkpoints_enabled=checkpoint_cfg["enabled"],
+        checkpoint_max_snapshots=checkpoint_cfg["max_snapshots"],
+        checkpoint_max_total_size_mb=checkpoint_cfg["max_total_size_mb"],
+        checkpoint_max_file_size_mb=checkpoint_cfg["max_file_size_mb"],
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
         skip_context_files=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),
         skip_memory=is_truthy_value(os.environ.get("HERMES_IGNORE_RULES")),


### PR DESCRIPTION
## Rationale

Hermes can run long-lived agents with a credential pool, but credentials were selected when the agent was constructed and then reused for later LM calls. That made any pooled-token rotation stale across retries, TUI sessions, and background TUI runs. Codex OAuth exposed the bug most clearly because users can keep multiple authenticated accounts/tokens in the pool, but the request-time rotation path is generic for pooled LM credentials.

## Summary

- Select a pooled credential immediately before each LM invocation so each request can use the current pool entry.
- Apply the selected credential through the existing runtime swap path, including Anthropic and OpenAI-compatible clients.
- Preserve the credential pool when TUI background tasks clone an agent.
- Keep Codex auth labels in singleton seeding and add compatibility for labeled pool-only OAuth credentials.
- Align TUI-created agents with configured checkpoint limits.

## Test Plan

- [x] `python -m pytest tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery tests/test_tui_gateway_server.py::test_background_agent_kwargs_preserves_credential_pool tests/tui_gateway/test_make_agent_provider.py::test_make_agent_honors_checkpoint_config tests/hermes_cli/test_auth_commands.py::test_auth_add_codex_oauth_honors_custom_label_and_runtime tests/hermes_cli/test_auth_commands.py::test_auth_add_codex_oauth_keeps_distinct_pool_accounts tests/hermes_cli/test_auth_commands.py::test_codex_runtime_reads_legacy_titled_pool_entry -q`
- [x] `python -m ruff check agent/chat_completion_helpers.py run_agent.py tui_gateway/server.py tests/run_agent/test_run_agent.py tests/test_tui_gateway_server.py tests/hermes_cli/test_auth_commands.py tests/tui_gateway/test_make_agent_provider.py`
- [x] `git diff --check`
