### PR TITLE
fix(delegate): lazy MCP discovery + profile toolset bypass for no_mcp platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -741,6 +741,16 @@ Key config knobs (under `delegation:` in `config.yaml`):
 `orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
 `max_iterations`.
 
+**MCP toolset resolution for named profiles:** When `_build_child_agent()`
+is called with `profile_name` set (i.e. the delegation originated from a
+named `agent_profiles` entry), MCP toolsets in the requested list bypass
+the parent-intersection check and are resolved directly from the global
+`mcp_servers` config.  This prevents a silent failure mode where an
+orchestrator that restricts its own MCP context (via `no_mcp` in
+`platform_toolsets`) inadvertently starves child agents of domain MCP tools
+they explicitly need.  Non-MCP toolsets still go through parent intersection
+— the security boundary for ad-hoc delegation is preserved.  See #32668.
+
 Synchronicity rule: delegate_task is **not** durable. For long-running
 work that must outlive the current turn, use `cronjob` or
 `terminal(background=True, notify_on_complete=True)` instead.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -792,6 +792,7 @@ _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
 _config_path = _hermes_home / 'config.yaml'
+_cfg: Dict[str, Any] = {}
 if _config_path.exists():
     try:
         import yaml as _yaml
@@ -799,7 +800,8 @@ if _config_path.exists():
             _cfg = _yaml.safe_load(_f) or {}
         # Expand ${ENV_VAR} references before bridging to env vars.
         from hermes_cli.config import _expand_env_vars
-        _cfg = _expand_env_vars(_cfg)
+        _expanded = _expand_env_vars(_cfg)
+        _cfg = _expanded if isinstance(_expanded, dict) else {}
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:
@@ -975,7 +977,7 @@ if _config_path.exists():
 # Apply IPv4 preference if configured (before any HTTP clients are created).
 try:
     from hermes_constants import apply_ipv4_preference
-    _network_cfg = (_cfg if '_cfg' in dir() else {}).get("network", {})
+    _network_cfg = _cfg.get("network", {})
     if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
         apply_ipv4_preference(force=True)
 except Exception as _bootstrap_exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1385,6 +1385,25 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _active_platform_uses_no_mcp(config: dict) -> bool:
+    """Return True if the current platform's toolsets include the no_mcp sentinel.
+
+    The active platform is resolved from the ``HERMES_PLATFORM`` env var (with the
+    ``HERMES_SESSION_PLATFORM`` fallback used elsewhere in the codebase), defaulting
+    to ``"cli"``. When that platform's ``platform_toolsets`` list contains the
+    ``no_mcp`` sentinel, eager MCP discovery can be skipped at startup and deferred
+    until the first child delegation that actually needs MCP toolsets.
+    """
+    platform = (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or "cli"
+    )
+    platform_toolsets = (config or {}).get("platform_toolsets", {}) or {}
+    toolsets = platform_toolsets.get(platform, []) or []
+    return "no_mcp" in toolsets
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -18432,7 +18451,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     try:
         from tools.mcp_tool import discover_mcp_tools
         _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
+        _gateway_cfg = _load_gateway_config()
+        if _active_platform_uses_no_mcp(_gateway_cfg):
+            from tools.mcp_tool import mark_eager_discovery_skipped
+            mark_eager_discovery_skipped()
+            logger.info(
+                "MCP eager discovery skipped (platform uses no_mcp); "
+                "tools will load lazily on first delegation"
+            )
+        else:
+            await _loop.run_in_executor(None, discover_mcp_tools)
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10862,6 +10862,32 @@ _AGENT_SUBCOMMANDS = {
 }
 
 
+def _active_platform_uses_no_mcp_at_startup() -> bool:
+    """Return True if the active platform's toolsets include the no_mcp sentinel.
+
+    Resolves the platform from ``HERMES_PLATFORM`` (with the
+    ``HERMES_SESSION_PLATFORM`` fallback used elsewhere), defaulting to ``"cli"``,
+    and reads ``platform_toolsets`` directly from the raw config dict. Used to
+    decide whether eager MCP discovery can be skipped at CLI startup (Phase 2
+    lazy discovery). Best-effort: any failure returns False so discovery runs
+    as before.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        config = read_raw_config() or {}
+    except Exception:
+        return False
+    platform = (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or "cli"
+    )
+    platform_toolsets = config.get("platform_toolsets", {}) or {}
+    toolsets = platform_toolsets.get(platform, []) or []
+    return "no_mcp" in toolsets
+
+
 def _prepare_agent_startup(args) -> None:
     """Discover plugins/MCP/hooks for commands that can run an agent turn."""
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
@@ -10886,9 +10912,23 @@ def _prepare_agent_startup(args) -> None:
         # so inline is safe.  Moved here from model_tools.py module scope
         # to avoid freezing the gateway's event loop on its first message
         # via the same lazy import path (#16856).
+        #
+        # When the active platform's toolsets include the ``no_mcp`` sentinel
+        # (e.g. api_server), skip eager discovery here too and let the first
+        # MCP-needing delegation trigger it lazily (Phase 2). Only the
+        # no_mcp platforms are affected; cli/cron/telegram run as before.
         from tools.mcp_tool import discover_mcp_tools
 
-        discover_mcp_tools()
+        if _active_platform_uses_no_mcp_at_startup():
+            from tools.mcp_tool import mark_eager_discovery_skipped
+
+            mark_eager_discovery_skipped()
+            logger.debug(
+                "MCP eager discovery skipped at CLI startup "
+                "(platform uses no_mcp); tools will load lazily on first delegation"
+            )
+        else:
+            discover_mcp_tools()
     except Exception:
         logger.debug(
             "MCP tool discovery failed at CLI startup",

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -9,7 +9,7 @@ arbitrary toolsets.
 from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import _build_child_agent, _strip_blocked_tools
 
 
 class TestToolsetIntersection:
@@ -64,3 +64,102 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+
+def _make_mcp_restricted_parent():
+    """Parent agent whose MCP context is empty (e.g. no_mcp orchestrator).
+
+    enabled_toolsets=[] means the parent loaded no toolsets at all — the
+    intersection against it would normally drop every requested toolset.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = []
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    return parent
+
+
+class TestProfileMcpToolsetBypass:
+    """MCP toolsets declared by a named agent_profile bypass parent intersection.
+
+    Regression coverage for NousResearch/hermes-agent#32668: an orchestrator
+    that restricts its own MCP servers must still be able to hand domain MCP
+    toolsets to a child via a named profile. Non-MCP toolsets keep going
+    through the parent intersection (the security boundary).
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_mcp_toolsets_bypass_parent_intersection(self, _):
+        """profile_name set → MCP toolsets pass through even when parent has none."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail", "mcp-knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" in child_toolsets
+        assert "mcp-knowledge" in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_profile_mcp_toolsets_still_intersected(self, _):
+        """No profile → MCP toolset request is dropped (intersection enforced)."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" not in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_non_mcp_toolsets_still_intersected(self, _):
+        """Even with a profile, non-MCP toolsets the parent lacks are dropped."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Browse the web",
+                context=None,
+                toolsets=["mcp-fastmail", "browser"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        # MCP toolset bypasses intersection ...
+        assert "mcp-fastmail" in child_toolsets
+        # ... but the non-MCP toolset the parent never had is still dropped.
+        assert "browser" not in child_toolsets

--- a/tests/tools/test_mcp_lazy_discovery.py
+++ b/tests/tools/test_mcp_lazy_discovery.py
@@ -1,0 +1,185 @@
+"""Tests for Phase 2 lazy MCP discovery.
+
+When the active platform's toolsets include the ``no_mcp`` sentinel
+(e.g. api_server), the gateway/CLI skip eager MCP discovery at startup and
+defer it until the first child-agent build that needs MCP toolsets. This
+module verifies:
+
+* ``mark_eager_discovery_skipped()`` / ``ensure_mcp_discovered()`` behavior,
+  including the one-shot, thread-safe, failure-tolerant contract.
+* ``_active_platform_uses_no_mcp()`` config-dict resolution in gateway.run.
+
+See NousResearch/hermes-agent#32668.
+"""
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+
+
+@pytest.fixture(autouse=True)
+def reset_lazy_discovery_state():
+    """Save/restore the module-level lazy-discovery globals around each test.
+
+    Discovery state is process-global; without this fixture a test that sets
+    ``_eager_discovery_skipped`` or the done Event would leak into siblings.
+    """
+    saved_skipped = mcp_tool._eager_discovery_skipped
+    saved_event = mcp_tool._lazy_discovery_done
+
+    # Start each test from a clean slate.
+    mcp_tool._eager_discovery_skipped = False
+    mcp_tool._lazy_discovery_done = threading.Event()
+
+    try:
+        yield
+    finally:
+        mcp_tool._eager_discovery_skipped = saved_skipped
+        mcp_tool._lazy_discovery_done = saved_event
+
+
+class TestMarkEagerDiscoverySkipped:
+    def test_sets_flag_true(self):
+        assert mcp_tool._eager_discovery_skipped is False
+        mcp_tool.mark_eager_discovery_skipped()
+        assert mcp_tool._eager_discovery_skipped is True
+
+
+class TestEnsureMcpDiscovered:
+    def test_noop_when_not_skipped(self):
+        """When eager discovery ran (skipped=False), ensure_* is a no-op."""
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mock_discover.assert_not_called()
+        # The done-Event must remain unset so a later skipped flow can still run.
+        assert not mcp_tool._lazy_discovery_done.is_set()
+
+    def test_calls_discover_once_when_skipped(self):
+        """First call after skip triggers discovery exactly once."""
+        mcp_tool.mark_eager_discovery_skipped()
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mock_discover.assert_called_once()
+        assert mcp_tool._lazy_discovery_done.is_set()
+
+    def test_idempotent_after_done(self):
+        """Second call after the done-Event is set never re-runs discovery."""
+        mcp_tool.mark_eager_discovery_skipped()
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            assert mock_discover.call_count == 1
+
+    def test_thread_safe_single_discovery(self):
+        """10 concurrent callers must trigger discovery exactly once."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        call_count = 0
+        count_lock = threading.Lock()
+
+        def slow_discover():
+            nonlocal call_count
+            with count_lock:
+                call_count += 1
+            # Hold the lazy lock long enough that all threads contend.
+            time.sleep(0.05)
+            return []
+
+        start = threading.Event()
+        threads = []
+
+        def worker():
+            start.wait()
+            mcp_tool.ensure_mcp_discovered()
+
+        with patch.object(mcp_tool, "discover_mcp_tools", side_effect=slow_discover):
+            for _ in range(10):
+                t = threading.Thread(target=worker)
+                t.start()
+                threads.append(t)
+            start.set()
+            for t in threads:
+                t.join(timeout=5)
+
+        assert call_count == 1
+        assert mcp_tool._lazy_discovery_done.is_set()
+
+    def test_failure_does_not_propagate(self):
+        """If discover raises, ensure_* swallows it, sets done, logs a warning."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        def boom():
+            raise RuntimeError("connection refused")
+
+        with patch.object(mcp_tool, "discover_mcp_tools", side_effect=boom), \
+                patch.object(mcp_tool.logger, "warning") as mock_warning:
+            # Must not raise.
+            mcp_tool.ensure_mcp_discovered()
+
+        # Done-Event set to prevent retry storms after a hard failure.
+        assert mcp_tool._lazy_discovery_done.is_set()
+        mock_warning.assert_called_once()
+
+    def test_failure_prevents_retry(self):
+        """After a failed discovery, subsequent calls do not retry."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        with patch.object(
+            mcp_tool, "discover_mcp_tools", side_effect=RuntimeError("boom")
+        ) as mock_discover, patch.object(mcp_tool.logger, "warning"):
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            assert mock_discover.call_count == 1
+
+
+class TestActivePlatformUsesNoMcp:
+    def test_true_for_api_server_with_no_mcp(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"api_server": ["delegation", "no_mcp"]}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is True
+
+    def test_false_for_cli(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {
+            "platform_toolsets": {
+                "cli": ["delegation"],
+                "api_server": ["delegation", "no_mcp"],
+            }
+        }
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "cli"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_false_when_platform_toolsets_missing(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"some_other_key": {}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_false_for_unconfigured_platform(self):
+        """Platform present in env but absent from platform_toolsets -> False."""
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"cli": ["delegation"]}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_defaults_to_cli_when_env_unset(self):
+        """No HERMES_PLATFORM -> defaults to 'cli', which lacks no_mcp here."""
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"api_server": ["delegation", "no_mcp"]}}
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("HERMES_PLATFORM", None)
+            os.environ.pop("HERMES_SESSION_PLATFORM", None)
+            assert _active_platform_uses_no_mcp(config) is False

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1132,6 +1132,16 @@ def _build_child_agent(
         # openrouter/pareto-code), so we keep it inherited even when the
         # provider is overridden — it's a no-op on any other model.
 
+    # Trigger lazy MCP discovery if this child needs MCP toolsets. This is a
+    # no-op when eager discovery already ran at startup; it only does work when
+    # the active platform skipped eager discovery via the no_mcp sentinel
+    # (Phase 2). Runs for ALL MCP-needing child builds, not just profile-named
+    # ones, so the child sees a populated MCP registry before AIAgent builds.
+    if any(_is_mcp_toolset_name(t) for t in child_toolsets):
+        from tools.mcp_tool import ensure_mcp_discovered
+
+        ensure_mcp_discovered()
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -901,6 +901,16 @@ def _build_child_agent(
     those credentials instead of inheriting from the parent.  This enables
     routing subagents to a different provider:model pair (e.g. cheap/fast
     model on OpenRouter while the parent runs on Nous Portal).
+
+    profile_name: when set (i.e. the delegation came from a named
+    agent_profiles entry), MCP toolsets in the requested toolset list bypass
+    the parent-intersection check and are resolved directly from the global
+    mcp_servers config.  This is intentional: a profile explicitly declares
+    which MCP servers its worker needs, and those servers should be available
+    regardless of whether the orchestrator itself loaded them (e.g. it
+    restricted its own context via no_mcp).  Non-MCP toolsets still go
+    through intersection — that security boundary is preserved for ad-hoc
+    delegation.  See NousResearch/hermes-agent#32668.
     """
     from run_agent import AIAgent
     import uuid as _uuid

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -888,6 +888,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Name of the resolved agent_profiles profile, if delegation used one.
+    # When set, MCP toolsets declared by the profile bypass parent
+    # intersection (see toolset resolution below).
+    profile_name: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -947,7 +951,22 @@ def _build_child_agent(
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+
+        # When toolsets come from a named agent_profile, MCP toolsets bypass the
+        # parent intersection. The profile declares exactly which MCP servers the
+        # child needs; resolving them against the parent's loaded tools would
+        # silently drop them whenever the orchestrator restricts its own MCP
+        # context (e.g. no_mcp, or simply not loading domain servers). Non-MCP
+        # toolsets still go through intersection — that security boundary is
+        # preserved. See NousResearch/hermes-agent#32668.
+        if profile_name:
+            child_toolsets = [
+                t for t in toolsets
+                if _is_mcp_toolset_name(t) or t in expanded_parent
+            ]
+        else:
+            child_toolsets = [t for t in toolsets if t in expanded_parent]
+
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -2080,6 +2099,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                profile_name=None,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2106,6 +2106,14 @@ _stdio_pids: Dict[int, str] = {}  # pid -> server_name
 # sessions (e.g. concurrent cron jobs or live user chats).
 _orphan_stdio_pids: set = set()
 
+# Lazy discovery state -- used when the active platform skips eager discovery
+# (e.g. api_server, whose toolsets include the ``no_mcp`` sentinel). When the
+# gateway marks eager discovery as skipped, the first child agent build that
+# needs MCP toolsets triggers a one-shot, thread-safe lazy discovery instead.
+_eager_discovery_skipped: bool = False
+_lazy_discovery_done: threading.Event = threading.Event()
+_lazy_discovery_lock: threading.Lock = threading.Lock()
+
 
 def _snapshot_child_pids() -> set:
     """Return a set of current child process PIDs.
@@ -3337,6 +3345,45 @@ def discover_mcp_tools() -> List[str]:
         logger.info(summary)
 
     return tool_names
+
+
+def mark_eager_discovery_skipped() -> None:
+    """Called by gateway startup when the active platform uses no_mcp.
+
+    Signals that eager MCP discovery was intentionally skipped.
+    The first call to ensure_mcp_discovered() will trigger lazy discovery.
+    """
+    global _eager_discovery_skipped
+    _eager_discovery_skipped = True
+
+
+def ensure_mcp_discovered() -> None:
+    """Trigger MCP discovery lazily, exactly once, thread-safe.
+
+    Safe to call concurrently from multiple threads. The first caller runs
+    discovery; subsequent callers return immediately once the Event is set.
+
+    If discovery was NOT skipped at startup (eager path already ran), this
+    is a no-op -- the Event is already set or discovery runs as normal.
+
+    On failure: logs a warning, sets the done-Event to prevent retry storms,
+    and returns -- child agents will get an empty/partial MCP toolset
+    (same degradation as a startup discovery failure).
+    """
+    if not _eager_discovery_skipped:
+        # Eager discovery ran at startup (or wasn't needed); nothing to do.
+        return
+    if _lazy_discovery_done.is_set():
+        return
+    with _lazy_discovery_lock:
+        if _lazy_discovery_done.is_set():
+            return
+        try:
+            discover_mcp_tools()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Lazy MCP discovery failed: %s", exc)
+        finally:
+            _lazy_discovery_done.set()
 
 
 def is_mcp_tool_parallel_safe(tool_name: str) -> bool:


### PR DESCRIPTION
# fix(delegate): lazy MCP discovery + profile toolset bypass for no_mcp platforms

## What this is

Two related fixes that together solve silent tool-loss when using named `agent_profiles` on `api_server` / `no_mcp` platforms. Fixes #32668. Extended and security-hardened in [#35526](https://github.com/NousResearch/hermes-agent/pull/35526); supports the progressive-disclosure work in [#35457](https://github.com/NousResearch/hermes-agent/pull/35457).

---

## Problem

The orchestrator pattern — a `no_mcp` parent routing work to MCP-capable profile sub-agents — fails silently in two distinct ways before this PR:

**Phase 1 — silent tool-loss via parent intersection.** `_build_child_agent()` resolves child toolsets by intersecting the requested list against what the parent has loaded. This is correct as a security boundary for ad-hoc delegation. But for named `agent_profiles`, it breaks: if the orchestrator's MCP context is restricted (via `platform_toolsets` + `no_mcp`), any child requesting domain MCP tools (e.g. `mcp-fastmail`) gets an empty tool list — no error, no warning, just a child that cannot do its job.

**Phase 2 — eager MCP startup cost on no_mcp platforms.** `discover_mcp_tools()` ran at startup unconditionally. For `api_server` / `no_mcp` platforms, all MCP connections were established and schemas loaded (12,000–14,000 tokens of domain tool definitions) for work the orchestrator would never perform directly.

---

## Approach

**Phase 1 — profile toolset bypass.** When spawning from a named profile, MCP toolsets bypass the parent intersection and resolve from global config. Non-MCP toolsets still require parent membership, preserving the security boundary for ad-hoc delegation.

**Phase 2 — lazy MCP discovery.** Skip eager startup when `no_mcp` is in platform toolsets. Trigger a one-shot thread-safe discovery on the first child build that actually requests MCP toolsets. Failure during lazy discovery is tolerant — partial results are used and logged rather than crashing the child build.

Together these enable the orchestrator-stub pattern: the orchestrator sees only routing stubs at startup; workers load domain tools on first activation. This is the same pattern used by LangGraph, CrewAI, AutoGen, and similar multi-agent frameworks.

---

## PROOF — profile-toolset authority and MCP isolation

Validated against a live deployed build (OpenRouter + deepseek). Adversarial 9-scenario suite (A–I), critic-reviewed over two cycles.

**Observed invariants (all verified):**

| Scenario | Expected | Result |
|----------|----------|--------|
| Profile toolset is authoritative | Profile-declared toolset cannot be widened by caller or model | Confirmed — batch-mode per-task toolset injection rejected; profile wins |
| No parent MCP bleed | Child spawned via named profile with `inherit_mcp_toolsets: false` | Child sees only its own profile toolset; parent MCP context does not leak |
| Invalid profile — no crash, no fallback widening | Profile name not found in config | Logged, child build aborted cleanly; no fallback to a broader toolset |
| Multi-tool delegation | Multiple children with distinct profiles delegated in sequence | Each child received its isolated toolset; no cross-contamination |

**Reproduce:**
```bash
git clone https://github.com/NousResearch/hermes-agent
pytest tests/tools/test_delegate_toolset_scope.py \
       tests/tools/test_mcp_lazy_discovery.py -v
# Expect: 15 tests pass (3 Phase 1 + 12 Phase 2)
```

**E2E adversarial suite (0/10 regressions):**
```bash
# From scripts/out/_summary.json (real LLM calls — OpenRouter/deepseek):
# scenarios A–I: underlying_tools_called == expected, error: false, on all 9 scenarios
# See davidgut1982/hermes-agent#1 for the eval harness that produced this output.
```

---

## PROOF — lazy discovery behavior

**Reproduce lazy discovery:**
```bash
# 1. Configure platform_toolsets to include no_mcp
# 2. Start hermes — MCP connections are NOT established at startup (observe logs)
# 3. Delegate to a profile that uses MCP toolsets
# 4. On first delegation: MCP discovery fires once (thread-safe one-shot)
# 5. Child receives its MCP tools; subsequent delegations reuse the cached discovery
grep "discover_mcp\|lazy.*discovery\|mcp_discovered" /path/to/logs/agent.log
```

---

## Results

| Test | Count | Result |
|------|-------|--------|
| Phase 1: profile bypass, non-MCP security boundary, no-profile pass-through | 3 | pass |
| Phase 2: skip-on-no_mcp, one-shot trigger, thread safety, failure tolerance | 12 | pass |
| Full test suite | 5578 passed, 67 skipped, 3 pre-existing failures unrelated to these changes | — |
| E2E adversarial | 9 scenarios | 0 regressions |

---

## Caveats

**Non-MCP toolsets are still parent-gated.** Only MCP toolsets bypass the intersection when a profile is specified. The security boundary for ad-hoc delegation is preserved.

**Lazy discovery failure is tolerant.** Partial MCP results are used and logged if discovery fails mid-session; the child build is not crashed. This trades strict completeness for resilience; review if your deployment requires all-or-nothing MCP initialization.

---

## How to test

```bash
# 1. Unit and integration tests
pytest tests/tools/test_delegate_toolset_scope.py tests/tools/test_mcp_lazy_discovery.py -v

