### PR TITLE
Feat/tavily search params

### DIFF
--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -162,7 +162,7 @@ class TavilyWebSearchProvider(WebSearchProvider):
     def supports_crawl(self) -> bool:
         return True
 
-    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+    def search(self, query: str, limit: int = 5, **kwargs: Any) -> Dict[str, Any]:
         """Execute a Tavily search."""
         try:
             from tools.interrupt import is_interrupted
@@ -170,14 +170,30 @@ class TavilyWebSearchProvider(WebSearchProvider):
             if is_interrupted():
                 return {"success": False, "error": "Interrupted"}
 
+            search_depth = str(kwargs.get("search_depth") or "advanced").strip().lower()
+            if search_depth not in {"basic", "advanced"}:
+                search_depth = "advanced"
+
+            try:
+                chunks_per_source = int(kwargs.get("chunks_per_source", 5))
+            except (TypeError, ValueError):
+                chunks_per_source = 5
+            chunks_per_source = min(max(chunks_per_source, 1), 5)
+
+            include_images = bool(kwargs.get("include_images", True))
+            include_image_descriptions = bool(kwargs.get("include_image_descriptions", True))
+
             logger.info("Tavily search: '%s' (limit=%d)", query, limit)
             raw = _tavily_request(
                 "search",
                 {
                     "query": query,
+                    "search_depth": search_depth,
+                    "chunks_per_source": chunks_per_source,
                     "max_results": min(limit, 20),
                     "include_raw_content": False,
-                    "include_images": False,
+                    "include_images": include_images,
+                    "include_image_descriptions": include_image_descriptions,
                 },
             )
             return _normalize_tavily_search_results(raw)

--- a/plugins/web/tavily/provider.py
+++ b/plugins/web/tavily/provider.py
@@ -175,9 +175,9 @@ class TavilyWebSearchProvider(WebSearchProvider):
                 search_depth = "advanced"
 
             try:
-                chunks_per_source = int(kwargs.get("chunks_per_source", 5))
+                chunks_per_source = int(kwargs.get("chunks_per_source", 3))
             except (TypeError, ValueError):
-                chunks_per_source = 5
+                chunks_per_source = 3
             chunks_per_source = min(max(chunks_per_source, 1), 5)
 
             include_images = bool(kwargs.get("include_images", True))

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -451,28 +451,69 @@ class TestParallelClientConfig:
 class TestWebSearchSchema:
     """Test suite for web_search tool schema and handler wiring."""
 
-    def test_schema_exposes_optional_limit(self):
+    def test_schema_exposes_only_tavily_search_options(self):
         import tools.web_tools
 
-        limit_schema = tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["properties"]["limit"]
+        props = tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["properties"]
 
-        assert limit_schema["type"] == "integer"
-        assert limit_schema["minimum"] == 1
-        assert limit_schema["maximum"] == 100
-        assert limit_schema["default"] == 5
-        assert "limit" not in tools.web_tools.WEB_SEARCH_SCHEMA["parameters"]["required"]
+        assert set(props) == {
+            "query",
+            "search_depth",
+            "chunks_per_source",
+            "max_results",
+            "include_images",
+            "include_image_descriptions",
+        }
+        assert props["search_depth"]["default"] == "advanced"
+        assert props["chunks_per_source"]["default"] == 5
+        assert props["max_results"]["default"] == 10
+        assert props["include_images"]["default"] is True
+        assert props["include_image_descriptions"]["default"] is True
 
-    def test_registered_handler_passes_limit(self):
+    def test_registered_handler_passes_tavily_search_options(self):
         import tools.web_tools
 
         entry = tools.web_tools.registry.get_entry("web_search")
         with patch("tools.web_tools.web_search_tool", return_value='{"success": true}') as mock_search:
-            result = entry.handler({"query": "site:example.com docs", "limit": 12})
+            result = entry.handler(
+                {
+                    "query": "site:example.com docs",
+                    "search_depth": "advanced",
+                    "chunks_per_source": 5,
+                    "max_results": 10,
+                    "include_images": True,
+                    "include_image_descriptions": True,
+                }
+            )
 
         assert result == '{"success": true}'
