### PR TITLE
fix(web): honor stored Firecrawl and xAI credentials

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -121,8 +121,14 @@ Firecrawl = _FirecrawlProxy()
 
 def _get_direct_firecrawl_config() -> Optional[tuple]:
     """Return explicit direct Firecrawl kwargs + cache key, or None when unset."""
-    api_key = os.getenv("FIRECRAWL_API_KEY", "").strip()
-    api_url = os.getenv("FIRECRAWL_API_URL", "").strip().rstrip("/")
+    try:
+        from hermes_cli.config import get_env_value
+
+        api_key = str(get_env_value("FIRECRAWL_API_KEY") or "").strip()
+        api_url = str(get_env_value("FIRECRAWL_API_URL") or "").strip().rstrip("/")
+    except Exception:
+        api_key = os.getenv("FIRECRAWL_API_KEY", "").strip()
+        api_url = os.getenv("FIRECRAWL_API_URL", "").strip().rstrip("/")
 
     if not api_key and not api_url:
         return None

--- a/tests/tools/test_web_providers_firecrawl.py
+++ b/tests/tools/test_web_providers_firecrawl.py
@@ -1,0 +1,62 @@
+"""Regression tests for the Firecrawl web provider config resolver."""
+
+
+def test_direct_config_reads_hermes_env_file(monkeypatch, tmp_path):
+    """Firecrawl should see keys saved in Hermes' .env, not just exported env."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+    (tmp_path / ".env").write_text(
+        "FIRECRAWL_API_KEY=fc-test-key\n"
+        "FIRECRAWL_API_URL=https://firecrawl.example.com/\n"
+    )
+
+    from plugins.web.firecrawl.provider import _get_direct_firecrawl_config
+
+    config = _get_direct_firecrawl_config()
+
+    assert config == (
+        {
+            "api_key": "fc-test-key",
+            "api_url": "https://firecrawl.example.com",
+        },
+        ("direct", "https://firecrawl.example.com", "fc-test-key"),
+    )
+
+
+def test_direct_config_falls_back_to_process_env_when_config_loader_unavailable(monkeypatch):
+    """Keep plugin import/use robust if hermes_cli.config cannot be imported."""
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-process-key")
+    monkeypatch.setenv("FIRECRAWL_API_URL", "https://firecrawl.process/")
+
+    import plugins.web.firecrawl.provider as firecrawl_provider
+
+    real_import = firecrawl_provider.__builtins__["__import__"]
+
+    def fake_import(name, *args, **kwargs):
+        if name == "hermes_cli.config":
+            raise ImportError("config unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setitem(firecrawl_provider.__builtins__, "__import__", fake_import)
+
+    config = firecrawl_provider._get_direct_firecrawl_config()
+
+    assert config == (
+        {
+            "api_key": "fc-process-key",
+            "api_url": "https://firecrawl.process",
+        },
+        ("direct", "https://firecrawl.process", "fc-process-key"),
+    )
+
+
+def test_direct_config_unset_when_neither_env_source_has_firecrawl(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    monkeypatch.delenv("FIRECRAWL_API_URL", raising=False)
+    (tmp_path / ".env").write_text("OTHER_KEY=value\n")
+
+    from plugins.web.firecrawl.provider import _get_direct_firecrawl_config
+
+    assert _get_direct_firecrawl_config() is None

--- a/tests/tools/test_web_providers_xai.py
+++ b/tests/tools/test_web_providers_xai.py
@@ -101,6 +101,25 @@ class TestXAIProviderIsAvailable:
         from plugins.web.xai.provider import XAIWebSearchProvider
         assert XAIWebSearchProvider().is_available() is True
 
+    def test_available_via_credential_pool_auth_store(self, monkeypatch, tmp_path):
+        """Cheap probe should also detect xai-oauth credentials that live only
+        in the credential pool, as produced by `hermes auth add xai-oauth`."""
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        auth_path = tmp_path / "auth.json"
+        auth_path.write_text(json.dumps({
+            "version": 1,
+            "providers": {"xai-oauth": {"tokens": {}}},
+            "credential_pool": {
+                "xai-oauth": [
+                    {"access_token": "ya29.pool-access-token", "base_url": "https://api.x.ai/v1"},
+                ],
+            },
+        }))
+
+        from plugins.web.xai.provider import XAIWebSearchProvider
+        assert XAIWebSearchProvider().is_available() is True
+
     def test_unavailable_when_no_env_and_no_auth_store(self, monkeypatch, tmp_path):
         monkeypatch.delenv("XAI_API_KEY", raising=False)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -733,6 +752,31 @@ class TestXAIProviderOAuthPath:
     boundary so the full ``tools.xai_http.resolve_xai_http_credentials``
     chain is exercised end-to-end.
     """
