### PR TITLE
fix(weixin/media): Windows drive path support in MEDIA tags + CDN upload fallback

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2412,8 +2412,17 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        media_path = (
+            r"`[^`\n]+`"
+            r"|\"[^\"\n]+\""
+            r"|'[^'\n]+'"
+            r"|(?:~/|/|[A-Za-z]:[\\/])"
+            r"\S+(?:[^\S\n]+\S+)*?"
+            r"\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)"
+            r"(?=[\s`\"',;:)\]}]|$)"
+        )
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            rf'''[`"']?MEDIA:\s*(?P<path>{media_path})[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -555,7 +555,11 @@ async def _upload_ciphertext(
     # "Timeout context manager should be used inside a task" errors when
     # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
     async def _do_upload() -> str:
-        async with session.post(upload_url, data=ciphertext, headers={"Content-Type": "application/octet-stream"}) as response:
+        headers = {
+            "Content-Type": "application/octet-stream",
+            "Content-Length": str(len(ciphertext)),
+        }
+        async with session.post(upload_url, data=ciphertext, headers=headers) as response:
             if response.status == 200:
                 encrypted_param = response.headers.get("x-encrypted-param")
                 if encrypted_param:
@@ -1926,18 +1930,32 @@ class WeixinAdapter(BasePlatformAdapter):
         # Prefer upload_full_url (direct CDN), fall back to constructed CDN URL
         # from upload_param.  Both paths use POST — the old PUT for
         # upload_full_url caused 404s on the WeChat CDN.
+        upload_urls: list[str] = []
         if upload_full_url:
-            upload_url = upload_full_url
-        elif upload_param:
-            upload_url = _cdn_upload_url(self._cdn_base_url, upload_param, filekey)
-        else:
+            upload_urls.append(upload_full_url)
+        if upload_param:
+            upload_param_url = _cdn_upload_url(self._cdn_base_url, upload_param, filekey)
+            if upload_param_url not in upload_urls:
+                upload_urls.append(upload_param_url)
+        if not upload_urls:
             raise RuntimeError(f"getUploadUrl returned neither upload_param nor upload_full_url: {upload_response}")
 
-        encrypted_query_param = await _upload_ciphertext(
-            self._send_session,
-            ciphertext=ciphertext,
-            upload_url=upload_url,
-        )
+        encrypted_query_param = None
+        upload_errors: list[str] = []
+        for upload_url in upload_urls:
+            try:
+                encrypted_query_param = await _upload_ciphertext(
+                    self._send_session,
+                    ciphertext=ciphertext,
+                    upload_url=upload_url,
+                )
+                break
+            except RuntimeError as exc:
+                upload_errors.append(str(exc))
+                if upload_url == upload_urls[-1]:
+                    raise
+        if encrypted_query_param is None:
+            raise RuntimeError(f"CDN upload failed: {'; '.join(upload_errors)}")
         context_token = self._token_store.get(self._account_id, chat_id)
         # The iLink API expects aes_key as base64(hex_string), not base64(raw_bytes).
         # Sending base64(raw_bytes) causes images to show as grey boxes on the

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -330,6 +330,18 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_media_tag_supports_windows_drive_paths(self):
+        content = "MEDIA:C:/Users/fkl26/Pictures/demo image.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("C:/Users/fkl26/Pictures/demo image.png", False)]
+        assert cleaned == ""
+
+    def test_media_tag_supports_windows_backslash_paths(self):
+        content = r"MEDIA:C:\Users\fkl26\Pictures\demo image.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [(r"C:\Users\fkl26\Pictures\demo image.png", False)]
+        assert cleaned == ""
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -512,7 +512,8 @@ class TestWeixinOutboundMedia:
         assert len(session.post_calls) == 1
         upload_url, upload_kwargs = session.post_calls[0]
         assert upload_url == "https://upload.example.com/media"
-        assert upload_kwargs["headers"] == {"Content-Type": "application/octet-stream"}
+        assert upload_kwargs["headers"]["Content-Type"] == "application/octet-stream"
+        assert upload_kwargs["headers"]["Content-Length"] == str(len(upload_kwargs["data"]))
         assert upload_kwargs["data"]
         # Timeout is now enforced externally via asyncio.wait_for() rather than
         # aiohttp.ClientTimeout, so it no longer appears as a post() kwarg.
@@ -521,6 +522,67 @@ class TestWeixinOutboundMedia:
         media = payload["msg"]["item_list"][0]["image_item"]["media"]
         assert media["encrypt_query_param"] == "enc-param"
         assert media["aes_key"] == expected_aes_key
+
+    def test_send_file_falls_back_to_upload_param_when_upload_full_url_5xx(self, tmp_path):
+        class _UploadResponse:
+            def __init__(self, status, encrypted_param=""):
+                self.status = status
+                self.headers = {"x-encrypted-param": encrypted_param} if encrypted_param else {}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def read(self):
+                return b""
+
+            async def text(self):
+                return "temporary cdn failure"
+
+        class _RecordingSession:
+            def __init__(self):
+                self.post_calls = []
+
+            def post(self, url, **kwargs):
+                self.post_calls.append((url, kwargs))
+                if len(self.post_calls) == 1:
+                    return _UploadResponse(500)
+                return _UploadResponse(200, encrypted_param="fallback-enc-param")
+
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"fake-png-bytes")
+
+        adapter = _make_adapter()
+        session = _RecordingSession()
+        adapter._session = session
+        adapter._send_session = session
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._cdn_base_url = "https://cdn.example.com/c2c"
+        adapter._token_store.get = lambda account_id, chat_id: None
+
+        with patch(
+            "gateway.platforms.weixin._get_upload_url",
+            new=AsyncMock(return_value={
+                "upload_full_url": "https://upload.example.com/media",
+                "upload_param": "encrypted=query&with spaces",
+            }),
+        ), patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock) as api_post_mock:
+            message_id = asyncio.run(adapter._send_file("wxid_test123", str(image_path), ""))
+
+        assert message_id.startswith("hermes-weixin-")
+        assert len(session.post_calls) == 2
+        assert session.post_calls[0][0] == "https://upload.example.com/media"
+        assert session.post_calls[1][0].startswith("https://cdn.example.com/c2c/upload?")
+        assert "encrypted_query_param=" in session.post_calls[1][0]
+        assert session.post_calls[0][1]["headers"]["Content-Length"] == str(
+            len(session.post_calls[0][1]["data"])
+        )
+        payload = api_post_mock.await_args.kwargs["payload"]
+        media = payload["msg"]["item_list"][0]["image_item"]["media"]
+        assert media["encrypt_query_param"] == "fallback-enc-param"
 
 
 class TestWeixinRemoteMediaSafety:


### PR DESCRIPTION
## Summary

Two fixes for WeChat native media delivery on Windows:

### 1. Windows drive path support in MEDIA tag parsing
`gateway/platforms/base.py` — Extends the MEDIA tag regex to parse Windows absolute paths (`C:\Users\...\image.png` and `C:/Users/.../image.png`). Previously only Unix paths (`/tmp/...`, `~/...`) were recognized.

### 2. CDN upload robustness
`gateway/platforms/weixin.py` — Adds Content-Length header to ciphertext uploads (some CDNs reject requests without it). Adds retry fallback: when `upload_full_url` returns 5xx, fall back to the upload_param URL path before failing.

## Tests
- `test_platform_base.py`: 2 new tests for Windows forward-slash and backslash paths
- `test_weixin.py`: Updated Content-Length assertion + new `test_send_file_falls_back_to_upload_param_when_upload_full_url_5xx`

## Verification
- All existing tests pass
- Verified on Windows with actual WeChat iLink media delivery