### PR TITLE
[codex] Fix GPT-5.5 Codex backend stream compatibility

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -741,11 +741,13 @@ def _preflight_codex_api_kwargs(
     if store is not False:
         raise ValueError("Codex Responses contract requires 'store' to be false.")
 
+    strip_reasoning_replay = api_kwargs.get("_strip_reasoning_replay") is True
+
     allowed_keys = {
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
-        "extra_headers", "extra_body", "timeout",
+        "extra_headers", "extra_body", "timeout", "_strip_reasoning_replay",
     }
     normalized: Dict[str, Any] = {
         "model": model,
@@ -830,6 +832,13 @@ def _preflight_codex_api_kwargs(
         raise ValueError(
             f"Codex Responses request has unsupported field(s): {', '.join(unexpected)}."
         )
+
+    if strip_reasoning_replay:
+        # chatgpt.com/backend-api/codex sometimes stalls gpt-5.5 when sent
+        # generic Responses reasoning replay knobs. Keep store=false, but omit
+        # these optional replay fields instead of waiting for a timeout.
+        normalized.pop("reasoning", None)
+        normalized.pop("include", None)
 
     return normalized
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,41 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _recover_codex_stream_response_from_parts(
+    agent,
+    collected_output_items: list,
+    has_tool_calls: bool,
+):
+    """Build a final response when the SDK fails after streaming usable events."""
+    if collected_output_items:
+        logger.debug(
+            "Codex stream: recovered %d output items after SDK finalization error",
+            len(collected_output_items),
+        )
+        return SimpleNamespace(output=list(collected_output_items), status="completed")
+    if agent._codex_streamed_text_parts and not has_tool_calls:
+        assembled = "".join(agent._codex_streamed_text_parts)
+        logger.debug(
+            "Codex stream: recovered %d text deltas (%d chars) after SDK finalization error",
+            len(agent._codex_streamed_text_parts),
+            len(assembled),
+        )
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[
+                        SimpleNamespace(type="output_text", text=assembled),
+                    ],
+                )
+            ],
+            status="completed",
+        )
+    return None
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -271,6 +306,22 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            if "'NoneType' object is not iterable" in str(exc):
+                recovered = _recover_codex_stream_response_from_parts(
+                    agent,
+                    collected_output_items,
+                    has_tool_calls,
+                )
+                if recovered is not None:
+                    logger.warning(
+                        "Codex Responses stream finalization failed after usable events; "
+                        "recovering from streamed content. %s error=%s",
+                        agent._client_log_context(),
+                        exc,
+                    )
+                    return recovered
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,6 +11,17 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+def _should_strip_reasoning_replay_for_codex_backend(
+    model: str,
+    is_codex_backend: bool,
+) -> bool:
+    """Return True when the ChatGPT Codex backend needs reasoning replay omitted."""
+    if not is_codex_backend:
+        return False
+    normalized_model = str(model or "").strip().lower()
+    return normalized_model == "gpt-5.5" or normalized_model.startswith("gpt-5.5-")
+
+
 class ResponsesApiTransport(ProviderTransport):
     """Transport for api_mode='codex_responses'.
 
@@ -175,6 +186,11 @@ class ResponsesApiTransport(ProviderTransport):
                 merged_extra_headers["session_id"] = cache_scope_id
                 merged_extra_headers["x-client-request-id"] = cache_scope_id
                 kwargs["extra_headers"] = merged_extra_headers
+            if _should_strip_reasoning_replay_for_codex_backend(
+                model,
+                bool(is_codex_backend),
+            ):
+                kwargs["_strip_reasoning_replay"] = True
 
         max_tokens = params.get("max_tokens")
         if max_tokens is not None and not is_codex_backend:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -513,3 +513,62 @@ class TestCodexTransportTimeout:
             request_overrides={"timeout": 450.0},
         )
         assert kw.get("timeout") == 450.0
+
+
+class TestCodexBackendGpt55Compatibility:
+    """gpt-5.5 on chatgpt.com/backend-api/codex needs a stricter payload."""
+
+    def test_preflight_strips_responses_reasoning_replay_for_gpt55_codex_backend(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            reasoning_config={"effort": "high"},
+            session_id="session-123",
+            is_codex_backend=True,
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        assert kw.get("reasoning") == {"effort": "high", "summary": "auto"}
+        assert kw.get("include") == ["reasoning.encrypted_content"]
+        assert kw.get("store") is False
+
+        sanitized = transport.preflight_kwargs(kw)
+
+        assert "reasoning" not in sanitized
+        assert "include" not in sanitized
+        assert sanitized["store"] is False
+        assert sanitized["model"] == "gpt-5.5"
+        assert sanitized["extra_headers"]["session_id"] == "session-123"
+
+    def test_preflight_keeps_reasoning_for_gpt55_on_non_codex_backend(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            reasoning_config={"effort": "high"},
+            session_id="session-123",
+            is_codex_backend=False,
+        )
+
+        sanitized = transport.preflight_kwargs(kw)
+
+        assert sanitized["reasoning"] == {"effort": "high", "summary": "auto"}
+        assert sanitized["include"] == ["reasoning.encrypted_content"]
+        assert sanitized["store"] is False
+
+    def test_preflight_keeps_reasoning_for_non_gpt55_codex_backend(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            reasoning_config={"effort": "high"},
+            session_id="session-123",
+            is_codex_backend=True,
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+
+        sanitized = transport.preflight_kwargs(kw)
+
+        assert sanitized["reasoning"] == {"effort": "high", "summary": "auto"}
+        assert sanitized["include"] == ["reasoning.encrypted_content"]
+        assert sanitized["store"] is False

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -174,6 +174,26 @@ class _FakeResponsesStream:
         return self._final_response
 
 
+class _FakeResponsesStreamRaisesDuringIteration:
+    def __init__(self, events, exc):
+        self._events = list(events)
+        self._exc = exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+        raise self._exc
+
+    def get_final_response(self):
+        raise AssertionError("get_final_response should not be reached")
+
+
 class _FakeCreateStream:
     def __init__(self, events):
         self._events = list(events)
@@ -482,6 +502,42 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_when_sdk_finalization_sees_none_output(monkeypatch):
+    """ChatGPT Codex can stream usable output then send response.output=None.
+
+    The OpenAI SDK raises ``TypeError("'NoneType' object is not iterable")``
+    while parsing that terminal response. Hermes should keep the streamed
+    message instead of surfacing a non-retryable local TypeError.
+    """
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="recovered ok")],
+    )
+    stream = _FakeResponsesStreamRaisesDuringIteration(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_item.added", item=output_item),
+            SimpleNamespace(type="response.output_text.delta", delta="recovered "),
+            SimpleNamespace(type="response.output_text.delta", delta="ok"),
+            SimpleNamespace(type="response.output_item.done", item=output_item),
+        ],
+        TypeError("'NoneType' object is not iterable"),
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: stream,
+            create=lambda **kwargs: _codex_message_response("fallback should not run"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "recovered ok"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

- Strip Responses reasoning replay fields only for `gpt-5.5` / `gpt-5.5-*` when using `chatgpt.com/backend-api/codex`.
- Keep `store=false` in the sanitized payload because the Codex backend rejects requests without that contract.
- Recover from a ChatGPT Codex stream finalization shape where usable output items/text deltas arrive, but the terminal response has `output=None` and the OpenAI SDK raises `TypeError("'NoneType' object is not iterable")`.
- Add focused regression coverage for the GPT-5.5 Codex backend payload path and the partial-output stream recovery path.

## Root Cause

Hermes was sending generic Responses reasoning replay knobs (`reasoning` and `include`) to the ChatGPT Codex backend for GPT-5.5. In live testing this path could stall before first byte, while removing `store` caused a hard backend rejection (`Store must be set to false`). The minimal compatible payload keeps `store=false` and omits only the optional reasoning replay fields for this backend/model combination.

A second live legal-profile repro showed another Codex backend/SDK compatibility issue: the stream emitted `response.output_item.done` and text deltas successfully, then the terminal response carried `output=None`. The OpenAI SDK tries to iterate `response.output` during final parsing and raises a local `TypeError`. Hermes now converts the already-streamed output items/text into a completed response instead of aborting the turn.

## Validation

- `/Users/ax/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/agent/transports/test_codex_transport.py -q` -> 48 passed
- `/Users/ax/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_codex_silent_hang_hint.py -q` -> 76 passed
- Live legal profile smoke test after the stream recovery patch returned successfully in about 4s and logged recovery from streamed content instead of surfacing `NoneType`.
