### PR TITLE
fix(gateway): accept text/config extensions in MEDIA tag regex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2413,7 +2413,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|md|json|ya?ml|toml|log|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -348,6 +348,19 @@ class TestExtractMedia:
         assert media == [("/tmp/x.jpg", False)]  # voice flag stays False
         assert "[[as_document]]" not in cleaned
 
+    @pytest.mark.parametrize(
+        "ext",
+        ["md", "json", "yaml", "yml", "toml", "log"],
+    )
+    def test_media_tag_accepts_text_config_extensions(self, ext):
+        """MEDIA: tags must extract text/config artifact paths so callers can
+        deliver them as file attachments instead of leaving the raw tag in
+        the platform message body (see issue #32601, bug 1)."""
+        content = f"MEDIA:/tmp/notes.{ext}"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [(f"/tmp/notes.{ext}", False)]
+        assert "MEDIA:" not in cleaned
+
     def test_both_directives_can_coexist(self):
         """A response could (rarely) contain both [[audio_as_voice]] for an
         ogg file AND [[as_document]] for an attached image. The voice flag


### PR DESCRIPTION
## What does this PR do?

`BasePlatformAdapter.extract_media()` recognizes `MEDIA:<path>` tags via a regex extension whitelist. The whitelist covers media/archive/office formats but omits common text and config types (`.md`, `.json`, `.yaml`, `.yml`, `.toml`, `.log`). Today, when a model emits `MEDIA:/tmp/notes.md`, the regex misses it and the raw `MEDIA:` text survives into the cleaned body, so WeChat/Feishu/Telegram/etc. all render the tag literally instead of routing the file through their document-upload paths.

This PR adds `md|json|ya?ml|toml|log` to the regex alternation. All other parts of the pattern (path wrapping, quote/backtick stripping, trailing-delimiter lookahead, `[[audio_as_voice]]` / `[[as_document]]` directives) are unchanged.

## Related Issue

Fixes #32601 (Bug 1 only — see Positioning below).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — extend the MEDIA tag regex alternation with `md|json|ya?ml|toml|log` (single-line change).
- `tests/gateway/test_platform_base.py` — add a parametrized test (\`TestExtractMedia.test_media_tag_accepts_text_config_extensions\`) covering each new extension.

## How to Test

1. Without the fix, ``BasePlatformAdapter.extract_media('MEDIA:/tmp/notes.md')`` returns ``([], 'MEDIA:/tmp/notes.md')`` — the tag leaks as text.
2. With the fix, it returns ``([('/tmp/notes.md', False)], '')``.
3. \`\`\`bash
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/gateway/test_platform_base.py -v -k TestExtractMedia
\`\`\`

   20 passed (6 new parametrized cases for md/json/yaml/yml/toml/log + 14 existing).

Adjacent suites (\`tests/gateway/test_media_extraction.py\`, \`test_weixin.py\`, \`test_wecom.py\`, \`test_feishu.py\`, \`test_dingtalk.py\`) also pass: 326 passed, 45 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(gateway): ...\`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (regex-internal change)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — regex matches absolute (\`/...\`) and tilde (\`~/...\`) paths consistently with the existing pattern; no Windows-path coupling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Issue #32601 lists two bugs:

| | Bug | Scope | This PR? |
|---|---|---|---|
| 1 | MEDIA tag leaks for text/config file types | \`gateway/platforms/base.py::extract_media\` — global (all platforms) | ✅ Covered here |
| 2 | \`send_weixin_direct()\` returns immediately on \`ret=-2\`/stale-token | \`gateway/platforms/weixin.py\` — WeChat-only | ❌ Distinct file, distinct fix, distinct test surface — left for a separate PR |

Keeping the two as separate PRs lets the regex change land independently of any WeChat session/retry semantics review. Happy to widen this PR to cover Bug 2 if preferred, or leave Bug 2 to another contributor.

> **Audited siblings**: \`BasePlatformAdapter.extract_local_files\` (same file, line ~2458) maintains an independent \`_LOCAL_MEDIA_EXTS\` tuple that already accepts \`.md\`, \`.json\`, \`.yaml\`, \`.yml\` for bare-path auto-delivery but is missing \`.toml\` and \`.log\`. Intentionally left out of this PR's scope to keep the diff to the MEDIA-tag path the issue specifically calls out. Happy to widen \`_LOCAL_MEDIA_EXTS\` to mirror the same set if useful.

## For New Skills

_N/A._