### PR TITLE
feat(opencode-go): route qwen3.7-max via anthropic_messages

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -402,6 +402,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         # OpenCode Go mixes API surfaces by model:
         # - GLM / Kimi use OpenAI-compatible chat completions under /v1
         # - MiniMax models use Anthropic Messages under /v1/messages
+        # - Qwen 3.7 uses Anthropic Messages under /v1/messages
         # Keep the provider base at /v1 and select api_mode per-model.
         inference_base_url="https://opencode.ai/zen/go/v1",
         api_key_env_vars=("OPENCODE_GO_API_KEY",),

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -399,6 +399,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "mimo-v2-omni",
         "minimax-m2.7",
         "minimax-m2.5",
+        "qwen3.7-max",
         "qwen3.6-plus",
         "qwen3.5-plus",
     ],
@@ -3014,6 +3015,8 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
 
     if provider == "opencode-go":
         if normalized.startswith("minimax-"):
+            return "anthropic_messages"
+        if normalized.startswith("qwen3.7-max"):
             return "anthropic_messages"
         return "chat_completions"
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -104,7 +104,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
-    "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.6-plus", "qwen3.5-plus"],
+    "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.7-max", "qwen3.6-plus", "qwen3.5-plus"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -414,6 +414,8 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-go", "opencode-go/kimi-k2.5") == "chat_completions"
         assert opencode_model_api_mode("opencode-go", "minimax-m2.5") == "anthropic_messages"
         assert opencode_model_api_mode("opencode-go", "opencode-go/minimax-m2.5") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-go", "qwen3.7-max") == "anthropic_messages"
+        assert opencode_model_api_mode("opencode-go", "opencode-go/qwen3.7-max") == "anthropic_messages"
 
 
 class TestAzureFoundryModelApiMode:


### PR DESCRIPTION
## What does this PR do?

Routes `qwen3.7-max` on OpenCode Go through the Anthropic Messages API (`/v1/messages`) instead of OpenAI-compatible chat completions (`/v1/chat/completions`).

The model rejects the `oa-compat` format with `HTTP 401: Model qwen3.7-max is not supported for format oa-compat` but works correctly via the Anthropic Messages endpoint — confirmed by direct API testing:

```
POST /chat/completions → 401 "not supported for format oa-compat"
POST /messages + x-api-key → 200 ✓ (returns thinking + content)
```

This follows the same pattern already established for MiniMax models on OpenCode Go. The provider config comment in `auth.py` already documents that OpenCode Go mixes API surfaces by model.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: Add `qwen3.7-max` to the `opencode-go` curated model list and route it to `anthropic_messages` api_mode in `opencode_model_api_mode()`
- `hermes_cli/setup.py`: Add `qwen3.7-max` to the setup wizard model list for OpenCode Go
- `hermes_cli/auth.py`: Update provider comment to document Qwen 3.7's Anthropic Messages requirement
- `tests/hermes_cli/test_model_validation.py`: Add assertions verifying `qwen3.7-max` and `opencode-go/qwen3.7-max` both resolve to `anthropic_messages`

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_model_validation.py
```

81 tests pass, 0 failed. Verified qwen3.7-max routing:
- Bare model: `opencode_model_api_mode("opencode-go", "qwen3.7-max") == "anthropic_messages"` ✓
- Prefixed model: `opencode_model_api_mode("opencode-go", "opencode-go/qwen3.7-max") == "anthropic_messages"` ✓
- Other models unaffected: `glm-5`, `kimi-k2.5`, `mimo-v2.5-pro` still resolve to `chat_completions` ✓

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (aarch64)

### Documentation & Housekeeping

- [x] N/A — no doc changes needed
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture changes
- [x] N/A — cross-platform compatibility unaffected
- [x] N/A — no tool behavior changes


## Infographic

![pr-32780-qwen37max-routing](https://v3b.fal.media/files/b/0a9bd747/e43tJA_mMSCgmD88zC5Jf_FZRXo1P9.png)
