### PR TITLE
feat(approval): whitelist read-only curl/wget to LAN/loopback in cron deny-mode

### DIFF
--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -153,6 +153,63 @@ class TestCronDenyMode:
             assert "dangerous" in result["message"].lower() or "delete" in result["message"].lower()
 
 
+class TestCronSafeLanUrlWhitelist:
+    """In cron deny-mode, read-only curl/wget against RFC1918/loopback hosts is allowed."""
+
+    def _clear(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+    def test_curl_private_ip_allowed(self, monkeypatch):
+        self._clear(monkeypatch)
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            for cmd in [
+                "curl http://192.168.1.50:61208/api/4/cpu",
+                "curl -s http://10.0.0.5/foo",
+                "wget http://172.16.0.1/bar",
+                "curl http://127.0.0.1:8080/health",
+            ]:
+                result = check_all_command_guards(cmd, "local")
+                assert result["approved"], f"Should be allowed: {cmd}"
+
+    def test_curl_public_ip_still_blocked(self, monkeypatch):
+        """Whitelist only covers RFC1918/loopback. Public IPs go through the normal gate."""
+        self._clear(monkeypatch)
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            from tools.approval import _is_safe_lan_url
+            assert not _is_safe_lan_url("curl http://8.8.8.8/foo")
+            assert not _is_safe_lan_url("curl https://1.1.1.1/")
+
+    def test_shell_metachars_disqualify_whitelist(self, monkeypatch):
+        """Any shell metacharacter that could chain a second command disqualifies the URL."""
+        self._clear(monkeypatch)
+        from tools.approval import _is_safe_lan_url
+        for cmd in [
+            "curl http://192.168.1.50; rm -rf /",
+            "curl http://10.0.0.5 && cat /etc/passwd",
+            "curl http://10.0.0.5 | sh",
+            "curl http://10.0.0.5 `whoami`",
+            "curl http://10.0.0.5 $(id)",
+        ]:
+            assert not _is_safe_lan_url(cmd), f"Should NOT be whitelisted: {cmd}"
+
+    def test_non_curl_wget_not_whitelisted(self, monkeypatch):
+        from tools.approval import _is_safe_lan_url
+        assert not _is_safe_lan_url("nc 192.168.1.50 22")
+        assert not _is_safe_lan_url("ssh user@10.0.0.5")
+        assert not _is_safe_lan_url("python -c 'import os' http://192.168.1.50")
+
+    def test_domain_name_not_whitelisted(self, monkeypatch):
+        """Whitelist requires a raw IP; domain names go through the normal flow."""
+        from tools.approval import _is_safe_lan_url
+        assert not _is_safe_lan_url("curl http://glances.local/api")
+        assert not _is_safe_lan_url("curl https://example.com")
+
+
 class TestCronApproveMode:
     """When HERMES_CRON_SESSION is set and cron_mode=approve, dangerous commands pass through."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -11,7 +11,9 @@ This module is the single source of truth for the dangerous command system:
 import contextvars
 import logging
 import os
+import ipaddress
 import re
+import shlex
 import sys
 import threading
 import time
@@ -477,6 +479,50 @@ def _normalize_command_for_detection(command: str) -> str:
     # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
     command = unicodedata.normalize('NFKC', command)
     return command
+
+
+def _is_safe_lan_url(command: str) -> bool:
+    """Return True if `command` is a read-only curl/wget hitting an RFC1918/loopback host.
+
+    Cron jobs need to be able to poll local-network HTTP endpoints (Glances,
+    Sonarr, Radarr, Uptime Kuma, …) without tripping the dangerous-command
+    gate. We allow this only for curl/wget against private/loopback IPs and
+    only when the command does not contain shell metacharacters that could
+    extend the action beyond an HTTP read.
+    """
+    if not command:
+        return False
+    if any(ch in command for ch in (";", "&&", "||", "|", "`", "$(")):
+        return False
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    binary = tokens[0].rsplit("/", 1)[-1]
+    if binary not in ("curl", "wget"):
+        return False
+    url = None
+    for tok in tokens[1:]:
+        if tok.startswith(("http://", "https://")):
+            url = tok
+            break
+    if not url:
+        return False
+    rest = url.split("://", 1)[1]
+    host = rest.split("/", 1)[0].split("?", 1)[0]
+    if "@" in host:
+        host = host.rsplit("@", 1)[1]
+    if host.startswith("["):
+        host = host[1:].split("]", 1)[0]
+    else:
+        host = host.split(":", 1)[0]
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return ip.is_private or ip.is_loopback
 
 
 def detect_dangerous_command(command: str) -> tuple:
@@ -970,6 +1016,8 @@ def check_dangerous_command(command: str, env_type: str,
         # Cron sessions: respect cron_mode config
         if env_var_enabled("HERMES_CRON_SESSION"):
             if _get_cron_approval_mode() == "deny":
+                if _is_safe_lan_url(command):
+                    return {"approved": True, "message": None}
                 return {
                     "approved": False,
                     "message": (
@@ -1207,6 +1255,8 @@ def check_all_command_guards(command: str, env_type: str,
         # Cron sessions: respect cron_mode config
         if env_var_enabled("HERMES_CRON_SESSION"):
             if _get_cron_approval_mode() == "deny":
+                if _is_safe_lan_url(command):
+                    return {"approved": True, "message": None}
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
                 if is_dangerous:


### PR DESCRIPTION
## Problem

Cron jobs frequently need to poll local-network HTTP endpoints (Glances, Sonarr, Radarr, Uptime Kuma, Home Assistant, etc.). With `cron_mode=deny` these calls get blocked the moment any unrelated security heuristic flags the command (e.g. "URL uses raw IP address"), forcing operators to either:

- drop to `cron_mode=approve` (loses **all** dangerous-command guards), or
- rewrite every cron prompt to dodge detection.

Neither is acceptable for a watchdog/monitoring cron that just needs to `curl http://192.168.1.50:61208/api/4/cpu`.

## Solution

Narrow whitelist gate inside the cron-deny branch only:

- Only `curl` and `wget` binaries (`rsplit('/')` so `/usr/bin/curl` works too).
- URL host must parse as RFC1918 or loopback (`ipaddress.ip_address(host).is_private or .is_loopback`).
- Any shell metacharacter that can chain a second command (`;`, `&&`, `||`, `|`, backtick, `\$(`) disqualifies the command.
- Domain names are **not** whitelisted — only literal LAN IPs.

Applied to both `check_dangerous_command()` and `check_all_command_guards()`.

## Tests

`tests/tools/test_cron_approval_mode.py::TestCronSafeLanUrlWhitelist` covers:

- private/loopback IPs allowed
- public IPs still blocked
- shell metachar chains (`curl http://10.0.0.5; rm -rf /`) rejected
- non-curl/wget binaries (`nc`, `ssh`) rejected
- domain names (`glances.local`, `example.com`) not whitelisted

All 29 tests in the file pass.

## Risk

Low. Whitelist is narrow and only active under `HERMES_CRON_SESSION=1` + `cron_mode=deny`. Interactive sessions and approve/yolo modes are unaffected.