### PR TITLE
fix: detect zombie processes in acquire_scoped_lock + allow macOS temp dir in path guard

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -649,7 +649,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                             for _line in _proc_status.read_text(encoding="utf-8").splitlines():
                                 if _line.startswith("State:"):
                                     _state = _line.split()[1]
-                                    if _state in {"T", "t"}:  # stopped or tracing stop
+                                    if _state in {"T", "t", "Z", "z"}:  # stopped, tracing stop, or zombie
                                         stale = True
                                     break
                     except (OSError, PermissionError):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -551,6 +551,40 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_replaces_zombie_process_record(self, tmp_path, monkeypatch):
+        """Zombie process (State: Z) should be treated as stale — os.kill(pid,0)
+        succeeds against zombies but the process is dead."""
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        # Process exists (os.kill succeeds) and start_time matches — looks alive
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+
+        # But /proc/{pid}/status reports zombie state
+        class _FakeProcStatus:
+            def exists(self):
+                return True
+            def read_text(self):
+                return "Name:  hermes\nState:  Z (zombie)\nPid:    99999\n"
+        def _fake_path(path_str):
+            if path_str == f"/proc/99999/status":
+                return _FakeProcStatus()
+            return Path(path_str)
+        monkeypatch.setattr(status, "Path", _fake_path)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
     def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
         """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -98,6 +98,11 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/db/something") is not None
 
+    def test_private_var_folders_temp_allowed(self):
+        """macOS user temp dir (/private/var/folders/...) is safe — not a system path."""
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path("/private/var/folders/5h/g4d49xh94rsgstv3hzbm09t00000gp/T/test.txt") is None
+
     def test_boot_still_blocked(self):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/boot/grub/grub.cfg") is not None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -154,6 +154,13 @@ _SENSITIVE_PATH_PREFIXES = (
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
+# Known-safe temporary directory prefixes that are exempt from sensitive-path
+# blocking.  macOS temp dirs live under /private/var/folders/ (the per-user
+# TMPDIR), which would otherwise be caught by the /private/var/ prefix guard.
+_SAFE_TEMP_PREFIXES = (
+    "/private/var/folders/",  # macOS user temp directory
+)
+
 
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
@@ -166,6 +173,10 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    # Allow known-safe temporary directories (e.g. macOS /private/var/folders/)
+    for safe_prefix in _SAFE_TEMP_PREFIXES:
+        if resolved.startswith(safe_prefix) or normalized.startswith(safe_prefix):
+            return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err


### PR DESCRIPTION
Two small fixes:

1. Zombie process detection in acquire_scoped_lock (#32661)
   Zombie processes (State: Z) respond to os.kill(pid, 0) but are dead.
   Added Z/z to /proc state check alongside existing T/t for stopped processes.

2. macOS temp dir blocked by path guard (#32681)
   /private/var/folders/ was caught by the /private/var/ prefix guard.
   Added _SAFE_TEMP_PREFIXES allowlist.

---

Changes:
- gateway/status.py: detect zombie state in /proc check (+1 line)
- tools/file_tools.py: _SAFE_TEMP_PREFIXES + check in _check_sensitive_path (+11 lines)
- tests/gateway/test_status.py: test_acquire_scoped_lock_replaces_zombie_process_record (+34 lines)
- tests/tools/test_file_write_safety.py: test_private_var_folders_temp_allowed (+5 lines)