### PR TITLE
feat: support Telegram guest messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -61,10 +61,17 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     synthetic/resumed sends that have no reply anchor fall back to Telegram's
     ``direct_messages_topic_id`` when the Bot API supports it.
     """
+    metadata: dict[str, Any] | None = None
+    if _platform_name(getattr(source, "platform", None)) == "telegram":
+        guest_query_id = getattr(source, "guest_query_id", None)
+        if guest_query_id:
+            metadata = {"telegram_guest_query_id": str(guest_query_id)}
     thread_id = getattr(source, "thread_id", None)
     if thread_id is None:
-        return None
-    metadata = {"thread_id": thread_id}
+        return metadata
+    if metadata is None:
+        metadata = {}
+    metadata["thread_id"] = thread_id
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -606,6 +606,15 @@ class TelegramAdapter(BasePlatformAdapter):
             api_kwargs = getattr(message, "api_kwargs", None) or {}
             if isinstance(api_kwargs, dict):
                 guest_query_id = api_kwargs.get("guest_query_id")
+        if guest_query_id is None:
+            to_dict = getattr(message, "to_dict", None)
+            if callable(to_dict):
+                try:
+                    message_dict = to_dict()
+                except Exception:
+                    message_dict = None
+                if isinstance(message_dict, dict):
+                    guest_query_id = message_dict.get("guest_query_id")
         return str(guest_query_id) if guest_query_id is not None else None
 
     @classmethod
@@ -5898,6 +5907,16 @@ class TelegramAdapter(BasePlatformAdapter):
         guest_query_id = self._message_guest_query_id(message)
         if guest_query_id:
             source.guest_query_id = guest_query_id
+        elif getattr(self, "_guest_mode", False):
+            api_kwargs = getattr(message, "api_kwargs", None)
+            logger.info(
+                "[%s] Guest-mode message has no guest_query_id: chat_id=%s message_id=%s api_kwargs_keys=%s message_dict_has_guest=%s",
+                self.name,
+                getattr(chat, "id", None),
+                getattr(message, "message_id", None),
+                sorted(api_kwargs.keys()) if isinstance(api_kwargs, dict) else None,
+                "guest_query_id" in (message.to_dict() if callable(getattr(message, "to_dict", None)) else {}),
+            )
         
         # Extract reply context if this message is a reply.
         # Prefer Telegram's native partial quote (message.quote, TextQuote)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -599,6 +599,16 @@ class TelegramAdapter(BasePlatformAdapter):
         return str(guest_query_id) if guest_query_id is not None else None
 
     @classmethod
+    def _message_guest_query_id(cls, message: Any) -> Optional[str]:
+        """Return Telegram Guest Bot query id from typed or SDK-lag message fields."""
+        guest_query_id = getattr(message, "guest_query_id", None)
+        if guest_query_id is None:
+            api_kwargs = getattr(message, "api_kwargs", None) or {}
+            if isinstance(api_kwargs, dict):
+                guest_query_id = api_kwargs.get("guest_query_id")
+        return str(guest_query_id) if guest_query_id is not None else None
+
+    @classmethod
     def _metadata_reply_to_message_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[int]:
         if not metadata:
             return None
@@ -5885,9 +5895,9 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
             message_id=str(message.message_id),
         )
-        guest_query_id = getattr(message, "guest_query_id", None)
+        guest_query_id = self._message_guest_query_id(message)
         if guest_query_id:
-            source.guest_query_id = str(guest_query_id)
+            source.guest_query_id = guest_query_id
         
         # Extract reply context if this message is a reply.
         # Prefer Telegram's native partial quote (message.quote, TextQuote)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -30,6 +30,7 @@ try:
         Application,
         CommandHandler,
         CallbackQueryHandler,
+        TypeHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
         filters,
@@ -48,6 +49,7 @@ except ImportError:
     Application = Any
     CommandHandler = Any
     CallbackQueryHandler = Any
+    TypeHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
     filters = None
@@ -103,9 +105,23 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".webp": "image/webp",
     ".gif": "image/gif",
 }
+_TELEGRAM_GUEST_MESSAGE_UPDATE_TYPE = "guest_message"
 
 
 MAX_COMMANDS_PER_SCOPE = 30
+
+
+def _telegram_allowed_updates():
+    """Return all PTB-known update types plus Bot API Guest Bot updates.
+
+    python-telegram-bot may lag newer Bot API update names. Passing the raw
+    update type string keeps polling/webhook registrations subscribed to Guest
+    Bot summons even before PTB grows a typed ``Update.guest_message`` field.
+    """
+    allowed: list[Any] = list(getattr(Update, "ALL_TYPES", ()))
+    if not any(getattr(item, "value", item) == _TELEGRAM_GUEST_MESSAGE_UPDATE_TYPE for item in allowed):
+        allowed.append(_TELEGRAM_GUEST_MESSAGE_UPDATE_TYPE)
+    return allowed
 
 
 def check_telegram_requirements() -> bool:
@@ -118,7 +134,7 @@ def check_telegram_requirements() -> bool:
     """
     global TELEGRAM_AVAILABLE, Update, Bot, Message, InlineKeyboardButton
     global InlineKeyboardMarkup, LinkPreviewOptions, Application
