### PR TITLE
fix: route auxiliary calls through configured fallbacks

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1473,6 +1473,31 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
 
 
 
+def _try_guard_recommended(
+    explicit_api_key: str = None, model: str = None
+) -> Tuple[Optional[OpenAI], Optional[str]]:
+    """Try the rate-limit guard's recommended provider for auxiliary tasks.
+
+    This mirrors the same routing the main conversation loop uses
+    (zai → opencode-go → deepseek PAYG), respecting watchdog state
+    so compression/summarisation don't retry exhausted providers.
+    """
+    try:
+        from agent.rate_limit_guard import get_auxiliary_recommendation
+    except ImportError:
+        return None, None
+
+    prov, rec_model = get_auxiliary_recommendation()
+    if not prov or not rec_model:
+        return None, None
+
+    # Resolve through the standard provider client path
+    result = resolve_provider_client(prov, model=rec_model)
+    if isinstance(result, tuple) and len(result) == 2:
+        return result
+    return None, None
+
+
 def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
@@ -1969,6 +1994,7 @@ def _get_provider_chain() -> List[tuple]:
     a caller explicitly requests it with a model.
     """
     return [
+        ("guard", _try_guard_recommended),  # Respect rate-limit guard first
         ("openrouter", _try_openrouter),
         ("nous", _try_nous),
         ("local/custom", _try_custom_endpoint),
@@ -4045,6 +4071,163 @@ def _get_task_extra_body(task: str) -> Dict[str, Any]:
     return {}
 
 
+def _configured_fallback_entries() -> List[Dict[str, Any]]:
+    """Return sanitized top-level fallback_providers entries from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except Exception:
+        return []
+    raw_entries = config.get("fallback_providers", []) if isinstance(config, dict) else []
+    if not isinstance(raw_entries, list):
+        return []
+    entries: List[Dict[str, Any]] = []
+    for raw in raw_entries:
+        if not isinstance(raw, dict):
+            continue
+        provider = str(raw.get("provider", "")).strip()
+        model = str(raw.get("model", "")).strip()
+        if not provider or not model:
+            continue
+        entry = dict(raw)
+        entry["provider"] = provider
+        entry["model"] = model
+        entries.append(entry)
+    return entries
+
+
+def _fallback_entry_api_key(entry: Dict[str, Any]) -> Optional[str]:
+    """Resolve an explicit api_key/key_env override for a fallback entry."""
+    raw_key = str(entry.get("api_key", "") or "").strip()
+    if raw_key:
+        return raw_key
+    key_env = str(
+        entry.get("key_env", "") or entry.get("api_key_env", "") or ""
+    ).strip()
+    if key_env:
+        return os.getenv(key_env, "").strip() or None
+    return None
+
+
+def _fallback_identity(provider: Optional[str], model: Optional[str], base_url: Optional[str]) -> tuple:
+    return (
+        _normalize_aux_provider(provider or ""),
+        (model or "").strip(),
+        (base_url or "").strip().rstrip("/"),
+    )
+
+
+def _fallback_error_is_retryable(exc: Exception) -> bool:
+    return _is_payment_error(exc) or _is_connection_error(exc) or _is_rate_limit_error(exc)
+
+
+def _rate_limit_guard_skips(provider: str, model: str) -> bool:
+    try:
+        from agent.rate_limit_guard import should_skip_provider
+        return bool(should_skip_provider(provider, model))
+    except Exception:
+        return False
+
+
+def _iter_configured_fallback_clients(
+    *,
+    task: Optional[str],
+    failed_provider: Optional[str],
+    failed_model: Optional[str],
+    failed_base_url: Optional[str],
+    async_mode: bool,
+    attempted: set,
+):
+    """Yield configured main fallback provider clients for auto auxiliary retry.
+
+    This intentionally does not mutate main-chat fallback state. It reuses the
+    standard auxiliary provider resolver so base_url/api_mode/key_env handling
+    stays centralized.
+    """
+    failed_identity = _fallback_identity(failed_provider, failed_model, failed_base_url)
+    for entry in _configured_fallback_entries():
+        provider = _normalize_aux_provider(entry.get("provider"))
+        model = str(entry.get("model", "") or "").strip()
+        base_url = str(entry.get("base_url", "") or "").strip() or None
+        api_mode = str(entry.get("api_mode", "") or "").strip() or None
+        identity = _fallback_identity(provider, model, base_url)
+        same_endpoint_as_failed = bool(
+            base_url
+            and failed_base_url
+            and base_url.rstrip("/") == str(failed_base_url).strip().rstrip("/")
+            and model == (failed_model or "").strip()
+        )
+        if identity in attempted or identity == failed_identity or same_endpoint_as_failed:
+            logger.info(
+                "Auxiliary %s: skipping configured fallback %s/%s (duplicate/current)",
+                task or "call", provider, model,
+            )
+            continue
+        attempted.add(identity)
+        if _is_provider_unhealthy(provider):
+            _log_skip_unhealthy(provider, task)
+            continue
+        if _rate_limit_guard_skips(provider, model):
+            logger.info(
+                "Auxiliary %s: skipping configured fallback %s/%s (rate-limit guard)",
+                task or "call", provider, model,
+            )
+            continue
+        api_key = _fallback_entry_api_key(entry)
+        try:
+            client, resolved_model = resolve_provider_client(
+                provider,
+                model=model,
+                async_mode=async_mode,
+                explicit_base_url=base_url,
+                explicit_api_key=api_key,
+                api_mode=api_mode,
+            )
+        except Exception as exc:
+            logger.info(
+                "Auxiliary %s: configured fallback %s/%s resolver failed: %s",
+                task or "call", provider, model, exc,
+            )
+            continue
+        if client is None:
+            logger.info(
+                "Auxiliary %s: configured fallback %s/%s unavailable",
+                task or "call", provider, model,
+            )
+            continue
+        yield provider, client, resolved_model or model, base_url
+
+
+def _build_fallback_kwargs(
+    provider: str,
+    model: str,
+    client: Any,
+    messages: list,
+    *,
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+    tools: Optional[list],
+    timeout: float,
+    extra_body: Dict[str, Any],
+    base_url: Optional[str] = None,
+) -> Dict[str, Any]:
+    client_base = str(getattr(client, "base_url", "") or "")
+    kwargs = _build_call_kwargs(
+        provider,
+        model,
+        messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        tools=tools,
+        timeout=timeout,
+        extra_body=extra_body,
+        base_url=client_base or base_url,
+    )
+    if _is_anthropic_compat_endpoint(provider, client_base):
+        kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+    return kwargs
+
+
 # ---------------------------------------------------------------------------
 # Anthropic-compatible endpoint detection + image block conversion
 # ---------------------------------------------------------------------------
