### PR TITLE
fix(compressor): treat unanswered user questions as Active Task, not 'None'

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -959,12 +959,22 @@ class ContextCompressor(ContextEngine):
 
         # Shared structured template (used by both paths).
         _template_sections = f"""## Active Task
-[THE SINGLE MOST IMPORTANT FIELD. Copy the user's most recent request or
-task assignment verbatim — the exact words they used. If multiple tasks
-were requested and only some are done, list only the ones NOT yet completed.
-Continuation should pick up exactly here. Example:
+[THE SINGLE MOST IMPORTANT FIELD. Capture the user's most recent unfulfilled
+input verbatim — the exact words they used. This includes:
+- Explicit task assignments ("refactor the auth module")
+- Questions awaiting an answer ("waarom staat X op Y?", "wat zijn de volgende stappen?")
+- Decisions awaiting input ("optie A of B?")
+- Ongoing discussions where the assistant owes the next substantive reply
+A conversation where the user just asked a question IS an active task — the
+task is "answer that question with full context". Do NOT write "None" merely
+because the user did not issue an imperative command; reserve "None" for the
+rare case where the last exchange was fully resolved and the user said
+something like "thanks, that's all".
+If multiple items are outstanding, list only the ones NOT yet completed.
+Continuation should pick up exactly here. Examples:
 "User asked: 'Now refactor the auth module to use JWT instead of sessions'"
-If no outstanding task exists, write "None."]
+"User asked: 'Waarom stond provider ineens op openrouter?' — needs investigation + answer"
+"User chose option A; awaiting implementation of step 2"]
 
 ## Goal
 [What the user is trying to accomplish overall]
@@ -1029,7 +1039,7 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
 {_template_sections}"""
         else:


### PR DESCRIPTION
## Problem

When context compression triggers right after the user asked a question (rather than issued an imperative command), the summary LLM writes `## Active Task: None` because the existing template describes Active Task as "the user's most recent request or task assignment".

The continuation assistant then reads `Active Task: None`, treats the conversation as resolved, and produces a generic status recap instead of answering the still-open question. This is the most common way context boundaries silently drop work.

Real example I hit: user asked "waarom liep ik 111 commits achter?" right before a compaction. Post-compaction the summary had `Active Task: None` and the assistant gave a recap of completed work instead of answering.

## Fix

Template-string changes only — no behaviour change in compression code.

1. Expand the Active Task field description to explicitly cover:
   - explicit task assignments
   - questions awaiting an answer
   - decisions awaiting input (A vs B)
   - ongoing discussions where the assistant owes the next substantive reply
2. State that 'None' is reserved for the rare case where the last exchange was fully resolved (e.g. "thanks, that's all").
3. Tighten the trailing CRITICAL instruction in the update prompt so the LLM cannot fall back to the old 'no imperative command → None' heuristic.

## Tests

All 83 existing tests in `tests/agent/test_context_compressor.py` pass. No new tests — the change is in prompt-template strings consumed by an LLM, not in deterministic code paths.