### PR TITLE
fix(tools): fall back to Python read on Windows where head is unavailable

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -26,6 +26,7 @@ Usage:
 """
 
 import os
+import platform
 import re
 import difflib
 from abc import ABC, abstractmethod
@@ -753,6 +754,14 @@ class ShellFileOperations(FileOperations):
             return _detect_line_ending(pre_content)
         # File may not exist (new write) — `head` exits 0 with empty
         # stdout in that case which yields None below.  Cheap probe.
+        # On Windows, `head` is not available; fall back to a direct Python read.
+        if platform.system() == "Windows":
+            try:
+                with open(path, "r", encoding="utf-8", errors="replace") as _f:
+                    sample = _f.read(4096)
+            except OSError:
+                return None
+            return _detect_line_ending(sample)
         head_cmd = f"head -c 4096 {self._escape_shell_arg(path)} 2>/dev/null"
         head_result = self._exec(head_cmd)
         if head_result.exit_code != 0 or not head_result.stdout:


### PR DESCRIPTION
﻿## What does this PR do?

`_detect_file_line_ending()` in `ShellFileOperations` uses `head -c 4096`
to sample the first 4 KB of a file when no pre-content is available.
`head` does not exist on Windows, so on a local-backend + Windows setup the
command always fails (non-zero exit), the method silently returns `None`,
and CRLF preservation is disabled for every write — even for files that already
use Windows line endings.

This adds a Windows-specific fallback that reads the first 4096 characters
directly via Python's built-in `open()`, keeping the same sampling logic
without relying on any external shell command.

## Related Issue

<!-- no related issue found -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

- `tools/file_operations.py`: added `import platform`; in
  `_detect_file_line_ending()` detect `platform.system() == "Windows"`
  and fall back to `open(...).read(4096)` instead of calling `head`.

## How to Test

1. On a Windows machine with a local backend, create a file with CRLF line endings
2. Call `write_file` on that file with new content that preserves CRLF
3. Verify the written file still uses CRLF (previously it would silently switch to LF)
4. Run: `pytest tests/ -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) — this PR is specifically about Windows
- [x] I've updated relevant documentation — or N/A

## Screenshots / Logs

<!-- Before/after visible in the commit diff -->
