### PR TITLE
fix(picker): show model.available entries in the model picker dropdown

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -52,6 +52,7 @@ class ConfigContext:
     current_base_url: str
     user_providers: dict
     custom_providers: list
+    custom_models: list
 
     def with_overrides(
         self,
@@ -90,11 +91,19 @@ def load_picker_context() -> ConfigContext:
         current_model = model_cfg.get("default", model_cfg.get("name", "")) or ""
         current_provider = model_cfg.get("provider", "") or ""
         current_base_url = model_cfg.get("base_url", "") or ""
+        # Read user-defined model list for the custom provider picker row.
+        available_models = model_cfg.get("available", [])
+        if isinstance(available_models, dict):
+            available_models = list(available_models.keys())
+        elif not isinstance(available_models, list):
+            available_models = []
+        available_models = [m for m in available_models if m]
     else:
         # config.model can be a bare string in older configs.
         current_model = str(model_cfg) if model_cfg else ""
         current_provider = ""
         current_base_url = ""
+        available_models = []
     raw = cfg.get("providers")
     return ConfigContext(
         current_provider=current_provider,
@@ -102,6 +111,7 @@ def load_picker_context() -> ConfigContext:
         current_base_url=current_base_url,
         user_providers=raw if isinstance(raw, dict) else {},
         custom_providers=get_compatible_custom_providers(cfg),
+        custom_models=available_models,
     )
 
 
@@ -137,6 +147,7 @@ def build_models_payload(
         current_model=ctx.current_model,
         user_providers=ctx.user_providers,
         custom_providers=ctx.custom_providers,
+        custom_models=ctx.custom_models,
         max_models=max_models,
     )
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1051,6 +1051,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
+    custom_models: list | None = None,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1732,6 +1733,24 @@ def list_authenticated_providers(
             })
             seen_slugs.add(slug.lower())
             _section4_emitted_slugs.add(slug.lower())
+
+    # --- 5. User-defined custom models from model.available ---
+    # If the user has model.available in model: but no endpoint-based custom
+    # provider row (sections 3/4) and no built-in row covering it, emit a
+    # skeleton ``custom`` row so the picker can show those models. Fixes
+    # the TUI/Dashboard model picker not showing model.available entries.
+    if custom_models and isinstance(custom_models, list) and custom_models:
+        if "custom" not in seen_slugs and "custom".lower() not in seen_slugs:
+            results.append({
+                "slug": "custom",
+                "name": "Custom endpoint",
+                "is_current": True,
+                "is_user_defined": True,
+                "models": list(custom_models),
+                "total_models": len(custom_models),
+                "source": "user-config",
+            })
+            seen_slugs.add("custom")
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))


### PR DESCRIPTION
## Problem

When using `model.available` in `config.yaml` under the `model:` section to define a custom list of available models, the TUI/Dashboard/Telegram model picker dropdown ignores this setting. Models listed in `model.available` do not appear in the picker menu, forcing users to switch via the `/model <name>` command instead.

The model switch itself works correctly (`/model qwen3.6:35b-a3b` works fine), but the **picker UI** — which is what users interact with when clicking the model dropdown — never reads `model.available`.

This is because the entire picker pipeline (`load_picker_context()` → `build_models_payload()` → `list_authenticated_providers()`) only reads `model.default`, `model.provider`, and `model.base_url` — `model.available` is silently dropped.

## Fix

3 small changes across 2 files to wire `model.available` through the picker:

### 1. `hermes_cli/inventory.py`

- Added `custom_models: list` field to `ConfigContext` dataclass
- Read `model.available` in `load_picker_context()` and store it in the context
- Threaded it through `build_models_payload()` → `list_authenticated_providers()`

### 2. `hermes_cli/model_switch.py`

- Added `custom_models` parameter to `list_authenticated_providers()` signature
- Added **Section 5** that emits a `custom` provider row in the picker using `model.available` entries when no other row covers it

## Testing

- Verified that `/model qwen3.6:35b-a3b` already works (config parsing was correct)
- Verified the picker now lists `model.available` entries in the dropdown
- No breaking changes — all callers use keyword arguments so the new parameter is safe

## Diff

\`\`\`diff
# hermes_cli/inventory.py
+    custom_models: list  # in ConfigContext dataclass

# In load_picker_context():
+        available_models = model_cfg.get("available", [])
+        if isinstance(available_models, dict):
+            available_models = list(available_models.keys())
+        elif not isinstance(available_models, list):
+            available_models = []
+        available_models = [m for m in available_models if m]
+        # (also in else branch: available_models = [])

+        custom_models=available_models,  # in ConfigContext constructor

+        custom_models=ctx.custom_models,  # in build_models_payload call

# hermes_cli/model_switch.py
+    custom_models: list | None = None,  # in list_authenticated_providers signature

+    # --- 5. User-defined custom models from model.available ---
+    if custom_models and isinstance(custom_models, list) and custom_models:
+        if "custom" not in seen_slugs and "custom".lower() not in seen_slugs:
+            results.append({
+                "slug": "custom",
+                "name": "Custom endpoint",
+                "is_current": True,
+                "is_user_defined": True,
+                "models": list(custom_models),
+                "total_models": len(custom_models),
+                "source": "user-config",
+            })
+            seen_slugs.add("custom")
\`\`\`
