### PR TITLE
feat: add cron show command

### DIFF
--- a/.hermes/plans/2026-05-27-cron-show-command.md
+++ b/.hermes/plans/2026-05-27-cron-show-command.md
@@ -1,0 +1,74 @@
+# Cron Show Command Implementation Plan
+
+> **For Hermes:** Use test-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a safe `hermes cron show <job>` command and matching `cronjob(action="show")` tool action so users/agents can inspect one scheduled job without scanning the full cron list.
+
+**Architecture:** Reuse the existing `resolve_job_ref()` name-or-ID resolver. Keep storage unchanged; expose a formatted full job payload from the tool and a readable detail view from the CLI. Do not alter scheduler behavior.
+
+**Tech Stack:** Python argparse CLI (`hermes_cli/main.py`, `hermes_cli/cron.py`), cron tool wrapper (`tools/cronjob_tools.py`), pytest via `scripts/run_tests.sh`.
+
+---
+
+### Task 1: Add failing CLI behavior test
+
+**Objective:** Prove `cron show` resolves a job and prints full details including prompt.
+
+**Files:**
+- Modify: `tests/hermes_cli/test_cron.py`
+
+**Steps:**
+1. Add `test_show_prints_job_details` using `create_job(...)` and `cron_command(Namespace(cron_command="show", job_id=job["id"]))`.
+2. Assert stdout contains `Job:`, job ID, name, schedule, prompt, and delivery target.
+3. Run `scripts/run_tests.sh tests/hermes_cli/test_cron.py::TestCronCommandLifecycle::test_show_prints_job_details -q`.
+4. Expected RED: fails because `show` is unknown.
+
+### Task 2: Add failing tool behavior test
+
+**Objective:** Prove `cronjob(action="show")` returns a single detailed job payload.
+
+**Files:**
+- Modify: `tests/tools/test_cronjob_tools.py`
+
+**Steps:**
+1. Add `test_show_returns_full_job_details` after create/list tests.
+2. Create a job with a prompt over 100 chars.
+3. Call `cronjob(action="show", job_id=created["job_id"])`.
+4. Assert success, `job.job_id`, `job.prompt` full text, and `job.prompt_preview` truncated.
+5. Run focused test; expected RED because action is unknown.
+
+### Task 3: Implement minimal show action
+
+**Objective:** Make both tests pass with the least production change.
+
+**Files:**
+- Modify: `tools/cronjob_tools.py`
+- Modify: `hermes_cli/cron.py`
+- Modify: `hermes_cli/main.py`
+
+**Steps:**
+1. Add optional full prompt to `_format_job(..., include_prompt=False)`.
+2. Add `if normalized == "show"` after job resolution in `cronjob()` returning `{success: True, job: _format_job(job, include_prompt=True)}`.
+3. Add `cron_show()` in `hermes_cli/cron.py`, using `_cron_api(action="show", job_id=...)` and printing human-readable fields.
+4. Dispatch `show` in `cron_command()`.
+5. Register argparse subparser `cron show job_id`.
+6. Run focused tests until green.
+
+### Task 4: Verify
+
+**Objective:** Confirm no regressions in cron-related surfaces.
+
+**Commands:**
+- `scripts/run_tests.sh tests/hermes_cli/test_cron.py tests/tools/test_cronjob_tools.py -q`
+- Optional smoke: `python -m hermes_cli.main cron --help` if import path permits.
+
+### Task 5: Commit and PR
+
+**Objective:** Leave Joe a reviewable branch/PR.
+
+**Commands:**
+- `git status --short`
+- `git add .hermes/plans/2026-05-27-cron-show-command.md hermes_cli/cron.py hermes_cli/main.py tools/cronjob_tools.py tests/hermes_cli/test_cron.py tests/tools/test_cronjob_tools.py`
+- `git commit -m "feat: add cron show command"`
+- `git push -u joe HEAD`
+- `gh pr create --repo NousResearch/hermes-agent --head joe102084:joe/nightly-cron-show --base main --title "feat: add cron show command" --body-file -`

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -268,6 +268,44 @@ def cron_edit(args):
     return 0
 
 
+def _print_optional(label: str, value) -> None:
+    if value not in (None, "", [], {}):
+        print(f"  {label}: {value}")
+
+
+def cron_show(args) -> int:
+    result = _cron_api(action="show", job_id=args.job_id)
+    if not result.get("success"):
+        print(color(f"Failed to show job: {result.get('error', 'unknown error')}", Colors.RED))
+        return 1
+
+    job = result.get("job", {})
+    print(color(f"Job: {job.get('name', args.job_id)}", Colors.CYAN))
+    print(f"  ID: {job.get('job_id', args.job_id)}")
+    print(f"  State: {job.get('state', '?')}")
+    print(f"  Schedule: {job.get('schedule', '?')}")
+    print(f"  Repeat: {job.get('repeat', '?')}")
+    print(f"  Next run: {job.get('next_run_at') or '?'}")
+    print(f"  Deliver: {job.get('deliver', 'local')}")
+    if job.get("skills"):
+        print(f"  Skills: {', '.join(job['skills'])}")
+    _print_optional("Model", job.get("model"))
+    _print_optional("Provider", job.get("provider"))
+    _print_optional("Profile", job.get("profile"))
+    _print_optional("Script", job.get("script"))
+    if job.get("no_agent"):
+        print("  Mode: no-agent (script stdout delivered directly)")
+    _print_optional("Workdir", job.get("workdir"))
+    _print_optional("Last run", job.get("last_run_at"))
+    _print_optional("Last status", job.get("last_status"))
+    _print_optional("Last delivery error", job.get("last_delivery_error"))
+    print("  Prompt:")
+    prompt = job.get("prompt") or ""
+    for line in prompt.splitlines() or [""]:
+        print(f"    {line}")
+    return 0
+
+
 def _job_action(action: str, job_id: str, success_verb: str) -> int:
     result = _cron_api(action=action, job_id=job_id)
     if not result.get("success"):
