### PR TITLE
fix(approval): track tirith_downgraded when always is silently downgraded to session

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1340,9 +1340,12 @@ def check_all_command_guards(command: str, env_type: str,
                 }
 
             # User approved — persist based on scope (same logic as CLI)
+            tirith_downgraded = False
             for key, _, is_tirith in warnings:
                 if choice == "session" or (choice == "always" and is_tirith):
                     approve_session(session_key, key)
+                    if choice == "always" and is_tirith:
+                        tirith_downgraded = True
                 elif choice == "always":
                     approve_session(session_key, key)
                     approve_permanent(key)
@@ -1351,7 +1354,8 @@ def check_all_command_guards(command: str, env_type: str,
                 # single time only, matching the CLI's behavior.
 
             return {"approved": True, "message": None,
-                    "user_approved": True, "description": combined_desc}
+                    "user_approved": True, "description": combined_desc,
+                    "tirith_downgraded": tirith_downgraded}
 
         # Fallback: no gateway callback registered (e.g. cron, batch).
         # Return approval_required for backward compat.
@@ -1416,10 +1420,13 @@ def check_all_command_guards(command: str, env_type: str,
         }
 
     # Persist approval for each warning individually
+    tirith_downgraded = False
     for key, _, is_tirith in warnings:
         if choice == "session" or (choice == "always" and is_tirith):
             # tirith: session only (no permanent broad allowlisting)
             approve_session(session_key, key)
+            if choice == "always" and is_tirith:
+                tirith_downgraded = True
         elif choice == "always":
             # dangerous patterns: permanent allowed
             approve_session(session_key, key)
@@ -1427,7 +1434,8 @@ def check_all_command_guards(command: str, env_type: str,
             save_permanent_allowlist(_permanent_approved)
 
     return {"approved": True, "message": None,
-            "user_approved": True, "description": combined_desc}
+            "user_approved": True, "description": combined_desc,
+            "tirith_downgraded": tirith_downgraded}
 
 
 # Load permanent allowlist from config on module import


### PR DESCRIPTION
## What does this PR do?

When a Tirith security finding is present and the user selects "always", the approval is silently downgraded to session-scoped (by design — Tirith findings should never be permanently allowlisted). However, the return dict from `check_all_command_guards()` did not indicate this downgrade, so downstream consumers (gateway platforms) could display "Approved permanently" when the approval was actually session-scoped.

This PR adds a `tirith_downgraded` boolean flag to the return dict in both the gateway and CLI approval paths.

## Related Issue

Fixes #32764

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)

## Changes Made

- `tools/approval.py`: Added `tirith_downgraded` tracking in both the gateway callback path (~line 1342) and the CLI interactive path (~line 1420). The flag is set to `True` when `choice == "always"` but `is_tirith` is `True`, causing the approval to be session-scoped instead of permanent. The flag is included in the return dict so gateway platforms can display the correct confirmation message.

## How to Test

1. Run the existing test suite: `scripts/run_tests.sh`
2. Verify the return dict includes `tirith_downgraded: True` when a Tirith finding downgrades "always" to session
3. Verify the return dict includes `tirith_downgraded: False` for non-Tirith "always" approvals

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix