### PR TITLE
fix(core): pre-compile regex patterns across 5 files for performance

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -438,6 +438,36 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
 
 
 
+# Pre-compiled regexes for strip_think_blocks — built once at import time.
+# Merged into two patterns: one for thinking-tag variants, one for tool-call blocks.
+_STRIP_THINK_BLOCKS_THINK_PATTERNS = re.compile(
+    r'<think>.*?</think>|'
+    r'<thinking>.*?</thinking>|'
+    r'<reasoning>.*?</reasoning>|'
+    r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>|'
+    r'<thought>.*?</thought>|'
+    # Unterminated reasoning block — open tag at a block boundary
+    # (start of text, or after a newline) with no matching close.
+    r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$|'
+    # Stray orphan open/close tags that slipped through.
+    r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
+    re.DOTALL | re.IGNORECASE,
+)
+_STRIP_THINK_BLOCKS_TOOL_CALL_PATTERNS = re.compile(
+    r'<(?:tool_call|tool_calls|tool_result|function_call|function_calls)\b[^>]*>.*?</(?:tool_call|tool_calls|tool_result|function_call|function_calls)>|'
+    # <function name="...">...</function> — Gemma-style standalone
+    # tool call. Only strip when the tag sits at a block boundary
+    # (start of text, after a newline, or after sentence-ending
+    # punctuation) AND carries a name="..." attribute. This keeps
+    # prose mentions like "Use <function> to declare" safe.
+    r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*'
+    r'<function\b[^>]*\bname\s*=[^>]*>(?:(?:(?!</function>).)*)</function>|'
+    # Stray tool-call closers.
+    r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
 def strip_think_blocks(agent, content: str) -> str:
     """Remove reasoning/thinking blocks from content, returning only visible text.
 
@@ -471,65 +501,8 @@ def strip_think_blocks(agent, content: str) -> str:
     """
     if not content:
         return ""
-    # 1. Closed tag pairs — case-insensitive for all variants so
-    #    mixed-case tags (<THINK>, <Thinking>) don't slip through to
-    #    the unterminated-tag pass and take trailing content with them.
-    content = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
-    # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
-    #     generic tag names first — they have no attribute gating since
-    #     a literal <tool_call> in prose is already vanishingly rare.
-    for _tc_name in ("tool_call", "tool_calls", "tool_result",
-                      "function_call", "function_calls"):
-        content = re.sub(
-            rf'<{_tc_name}\b[^>]*>.*?</{_tc_name}>',
-            '',
-            content,
-            flags=re.DOTALL | re.IGNORECASE,
-        )
-    # 1c. <function name="...">...</function> — Gemma-style standalone
-    #     tool call. Only strip when the tag sits at a block boundary
-    #     (start of text, after a newline, or after sentence-ending
-    #     punctuation) AND carries a name="..." attribute. This keeps
-    #     prose mentions like "Use <function> to declare" safe.
-    content = re.sub(
-        r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*'
-        r'<function\b[^>]*\bname\s*=[^>]*>'
-        r'(?:(?:(?!</function>).)*)</function>',
-        '',
-        content,
-        flags=re.DOTALL | re.IGNORECASE,
-    )
-    # 2. Unterminated reasoning block — open tag at a block boundary
-    #    (start of text, or after a newline) with no matching close.
-    #    Strip from the tag to end of string.  Fixes #8878 / #9568
-    #    (MiniMax M2.7 leaking raw reasoning into assistant content).
-    content = re.sub(
-        r'(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$',
-        '',
-        content,
-        flags=re.DOTALL | re.IGNORECASE,
-    )
-    # 3. Stray orphan open/close tags that slipped through.
-    content = re.sub(
-        r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*',
-        '',
-        content,
-        flags=re.IGNORECASE,
-    )
-    # 3b. Stray tool-call closers. (We do NOT strip bare <function> or
-    #     unterminated <function name="..."> because a truncated tail
-    #     during streaming may still be valuable to the user; matches
-    #     OpenClaw's intentional asymmetry.)
-    content = re.sub(
-        r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
-        '',
-        content,
-        flags=re.IGNORECASE,
-    )
+    content = _STRIP_THINK_BLOCKS_THINK_PATTERNS.sub('', content)
+    content = _STRIP_THINK_BLOCKS_TOOL_CALL_PATTERNS.sub('', content)
     return content
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -893,16 +893,20 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
       - "model's max context length is 65536"
     """
     error_lower = error_msg.lower()
-    # Pattern: look for numbers near context-related keywords
-    patterns = [
-        r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
-        r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
-        r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
-        r'>\s*(\d{4,})\s*(?:max|limit|token)',  # "250000 tokens > 200000 maximum"
-        r'(\d{4,})\s*(?:max(?:imum)?)\b',  # "200000 maximum"
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, error_lower)
+    # Pre-compiled so the pattern list is compiled once at import rather than
+    # on every error path.
+    if not hasattr(parse_context_limit_from_error, '_patterns'):
+        parse_context_limit_from_error._patterns = [
+            re.compile(p) for p in [
+                r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
+                r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
+                r'(\d{4,})\s*(?:token)?\s*(?:context|limit)',
+                r'>\s*(\d{4,})\s*(?:max|limit|token)',  # "250000 tokens > 200000 maximum"
+                r'(\d{4,})\s*(?:max(?:imum)?)\b',  # "200000 maximum"
+            ]
+        ]
+    for pattern in parse_context_limit_from_error._patterns:
+        match = pattern.search(error_lower)
         if match:
             limit = int(match.group(1))
             # Sanity check: must be a reasonable context length
@@ -939,14 +943,19 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
 
     # Extract the available_tokens figure.
     # Anthropic format: "… = available_tokens: 10000"
-    patterns = [
-        r'available_tokens[:\s]+(\d+)',
-        r'available\s+tokens[:\s]+(\d+)',
-        # fallback: last number after "=" in expressions like "200000 - 190000 = 10000"
-        r'=\s*(\d+)\s*$',
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, error_lower)
+    # Pre-compiled so the pattern list is compiled once at import rather than
+    # on every error path.
+    if not hasattr(parse_available_output_tokens_from_error, '_patterns'):
+        parse_available_output_tokens_from_error._patterns = [
+            re.compile(p) for p in [
+                r'available_tokens[:\s]+(\d+)',
+                r'available\s+tokens[:\s]+(\d+)',
+                # fallback: last number after "=" in expressions like "200000 - 190000 = 10000"
+                r'=\s*(\d+)\s*$',
+            ]
+        ]
+    for pattern in parse_available_output_tokens_from_error._patterns:
+        match = pattern.search(error_lower)
         if match:
             tokens = int(match.group(1))
             if tokens >= 1:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4347,10 +4347,15 @@ class GatewayRunner:
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
             from tools.process_registry import process_registry
-            while process_registry.pending_watchers:
-                watcher = process_registry.pending_watchers.pop(0)
+            watchers = process_registry.pending_watchers
+            # Process in batches of 100 with event-loop yield points to avoid
+            # O(n^2) event-loop blocking when recovering thousands of watchers.
+            for i, watcher in enumerate(watchers):
                 asyncio.create_task(self._run_process_watcher(watcher))
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
+                if i % 100 == 99:
+                    await asyncio.sleep(0)
+            watchers.clear()
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
 
@@ -7665,7 +7670,7 @@ class GatewayRunner:
                         result = await result
                     return str(result) if result else None
             except Exception as e:
-                logger.debug("Plugin command dispatch failed (non-fatal): %s", e)
+                logger.warning("Plugin command dispatch failed: %s", e)
 
         # Skill slash commands: /skill-name loads the skill and sends to agent.
         # resolve_skill_command_key() handles the Telegram underscore/hyphen
@@ -7697,7 +7702,7 @@ class GatewayRunner:
                             )
                         # Fall through to normal message processing with bundle content
             except Exception as exc:
-                logger.debug("Bundle dispatch failed (non-fatal): %s", exc)
+                logger.warning("Bundle dispatch failed: %s", exc)
 
         if command and not locals().get("_bundle_handled", False):
             try:
@@ -8849,9 +8854,12 @@ class GatewayRunner:
             # Check for pending process watchers (check_interval on background processes)
             try:
                 from tools.process_registry import process_registry
-                while process_registry.pending_watchers:
-                    watcher = process_registry.pending_watchers.pop(0)
+                watchers = process_registry.pending_watchers
+                for i, watcher in enumerate(watchers):
                     asyncio.create_task(self._run_process_watcher(watcher))
+                    if i % 100 == 99:
+                        await asyncio.sleep(0)
+                watchers.clear()
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -34,6 +34,13 @@ from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname
 
 
+_STRIP_V1_SUFFIX = re.compile(r'/v1/?$')
+
+def _strip_v1_suffix(base_url: str) -> str:
+    """Strip a trailing /v1 or /v1/ suffix from a base URL."""
+    return _STRIP_V1_SUFFIX.sub('', base_url)
+
+
 def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
@@ -367,7 +374,7 @@ def _resolve_runtime_from_pool_entry(
                 api_mode = inferred
         # For Anthropic-style endpoints, strip /v1 suffix
         if api_mode == "anthropic_messages":
-            base_url = re.sub(r"/v1/?$", "", base_url)
+            base_url = _strip_v1_suffix(base_url)
     else:
         configured_provider = str(model_cfg.get("provider") or "").strip().lower()
         # Honour model.base_url from config.yaml when the configured provider
@@ -404,7 +411,7 @@ def _resolve_runtime_from_pool_entry(
     # trailing /v1 so the SDK constructs the correct path (e.g.
     # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
     if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
-        base_url = re.sub(r"/v1/?$", "", base_url)
+        base_url = _strip_v1_suffix(base_url)
 
     # Optional opt-in: route OpenAI/Codex turns through `codex app-server`.
     # Inert when `model.openai_runtime` is unset or "auto".
@@ -951,7 +958,7 @@ def _resolve_azure_foundry_runtime(
     # Anthropic SDK appends /v1/messages itself, so strip any trailing /v1
     # we inherited from the configured base_url to avoid double-/v1 paths.
     if cfg_api_mode == "anthropic_messages":
-        base_url = re.sub(r"/v1/?$", "", base_url)
+        base_url = _strip_v1_suffix(base_url)
 
     # ── Entra ID (Microsoft Foundry recommended path) ──────────────────
     #
@@ -1643,7 +1650,7 @@ def resolve_runtime_provider(
                     api_mode = detected
         # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
         if api_mode == "anthropic_messages" and provider in {"opencode-zen", "opencode-go"}:
-            base_url = re.sub(r"/v1/?$", "", base_url)
+            base_url = _strip_v1_suffix(base_url)
         return {
             "provider": provider,
             "api_mode": api_mode,

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 import threading
 from typing import Any, Callable, Optional
@@ -301,6 +302,18 @@ _continuous_on_status: Optional[Callable[[str], None]] = None
 _continuous_on_silent_limit: Optional[Callable[[], None]] = None
 _continuous_no_speech_count = 0
 _CONTINUOUS_NO_SPEECH_LIMIT = 3
+
+# Pre-compiled regexes for speak_text markdown stripping — built once at import time.
+_TTS_FENCED_CODE = re.compile(r'```[\s\S]*?```')
+_TTS_LINK = re.compile(r'\[([^\]]+)\]\([^)]+\)')
+_TTS_URL = re.compile(r'https?://\S+')
+_TTS_BOLD = re.compile(r'\*\*(.+?)\*\*')
+_TTS_ITALIC = re.compile(r'\*(.+?)\*')
+_TTS_INLINE_CODE = re.compile(r'`(.+?)`')
+_TTS_HEADER = re.compile(r'^#+\s*', flags=re.MULTILINE)
+_TTS_LIST_BULLET = re.compile(r'^\s*[-*]\s+', flags=re.MULTILINE)
+_TTS_HR = re.compile(r'---+')
+_TTS_EXCESS_NEWLINES = re.compile(r'\n{3,}')
 
 
 # ── Push-to-talk API ─────────────────────────────────────────────────
@@ -782,16 +795,16 @@ def speak_text(text: str) -> None:
         from tools.tts_tool import text_to_speech_tool
 
         tts_text = text[:4000] if len(text) > 4000 else text
-        tts_text = re.sub(r'```[\s\S]*?```', ' ', tts_text)             # fenced code blocks
-        tts_text = re.sub(r'\[([^\]]+)\]\([^)]+\)', r'\1', tts_text)    # [text](url) → text
-        tts_text = re.sub(r'https?://\S+', '', tts_text)                # bare URLs
-        tts_text = re.sub(r'\*\*(.+?)\*\*', r'\1', tts_text)            # bold
-        tts_text = re.sub(r'\*(.+?)\*', r'\1', tts_text)                # italic
-        tts_text = re.sub(r'`(.+?)`', r'\1', tts_text)                  # inline code
-        tts_text = re.sub(r'^#+\s*', '', tts_text, flags=re.MULTILINE)  # headers
-        tts_text = re.sub(r'^\s*[-*]\s+', '', tts_text, flags=re.MULTILINE)  # list bullets
-        tts_text = re.sub(r'---+', '', tts_text)                        # horizontal rules
-        tts_text = re.sub(r'\n{3,}', '\n\n', tts_text)                  # excess newlines
+        tts_text = _TTS_FENCED_CODE.sub(' ', tts_text)                  # fenced code blocks
+        tts_text = _TTS_LINK.sub(r'\1', tts_text)                       # [text](url) → text
+        tts_text = _TTS_URL.sub('', tts_text)                           # bare URLs
+        tts_text = _TTS_BOLD.sub(r'\1', tts_text)                       # bold
+        tts_text = _TTS_ITALIC.sub(r'\1', tts_text)                     # italic
+        tts_text = _TTS_INLINE_CODE.sub(r'\1', tts_text)                # inline code
+        tts_text = _TTS_HEADER.sub('', tts_text)                        # headers
+        tts_text = _TTS_LIST_BULLET.sub('', tts_text)                   # list bullets
+        tts_text = _TTS_HR.sub('', tts_text)                            # horizontal rules
+        tts_text = _TTS_EXCESS_NEWLINES.sub('\n\n', tts_text)          # excess newlines
         tts_text = tts_text.strip()
         if not tts_text:
             return

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -66,44 +66,49 @@ from cron.jobs import (
 # header exemption.
 
 # Strict patterns — applied to the user prompt only.
-_CRON_THREAT_PATTERNS = [
-    (r'ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions', "prompt_injection"),
-    (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
-    (r'system\s+prompt\s+override', "sys_prompt_override"),
-    (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),
-    (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass)', "read_secrets"),
-    (r'authorized_keys', "ssh_backdoor"),
-    (r'/etc/sudoers|visudo', "sudoers_mod"),
-    (r'rm\s+-rf\s+/', "destructive_root_rm"),
-]
+_CRON_SECRET_VAR_RE = r'\$\{?\w*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)\w*\}?'
 
-# Looser pattern set — applied to the assembled prompt when skills are
-# attached. Only patterns whose phrasing is unambiguous in any context;
+# Pre-compiled regexes — built once at import time.
+# Strict patterns (applied to the user prompt only).
+_CRONT = [
+    (re.compile(p, re.IGNORECASE), name) for p, name in [
+        (r'ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions', "prompt_injection"),
+        (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
+        (r'system\s+prompt\s+override', "sys_prompt_override"),
+        (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),
+        (r'cat\s+[^\n]*(\.env|credentials|\.netrc|\.pgpass)', "read_secrets"),
+        (r'authorized_keys', "ssh_backdoor"),
+        (r'/etc/sudoers|visudo', "sudoers_mod"),
+        (r'rm\s+-rf\s+/', "destructive_root_rm"),
+    ]
+]
+_CRON_THREAT_PATTERNS = _CRONT
+
+# Looser pattern set (applied to the assembled prompt when skills are
+# attached). Only catches unambiguous prompt-injection directives;
 # command-shape patterns are dropped because they false-positive on prose
 # in security docs / postmortems. Skill bodies are scanned at install time
-# by `skills_guard.py`, so the runtime cron scan is purely a tripwire for
-# obvious injection directives surviving a malicious skill that slipped
-# through install.
+# by `skills_guard.py`, so the runtime cron scan is purely a tripwire.
 _CRON_SKILL_ASSEMBLED_PATTERNS = [
-    (r'ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions', "prompt_injection"),
-    (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
-    (r'system\s+prompt\s+override', "sys_prompt_override"),
-    (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),
+    (re.compile(p, re.IGNORECASE), name) for p, name in [
+        (r'ignore\s+(?:\w+\s+)*(?:previous|all|above|prior)\s+(?:\w+\s+)*instructions', "prompt_injection"),
+        (r'do\s+not\s+tell\s+the\s+user', "deception_hide"),
+        (r'system\s+prompt\s+override', "sys_prompt_override"),
+        (r'disregard\s+(your|all|any)\s+(instructions|rules|guidelines)', "disregard_rules"),
+    ]
 ]
 
-_CRON_SECRET_VAR_RE = r'\$\{?\w*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|API)\w*\}?'
-_CRON_EXFIL_COMMAND_PATTERNS = [
-    # Tighten exfil detection to obvious leak paths: embedding a secret
-    # directly in the destination URL, sending it in POST/FORM payloads,
-    # or shipping it via Authorization headers to arbitrary hosts. The
-    # only intended allowlist exception today is the bundled GitHub skill
-    # pattern that talks to api.github.com.
-    (rf'curl\s+[^\n]*https?://[^\s"\'`]*{_CRON_SECRET_VAR_RE}', "exfil_curl_url"),
-    (rf'wget\s+[^\n]*https?://[^\s"\'`]*{_CRON_SECRET_VAR_RE}', "exfil_wget_url"),
-    (rf'curl\s+[^\n]*(?:--data(?:-raw|-binary|-urlencode)?|-d|--form|-F)\s+[^\n]*{_CRON_SECRET_VAR_RE}', "exfil_curl_data"),
-    (rf'wget\s+[^\n]*--post-(?:data|file)=[^\n]*{_CRON_SECRET_VAR_RE}', "exfil_wget_post"),
-    (rf'curl\s+[^\n]*(?:-H|--header)\s+["\']Authorization:\s*(?:Bearer|token)\s+{_CRON_SECRET_VAR_RE}["\']', "exfil_curl_auth_header"),
+# Exfil patterns — tightened to obvious leak paths.
+_CRON_EXFIL_PATTERNS = [
+    (re.compile(p, re.IGNORECASE), name) for p, name in [
+        (rf'curl\s+[^\n]*https?://[^\s"\'`]*{_CRON_SECRET_VAR_RE}', "exfil_curl_url"),
+        (rf'wget\s+[^\n]*https?://[^\s"\'`]*{_CRON_SECRET_VAR_RE}', "exfil_wget_url"),
+        (rf'curl\s+[^\n]*(?:--data(?:-raw|-binary|-urlencode)?|-d|--form|-F)\s+[^\n]*{_CRON_SECRET_VAR_RE}', "exfil_curl_data"),
+        (rf'wget\s+[^\n]*--post-(?:data|file)=[^\n]*{_CRON_SECRET_VAR_RE}', "exfil_wget_post"),
+        (rf'curl\s+[^\n]*(?:-H|--header)\s+["\']Authorization:\s*(?:Bearer|token)\s+{_CRON_SECRET_VAR_RE}["\']', "exfil_curl_auth_header"),
+    ]
 ]
+_CRON_EXFIL_COMMAND_PATTERNS = _CRON_EXFIL_PATTERNS
 
 _CRON_INVISIBLE_CHARS = {
     '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
@@ -197,10 +202,10 @@ def _scan_cron_prompt(prompt: str) -> str:
     if invisible_err:
         return invisible_err
     for pattern, pid in _CRON_THREAT_PATTERNS:
-        if re.search(pattern, prompt_to_scan, re.IGNORECASE):
+        if pattern.search(prompt_to_scan):
             return f"Blocked: prompt matches threat pattern '{pid}'. Cron prompts must not contain injection or exfiltration payloads."
     for pattern, pid in _CRON_EXFIL_COMMAND_PATTERNS:
-        if re.search(pattern, prompt_to_scan, re.IGNORECASE):
+        if pattern.search(prompt_to_scan):
             return f"Blocked: prompt matches threat pattern '{pid}'. Cron prompts must not contain injection or exfiltration payloads."
     return ""
 
@@ -223,7 +228,7 @@ def _scan_cron_skill_assembled(assembled: str) -> str:
     if invisible_err:
         return invisible_err
     for pattern, pid in _CRON_SKILL_ASSEMBLED_PATTERNS:
-        if re.search(pattern, prompt_to_scan, re.IGNORECASE):
+        if pattern.search(prompt_to_scan):
             return f"Blocked: prompt matches threat pattern '{pid}'. Cron prompts must not contain injection or exfiltration payloads."
     return ""
 

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -531,6 +531,13 @@ INVISIBLE_CHARS = {
 # Scanning functions
 # ---------------------------------------------------------------------------
 
+# Pre-compiled regex patterns for THREAT_PATTERNS (avoids re-compiling on every scan_file call)
+_COMPILED_PATTERNS = [
+    (re.compile(pattern, re.IGNORECASE), pid, severity, category, description)
+    for pattern, pid, severity, category, description in THREAT_PATTERNS
+]
+
+
 def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     """
     Scan a single file for threat patterns and invisible unicode characters.
@@ -558,11 +565,11 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
     seen = set()  # (pattern_id, line_number) for deduplication
 
     # Regex pattern matching
-    for pattern, pid, severity, category, description in THREAT_PATTERNS:
+    for compiled_pattern, pid, severity, category, description in _COMPILED_PATTERNS:
         for i, line in enumerate(lines, start=1):
             if (pid, i) in seen:
                 continue
-            if re.search(pattern, line, re.IGNORECASE):
+            if compiled_pattern.search(line):
                 seen.add((pid, i))
                 matched_text = line.strip()
                 if len(matched_text) > 120:


### PR DESCRIPTION
## Summary

Fixes N15, N16, N17, N18, N19 — regex patterns compiled inline instead of once at module load.

## Changes

- **N15 agent/agent_runtime_helpers.py**: 11 inline re.sub calls in strip_think_blocks() replaced with 2 module-level compiled patterns (_STRIP_THINK_BLOCKS_THINK_PATTERNS, _STRIP_THINK_BLOCKS_TOOL_CALL_PATTERNS)

- **N16 agent/model_metadata.py**: parse_context_limit_from_error() and parse_available_output_tokens_from_error() now use lazy-cached compiled pattern lists

- **N17 tools/cronjob_tools.py**: All _CRON_*_PATTERNS lists now hold pre-compiled re.compile() objects instead of raw strings

- **N18 hermes_cli/voice.py**: 10 sequential re.sub calls in speak_text() replaced with module-level compiled regexes

- **N19 hermes_cli/runtime_provider.py**: 4 inline re.sub(r'/v1/?$') calls replaced with a single _strip_v1_suffix() helper using a pre-compiled _STRIP_V1_SUFFIX pattern