-        mock_search.assert_called_once_with("site:example.com docs", limit=12)
+        mock_search.assert_called_once_with(
+            "site:example.com docs",
+            max_results=10,
+            search_depth="advanced",
+            chunks_per_source=5,
+            include_images=True,
+            include_image_descriptions=True,
+        )
 
-    def test_registered_handler_defaults_limit_to_five(self):
+    def test_registered_handler_accepts_legacy_limit_alias(self):
+        import tools.web_tools
+
+        entry = tools.web_tools.registry.get_entry("web_search")
+        with patch("tools.web_tools.web_search_tool", return_value='{"success": true}') as mock_search:
+            result = entry.handler({"query": "docs", "limit": 7})
+
+        assert result == '{"success": true}'
+        mock_search.assert_called_once_with(
+            "docs",
+            max_results=7,
+            search_depth="advanced",
+            chunks_per_source=5,
+            include_images=True,
+            include_image_descriptions=True,
+        )
+
+    def test_registered_handler_defaults_to_requested_tavily_values(self):
         import tools.web_tools
 
         entry = tools.web_tools.registry.get_entry("web_search")
@@ -480,7 +521,14 @@ class TestWebSearchSchema:
             result = entry.handler({"query": "docs"})
 
         assert result == '{"success": true}'
-        mock_search.assert_called_once_with("docs", limit=5)
+        mock_search.assert_called_once_with(
+            "docs",
+            max_results=10,
+            search_depth="advanced",
+            chunks_per_source=5,
+            include_images=True,
+            include_image_descriptions=True,
+        )
 
     def test_web_search_clamps_limit_before_backend_call(self):
         import tools.web_tools

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -465,8 +465,8 @@ class TestWebSearchSchema:
             "include_image_descriptions",
         }
         assert props["search_depth"]["default"] == "advanced"
-        assert props["chunks_per_source"]["default"] == 5
-        assert props["max_results"]["default"] == 10
+        assert props["chunks_per_source"]["default"] == 3
+        assert props["max_results"]["default"] == 5
         assert props["include_images"]["default"] is True
         assert props["include_image_descriptions"]["default"] is True
 
@@ -479,7 +479,7 @@ class TestWebSearchSchema:
                 {
                     "query": "site:example.com docs",
                     "search_depth": "advanced",
-                    "chunks_per_source": 5,
+                    "chunks_per_source": 3,
                     "max_results": 10,
                     "include_images": True,
                     "include_image_descriptions": True,
@@ -491,7 +491,7 @@ class TestWebSearchSchema:
             "site:example.com docs",
             max_results=10,
             search_depth="advanced",
-            chunks_per_source=5,
+            chunks_per_source=3,
             include_images=True,
             include_image_descriptions=True,
         )
@@ -508,7 +508,7 @@ class TestWebSearchSchema:
             "docs",
             max_results=7,
             search_depth="advanced",
-            chunks_per_source=5,
+            chunks_per_source=3,
             include_images=True,
             include_image_descriptions=True,
         )
@@ -523,9 +523,9 @@ class TestWebSearchSchema:
         assert result == '{"success": true}'
         mock_search.assert_called_once_with(
             "docs",
-            max_results=10,
+            max_results=5,
             search_depth="advanced",
-            chunks_per_source=5,
+            chunks_per_source=3,
             include_images=True,
             include_image_descriptions=True,
         )

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -183,13 +183,28 @@ class TestWebSearchTavily:
 
         with patch("tools.web_tools._get_backend", return_value="tavily"), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}), \
-             patch("tools.web_tools.httpx.post", return_value=mock_response), \
+             patch("tools.web_tools.httpx.post", return_value=mock_response) as mock_post, \
              patch("tools.interrupt.is_interrupted", return_value=False):
             from tools.web_tools import web_search_tool
