### PR TITLE
fix(gateway): require explicit admin policy for slash command gating

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9451,7 +9451,7 @@ class GatewayRunner:
         if not canonical_cmd:
             return None
         policy = _policy_for_source(self.config, source)
-        if not policy.enabled or policy.can_run(source.user_id, canonical_cmd):
+        if policy.can_run(source.user_id, canonical_cmd):
             return None
         logger.info(
             "Slash command /%s denied for %s:%s (not admin, not in user_allowed_commands)",


### PR DESCRIPTION
## Summary

Slash command gating was incorrectly allowing all commands when no admin list was configured in gateway.yaml. This was a security bypass — the intent was to require explicit configuration.

## What Was Fixed

Gateway slash commands (stop, reset, model, etc.) now require an explicit admin policy to be configured. When no admin list is present, commands are denied with a clear error rather than silently allowing all.