+
+    def test_resolver_uses_credential_pool_when_singleton_tokens_empty(self, monkeypatch, tmp_path):
+        """`hermes auth add xai-oauth` may place tokens only in the credential
+        pool. Direct xAI integrations should still resolve those credentials."""
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "providers": {"xai-oauth": {"tokens": {}}},
+            "credential_pool": {
+                "xai-oauth": [
+                    {
+                        "access_token": "ya29.pool-access-token",
+                        "base_url": "https://api.x.ai/v1",
+                    },
+                ],
+            },
+        }))
+
+        from tools.xai_http import resolve_xai_http_credentials
+
+        creds = resolve_xai_http_credentials()
+        assert creds["provider"] == "xai-oauth"
+        assert creds["api_key"] == "ya29.pool-access-token"
+        assert creds["base_url"] == "https://api.x.ai/v1"
 
     def test_search_uses_oauth_bearer_token_and_base_url(self, monkeypatch):
         from plugins.web.xai import provider as xai_provider

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -40,7 +40,21 @@ def has_xai_credentials() -> bool:
         xai_state = providers.get("xai-oauth") if isinstance(providers, dict) else None
         tokens = xai_state.get("tokens") if isinstance(xai_state, dict) else None
         access_token = tokens.get("access_token") if isinstance(tokens, dict) else None
-        return bool(str(access_token or "").strip())
+        if str(access_token or "").strip():
+            return True
+
+        # Newer `hermes auth add xai-oauth` flows may store credentials only
+        # in the credential pool. Keep this probe cheap: single auth.json read,
+        # no token refresh, no auth-store lock.
+        pool = store.get("credential_pool") if isinstance(store, dict) else None
+        xai_pool = pool.get("xai-oauth") if isinstance(pool, dict) else None
+        if isinstance(xai_pool, list):
+            return any(
+                str((entry or {}).get("access_token") or "").strip()
+                for entry in xai_pool
+                if isinstance(entry, dict)
+            )
+        return False
     except Exception:
         return False
 
@@ -116,6 +130,29 @@ def resolve_xai_http_credentials(*, force_refresh: bool = False) -> Dict[str, st
                 "api_key": access_token,
                 "base_url": base_url or "https://api.x.ai/v1",
             }
+    except Exception:
+        pass
+
+    try:
+        from hermes_constants import get_hermes_home
+
+        auth_path = get_hermes_home() / "auth.json"
+        if auth_path.exists():
+            store = json.loads(auth_path.read_text())
+            pool = store.get("credential_pool") if isinstance(store, dict) else None
+            xai_pool = pool.get("xai-oauth") if isinstance(pool, dict) else None
+            if isinstance(xai_pool, list):
+                for entry in xai_pool:
+                    if not isinstance(entry, dict):
+                        continue
+                    access_token = str(entry.get("access_token") or "").strip()
+                    if access_token:
+                        base_url = str(entry.get("base_url") or "https://api.x.ai/v1").strip().rstrip("/")
+                        return {
+                            "provider": "xai-oauth",
+                            "api_key": access_token,
+                            "base_url": base_url or "https://api.x.ai/v1",
+                        }
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- make Firecrawl direct config resolve `FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` through Hermes config/.env loading before falling back to process env
- make xAI OAuth availability and credential resolution detect `credential_pool.xai-oauth` entries in `auth.json`
- add regression coverage for both Firecrawl .env config and xAI credential-pool OAuth tokens

## Test Plan
- `python -m pytest tests/tools/test_web_providers_firecrawl.py tests/tools/test_web_providers_xai.py -q -o 'addopts='`
