### PR TITLE
fix(gateway): match uppercase media extensions in MEDIA: pattern

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2412,8 +2412,10 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        # IGNORECASE so uppercase extensions (.JPG, .MP4, ...) are matched too.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?''',
+            re.IGNORECASE,
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -361,6 +361,30 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    def test_media_tag_matches_uppercase_extension(self):
+        """Regression: MEDIA: paths with uppercase extensions (e.g. .JPG from
+        a 表情包 folder) must be extracted just like lowercase. Without
+        re.IGNORECASE on media_pattern, the entire MEDIA:... token leaks
+        through as plain text to the user."""
+        content = "MEDIA:/Users/zhangjinshi/biaoqingbao/cat/IMG_0001.JPG"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/Users/zhangjinshi/biaoqingbao/cat/IMG_0001.JPG", False)]
+        assert "MEDIA:" not in cleaned
+
+    def test_media_tag_matches_mixed_case_extensions(self):
+        """Cover the common cases: .JPG, .PNG, .MP4, .Jpeg — all should
+        extract and be stripped from cleaned text."""
+        content = (
+            "MEDIA:/a/b.PNG\n"
+            "MEDIA:/a/c.JPG\n"
+            "MEDIA:/a/d.Jpeg\n"
+            "MEDIA:/a/e.MP4"
+        )
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        paths = [p for p, _ in media]
+        assert paths == ["/a/b.PNG", "/a/c.JPG", "/a/d.Jpeg", "/a/e.MP4"]
+        assert "MEDIA:" not in cleaned
+
 
 class TestMediaDeliveryPathValidation:
     def _patch_roots(self, monkeypatch, *roots):


### PR DESCRIPTION
## Summary

The `MEDIA:<path>` regex in `BasePlatformAdapter.extract_media` (`gateway/platforms/base.py`) hardcodes lowercase file extensions (`png|jpe?g|gif|webp|mp4|...`) and is compiled **without** `re.IGNORECASE`. As a result, any path the agent emits with an uppercase extension — common for camera-style filenames like `IMG_0001.JPG` — silently bypasses the MEDIA extraction path and gets shipped to the user as plain text instead of being delivered as a native media attachment.

In practice this affects anyone whose media library was sourced from a smartphone or DSLR (which routinely produce `.JPG` / `.MP4` / `.MOV`), or whose OS / file picker preserves uppercase suffixes.

## Reproduction

Before this fix:

```python
import re
pattern = re.compile(
    r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
)
assert pattern.search('MEDIA:/photos/IMG_0001.jpg')   # OK
assert pattern.search('MEDIA:/photos/IMG_0001.JPG')   # AssertionError — None
```

End-to-end symptom: the user receives the literal string `MEDIA:/photos/IMG_0001.JPG` in their chat instead of the photo.

## Fix

Add `re.IGNORECASE` to `media_pattern`. The regex body itself is unchanged.

`extract_local_files`'s bare-path matcher already uses `re.IGNORECASE`, so no change is needed there — only the explicit `MEDIA:` tag path was affected.

## Tests

Adds two regression tests to `tests/gateway/test_platform_base.py`:

1. `test_extract_media_uppercase_jpg_extension` — single uppercase extension (`IMG_0001.JPG`).
2. `test_extract_media_mixed_case_extensions` — `.PNG`, `.JPG`, `.Jpeg`, `.MP4` mixed in one response.

Both fail without the flag and pass with it.

```
$ pytest tests/gateway/test_platform_base.py -q
103 passed, 2 skipped
```

## Relationship to #29620

PR #29620 also incidentally adds `re.IGNORECASE` (alongside a character-class reorder). Its stated motivation — that `\]` inside the lookahead character class prematurely terminates the class — does not actually reproduce; the original character class compiles and matches `MEDIA:/tmp/test.png)` / `]` / `}` correctly. The real bug being fixed there is the missing `re.IGNORECASE`, which is what this PR isolates with a minimal diff and dedicated regression tests. Happy to defer to #29620 if reviewers prefer that branch.
