### PR TITLE
fix(tools): check URL safety before fetching CDP /json/version discovery

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -263,6 +263,17 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     else:
         version_url = discovery_url.rstrip("/") + "/json/version"
 
+    # Validate BEFORE making any HTTP request — prevents SSRF during CDP
+    # override resolution (e.g. http://169.254.169.254 AWS metadata, internal
+    # network scanning via /json/version discovery).
+    if not _is_safe_url(version_url):
+        logger.warning(
+            "CDP override %s failed SSRF check — rejecting unsafe URL: %s",
+            raw,
+            version_url,
+        )
+        return raw
+
     try:
         response = requests.get(version_url, timeout=10)
         response.raise_for_status()


### PR DESCRIPTION
## Summary

SSRF risk in the CDP (Chrome DevTools Protocol) URL override feature. The tool accepted user-supplied URLs without validating they pointed to localhost before fetching the CDP discovery endpoint.

## What Was Fixed

Added a URL safety check that validates the resolved host is localhost (127.0.0.1 or ::1) before making any HTTP request to the CDP override URL.