### PR TITLE
[codex] fix codex summary calls without tools

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1208,6 +1208,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         if agent.api_mode == "codex_responses":
             codex_kwargs = agent._build_api_kwargs(api_messages)
             codex_kwargs.pop("tools", None)
+            codex_kwargs.pop("tool_choice", None)
+            codex_kwargs.pop("parallel_tool_calls", None)
             summary_response = agent._run_codex_stream(codex_kwargs)
             _ct_sum = agent._get_transport()
             _cnr_sum = _ct_sum.normalize_response(summary_response)
@@ -1290,6 +1292,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "codex_responses":
                 codex_kwargs = agent._build_api_kwargs(api_messages)
                 codex_kwargs.pop("tools", None)
+                codex_kwargs.pop("tool_choice", None)
+                codex_kwargs.pop("parallel_tool_calls", None)
                 retry_response = agent._run_codex_stream(codex_kwargs)
                 _ct_retry = agent._get_transport()
                 _cnr_retry = _ct_retry.normalize_response(retry_response)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2653,6 +2653,48 @@ class TestHandleMaxIterations:
             for item in input_items
         )
 
+    def test_codex_summary_strips_tool_controls_when_tools_removed(self, agent):
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+        agent._cached_system_prompt = "You are helpful."
+        captured = {}
+
+        monkey_kwargs = {
+            "model": "gpt-5.5",
+            "input": [{"role": "user", "content": "do stuff"}],
+            "tools": [{"type": "function", "name": "web_search"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+
+        def fake_run_codex_stream(kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text="Summary")],
+                    )
+                ],
+            )
+
+        with (
+            patch.object(agent, "_build_api_kwargs", return_value=monkey_kwargs.copy()),
+            patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream),
+        ):
+            result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
+
+        assert result == "Summary"
+        assert "tools" not in captured
+        assert "tool_choice" not in captured
+        assert "parallel_tool_calls" not in captured
+
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [
             {


### PR DESCRIPTION
## Summary

Fix the max-iteration summary path for `codex_responses` transports when Hermes intentionally removes tools before asking the model for a final answer.

## Root Cause

`handle_max_iterations` builds regular Codex/Responses kwargs, then removes `tools` so the summary call cannot invoke tools. When the original request had tools, `_build_api_kwargs` also included tool-only controls such as `tool_choice="auto"` and `parallel_tool_calls=True`. Sending those controls without a `tools` array makes xAI/Grok reject the request with HTTP 400: `A tool_choice was set on the request but no tools were specified.`

## Changes

- Strip `tool_choice` and `parallel_tool_calls` in both primary and retry max-iteration summary calls when `tools` is removed.
- Add regression coverage ensuring codex summary calls do not retain tool controls after tool removal.

## Credit

Co-authored-by: @MartyLake

## Validation

- `uv run --extra dev pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_codex_summary_strips_tool_controls_when_tools_removed -q`