### PR TITLE
feat: add TrueNAS Scale and UnRAID read-only monitoring tools

### DIFF
--- a/tools/truenas_tool.py
+++ b/tools/truenas_tool.py
@@ -1,0 +1,320 @@
+"""TrueNAS tool for querying NAS system status via REST API.
+
+Registers a single LLM-callable tool:
+- ``truenas_query`` — query TrueNAS system information (status, pools,
+  disks, shares, alerts, services, or full summary).
+
+Authentication uses a TrueNAS API key via ``TRUENAS_API_KEY`` env var.
+The TrueNAS URL is read from ``TRUENAS_URL`` (default: https://truenas.local).
+"""
+
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Kept for backward compatibility (e.g. test monkeypatching); prefer _get_config().
+_TRUENAS_URL: str = ""
+_TRUENAS_API_KEY: str = ""
+
+# TLS: TrueNAS uses self-signed certs by default, so we accept all.
+_CTX = ssl._create_unverified_context()
+
+
+def _get_config():
+    """Return (truenas_url, truenas_api_key) from env vars at call time."""
+    return (
+        (
+            _TRUENAS_URL
+            or os.getenv("TRUENAS_URL", "https://truenas.local")
+        ).rstrip("/"),
+        _TRUENAS_API_KEY or os.getenv("TRUENAS_API_KEY", ""),
+    )
+
+
+def _check_truenas_available() -> bool:
+    """Return True if TRUENAS_API_KEY is set so the tool is gated correctly."""
+    _, key = _get_config()
+    return bool(key)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _api_get(path: str, timeout: int = 15) -> dict:
+    """Make a GET request to the TrueNAS REST API and return parsed JSON."""
+    url, key = _get_config()
+    if not key:
+        return {"error": "TRUENAS_API_KEY not set. Add it to ~/.hermes/.env"}
+    full_url = f"{url}/api/v2.0{path}"
+    req = urllib.request.Request(full_url)
+    req.add_header("Authorization", f"Bearer {key}")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, context=_CTX, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        return {"error": f"HTTP {e.code}: {body}"}
+    except urllib.error.URLError as e:
+        return {"error": f"Connection failed: {e.reason}"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_bytes(n: int) -> str:
+    """Format bytes to human-readable string."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} PB"
+
+
+def _format_disk(disk: dict) -> dict:
+    """Compact disk summary."""
+    return {
+        "name": disk.get("name", "?"),
+        "serial": disk.get("serial", "?"),
+        "size": _format_bytes(disk.get("size", 0)),
+        "model": disk.get("model", "?"),
+        "pool": disk.get("pool", "-"),
+        "rotation_rate": disk.get("rotation_rate", 0),
+        "type": disk.get("type", "?"),
+    }
+
+
+def _format_pool(pool: dict) -> dict:
+    """Compact pool summary."""
+    topology = pool.get("topology", {})
+    vdevs = []
+    for vdev in topology.get("data", []):
+        children = [
+            c.get("name", "?") for c in vdev.get("children", [])
+        ]
+        vdevs.append({
+            "type": vdev.get("type", "?"),
+            "status": vdev.get("status", "?"),
+            "disks": children,
+        })
+    scan = pool.get("scan", {})
+    return {
+        "name": pool.get("name", "?"),
+        "status": pool.get("status", "?"),
+        "healthy": pool.get("healthy", False),
+        "size": _format_bytes(pool.get("size", 0)),
+        "used": _format_bytes(pool.get("allocated", 0)),
+        "free": _format_bytes(pool.get("free", 0)),
+        "fragmentation": pool.get("fragmentation", "?"),
+        "vdevs": vdevs,
+        "last_scrub": scan.get("state", "?"),
+        "scrub_errors": scan.get("errors", 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Query handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_summary() -> str:
+    """Full system summary — system info + pools + alerts."""
+    system = _api_get("/system/info")
+    if "error" in system:
+        return json.dumps(system)
+
+    pools_data = _api_get("/pool")
+    alerts_data = _api_get("/alert/list")
+
+    pools = [_format_pool(p) for p in pools_data] if isinstance(pools_data, list) else []
+    alerts = list(alerts_data) if isinstance(alerts_data, list) else []
+
+    status = system.get("status", "?")
+    # TrueNAS Scale doesn't return status in system/info; infer from pool health
+    pool_healthy = all(p["healthy"] for p in pools) if pools else True
+
+    summary = {
+        "hostname": system.get("hostname", "?"),
+        "version": system.get("version", "?"),
+        "uptime": system.get("uptime", "?"),
+        "cpu": system.get("model", "?"),
+        "cores": system.get("physical_cores", "?"),
+        "memory": _format_bytes(system.get("physmem", 0)),
+        "timezone": system.get("timezone", "?"),
+        "status": "ONLINE" if pool_healthy else "DEGRADED",
+        "pools": pools,
+        "alerts": alerts,
+    }
+    return json.dumps(summary, indent=2, ensure_ascii=False)
+
+
+def _handle_pools() -> str:
+    """List all pools with vdev topology and health."""
+    data = _api_get("/pool")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data)
+    pools = [_format_pool(p) for p in data]
+    return json.dumps({"count": len(pools), "pools": pools}, indent=2, ensure_ascii=False)
+
+
+def _handle_disks() -> str:
+    """List all disks with serial, model, size."""
+    data = _api_get("/disk")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data)
+    disks = [_format_disk(d) for d in data]
+    return json.dumps({"count": len(disks), "disks": disks}, indent=2, ensure_ascii=False)
+
+
+def _handle_shares() -> str:
+    """List SMB and NFS shares."""
+    smb = _api_get("/sharing/smb")
+    nfs = _api_get("/sharing/nfs")
+
+    result = {}
+    if isinstance(smb, list):
+        result["smb"] = [
+            {"name": s.get("name", "?"), "path": s.get("path", "?"), "enabled": s.get("enabled", False)}
+            for s in smb
+        ]
+    elif isinstance(smb, dict) and "error" in smb:
+        result["smb_error"] = smb["error"]
+
+    if isinstance(nfs, list):
+        result["nfs"] = [
+            {"path": s.get("path", "?"), "enabled": s.get("enabled", False), "networks": s.get("networks", [])}
+            for s in nfs
+        ]
+    elif isinstance(nfs, dict) and "error" in nfs:
+        result["nfs_error"] = nfs["error"]
+
+    result["smb_count"] = len(result.get("smb", []))
+    result["nfs_count"] = len(result.get("nfs", []))
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+def _handle_alerts() -> str:
+    """List active alerts/warnings."""
+    data = _api_get("/alert/list")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data)
+    return json.dumps({"count": len(data), "alerts": data}, indent=2, ensure_ascii=False)
+
+
+def _handle_services() -> str:
+    """List services and their running/auto-start status."""
+    data = _api_get("/service")
+    if isinstance(data, dict) and "error" in data:
+        return json.dumps(data)
+
+    # Known service labels for readability
+    labels = {
+        "cifs": "SMB", "nfs": "NFS", "ssh": "SSH",
+        "ftp": "FTP", "tftp": "TFTP", "openvpn": "OpenVPN",
+        "snmp": "SNMP", "ups": "UPS", "iscsitarget": "iSCSI",
+        "webshell": "Web Shell", "nvmet": "NVMe-oF",
+    }
+
+    services = []
+    for s in data:
+        name = s.get("service", "?")
+        services.append({
+            "name": name,
+            "label": labels.get(name, name),
+            "running": s.get("state", False),
+            "auto_start": s.get("enable", False),
+        })
+
+    return json.dumps({"count": len(services), "services": services}, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+_ACTIONS = {
+    "summary": _handle_summary,
+    "pools": _handle_pools,
+    "disks": _handle_disks,
+    "shares": _handle_shares,
+    "alerts": _handle_alerts,
+    "services": _handle_services,
+}
+
+
+def _handle_query(action: str, task_id: str = None) -> str:
+    """Dispatch to the appropriate handler."""
+    handler = _ACTIONS.get(action)
+    if not handler:
+        valid = ", ".join(sorted(_ACTIONS))
+        return json.dumps({
+            "error": f"Unknown action '{action}'. Valid actions: {valid}",
+        })
+    return handler()
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+TRUENAS_QUERY_SCHEMA = {
+    "name": "truenas_query",
+    "description": (
+        "Query a TrueNAS Scale system over its REST API. "
+        "Returns JSON with system information. "
+        "Requires TRUENAS_API_KEY and TRUENAS_URL environment variables to be set. "
+        "All operations are read-only."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "description": (
+                    "What information to retrieve:\n"
+                    "- **summary**: Full system overview (hostname, version, uptime, CPU, RAM, pool health, alerts)\n"
+                    "- **pools**: ZFS pool list with vdev topology, health, capacity\n"
+                    "- **disks**: Physical disk list with serial, model, size\n"
+                    "- **shares**: SMB and NFS share list\n"
+                    "- **alerts**: Active alerts and warnings\n"
+                    "- **services**: Service status (running/stopped, auto-start enabled)"
+                ),
+                "enum": ["summary", "pools", "disks", "shares", "alerts", "services"],
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="truenas_query",
+    toolset="truenas",
+    schema=TRUENAS_QUERY_SCHEMA,
+    handler=lambda args, **kw: _handle_query(
+        action=args.get("action", ""), task_id=kw.get("task_id")),
+    check_fn=_check_truenas_available,
+    requires_env=["TRUENAS_API_KEY"],
+    emoji="🖥️",
+)

--- a/tools/unraid_tool.py
+++ b/tools/unraid_tool.py
@@ -1,0 +1,333 @@
+"""UnRAID tool for querying NAS system status via GraphQL API.
+
+Registers a single LLM-callable tool:
+- ``unraid_query`` — query UnRAID system information (info, disks, docker
+  containers, notifications, or full summary).
+
+Authentication uses an UnRAID API key via ``UNRAID_API_KEY`` env var.
+The UnRAID URL is read from ``UNRAID_URL`` (default: https://unraid.local).
+
+NOTE: The API key must have proper data access permissions (READ_ANY) for
+data queries in UnRAID Settings → API Keys. Schema introspection queries
+work without auth, but data queries require authorized API keys.
+"""
+
+import json
+import logging
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_UNRAID_URL: str = ""
+_UNRAID_API_KEY: str = ""
+
+_CTX = ssl._create_unverified_context()
+
+
+def _get_config():
+    """Return (unraid_url, unraid_api_key) from env vars at call time."""
+    return (
+        (
+            _UNRAID_URL
+            or os.getenv("UNRAID_URL", "https://unraid.local")
+        ).rstrip("/"),
+        _UNRAID_API_KEY or os.getenv("UNRAID_API_KEY", ""),
+    )
+
+
+def _check_unraid_available() -> bool:
+    """Return True if UNRAID_API_KEY is set."""
+    _, key = _get_config()
+    return bool(key)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _gql(query: str, timeout: int = 15) -> dict:
+    """Send a GraphQL query to UnRAID and return parsed JSON."""
+    url, key = _get_config()
+    if not key:
+        return {"error": "UNRAID_API_KEY not set. Add it to ~/.hermes/.env"}
+
+    graphql_url = f"{url}/graphql"
+    payload = json.dumps({"query": query}).encode()
+    req = urllib.request.Request(graphql_url, data=payload)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("x-api-key", key)
+
+    try:
+        with urllib.request.urlopen(req, context=_CTX, timeout=timeout) as resp:
+            parsed = json.loads(resp.read().decode())
+            # GraphQL returns 200 even when there are errors; check both paths
+            if parsed.get("errors"):
+                error_msgs = [e.get("message", "?") for e in parsed["errors"]]
+                return {"error": "; ".join(error_msgs)}
+            if parsed.get("data") is None:
+                return {"error": "GraphQL returned null data"}
+            return parsed
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        return {"error": f"HTTP {e.code}: {body[:300]}"}
+    except urllib.error.URLError as e:
+        return {"error": f"Connection failed: {e.reason}"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_bytes(kb: int) -> str:
+    """Format kilobytes to human-readable string."""
+    if not kb:
+        return "?"
+    n = kb * 1024  # convert to bytes
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} PB"
+
+
+# ---------------------------------------------------------------------------
+# Query handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_info() -> str:
+    """System info — CPU, OS, uptime."""
+    # InfoOs fields: hostname, distro, kernel, uptime
+    # InfoCpu fields: model, cores, threads
+    # InfoVersions: has core (CoreVersions) and packages (PackageVersions)
+    result = _gql("""
+    {
+      info {
+        time
+        cpu { model cores threads }
+        os { hostname distro kernel uptime }
+      }
+    }
+    """)
+    if "error" in result:
+        return json.dumps(result)
+
+    data = result.get("data", {}).get("info", {})
+    cpu = data.get("cpu", {})
+    os_info = data.get("os", {})
+
+    info = {
+        "hostname": os_info.get("hostname", "?"),
+        "os": "UnRAID",
+        "distro": os_info.get("distro", "?"),
+        "kernel": os_info.get("kernel", "?"),
+        "uptime": os_info.get("uptime", "?"),
+        "cpu": {
+            "model": cpu.get("model", "?"),
+            "cores": cpu.get("cores", 0),
+            "threads": cpu.get("threads", 0),
+        },
+        "note": "Memory info unavailable via UnRAID GraphQL API",
+    }
+    return json.dumps(info, indent=2, ensure_ascii=False)
+
+
+def _handle_disks() -> str:
+    """List all disks."""
+    # Disk fields: name, size(Float), type, serialNum, smartStatus(DiskSmartStatus), temperature(Float)
+    result = _gql("{ disks { name size type serialNum temperature smartStatus } }")
+    if "error" in result:
+        return json.dumps(result)
+
+    disks_data = result.get("data", {}).get("disks", [])
+    disks = []
+    for d in disks_data:
+        smart = d.get("smartStatus")
+        if isinstance(smart, dict):
+            smart = smart.get("name", "?")
+        disks.append({
+            "name": d.get("name", "?"),
+            "size": _format_bytes(d.get("size", 0)),
+            "type": d.get("type", "?"),
+            "serial": d.get("serialNum", "?"),
+            "temperature": d.get("temperature", "?"),
+            "smart_status": smart,
+        })
+    return json.dumps({"count": len(disks), "disks": disks}, indent=2, ensure_ascii=False)
+
+
+def _handle_docker() -> str:
+    """List Docker containers."""
+    # Query: docker { containers { names, image, status, state { ... } } }
+    result = _gql("{ docker { containers { names image status } } }")
+    if "error" in result:
+        return json.dumps(result)
+
+    containers = result.get("data", {}).get("docker", {}).get("containers", [])
+    formatted = []
+    for c in containers:
+        formatted.append({
+            "name": (c.get("names") or ["?"])[0],
+            "image": c.get("image", "?"),
+            "status": c.get("status", "?"),
+        })
+    return json.dumps({"count": len(formatted), "containers": formatted}, indent=2, ensure_ascii=False)
+
+
+def _handle_alerts() -> str:
+    """List notifications / alerts."""
+    # Notifications has: overview(NotificationOverview), warningsAndAlerts([Notification!]!)
+    result = _gql("{ notifications { warningsAndAlerts { id } } }")
+    if "error" in result:
+        return json.dumps(result)
+
+    alerts = result.get("data", {}).get("notifications", {}).get("warningsAndAlerts", [])
+    return json.dumps({"count": len(alerts), "alerts": alerts}, indent=2, ensure_ascii=False)
+
+
+def _handle_summary() -> str:
+    """Full system summary."""
+    info_result = _gql("""
+    {
+      info {
+        time
+        cpu { model cores threads }
+        os { hostname distro kernel uptime }
+      }
+    }
+    """)
+    disks_result = _gql("{ disks { name size type serialNum temperature smartStatus } }")
+    docker_result = _gql("{ docker { containers { names image status } } }")
+    alerts_result = _gql("{ notifications { warningsAndAlerts { id } } }")
+
+    summary = {"status": "unknown"}
+
+    if "error" not in info_result:
+        data = info_result.get("data", {}).get("info", {})
+        cpu = data.get("cpu", {})
+        os_info = data.get("os", {})
+        summary["hostname"] = os_info.get("hostname", "?")
+        summary["os"] = "UnRAID"
+        summary["kernel"] = os_info.get("kernel", "?")
+        summary["uptime"] = os_info.get("uptime", "?")
+        summary["cpu"] = {
+            "model": cpu.get("model", "?"),
+            "cores": cpu.get("cores", 0),
+        }
+        summary["status"] = "ONLINE"
+
+    if "error" not in disks_result:
+        disks_data = disks_result.get("data", {}).get("disks", [])
+        summary["disks"] = [
+            {"name": d.get("name", "?"), "size": _format_bytes(d.get("size", 0)),
+             "type": d.get("type", "?"), "smart": d.get("smartStatus", {})}
+            for d in disks_data
+        ]
+        summary["disk_count"] = len(disks_data)
+    else:
+        summary["disks"] = []
+        summary["disk_error"] = disks_result["error"]
+
+    if "error" not in docker_result:
+        containers = docker_result.get("data", {}).get("docker", {}).get("containers", [])
+        summary["docker"] = [
+            {"name": (c.get("names") or ["?"])[0], "image": c.get("image", "?"), "status": c.get("status", "?")}
+            for c in containers
+        ]
+        summary["docker_count"] = len(containers)
+
+    if "error" not in alerts_result:
+        alerts = alerts_result.get("data", {}).get("notifications", {}).get("warningsAndAlerts", [])
+        summary["alerts"] = alerts
+        summary["alert_count"] = len(alerts)
+    else:
+        summary["alerts"] = []
+
+    return json.dumps(summary, indent=2, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+_ACTIONS = {
+    "summary": _handle_summary,
+    "info": _handle_info,
+    "disks": _handle_disks,
+    "docker": _handle_docker,
+    "alerts": _handle_alerts,
+}
+
+
+def _handle_query(action: str, task_id: str = None) -> str:
+    """Dispatch to the appropriate handler."""
+    handler = _ACTIONS.get(action)
+    if not handler:
+        valid = ", ".join(sorted(_ACTIONS))
+        return json.dumps({
+            "error": f"Unknown action '{action}'. Valid actions: {valid}",
+        })
+    return handler()
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+UNRAID_QUERY_SCHEMA = {
+    "name": "unraid_query",
+    "description": (
+        "Query an UnRAID server over its GraphQL API. "
+        "Returns JSON with system information. "
+        "Requires UNRAID_API_KEY and UNRAID_URL environment variables. "
+        "All operations are read-only. "
+        "Note: API key must have READ_ANY data permissions in UnRAID Settings."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "description": (
+                    "What information to retrieve:\n"
+                    "- **summary**: Full system overview (CPU, OS, disks, Docker, alerts)\n"
+                    "- **info**: System information (OS, kernel, CPU, uptime)\n"
+                    "- **disks**: Physical disk list with serial, size, SMART status\n"
+                    "- **docker**: Docker container list (names, images, status)\n"
+                    "- **alerts**: Active notifications and warnings"
+                ),
+                "enum": ["summary", "info", "disks", "docker", "alerts"],
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="unraid_query",
+    toolset="unraid",
+    schema=UNRAID_QUERY_SCHEMA,
+    handler=lambda args, **kw: _handle_query(
+        action=args.get("action", ""), task_id=kw.get("task_id")),
+    check_fn=_check_unraid_available,
+    requires_env=["UNRAID_API_KEY"],
+    emoji="🖥️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,10 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # TrueNAS Scale (gated on TRUENAS_API_KEY via check_fn)
+    "truenas_query",
+    # UnRAID (gated on UNRAID_API_KEY via check_fn)
+    "unraid_query",
 ]
 
 # Webhook events may originate from untrusted third-party content (for example,
@@ -246,6 +250,18 @@ TOOLSETS = {
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",
         "tools": ["ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service"],
+        "includes": []
+    },
+
+    "truenas": {
+        "description": "TrueNAS Scale system monitoring — query pools, disks, shares, services, and alerts via REST API",
+        "tools": ["truenas_query"],
+        "includes": []
+    },
+
+    "unraid": {
+        "description": "UnRAID server system monitoring — query info, disks, Docker containers, and alerts via GraphQL API",
+        "tools": ["unraid_query"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Add two new read-only system monitoring tools for popular NAS platforms:

### truenas_query
Query TrueNAS Scale systems via REST API v2.0. Supports:
- `summary` — full system overview (hostname, version, uptime, CPU, RAM, pool health, alerts)
- `pools` — ZFS pool list with vdev topology, health, capacity
- `disks` — physical disk list with serial, model, size
- `shares` — SMB and NFS share list
- `alerts` — active alerts and warnings
- `services` — running/stopped status with auto-start info

### unraid_query
Query UnRAID servers via GraphQL API. Supports:
- `summary` — full system overview (hostname, CPU, disks, Docker, alerts)
- `info` — system information (OS, kernel, CPU model/cores, uptime)
- `disks` — physical disk list with serial, size, SMART status, temperature
- `docker` — Docker container list (names, images, status)
- `alerts` — active notifications and warnings

## Configuration

Both tools use environment variables for configuration (no hardcoded credentials):
- `TRUENAS_URL` / `TRUENAS_API_KEY` for TrueNAS
- `UNRAID_URL` / `UNRAID_API_KEY` for UnRAID

## Implementation

- Gated via `check_fn` — tools only appear when the required API key env var is set
- All operations are read-only
- Self-signed SSL certs accepted (both platforms use self-signed certs by default)
- Follows the same pattern as the existing `homeassistant` toolset (env-based config, check_fn gating, toolset definition in toolsets.py)
- Auto-discovered via `tools/registry.py` — no manual import needed

## Testing

Both tools were tested against live TrueNAS Scale 25.10.3.1 and UnRAID 7.x systems:
- TrueNAS: all 6 actions verified working
- UnRAID: all 5 actions verified working (GraphQL schema details documented in code comments)

## Files changed

- `tools/truenas_tool.py` — new TrueNAS tool (~320 lines)
- `tools/unraid_tool.py` — new UnRAID tool (~330 lines)
- `toolsets.py` — added toolset definitions and registered both tools in `_HERMES_CORE_TOOLS`
