### PR TITLE
fix(gateway): preserve launchd Hermes home on reinstall

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import plistlib
 import shutil
 import signal
 import subprocess
@@ -3007,14 +3008,46 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
-def generate_launchd_plist() -> str:
+def _read_launchd_preserved_values(plist_path: Path) -> dict[str, str]:
+    """Read service-scoped launchd values that should survive plist refreshes."""
+    try:
+        with plist_path.open("rb") as f:
+            data = plistlib.load(f)
+    except Exception:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    preserved: dict[str, str] = {}
+    env = data.get("EnvironmentVariables")
+    if isinstance(env, dict):
+        for key in ("HERMES_HOME", "PATH", "VIRTUAL_ENV"):
+            value = env.get(key)
+            if isinstance(value, str) and value.strip():
+                preserved[key] = value
+
+    for key in ("StandardOutPath", "StandardErrorPath"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            preserved[key] = value
+
+    return preserved
+
+
+def generate_launchd_plist(preserved_values: dict[str, str] | None = None) -> str:
+    preserved_values = preserved_values or {}
     python_path = get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
     # _stable_service_working_dir() for the rationale (same rot risk applies
     # to launchd's WorkingDirectory as to systemd's).
-    working_dir = _stable_service_working_dir()
-    hermes_home = str(get_hermes_home().resolve())
-    log_dir = get_hermes_home() / "logs"
+    hermes_home = preserved_values.get("HERMES_HOME") or str(get_hermes_home().resolve())
+    working_dir = (
+        str(Path(hermes_home).resolve())
+        if preserved_values.get("HERMES_HOME") and Path(hermes_home).is_dir()
+        else _stable_service_working_dir()
+    )
+    log_dir = Path(hermes_home) / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     label = get_launchd_label()
     profile_arg = _profile_arg(hermes_home)
@@ -3024,7 +3057,9 @@ def generate_launchd_plist() -> str:
     # the systemd unit), then capture the user's full shell PATH so every
     # user-installed tool (node, ffmpeg, …) is reachable.
     detected_venv = _detect_venv_dir()
-    venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
+    venv_dir = preserved_values.get("VIRTUAL_ENV") or (
+        str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
+    )
     # Resolve the directory containing the node binary (e.g. Homebrew, nvm)
     # so it's explicitly in PATH even if the user's shell PATH changes later.
     priority_dirs = _build_service_path_dirs()
@@ -3033,11 +3068,13 @@ def generate_launchd_plist() -> str:
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
         if resolved_node_dir not in priority_dirs:
             priority_dirs.append(resolved_node_dir)
-    sane_path = ":".join(
+    sane_path = preserved_values.get("PATH") or ":".join(
         dict.fromkeys(
             priority_dirs + [p for p in os.environ.get("PATH", "").split(":") if p]
         )
     )
+    stdout_path = preserved_values.get("StandardOutPath") or f"{log_dir}/gateway.log"
+    stderr_path = preserved_values.get("StandardErrorPath") or f"{log_dir}/gateway.error.log"
 
     # Build ProgramArguments array, including --profile when using a named profile
     prog_args = [
@@ -3092,10 +3129,10 @@ def generate_launchd_plist() -> str:
     </dict>
     
     <key>StandardOutPath</key>
-    <string>{log_dir}/gateway.log</string>
+    <string>{stdout_path}</string>
     
     <key>StandardErrorPath</key>
-    <string>{log_dir}/gateway.error.log</string>
+    <string>{stderr_path}</string>
 </dict>
 </plist>
 """
@@ -3108,7 +3145,7 @@ def launchd_plist_is_current() -> bool:
         return False
 
     installed = plist_path.read_text(encoding="utf-8")
-    expected = generate_launchd_plist()
+    expected = generate_launchd_plist(_read_launchd_preserved_values(plist_path))
     return _normalize_launchd_plist_for_comparison(
         installed
     ) == _normalize_launchd_plist_for_comparison(expected)
@@ -3125,7 +3162,8 @@ def refresh_launchd_plist_if_needed() -> bool:
     if not plist_path.exists() or launchd_plist_is_current():
         return False
 
-    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+    preserved_values = _read_launchd_preserved_values(plist_path)
+    plist_path.write_text(generate_launchd_plist(preserved_values), encoding="utf-8")
     label = get_launchd_label()
     # Bootout/bootstrap so launchd picks up the new definition
     subprocess.run(
@@ -3159,7 +3197,10 @@ def launchd_install(force: bool = False):
 
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     print(f"Installing launchd service to: {plist_path}")
-    plist_path.write_text(generate_launchd_plist())
+    preserved_values = (
+        _read_launchd_preserved_values(plist_path) if plist_path.exists() else {}
+    )
+    plist_path.write_text(generate_launchd_plist(preserved_values), encoding="utf-8")
 
     subprocess.run(
         ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -498,6 +499,51 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
+
+    def test_launchd_install_preserves_existing_custom_hermes_home(
+        self, tmp_path, monkeypatch
+    ):
+        """Reinstalling must not silently reset a custom LaunchAgent HERMES_HOME."""
+        current_home = tmp_path / "default-hermes"
+        custom_home = tmp_path / "custom-hermes"
+        custom_venv = tmp_path / "custom-venv"
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        custom_path = "/custom/bin:/usr/bin"
+        current_home.mkdir()
+        custom_home.mkdir()
+        custom_venv.mkdir()
+
+        monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: current_home)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        installed = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+        installed["EnvironmentVariables"]["HERMES_HOME"] = str(custom_home)
+        installed["EnvironmentVariables"]["PATH"] = custom_path
+        installed["EnvironmentVariables"]["VIRTUAL_ENV"] = str(custom_venv)
+        installed["StandardOutPath"] = f"{custom_home}/logs/gateway.log"
+        installed["StandardErrorPath"] = f"{custom_home}/logs/gateway.error.log"
+        installed["ThrottleInterval"] = 10
+        plist_path.write_bytes(plistlib.dumps(installed))
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_install()
+
+        updated = plistlib.loads(plist_path.read_bytes())
+        assert updated["EnvironmentVariables"]["HERMES_HOME"] == str(custom_home)
+        assert updated["EnvironmentVariables"]["PATH"] == custom_path
+        assert updated["EnvironmentVariables"]["VIRTUAL_ENV"] == str(custom_venv)
+        assert updated["StandardOutPath"] == f"{custom_home}/logs/gateway.log"
+        assert updated["StandardErrorPath"] == f"{custom_home}/logs/gateway.error.log"
+        assert "ThrottleInterval" not in updated
+        assert str(current_home) not in plist_path.read_text(encoding="utf-8")
+        assert any(cmd[:2] == ["launchctl", "bootstrap"] for cmd in calls)
 
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"


### PR DESCRIPTION
## What does this PR do?

Fixes the macOS LaunchAgent reinstall path so `hermes gateway install` no longer silently resets an existing service from a custom `HERMES_HOME` back to the current shell/default Hermes home.

The fix reads service-scoped values from the existing plist before regenerating it, then preserves:

- `EnvironmentVariables.HERMES_HOME`
- `EnvironmentVariables.PATH`
- `EnvironmentVariables.VIRTUAL_ENV`
- `StandardOutPath`
- `StandardErrorPath`

This keeps the repair/reinstall behavior intact while preventing an existing custom gateway home, path, venv, or log target from being overwritten by the caller's current environment. The stale-plist comparison also uses those preserved values so a valid custom-home plist does not keep looking outdated forever.

## Related Issue

Fixes #32741

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: add plist parsing for existing launchd service values and preserve those values during plist comparison, refresh, and force reinstall.
- `tests/hermes_cli/test_gateway_service.py`: add regression coverage for reinstalling an outdated LaunchAgent plist while preserving custom `HERMES_HOME`, `PATH`, `VIRTUAL_ENV`, stdout log path, and stderr log path.

## How to Test

1. Install gateway once with a custom `HERMES_HOME`.
2. Run `hermes gateway install` later from an environment where `HERMES_HOME` is unset or different.
3. Verify the installed plist still points at the original custom service values.

Automated verification run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py -- -q -k launchd
uv run ruff check .
python scripts/check-windows-footguns.py --all
git diff --check
```

Results:

- launchd slice: 14 passed
- ruff: passed
- Windows footgun scan: passed
- whitespace check: passed

I also tried the full `tests/hermes_cli/test_gateway_service.py` file on macOS. The launchd tests passed, but six unrelated systemd tests fail on current `upstream/main` before this patch's launchd path because `_preflight_user_systemd()` rejects the local non-Linux D-Bus/systemd environment.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is covered by launchd plist regression tests.
