### PR TITLE
fix(gateway): restart manual Windows gateway

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3916,12 +3916,27 @@ class GatewayRunner:
             import textwrap
             from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
 
+            use_windows_service_spawn = False
+            try:
+                from hermes_cli.gateway_windows import (
+                    is_startup_entry_installed,
+                    is_task_registered,
+                )
+
+                use_windows_service_spawn = bool(
+                    is_task_registered() or is_startup_entry_installed()
+                )
+            except Exception:
+                use_windows_service_spawn = False
+
+            watcher_mode = "service-spawn" if use_windows_service_spawn else "cli-restart"
             cmd_argv = [*hermes_cmd, "gateway", "restart"]
             watcher = textwrap.dedent(
                 """
                 import os, subprocess, sys, time
                 pid = int(sys.argv[1])
-                cmd = sys.argv[2:]
+                mode = sys.argv[2]
+                cmd = sys.argv[3:]
                 deadline = time.monotonic() + 120
 
                 def _alive(p):
@@ -3955,19 +3970,23 @@ class GatewayRunner:
                     if not _alive(pid):
                         break
                     time.sleep(0.2)
-                _CREATE_NEW_PROCESS_GROUP = 0x00000200
-                _DETACHED_PROCESS = 0x00000008
-                _CREATE_NO_WINDOW = 0x08000000
-                subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    creationflags=_CREATE_NEW_PROCESS_GROUP | _DETACHED_PROCESS | _CREATE_NO_WINDOW,
-                )
+                if mode == "service-spawn":
+                    from hermes_cli.gateway_windows import _spawn_detached
+                    _spawn_detached()
+                else:
+                    _CREATE_NEW_PROCESS_GROUP = 0x00000200
+                    _DETACHED_PROCESS = 0x00000008
+                    _CREATE_NO_WINDOW = 0x08000000
+                    subprocess.Popen(
+                        cmd,
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        creationflags=_CREATE_NEW_PROCESS_GROUP | _DETACHED_PROCESS | _CREATE_NO_WINDOW,
+                    )
                 """
             ).strip()
             subprocess.Popen(
-                [sys.executable, "-c", watcher, str(current_pid), *cmd_argv],
+                [sys.executable, "-c", watcher, str(current_pid), watcher_mode, *cmd_argv],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 **windows_detach_popen_kwargs(),

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -976,7 +976,7 @@ def status(deep: bool = False) -> None:
         print("  hermes gateway install")
 
 
-def start() -> None:
+def start(*, prompt_install: bool = True) -> None:
     """Start the gateway. Prefers /Run on the scheduled task if present."""
     _assert_windows()
     running_pids = _gateway_pids()
@@ -988,6 +988,11 @@ def start() -> None:
     startup_installed = is_startup_entry_installed()
 
     if not task_installed and not startup_installed:
+        if not prompt_install:
+            pid = _spawn_detached()
+            _report_gateway_start(f"direct spawn (PID {pid})")
+            return
+
         from hermes_cli.setup import prompt_yes_no
 
         print("✗ Gateway service is not installed")
@@ -1109,4 +1114,4 @@ def restart() -> None:
     stop()
     # Give Windows a moment to release the listening port.
     time.sleep(1.0)
-    start()
+    start(prompt_install=False)

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -1,12 +1,15 @@
 import asyncio
 import shutil
 import subprocess
+import sys
+from types import SimpleNamespace
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import gateway.run as gateway_run
+import hermes_cli._subprocess_compat as subprocess_compat
 from agent.i18n import t
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
@@ -202,6 +205,86 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_command_uses_windows_service_spawn(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["C:/Hermes/hermes.exe"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.gateway_windows",
+        SimpleNamespace(
+            is_task_registered=lambda: True,
+            is_startup_entry_installed=lambda: False,
+        ),
+    )
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {"creationflags": 0x1234},
+    )
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[:3] == [gateway_run.sys.executable, "-c", cmd[2]]
+    assert cmd[3:5] == ["321", "service-spawn"]
+    assert "_spawn_detached()" in cmd[2]
+    assert kwargs["stdout"] is subprocess.DEVNULL
+    assert kwargs["stderr"] is subprocess.DEVNULL
+    assert kwargs["creationflags"] == 0x1234
+
+
+@pytest.mark.asyncio
+async def test_launch_detached_restart_command_keeps_windows_cli_restart_without_service(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    popen_calls = []
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "win32")
+    monkeypatch.setattr(gateway_run, "_resolve_hermes_bin", lambda: ["C:/Hermes/hermes.exe"])
+    monkeypatch.setattr(gateway_run.os, "getpid", lambda: 321)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.gateway_windows",
+        SimpleNamespace(
+            is_task_registered=lambda: False,
+            is_startup_entry_installed=lambda: False,
+        ),
+    )
+    monkeypatch.setattr(
+        subprocess_compat,
+        "windows_detach_popen_kwargs",
+        lambda: {"creationflags": 0x5678},
+    )
+
+    def fake_popen(cmd, **kwargs):
+        popen_calls.append((cmd, kwargs))
+        return MagicMock()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    await runner._launch_detached_restart_command()
+
+    assert len(popen_calls) == 1
+    cmd, kwargs = popen_calls[0]
+    assert cmd[3:5] == ["321", "cli-restart"]
+    assert cmd[-3:] == ["C:/Hermes/hermes.exe", "gateway", "restart"]
+    assert "_spawn_detached()" in cmd[2]
+    assert kwargs["creationflags"] == 0x5678
 
 
 # ── Shutdown notification tests ──────────────────────────────────────

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -349,6 +349,33 @@ def test_start_noops_when_gateway_already_running(monkeypatch, capsys):
     assert "27128" in out
 
 