-    global CommandHandler, CallbackQueryHandler, TelegramMessageHandler
+    global CommandHandler, CallbackQueryHandler, TypeHandler, TelegramMessageHandler
     global ContextTypes, filters, ParseMode, ChatType, HTTPXRequest
     if TELEGRAM_AVAILABLE:
         return True
@@ -137,6 +153,7 @@ def check_telegram_requirements() -> bool:
         from telegram.ext import (
             Application as _App, CommandHandler as _CH,
             CallbackQueryHandler as _CQH,
+            TypeHandler as _TH,
             MessageHandler as _MH,
             ContextTypes as _CT, filters as _filters,
         )
@@ -153,6 +170,7 @@ def check_telegram_requirements() -> bool:
     Application = _App
     CommandHandler = _CH
     CallbackQueryHandler = _CQH
+    TypeHandler = _TH
     TelegramMessageHandler = _MH
     ContextTypes = _CT
     filters = _filters
@@ -572,6 +590,13 @@ class TelegramAdapter(BasePlatformAdapter):
             return None
         topic_id = metadata.get("direct_messages_topic_id") or metadata.get("telegram_direct_messages_topic_id")
         return str(topic_id) if topic_id is not None else None
+
+    @classmethod
+    def _metadata_guest_query_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not metadata:
+            return None
+        guest_query_id = metadata.get("telegram_guest_query_id") or metadata.get("guest_query_id")
+        return str(guest_query_id) if guest_query_id is not None else None
 
     @classmethod
     def _metadata_reply_to_message_id(cls, metadata: Optional[Dict[str, Any]]) -> Optional[int]:
@@ -1080,7 +1105,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             try:
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=_telegram_allowed_updates(),
                     drop_pending_updates=False,
                     error_callback=self._polling_error_callback_ref,
                 )
@@ -1579,6 +1604,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
+            self._app.add_handler(TypeHandler(
+                Update,
+                self._handle_guest_message_update,
+                block=False,
+            ), group=1)
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
             
@@ -1643,7 +1673,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     url_path=webhook_path,
                     webhook_url=webhook_url,
                     secret_token=webhook_secret,
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=_telegram_allowed_updates(),
                     drop_pending_updates=True,
                 )
                 self._webhook_mode = True
@@ -1676,7 +1706,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._polling_error_callback_ref = _polling_error_callback
 
                 await self._app.updater.start_polling(
-                    allowed_updates=Update.ALL_TYPES,
+                    allowed_updates=_telegram_allowed_updates(),
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )
@@ -1802,6 +1832,54 @@ class TelegramAdapter(BasePlatformAdapter):
         else:  # "first" (default)
             return chunk_index == 0
 
+    async def _send_guest_query_answer(self, guest_query_id: str, message_text: str) -> SendResult:
+        """Reply to a Bot API Guest Bot query via answerGuestQuery.
+
+        Telegram's official Guest Bot flow does not allow a bot that is not a
+        chat member to use sendMessage into that chat. The incoming Message has
+        ``guest_query_id`` and must be answered with ``answerGuestQuery`` using
+        an InlineQueryResult payload.
+        """
+        parse_mode = "MarkdownV2"
+        result_payload = {
+            "type": "article",
+            "id": "hermes-response",
+            "title": "Hermes response",
+            "input_message_content": {
+                "message_text": message_text,
+                "parse_mode": parse_mode,
+            },
+        }
+        data = {
+            "guest_query_id": guest_query_id,
+            # Official Bot API parameter is a JSON-serialized InlineQueryResult.
+            "result": json.dumps(result_payload, ensure_ascii=False),
+        }
+        bot = self._bot
+        answer_guest_query = getattr(bot, "answer_guest_query", None)
+        if callable(answer_guest_query):
+            response = answer_guest_query(guest_query_id=guest_query_id, result=result_payload)
+            if asyncio.iscoroutine(response):
+                response = await response
+        else:
+            post = getattr(bot, "_post", None)
+            if not callable(post):
+                return SendResult(success=False, error="Bot API client cannot call answerGuestQuery")
+            response = post("answerGuestQuery", data=data)
+            if asyncio.iscoroutine(response):
+                response = await response
+
+        inline_message_id = None
+        if isinstance(response, dict):
+            inline_message_id = response.get("inline_message_id")
+        else:
+            inline_message_id = getattr(response, "inline_message_id", None)
+        return SendResult(
+            success=True,
+            message_id=str(inline_message_id) if inline_message_id else None,
+            raw_response={"guest_query_id": guest_query_id, "response": response},
+        )
+
     async def send(
         self,
         chat_id: str,
@@ -1837,6 +1915,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 ]
             
             message_ids = []
