### PR TITLE
fix(mcp): don't trip circuit breaker on tool-level semantic errors

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -250,3 +250,117 @@ def test_circuit_breaker_cleared_on_reconnect(monkeypatch, tmp_path):
         )
     finally:
         _cleanup(mcp_tool, "srv")
+
+
+# ---------------------------------------------------------------------------
+# Semantic-error vs transport-error distinction (regression for the
+# "get_page → put_page" trap)
+# ---------------------------------------------------------------------------
+
+
+def _make_call_returning_error(error_text: str):
+    """Build an async call_tool stub that simulates an MCP tool returning
+    a structured error result (``isError=True``). The handler wraps the
+    block text as ``{"error": "<error_text>"}`` for the agent.
+
+    This is how real MCP servers like gbrain signal semantic failures
+    (e.g. "page_not_found") — the tool ran successfully but reported a
+    structured negative result.
+    """
+    async def _call(*a, **kw):
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = error_text
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    return _call
+
+
+def test_semantic_error_envelope_does_not_bump_breaker(monkeypatch, tmp_path):
+    """A tool that returns a structured semantic-error envelope (e.g.
+    ``{"error": "page_not_found"}``) MUST NOT bump the server-level
+    circuit-breaker counter.
+
+    Regression: prior to this fix, ANY response containing an ``error``
+    key bumped the counter. Common agent flows like ``get_page → if
+    missing, put_page`` would trip the breaker after 3 cache misses and
+    lock the entire server for the cooldown window. The MCP server was
+    healthy the whole time — it just reported a structured negative
+    result for the read probes, which the breaker mis-classified as
+    server failures.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    # gbrain-shape envelope: tool ran, returned a structured "not found"
+    # result via isError=True. The MCP server is healthy.
+    envelope = json.dumps({
+        "error": "page_not_found",
+        "message": "Page not found: people/nonexistent",
+        "suggestion": "Page may be soft-deleted; pass include_deleted=true",
+    })
+
+    _install_stub_server(mcp_tool, "srv", _make_call_returning_error(envelope))
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "get_page", 10.0)
+
+        # Hit the handler 5x — well above the breaker threshold (3).
+        # The counter MUST stay at zero throughout: every "page_not_found"
+        # is a healthy semantic response, not a server failure.
+        for i in range(5):
+            result = handler({"slug": f"people/probe-{i}"})
+            parsed = json.loads(result)
+            # Confirm we got the envelope back (handler didn't short-circuit).
+            # The handler wraps the tool's error_text inside its own "error"
+            # field, so the gbrain-shape envelope appears as a substring.
+            assert "page_not_found" in parsed.get("error", ""), (
+                f"call {i}: handler should pass through the semantic error, "
+                f"not short-circuit. Got: {parsed}"
+            )
+
+        # The counter MUST be 0 — none of the 5 semantic errors counted.
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0, (
+            "semantic errors must not bump the breaker; got count="
+            f"{mcp_tool._server_error_counts.get('srv', 0)}"
+        )
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_unknown_error_envelope_still_bumps_breaker(monkeypatch, tmp_path):
+    """Errors NOT matching any known semantic pattern must continue to
+    bump the breaker. Preserves existing behavior for unknown errors —
+    fail closed on anything that might indicate a real server problem.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    # An "unknown" error string that doesn't match any semantic pattern.
+    envelope = "weird_internal_explosion: something nobody expected"
+
+    _install_stub_server(mcp_tool, "srv", _make_call_returning_error(envelope))
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+
+        # Hit the handler 3 times.
+        for _ in range(3):
+            handler({})
+
+        # Counter should have bumped 3x (matching threshold).
+        count = mcp_tool._server_error_counts.get("srv", 0)
+        assert count >= mcp_tool._CIRCUIT_BREAKER_THRESHOLD, (
+            f"unknown-pattern errors must still bump breaker; got count={count}"
+        )
+    finally:
+        _cleanup(mcp_tool, "srv")

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2393,11 +2393,39 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
+            # Check if the MCP tool itself returned an error.
+            #
+            # IMPORTANT: distinguish tool-level *semantic* errors (the MCP
+            # call succeeded and the tool reported a structured failure mode
+            # like "page_not_found" or "invalid_params") from real
+            # transport/internal errors. The server-level circuit breaker
+            # is meant to detect when the MCP SERVER is broken — not when
+            # a tool returns a perfectly-valid "no such resource" reply.
+            #
+            # Without this distinction, common agent patterns like
+            # "get_page → if missing, put_page" trip the breaker on the
+            # first 3 misses and lock the entire server. See gbrain
+            # voice-note-ingest flow.
             try:
                 parsed = json.loads(result)
                 if "error" in parsed:
-                    _bump_server_error(server_name)
+                    err_str = str(parsed.get("error", "")).lower()
+                    # Known semantic-error patterns: tool ran fine, just
+                    # reported a structured negative result. These do NOT
+                    # indicate server health problems — do not bump.
+                    _SEMANTIC_ERROR_PATTERNS = (
+                        "page_not_found", "not_found", "no such",
+                        "does not exist", "doesn't exist",
+                        "invalid_params", "invalid_input", "invalid_argument",
+                        "validation_error", "validation failed",
+                        "permission_denied", "unauthorized", "forbidden",
+                        "already_exists", "conflict", "duplicate",
+                        "rate_limit", "rate_limited", "too_many_requests",
+                    )
+                    if any(p in err_str for p in _SEMANTIC_ERROR_PATTERNS):
+                        _reset_server_error(server_name)  # tool worked, even if logic said no
+                    else:
+                        _bump_server_error(server_name)  # unknown error → assume real
                 else:
                     _reset_server_error(server_name)  # success — reset
             except (json.JSONDecodeError, TypeError):


