### PR TITLE
fix(secrets): stay silent when Bitwarden enabled but unconfigured

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -587,6 +587,14 @@ def apply_bitwarden_secrets(
         return result
 
     access_token = os.environ.get(access_token_env, "").strip()
+
+    # `enabled: true` with neither a token nor a project configured means
+    # the integration was never actually set up — stay silent rather than
+    # nagging on every startup.  The warnings below are only actionable
+    # once setup is partway done (one of the two is present).  See #32715.
+    if not access_token and not project_id:
+        return result
+
     if not access_token:
         result.error = (
             f"secrets.bitwarden.enabled is true but {access_token_env} is "

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -413,6 +413,18 @@ def test_apply_disabled_returns_empty():
     assert not result.error
 
 
+def test_apply_unconfigured_is_silent(monkeypatch):
+    # enabled: true but neither a token nor a project_id — the integration
+    # was never set up, so we must not nag on startup (#32715).
+    monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+    result = bw.apply_bitwarden_secrets(
+        enabled=True, project_id="", auto_install=False
+    )
+    assert result.ok
+    assert not result.error
+    assert not result.applied
+
+
 def test_apply_missing_token(monkeypatch):
     monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
     result = bw.apply_bitwarden_secrets(


### PR DESCRIPTION
## What does this PR do?

Stops the repeated `Bitwarden Secrets Manager: ... BWS_ACCESS_TOKEN is not set` warning from printing on every Hermes startup for users who never actually set up Bitwarden Secrets Manager.

When `secrets.bitwarden.enabled` is `true` but **neither** an access token **nor** a `project_id` is configured, the integration was never set up — the warning is pure noise. We now return a clean (no-error) result in that case so nothing is printed. The token / `project_id` warnings still fire once setup is partway done (one of the two present), where they're genuinely actionable.

Note on the two other options the reporter suggested: both are already in `main`. The default config ships `secrets.bitwarden.enabled: false` (`hermes_cli/config.py`), and the status line is already deduplicated to print once per process via the applied-home guard added in #32271. This PR closes the remaining gap for configs that have `enabled: true` with nothing else filled in.

## Related Issue

Refs #32715

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/secret_sources/bitwarden.py`: in `apply_bitwarden_secrets`, return early with a clean `FetchResult` (no `error`) when enabled but both the access token and `project_id` are empty, so no warning is emitted.
- `tests/test_bitwarden_secrets.py`: add `test_apply_unconfigured_is_silent` covering the no-token + no-project_id case; existing `test_apply_missing_token` (has project_id) and `test_apply_missing_project_id` (has token) still assert the warning fires when setup is partway done.

## How to Test

1. With a config where `secrets.bitwarden.enabled: true`, no `BWS_ACCESS_TOKEN`, and an empty `project_id`, run `hermes` — the Bitwarden warning no longer prints.
2. Set a `project_id` (but still no token) and run `hermes` — the `BWS_ACCESS_TOKEN is not set` warning prints (actionable, partway-configured case).
3. `pytest tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py -q` — all pass (45 tests).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the affected suites (45 passed). Note: the `scripts/run_tests.sh` wrapper aborts in this environment because `pytest-timeout` isn't installed there (`unrecognized arguments: --timeout`); direct `pytest --timeout=60` passes.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior-only change; existing docs describe the partway-configured warnings, which still fire)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (no process/path/signal/subprocess code; `scripts/check-windows-footguns.py` clean)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

<!-- autocontrib:worker-id=issue-new-f15dd9bf kind=pr-open -->