### PR TITLE
feat(skills/note-taking): notes-extract — local notes → People/Project entries

### DIFF
--- a/optional-skills/note-taking/notes-extract/SKILL.md
+++ b/optional-skills/note-taking/notes-extract/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: notes-extract
+description: Extract people and project facts from local files.
+version: 1.0.0
+author: David Murray (thedavidmurray)
+license: MIT
+metadata:
+  hermes:
+    tags: [Productivity, Notes, Knowledge]
+    related_skills: [obsidian]
+---
+
+# Notes Extract Skill
+
+Turn a folder of local markdown notes into structured **People** and
+**Idea/Project** files inside a vault: scan notes, extract facts/commitments/
+ideas, and write them into per-entity files keyed by a stable claim id so
+re-runs never duplicate. It does **not** do general Obsidian CRUD (use the
+`obsidian` skill for that), makes **no** network/API calls, and **never**
+modifies text you wrote outside its managed fences.
+
+## When to Use
+
+Load this when the user wants to build or refresh a "People DB" / "Project DB"
+from their own notes — e.g. "pull commitments and project ideas out of my notes
+into per-person and per-project files," or to re-sync those files after adding
+notes. For reading, searching, or editing individual notes, use the `obsidian`
+skill instead.
+
+## Prerequisites
+
+- A vault directory of `.md` / `.txt` notes. Vault resolution follows the
+  `obsidian` skill (see `skills/note-taking/obsidian/SKILL.md`): use
+  `OBSIDIAN_VAULT_PATH`, falling back to `~/Documents/Obsidian Vault`. File
+  tools do not expand shell variables — resolve the vault to a concrete absolute
+  path first, and remember vault paths may contain spaces.
+- Optional `NOTES_EXTRACT_SOURCES`: comma-separated **extra** plaintext source
+  directories to scan in addition to the vault.
+- No API keys, secrets, or external packages — scripts are Python stdlib only,
+  and the extraction itself is done by you (the model), not a third-party API.
+
+## How to Run
+
+Invoke the two scripts through the `terminal` tool. `SKILL_DIR` is the directory
+containing this SKILL.md.
+
+```bash
+# 1. Which notes are new or changed?
+python3 SKILL_DIR/scripts/notes_scan.py --vault "/abs/vault path"
+
+# 2. After extracting entries from ONE note, merge them in:
+python3 SKILL_DIR/scripts/upsert_entry.py --vault "/abs/vault path" \
+    --source-path "/abs/vault path/note.md" --source-link "note" \
+    --source-sha "<sha from scan>" --entries-json '[ ... ]'
+```
+
+## Quick Reference
+
+| Script | Purpose | Key args |
+|---|---|---|
+| `notes_scan.py` | List new/changed notes as JSON (read-only) | `--vault`, `--sources`, `--all` |
+| `upsert_entry.py` | Merge one note's entries into entity files | `--vault`, `--source-path`, `--source-link`, `--source-sha`, `--entries-json` |
+
+Entry/claim shape, ids, and managed-region format are documented in
+`references/schema.md`. Generated files match `templates/person.md` and
+`templates/project.md`.
+
+## Procedure
+
+1. Resolve the vault to an absolute path (per Prerequisites).
+2. Run `notes_scan.py`. It emits a JSON array of `{path, link, source_id, sha,
+   status, text}` for each new/changed note.
+3. For **each** scanned note, read its `text` and extract a JSON array of
+   entries — one per fact/commitment/topic (person) or idea/decision/blocker/
+   todo (project). Each entry carries an `entity`, a `section`, a normalized
+   `claim` `{subject, predicate, object}`, the human-readable `text`, and `op`
+   (`assert` default, or `retract`). See `references/schema.md`.
+4. Run `upsert_entry.py` once per note, passing that note's entries plus its
+   `source-path`, `source-link`, and `source-sha`. The script resolves the
+   entity, writes bullets inside managed fences, dedupes by claim id, and
+   reconciles against the note's previous run (stale entries are removed).
+5. Report the per-file actions and any `needs_confirm` slug collisions from the
+   script's JSON output. The model emits the `claim`; the script owns all
+   identity, dedup, and merge logic — never hand-write merge logic.
+
+To verify or repair a person/project file, read it with `read_file`; to make a
+manual correction, edit **outside** the fenced regions with `patch` — the skill
+will preserve it. Use `search_files` to locate generated files under `People/`
+and `Ideas-Projects/`.
+
+## Pitfalls
+
+- **Dedup is claim-keyed, best-effort.** Two entries with the same
+  `{subject, predicate, object}` collapse to one id; if the model emits
+  inconsistent claims for the same fact, near-duplicates can still appear. Keep
+  `claim` fields normalized and lowercase.
+- **No automatic contradiction handling.** A later note that contradicts an
+  earlier fact does not auto-retract it. Emit an explicit `"op": "retract"`
+  entry to move the old bullet to a `<section>-archive` region.
+- **Same-name people are not merged blindly.** A slug collision with a different
+  entity creates `<slug>-2.md` and reports `needs_confirm`; confirm with the
+  user before treating them as one person.
+- **Only fenced content is managed.** Anything outside the
+  `notes-extract:begin/end` fences is yours; the skill never edits or reorders
+  it. State lives under `HERMES_HOME`, never in the vault.
+- **Out of scope:** Apple Notes, always-on recording devices, and database
+  backends are not handled here.
+
+## Verification
+
+Scanning twice with no new notes, and re-running an upsert with unchanged
+entries, must both be no-ops:
+
+```bash
+python3 SKILL_DIR/scripts/notes_scan.py --vault "/abs/vault path"
+# → after a full run, a second scan returns [] and a repeated upsert reports
+#   every file "unchanged" (no diff).
+```

--- a/optional-skills/note-taking/notes-extract/references/schema.md
+++ b/optional-skills/note-taking/notes-extract/references/schema.md
@@ -1,0 +1,65 @@
+# notes-extract data contract
+
+## Structured entry (model → `upsert_entry.py`)
+
+The model reads scanned notes and emits a JSON array of entries for **one**
+source note. Scripts never parse semantics — the model produces the `claim`;
+the script handles identity, dedup, and merging deterministically.
+
+```json
+{
+  "entity": { "kind": "person|project", "name": "Jane Doe", "aliases": ["Jane"] },
+  "section": "facts",
+  "claim":   { "subject": "jane", "predicate": "employer", "object": "acme" },
+  "text":    "VP Eng at Acme.",
+  "op":      "assert"
+}
+```
+
+- **section** — person: `facts`, `commitments`, `topics`; project: `ideas`,
+  `decisions`, `blockers`, `todos`.
+- **claim** — a normalized `{subject, predicate, object}` triple. This is the
+  dedup key, *not* the prose. Rewording `text` keeps the same claim → same
+  entry, so re-runs don't duplicate. A different source asserting the same claim
+  gets its own entry, preserving provenance.
+- **op** — `assert` (default) adds/updates the bullet; `retract` moves it to a
+  `<section>-archive` region.
+
+## Entry id
+
+`nx-` + `sha256(entity_id, section, claim.subject, claim.predicate, claim.object,
+source_id)[:8]`, written as an Obsidian block id at the end of the bullet:
+
+```
+- VP Eng at Acme. [[2026-05-20 Standup]] (2026-05-26) ^nx-7f3a9c01
+```
+
+## Entity identity
+
+- `entity_id` is derived from the canonical (first-seen) name and stored as
+  `id:` in frontmatter.
+- The **slug** (filename) is NFKD-transliterated ASCII; pure non-ASCII names
+  fall back to a short hash. Names are NFC-normalized first.
+- An **alias index** in state maps normalized name/alias → `entity_id`, so
+  "Jane", "Jane Doe" route to the same file.
+- A slug collision with a *different* entity gets a `-2` suffix and a
+  `needs_confirm` flag in the run report — two people are never silently merged.
+
+## Managed regions
+
+Generated bullets live between fences; everything outside is human-owned and
+never modified:
+
+```
+## Facts
+<!-- notes-extract:begin facts -->
+- ... ^nx-...
+<!-- notes-extract:end facts -->
+```
+
+## State (cache, not source of truth)
+
+Stored under `HERMES_HOME/notes-extract/<vault-hash>.json` (never in the vault).
+Records per-source sha + emitted entry ids (for change detection and per-source
+reconciliation) and the entity/alias index. If deleted, a rescan re-derives the
+same content from the `^nx-` ids already present in the files.

--- a/optional-skills/note-taking/notes-extract/scripts/_state.py
+++ b/optional-skills/note-taking/notes-extract/scripts/_state.py
@@ -1,0 +1,144 @@
+"""Shared helpers for the notes-extract skill: HERMES_HOME state, identity, IO.
+
+Stdlib-only and cross-platform. State lives under HERMES_HOME (never inside the
+user's vault), mirroring the convention used by other Hermes skill scripts. All
+text IO is UTF-8 and atomic (write temp + os.replace) so a crash mid-run never
+leaves a half-written file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import unicodedata
+from datetime import datetime, timezone
+from pathlib import Path
+
+STATE_VERSION = 1
+
+# Section keys allowed per entity kind. Order is the canonical heading order.
+PERSON_SECTIONS = ("facts", "commitments", "topics")
+PROJECT_SECTIONS = ("ideas", "decisions", "blockers", "todos")
+
+
+def get_hermes_home() -> Path:
+    """Return the Hermes home directory (default: ~/.hermes).
+
+    Mirrors hermes_constants.get_hermes_home() without requiring it on the path.
+    """
+    val = os.environ.get("HERMES_HOME", "").strip()
+    return Path(val) if val else Path.home() / ".hermes"
+
+
+def now_iso(clock=None) -> str:
+    """UTC date stamp (YYYY-MM-DD). `clock` is injectable for deterministic tests."""
+    dt = (clock or (lambda: datetime.now(timezone.utc)))()
+    return dt.strftime("%Y-%m-%d")
+
+
+def nfc(text: str) -> str:
+    """Normalize to NFC (macOS stores filenames NFD; normalize everywhere)."""
+    return unicodedata.normalize("NFC", text)
+
+
+def norm_key(text: str) -> str:
+    """Lowercased, whitespace-collapsed NFC key for alias/claim matching."""
+    return re.sub(r"\s+", " ", nfc(text).strip().lower())
+
+
+def slugify(name: str) -> str:
+    """Filesystem-safe slug. Transliterate to ASCII; fall back to a hash."""
+    decomposed = unicodedata.normalize("NFKD", nfc(name))
+    ascii_only = "".join(c for c in decomposed if not unicodedata.combining(c))
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_only.lower()).strip("-")
+    if not slug:
+        slug = "n-" + hashlib.sha256(nfc(name).encode("utf-8")).hexdigest()[:8]
+    return slug
+
+
+def entity_id(kind: str, name: str) -> str:
+    """Deterministic id derived from the canonical (first-seen) name."""
+    digest = hashlib.sha256(norm_key(name).encode("utf-8")).hexdigest()[:10]
+    return f"{kind}-{digest}"
+
+
+def source_id(vault: Path, source_path: Path) -> str:
+    """Stable id for a source note, keyed on its path relative to the vault."""
+    try:
+        rel = source_path.resolve().relative_to(vault.resolve()).as_posix()
+    except ValueError:
+        rel = source_path.resolve().as_posix()
+    return "src-" + hashlib.sha256(rel.encode("utf-8")).hexdigest()[:12]
+
+
+def entry_id(eid: str, section: str, claim: dict, src_id: str) -> str:
+    """Stable entry id keyed on the CLAIM + source, not on prose.
+
+    Rewording the same fact maps to the same id (no duplicate); a second source
+    asserting the same claim yields a distinct id (provenance preserved).
+    """
+    parts = [
+        eid,
+        section,
+        norm_key(claim.get("subject", "")),
+        norm_key(claim.get("predicate", "")),
+        norm_key(claim.get("object", "")),
+        src_id,
+    ]
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()[:8]
+    return "nx-" + digest
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Write UTF-8 text atomically (temp file in same dir + os.replace)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+
+def state_path(vault: Path) -> Path:
+    """Per-vault state cache under HERMES_HOME, keyed by vault path hash."""
+    key = hashlib.sha256(str(vault.resolve()).encode("utf-8")).hexdigest()[:16]
+    return get_hermes_home() / "notes-extract" / f"{key}.json"
+
+
+def empty_state(vault: Path) -> dict:
+    return {
+        "version": STATE_VERSION,
+        "vault": str(vault.resolve()),
+        "sources": {},      # source_id -> {path, link, sha, entries: [{id, entity_id, section}]}
+        "entities": {},     # entity_id -> {kind, slug, name, aliases}
+        "alias_index": {},  # norm_key(name/alias) -> entity_id
+    }
+
+
+def load_state(vault: Path) -> dict:
+    p = state_path(vault)
+    if not p.exists():
+        return empty_state(vault)
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return empty_state(vault)
+    if data.get("version") != STATE_VERSION:
+        return empty_state(vault)
+    return data
+
+
+def save_state(vault: Path, state: dict) -> None:
+    atomic_write_text(state_path(vault), json.dumps(state, indent=2, ensure_ascii=False))

--- a/optional-skills/note-taking/notes-extract/scripts/notes_scan.py
+++ b/optional-skills/note-taking/notes-extract/scripts/notes_scan.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Enumerate local note sources and report which are new or changed.
+
+Walks the Obsidian vault (and any extra plaintext source dirs) for .md/.txt
+notes, hashes each, diffs against the notes-extract state cache, and emits JSON
+the model reads to decide what to extract. Output dirs (People/, Ideas-Projects/)
+and dotfiles are skipped so generated files are never re-ingested. Read-only:
+this script never writes state — upsert_entry.py owns that.
+
+Usage (invoke through the `terminal` tool):
+  python notes_scan.py --vault "/path/to/vault"            # new + changed notes
+  python notes_scan.py --vault "/path" --sources "/a,/b"   # extra source dirs
+  python notes_scan.py --vault "/path" --all               # include unchanged
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from _state import load_state, sha256_text, source_id as make_source_id  # noqa: E402
+
+SKIP_DIRS = {"People", "Ideas-Projects"}
+NOTE_SUFFIXES = {".md", ".txt"}
+
+
+def iter_notes(roots: list[Path]):
+    """Yield note files under each root, skipping output + hidden dirs."""
+    seen = set()
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*")):
+            if path.suffix.lower() not in NOTE_SUFFIXES or not path.is_file():
+                continue
+            rel_parts = path.relative_to(root).parts
+            if any(p.startswith(".") or p in SKIP_DIRS for p in rel_parts):
+                continue
+            key = path.resolve()
+            if key in seen:
+                continue
+            seen.add(key)
+            yield path
+
+
+def scan(vault: Path, extra_sources: list[Path], state: dict, include_unchanged: bool) -> list[dict]:
+    known = {sid: rec.get("sha") for sid, rec in state.get("sources", {}).items()}
+    out = []
+    for path in iter_notes([vault, *extra_sources]):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        sha = sha256_text(text)
+        sid = make_source_id(vault, path)
+        if sid not in known:
+            status = "new"
+        elif known[sid] != sha:
+            status = "changed"
+        else:
+            status = "unchanged"
+        if status == "unchanged" and not include_unchanged:
+            continue
+        out.append({
+            "path": str(path),
+            "link": path.stem,           # Obsidian wikilink target (basename, no ext)
+            "source_id": sid,
+            "sha": sha,
+            "status": status,
+            "text": text,
+        })
+    return out
+
+
+def resolve_sources(args) -> tuple[Path, list[Path]]:
+    vault_arg = args.vault or os.environ.get("OBSIDIAN_VAULT_PATH", "").strip()
+    if not vault_arg:
+        vault_arg = str(Path.home() / "Documents" / "Obsidian Vault")
+    vault = Path(vault_arg)
+    raw = args.sources or os.environ.get("NOTES_EXTRACT_SOURCES", "")
+    extra = [Path(s.strip()) for s in raw.split(",") if s.strip()]
+    return vault, extra
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Report new/changed local notes as JSON.")
+    p.add_argument("--vault", default="")
+    p.add_argument("--sources", default="", help="Comma-separated extra source dirs")
+    p.add_argument("--all", action="store_true", help="Include unchanged notes")
+    args = p.parse_args(argv)
+
+    vault, extra = resolve_sources(args)
+    state = load_state(vault)
+    results = scan(vault, extra, state, include_unchanged=args.all)
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/note-taking/notes-extract/scripts/upsert_entry.py
+++ b/optional-skills/note-taking/notes-extract/scripts/upsert_entry.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Idempotently merge extracted entries into People/Project entity files.
+
+Reads a batch of structured entries for ONE source note (JSON) and writes them
+into per-entity markdown files inside managed-region fences. Only content
+between the fences is ever rewritten; anything a human types outside them is
+preserved byte-for-byte. Entries are addressed by a claim-keyed stable id, so
+rewording a fact does not duplicate it and re-running is convergent.
+
+Usage (invoke through the `terminal` tool):
+  python upsert_entry.py --vault "/path/to/vault" \
+      --source-path "/path/to/note.md" --source-link "note" --source-sha SHA \
+      --entries-json '[{entry}, ...]'      # or --entries-file PATH, or stdin
+
+Entry shape:
+  {"entity": {"kind": "person|project", "name": "...", "aliases": ["..."]},
+   "section": "facts|commitments|topics|ideas|decisions|blockers|todos",
+   "claim": {"subject": "...", "predicate": "...", "object": "..."},
+   "text": "human-readable bullet", "op": "assert|retract"}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from _state import (  # noqa: E402
+    PERSON_SECTIONS,
+    PROJECT_SECTIONS,
+    atomic_write_text,
+    entity_id as make_entity_id,
+    entry_id as make_entry_id,
+    load_state,
+    norm_key,
+    now_iso,
+    nfc,
+    save_state,
+    slugify,
+)
+
+BULLET_ID_RE = re.compile(r"\s\^(nx-[0-9a-f]{8})\s*$")
+BULLET_DATE_RE = re.compile(r"\((\d{4}-\d{2}-\d{2})\)")
+OUTPUT_DIRS = {"person": "People", "project": "Ideas-Projects"}
+
+
+# --------------------------------------------------------------------------- #
+# Frontmatter (minimal, deterministic — we own these files)
+# --------------------------------------------------------------------------- #
+def split_frontmatter(text: str) -> tuple[dict, str]:
+    """Return ({key: rawvalue}, body). Empty dict + full text if no frontmatter."""
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    fm_block = text[4:end]
+    body = text[end + 5:]
+    fm: dict = {}
+    for line in fm_block.splitlines():
+        m = re.match(r"^([A-Za-z_][\w-]*):\s*(.*)$", line)
+        if m:
+            fm[m.group(1)] = m.group(2).strip()
+    return fm, body
+
+
+def render_frontmatter(fm: dict, kind: str) -> str:
+    keys = ["type", "id", "name", "aliases"]
+    if kind == "project":
+        keys.append("status")
+    keys.append("updated")
+    lines = ["---"]
+    for k in keys:
+        if k in fm:
+            lines.append(f"{k}: {fm[k]}")
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
+def aliases_to_field(aliases: list[str]) -> str:
+    return "[" + ", ".join(sorted(set(a for a in aliases if a))) + "]"
+
+
+def field_to_aliases(value: str) -> list[str]:
+    value = value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+    return [a.strip() for a in value.split(",") if a.strip()]
+
+
+# --------------------------------------------------------------------------- #
+# Managed-region engine (pure functions on body text)
+# --------------------------------------------------------------------------- #
+def markers(region: str) -> tuple[str, str]:
+    return (f"<!-- notes-extract:begin {region} -->",
+            f"<!-- notes-extract:end {region} -->")
+
+
+def heading_for(section: str) -> str:
+    return section.capitalize()
+
+
+def region_bounds(body: str, region: str) -> tuple[int, int] | None:
+    begin, end = markers(region)
+    b = body.find(begin)
+    if b == -1:
+        return None
+    e = body.find(end, b)
+    if e == -1:
+        return None
+    return (b, e + len(end))
+
+
+def read_region_bullets(body: str, region: str) -> list[tuple[str, str]]:
+    """Return [(entry_id, full_bullet_line)] inside the region, in order."""
+    bounds = region_bounds(body, region)
+    if bounds is None:
+        return []
+    begin, end = markers(region)
+    inner = body[bounds[0] + len(begin):body.find(end, bounds[0])]
+    out = []
+    for line in inner.splitlines():
+        m = BULLET_ID_RE.search(line)
+        if m and line.lstrip().startswith("-"):
+            out.append((m.group(1), line.rstrip()))
+    return out
+
+
+def write_region(body: str, region: str, bullets: list[str], heading: str) -> str:
+    """Replace (or create) the region with exactly these bullet lines."""
+    begin, end = markers(region)
+    block = begin + "\n" + ("\n".join(bullets) + "\n" if bullets else "") + end
+    bounds = region_bounds(body, region)
+    if bounds is not None:
+        return body[:bounds[0]] + block + body[bounds[1]:]
+    # No region yet — attach under its heading if present, else append.
+    head_re = re.compile(rf"^##\s+{re.escape(heading)}\s*$", re.MULTILINE)
+    m = head_re.search(body)
+    insertion = "\n" + block + "\n"
+    if m:
+        at = m.end()
+        return body[:at] + "\n" + block + "\n" + body[at:]
+    sep = "" if body.endswith("\n\n") or body == "" else ("\n" if body.endswith("\n") else "\n\n")
+    return body + sep + f"## {heading}\n" + insertion
+
+
+# --------------------------------------------------------------------------- #
+# Entity file resolution (slug + collision)
+# --------------------------------------------------------------------------- #
+def existing_id(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    fm, _ = split_frontmatter(path.read_text(encoding="utf-8"))
+    return fm.get("id")
+
+
+def resolve_path(vault: Path, kind: str, slug: str, eid: str,
+                 claimed: "dict[Path, str] | None" = None) -> tuple[Path, bool]:
+    """Return (path, collided). Suffix -2.. if the slug is taken by a different id.
+
+    `claimed` maps paths already assigned in THIS batch → their entity id, so two
+    new same-slug entities in one run don't both land on <slug>.md.
+    """
+    claimed = claimed or {}
+    base = vault / OUTPUT_DIRS[kind]
+
+    def taken_by_other(path: Path) -> bool:
+        disk = existing_id(path)
+        if disk not in (None, eid):
+            return True
+        return claimed.get(path) not in (None, eid)
+
+    candidate = base / f"{slug}.md"
+    if not taken_by_other(candidate):
+        return candidate, False
+    n = 2
+    while True:
+        candidate = base / f"{slug}-{n}.md"
+        if not taken_by_other(candidate):
+            return candidate, True
+        n += 1
+
+
+# --------------------------------------------------------------------------- #
+# Core upsert
+# --------------------------------------------------------------------------- #
+def bullet_line(text: str, link: str, date: str, eid: str) -> str:
+    link_part = f" [[{link}]]" if link else ""
+    return f"- {text.strip()}{link_part} ({date}) ^{eid}"
+
+
+def resolve_entity(state: dict, kind: str, name: str, aliases: list[str]) -> str:
+    """Find an existing entity by name/alias, else mint a deterministic id."""
+    keys = [norm_key(name)] + [norm_key(a) for a in aliases]
+    for k in keys:
+        if k in state["alias_index"]:
+            return state["alias_index"][k]
+    return make_entity_id(kind, name)
+
+
+def upsert_source(vault: Path, source_path: str, source_link: str, source_sha: str,
+                  entries: list[dict], state: dict, clock=None) -> dict:
+    """Apply all entries from one source; reconcile against prior run. Mutates state."""
+    from _state import source_id as make_source_id
+
+    date = now_iso(clock)
+    sid = make_source_id(vault, Path(source_path))
+    valid_sections = {"person": PERSON_SECTIONS, "project": PROJECT_SECTIONS}
+
+    # New id set for this source, with where each lives.
+    new_records: list[dict] = []
+    # Group desired edits by target file.
+    per_file: dict[Path, dict] = {}
+
+    def file_ctx(kind, name, aliases):
+        eid = resolve_entity(state, kind, name, aliases)
+        claimed = {p: c["eid"] for p, c in per_file.items()}
+        ent = state["entities"].get(eid)
+        if ent is None:
+            slug = slugify(name)
+            path, collided = resolve_path(vault, kind, slug, eid, claimed)
+            ent = {"kind": kind, "slug": path.stem, "name": nfc(name),
+                   "aliases": sorted(set(aliases))}
+            state["entities"][eid] = ent
+        else:
+            path, collided = resolve_path(vault, kind, ent["slug"], eid, claimed)
+            for a in aliases:
+                if a and a not in ent["aliases"]:
+                    ent["aliases"].append(a)
+        for k in [norm_key(name)] + [norm_key(a) for a in aliases]:
+            state["alias_index"].setdefault(k, eid)
+        if path not in per_file:
+            per_file[path] = {"eid": eid, "kind": kind, "ent": ent,
+                              "assert": {}, "retract": set(), "collided": collided}
+        return eid, path
+
+    report = {"entries": [], "needs_confirm": [], "removed": []}
+
+    for e in entries:
+        ent_meta = e.get("entity", {})
+        kind = ent_meta.get("kind")
+        name = ent_meta.get("name", "").strip()
+        section = e.get("section", "")
+        if kind not in valid_sections or not name or section not in valid_sections[kind]:
+            report["entries"].append({"text": e.get("text", ""), "action": "skipped-invalid"})
+            continue
+        aliases = [a for a in ent_meta.get("aliases", []) if a]
+        eid, path = file_ctx(kind, name, aliases)
+        rid = make_entry_id(eid, section, e.get("claim", {}), sid)
+        op = e.get("op", "assert")
+        if op == "retract":
+            per_file[path]["retract"].add((section, rid))
+        else:
+            per_file[path]["assert"][(section, rid)] = {"text": e.get("text", ""), "link": source_link}
+            new_records.append({"id": rid, "entity_id": eid, "section": section})
+        if per_file[path]["collided"]:
+            report["needs_confirm"].append(str(path))
+
+    # Per-source reconciliation: stale ids (previously from this source, not now).
+    prior = state["sources"].get(sid, {}).get("entries", [])
+    new_ids = {r["id"] for r in new_records}
+    for rec in prior:
+        if rec["id"] not in new_ids:
+            ent = state["entities"].get(rec["entity_id"])
+            if not ent:
+                continue
+            path = vault / OUTPUT_DIRS[ent["kind"]] / f"{ent['slug']}.md"
+            per_file.setdefault(path, {"eid": rec["entity_id"], "kind": ent["kind"],
+                                       "ent": ent, "assert": {}, "retract": set(),
+                                       "collided": False})
+            per_file[path]["retract"].add((rec["section"], rec["id"]))
+            report["removed"].append(rec["id"])
+
+    # Apply edits per file, atomically, bumping `updated:` only on real change.
+    for path, ctx in per_file.items():
+        _apply_file(path, ctx, date, report)
+
+    # Record source state (sha + entries) for next run's diff + reconciliation.
+    state["sources"][sid] = {
+        "path": str(Path(source_path)),
+        "link": source_link,
+        "sha": source_sha,
+        "entries": new_records,
+    }
+    return report
+
+
+def _apply_file(path: Path, ctx: dict, date: str, report: dict) -> None:
+    kind, ent, eid = ctx["kind"], ctx["ent"], ctx["eid"]
+    sections = PERSON_SECTIONS if kind == "person" else PROJECT_SECTIONS
+
+    if path.exists():
+        old_text = path.read_text(encoding="utf-8")
+        fm, body = split_frontmatter(old_text)
+    else:
+        old_text = None
+        fm, body = {}, ""
+
+    # Ensure frontmatter scalars.
+    fm["type"] = kind
+    fm["id"] = eid
+    fm["name"] = ent["name"]
+    fm["aliases"] = aliases_to_field(ent["aliases"])
+    if kind == "project":
+        fm.setdefault("status", "active")
+
+    new_body = body
+    # Asserts: upsert bullet into its section region. Value: rid -> {text, link}.
+    by_section_assert: dict[str, dict[str, dict]] = {}
+    for (section, rid), line in ctx["assert"].items():
+        by_section_assert.setdefault(section, {})[rid] = line
+    # Retracts: move to <section>-archive.
+    by_section_retract: dict[str, set[str]] = {}
+    for (section, rid) in ctx["retract"]:
+        by_section_retract.setdefault(section, set()).add(rid)
+
+    for section in sections:
+        asserts = by_section_assert.get(section, {})
+        retracts = by_section_retract.get(section, set())
+        if not asserts and not retracts:
+            continue
+        current = read_region_bullets(new_body, section)
+        current_map = dict(current)
+        order = [rid for rid, _ in current]
+        archived = read_region_bullets(new_body, f"{section}-archive")
+        archived_map = dict(archived)
+        archived_order = [rid for rid, _ in archived]
+
+        for rid in retracts:
+            if rid in current_map:
+                if rid not in archived_map:
+                    archived_order.append(rid)
+                archived_map[rid] = current_map[rid]
+                del current_map[rid]
+                order = [r for r in order if r != rid]
+        for rid, info in asserts.items():
+            old = current_map.get(rid)
+            # Preserve an existing entry's first-seen date so re-running on a
+            # later day is a no-op; only brand-new entries get today's date.
+            d = date
+            if old:
+                m = BULLET_DATE_RE.search(old)
+                if m:
+                    d = m.group(1)
+            line = bullet_line(info["text"], info["link"], d, rid)
+            if rid not in current_map:
+                order.append(rid)
+            current_map[rid] = line
+
+        new_body = write_region(new_body, section,
+                                [current_map[r] for r in order], heading_for(section))
+        if archived_map:
+            new_body = write_region(new_body, f"{section}-archive",
+                                    [archived_map[r] for r in archived_order],
+                                    f"{heading_for(section)} (archived)")
+
+    body_changed = (new_body != body) or (old_text is None)
+    if not body_changed:
+        report["entries"].append({"file": str(path), "action": "unchanged"})
+        return
+    fm["updated"] = date
+    atomic_write_text(path, render_frontmatter(fm, kind) + new_body)
+    report["entries"].append({"file": str(path), "action": "written"})
+
+
+def _load_entries(args) -> list[dict]:
+    if args.entries_json:
+        raw = args.entries_json
+    elif args.entries_file:
+        raw = Path(args.entries_file).read_text(encoding="utf-8")
+    else:
+        raw = sys.stdin.read()
+    data = json.loads(raw)
+    return data if isinstance(data, list) else [data]
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Merge extracted entries into entity files.")
+    p.add_argument("--vault", required=True)
+    p.add_argument("--source-path", required=True)
+    p.add_argument("--source-link", default="")
+    p.add_argument("--source-sha", default="")
+    p.add_argument("--entries-json", default="")
+    p.add_argument("--entries-file", default="")
+    args = p.parse_args(argv)
+
+    vault = Path(args.vault)
+    entries = _load_entries(args)
+    state = load_state(vault)
+    report = upsert_source(vault, args.source_path, args.source_link,
+                           args.source_sha, entries, state)
+    save_state(vault, state)
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/note-taking/notes-extract/templates/person.md
+++ b/optional-skills/note-taking/notes-extract/templates/person.md
@@ -1,0 +1,26 @@
+---
+type: person
+id: person-0000000000
+name: Full Name
+aliases: [Nickname]
+updated: YYYY-MM-DD
+---
+
+## Facts
+<!-- notes-extract:begin facts -->
+- Example fact. [[Source Note]] (YYYY-MM-DD) ^nx-00000000
+<!-- notes-extract:end facts -->
+
+## Commitments
+<!-- notes-extract:begin commitments -->
+<!-- notes-extract:end commitments -->
+
+## Topics
+<!-- notes-extract:begin topics -->
+<!-- notes-extract:end topics -->
+
+<!--
+Bullets between the notes-extract:begin / :end fences are managed by the skill
+and addressed by their ^nx-id. Anything you write OUTSIDE the fences (extra
+sections, notes, edits) is never touched. Edit freely outside the fences.
+-->

--- a/optional-skills/note-taking/notes-extract/templates/project.md
+++ b/optional-skills/note-taking/notes-extract/templates/project.md
@@ -1,0 +1,30 @@
+---
+type: project
+id: project-0000000000
+name: Project Name
+aliases: [Alias]
+status: active
+updated: YYYY-MM-DD
+---
+
+## Ideas
+<!-- notes-extract:begin ideas -->
+<!-- notes-extract:end ideas -->
+
+## Decisions
+<!-- notes-extract:begin decisions -->
+<!-- notes-extract:end decisions -->
+
+## Blockers
+<!-- notes-extract:begin blockers -->
+<!-- notes-extract:end blockers -->
+
+## Todos
+<!-- notes-extract:begin todos -->
+<!-- notes-extract:end todos -->
+
+<!--
+Bullets between the notes-extract:begin / :end fences are managed by the skill
+and addressed by their ^nx-id. Anything you write OUTSIDE the fences is never
+touched. A retracted item moves to a "<section>-archive" fenced region.
+-->

--- a/tests/skills/test_notes_extract_skill.py
+++ b/tests/skills/test_notes_extract_skill.py
@@ -1,0 +1,261 @@
+"""Tests for the notes-extract skill (scan + idempotent managed-region upsert).
+
+Hermetic: tmp vault (path contains a space), HERMES_HOME monkeypatched to tmp,
+an injected fixed clock, and no network. Mirrors the stdlib+pytest convention
+used by other skill tests.
+"""
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills/note-taking/notes-extract/scripts"
+)
+SKILL_MD = SCRIPTS.parent / "SKILL.md"
+
+FIXED1 = lambda: datetime(2026, 1, 2, tzinfo=timezone.utc)  # noqa: E731
+FIXED2 = lambda: datetime(2026, 3, 4, tzinfo=timezone.utc)  # noqa: E731
+
+
+@pytest.fixture
+def mods(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    monkeypatch.delenv("OBSIDIAN_VAULT_PATH", raising=False)
+    monkeypatch.delenv("NOTES_EXTRACT_SOURCES", raising=False)
+    monkeypatch.syspath_prepend(str(SCRIPTS))
+    import _state
+    import notes_scan
+    import upsert_entry
+    return _state, notes_scan, upsert_entry
+
+
+@pytest.fixture
+def vault(tmp_path):
+    v = tmp_path / "my vault"  # space in path on purpose
+    v.mkdir()
+    return v
+
+
+def person_entry(name, section, claim, text, aliases=None, op="assert"):
+    return {
+        "entity": {"kind": "person", "name": name, "aliases": aliases or []},
+        "section": section, "claim": claim, "text": text, "op": op,
+    }
+
+
+def run(mods, vault, entries, source="note.md", link="note", sha="s1", clock=FIXED1):
+    _state, _, upsert = mods
+    state = _state.load_state(vault)
+    rep = upsert.upsert_source(vault, str(vault / source), link, sha, entries, state, clock)
+    _state.save_state(vault, state)
+    return rep
+
+
+def bullets(mods, path, region):
+    _, _, upsert = mods
+    return upsert.read_region_bullets(path.read_text(encoding="utf-8"), region)
+
+
+# --------------------------------------------------------------------------- #
+# upsert_entry
+# --------------------------------------------------------------------------- #
+def test_create_new_person_file(mods, vault):
+    run(mods, vault, [person_entry("Jane Doe", "facts",
+        {"subject": "jane", "predicate": "employer", "object": "acme"}, "VP Eng at Acme.")])
+    f = vault / "People" / "jane-doe.md"
+    assert f.exists()
+    text = f.read_text(encoding="utf-8")
+    assert "type: person" in text
+    assert "updated: 2026-01-02" in text
+    b = bullets(mods, f, "facts")
+    assert len(b) == 1
+    assert b[0][0].startswith("nx-")
+    assert "VP Eng at Acme." in b[0][1]
+    assert "[[note]]" in b[0][1]
+
+
+def test_reworded_same_claim_keeps_one_bullet(mods, vault):
+    claim = {"subject": "jane", "predicate": "employer", "object": "acme"}
+    run(mods, vault, [person_entry("Jane Doe", "facts", claim, "VP Eng at Acme.")])
+    run(mods, vault, [person_entry("Jane Doe", "facts", claim, "Jane is VP of Engineering at Acme.")])
+    b = bullets(mods, vault / "People" / "jane-doe.md", "facts")
+    assert len(b) == 1
+    assert "VP of Engineering" in b[0][1]
+
+
+def test_two_sources_same_claim_two_bullets(mods, vault):
+    claim = {"subject": "jane", "predicate": "employer", "object": "acme"}
+    run(mods, vault, [person_entry("Jane Doe", "facts", claim, "VP Eng.")], source="a.md", link="a")
+    run(mods, vault, [person_entry("Jane Doe", "facts", claim, "VP Eng.")], source="b.md", link="b")
+    b = bullets(mods, vault / "People" / "jane-doe.md", "facts")
+    assert len(b) == 2  # distinct provenance preserved
+
+
+def test_section_routing_person_and_project(mods, vault):
+    run(mods, vault, [
+        person_entry("Jane Doe", "facts", {"subject": "j", "predicate": "p", "object": "o"}, "f"),
+        person_entry("Jane Doe", "topics", {"subject": "j", "predicate": "likes", "object": "tea"}, "tea"),
+        {"entity": {"kind": "project", "name": "Flow Viz", "aliases": []},
+         "section": "ideas", "claim": {"subject": "fv", "predicate": "idea", "object": "x"},
+         "text": "Add a heatmap.", "op": "assert"},
+    ])
+    pf = vault / "People" / "jane-doe.md"
+    assert len(bullets(mods, pf, "facts")) == 1
+    assert len(bullets(mods, pf, "topics")) == 1
+    prj = vault / "Ideas-Projects" / "flow-viz.md"
+    assert prj.exists()
+    assert "type: project" in prj.read_text(encoding="utf-8")
+    assert len(bullets(mods, prj, "ideas")) == 1
+
+
+def test_idempotent_rerun_no_diff(mods, vault):
+    entries = [person_entry("Jane Doe", "facts",
+               {"subject": "j", "predicate": "e", "object": "a"}, "Fact.")]
+    run(mods, vault, entries)
+    f = vault / "People" / "jane-doe.md"
+    before = f.read_text(encoding="utf-8")
+    rep = run(mods, vault, entries)  # identical, same clock
+    after = f.read_text(encoding="utf-8")
+    assert before == after
+    assert all(e["action"] == "unchanged" for e in rep["entries"])
+
+
+def test_hand_edit_outside_fences_preserved(mods, vault):
+    run(mods, vault, [person_entry("Jane Doe", "facts",
+        {"subject": "j", "predicate": "e", "object": "a"}, "Fact.")], source="n1.md")
+    f = vault / "People" / "jane-doe.md"
+    marker = "\n## My private notes\nHand-written. Do not touch.\n"
+    f.write_text(f.read_text(encoding="utf-8") + marker, encoding="utf-8")
+    # A different note adds another fact → region rewrite in the same section.
+    run(mods, vault, [person_entry("Jane Doe", "facts",
+        {"subject": "j", "predicate": "city", "object": "nyc"}, "Lives in NYC.")], source="n2.md")
+    text = f.read_text(encoding="utf-8")
+    assert marker in text  # byte-for-byte preserved
+    assert len(bullets(mods, f, "facts")) == 2
+
+
+def test_retract_moves_to_archive(mods, vault):
+    claim = {"subject": "j", "predicate": "employer", "object": "acme"}
+    run(mods, vault, [person_entry("Jane Doe", "facts", claim, "At Acme.")])
+    run(mods, vault, [person_entry("Jane Doe", "facts", claim, "At Acme.", op="retract")])
+    f = vault / "People" / "jane-doe.md"
+    assert len(bullets(mods, f, "facts")) == 0
+    assert len(bullets(mods, f, "facts-archive")) == 1
+
+
+def test_updated_bumps_only_on_change(mods, vault):
+    e1 = [person_entry("Jane Doe", "facts", {"subject": "j", "predicate": "e", "object": "a"}, "F1.")]
+    run(mods, vault, e1, clock=FIXED1)
+    f = vault / "People" / "jane-doe.md"
+    run(mods, vault, e1, clock=FIXED2)  # unchanged content
+    assert "updated: 2026-01-02" in f.read_text(encoding="utf-8")
+    run(mods, vault, [person_entry("Jane Doe", "facts",
+        {"subject": "j", "predicate": "city", "object": "nyc"}, "New.")], clock=FIXED2)
+    assert "updated: 2026-03-04" in f.read_text(encoding="utf-8")
+
+
+def test_nfc_slug_collision_suffixes_and_flags(mods, vault):
+    rep = run(mods, vault, [
+        person_entry("Cafe", "facts", {"subject": "c", "predicate": "p", "object": "o1"}, "one"),
+        person_entry("Café", "facts", {"subject": "c", "predicate": "p", "object": "o2"}, "two"),
+    ])
+    assert (vault / "People" / "cafe.md").exists()
+    assert (vault / "People" / "cafe-2.md").exists()
+    assert any("cafe-2.md" in p for p in rep["needs_confirm"])
+
+
+def test_per_source_reconciliation_removes_stale(mods, vault):
+    a = person_entry("Jane Doe", "facts", {"subject": "j", "predicate": "e", "object": "acme"}, "A")
+    b = person_entry("Jane Doe", "facts", {"subject": "j", "predicate": "city", "object": "nyc"}, "B")
+    run(mods, vault, [a, b], source="n.md", sha="sha-v1")
+    f = vault / "People" / "jane-doe.md"
+    assert len(bullets(mods, f, "facts")) == 2
+    run(mods, vault, [a], source="n.md", sha="sha-v2")  # same source, B dropped
+    remaining = bullets(mods, f, "facts")
+    assert len(remaining) == 1
+    assert "A" in remaining[0][1] and "B" not in remaining[0][1]
+
+
+def test_alias_routes_to_same_entity(mods, vault):
+    run(mods, vault, [person_entry("Jane Doe", "facts",
+        {"subject": "j", "predicate": "e", "object": "a"}, "F1", aliases=["Jane"])], source="n1.md")
+    run(mods, vault, [person_entry("Jane", "facts",
+        {"subject": "j", "predicate": "city", "object": "nyc"}, "F2")], source="n2.md")
+    assert (vault / "People" / "jane-doe.md").exists()
+    assert not (vault / "People" / "jane.md").exists()
+    assert len(bullets(mods, vault / "People" / "jane-doe.md", "facts")) == 2
+
+
+# --------------------------------------------------------------------------- #
+# notes_scan
+# --------------------------------------------------------------------------- #
+def _write(p: Path, text: str):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_scan_new_changed_unchanged(mods, vault):
+    _state, notes_scan, _ = mods
+    note = vault / "a note.md"
+    _write(note, "# A\nhello")
+
+    res = notes_scan.scan(vault, [], _state.load_state(vault), include_unchanged=False)
+    assert len(res) == 1 and res[0]["status"] == "new"
+    assert res[0]["link"] == "a note"
+
+    # Record it (empty extraction still records the source sha).
+    run(mods, vault, [], source="a note.md", link="a note", sha=res[0]["sha"])
+    assert notes_scan.scan(vault, [], _state.load_state(vault), include_unchanged=False) == []
+
+    _write(note, "# A\nhello world")  # change content
+    res2 = notes_scan.scan(vault, [], _state.load_state(vault), include_unchanged=False)
+    assert len(res2) == 1 and res2[0]["status"] == "changed"
+
+
+def test_scan_skips_generated_and_dotdirs(mods, vault):
+    _state, notes_scan, _ = mods
+    _write(vault / "real.md", "x")
+    _write(vault / "People" / "jane.md", "generated")
+    _write(vault / "Ideas-Projects" / "p.md", "generated")
+    _write(vault / ".obsidian" / "config.md", "hidden")
+    res = notes_scan.scan(vault, [], _state.load_state(vault), include_unchanged=True)
+    links = {r["link"] for r in res}
+    assert links == {"real"}
+
+
+def test_scan_extra_sources(mods, vault, tmp_path):
+    _state, notes_scan, _ = mods
+    extra = tmp_path / "extra notes"
+    _write(extra / "ext.txt", "external note")
+    res = notes_scan.scan(vault, [extra], _state.load_state(vault), include_unchanged=True)
+    assert any(r["link"] == "ext" for r in res)
+
+
+# --------------------------------------------------------------------------- #
+# helpers + frontmatter lint
+# --------------------------------------------------------------------------- #
+def test_split_frontmatter(mods):
+    _, _, upsert = mods
+    fm, body = upsert.split_frontmatter("---\ntype: person\nid: x\n---\n## Facts\n")
+    assert fm["type"] == "person" and fm["id"] == "x"
+    assert body == "## Facts\n"
+    fm2, body2 = upsert.split_frontmatter("no frontmatter")
+    assert fm2 == {} and body2 == "no frontmatter"
+
+
+def test_slugify_unicode(mods):
+    _state, _, _ = mods
+    assert _state.slugify("José O'Brien") == "jose-o-brien"
+    assert _state.slugify("Anne-Marie") == "anne-marie"
+    assert _state.slugify("张伟").startswith("n-")  # pure CJK → hash fallback
+
+
+def test_description_under_60_chars():
+    text = SKILL_MD.read_text(encoding="utf-8")
+    m = re.search(r"^description:\s*(.+)$", text, re.MULTILINE)
+    assert m, "description missing"
+    assert len(m.group(1).strip()) <= 60, len(m.group(1).strip())


### PR DESCRIPTION
## Summary

Adds an **optional** skill, `notes-extract`, that turns local markdown notes into structured **People** and **Idea/Project** files inside a vault. Scan notes → the agent extracts facts/commitments/ideas → the scripts write them into per-entity files keyed by a stable claim id, so re-runs are idempotent and never duplicate.

Scoped MVP of the *local-notes* half of #12325 (the recording-device and DB-backend halves are intentionally out of scope — see below).

## Placement

Under `optional-skills/note-taking/`, not bundled `skills/`. It's a vault/notes-oriented personal workflow that imposes a specific file layout, so it doesn't meet CONTRIBUTING's "broadly useful to most users" bar for bundled skills — but it ships with the repo and installs cleanly via `hermes skills install`.

## Design (the correctness floor)

A naive "append what the model extracts" pipeline degrades into an accreting pile of duplicate/contradictory bullets. This avoids that:

- **Claim-keyed stable ids.** Each entry's id = `sha(entity_id, section, {subject,predicate,object}, source_id)` — keyed on the *claim*, not the prose. Rewording a fact keeps the same id (no duplicate); a second source asserting the same claim keeps its own id (provenance preserved).
- **Managed-region fences.** Generated bullets live between `<!-- notes-extract:begin … -->` / `:end` markers (Obsidian `^block-ids`). Anything a human writes *outside* the fences is preserved byte-for-byte. First-seen dates are kept, so re-running on a later day is a no-op.
- **Per-source reconciliation.** Re-extracting a changed note converges (stale entries are removed), never append-only.
- **Identity.** NFC-normalized slugs (macOS stores NFD) with a hash fallback for non-ASCII names, an alias index, and an explicit `needs_confirm` flag on slug collisions — two different people are never silently merged.
- **State** is a rebuildable cache under `HERMES_HOME` (never written into the user's vault); writes are atomic (temp + `os.replace`). Stdlib only — no deps, no secrets, no network. The model emits the `claim`; the scripts own all identity/dedup/merge logic.

## Out of scope (documented extension points)

Apple Notes, always-on recording devices (Omi/Limitless/Friend/Plaud), database backends, automatic contradiction/supersession detection, and wikilink auto-repair.

## Files

- `optional-skills/note-taking/notes-extract/` — `SKILL.md`, `scripts/{_state,notes_scan,upsert_entry}.py`, `references/schema.md`, `templates/{person,project}.md`
- `tests/skills/test_notes_extract_skill.py`

## Test plan

Hermetic (stdlib + pytest, fixed clock, tmp `HERMES_HOME`, tmp vault with a space in its path, no network). Covers scan (new/changed/unchanged + skips generated/dot dirs + extra sources), and upsert (create, claim-dedup, multi-source provenance, idempotent rerun, hand-edit preservation, retract→archive, updated-bump-only-on-change, NFC slug collision, per-source reconciliation, alias routing), plus a description-length lint.

```
scripts/run_tests.sh tests/skills/test_notes_extract_skill.py -- -q   # 17 passed
ruff check .                          # clean
python scripts/check-windows-footguns.py --all   # clean
```

Tested on macOS (Apple Silicon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
