### PR TITLE
fix(cron): clarify schedule is required for create in tool schema

### DIFF
--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -1,0 +1,41 @@
+"""Tests for the cronjob tool schema shape.
+
+Guards the description text that flags ``schedule`` (and ``prompt``) as
+REQUIRED for ``action=create`` — the load-bearing fix for description-driven
+models (e.g. Grok) that omit schedule when the schema only lists ``action``
+in ``required[]``. See issue #32427 / PR #32448.
+"""
+
+from __future__ import annotations
+
+
+def test_cronjob_schema_action_description_flags_create_requirements():
+    """`action` description must state schedule + prompt are required for create."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    action_desc = CRONJOB_SCHEMA["parameters"]["properties"]["action"]["description"]
+    assert "action=create" in action_desc
+    assert "schedule" in action_desc
+    assert "REQUIRED" in action_desc
+
+
+def test_cronjob_schema_schedule_description_flags_required_for_create():
+    """`schedule` description must explicitly state REQUIRED for action=create."""
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    schedule_desc = CRONJOB_SCHEMA["parameters"]["properties"]["schedule"]["description"]
+    assert "REQUIRED" in schedule_desc
+    assert "action=create" in schedule_desc
+
+
+def test_cronjob_schema_required_array_unchanged():
+    """`required[]` stays minimal — `action` only.
+
+    The schema intentionally does NOT promote schedule/prompt into the
+    top-level required array because they're only mandatory for
+    action=create, not for list/remove/pause/etc. The description text
+    carries the conditional requirement instead.
+    """
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    assert CRONJOB_SCHEMA["parameters"]["required"] == ["action"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -706,7 +706,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run"
+                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
             },
             "job_id": {
                 "type": "string",
@@ -718,7 +718,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp"
+                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
             },
             "name": {
                 "type": "string",


### PR DESCRIPTION
Salvage of #32448. Tells description-driven models (Grok) that `schedule` is required when `action=create`, so they stop looping on the `schedule is required for create` validator (issue #32427).

## Changes
- `tools/cronjob_tools.py`: `action` and `schedule` descriptions now explicitly say REQUIRED for `action=create`, with concrete examples. (+2/-2)
- `tests/cron/test_cronjob_schema.py`: guard the description text + assert `required[]` stays `["action"]` so we don't regress the create-only conditional.

## Dropped from the original PR
The contributor's second commit added a JSON-Schema `if/then` block. Dropped it: Gemini's allowlist drops unknown keywords, Anthropic doesn't enforce `if/then` (and doesn't strip it either — harmless but inert), and xAI/Grok itself was already ignoring the schema (which is why this bug exists). The description text is the layer that actually moves Grok. Keeping the diff minimal.

## Validation
`scripts/run_tests.sh tests/cron/` — 386/386 passing.

Credits @ygd58 — original commit cherry-picked with authorship preserved.

Closes #32427
Closes #32448

## Infographic

![cronjob-schedule-fix](https://v3b.fal.media/files/b/0a9bce07/mGWWetWFVrWwZJbQJRdyl_4GfhtT6T.png)