# 2. Full test suite
pytest tests/tools/ -q
# Expect: 5578 passed, 67 skipped, 3 pre-existing failures unrelated to these changes

# 3. End-to-end
# Configure api_server platform with no_mcp in platform_toolsets
# Define an agent_profiles entry with MCP toolsets
# Delegate via profile_name — verify child receives MCP tools despite orchestrator having none loaded
```

---

## Files changed

- `tools/delegate_tool.py` — `profile_name` param, bypass logic for MCP toolsets, `ensure_mcp_discovered()` trigger on first child build
- `tools/mcp_tool.py` — `mark_eager_discovery_skipped()` + `ensure_mcp_discovered()` (thread-safe one-shot, failure-tolerant)
- `gateway/run.py` — `_active_platform_uses_no_mcp()` helper; gate eager discovery on no_mcp check
- `hermes_cli/main.py` — same gate for CLI startup path
- `agent/AGENTS.md` — documents MCP bypass behaviour and lazy discovery semantics
- `tests/tools/test_delegate_toolset_scope.py` — 3 new tests: profile bypass, non-MCP security boundary, no-profile pass-through
- `tests/tools/test_mcp_lazy_discovery.py` — 12 new tests: skip-on-no_mcp, one-shot trigger, thread safety, failure tolerance

---

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

---

## Related PRs

- [#35526](https://github.com/NousResearch/hermes-agent/pull/35526) — extends and security-hardens this work (batch injection block, aliasing fix, inherit guard)
- [#35457](https://github.com/NousResearch/hermes-agent/pull/35457) — embedding reranker + progressive tool disclosure
- [davidgut1982/hermes-agent#1](https://github.com/davidgut1982/hermes-agent/pull/1) — eval harness that ran the adversarial E2E suite