@@ -4544,19 +4727,68 @@ def call_llm(
                 reason = "rate limit"
             else:
                 reason = "connection error"
-            logger.info("Auxiliary %s: %s on %s (%s), trying fallback",
+            logger.info("Auxiliary %s: %s on %s (%s), trying configured fallback chain",
                         task or "call", reason, resolved_provider, first_err)
-            fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
-            if fb_client is not None:
-                fb_kwargs = _build_call_kwargs(
-                    fb_label, fb_model, messages,
-                    temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
+            attempted = {
+                _fallback_identity(
+                    resolved_provider,
+                    final_model or resolved_model,
+                    _base_info or resolved_base_url,
+                )
+            }
+            for fb_label, fb_client, fb_model, fb_base_url in _iter_configured_fallback_clients(
+                task=task,
+                failed_provider=resolved_provider,
+                failed_model=final_model or resolved_model,
+                failed_base_url=_base_info or resolved_base_url,
+                async_mode=False,
+                attempted=attempted,
+            ):
+                logger.info(
+                    "Auxiliary %s: trying configured fallback %s/%s after %s",
+                    task or "call", fb_label, fb_model, reason,
+                )
+                fb_kwargs = _build_fallback_kwargs(
+                    fb_label,
+                    fb_model,
+                    fb_client,
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=effective_timeout,
                     extra_body=effective_extra_body,
-                    base_url=str(getattr(fb_client, "base_url", "") or ""))
-                return _validate_llm_response(
-                    fb_client.chat.completions.create(**fb_kwargs), task)
+                    base_url=fb_base_url,
+                )
+                try:
+                    return _validate_llm_response(
+                        fb_client.chat.completions.create(**fb_kwargs), task)
+                except Exception as fb_err:
+                    if not _fallback_error_is_retryable(fb_err):
+                        raise
+                    logger.info(
+                        "Auxiliary %s: configured fallback %s/%s failed with retryable error: %s",
+                        task or "call", fb_label, fb_model, fb_err,
+                    )
+                    continue
+
+            fb_result = _try_payment_fallback(resolved_provider, task, reason=reason)
+            if fb_result:
+                fb_client, fb_model, fb_label = fb_result
+                if fb_client is not None:
+                    fb_kwargs = _build_fallback_kwargs(
+                        fb_label,
+                        fb_model,
+                        fb_client,
+                        messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                    )
+                    return _validate_llm_response(
+                        fb_client.chat.completions.create(**fb_kwargs), task)
         # Connection/timeout errors leave the cached client poisoned (closed
         # httpx transport, half-read stream, dead async loop).  Drop it from
         # the cache regardless of whether we found a fallback above so the
@@ -4568,7 +4800,7 @@ def call_llm(
             except Exception:
                 logger.debug("Auxiliary: cache eviction after connection error failed",
                              exc_info=True)
-        raise
+        raise first_err
 
 
 def extract_content_or_reasoning(response) -> str:
@@ -4869,25 +5101,75 @@ async def async_call_llm(
                 reason = "rate limit"
             else:
                 reason = "connection error"
-            logger.info("Auxiliary %s (async): %s on %s (%s), trying fallback",
+            logger.info("Auxiliary %s (async): %s on %s (%s), trying configured fallback chain",
                         task or "call", reason, resolved_provider, first_err)
-            fb_client, fb_model, fb_label = _try_payment_fallback(
-                resolved_provider, task, reason=reason)
-            if fb_client is not None:
-                fb_kwargs = _build_call_kwargs(
-                    fb_label, fb_model, messages,
-                    temperature=temperature, max_tokens=max_tokens,
-                    tools=tools, timeout=effective_timeout,
-                    extra_body=effective_extra_body,
-                    base_url=str(getattr(fb_client, "base_url", "") or ""))
-                # Convert sync fallback client to async
-                async_fb, async_fb_model = _to_async_client(
-                    fb_client, fb_model or "", is_vision=(task == "vision")
+            attempted = {
+                _fallback_identity(
+                    resolved_provider,
+                    final_model or resolved_model,
+                    _client_base or resolved_base_url,
                 )
-                if async_fb_model and async_fb_model != fb_kwargs.get("model"):
-                    fb_kwargs["model"] = async_fb_model
-                return _validate_llm_response(
-                    await async_fb.chat.completions.create(**fb_kwargs), task)
+            }
+            for fb_label, fb_client, fb_model, fb_base_url in _iter_configured_fallback_clients(
+                task=task,
+                failed_provider=resolved_provider,
+                failed_model=final_model or resolved_model,
+                failed_base_url=_client_base or resolved_base_url,
+                async_mode=True,
+                attempted=attempted,
+            ):
+                logger.info(
+                    "Auxiliary %s (async): trying configured fallback %s/%s after %s",
+                    task or "call", fb_label, fb_model, reason,
+                )
+                fb_kwargs = _build_fallback_kwargs(
+                    fb_label,
+                    fb_model,
+                    fb_client,
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=effective_timeout,
+                    extra_body=effective_extra_body,
+                    base_url=fb_base_url,
+                )
+                try:
+                    return _validate_llm_response(
+                        await fb_client.chat.completions.create(**fb_kwargs), task)
+                except Exception as fb_err:
+                    if not _fallback_error_is_retryable(fb_err):
+                        raise
+                    logger.info(
+                        "Auxiliary %s (async): configured fallback %s/%s failed with retryable error: %s",
+                        task or "call", fb_label, fb_model, fb_err,
+                    )
+                    continue
+
+            fb_result = _try_payment_fallback(resolved_provider, task, reason=reason)
+            if fb_result:
+                fb_client, fb_model, fb_label = fb_result
+                if fb_client is not None:
+                    fb_kwargs = _build_fallback_kwargs(
+                        fb_label,
+                        fb_model,
+                        fb_client,
+                        messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        tools=tools,
+                        timeout=effective_timeout,
+                        extra_body=effective_extra_body,
+                    )
+                    # Convert legacy sync fallback client to async. Configured
+                    # fallbacks above request async clients directly.
+                    async_fb, async_fb_model = _to_async_client(
+                        fb_client, fb_model or "", is_vision=(task == "vision")
+                    )
+                    if async_fb_model and async_fb_model != fb_kwargs.get("model"):
+                        fb_kwargs["model"] = async_fb_model
+                    return _validate_llm_response(
+                        await async_fb.chat.completions.create(**fb_kwargs), task)
         # Mirror the sync path: drop poisoned clients on connection/timeout
         # so the next aux call rebuilds.  See issue #23432.
         if _is_connection_error(first_err):
@@ -4896,4 +5178,4 @@ async def async_call_llm(
             except Exception:
                 logger.debug("Auxiliary (async): cache eviction after connection error failed",
                              exc_info=True)
-        raise
+        raise first_err

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -986,11 +986,11 @@ class TestIsRateLimitError:
 class TestGetProviderChain:
     """_get_provider_chain() resolves functions at call time (testable)."""
 
-    def test_returns_four_entries(self):
+    def test_returns_five_entries_with_guard(self):
         chain = _get_provider_chain()
-        assert len(chain) == 4
+        assert len(chain) == 5
         labels = [label for label, _ in chain]
-        assert labels == ["openrouter", "nous", "local/custom", "api-key"]
+        assert labels == ["guard", "openrouter", "nous", "local/custom", "api-key"]
         # Codex is deliberately NOT in this chain — see _get_provider_chain
         # docstring. ChatGPT-account Codex has a shifting model allow-list;
         # guessing a model to fall back on breaks more often than it helps.
@@ -1001,7 +1001,7 @@ class TestGetProviderChain:
         sentinel = lambda: ("patched", "model")
         with patch("agent.auxiliary_client._try_openrouter", sentinel):
             chain = _get_provider_chain()
-        assert chain[0] == ("openrouter", sentinel)
+        assert chain[1] == ("openrouter", sentinel)  # guard now at [0]
 
 
 class TestTryPaymentFallback:
@@ -1110,6 +1110,296 @@ class TestCallLlmPaymentFallback:
             )
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
+
+    def test_auto_uses_configured_fallback_providers_before_legacy_chain(self):
+        """Auto auxiliary calls should walk configured main fallback_providers first."""
+        primary_client = MagicMock()
+        primary_client.base_url = "https://chatgpt.com/backend-api/codex"
+        primary_client.chat.completions.create.side_effect = self._make_429_rate_limit_error()
+
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://api.z.ai/api/coding/paas/v4"
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="configured fallback response"))
+        ])
+
+        cfg = {
+            "fallback_providers": [
+                {
+                    "provider": "zai",
+                    "model": "glm-5.1",
+                    "base_url": "https://api.z.ai/api/coding/paas/v4",
+                    "api_mode": "chat_completions",
+                },
+                {"provider": "deepseek", "model": "deepseek-v4-pro"},
+            ]
+        }
+
+        resolve_calls = []
+
+        def fake_resolve(provider, **kwargs):
+            resolve_calls.append((provider, kwargs))
+            assert provider == "zai"
+            assert kwargs["model"] == "glm-5.1"
+            assert kwargs["explicit_base_url"] == "https://api.z.ai/api/coding/paas/v4"
+            assert kwargs["api_mode"] == "chat_completions"
+            assert kwargs.get("async_mode") in {False, None}
+            return fallback_client, "glm-5.1"
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None) as legacy:
+            result = call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "configured fallback response"
+        assert [provider for provider, _ in resolve_calls] == ["zai"]
+        assert not legacy.called
+
+    def test_configured_fallback_chain_continues_after_first_fallback_rate_limit(self):
+        """If one configured fallback 429s, auxiliary should try the next configured fallback."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429_rate_limit_error("primary 429")
+
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/coding/paas/v4"
+        zai_client.chat.completions.create.side_effect = self._make_429_rate_limit_error("zai 429")
+
+        go_client = MagicMock()
+        go_client.base_url = "https://opencode.ai/zen/go/v1"
+        go_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="go response"))
+        ])
+
+        cfg = {
+            "fallback_providers": [
+                {"provider": "zai", "model": "glm-5.1"},
+                {"provider": "opencode-go", "model": "deepseek-v4-pro"},
+            ]
+        }
+
+        clients = {
+            "zai": (zai_client, "glm-5.1"),
+            "opencode-go": (go_client, "deepseek-v4-pro"),
+        }
+        resolve_calls = []
+
+        def fake_resolve(provider, **kwargs):
+            resolve_calls.append(provider)
+            return clients[provider]
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None) as legacy:
+            result = call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "go response"
+        assert resolve_calls == ["zai", "opencode-go"]
+        assert not legacy.called
+
+    def test_primary_connection_error_still_evicts_after_configured_fallback_rate_limit(self):
+        """Fallback errors must not mask primary connection-error cache eviction."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = Exception("connection refused: timeout")
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.side_effect = self._make_429_rate_limit_error("fallback 429")
+        cfg = {"fallback_providers": [{"provider": "zai", "model": "glm-5.1"}]}
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fallback_client, "glm-5.1")), \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None), \
+             patch("agent.auxiliary_client._evict_cached_client_instance") as evict:
+            with pytest.raises(Exception, match="connection refused"):
+                call_llm(
+                    task="session_search",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+
+        evict.assert_called_once_with(primary_client)
+
+    def test_primary_rate_limit_not_evicted_when_configured_fallback_connection_fails(self):
+        """A fallback connection error must not make us evict the primary rate-limited client."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429_rate_limit_error("primary 429")
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.side_effect = Exception("connection refused: fallback timeout")
+        cfg = {"fallback_providers": [{"provider": "zai", "model": "glm-5.1"}]}
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fallback_client, "glm-5.1")), \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None), \
+             patch("agent.auxiliary_client._evict_cached_client_instance") as evict:
+            with pytest.raises(Exception, match="primary 429"):
+                call_llm(
+                    task="session_search",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+
+        assert not evict.called
+
+    def test_explicit_provider_does_not_use_configured_fallback_chain(self):
+        """Explicit auxiliary providers are hard constraints and should not roam."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = self._make_429_rate_limit_error()
+
+        cfg = {"fallback_providers": [{"provider": "opencode-go", "model": "deepseek-v4-pro"}]}
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "glm-5.1")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("zai", "glm-5.1", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client") as resolve_fallback, \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None):
+            with pytest.raises(Exception, match="Rate limit"):
+                call_llm(
+                    task="session_search",
+                    provider="zai",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+
+        assert not resolve_fallback.called
+
+
+class TestAsyncCallLlmConfiguredFallback:
+    """async_call_llm() should mirror configured fallback behavior for session summaries."""
+
+    def _make_429_rate_limit_error(self, msg="Rate limit exceeded, try again in 60 seconds"):
+        exc = Exception(msg)
+        exc.status_code = 429
+        return exc
+
+    @pytest.mark.asyncio
+    async def test_async_auto_uses_configured_fallback_provider_directly(self):
+        primary_client = MagicMock()
+        primary_client.base_url = "https://chatgpt.com/backend-api/codex"
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_429_rate_limit_error()
+        )
+
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://api.z.ai/api/coding/paas/v4"
+        fallback_client.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[
+            MagicMock(message=MagicMock(content="async configured fallback"))
+        ]))
+
+        cfg = {
+            "fallback_providers": [
+                {"provider": "zai", "model": "glm-5.1", "key_env": "GLM_API_KEY"},
+            ]
+        }
+        resolve_calls = []
+
+        def fake_resolve(provider, **kwargs):
+            resolve_calls.append((provider, kwargs))
+            assert kwargs["async_mode"] is True
+            assert kwargs["explicit_api_key"] == "glm-key"
+            return fallback_client, "glm-5.1"
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch.dict(os.environ, {"GLM_API_KEY": "glm-key"}), \
+             patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None) as legacy, \
+             patch("agent.auxiliary_client._to_async_client") as to_async:
+            result = await async_call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "async configured fallback"
+        assert [provider for provider, _ in resolve_calls] == ["zai"]
+        assert not legacy.called
+        assert not to_async.called
+
+    @pytest.mark.asyncio
+    async def test_async_primary_connection_error_still_evicts_after_configured_fallback_rate_limit(self):
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("connection refused: timeout")
+        )
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_429_rate_limit_error("fallback 429")
+        )
+        cfg = {"fallback_providers": [{"provider": "zai", "model": "glm-5.1"}]}
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fallback_client, "glm-5.1")), \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None), \
+             patch("agent.auxiliary_client._evict_cached_client_instance") as evict:
+            with pytest.raises(Exception, match="connection refused"):
+                await async_call_llm(
+                    task="session_search",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+
+        evict.assert_called_once_with(primary_client)
+
+    @pytest.mark.asyncio
+    async def test_async_primary_rate_limit_not_evicted_when_configured_fallback_connection_fails(self):
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=self._make_429_rate_limit_error("primary 429")
+        )
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create = AsyncMock(
+            side_effect=Exception("connection refused: fallback timeout")
+        )
+        cfg = {"fallback_providers": [{"provider": "zai", "model": "glm-5.1"}]}
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                   return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "gpt-5.5", None, None, None)), \
+             patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fallback_client, "glm-5.1")), \
+             patch("agent.auxiliary_client._try_payment_fallback", return_value=None), \
+             patch("agent.auxiliary_client._evict_cached_client_instance") as evict:
+            with pytest.raises(Exception, match="primary 429"):
+                await async_call_llm(
+                    task="session_search",
+                    messages=[{"role": "user", "content": "hello"}],
+                )
+
+        assert not evict.called
+
 
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
@@ -2735,6 +3025,7 @@ class TestAuxUnhealthyCache:
         with patch("agent.auxiliary_client._read_main_provider", return_value="openrouter"), \
              patch("agent.auxiliary_client._read_main_model", return_value="anthropic/claude-sonnet-4.6"), \
              patch("agent.auxiliary_client.resolve_provider_client") as step1, \
