### PR TITLE
fix(qqbot): authorize dm chat_type in interaction approval

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1082,7 +1082,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in ("c2c", "dm"):
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2199,3 +2199,100 @@ class TestCloseCodeClassification:
         assert 4001 in fatal_codes
         assert 4915 in fatal_codes
 
+
+# ---------------------------------------------------------------------------
+# _is_authorized_interaction_for_session
+#
+# Regression: prior to this test, the authorization check matched only the
+# "c2c" chat_type literal, but C2C session keys are constructed with
+# chat_type="dm" (see SessionDB.session_key for QQBot DMs).  As a result,
+# every approval / update button click in a QQ private chat was incorrectly
+# rejected with "Rejected unauthorized approval click", and any tool requiring
+# user approval would block forever.
+# ---------------------------------------------------------------------------
+
+class TestIsAuthorizedInteractionForSession:
+    def _make_adapter(self):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="appid", client_secret="sec"))
+
+    def _make_event(self, *, operator="", group="", guild="", scene="c2c"):
+        return SimpleNamespace(
+            operator_openid=operator,
+            group_openid=group,
+            guild_id=guild,
+            scene=scene,
+            button_data="",
+        )
+
+    # --- c2c (legacy chat_type label) -------------------------------------
+    def test_c2c_match_grants(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="USER1")
+        key = "agent:main:qqbot:c2c:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is True
+
+    def test_c2c_mismatch_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="EVE")
+        key = "agent:main:qqbot:c2c:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is False
+
+    # --- dm (actual chat_type used in QQBot DM session keys) --------------
+    # Regression coverage for the original bug.
+    def test_dm_match_grants(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="USER1")
+        key = "agent:main:qqbot:dm:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is True
+
+    def test_dm_mismatch_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="EVE")
+        key = "agent:main:qqbot:dm:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is False
+
+    # --- group / guild ----------------------------------------------------
+    def test_group_match_grants(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="USER1", group="GRP1")
+        key = "agent:main:qqbot:group:GRP1:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is True
+
+    def test_group_chat_mismatch_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="USER1", group="GRP2")
+        key = "agent:main:qqbot:group:GRP1:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is False
+
+    def test_group_user_mismatch_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="EVE", group="GRP1")
+        key = "agent:main:qqbot:group:GRP1:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is False
+
+    # --- malformed / unknown ---------------------------------------------
+    def test_unknown_chat_type_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="USER1")
+        key = "agent:main:qqbot:mystery:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is False
+
+    def test_empty_operator_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="")
+        key = "agent:main:qqbot:dm:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is False
+
+    def test_wrong_platform_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="USER1")
+        key = "agent:main:telegram:dm:USER1"
+        assert adapter._is_authorized_interaction_for_session(event, key) is False
+
+    def test_malformed_key_denies(self):
+        adapter = self._make_adapter()
+        event = self._make_event(operator="USER1")
+        assert adapter._is_authorized_interaction_for_session(event, "not:a:valid:key") is False
+        assert adapter._is_authorized_interaction_for_session(event, "") is False
+


### PR DESCRIPTION
## Problem

Approval / update button clicks from QQ private chats are unconditionally rejected with:

```
WARNING [QQBot:<app_id>] Rejected unauthorized approval click for session
   agent:main:qqbot:dm:<openid> (operator=<openid>)
```

…even though the operator's `openid` matches the session owner. As a result, any tool requiring user approval (sensitive commands, MCP confirmations, etc.) blocks the agent indefinitely on the QQBot platform.

## Root cause

QQBot DM session keys are constructed as `agent:main:qqbot:dm:<openid>`, so `_parse_gateway_session_key` returns `chat_type == "dm"`. But `_is_authorized_interaction_for_session` only accepts the literal `c2c`:

```python
if chat_type == "c2c":
    return bool(chat_id) and operator == chat_id
```

DMs fall through to the final `return False` and the click is rejected.

## Fix

Accept both `c2c` (legacy literal) and `dm` (what the SessionDB actually emits for QQ private chats).

```diff
- if chat_type == "c2c":
+ if chat_type in ("c2c", "dm"):
      return bool(chat_id) and operator == chat_id
```

## Tests

Adds `TestIsAuthorizedInteractionForSession` with 11 cases:

- c2c / dm match grants
- c2c / dm mismatch denies
- group match grants
- group chat/user mismatch denies
- unknown chat_type denies
- empty operator denies
- wrong platform denies
- malformed session_key denies

All 170 tests in `tests/gateway/test_qqbot.py` pass after the fix; the new `test_dm_match_grants` reliably fails against `main` (verified by reverting the one-line change locally), so it is real regression coverage rather than tautology.

## Reproduction

Reproduced live in a private QQBot deployment: prior to the fix, every approval button click in a QQ DM produced the unauthorized warning and the tool call hung. After the fix, the same click logged:

```
INFO [QQBot:<app_id>] Button resolved 1 approval(s) for session
   agent:main:qqbot:dm:<openid> (choice=always, operator=<openid>)
```

…and the agent continued normally.

Made with [Cursor](https://cursor.com)