### PR TITLE
fix(tools): remove shell=True from local STT command execution

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -403,12 +403,12 @@ class TestTranscribeLocalCommand:
             return _TempDir()
 
         def fake_run(cmd, *args, **kwargs):
-            if isinstance(cmd, list):
-                output_path = cmd[-1]
-                with open(output_path, "wb") as handle:
-                    handle.write(b"RIFF....WAVEfmt ")
-                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
+            # PR #32694: command is always passed as a list (no shell=True).
+            # The fake must therefore handle the list form and write a transcript
+            # file directly so the post-run glob can find it.
+            assert isinstance(cmd, list), (
+                f"subprocess.run should be called with a list (no shell=True); got {type(cmd).__name__}"
+            )
             (out_dir / "test.txt").write_text("hello from local command\n", encoding="utf-8")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1203,12 +1203,16 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 language=shlex.quote(language),
                 model=shlex.quote(normalized_model),
             )
-            # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.
-            use_shell = bool(os.getenv(LOCAL_STT_COMMAND_ENV, "").strip())
-            if use_shell:
-                subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
-            else:
-                subprocess.run(shlex.split(command), check=True, capture_output=True, text=True)
+            # Always parse as a list to prevent shell injection.
+            # shlex.split treats the entire template as literal arguments —
+            # no shell metacharacters (;, |, &&, $, ``) are interpreted.
+            # Individual placeholders are already protected by shlex.quote().
+            subprocess.run(
+                shlex.split(command),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
             
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))


### PR DESCRIPTION
## Summary

Shell command injection risk in the local STT (speech-to-text) transcription escape hatch. User-controlled input was interpolated into a shell command via `shell=True`.

## What Was Fixed

Removed `shell=True` from the STT subprocess call. Input is now passed as arguments to the subprocess directly, preventing any shell injection.