### PR DESCRIPTION
## What does this PR do?

Fixes a circuit-breaker bug in `tools/mcp_tool.py` that mis-classifies tool-level *semantic* errors (e.g. `page_not_found`, `invalid_params`, `permission_denied`) as server-health failures, and trips the breaker as if the MCP server itself were unreachable.

The breaker treats ANY response containing an `"error"` key as a failure. But a successful MCP call that returns a structured negative result (the tool ran, the tool said "no such resource") is not a sign the server is broken. The server is healthy and responded correctly; the caller just asked for something that doesn't exist or isn't allowed.

**Real-world impact:** any agent flow that does check-then-write (e.g. `get_page → if missing, put_page`) trips the breaker after 3 cache misses and locks the entire server for the cooldown window. I discovered this debugging a gbrain voice-note-ingest pipeline — every voice memo my Hermes received got stashed in a Kanban TODO list instead of becoming a brain page, because the routine "does `people/<name>` exist yet?" probe pattern was tripping the breaker on every fresh entity. The gbrain MCP server was healthy and reachable the entire time.

## Related Issue

I didn't open one separately — the title + this body should be enough to reproduce. Happy to file an issue first if maintainers prefer.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py:2398-2402` — inside the json-parse path, when the response contains an `"error"` key, check the error string against a substring list of known semantic-error patterns. If it matches, reset the breaker counter (the tool ran fine, the server is healthy). If it doesn't match, continue to bump (preserves fail-closed behavior for unrecognized errors). The transport-error path at `:2429` is unchanged.

- `tests/tools/test_mcp_circuit_breaker.py` — extends with two new cases:
  - `test_semantic_error_envelope_does_not_bump_breaker` — hits a stub server 5x with `isError=True` + `page_not_found` envelopes (above the threshold of 3). Asserts counter stays at zero throughout.
  - `test_unknown_error_envelope_still_bumps_breaker` — hits a stub server 3x with an error string matching no semantic pattern. Asserts counter bumps to threshold (regression guard for the "fail-closed on unknown errors" contract).

## How to Test

1. `pytest tests/tools/test_mcp_circuit_breaker.py -v` → all 5 tests pass (3 existing + 2 new). Tests use the same stub-server pattern as the existing breaker tests in this file.

2. Real-world repro (the path I discovered the bug on): connect any MCP server that has a `get_X` tool which returns a structured `{"error": "not_found"}` envelope when the resource doesn't exist. Configure an agent flow that does `get_X → if missing, put_X`. Pre-fix: after 3 misses, every subsequent call to that server short-circuits with "MCP server X is unreachable after 3 consecutive failures." Post-fix: the breaker stays closed, the `put_X` call goes through, the resource gets created.

3. Stable on my Mac mini for 24+ hours now. The full voice-note-ingest → gbrain pipeline that originally failed (Hermes ↔ gbrain stdio MCP, Telegram inbound, faster-whisper STT, local Ollama fallback) now creates brain pages correctly end-to-end.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(mcp): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] My PR contains **only** changes related to this fix (one commit, two files)
- [x] I've run `pytest tests/tools/test_mcp_circuit_breaker.py -q` — all 5 tests pass
- [x] I've added tests for my changes (two new cases pinning both directions of the contract)
- [x] I've tested on my platform: macOS 15.5 (Apple Silicon)

### Documentation & Housekeeping

- [x] No README/docs changes needed — the bug is invisible to users; the fix only affects internal breaker behavior. The fix block is inline-commented at the patch site so the next reader knows the constraint.
- [x] N/A `cli-config.yaml.example` (no config keys added)
- [x] N/A `CONTRIBUTING.md` / `AGENTS.md` (no architecture or workflow changes)
- [x] N/A cross-platform — pure Python, no OS-specific code paths
- [x] N/A tool descriptions/schemas (no tool behavior changes)

## Screenshots / Logs

**Before** (pre-patch — circuit breaker tripping on legitimate get_page misses):

```
WARNING agent.tool_executor: Tool mcp_gbrain_get_page returned error (0.06s):
  {"error": "{"error": "page_not_found", "message": "Page not found: ..."}"}
WARNING agent.tool_executor: Tool mcp_gbrain_get_page returned error (0.06s):
  {"error": "{"error": "page_not_found", ...}"}
WARNING agent.tool_executor: Tool mcp_gbrain_get_page returned error (0.06s):
  {"error": "{"error": "page_not_found", ...}"}
WARNING agent.tool_executor: Tool mcp_gbrain_put_page returned error (0.00s):
  {"error": "MCP server 'gbrain' is unreachable after 3 consecutive failures."}
WARNING agent.tool_executor: Tool mcp_gbrain_put_page returned error (0.00s):
  {"error": "MCP server 'gbrain' is unreachable after 3 consecutive failures."}
```

`put_page` returns in `0.00s` because the breaker is short-circuiting before the call reaches the (perfectly healthy) MCP subprocess.

**After** (post-patch — same agent flow, voice memo arrives, brain page lands):

```
12:15:41 [Telegram] Cached user voice at audio_xxxxxx.ogg
12:15:41 inbound message: platform=telegram chat=... msg=''
12:16:11 response ready: platform=telegram chat=... time=30.5s api_calls=4 response=46 chars
```

```
$ gbrain list -n 5
ideas/agent-phone-prospect-calling   idea   2026-05-26   Agent phone prospect calling   ← created via this fix
...
```