### PR TITLE
feat: add MCP registry metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Hermes Agent ☤
 
+<!-- mcp-name: io.github.nousresearch/hermes-agent -->
+
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
@@ -134,13 +136,26 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |
 | [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) | Persistent memory, user profiles, best practices |
-| [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities |
+| [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Connect any MCP server for extended capabilities; expose Hermes itself with `hermes mcp serve` |
 | [Cron Scheduling](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) | Scheduled tasks with platform delivery |
 | [Context Files](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) | Project context that shapes every conversation |
 | [Architecture](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) | Project structure, agent loop, key classes |
 | [Contributing](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) | Development setup, PR process, code style |
 | [CLI Reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) | All commands and flags |
 | [Environment Variables](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) | Complete env var reference |
+
+### MCP registry metadata
+
+Hermes can run as an MCP server for other clients:
+
+```bash
+pip install "hermes-agent[mcp]"
+hermes mcp serve
+```
+
+This repository includes `server.json` metadata for MCP registries. Clients that cannot parse PyPI extras should install `hermes-agent[mcp]` first, then launch the registered package with the fixed arguments `mcp serve`.
+
+The registry package entry intentionally uses the `hermes-agent` console script with fixed package arguments (`mcp`, `serve`). The regular `hermes mcp serve` command remains the human-friendly fallback for clients that already have Hermes installed locally.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,7 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "mcp_serve", "utils"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -4227,6 +4227,12 @@ def main(
     Toolset Examples:
         - "research": Web search, extract, crawl + vision tools
     """
+    if query == "mcp" and model == "serve":
+        from mcp_serve import run_mcp_server
+
+        run_mcp_server(verbose=verbose)
+        return
+
     print("🤖 AI Agent with Tool Calling")
     print("=" * 50)
     

--- a/server.json
+++ b/server.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nousresearch/hermes-agent",
+  "title": "Hermes Agent",
+  "description": "Expose Hermes Agent sessions, conversations, messages, and attachments to MCP-compatible clients.",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github",
+    "id": "1024554267"
+  },
+  "version": "0.14.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "hermes-agent",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "io.github.nousresearch/hermes-agent": {
+        "installExtra": "mcp",
+        "recommendedInstall": "pip install \"hermes-agent[mcp]\"",
+        "launchCommand": "hermes-agent mcp serve",
+        "fallbackLaunchCommand": "hermes mcp serve",
+        "docs": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp"
+      }
+    }
+  }
+}

--- a/tests/test_mcp_serve_entrypoint.py
+++ b/tests/test_mcp_serve_entrypoint.py
@@ -1,0 +1,28 @@
+"""Regression tests for package entry points that launch MCP server mode."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def test_hermes_agent_console_script_routes_mcp_serve(monkeypatch):
+    """Keep ``hermes-agent mcp serve`` usable for MCP registry launches.
+
+    Hermes' human-facing command is ``hermes mcp serve``. MCP registry package
+    metadata launches the PyPI package console command with fixed package
+    arguments (``mcp``, ``serve``), so the legacy ``hermes-agent`` console
+    script must route that pair to MCP server mode instead of treating it as a
+    chat query/model pair.
+    """
+    import run_agent
+
+    called = {}
+    fake_mcp_serve = types.SimpleNamespace(
+        run_mcp_server=lambda verbose=False: called.setdefault("verbose", verbose)
+    )
+    monkeypatch.setitem(sys.modules, "mcp_serve", fake_mcp_serve)
+
+    run_agent.main(query="mcp", model="serve", verbose=True)
+
+    assert called == {"verbose": True}

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -1,6 +1,7 @@
 """Regression tests for packaging metadata in pyproject.toml."""
 
 from pathlib import Path
+import json
 import tomllib
 
 
@@ -11,11 +12,15 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
-def _load_package_data():
+def _load_setuptools_config():
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject_path.open("rb") as handle:
         tool = tomllib.load(handle)["tool"]
-    return tool["setuptools"]["package-data"]
+    return tool["setuptools"]
+
+
+def _load_package_data():
+    return _load_setuptools_config()["package-data"]
 
 
 def test_matrix_extra_not_in_all():
@@ -110,6 +115,46 @@ def test_feishu_extra_includes_qrcode_for_qr_login():
 
     feishu_extra = optional_dependencies["feishu"]
     assert any(dep.startswith("qrcode") for dep in feishu_extra)
+
+
+def test_mcp_server_module_is_packaged_for_cli_entrypoint():
+    """`hermes mcp serve` imports top-level mcp_serve from wheel installs."""
+    setuptools_config = _load_setuptools_config()
+
+    assert "mcp_serve" in setuptools_config["py-modules"]
+
+
+def test_mcp_registry_metadata_matches_packaging_contract():
+    """Keep root server.json aligned with the PyPI package entry point."""
+    root = Path(__file__).resolve().parents[1]
+    with (root / "server.json").open(encoding="utf-8") as handle:
+        server = json.load(handle)
+
+    package = server["packages"][0]
+    assert server["name"] == "io.github.nousresearch/hermes-agent"
+    assert package["registryType"] == "pypi"
+    assert package["registryBaseUrl"] == "https://pypi.org"
+    assert package["identifier"] == "hermes-agent"
+    assert package["runtimeHint"] == "uvx"
+    assert package["transport"] == {"type": "stdio"}
+    assert package["packageArguments"] == [
+        {"type": "positional", "value": "mcp"},
+        {"type": "positional", "value": "serve"},
+    ]
+    assert "version" not in package, (
+        "Do not pin server.json to a possibly stale PyPI artifact; registry "
+        "submission should use the latest released wheel after this change ships."
+    )
+
+    publisher_meta = server["_meta"]["io.modelcontextprotocol.registry/publisher-provided"][
+        "io.github.nousresearch/hermes-agent"
+    ]
+    assert publisher_meta["recommendedInstall"] == 'pip install "hermes-agent[mcp]"'
+    assert publisher_meta["launchCommand"] == "hermes-agent mcp serve"
+    assert publisher_meta["fallbackLaunchCommand"] == "hermes mcp serve"
+
+    optional_dependencies = _load_optional_dependencies()
+    assert "mcp" in optional_dependencies
 
 
 def test_dashboard_plugin_manifests_and_assets_are_packaged():


### PR DESCRIPTION
## Summary
- add root `server.json` metadata for publishing Hermes Agent's MCP server to MCP registries
- document install/launch guidance for `hermes-agent[mcp]` and `hermes mcp serve`
- package `mcp_serve` in wheels and keep `hermes-agent mcp serve` routed to MCP server mode for registry package launches
- add regression coverage for the registry metadata contract and console entrypoint route

## Test Plan
- [x] `server.json` validates against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- [x] `scripts/run_tests.sh tests/test_project_metadata.py tests/test_mcp_serve_entrypoint.py`
- [x] `git diff --check`

## Notes
- `server.json` intentionally does not pin a package-level PyPI version so registry submission can use the latest released wheel after this source change ships.
- Clients that cannot install PyPI extras from registry metadata should install `hermes-agent[mcp]` before launching the registered package arguments `mcp serve`.