-            result = json.loads(web_search_tool("test query", limit=3))
+            result = json.loads(
+                web_search_tool(
+                    "test query",
+                    max_results=10,
+                    search_depth="advanced",
+                    chunks_per_source=5,
+                    include_images=True,
+                    include_image_descriptions=True,
+                )
+            )
             assert result["success"] is True
             assert len(result["data"]["web"]) == 1
             assert result["data"]["web"][0]["title"] == "Result"
+            payload = mock_post.call_args.kwargs["json"]
+            assert payload["search_depth"] == "advanced"
+            assert payload["chunks_per_source"] == 5
+            assert payload["max_results"] == 10
+            assert payload["include_images"] is True
+            assert payload["include_image_descriptions"] is True
 
 
 # ─── web_extract_tool (Tavily dispatch) ───────────────────────────────────────

--- a/tests/tools/test_web_tools_tavily.py
+++ b/tests/tools/test_web_tools_tavily.py
@@ -191,7 +191,7 @@ class TestWebSearchTavily:
                     "test query",
                     max_results=10,
                     search_depth="advanced",
-                    chunks_per_source=5,
+                    chunks_per_source=3,
                     include_images=True,
                     include_image_descriptions=True,
                 )
@@ -201,7 +201,7 @@ class TestWebSearchTavily:
             assert result["data"]["web"][0]["title"] == "Result"
             payload = mock_post.call_args.kwargs["json"]
             assert payload["search_depth"] == "advanced"
