### PR TITLE
fix(config): bridge providers.acp settings to Copilot ACP env vars

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3298,6 +3298,45 @@ def _normalize_custom_provider_entry(
     return normalized
 
 
+# Settings-only blocks under ``providers`` — not OpenAI-compatible custom providers.
+_ACP_PROVIDER_CONFIG_KEYS = frozenset({"acp", "copilot-acp"})
+
+
+def _bridge_acp_provider_settings(config: Dict[str, Any]) -> None:
+    """Bridge ``providers.acp`` settings into Copilot ACP env vars.
+
+    ``providers.acp`` holds local CLI settings (binary path, args) rather than
+    a ``base_url``/``api_key`` pair.  Without this bridge, ``copilot_path`` was
+    ignored and ``_normalize_custom_provider_entry`` logged unknown-key warnings
+    on every config load.
+    """
+    providers = config.get("providers")
+    if not isinstance(providers, dict):
+        return
+
+    for key in _ACP_PROVIDER_CONFIG_KEYS:
+        entry = providers.get(key)
+        if not isinstance(entry, dict):
+            continue
+
+        command = entry.get("copilot_path") or entry.get("command")
+        if isinstance(command, str) and command.strip():
+            if not os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip():
+                os.environ["HERMES_COPILOT_ACP_COMMAND"] = command.strip()
+            if not os.getenv("COPILOT_CLI_PATH", "").strip():
+                os.environ["COPILOT_CLI_PATH"] = command.strip()
+
+        args = entry.get("args")
+        if isinstance(args, str) and args.strip():
+            if not os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip():
+                os.environ["HERMES_COPILOT_ACP_ARGS"] = args.strip()
+        elif isinstance(args, list):
+            joined = " ".join(str(a).strip() for a in args if str(a).strip())
+            if joined and not os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip():
+                os.environ["HERMES_COPILOT_ACP_ARGS"] = joined
+        break
+
+
 def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, Any]]:
     """Normalize ``providers`` config entries into the legacy custom-provider shape."""
     if not isinstance(providers_dict, dict):
@@ -3305,6 +3344,8 @@ def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, An
 
     custom_providers: List[Dict[str, Any]] = []
     for key, entry in providers_dict.items():
+        if str(key).strip().lower() in _ACP_PROVIDER_CONFIG_KEYS:
+            continue
         normalized = _normalize_custom_provider_entry(entry, provider_key=str(key))
         if normalized is not None:
             custom_providers.append(normalized)
@@ -4590,6 +4631,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
         expanded = _expand_env_vars(normalized)
+        _bridge_acp_provider_settings(expanded)
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_key is not None:
             # Cache stores a separate deepcopy so subsequent ``load_config()``

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -392,7 +392,7 @@ Full config reference: https://hermes-agent.nousresearch.com/docs/user-guide/con
 | OpenCode Go | API key | `OPENCODE_GO_API_KEY` |
 | Qwen OAuth | OAuth | `hermes login --provider qwen-oauth` |
 | Custom endpoint | Config | `model.base_url` + `model.api_key` in config.yaml |
-| GitHub Copilot ACP | External | `COPILOT_CLI_PATH` or Copilot CLI |
+| GitHub Copilot ACP | External | `providers.acp.copilot_path` in config.yaml, or `COPILOT_CLI_PATH` / `HERMES_COPILOT_ACP_COMMAND` |
 
 Full provider docs: https://hermes-agent.nousresearch.com/docs/integrations/providers
 

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -5,11 +5,16 @@ accepted as base_url, and unknown keys go unreported.
 """
 
 import logging
+import os
 from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.config import _normalize_custom_provider_entry
+from hermes_cli.config import (
+    _bridge_acp_provider_settings,
+    _normalize_custom_provider_entry,
+    providers_dict_to_custom_providers,
+)
 
 
 class TestNormalizeCustomProviderEntry:
@@ -193,3 +198,36 @@ class TestNormalizeCustomProviderEntry:
         result = _normalize_custom_provider_entry(entry)
         assert result is not None
         assert "models" not in result
+
+
+class TestAcpProviderConfig:
+    """Tests for providers.acp settings-only blocks."""
+
+    def test_acp_entry_skipped_from_custom_providers(self):
+        result = providers_dict_to_custom_providers({
+            "acp": {"copilot_path": "/opt/homebrew/bin/copilot"},
+            "ollama": {"base_url": "http://127.0.0.1:11434/v1"},
+        })
+        names = [entry["name"] for entry in result]
+        assert names == ["ollama"]
+
+    def test_bridge_copilot_path_to_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_COPILOT_ACP_COMMAND", raising=False)
+        monkeypatch.delenv("COPILOT_CLI_PATH", raising=False)
+        config = {"providers": {"acp": {"copilot_path": "/opt/homebrew/bin/copilot"}}}
+        _bridge_acp_provider_settings(config)
+        assert os.environ["HERMES_COPILOT_ACP_COMMAND"] == "/opt/homebrew/bin/copilot"
+        assert os.environ["COPILOT_CLI_PATH"] == "/opt/homebrew/bin/copilot"
+
+    def test_bridge_does_not_override_existing_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_COPILOT_ACP_COMMAND", "/existing/copilot")
+        config = {"providers": {"acp": {"copilot_path": "/opt/homebrew/bin/copilot"}}}
+        _bridge_acp_provider_settings(config)
+        assert os.environ["HERMES_COPILOT_ACP_COMMAND"] == "/existing/copilot"
+
+    def test_acp_copilot_path_no_unknown_key_warning(self, caplog):
+        entry = {"copilot_path": "/opt/homebrew/bin/copilot"}
+        with caplog.at_level(logging.WARNING):
+            result = providers_dict_to_custom_providers({"acp": entry})
+        assert result == []
+        assert "unknown config keys ignored" not in caplog.text


### PR DESCRIPTION
## Summary
- Bridge `providers.acp.copilot_path` / `args` into `HERMES_COPILOT_ACP_COMMAND` and `HERMES_COPILOT_ACP_ARGS` at config load
- Skip the ACP settings block from custom-provider normalization to stop recurring `unknown config keys ignored: copilot_path` warnings
- Document the config.yaml path in the hermes-agent skill

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_provider_config_validation.py`