### PR TITLE
fix(env_loader): add threading.Lock to _APPLIED_HOMES to prevent TOCTOU race

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -37,6 +38,7 @@ _SECRET_SOURCES: dict[str, str] = {}
 # in-process cache prevents redundant network calls, but the print, the
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
+_APPLIED_HOMES_LOCK = threading.Lock()
 
 
 def get_secret_source(env_var: str) -> str | None:
@@ -265,9 +267,10 @@ def _apply_external_secret_sources(home_path: Path) -> None:
     process).
     """
     home_key = str(Path(home_path).resolve())
-    if home_key in _APPLIED_HOMES:
-        return
-    _APPLIED_HOMES.add(home_key)
+    with _APPLIED_HOMES_LOCK:
+        if home_key in _APPLIED_HOMES:
+            return
+        _APPLIED_HOMES.add(home_key)
 
     try:
         cfg = _load_secrets_config(home_path)


### PR DESCRIPTION
﻿## What does this PR do?

`_apply_external_secret_sources()` uses a module-level `set` called
`_APPLIED_HOMES` as an idempotency guard to avoid running Bitwarden pulls
more than once per home directory per process.  The check-then-set sequence
is not protected by a lock:

`python
if home_key in _APPLIED_HOMES:   # check
    return
_APPLIED_HOMES.add(home_key)     # use
`

When two threads call `load_hermes_dotenv()` concurrently (e.g. gateway
startup spawning multiple handler threads), both can pass the `in` check
before either executes the `add`, causing the Bitwarden CLI to be invoked
twice simultaneously.  Concurrent Bitwarden CLI calls can fail or corrupt
the cached credential state.

The fix wraps the check-and-add in `threading.Lock()` so only one thread
can pass through the guard at a time.

## Related Issue

<!-- no related issue found -->

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

- `hermes_cli/env_loader.py`: added `import threading`; added module-level
  `_APPLIED_HOMES_LOCK = threading.Lock()`; wrapped the idempotency guard
  in `_apply_external_secret_sources()` with `with _APPLIED_HOMES_LOCK`.

## How to Test

1. Spawn two threads that both call `load_hermes_dotenv()` with the same
   home path simultaneously
2. Verify `_apply_external_secret_sources()` executes only once (e.g. mock
   the Bitwarden call and assert it was called exactly once)
3. Run: `pytest tests/ -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've considered cross-platform impact — or N/A

## Screenshots / Logs

<!-- Before/after visible in the commit diff -->
