### PR TITLE
fix(discord): accept bot role mentions

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3663,6 +3663,44 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _mentioned_bot_role_ids(self, message: Any) -> set[str]:
+        """Return bot-owned role IDs mentioned by a Discord message.
+
+        Discord exposes user mentions and role mentions separately.  Users often
+        mention a bot's server role (for example ``@Hermes Bot``) expecting it
+        to wake the bot, so role mentions should satisfy ``require_mention``
+        only when the mentioned role is actually assigned to this bot.
+        """
+        role_mentions = getattr(message, "role_mentions", None) or []
+        mentioned_role_ids = {
+            str(role_id)
+            for role in role_mentions
+            for role_id in (getattr(role, "id", role),)
+            if role_id is not None
+        }
+        if not mentioned_role_ids:
+            return set()
+
+        guild = getattr(message, "guild", None) or getattr(getattr(message, "channel", None), "guild", None)
+        member = getattr(guild, "me", None) if guild is not None else None
+        if member is None and guild is not None:
+            get_member = getattr(guild, "get_member", None)
+            user_id = getattr(getattr(self, "_client", None), "user", None)
+            user_id = getattr(user_id, "id", None)
+            if callable(get_member) and user_id is not None:
+                try:
+                    member = get_member(user_id)
+                except Exception:
+                    member = None
+
+        bot_role_ids = {
+            str(role_id)
+            for role in (getattr(member, "roles", None) or [])
+            for role_id in (getattr(role, "id", role),)
+            if role_id is not None
+        }
+        return mentioned_role_ids & bot_role_ids
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4489,10 +4527,15 @@ class DiscordAdapter(BasePlatformAdapter):
             if snapshot_text_parts and not raw_content:
                 raw_content = "\n".join(snapshot_text_parts)
                 normalized_content = raw_content
-        if self._client.user and self._client.user in message.mentions:
+        mentioned_bot_role_ids = self._mentioned_bot_role_ids(message)
+        client_user = getattr(self._client, "user", None)
+        if (client_user and client_user in message.mentions) or mentioned_bot_role_ids:
             mention_prefix = True
-            normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
-            normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+            if client_user:
+                normalized_content = normalized_content.replace(f"<@{client_user.id}>", "").strip()
+                normalized_content = normalized_content.replace(f"<@!{client_user.id}>", "").strip()
+            for role_id in mentioned_bot_role_ids:
+                normalized_content = normalized_content.replace(f"<@&{role_id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -59,7 +59,7 @@ class FakeTextChannel:
     def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server"):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=987, name=guild_name)
         self.topic = None
 
     def history(self, *, limit, before, after=None, oldest_first=None):
@@ -73,7 +73,7 @@ class FakeForumChannel:
     def __init__(self, channel_id: int = 1, name: str = "support-forum", guild_name: str = "Hermes Server"):
         self.id = channel_id
         self.name = name
-        self.guild = SimpleNamespace(name=guild_name)
+        self.guild = SimpleNamespace(id=987, name=guild_name)
         self.type = 15
         self.topic = None
 
@@ -84,7 +84,7 @@ class FakeThread:
         self.name = name
         self.parent = parent
         self.parent_id = getattr(parent, "id", None)
-        self.guild = getattr(parent, "guild", None) or SimpleNamespace(name=guild_name)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(id=987, name=guild_name)
         self.topic = None
 
     def history(self, *, limit, before, after=None, oldest_first=None):
@@ -125,16 +125,18 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None, msg_type=None):
+def make_message(*, channel, content: str, mentions=None, role_mentions=None, msg_type=None):
     author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
+        role_mentions=list(role_mentions or []),
         attachments=[],
         reference=None,
         created_at=datetime.now(timezone.utc),
         channel=channel,
+        guild=getattr(channel, "guild", None),
         author=author,
         type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
     )
@@ -345,6 +347,47 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "hello with mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_accepts_bot_role_mentions_when_required(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_role = SimpleNamespace(id=555, name="Hermes Bot")
+    channel = FakeTextChannel(channel_id=321)
+    channel.guild.me = SimpleNamespace(roles=[bot_role])
+    message = make_message(
+        channel=channel,
+        content=f"<@&{bot_role.id}> hello through role mention",
+        role_mentions=[bot_role],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello through role mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_ignores_unrelated_role_mentions_when_required(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_role = SimpleNamespace(id=555, name="Hermes Bot")
+    unrelated_role = SimpleNamespace(id=777, name="Other Bot")
+    channel = FakeTextChannel(channel_id=321)
+    channel.guild.me = SimpleNamespace(roles=[bot_role])
+    message = make_message(
+        channel=channel,
+        content=f"<@&{unrelated_role.id}> hello through role mention",
+        role_mentions=[unrelated_role],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- let Discord messages that mention a bot-owned role satisfy require_mention
- strip the bot role mention from normalized message text
- keep unrelated role mentions ignored when require_mention is enabled

## Tests
- ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_discord_free_response.py -q
- git diff --check
- ~/.hermes/hermes-agent/venv/bin/python - <<'PY'
import plugins.platforms.discord.adapter
print('discord_adapter_import_ok')
PY