+def test_restart_without_installed_service_spawns_directly_without_prompt(monkeypatch):
+    """Manual restart should recover even when no Windows login service is installed."""
+    calls = []
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_gateway_pids", lambda: [])
+    monkeypatch.setattr(gateway_windows, "is_task_registered", lambda: False)
+    monkeypatch.setattr(gateway_windows, "is_startup_entry_installed", lambda: False)
+    monkeypatch.setattr(gateway_windows, "stop", lambda: calls.append("stop"))
+    monkeypatch.setattr(gateway_windows.time, "sleep", lambda seconds: calls.append(("sleep", seconds)))
+    monkeypatch.setattr(gateway_windows, "_spawn_detached", lambda path=None: calls.append(("spawn", path)) or 12345)
+    monkeypatch.setattr(gateway_windows, "_report_gateway_start", lambda via: calls.append(("report_start", via)))
+    monkeypatch.setattr(
+        setup,
+        "prompt_yes_no",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("restart must not prompt to install")),
+    )
+
+    gateway_windows.restart()
+
+    assert calls == [
+        "stop",
+        ("sleep", 1.0),
+        ("spawn", None),
+        ("report_start", "direct spawn (PID 12345)"),
+    ]
+
+
 def test_install_startup_fallback_does_not_spawn_when_gateway_already_running(monkeypatch, tmp_path, capsys):
     """Repeated Windows fallback installs should not spawn duplicate gateways."""
     script_path, calls = _arrange_startup_fallback(monkeypatch, tmp_path, [24476])


### PR DESCRIPTION
## Summary
- Fix Windows `hermes gateway restart` so it can recover a manually started gateway when no Scheduled Task or Startup entry is installed.
- Keep normal `hermes gateway start` behavior unchanged: explicit starts still offer to install the login service.
- Add a regression test that ensures restart does not enter the install prompt path before direct-spawning the gateway.

Fixes #32779

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -- -q -k restart_without_installed_service_spawns_directly_without_prompt`
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_windows.py -- -q`
- `scripts/run_tests.sh tests/hermes_cli/test_gateway.py -- -q -k "gateway_restart_on_windows"`
- `uv run ruff check hermes_cli/gateway_windows.py tests/hermes_cli/test_gateway_windows.py`
- `python scripts/check-windows-footguns.py --all`
- `git diff --check`

## Notes
This is unit-tested with monkeypatches only; it does not touch the local Windows service/task state.