-            assert payload["chunks_per_source"] == 5
+            assert payload["chunks_per_source"] == 3
             assert payload["max_results"] == 10
             assert payload["include_images"] is True
             assert payload["include_image_descriptions"] is True

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -184,9 +184,9 @@ def check_sandbox_requirements() -> bool:
 _TOOL_STUBS = {
     "web_search": (
         "web_search",
-        "query: str, limit: int = 5",
+        'query: str, search_depth: str = "advanced", chunks_per_source: int = 3, max_results: int = 5, include_images: bool = True, include_image_descriptions: bool = True',
         '"""Search the web. Returns dict with data.web list of {url, title, description}."""',
-        '{"query": query, "limit": limit}',
+        '{"query": query, "search_depth": search_depth, "chunks_per_source": chunks_per_source, "max_results": max_results, "include_images": include_images, "include_image_descriptions": include_image_descriptions}',
     ),
     "web_extract": (
         "web_extract",
@@ -1649,8 +1649,8 @@ def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
 # Ordered to match the canonical display order.
 _TOOL_DOC_LINES = [
     ("web_search",
-     "  web_search(query: str, limit: int = 5) -> dict\n"
-     "    Returns {\"data\": {\"web\": [{\"url\", \"title\", \"description\"}, ...]}}"),
+     '  web_search(query: str, search_depth: str = "advanced", chunks_per_source: int = 3, max_results: int = 5, include_images: bool = True, include_image_descriptions: bool = True) -> dict\n'
+     '    Returns {"data": {"web": [{"url", "title", "description"}, ...]}}'),
     ("web_extract",
      "  web_extract(urls: list[str]) -> dict\n"
      "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown"),

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -743,50 +743,38 @@ def clean_base64_images(text: str) -> str:
 # dispatchers in this file resolve them via get_active_*_provider().
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+def web_search_tool(
+    query: str,
+    limit: int = 5,
+    max_results: Optional[int] = None,
+    search_depth: str = "advanced",
+    chunks_per_source: int = 5,
+    include_images: bool = True,
+    include_image_descriptions: bool = True,
+) -> str:
     """
-    Search the web for information using available search API backend.
+    Search the web for information using the configured search backend.
 
-    This function provides a generic interface for web search that can work
-    with multiple backends (Parallel or Firecrawl).
-
-    Note: This function returns search result metadata only (URLs, titles, descriptions).
-    Use web_extract_tool to get full content from specific URLs.
-    
-    Args:
-        query (str): The search query to look up
-        limit (int): Maximum number of results to return (default: 5)
-    
-    Returns:
-        str: JSON string containing search results with the following structure:
-             {
-                 "success": bool,
-                 "data": {
-                     "web": [
-                         {
-                             "title": str,
-                             "url": str,
-                             "description": str,
-                             "position": int
-                         },
-                         ...
-                     ]
-                 }
-             }
-    
-    Raises:
-        Exception: If search fails or API key is not set
+    Note: This function returns search result metadata only (URLs, titles,
+    descriptions). Use web_extract_tool to get full content from specific URLs.
+    Tavily-specific search options are forwarded only when Tavily is the active
+    backend; other providers ignore them.
     """
+    effective_max_results = max_results if max_results is not None else limit
     try:
-        limit = int(limit)
+        effective_max_results = int(effective_max_results)
     except (TypeError, ValueError):
-        limit = 5
-    limit = min(max(limit, 1), 100)
+        effective_max_results = 10 if max_results is not None else 5
+    effective_max_results = min(max(effective_max_results, 1), 100)
 
     debug_call_data = {
         "parameters": {
             "query": query,
-            "limit": limit
+            "max_results": effective_max_results,
+            "search_depth": search_depth,
+            "chunks_per_source": chunks_per_source,
+            "include_images": include_images,
+            "include_image_descriptions": include_image_descriptions,
         },
         "error": None,
         "results_count": 0,
@@ -826,10 +814,20 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             }
         else:
             logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
+                "Web search via %s: '%s' (max_results: %d)",
+                provider.name, query, effective_max_results,
             )
-            response_data = provider.search(query, limit)
+            if provider.name == "tavily":
+                response_data = provider.search(
+                    query,
+                    effective_max_results,
+                    search_depth=search_depth,
+                    chunks_per_source=chunks_per_source,
+                    include_images=include_images,
+                    include_image_descriptions=include_image_descriptions,
+                )
+            else:
+                response_data = provider.search(query, effective_max_results)
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -1500,7 +1498,7 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": "Search the web for information. Returns up to 10 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1508,12 +1506,35 @@ WEB_SEARCH_SCHEMA = {
                 "type": "string",
                 "description": "The search query to look up on the web. You may include backend-supported operators such as site:example.com, filetype:pdf, intitle:word, -term, or \"exact phrase\"."
             },
-            "limit": {
+            "search_depth": {
+                "type": "string",
+                "description": "Search depth for Tavily-backed web search.",
+                "enum": ["basic", "advanced"],
+                "default": "advanced"
+            },
+            "chunks_per_source": {
                 "type": "integer",
-                "description": "Maximum number of results to return. Defaults to 5.",
+                "description": "Maximum Tavily chunks to return per source.",
                 "minimum": 1,
-                "maximum": 100,
+                "maximum": 5,
                 "default": 5
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum number of results to return. Defaults to 10.",
+                "minimum": 1,
+                "maximum": 20,
+                "default": 10
+            },
+            "include_images": {
+                "type": "boolean",
+                "description": "Whether to include result images when supported.",
+                "default": True
+            },
+            "include_image_descriptions": {
+                "type": "boolean",
+                "description": "Whether to include descriptions for returned images when supported.",
+                "default": True
             }
         },
         "required": ["query"]
@@ -1541,7 +1562,14 @@ registry.register(
     name="web_search",
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
+    handler=lambda args, **kw: web_search_tool(
+        args.get("query", ""),
+        max_results=args.get("max_results", args.get("limit", 10)),
+        search_depth=args.get("search_depth", "advanced"),
+        chunks_per_source=args.get("chunks_per_source", 5),
+        include_images=args.get("include_images", True),
+        include_image_descriptions=args.get("include_image_descriptions", True),
+    ),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -748,7 +748,7 @@ def web_search_tool(
     limit: int = 5,
     max_results: Optional[int] = None,
     search_depth: str = "advanced",
-    chunks_per_source: int = 5,
+    chunks_per_source: int = 3,
     include_images: bool = True,
     include_image_descriptions: bool = True,
 ) -> str:
@@ -764,7 +764,7 @@ def web_search_tool(
     try:
         effective_max_results = int(effective_max_results)
     except (TypeError, ValueError):
-        effective_max_results = 10 if max_results is not None else 5
+        effective_max_results = 5
     effective_max_results = min(max(effective_max_results, 1), 100)
 
     debug_call_data = {
@@ -1498,7 +1498,7 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 10 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1517,14 +1517,14 @@ WEB_SEARCH_SCHEMA = {
                 "description": "Maximum Tavily chunks to return per source.",
                 "minimum": 1,
                 "maximum": 5,
-                "default": 5
+                "default": 3
             },
             "max_results": {
                 "type": "integer",
-                "description": "Maximum number of results to return. Defaults to 10.",
+                "description": "Maximum number of results to return. Defaults to 5.",
                 "minimum": 1,
-                "maximum": 20,
-                "default": 10
+                "maximum": 100,
+                "default": 5
             },
             "include_images": {
                 "type": "boolean",
@@ -1564,9 +1564,9 @@ registry.register(
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(
         args.get("query", ""),
-        max_results=args.get("max_results", args.get("limit", 10)),
+        max_results=args.get("max_results", args.get("limit", 5)),
         search_depth=args.get("search_depth", "advanced"),
-        chunks_per_source=args.get("chunks_per_source", 5),
+        chunks_per_source=args.get("chunks_per_source", 3),
         include_images=args.get("include_images", True),
         include_image_descriptions=args.get("include_image_descriptions", True),
     ),


### PR DESCRIPTION
What does this PR do?                                                                                                                                        
                                                                                                                                                              
 Exposes a small, Tavily-specific subset of web_search parameters to the agent while keeping the change surface minimal and preserving backward compatibility 
 for legacy internal callers.                                                                                                                                 
                                                                                                                                                              
 Previously, Hermes’s generic web_search tool only exposed query and limit, and the Tavily provider hardcoded search behavior internally. This PR makes the   
 following Tavily search options configurable through the web_search tool schema:                                                                             
                                                                                                                                                              
 - search_depth with default advanced                                                                                                                         
 - chunks_per_source with default 3                                                                                                                           
 - max_results with the original generic search behavior preserved:                                                                                           
     - default 5                                                                                                                                              
     - range 1..100                                                                                                                                           
 - include_images with default true                                                                                                                           
 - include_image_descriptions with default true                                                                                                               
                                                                                                                                                              
 No other Tavily parameters are exposed.                                                                                                                      
                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                           
                                                                                                                                                              
 Type of Change                                                                                                                                               
                                                                                                                                                              
 - 🐛 Bug fix (non-breaking change that fixes an issue)                                                                                                       
 - ✨ New feature (non-breaking change that adds functionality)                                                                                               
 - 🔒 Security fix                                                                                                                                            
 - 📝 Documentation update                                                                                                                                    
 - ✅ Tests (adding or improving test coverage)                                                                                                               
 - ♻️ Refactor (no behavior change)                                                                                                                           
 - 🎯 New skill (bundled or hub)                                                                                                                              
                                                                                                                                                              
 Changes Made                                                                                                                                                 
                                                                                                                                                              
 - Updated tools/web_tools.py                                                                                                                                 
     - Expanded WEB_SEARCH_SCHEMA to expose only:                                                                                                             
           - query                                                                                                                                            
           - search_depth                                                                                                                                     
           - chunks_per_source                                                                                                                                
           - max_results                                                                                                                                      
           - include_images                                                                                                                                   
           - include_image_descriptions                                                                                                                       
     - Preserved generic search semantics for max_results:                                                                                                    
           - default 5                                                                                                                                        
           - range 1..100                                                                                                                                     
     - Set default chunks_per_source to 3                                                                                                                     
     - Updated the web_search handler to pass these options through to web_search_tool(...)                                                                   
     - Added legacy alias handling so limit maps to max_results internally when present                                                                       
     - Forwarded the extra parameters only when the active provider is tavily                                                                                 
 - Updated plugins/web/tavily/provider.py                                                                                                                     
     - Extended TavilyWebSearchProvider.search(...) to accept kwargs for:                                                                                     
           - search_depth                                                                                                                                     
           - chunks_per_source                                                                                                                                
           - include_images                                                                                                                                   
           - include_image_descriptions                                                                                                                       
     - Added those fields to the Tavily /search payload                                                                                                       
     - Set the Tavily-side default for chunks_per_source to 3                                                                                                 
     - Kept existing normalization and error handling unchanged                                                                                               
 - Updated tests/tools/test_web_tools_tavily.py                                                                                                               
     - Added assertions that the Tavily search payload includes:                                                                                              
           - search_depth=advanced                                                                                                                            
           - chunks_per_source=3                                                                                                                              
           - include_images=true                                                                                                                              
           - include_image_descriptions=true                                                                                                                  
 - Updated tests/tools/test_web_tools_config.py                                                                                                               
     - Replaced schema assertions for legacy limit with assertions for the new Tavily-specific exposed parameters                                             
     - Verified max_results keeps the generic default/range behavior                                                                                          
     - Updated handler wiring tests to validate the new arguments                                                                                             
     - Added coverage for legacy limit aliasing to max_results                                                                                                
                                                                                                                                                              
 How to Test                                                                                                                                                  
                                                                                                                                                              
 1. Create and activate a virtualenv, then install Hermes from the repo root:                                                                                 
   ```bash                                                                                                                                                    
     python3 -m venv .venv                                                                                                                                    
     source .venv/bin/activate                                                                                                                                
     python -m pip install -U pip                                                                                                                             
     pip install -e .                                                                                                                                         
   ```                                                                                                                                                        
 2. Set a Tavily key and ensure Tavily is selected as the web backend:                                                                                        
   ```bash                                                                                                                                                    
     export TAVILY_API_KEY=your_key_here                                                                                                                      
     python -m hermes_cli.main tools                                                                                                                          
   ```                                                                                                                                                        
 3. Run the targeted tests:                                                                                                                                   
   ```bash                                                                                                                                                    
     scripts/run_tests.sh tests/tools/test_web_tools_tavily.py -q                                                                                             
     scripts/run_tests.sh tests/tools/test_web_tools_config.py -q                                                                                             
   ```                                                                                                                                                        
 4. Verify end-to-end behavior through Hermes with a one-shot prompt:                                                                                         
   ```bash                                                                                                                                                    
     python -m hermes_cli.main chat -v -q 'Search the web for python asyncio tutorial and summarize the results.'                                             
   ```                                                                                                                                                        
 5. Optionally verify explicit parameter usage through Hermes:                                                                                                
   ```bash                                                                                                                                                    
     python -m hermes_cli.main chat -v -q 'Call web_search with query="python asyncio tutorial", search_depth="advanced", chunks_per_source=3, max_results=5, 
 include_images=true, include_image_descriptions=true. Then summarize the results.'                                                                           
   ```                                                                                                                                                        
                                                                                                                                                              
 Checklist                                                                                                                                                    
                                                                                                                                                              
 ### Code                                                                                                                                                     
                                                                                                                                                              
 - I've read the Contributing Guide                                                                                                                           
 - My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)                                                                           
 - I searched for existing PRs to make sure this isn't a duplicate                                                                                            
 - My PR contains only changes related to this fix/feature (no unrelated commits)                                                                             
 - I've run pytest tests/ -q and all tests pass                                                                                                               
 - I've added tests for my changes (required for bug fixes, strongly encouraged for features)                                                                 
 - I've tested on my platform: macOS                                                                                                                          
                                                                                                                                                              
 ### Documentation & Housekeeping                                                                                                                             
                                                                                                                                                              
 - I've updated relevant documentation (README, docs/, docstrings) — or N/A                                                                                   
 - I've updated cli-config.yaml.example if I added/changed config keys — or N/A                                                                               
 - I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A                                                                  
 - I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A                                                                
 - I've updated tool descriptions/schemas if I changed tool behavior — or N/A                                                                                 
                                                                                                                                                              
 Screenshots / Logs                                                                                                                                           
                                                                                                                                                              
 N/A                                                                       