### PR TITLE
fix(cron): release tick lock before running jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1901,6 +1901,19 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         for job in due_jobs:
             advance_next_run(job["id"])
 
+        # The global tick lock protects only scheduler metadata transitions
+        # (select due jobs + advance their next run). Job execution can take
+        # minutes and must not block later ticks or unrelated due jobs.
+        if fcntl:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        elif msvcrt:
+            try:
+                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+        lock_fd.close()
+        lock_fd = None
+
         # Resolve max parallel workers: env var > config.yaml > unbounded.
         # Set HERMES_CRON_MAX_PARALLEL=1 to restore old serial behaviour.
         _max_workers: Optional[int] = None
@@ -2022,17 +2035,18 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
         return sum(_results)
     finally:
-        if fcntl:
-            try:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-            except (OSError, IOError):
-                pass
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        if lock_fd is not None:
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
 
 
 if __name__ == "__main__":

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2319,6 +2319,52 @@ class TestParallelTick:
         assert len(ends) == 2
         assert max(starts) < min(ends), f"Jobs not concurrent: {call_order}"
 
+    def test_tick_releases_global_lock_before_running_jobs(self):
+        """A long-running job must not keep the global tick lock held.
+
+        Regression for production scheduler wedges: one cron job was executing
+        while later ticks skipped with "another instance holds the lock", so
+        unrelated due jobs and smoke tests stayed stuck behind it.
+        """
+        import threading
+        import time
+        from cron.scheduler import tick
+
+        job_started = threading.Event()
+        release_job = threading.Event()
+        get_due_calls = []
+
+        def mock_get_due_jobs():
+            get_due_calls.append(time.monotonic())
+            if len(get_due_calls) == 1:
+                return [{"id": "slow-job", "name": "slow", "deliver": "local"}]
+            return []
+
+        def mock_run_job(job):
+            job_started.set()
+            assert release_job.wait(timeout=5)
+            return (True, "output", "response", None)
+
+        with patch("cron.scheduler.get_due_jobs", side_effect=mock_get_due_jobs), \
+             patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.run_job", side_effect=mock_run_job), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result", return_value=None), \
+             patch("cron.scheduler.mark_job_run"):
+            first_tick = threading.Thread(target=tick, kwargs={"verbose": False})
+            first_tick.start()
+            assert job_started.wait(timeout=5)
+
+            # If the first tick still holds .tick.lock while executing the job,
+            # this call returns before get_due_jobs() runs. After the fix, it
+            # acquires the lock, observes no due jobs, and returns normally.
+            assert tick(verbose=False) == 0
+            assert len(get_due_calls) == 2
+
+            release_job.set()
+            first_tick.join(timeout=5)
+            assert not first_tick.is_alive()
+
     def test_parallel_jobs_isolated_contextvars(self):
         """Each job's ContextVars must be isolated — no cross-contamination."""
         from gateway.session_context import get_session_env


### PR DESCRIPTION
## Summary

- release the global cron `.tick.lock` after selecting due jobs and advancing `next_run_at`
- keep job execution outside the scheduler metadata critical section
- guard the final cleanup path so it only unlocks/closes the fd when still held
- add a regression test proving a second tick can acquire the lock while a first tick is still running a slow job

## Why

A long-running or wedged cron job can currently hold `~/.hermes/cron/.tick.lock` for the entire job runtime. Later ticks return `0` with the lock held, so unrelated due jobs and smoke tests stay stuck behind the slow job.

This reproduces the scheduler wedge described in #3752 and matches the lock-scope bug discussed in #27492 / #29350.

## Test plan

- `uv run pytest tests/cron/test_scheduler.py::TestParallelTick -q -o addopts=''`

Result: `4 passed in 1.33s`