+            guest_query_id = self._metadata_guest_query_id(metadata)
+            if guest_query_id:
+                # Official Telegram Guest Bot replies go through
+                # answerGuestQuery, not sendMessage, because the bot is not a
+                # member of the chat that summoned it.
+                return await self._send_guest_query_answer(guest_query_id, chunks[0])
+
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
@@ -4937,15 +5022,73 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[%s] Forum command lazy-registration failed: %s", self.name, e)
 
+    def _guest_message_from_update(self, update: Update) -> Optional[Message]:
+        """Return a Bot API Guest Bots message from a PTB Update, if present.
+
+        PTB versions released before Bot API Guest Bots know nothing about the
+        ``guest_message`` update field. They preserve it under
+        ``Update.api_kwargs`` as a raw dict, so decode it into a normal Message
+        object before it enters Hermes' shared Telegram message pipeline.
+        """
+        direct_guest_message = getattr(update, "guest_message", None)
+        if direct_guest_message is not None:
+            return direct_guest_message
+
+        api_kwargs = getattr(update, "api_kwargs", None) or {}
+        raw_guest_message = api_kwargs.get(_TELEGRAM_GUEST_MESSAGE_UPDATE_TYPE)
+        if raw_guest_message is None:
+            return None
+        if not isinstance(raw_guest_message, dict):
+            return raw_guest_message
+
+        de_json = getattr(Message, "de_json", None)
+        if not callable(de_json):
+            return raw_guest_message
+        try:
+            return de_json(raw_guest_message, getattr(self, "_bot", None))
+        except Exception:
+            logger.warning("[%s] Failed to decode Telegram guest_message update", self.name, exc_info=True)
+            return None
+
     def _effective_update_message(self, update: Update) -> Optional[Message]:
-        """Return the message-like payload for normal messages and channel posts.
+        """Return the message-like payload for normal, channel, and guest updates.
 
         Telegram exposes channel broadcasts as ``update.channel_post`` rather
-        than ``update.message``.  MessageHandler filters can still dispatch
-        those updates, so handlers must use ``effective_message`` to avoid
-        consuming channel posts without ever building a gateway event.
+        than ``update.message``. Bot API 10.0 Guest Bots similarly deliver
+        summoned messages as ``update.guest_message`` when the bot is mentioned
+        from a chat where it is not a participant. MessageHandler filters can
+        still dispatch these updates, so handlers must look beyond
+        ``effective_message``/``message`` to avoid dropping them before Hermes
+        can build a gateway event.
         """
-        return getattr(update, "effective_message", None) or getattr(update, "message", None)
+        # Prefer concrete payload fields over ``effective_message``. In real
+        # PTB updates these are equivalent for ordinary messages, but several
+        # tests use MagicMock Update objects where accessing an unset
+        # ``effective_message`` fabricates a truthy mock and hides the actual
+        # ``message`` field.
+        return (
+            getattr(update, "message", None)
+            or getattr(update, "channel_post", None)
+            or self._guest_message_from_update(update)
+            or getattr(update, "effective_message", None)
+        )
+
+    async def _handle_guest_message_update(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Dispatch Telegram Bot API Guest Bots updates through existing handlers."""
+        msg = self._guest_message_from_update(update)
+        if not msg:
+            return
+        if getattr(msg, "text", None):
+            text = msg.text or ""
+            if text.startswith("/"):
+                await self._handle_command(update, context)
+            else:
+                await self._handle_text_message(update, context)
+            return
+        if getattr(msg, "location", None) or getattr(msg, "venue", None):
+            await self._handle_location_message(update, context)
+            return
+        await self._handle_media_message(update, context)
 
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
@@ -4961,7 +5104,7 @@ class TelegramAdapter(BasePlatformAdapter):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
-        await self._ensure_forum_commands(update.message)
+        await self._ensure_forum_commands(msg)
 
         event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
