### PR TITLE
fix(cron): keep MCP servers when a job sets enabled_toolsets (#23997)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -80,12 +80,59 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     return disabled
 
 
+def _enabled_mcp_server_names(cfg: dict) -> set[str]:
+    """Names of MCP servers that are globally enabled in config.yaml.
+
+    Mirrors the ``enabled_mcp_servers`` computation in
+    ``hermes_cli.tools_config._get_platform_tools`` so cron resolves MCP
+    membership identically to the gateway / CLI platforms.
+    """
+    from utils import is_truthy_value
+
+    mcp_servers = (cfg or {}).get("mcp_servers") or {}
+    return {
+        str(name)
+        for name, server_cfg in mcp_servers.items()
+        if isinstance(server_cfg, dict)
+        and is_truthy_value(server_cfg.get("enabled", True), default=True)
+    }
+
+
+def _merge_mcp_into_per_job_toolsets(per_job: list[str], cfg: dict) -> list[str]:
+    """Layer enabled MCP servers onto a per-job ``enabled_toolsets`` allowlist.
+
+    A per-job list scopes the *native* toolsets, but on its own it silently
+    drops every MCP server: ``discover_mcp_tools()`` registers the tools into
+    the global registry, yet ``get_tool_definitions(enabled_toolsets=...)``
+    only keeps toolsets named in the list. The agent then rejects every
+    ``mcp_*`` call with "Unknown tool". This restores parity with
+    ``_get_platform_tools`` MCP semantics:
+
+      * ``no_mcp`` sentinel present  -> no MCP servers (sentinel stripped)
+      * one or more MCP server names already listed -> treat as an allowlist,
+        add nothing further (the user named exactly the servers they want)
+      * otherwise -> union in every globally-enabled MCP server
+    """
+    result = [t for t in per_job if t != "no_mcp"]
+    if "no_mcp" in per_job:
+        return result
+    enabled_mcp = _enabled_mcp_server_names(cfg)
+    if set(result) & enabled_mcp:
+        return result
+    for name in sorted(enabled_mcp):
+        if name not in result:
+            result.append(name)
+    return result
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
     Precedence:
     1. Per-job ``enabled_toolsets`` (set via ``cronjob`` tool on create/update).
-       Keeps the agent's job-scoped toolset override intact — #6130.
+       Keeps the agent's job-scoped toolset override intact — #6130. Enabled
+       MCP servers are layered on per ``_merge_mcp_into_per_job_toolsets`` so a
+       native-toolset allowlist does not silently strip MCP tools.
     2. Per-platform ``hermes tools`` config for the ``cron`` platform.
        Mirrors gateway behavior (``_get_platform_tools(cfg, platform_key)``)
        so users can gate cron toolsets globally without recreating every job.
@@ -99,7 +146,7 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """
     per_job = job.get("enabled_toolsets")
     if per_job:
-        return per_job
+        return _merge_mcp_into_per_job_toolsets(list(per_job), cfg or {})
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load
         return sorted(_get_platform_tools(cfg or {}, "cron"))

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,9 +7,67 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+class TestPerJobToolsetMcpMerge:
+    """A per-job enabled_toolsets allowlist must not silently drop MCP servers."""
+
+    CFG = {
+        "mcp_servers": {
+            "finnhub": {"enabled": True},
+            "playwright": {"enabled": True},
+            "disabled_one": {"enabled": False},
+            "string_enabled": {"enabled": "true"},
+            "not_a_dict": "ignored",
+        }
+    }
+
+    def _enabled_names(self):
+        return {"finnhub", "playwright", "string_enabled"}
+
+    def test_native_only_list_gets_all_enabled_mcp_servers(self):
+        result = _merge_mcp_into_per_job_toolsets(["web", "terminal"], self.CFG)
+        assert result[:2] == ["web", "terminal"]
+        assert set(result) == {"web", "terminal"} | self._enabled_names()
+
+    def test_disabled_servers_are_not_added(self):
+        result = _merge_mcp_into_per_job_toolsets(["web"], self.CFG)
+        assert "disabled_one" not in result
+
+    def test_explicit_mcp_name_is_treated_as_allowlist(self):
+        # User named one server -> add nothing further.
+        result = _merge_mcp_into_per_job_toolsets(["web", "finnhub"], self.CFG)
+        assert result == ["web", "finnhub"]
+        assert "playwright" not in result
+
+    def test_no_mcp_sentinel_opts_out_and_is_stripped(self):
+        result = _merge_mcp_into_per_job_toolsets(["web", "no_mcp"], self.CFG)
+        assert result == ["web"]
+        assert not (set(result) & self._enabled_names())
+
+    def test_no_mcp_config_adds_nothing(self):
+        result = _merge_mcp_into_per_job_toolsets(["web"], {})
+        assert result == ["web"]
+
+    def test_no_duplicate_when_listed_name_also_globally_enabled(self):
+        result = _merge_mcp_into_per_job_toolsets(["finnhub", "finnhub"], self.CFG)
+        assert result.count("finnhub") == 2  # input dups preserved, none added
+
+    def test_resolver_uses_merge_for_per_job_lists(self):
+        job = {"enabled_toolsets": ["web", "terminal"]}
+        result = _resolve_cron_enabled_toolsets(job, self.CFG)
+        assert set(result) == {"web", "terminal"} | self._enabled_names()
+
+    def test_resolver_empty_per_job_falls_through_to_platform(self):
+        # No per-job list -> delegates to _get_platform_tools (returns a set
+        # sorted into a list, or None on failure). Just assert it does not
+        # raise and is not the merged per-job shape.
+        job = {"enabled_toolsets": None}
+        result = _resolve_cron_enabled_toolsets(job, self.CFG)
+        assert result is None or isinstance(result, list)
 
 
 class TestResolveOrigin:


### PR DESCRIPTION
## What does this PR do?

Fixes the root cause behind #23997 from the cron resolver side: a per-job `enabled_toolsets` list silently drops every MCP server.

`_resolve_cron_enabled_toolsets()` short-circuits with `if per_job: return per_job`. `discover_mcp_tools()` (called just before the cron `AIAgent` is built) still registers every server's tools into the global registry, but `get_tool_definitions(enabled_toolsets=...)` only keeps toolsets named in the list. The agent then rejects each `mcp_*` call with "Unknown tool". A job scoped to e.g. `["web", "terminal"]` therefore runs with **zero** MCP tools even though `hermes mcp list` shows them enabled — exactly the 283-session / 0-MCP-call symptom in #23997.

This layers enabled MCP servers onto the per-job list using the **same semantics already implemented in `_get_platform_tools`** for the no-per-job path, so cron resolves MCP membership identically whether or not a job carries an explicit native allowlist:

- `no_mcp` sentinel present → no MCP servers (sentinel stripped)
- one or more MCP server names already listed → treated as an allowlist, nothing further added
- otherwise → union in every globally-enabled MCP server

The empty/`None` per-job path is unchanged (still delegates to `_get_platform_tools(cfg, "cron")`).

## Related Issue

Fixes #23997

Complementary to (not overlapping with) the draft PR #24104: that PR teaches `validate_toolset()` to accept the documented `server:tool` / `mcp:server` *colon syntax forms*. This PR addresses the orthogonal case where a job's native-toolset allowlist drops MCP entirely regardless of syntax. The two can land independently; together they cover both "I named the server but in a colon form" and "I only named native toolsets and expected MCP to still be there".

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`cron/scheduler.py`** — add `_enabled_mcp_server_names(cfg)` and `_merge_mcp_into_per_job_toolsets(per_job, cfg)`; call the latter from `_resolve_cron_enabled_toolsets` on the per-job branch. MCP-enabled detection reuses the public `utils.is_truthy_value` to match the bool-coercion in `_get_platform_tools`.
- **`tests/cron/test_scheduler.py`** — `TestPerJobToolsetMcpMerge`: 8 cases covering native-only union, disabled-server exclusion, explicit-name allowlist, `no_mcp` opt-out, empty config, dedup, and the resolver entrypoint.

## How to Test

1. Configure at least one MCP server (`enabled: true`) in `config.yaml`.
2. Create a cron job with a native-only allowlist, e.g. `enabled_toolsets: ["web", "terminal"]`.
3. Before this change: the cron session's tool array contains zero `mcp_*` tools; the model emits "Unknown tool 'mcp_…'". After: every globally-enabled MCP server is available.
4. `pytest tests/cron/test_scheduler.py -q` — 8 new cases pass; full `tests/cron/` (177) green.

## Platforms tested

- macOS 15 (Darwin 25.5.0), project venv, Python 3.11

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] PR contains only changes related to this fix
- [x] `pytest tests/cron/ -q` passes (177)
- [x] Added tests for the change
- [x] Documentation / config example — N/A (no user-facing config keys added)