### PR TITLE
fix(send_message): add SMTP timeout to prevent indefinite hangs

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1290,12 +1290,14 @@ async def _send_email(extra, chat_id, message):
         msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
-        server = smtplib.SMTP(smtp_host, smtp_port)
+        server = smtplib.SMTP(smtp_host, smtp_port, timeout=30)
         server.starttls(context=ssl.create_default_context())
         server.login(address, password)
         server.send_message(msg)
         server.quit()
         return {"success": True, "platform": "email", "chat_id": chat_id}
+    except TimeoutError:
+        return _error(f"Email send timed out after 30s: {smtp_host}:{smtp_port}")
     except Exception as e:
         return _error(f"Email send failed: {e}")
 


### PR DESCRIPTION
## Summary

smtplib.SMTP() was called without a timeout parameter. Network issues or unresponsive SMTP servers would block the tool indefinitely.

## What Was Fixed

Added timeout=30 to smtplib.SMTP(). Added a specific TimeoutError handler that returns a clear error message instead of a generic failure.