@@ -5161,27 +5304,25 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
-                if _m.sticker:
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                if msg.sticker:
                     _observe_type = MessageType.STICKER
-                elif _m.photo:
+                elif msg.photo:
                     _observe_type = MessageType.PHOTO
-                elif _m.video:
+                elif msg.video:
                     _observe_type = MessageType.VIDEO
-                elif _m.audio:
+                elif msg.audio:
                     _observe_type = MessageType.AUDIO
-                elif _m.voice:
+                elif msg.voice:
                     _observe_type = MessageType.VOICE
                 else:
                     _observe_type = MessageType.DOCUMENT
-                self._observe_unmentioned_group_message(_m, _observe_type, update_id=update.update_id)
+                self._observe_unmentioned_group_message(msg, _observe_type, update_id=update.update_id)
             return
-
-        msg = update.message
         
         # Determine media type
         if msg.sticker:
@@ -5651,12 +5792,22 @@ class TelegramAdapter(BasePlatformAdapter):
         # Determine chat type.  Normalize through ``str`` so tests/mocks and
         # python-telegram-bot enum values both work (``ChatType.CHANNEL`` is
         # string-like, but mocks often provide plain strings).
-        telegram_chat_type = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        raw_chat_type = getattr(chat, "type", "")
+        raw_chat_type_value = getattr(raw_chat_type, "value", None)
+        if isinstance(raw_chat_type_value, str):
+            telegram_chat_type = raw_chat_type_value.lower()
+        else:
+            telegram_chat_type = str(raw_chat_type).split(".")[-1].lower()
         chat_type = "dm"
         if telegram_chat_type in {"group", "supergroup"}:
             chat_type = "group"
         elif telegram_chat_type == "channel":
             chat_type = "channel"
+        elif str(getattr(chat, "id", "")).startswith("-") and user:
+            # Conservative fallback for mocked or SDK-lagged chat type values:
+            # Telegram private chats use positive ids, while groups/supergroups
+            # use negative ids and include a sender on incoming messages.
+            chat_type = "group"
 
         # Resolve Telegram topic name and skill binding.
         # Only preserve message_thread_id when Telegram marks the message as
@@ -5734,6 +5885,9 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
             message_id=str(message.message_id),
         )
+        guest_query_id = getattr(message, "guest_query_id", None)
+        if guest_query_id:
+            source.guest_query_id = str(guest_query_id)
         
         # Extract reply context if this message is a reply.
         # Prefer Telegram's native partial quote (message.quote, TextQuote)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -91,6 +91,9 @@ class SessionSource:
     guild_id: Optional[str] = None  # Discord guild / Slack workspace / Matrix server scope
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
+    # Telegram Bot API 10.0 Guest Bot reply token. Ephemeral, intentionally not
+    # serialized in to_dict() so old guest queries are not reused after resume.
+    guest_query_id: Optional[str] = None
     
     @property
     def description(self) -> str:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -1130,6 +1130,17 @@ class TestTelegramGuestMentionGating:
 
         assert event.source.guest_query_id == "guest-query-raw"
 
+    def test_build_message_event_preserves_guest_query_id_from_message_to_dict(self):
+        """Some SDK paths expose unknown Guest Bot fields only via Message.to_dict()."""
+        adapter = _guest_test_adapter()
+        message = _guest_group_message("summoned as guest @hermes_bot")
+        delattr(message, "guest_query_id")
+        message.to_dict = lambda: {"guest_query_id": "guest-query-dict"}
+
+        event = adapter._build_message_event(message, msg_type=MessageType.TEXT, update_id=999)
+
+        assert event.source.guest_query_id == "guest-query-dict"
+
     @pytest.mark.asyncio
     async def test_send_guest_query_uses_answer_guest_query_not_send_message(self):
         """Guest Bot responses follow Telegram's answerGuestQuery method."""

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -1119,6 +1119,17 @@ class TestTelegramGuestMentionGating:
 
         assert event.source.guest_query_id == "guest-query-123"
 
