### PR TITLE
fix(cron): defer hermes update while a cron job is running

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -170,6 +170,34 @@ def _get_lock_paths() -> tuple[Path, Path]:
     return lock_dir, lock_dir / ".tick.lock"
 
 
+def is_tick_active() -> bool:
+    """True if a cron tick currently holds ``.tick.lock`` (a job is mid-run).
+
+    Used by the ``hermes update`` paths (Telegram ``/update`` and CLI) to defer
+    restarting the gateway while a cron job runs, so an update-triggered SIGTERM
+    cannot kill an in-flight scheduled agent. Non-blocking. Fails OPEN (returns
+    False) on any detection error so a detection bug can never permanently block
+    updates.
+    """
+    if fcntl is None:
+        return False
+    try:
+        _, lock_file = _get_lock_paths()
+        if not lock_file.exists():
+            return False
+        fd = open(lock_file, "a", encoding="utf-8")
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            return False
+        except OSError:
+            return True
+        finally:
+            fd.close()
+    except Exception:
+        return False
+
+
 @contextmanager
 def _job_profile_context(job_id: str, profile: Optional[str]):
     """Temporarily run a job under a specific Hermes profile.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13915,6 +13915,16 @@ class GatewayRunner:
         if not hermes_cmd:
             return t("gateway.update.hermes_cmd_not_found")
 
+        # Defer if a cron job is mid-run so the gateway restart this update
+        # triggers (SIGTERM) cannot kill an in-flight scheduled agent.
+        try:
+            from cron.scheduler import is_tick_active
+            if is_tick_active():
+                return ("Cron job running - update deferred so it is not "
+                        "interrupted. Retry after it finishes.")
+        except Exception:
+            pass
+
         pending_path = _hermes_home / ".update_pending.json"
         output_path = _hermes_home / ".update_output.txt"
         exit_code_path = _hermes_home / ".update_exit_code"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8740,6 +8740,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
     # Pre-update backup — runs before any git/file mutation so users can
     # always roll back to the exact state they had before this update.
+    # Defer if a cron job is mid-run so the gateway restart this update
+    # triggers cannot kill an in-flight scheduled agent (unless --force).
+    try:
+        from cron.scheduler import is_tick_active
+        if is_tick_active() and not getattr(args, "force", False):
+            print("Cron job currently running - deferring update to avoid "
+                  "interrupting it.")
+            print("Retry after it finishes, or re-run with --force to override.")
+            sys.exit(0)
+    except SystemExit:
+        raise
+    except Exception:
+        pass
+
     _run_pre_update_backup(args)
 
     # Try git-based update first, fall back to ZIP download on Windows


### PR DESCRIPTION
## Problem

A manual `hermes update` (Telegram `/update` or CLI) restarts the gateway with a SIGTERM. Cron jobs execute in `cron/scheduler.py`'s `ThreadPoolExecutor` and are **not** tracked in the gateway's `_running_agents`, so the shutdown drain (`_drain_active_agents`) reports `active_at_start=0` and does not wait for them. An update that lands mid-run kills the in-flight scheduled agent before it finishes.

Observed in production: a weekly audit cron died mid-synthesis when an update fired ~3s after its last tool result (a model call was in flight at the SIGTERM), leaving its post-run state bookkeeping unwritten.

## Fix

Add `cron.scheduler.is_tick_active()` — a non-blocking `flock` test of the existing `.tick.lock`, which `tick()` already holds for the duration of a run. Both update entry points consult it and **defer** (rather than restart) while a cron job is running:

- `gateway/run.py` `_handle_update_command` — checked **before** `.update_pending.json` is written, so a deferral leaves no stale pending marker.
- `hermes_cli/main.py` `_cmd_update_impl` — checked **before** the pre-update backup; `--force` overrides.

Fails **open**: any detection error returns `False`, so a detection bug can never permanently block updates.

## Scope / known limitation

This covers the **update-initiated** SIGTERM. It does not cover an OS/watchdog SIGTERM under load (see #32762); the lock is also released early on the inactivity-timeout path (`_cron_pool.shutdown(wait=False, cancel_futures=True)`), so a hung agent is not fully protected. Full coverage would need cron-run state that survives restart — this PR is the cheap, high-value first layer.

## Testing

- `is_tick_active()` returns `False` when the lock is free, `True` while held (separate process), `False` after release.
- Same-process detection verified: the in-process cron ticker holds the lock in the same process that tests it; a second `flock(LOCK_EX | LOCK_NB)` fails with `EAGAIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
