### PR TITLE
fix(cron): resolve dict model overrides and enforce min context

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -132,6 +132,38 @@ DEFAULT_FALLBACK_CONTEXT = CONTEXT_PROBE_TIERS[0]
 # Sessions, model switches, and cron jobs should reject models below this.
 MINIMUM_CONTEXT_LENGTH = 64_000
 
+
+def assert_minimum_agent_context(
+    model: str,
+    *,
+    provider: str = "",
+    base_url: str = "",
+    config_context_length: int | None = None,
+) -> int:
+    """Validate that *model* meets Hermes' minimum context requirement.
+
+    Returns the resolved context length.  Raises ``ValueError`` with a
+    user-facing message when the model is below ``MINIMUM_CONTEXT_LENGTH``.
+    """
+    model_text = str(model or "").strip()
+    if not model_text:
+        return 0
+    ctx = get_model_context_length(
+        model_text,
+        base_url=base_url or "",
+        provider=provider or "",
+        config_context_length=config_context_length,
+    )
+    if ctx < MINIMUM_CONTEXT_LENGTH:
+        raise ValueError(
+            f"Model {model_text!r} has a context window of {ctx:,} tokens, "
+            f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
+            f"by Hermes Agent. Choose a model with at least "
+            f"{MINIMUM_CONTEXT_LENGTH // 1000}K context."
+        )
+    return ctx
+
+
 # Thin fallback defaults — only broad model family patterns.
 # These fire only when provider is unknown AND models.dev/OpenRouter/Anthropic
 # all miss. Replaced the previous 80+ entry dict.

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -85,6 +85,79 @@ def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = N
     return normalized
 
 