+    def test_build_message_event_preserves_guest_query_id_from_api_kwargs(self):
+        """SDK-lagged Message objects keep unknown guest_query_id in api_kwargs."""
+        adapter = _guest_test_adapter()
+        message = _guest_group_message("summoned as guest @hermes_bot")
+        delattr(message, "guest_query_id")
+        message.api_kwargs = {"guest_query_id": "guest-query-raw"}
+
+        event = adapter._build_message_event(message, msg_type=MessageType.TEXT, update_id=999)
+
+        assert event.source.guest_query_id == "guest-query-raw"
+
     @pytest.mark.asyncio
     async def test_send_guest_query_uses_answer_guest_query_not_send_message(self):
         """Guest Bot responses follow Telegram's answerGuestQuery method."""

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -5,6 +5,7 @@ conversion pipeline), and edge cases that could produce invalid MarkdownV2
 or corrupt user-visible content.
 """
 
+import json
 import re
 import sys
 from types import SimpleNamespace
@@ -12,7 +13,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import PlatformConfig
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
 
 
 # ---------------------------------------------------------------------------
@@ -39,6 +41,7 @@ from gateway.platforms.telegram import (  # noqa: E402
     TelegramAdapter,
     _escape_mdv2,
     _strip_mdv2,
+    _telegram_allowed_updates,
     _wrap_markdown_tables,
 )
 
@@ -915,10 +918,15 @@ def _guest_test_adapter(*, guest_mode=True, require_mention=True, allowed_chats=
             "guest_mode": guest_mode,
             "require_mention": require_mention,
             "allowed_chats": allowed_chats or ["-100200"],
+            "allowed_topics": [],
+            "ignored_threads": [],
+            "exclusive_bot_mentions": False,
+            "mention_patterns": [],
         },
     )
     adapter = object.__new__(TelegramAdapter)
     adapter.config = config
+    adapter.platform = Platform.TELEGRAM
     adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
     adapter._mention_patterns = adapter._compile_mention_patterns()
     # PR db50af910 added a TELEGRAM_ALLOWED_USERS allowlist gate to
@@ -937,14 +945,23 @@ def _guest_group_message(text, *, chat_id=-100201, entities=None, reply_to_bot=F
         entities=entities or [],
         caption_entities=[],
         message_thread_id=None,
-        chat=SimpleNamespace(id=chat_id, type="group"),
-        from_user=SimpleNamespace(id=111),
+        message_id=321,
+        date=None,
+        guest_query_id=None,
+        chat=SimpleNamespace(id=chat_id, type="group", title="Guest chat"),
+        from_user=SimpleNamespace(id=111, full_name="Ada"),
         reply_to_message=reply_to_message,
     )
 
 
 def _guest_mention_entity(text, mention="@hermes_bot"):
     return SimpleNamespace(type="mention", offset=text.index(mention), length=len(mention))
+
+
+def test_telegram_allowed_updates_includes_guest_message():
+    allowed = _telegram_allowed_updates()
+
+    assert "guest_message" in {getattr(item, "value", item) for item in allowed}
 
 
 class TestTelegramGuestMentionGating:
@@ -1012,3 +1029,121 @@ class TestTelegramGuestMentionGating:
         message.caption_entities = [_guest_mention_entity(text)]
 
         assert adapter._should_process_message(message) is True
+
+    def test_effective_update_message_accepts_bot_api_guest_message(self):
+        """Telegram Bot API Guest Bots deliver summoned messages as update.guest_message."""
+        adapter = _guest_test_adapter()
+        guest_message = _guest_group_message("summoned as guest @hermes_bot")
+        update = SimpleNamespace(
+            effective_message=None,
+            message=None,
+            channel_post=None,
+            guest_message=guest_message,
+        )
+
+        assert adapter._effective_update_message(update) is guest_message
+
+    def test_effective_update_message_decodes_guest_message_api_kwargs(self, monkeypatch):
+        """Older PTB versions preserve unknown guest_message updates in api_kwargs."""
+        adapter = _guest_test_adapter()
+        decoded_message = _guest_group_message("summoned as guest @hermes_bot")
+
+        from gateway.platforms import telegram as telegram_module
+        monkeypatch.setattr(telegram_module.Message, "de_json", lambda raw, bot: decoded_message)
+
+        update = SimpleNamespace(
+            effective_message=None,
+            message=None,
+            channel_post=None,
+            api_kwargs={
+                "guest_message": {
+                    "message_id": 321,
+                    "date": 0,
+                    "chat": {"id": -100201, "type": "group", "title": "Guest chat"},
+                    "from": {"id": 111, "is_bot": False, "first_name": "Ada"},
+                    "text": "summoned as guest @hermes_bot",
+                    "entities": [{"type": "mention", "offset": 18, "length": 11}],
+                }
+            },
+        )
+
+        message = adapter._effective_update_message(update)
+
+        assert message is not None
+        assert message.text == "summoned as guest @hermes_bot"
+        assert message.chat.id == -100201
+
+    @pytest.mark.asyncio
+    async def test_handle_text_message_dispatches_guest_message_updates(self):
+        """Guest Bot updates should flow through the normal text-message dispatcher."""
+        adapter = _guest_test_adapter()
+        text = "summoned as guest @hermes_bot"
+        guest_message = _guest_group_message(
+            text,
+            entities=[_guest_mention_entity(text)],
+        )
+        guest_message.message_id = 321
+        update = SimpleNamespace(
+            update_id=12345,
+            effective_message=None,
+            message=None,
+            channel_post=None,
+            guest_message=guest_message,
+        )
+        adapter._ensure_forum_commands = AsyncMock()
+        adapter._enqueue_text_event = MagicMock()
+        adapter._build_message_event = MagicMock(
+            return_value=SimpleNamespace(text=text, raw_message=guest_message, message_type=None)
+        )
+        adapter._apply_telegram_group_observe_attribution = lambda event: event
+        def clean_trigger_text(text):
+            return text
+
+        adapter._clean_bot_trigger_text = clean_trigger_text
+
+        await adapter._handle_text_message(update, None)
+
+        adapter._build_message_event.assert_called_once()
+        assert adapter._build_message_event.call_args.args[0] is guest_message
+        assert adapter._build_message_event.call_args.args[1] is not None
+        assert adapter._build_message_event.call_args.kwargs == {"update_id": 12345}
+        adapter._enqueue_text_event.assert_called_once()
+
+    def test_build_message_event_preserves_guest_query_id_for_official_reply_flow(self):
+        """Official Guest Bot replies must use Message.guest_query_id with answerGuestQuery."""
+        adapter = _guest_test_adapter()
+        message = _guest_group_message("summoned as guest @hermes_bot")
+        message.guest_query_id = "guest-query-123"
+
+        event = adapter._build_message_event(message, msg_type=MessageType.TEXT, update_id=999)
+
+        assert event.source.guest_query_id == "guest-query-123"
+
+    @pytest.mark.asyncio
+    async def test_send_guest_query_uses_answer_guest_query_not_send_message(self):
+        """Guest Bot responses follow Telegram's answerGuestQuery method."""
+        adapter = _guest_test_adapter()
+        bot = SimpleNamespace(
+            _post=AsyncMock(return_value={"inline_message_id": "inline-123"}),
+            send_message=AsyncMock(),
+        )
+        adapter._bot = bot
+
+        result = await adapter.send(
+            "-100201",
+            "**hi from guest mode**",
+            metadata={"telegram_guest_query_id": "guest-query-123"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "inline-123"
+        bot.send_message.assert_not_called()
+        bot._post.assert_awaited_once()
+        endpoint, = bot._post.call_args.args
+        assert endpoint == "answerGuestQuery"
+        data = bot._post.call_args.kwargs["data"]
+        assert data["guest_query_id"] == "guest-query-123"
+        payload = json.loads(data["result"])
+        assert payload["type"] == "article"
+        assert payload["input_message_content"]["message_text"] == "*hi from guest mode*"
+        assert payload["input_message_content"]["parse_mode"] == "MarkdownV2"


### PR DESCRIPTION
## Summary
- Subscribe Telegram polling/webhooks to the official Bot API 10.0 `guest_message` update type.
- Decode guest messages from either typed `Update.guest_message` or SDK-lagged `Update.api_kwargs["guest_message"]`.
- Route Guest Bot replies through official `answerGuestQuery` with `Message.guest_query_id`, instead of `sendMessage` into chats where the bot is not a member.
- Preserve guest-query metadata through the gateway response path and keep normal/group/channel routing intact.

Official Telegram docs used:
- Bot API 10.0 adds `Update.guest_message`, `Message.guest_query_id`, `SentGuestMessage`, and `answerGuestQuery`.
- `answerGuestQuery` requires `guest_query_id` plus an `InlineQueryResult` result payload.

## Test Plan
- `python -m pytest tests/gateway/test_telegram*.py -q`
  - Result: `557 passed`
- `python -m py_compile gateway/platforms/telegram.py gateway/platforms/base.py gateway/session.py tests/gateway/test_telegram_format.py`
- `git diff --check`
