### PR TITLE
fix(memory): add hindsight_client import check for local_external mode

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -600,6 +600,14 @@ class HindsightMemoryProvider(MemoryProvider):
                 available, _ = _check_local_runtime()
                 return available
             if mode == "local_external":
+                try:
+                    importlib.import_module("hindsight_client")
+                except ImportError:
+                    logger.warning(
+                        "hindsight-client package is not installed. "
+                        "Install it with: uv pip install hindsight-client"
+                    )
+                    return False
                 return True
             has_key = bool(
                 cfg.get("apiKey")


### PR DESCRIPTION
## Problem

In `local_external` mode, `is_available()` returns `True` unconditionally (line 602-603), causing `hermes memory status` to report Hindsight as "available ✓" even when the `hindsight-client` Python package is not installed in the runtime.

This creates a false-positive that only surfaces at runtime when `hindsight_recall` / `hindsight_reflect` tools fail with:

```
ModuleNotFoundError: No module named 'hindsight_client'
```

This is especially confusing in Docker deployments where:
- The external Hindsight backend is healthy (health check passes, direct REST works)
- `hermes memory status` says everything is fine
- But the actual TUI/gateway tools crash

The root cause: #18924 proposed a fix for this but was closed without merging. The `local_external` branch of `is_available()` never got the import guard that `local_embedded` has via `_check_local_runtime()`.

## Fix

Add an `importlib.import_module("hindsight_client")` guard to the `local_external` branch. If the package is missing, log a warning and return `False` so `hermes memory status` accurately reflects reality.

```python
if mode == "local_external":
    try:
        importlib.import_module("hindsight_client")
    except ImportError:
        logger.warning(
            "hindsight-client package is not installed. "
            "Install it with: uv pip install hindsight-client"
        )
        return False
    return True
```

This is a minimal, targeted fix — 8 lines, one file, no new dependencies.

## Testing

Field-tested in a Docker Compose deployment:
- Without `hindsight-client`: `is_available()` returns `False` with warning log → status no longer lies
- With `hindsight-client` installed via `uv`: `is_available()` returns `True` → tools work correctly

Refs: #18876