+             patch("agent.auxiliary_client._try_guard_recommended", return_value=(None, None)), \
              patch("agent.auxiliary_client._try_openrouter") as or_try, \
              patch("agent.auxiliary_client._try_nous", return_value=(nous_client, "n-model")), \
              patch("agent.auxiliary_client._try_custom_endpoint", return_value=(None, None)), \


### PR DESCRIPTION
## Summary
- route auto auxiliary LLM retries through top-level `fallback_providers` before legacy auxiliary fallback
- preserve explicit auxiliary provider pins as hard constraints
- keep sync and async auxiliary fallback behavior aligned
- skip duplicate/current/unhealthy/rate-guarded fallback entries and continue past resolver/retryable fallback failures
- preserve primary connection-error cache eviction semantics when configured fallbacks also fail

## Test plan
- `python -m compileall -q agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `python -m pytest tests/agent/test_auxiliary_client.py tests/agent/test_unsupported_temperature_retry.py tests/agent/test_unsupported_parameter_retry.py tests/agent/test_nous_rate_guard.py tests/agent/test_rate_limit_tracker.py tests/run_agent/test_provider_fallback.py tests/gateway/test_session_model_override_routing.py -q -o 'addopts='`
  - 283 passed

## Review
- static scan of added lines found no hardcoded secrets, shell injection, eval/exec, pickle, or SQL string-formatting patterns
- independent pre-commit review passed with no security concerns or blocking logic errors
