### PR TITLE
fix: honor gateway channel toolsets by source

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11686,8 +11686,8 @@ class GatewayRunner:
 
             platform_key = _platform_config_key(source.platform)
 
-            from hermes_cli.tools_config import _get_platform_tools
-            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            from gateway.topic_toolsets import resolve_gateway_toolsets
+            enabled_toolsets = sorted(resolve_gateway_toolsets(user_config, platform_key, source))
             agent_cfg = user_config.get("agent") or {}
             disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
 
@@ -15775,8 +15775,8 @@ class GatewayRunner:
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
 
-        from hermes_cli.tools_config import _get_platform_tools
-        enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+        from gateway.topic_toolsets import resolve_gateway_toolsets
+        enabled_toolsets = sorted(resolve_gateway_toolsets(user_config, platform_key, source))
         agent_cfg_local = user_config.get("agent") or {}
         disabled_toolsets = agent_cfg_local.get("disabled_toolsets") or None
 

--- a/gateway/topic_toolsets.py
+++ b/gateway/topic_toolsets.py
@@ -1,0 +1,129 @@
+"""Source-aware gateway toolset resolution.
+
+Messaging gateways usually have a broad platform-level fallback such as
+``platform_toolsets.telegram``. Forum topics/channels can optionally narrow
+that via ``<platform>.channel_toolsets`` without changing the global fallback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from copy import deepcopy
+from typing import Any
+
+
+def _as_toolset_list(value: Any) -> list[str] | None:
+    """Normalize a channel-toolset config value.
+
+    ``None`` means absent/invalid. An empty list is a valid explicit value;
+    it is passed through to the platform resolver unchanged.
+    """
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, dict)):
+        return [str(part).strip() for part in value if str(part).strip()]
+    return None
+
+
+def _channel_toolset_candidates(platform_key: str, source: Any) -> list[str]:
+    """Return route keys from most-specific to least-specific."""
+    chat_id = getattr(source, "chat_id", None)
+    parent_chat_id = getattr(source, "parent_chat_id", None)
+    thread_id = getattr(source, "thread_id", None)
+    chat_type = getattr(source, "chat_type", None)
+
+    candidates: list[str] = []
+
+    def add(value: Any) -> None:
+        if value is None:
+            return
+        key = str(value).strip()
+        if key and key not in candidates:
+            candidates.append(key)
+
+    if chat_id is not None and thread_id is not None:
+        add(f"{chat_id}:{thread_id}")
+    if parent_chat_id is not None and thread_id is not None:
+        add(f"{parent_chat_id}:{thread_id}")
+    if thread_id is not None:
+        add(thread_id)
+
+    # Telegram may omit message_thread_id for forum General. The Telegram
+    # adapter normalizes this for normal messages, but keep the resolver robust
+    # for synthetic/resumed sends and tests.
+    if platform_key == "telegram" and thread_id is None and chat_type == "group":
+        add("1")
+
+    add(chat_id)
+    add(parent_chat_id)
+    add("default")
+    return candidates
+
+
+def resolve_channel_toolset_names(
+    config: dict[str, Any] | None,
+    platform_key: str,
+    source: Any,
+) -> list[str] | None:
+    """Resolve raw toolset names for a source-specific channel/topic.
+
+    Config format::
+
+        telegram:
+          channel_toolsets:
+            default: [web, skills, no_mcp]
+            "255": [web, terminal, file, no_mcp]
+            "-100123:260": [web, lighthouse]
+
+    Precedence:
+      1. exact ``chat_id:thread_id``;
+      2. exact ``parent_chat_id:thread_id``;
+      3. ``thread_id``;
+      4. Telegram forum General fallback ``1`` when thread id is absent;
+      5. ``chat_id``;
+      6. ``parent_chat_id``;
+      7. ``default``.
+    """
+    cfg = config or {}
+    platform_cfg = cfg.get(platform_key) or {}
+    if not isinstance(platform_cfg, dict):
+        return None
+    channel_toolsets = platform_cfg.get("channel_toolsets") or {}
+    if not isinstance(channel_toolsets, dict):
+        return None
+
+    for key in _channel_toolset_candidates(platform_key, source):
+        if key not in channel_toolsets:
+            continue
+        names = _as_toolset_list(channel_toolsets.get(key))
+        if names is not None:
+            return names
+    return None
+
+
+def resolve_gateway_toolsets(
+    config: dict[str, Any] | None,
+    platform_key: str,
+    source: Any,
+) -> set[str]:
+    """Resolve effective toolsets for a gateway turn.
+
+    Falls back to ``platform_toolsets.<platform>`` exactly as before when no
+    source-specific ``<platform>.channel_toolsets`` entry matches.
+    """
+    from hermes_cli.tools_config import _get_platform_tools
+
+    cfg = config or {}
+    channel_toolsets = resolve_channel_toolset_names(cfg, platform_key, source)
+    if channel_toolsets is None:
+        return _get_platform_tools(cfg, platform_key)
+
+    overlay = deepcopy(cfg)
+    platform_toolsets = overlay.get("platform_toolsets")
+    if not isinstance(platform_toolsets, dict):
+        platform_toolsets = {}
+    else:
+        platform_toolsets = dict(platform_toolsets)
+    platform_toolsets[platform_key] = channel_toolsets
+    overlay["platform_toolsets"] = platform_toolsets
+    return _get_platform_tools(overlay, platform_key)

--- a/tests/gateway/test_topic_toolsets.py
+++ b/tests/gateway/test_topic_toolsets.py
@@ -1,0 +1,106 @@
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.topic_toolsets import resolve_channel_toolset_names, resolve_gateway_toolsets
+
+
+def _source(chat_id="-1001", thread_id: str | None = "255", chat_type="group", parent_chat_id=None):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        thread_id=thread_id,
+        parent_chat_id=parent_chat_id,
+    )
+
+
+def test_exact_chat_thread_toolsets_win_over_thread_and_default():
+    cfg = {
+        "telegram": {
+            "channel_toolsets": {
+                "default": ["web", "no_mcp"],
+                "255": ["web", "terminal", "no_mcp"],
+                "-1001:255": ["file", "lighthouse"],
+            }
+        },
+        "mcp_servers": {
+            "lighthouse": {"enabled": True},
+            "plaud": {"enabled": True},
+        },
+        "platform_toolsets": {"telegram": ["web", "terminal"]},
+    }
+
+    names = resolve_channel_toolset_names(cfg, "telegram", _source())
+    assert names == ["file", "lighthouse"]
+
+    effective = resolve_gateway_toolsets(cfg, "telegram", _source())
+    assert "file" in effective
+    assert "lighthouse" in effective
+    assert "plaud" not in effective
+    assert "terminal" not in effective
+
+
+def test_thread_toolsets_allowlist_mcp_server_without_default_mcp_surface():
+    cfg = {
+        "telegram": {"channel_toolsets": {"260": ["web", "lighthouse"]}},
+        "mcp_servers": {
+            "lighthouse": {"enabled": True},
+            "plaud": {"enabled": True},
+        },
+        "platform_toolsets": {"telegram": ["web", "terminal"]},
+    }
+
+    effective = resolve_gateway_toolsets(cfg, "telegram", _source(thread_id="260"))
+    assert "web" in effective
+    assert "lighthouse" in effective
+    assert "plaud" not in effective
+    assert "terminal" not in effective
+
+
+def test_default_channel_toolsets_can_disable_all_mcp():
+    cfg = {
+        "telegram": {"channel_toolsets": {"default": ["web", "no_mcp"]}},
+        "mcp_servers": {
+            "lighthouse": {"enabled": True},
+            "plaud": {"enabled": True},
+        },
+        "platform_toolsets": {"telegram": ["web", "terminal"]},
+    }
+
+    effective = resolve_gateway_toolsets(cfg, "telegram", _source(thread_id="999"))
+    assert "web" in effective
+    assert "terminal" not in effective
+    assert "lighthouse" not in effective
+    assert "plaud" not in effective
+
+
+def test_missing_channel_toolsets_falls_back_to_platform_toolsets():
+    cfg = {
+        "platform_toolsets": {"telegram": ["web", "terminal", "no_mcp"]},
+        "mcp_servers": {"lighthouse": {"enabled": True}},
+    }
+
+    effective = resolve_gateway_toolsets(cfg, "telegram", _source(thread_id="999"))
+    assert "web" in effective
+    assert "terminal" in effective
+    assert "lighthouse" not in effective
+
+
+def test_telegram_general_without_thread_uses_topic_one_before_default():
+    cfg = {
+        "telegram": {
+            "channel_toolsets": {
+                "1": ["clarify", "no_mcp"],
+                "default": ["web", "no_mcp"],
+            }
+        },
+        "mcp_servers": {"lighthouse": {"enabled": True}},
+    }
+
+    effective = resolve_gateway_toolsets(
+        cfg,
+        "telegram",
+        _source(thread_id=None, chat_type="group"),
+    )
+    assert "clarify" in effective
+    assert "web" not in effective
+    assert "lighthouse" not in effective


### PR DESCRIPTION
## Summary
- resolve gateway toolsets from source-specific `<platform>.channel_toolsets` before falling back to `platform_toolsets.<platform>`
- support Telegram forum topic precedence: `chat_id:thread_id` → `parent_chat_id:thread_id` → `thread_id` → General `1` → chat → parent chat → `default`
- cover MCP allowlisting/`no_mcp` behavior with gateway tests

## Tests
- `PYTHONPATH=/opt/data/hermes-agent-topic-routing /opt/hermes/.venv/bin/python -m pytest tests/gateway/test_topic_toolsets.py tests/hermes_cli/test_mcp_tools_config.py -q -o addopts=`
