### PR TITLE
feat: add machine-readable sessions list formats

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -491,6 +491,63 @@ def _relative_time(ts) -> str:
     return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
 
 
+def _clean_tsv_cell(value) -> str:
+    """Return a single TSV cell with tabs/newlines normalized to spaces."""
+    if value is None:
+        return ""
+    return str(value).replace("\t", " ").replace("\r", " ").replace("\n", " ")
+
+
+def _session_list_record(session: dict) -> dict:
+    """Return stable, non-sensitive fields for machine-readable list output."""
+    columns = ("id", "title", "preview", "last_active", "source")
+    return {col: session.get(col) for col in columns}
+
+
+def _format_sessions_list(sessions: list[dict], output_format: str = "table") -> str:
+    """Format rich session rows for ``hermes sessions list``.
+
+    ``table`` preserves the existing human-readable output. ``json`` and
+    ``tsv`` are stable machine-readable formats for wrappers and scripts.
+    """
+    if output_format == "json":
+        return json.dumps([_session_list_record(s) for s in sessions], ensure_ascii=False) + "\n"
+
+    if output_format == "tsv":
+        columns = ["id", "title", "preview", "last_active", "source"]
+        lines = ["\t".join(columns)]
+        for s in sessions:
+            record = _session_list_record(s)
+            lines.append("\t".join(_clean_tsv_cell(record.get(col)) for col in columns))
+        return "\n".join(lines) + "\n"
+
+    if output_format != "table":
+        raise ValueError(f"Unsupported sessions list format: {output_format}")
+
+    lines = []
+    has_titles = any(s.get("title") for s in sessions)
+    if has_titles:
+        lines.append(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+        lines.append("─" * 110)
+    else:
+        lines.append(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
+        lines.append("─" * 95)
+    for s in sessions:
+        last_active = _relative_time(s.get("last_active"))
+        preview = (
+            s.get("preview", "")[:38]
+            if has_titles
+            else s.get("preview", "")[:48]
+        )
+        sid = s["id"]
+        if has_titles:
+            title = (s.get("title") or "—")[:30]
+            lines.append(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
+        else:
+            lines.append(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+    return "\n".join(lines) + "\n"
+
+
 def _has_any_provider_configured() -> bool:
     """Check if at least one inference provider is usable."""
     from hermes_cli.config import get_env_path, get_hermes_home, load_config
@@ -13044,6 +13101,12 @@ Examples:
     sessions_list.add_argument(
         "--limit", type=int, default=20, help="Max sessions to show"
     )
+    sessions_list.add_argument(
+        "--format",
+        choices=("table", "json", "tsv"),
+        default="table",
+        help="Output format for sessions list (default: table)",
+    )
 
     sessions_export = sessions_subparsers.add_parser(
         "export", help="Export sessions to a JSONL file"
@@ -13124,27 +13187,7 @@ Examples:
             if not sessions:
                 print("No sessions found.")
                 return
-            has_titles = any(s.get("title") for s in sessions)
-            if has_titles:
-                print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-                print("─" * 110)
-            else:
-                print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
-                print("─" * 95)
-            for s in sessions:
-                last_active = _relative_time(s.get("last_active"))
-                preview = (
-                    s.get("preview", "")[:38]
-                    if has_titles
-                    else s.get("preview", "")[:48]
-                )
-                if has_titles:
-                    title = (s.get("title") or "—")[:30]
-                    sid = s["id"]
-                    print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
-                else:
-                    sid = s["id"]
-                    print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+            sys.stdout.write(_format_sessions_list(sessions, args.format))
 
         elif action == "export":
             if args.session_id:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13736,6 +13736,12 @@ def main():
         help="Only sessions in one workspace: a git repo root or project dir "
         "(matched by path substring or basename).",
     )
+    sessions_list.add_argument(
+        "--format",
+        choices=("table", "json", "tsv"),
+        default="table",
+        help="Output format for sessions list (default: table)",
+    )
 
     def _add_session_filter_args(p, default_older_help):
         p.add_argument(

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -19,6 +19,7 @@ one-way (main.py imports this module; the reverse happens only lazily at call
 time — no import cycle).
 """
 
+import json
 import os
 import sys
 from pathlib import Path
@@ -53,6 +54,115 @@ def _confirm_prompt(prompt: str) -> bool:
         return input(prompt).strip().lower() in {"y", "yes"}
     except (EOFError, KeyboardInterrupt):
         return False
+
+
+_SESSION_LIST_COLUMNS = ("id", "title", "preview", "last_active", "source")
+
+
+def _clean_tsv_cell(value) -> str:
+    """Return one TSV cell with row and column separators normalized."""
+    if value is None:
+        return ""
+    return str(value).replace("\t", " ").replace("\r", " ").replace("\n", " ")
+
+
+def _session_list_record(session: dict) -> dict:
+    """Project one session onto the stable, non-sensitive list schema."""
+    return {column: session.get(column) for column in _SESSION_LIST_COLUMNS}
+
+
+def _format_sessions_list(
+    sessions: list[dict],
+    output_format: str = "table",
+    *,
+    workspace_filter: str = "",
+    workspace_key=None,
+) -> str:
+    """Render ``hermes sessions list`` without exposing full session rows."""
+    if output_format == "json":
+        records = [_session_list_record(session) for session in sessions]
+        return json.dumps(records, ensure_ascii=False) + "\n"
+
+    if output_format == "tsv":
+        lines = ["\t".join(_SESSION_LIST_COLUMNS)]
+        for session in sessions:
+            record = _session_list_record(session)
+            lines.append(
+                "\t".join(
+                    _clean_tsv_cell(record.get(column))
+                    for column in _SESSION_LIST_COLUMNS
+                )
+            )
+        return "\n".join(lines) + "\n"
+
+    if output_format != "table":
+        raise ValueError(f"Unsupported sessions list format: {output_format}")
+
+    get_workspace_key = workspace_key or (lambda _session: None)
+
+    def _workspace_label(session):
+        key = get_workspace_key(session)
+        return (os.path.basename(key.rstrip("/\\")) or key) if key else "—"
+
+    has_workspaces = bool(workspace_filter) or any(
+        get_workspace_key(session) for session in sessions
+    )
+    has_titles = any(session.get("title") for session in sessions)
+    lines = []
+
+    if has_workspaces:
+        if has_titles:
+            lines.append(
+                f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}"
+            )
+            lines.append("─" * 110)
+        else:
+            lines.append(
+                f"{'Preview':<38} {'Workspace':<18} {'Last Active':<13} "
+                f"{'Src':<6} {'ID'}"
+            )
+            lines.append("─" * 100)
+        for session in sessions:
+            last_active = _relative_time(session.get("last_active"))
+            workspace = _workspace_label(session)[:16]
+            if has_titles:
+                title = (session.get("title") or "—")[:26]
+                lines.append(
+                    f"{title:<28} {workspace:<18} {last_active:<13} "
+                    f"{session['id']}"
+                )
+            else:
+                preview = session.get("preview", "")[:36]
+                lines.append(
+                    f"{preview:<38} {workspace:<18} {last_active:<13} "
+                    f"{session['source']:<6} {session['id']}"
+                )
+        return "\n".join(lines) + "\n"
+
+    if has_titles:
+        lines.append(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+        lines.append("─" * 110)
+    else:
+        lines.append(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
+        lines.append("─" * 95)
+    for session in sessions:
+        last_active = _relative_time(session.get("last_active"))
+        preview = (
+            session.get("preview", "")[:38]
+            if has_titles
+            else session.get("preview", "")[:48]
+        )
+        if has_titles:
+            title = (session.get("title") or "—")[:30]
+            lines.append(
+                f"{title:<32} {preview:<40} {last_active:<13} {session['id']}"
+            )
+        else:
+            lines.append(
+                f"{preview:<50} {last_active:<13} "
+                f"{session['source']:<6} {session['id']}"
+            )
+    return "\n".join(lines) + "\n"
 
 
 #: Default age floor for `hermes sessions prune --never-active`.  Deliberately
@@ -347,58 +457,19 @@ def cmd_sessions(args, sessions_parser=None):
 
             sessions = [s for s in sessions if _in_workspace(s)]
 
-        if not sessions:
+        output_format = getattr(args, "format", "table")
+        if not sessions and output_format == "table":
             print("No sessions found.")
+            db.close()
             return
-
-        # Short workspace label: the repo/dir basename, "—" when unbound. The
-        # Workspace column only appears once at least one session carries one
-        # (or when filtering), so all-unbound listings read as before.
-        def _ws_label(s):
-            key = _ws_key(s)
-            return (os.path.basename(key.rstrip("/\\")) or key) if key else "—"
-
-        has_ws = bool(_ws_filter) or any(_ws_key(s) for s in sessions)
-        has_titles = any(s.get("title") for s in sessions)
-
-        if has_ws:
-            if has_titles:
-                print(f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}")
-                print("─" * 110)
-            else:
-                print(f"{'Preview':<38} {'Workspace':<18} {'Last Active':<13} {'Src':<6} {'ID'}")
-                print("─" * 100)
-            for s in sessions:
-                last_active = _relative_time(s.get("last_active"))
-                ws = _ws_label(s)[:16]
-                if has_titles:
-                    title = (s.get("title") or "—")[:26]
-                    print(f"{title:<28} {ws:<18} {last_active:<13} {s['id']}")
-                else:
-                    preview = s.get("preview", "")[:36]
-                    print(f"{preview:<38} {ws:<18} {last_active:<13} {s['source']:<6} {s['id']}")
-            return
-
-        if has_titles:
-            print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-            print("─" * 110)
-        else:
-            print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
-            print("─" * 95)
-        for s in sessions:
-            last_active = _relative_time(s.get("last_active"))
-            preview = (
-                s.get("preview", "")[:38]
-                if has_titles
-                else s.get("preview", "")[:48]
+        sys.stdout.write(
+            _format_sessions_list(
+                sessions,
+                output_format,
+                workspace_filter=_ws_filter,
+                workspace_key=_ws_key,
             )
-            if has_titles:
-                title = (s.get("title") or "—")[:30]
-                sid = s["id"]
-                print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
-            else:
-                sid = s["id"]
-                print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+        )
 
     elif action == "export":
         from hermes_cli.session_filters import (

--- a/tests/hermes_cli/test_sessions_list_format.py
+++ b/tests/hermes_cli/test_sessions_list_format.py
@@ -1,0 +1,72 @@
+import json
+
+from hermes_cli.main import _format_sessions_list
+
+
+SESSIONS = [
+    {
+        "id": "20260525_213536_16412f",
+        "source": "cli",
+        "title": "Test Message Confirmation",
+        "preview": "test preview",
+        "last_active": 1760000000.0,
+        "started_at": 1759999900.0,
+        "message_count": 4,
+        "system_prompt": "private prompt content should not appear in list JSON",
+    },
+    {
+        "id": "20260525_204817_9bb28c",
+        "source": "telegram",
+        "title": None,
+        "preview": "hello\tworld\nagain",
+        "last_active": 1759990000.0,
+        "started_at": 1759989900.0,
+        "message_count": 2,
+    },
+]
+
+
+def test_sessions_list_json_format_is_machine_readable():
+    output = _format_sessions_list(SESSIONS, output_format="json")
+
+    data = json.loads(output)
+
+    assert data == [
+        {
+            "id": "20260525_213536_16412f",
+            "title": "Test Message Confirmation",
+            "preview": "test preview",
+            "last_active": 1760000000.0,
+            "source": "cli",
+        },
+        {
+            "id": "20260525_204817_9bb28c",
+            "title": None,
+            "preview": "hello\tworld\nagain",
+            "last_active": 1759990000.0,
+            "source": "telegram",
+        },
+    ]
+    assert "system_prompt" not in output
+    assert output.endswith("\n")
+
+
+def test_sessions_list_tsv_format_has_stable_columns_and_escapes_newlines_tabs():
+    output = _format_sessions_list(SESSIONS, output_format="tsv")
+
+    lines = output.splitlines()
+
+    assert lines[0] == "id\ttitle\tpreview\tlast_active\tsource"
+    assert lines[1] == "20260525_213536_16412f\tTest Message Confirmation\ttest preview\t1760000000.0\tcli"
+    assert lines[2] == "20260525_204817_9bb28c\t\thello world again\t1759990000.0\ttelegram"
+
+
+def test_sessions_list_table_format_preserves_existing_human_columns():
+    output = _format_sessions_list(SESSIONS, output_format="table")
+
+    assert "Title" in output
+    assert "Preview" in output
+    assert "Last Active" in output
+    assert "ID" in output
+    assert "Test Message Confirmation" in output
+    assert "20260525_213536_16412f" in output

--- a/tests/hermes_cli/test_sessions_list_format.py
+++ b/tests/hermes_cli/test_sessions_list_format.py
@@ -1,0 +1,142 @@
+import json
+from types import SimpleNamespace
+
+import hermes_state
+from hermes_cli import sessions_cmd
+
+
+def _seed_session(
+    db_path,
+    *,
+    session_id="session-alpha",
+    workspace="alpha",
+    preview="hello world",
+):
+    with hermes_state.SessionDB(db_path=db_path) as db:
+        db.create_session(
+            session_id,
+            source="cli",
+            model="test-model",
+            git_repo_root=f"/work/{workspace}",
+            system_prompt="private prompt content must not appear in list output",
+        )
+        db.set_session_title(session_id, f"Project {workspace.title()}")
+        db.append_message(session_id, role="user", content=preview)
+
+
+def _run_list(monkeypatch, capsys, db_path, **overrides):
+    session_db_type = hermes_state.SessionDB
+    monkeypatch.setattr(
+        hermes_state,
+        "SessionDB",
+        lambda: session_db_type(db_path=db_path),
+    )
+    args = SimpleNamespace(
+        sessions_action="list",
+        source=None,
+        limit=20,
+        workspace=None,
+        format="table",
+    )
+    for name, value in overrides.items():
+        setattr(args, name, value)
+
+    sessions_cmd.cmd_sessions(args)
+    return capsys.readouterr().out
+
+
+def test_sessions_list_json_is_stable_filtered_and_non_sensitive(
+    tmp_path, monkeypatch, capsys
+):
+    db_path = tmp_path / "state.db"
+    _seed_session(db_path, workspace="alpha")
+    _seed_session(db_path, session_id="session-beta", workspace="beta")
+
+    output = _run_list(
+        monkeypatch,
+        capsys,
+        db_path,
+        workspace="alpha",
+        format="json",
+    )
+
+    data = json.loads(output)
+    assert len(data) == 1
+    record = data[0]
+    assert set(record) == {"id", "title", "preview", "last_active", "source"}
+    assert record == {
+        "id": "session-alpha",
+        "title": "Project Alpha",
+        "preview": "hello world",
+        "last_active": record["last_active"],
+        "source": "cli",
+    }
+    assert isinstance(record["last_active"], (int, float))
+    assert "system_prompt" not in output
+    assert "private prompt" not in output
+    assert output.endswith("\n")
+
+
+def test_sessions_list_json_empty_filter_is_valid_array(tmp_path, monkeypatch, capsys):
+    db_path = tmp_path / "state.db"
+    _seed_session(db_path)
+
+    output = _run_list(
+        monkeypatch,
+        capsys,
+        db_path,
+        workspace="missing",
+        format="json",
+    )
+
+    assert json.loads(output) == []
+    assert output == "[]\n"
+
+
+def test_sessions_list_tsv_has_stable_columns_and_single_line_cells(
+    tmp_path, monkeypatch, capsys
+):
+    db_path = tmp_path / "state.db"
+    _seed_session(db_path, preview="hello\tworld\nagain")
+
+    output = _run_list(monkeypatch, capsys, db_path, format="tsv")
+    lines = output.splitlines()
+
+    assert lines[0] == "id\ttitle\tpreview\tlast_active\tsource"
+    assert len(lines) == 2
+    assert lines[1].startswith("session-alpha\tProject Alpha\thello world again\t")
+    assert lines[1].endswith("\tcli")
+
+
+def test_sessions_list_tsv_empty_filter_emits_header_only(
+    tmp_path, monkeypatch, capsys
+):
+    db_path = tmp_path / "state.db"
+    _seed_session(db_path)
+
+    output = _run_list(
+        monkeypatch,
+        capsys,
+        db_path,
+        workspace="missing",
+        format="tsv",
+    )
+
+    assert output == "id\ttitle\tpreview\tlast_active\tsource\n"
+
+
+def test_sessions_list_table_preserves_workspace_columns(
+    tmp_path, monkeypatch, capsys
+):
+    db_path = tmp_path / "state.db"
+    _seed_session(db_path)
+    monkeypatch.setattr(sessions_cmd, "_relative_time", lambda _timestamp: "2h ago")
+
+    output = _run_list(monkeypatch, capsys, db_path, format="table")
+
+    assert output == (
+        f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}\n"
+        + "─" * 110
+        + "\n"
+        + f"{'Project Alpha':<28} {'alpha':<18} {'2h ago':<13} session-alpha\n"
+    )

--- a/website/docs/user-guide/sessions.md
+++ b/website/docs/user-guide/sessions.md
@@ -317,7 +317,22 @@ hermes sessions list --source telegram
 
 # Show more sessions
 hermes sessions list --limit 50
+
+# Filter to one workspace
+hermes sessions list --workspace hermes-agent
+
+# Emit a stable JSON array for scripts
+hermes sessions list --format json | jq '.[].id'
+
+# Emit tab-separated rows
+hermes sessions list --format tsv
 ```
+
+The default `table` format remains human-readable. The `json` and `tsv`
+formats expose only the stable, non-sensitive fields `id`, `title`, `preview`,
+`last_active`, and `source`; all list filters are applied before serialization.
+An empty JSON result is `[]`, while an empty TSV result contains only the
+header row.
 
 When sessions have titles, the output shows titles, previews, and relative timestamps:
 


### PR DESCRIPTION
## Summary

- add `--format table|json|tsv` to `hermes sessions list`
- preserve the existing table output, including the workspace-aware table branch, as the default
- emit a stable, non-sensitive machine-readable projection: `id`, `title`, `preview`, `last_active`, `source`
- define script-friendly empty output: `[]\n` for JSON and a header-only row for TSV
- normalize tabs and newlines inside TSV cells
- document JSON/TSV usage and the stable output contract

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_sessions_list_format.py -q` — 5 passed
- `scripts/run_tests.sh tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_sessions_list_format.py -q` — 13 passed
- `.venv/bin/ruff check hermes_cli/main.py hermes_cli/sessions_cmd.py tests/hermes_cli/test_sessions_list_format.py`
- `.venv/bin/python scripts/check-windows-footguns.py --diff upstream/main`
- `git diff --check upstream/main...HEAD`
- manual CLI verification for help, empty JSON, and empty TSV output

The branch has been refreshed onto current `main`. Tests exercise the real `cmd_sessions` path with a temporary session database and cover filtering, empty results, TSV normalization, sensitive-field exclusion, and exact preservation of workspace-aware table output.