### PR TITLE
fix(gateway): require admin for shell-execution quick commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7609,6 +7609,17 @@ class GatewayRunner:
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
+                    # Guard: shell-exec quick commands require admin to prevent
+                    # arbitrary command execution by any authenticated user.
+                    from gateway.slash_access import policy_for_source as _policy_for_source
+
+                    source = getattr(event, "source", None)
+                    user_id = (source.user_id if source else None)
+                    if not _policy_for_source(self.config, source).is_admin(user_id):
+                        return (
+                            f"Quick command '/{command}' is not available: "
+                            f"shell-execution commands require admin access."
+                        )
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:


### PR DESCRIPTION
## Summary

Quick commands defined with `type: exec` in the gateway config allow admins to define shell commands that bypass the agent loop and execute directly on the gateway host. However, the exec path had no authorization check — any authenticated user could trigger any configured shell command, regardless of their admin status.

## Fix

Add an admin gate before executing `type: exec` quick commands, using the existing `policy_for_source().is_admin()` check that other privileged operations in the codebase rely on.

**Before**: any authenticated user could trigger `/my-shell-cmd` if it was configured as a quick command.

**After**: only users confirmed as admin by the access policy can execute `type: exec` quick commands. Non-admin users receive an error message: `Quick command '/{cmd}' is not available: shell-execution commands require admin access.`

## Changes

- `gateway/run.py`: Added admin authorization check at the top of the `type: exec` quick command branch.

## Security Note

This fix aligns `type: exec` quick commands with other privileged operations in the gateway. Shell-execution quick commands run in the gateway process with the same environment variables available to the gateway (including API keys), which is why admin-level access is required to configure and execute them.