### PR TITLE
fix(platforms): WeCom path traversal guard and safe YAML loading

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1128,6 +1128,22 @@ class WeComAdapter(BasePlatformAdapter):
         if not local_path.is_absolute():
             local_path = (Path.cwd() / local_path).resolve()
 
+        # Prevent path traversal: reject paths that escape the Hermes working
+        # directory or attempt to access sensitive system files.
+        try:
+            local_path = local_path.resolve()
+            cwd = str(Path.cwd().resolve())
+            local_path_str = str(local_path)
+            # Must be under cwd or under HERMES_HOME
+            hermes_home = os.environ.get("HERMES_HOME", cwd)
+            if not (local_path_str.startswith(cwd + os.sep) or
+                    local_path_str.startswith(hermes_home + os.sep)):
+                raise ValueError(f"Path {local_path} is outside allowed directory")
+        except ValueError:
+            raise
+        except Exception:
+            pass  # Fall through to exists/is_file checks
+
         if not local_path.exists() or not local_path.is_file():
             raise FileNotFoundError(f"Media file not found: {local_path}")
 

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -201,8 +201,7 @@ def apply_migration(
             config_changed=False,
         )
 
-    yaml = YAML(typ="rt")
-    yaml.preserve_quotes = True
+    yaml = YAML(typ="safe")
     with config_path.open("r", encoding="utf-8") as fh:
         doc = yaml.load(fh)
 


### PR DESCRIPTION
## Summary

Fixes N23 (YAML RCE) and N24 (WeCom path traversal).

## N23 — YAML RCE in xai_retirement.py

`YAML(typ='rt')` allows arbitrary Python object construction from YAML tags. Changed to `typ='safe'` which only permits simple types.

## N24 — WeCom path traversal in _load_outbound_media()

`file://` URLs were resolved with `Path.resolve()` but had no containment check. An attacker could read `/etc/passwd` or other sensitive files.

Added path containment guard: resolved paths must be under `cwd()` or `HERMES_HOME`, otherwise `ValueError` is raised before reading.