@@ -304,6 +342,9 @@ def cron_command(args):
 
     if subcmd == "edit":
         return cron_edit(args)
+
+    if subcmd == "show":
+        return cron_show(args)
 
     if subcmd == "pause":
         return _job_action("pause", args.job_id, "Paused")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11889,6 +11889,12 @@ def main():
         help="Hermes profile name to run the job under. Use 'default' for the root profile. Pass empty string to clear.",
     )
 
+    # inspect one job
+    cron_show = cron_subparsers.add_parser(
+        "show", help="Show full details for one scheduled job"
+    )
+    cron_show.add_argument("job_id", help="Job ID or exact job name to inspect")
+
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")
     cron_pause.add_argument("job_id", help="Job ID to pause")

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -111,3 +111,24 @@ class TestCronCommandLifecycle:
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
         assert jobs[0]["profile"] == "default"
+
+    def test_show_prints_job_details(self, tmp_cron_dir, capsys):
+        job = create_job(
+            prompt="Send Joe a focused morning summary of recurring ops.",
+            schedule="every 1h",
+            name="Morning ops",
+            deliver="local",
+            skills=["blogwatcher"],
+        )
+
+        result = cron_command(Namespace(cron_command="show", job_id=job["id"]))
+
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "Job:" in out
+        assert job["id"] in out
+        assert "Morning ops" in out
+        assert "every 60m" in out
+        assert "local" in out
+        assert "blogwatcher" in out
+        assert "Send Joe a focused morning summary of recurring ops." in out

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -231,6 +231,29 @@ class TestUnifiedCronjobTool:
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
 
+    def test_show_returns_full_job_details(self):
+        prompt = "Summarize Joe's recurring personal ops and preserve enough context for audit."
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt=prompt,
+                schedule="every 1h",
+                name="Ops audit",
+                deliver="local",
+                skills=["blogwatcher"],
+            )
+        )
+
+        shown = json.loads(cronjob(action="show", job_id=created["job_id"]))
+
+        assert shown["success"] is True
+        assert shown["job"]["job_id"] == created["job_id"]
+        assert shown["job"]["name"] == "Ops audit"
+        assert shown["job"]["prompt"] == prompt
+        assert shown["job"]["prompt_preview"] == prompt
+        assert shown["job"]["skills"] == ["blogwatcher"]
+        assert shown["job"]["deliver"] == "local"
+
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -379,7 +379,7 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     return None
 
 
-def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
+def _format_job(job: Dict[str, Any], *, include_prompt: bool = False) -> Dict[str, Any]:
     prompt = str(job.get("prompt") or "")
     skills = _canonical_skills(job.get("skill"), job.get("skills"))
     job_id = str(job.get("id") or "unknown")
@@ -393,6 +393,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "model": job.get("model"),
         "provider": job.get("provider"),
         "base_url": job.get("base_url"),
+        "profile": job.get("profile"),
         "schedule": job.get("schedule_display") or "?",
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
@@ -405,6 +406,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
     }
+    if include_prompt:
+        result["prompt"] = prompt
     if job.get("script"):
         result["script"] = job["script"]
     if job.get("no_agent"):
@@ -558,6 +561,9 @@ def cronjob(
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
 
+        if normalized == "show":
+            return json.dumps({"success": True, "job": _format_job(job, include_prompt=True)}, indent=2)
+
         if normalized == "remove":
             removed = remove_job(job_id)
             if not removed:
@@ -688,6 +694,7 @@ CRONJOB_SCHEMA = {
 
 Use action='create' to schedule a new job from a prompt or one or more skills.
 Use action='list' to inspect jobs.
+Use action='show' with a job_id or exact job name to inspect one job's full details, including the full prompt.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
@@ -706,11 +713,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run"
+                "description": "One of: create, list, show, update, pause, resume, remove, run"
             },
             "job_id": {
                 "type": "string",
-                "description": "Required for update/pause/resume/remove/run"
+                "description": "Required for show/update/pause/resume/remove/run"
             },
             "prompt": {
                 "type": "string",


### PR DESCRIPTION
## Summary
- Add `hermes cron show <job_id_or_exact_name>` for a focused detail view of one scheduled job.
- Add `cronjob(action="show")` so agents can inspect the full stored job payload, including the full prompt, without scanning the whole list.
- Include the implementation plan used for this small spec/TDD change.

## Test Plan
- [x] RED: new CLI/tool tests failed before implementation
- [x] `python -m pytest tests/hermes_cli/test_cron.py tests/tools/test_cronjob_tools.py -q -o 'addopts='`
- [x] `python -m hermes_cli.main cron --help | grep -q "show"`

## Notes
- `scripts/run_tests.sh tests/hermes_cli/test_cron.py tests/tools/test_cronjob_tools.py` is currently blocked in this checkout because pytest cannot parse `--timeout=30 --timeout-method=signal` from `pyproject.toml`; this indicates the active dev env is missing the `pytest-timeout` plugin. Direct pytest with `-o 'addopts='` was used as the documented fallback for focused smoke checks.
