### PR TITLE
fix(tools): clamp patch failure counter to 10 to prevent unbounded growth

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -276,7 +276,8 @@ def _record_patch_failure(task_id: str, resolved_path: str) -> int:
                 del task_failures[first_key]
             except StopIteration:
                 pass
-        task_failures[resolved_path] = task_failures.get(resolved_path, 0) + 1
+        count = task_failures.get(resolved_path, 0) + 1
+        task_failures[resolved_path] = min(count, 10)
         return task_failures[resolved_path]
 
 


### PR DESCRIPTION
﻿## What does this PR do?

`_record_patch_failure()` increments a per-file failure counter without
any upper bound. In long-running sessions where the agent repeatedly fails
to patch the same file, the counter grows indefinitely. While Python's
arbitrary-precision integers prevent an overflow, an ever-growing count
produces misleading escalation messages (e.g. "This is failure #10000")
and wastes memory.

The fix clamps the stored value to 10 with `min(count, 10)`. The
escalation hint already triggers at 3; no caller needs a count higher
than 10, so clamping has no behavioral effect beyond bounding the value.

## Related Issue

<!-- no related issue found -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

- `tools/file_tools.py`: in `_record_patch_failure()`, replaced the
  single increment-and-store line with `count = ... + 1` /
  `task_failures[resolved_path] = min(count, 10)` to cap the counter.

## How to Test

1. Trigger repeated patch failures on the same file (e.g. pass a wrong `old_string` 15 times)
2. Inspect `_patch_failure_tracker` — the count for that path must not exceed 10
3. Verify the escalation hint still fires correctly at failure #3
4. Run: `pytest tests/ -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've considered cross-platform impact — or N/A

## Screenshots / Logs

<!-- Before/after visible in the commit diff -->