+def resolve_job_model_override(job: Dict[str, Any]) -> tuple[Optional[str], Optional[str]]:
+    """Return ``(model_name, provider)`` from a cron job record.
+
+    Some jobs store ``model`` as a dict ``{"provider": "...", "model": "..."}``
+    (cronjob tool schema).  The scheduler and ``AIAgent`` require plain strings.
+    """
+    raw_model = job.get("model")
+    provider_raw = job.get("provider")
+    provider = str(provider_raw).strip() if provider_raw else None
+
+    if isinstance(raw_model, dict):
+        if not provider:
+            nested = raw_model.get("provider")
+            provider = str(nested).strip() if nested else None
+        nested_model = raw_model.get("model")
+        model = str(nested_model).strip() if nested_model else None
+    elif isinstance(raw_model, str):
+        model = raw_model.strip() or None
+    else:
+        model = None
+
+    return model, provider
+
+
+def _resolve_cron_model_fields(
+    model: Any = None,
+    provider: Any = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Normalize cron job model/provider inputs (string or dict)."""
+    if isinstance(model, dict):
+        resolved_model, resolved_provider = resolve_job_model_override(
+            {"model": model, "provider": provider}
+        )
+        return resolved_model, resolved_provider
+    model_text = str(model).strip() if isinstance(model, str) else None
+    provider_text = str(provider).strip() if isinstance(provider, str) else None
+    return model_text or None, provider_text or None
+
+
+def _resolve_provider_base_url(provider: Optional[str], base_url: Optional[str] = None) -> str:
+    """Best-effort base URL for model context probing."""
+    if base_url:
+        return str(base_url).strip().rstrip("/")
+    if not provider:
+        return ""
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(requested=str(provider).strip())
+        return str(runtime.get("base_url") or "").strip().rstrip("/")
+    except Exception:
+        return ""
+
+
+def validate_cron_agent_model(
+    model: Optional[str],
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+    *,
+    no_agent: bool = False,
+) -> None:
+    """Reject agent cron jobs whose model context is below Hermes minimum."""
+    if no_agent or not model:
+        return
+    from agent.model_metadata import assert_minimum_agent_context
+
+    assert_minimum_agent_context(
+        model,
+        provider=provider or "",
+        base_url=_resolve_provider_base_url(provider, base_url),
+    )
+
+
 def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
     """Return a job dict with canonical `skills` and legacy `skill` fields aligned."""
     normalized = dict(job)
@@ -617,11 +690,8 @@ def create_job(
     now = _hermes_now().isoformat()
 
     normalized_skills = _normalize_skill_list(skill, skills)
-    normalized_model = str(model).strip() if isinstance(model, str) else None
-    normalized_provider = str(provider).strip() if isinstance(provider, str) else None
+    normalized_model, normalized_provider = _resolve_cron_model_fields(model, provider)
     normalized_base_url = str(base_url).strip().rstrip("/") if isinstance(base_url, str) else None
-    normalized_model = normalized_model or None
-    normalized_provider = normalized_provider or None
     normalized_base_url = normalized_base_url or None
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
@@ -639,6 +709,13 @@ def create_job(
             "no_agent=True requires a script — with no agent and no script "
             "there is nothing for the job to run."
         )
+
+    validate_cron_agent_model(
+        normalized_model,
+        normalized_provider,
+        normalized_base_url,
+        no_agent=normalized_no_agent,
+    )
 
     # Normalize context_from: accept str or list of str, store as list or None
     if isinstance(context_from, str):
@@ -790,6 +867,16 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             updated["skills"] = normalized_skills
             updated["skill"] = normalized_skills[0] if normalized_skills else None
 
+        if "model" in updates or "provider" in updates:
+            resolved_model, resolved_provider = _resolve_cron_model_fields(
+                updated.get("model"),
+                updated.get("provider"),
+            )
+            if "model" in updates:
+                updated["model"] = resolved_model
+            if "provider" in updates:
+                updated["provider"] = resolved_provider
+
         if schedule_changed:
             updated_schedule = updated["schedule"]
             # The API may pass schedule as a raw string (e.g. "every 10m")
@@ -807,6 +894,14 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
             updated["next_run_at"] = compute_next_run(updated["schedule"])
+
+        post_model, post_provider = resolve_job_model_override(updated)
+        validate_cron_agent_model(
+            post_model,
+            post_provider,
+            updated.get("base_url"),
+            no_agent=bool(updated.get("no_agent")),
+        )
 
         jobs[i] = updated
         save_jobs(jobs)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1483,7 +1483,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 else str(delivery_target["thread_id"])
             )
 
-        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
+        from cron.jobs import resolve_job_model_override
+
+        model, _job_provider_override = resolve_job_model_override(job)
+        if not model:
+            model = os.getenv("HERMES_MODEL") or ""
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
@@ -1495,7 +1499,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     _cfg = yaml.safe_load(_f) or {}
                 _cfg = _expand_env_vars(_cfg)
                 _model_cfg = _cfg.get("model", {})
-                if not job.get("model"):
+                if not model:
                     if isinstance(_model_cfg, str):
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
@@ -1552,7 +1556,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # circuits that precedence and can resurrect old providers (for
             # example DeepSeek) for cron jobs that do not pin provider/model.
             runtime_kwargs = {
-                "requested": job.get("provider"),
+                "requested": _job_provider_override or job.get("provider"),
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -24,12 +24,59 @@ from cron.jobs import (
     advance_next_run,
     get_due_jobs,
     save_job_output,
+    resolve_job_model_override,
+    validate_cron_agent_model,
 )
 
 
 # =========================================================================
 # parse_duration
 # =========================================================================
+
+class TestResolveJobModelOverride:
+    def test_dict_model_override(self):
+        model, provider = resolve_job_model_override(
+            {"model": {"provider": "ollama", "model": "qwen2.5:72b"}}
+        )
+        assert model == "qwen2.5:72b"
+        assert provider == "ollama"
+
+    def test_string_model_with_top_level_provider(self):
+        model, provider = resolve_job_model_override(
+            {"model": "composer-2.5-fast", "provider": "copilot-acp"}
+        )
+        assert model == "composer-2.5-fast"
+        assert provider == "copilot-acp"
+
+
+class TestValidateCronAgentModel:
+    def test_rejects_low_context_model(self, tmp_cron_dir):
+        with patch("agent.model_metadata.get_model_context_length", return_value=32_768):
+            with pytest.raises(ValueError, match="below the minimum"):
+                create_job(
+                    prompt="test",
+                    schedule="every 1h",
+                    model="qwen2.5:72b",
+                    provider="ollama",
+                )
+
+    def test_skips_validation_for_no_agent_jobs(self, tmp_cron_dir):
+        job = create_job(
+            prompt="",
+            schedule="every 1h",
+            script="watchdog.py",
+            no_agent=True,
+            model="qwen2.5:72b",
+            provider="ollama",
+        )
+        assert job["no_agent"] is True
+
+    def test_update_job_validates_model_override(self, tmp_cron_dir):
+        job = create_job(prompt="test", schedule="every 1h")
+        with patch("agent.model_metadata.get_model_context_length", return_value=32_768):
+            with pytest.raises(ValueError, match="below the minimum"):
+                update_job(job["id"], {"model": "qwen2.5:72b", "provider": "ollama"})
+
 
 class TestParseDuration:
     def test_minutes(self):

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1021,6 +1021,25 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
 
+    def test_run_job_coerces_dict_model_override(self, tmp_path):
+        job = {
+            "id": "dict-model-job",
+            "name": "test",
+            "prompt": "hello",
+            "model": {"provider": "ollama", "model": "qwen2.5:72b"},
+            "provider": "ollama",
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["model"] == "qwen2.5:72b"
+
     def test_run_job_disabled_toolsets_layer_user_config_on_baseline(self, tmp_path):
         """agent.disabled_toolsets must be honoured in cron — issue #25752.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2342,6 +2342,20 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     return None
 
 
+def _validate_delegation_model(creds: dict) -> dict:
+    """Ensure delegation model meets Hermes minimum context at config time."""
+    model = creds.get("model")
+    if model:
+        from agent.model_metadata import assert_minimum_agent_context
+
+        assert_minimum_agent_context(
+            str(model),
+            provider=str(creds.get("provider") or ""),
+            base_url=str(creds.get("base_url") or ""),
+        )
+    return creds
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -2407,23 +2421,23 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
             api_mode = configured_api_mode
 
-        return {
+        return _validate_delegation_model({
             "model": configured_model,
             "provider": provider,
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
-        }
+        })
 
     if not configured_provider:
         # No provider override — child inherits everything from parent
-        return {
+        return _validate_delegation_model({
             "model": configured_model,
             "provider": None,
             "base_url": None,
             "api_key": None,
             "api_mode": None,
-        }
+        })
 
     # Provider is configured — resolve full credentials
     try:
@@ -2445,7 +2459,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Set the appropriate environment variable or run 'hermes auth'."
         )
 
-    return {
+    return _validate_delegation_model({
         "model": configured_model or runtime.get("model") or None,
         "provider": configured_provider if runtime.get("provider") == _RUNTIME_PROVIDER_CUSTOM else runtime.get("provider"),
         "base_url": runtime.get("base_url"),
@@ -2453,7 +2467,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
-    }
+    })
 
 
 def _load_config() -> dict:


### PR DESCRIPTION
## Summary
- Add `resolve_job_model_override()` so cron jobs with dict-shaped `model` fields (from cronjob tool schema) pass plain strings to `AIAgent`
- Add `assert_minimum_agent_context()` and reject cron/delegation models below 64K context at config time
- Scheduler uses resolved provider override when building runtime kwargs

## Test plan
- [x] `scripts/run_tests.sh tests/cron/test_jobs.py tests/cron/test_scheduler.py`