### PR TITLE
fix: prevent silent message loss when state.db persistence fails

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1077,7 +1077,6 @@ def init_agent(
     agent._parent_session_id = parent_session_id
     agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
     agent._session_db_created = False  # DB row deferred to run_conversation()
-    agent._session_db_failed = False
     agent._session_db_create_fail_count = 0
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1078,6 +1078,7 @@ def init_agent(
     agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
     agent._session_db_created = False  # DB row deferred to run_conversation()
     agent._session_db_failed = False
+    agent._session_db_create_fail_count = 0
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1077,6 +1077,7 @@ def init_agent(
     agent._parent_session_id = parent_session_id
     agent._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
     agent._session_db_created = False  # DB row deferred to run_conversation()
+    agent._session_db_failed = False
     agent._session_init_model_config = {
         "max_iterations": agent.max_iterations,
         "reasoning_config": reasoning_config,

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -413,6 +413,7 @@ def _run_review_in_thread(
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
+                session_db=getattr(agent, "_session_db", None),
             )
             review_agent._memory_write_origin = "background_review"
             review_agent._memory_write_context = "background_review"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -282,6 +282,158 @@ def _redact_gateway_user_facing_secrets(text: str) -> str:
     return redacted
 
 
+def _recover_pending_messages(session_db, profile: Optional[str] = None) -> int:
+    """
+    Recover pending messages from *.pending.jsonl files to session DB.
+
+    Returns the number of recovered messages.
+    """
+    if session_db is None:
+        logger.debug("Session DB not available; skipping pending message recovery")
+        return 0
+
+    from hermes_constants import get_hermes_home
+    import json
+
+    # Determine base directory with profile isolation
+    base = get_hermes_home()
+    if profile and profile != "default":
+        base = base / "profiles" / profile
+
+    sessions_dir = base / "sessions"
+    if not sessions_dir.exists():
+        return 0
+
+    recovered_count = 0
+    pending_files = list(sessions_dir.glob("*.pending.jsonl"))
+
+    if not pending_files:
+        return 0
+
+    logger.info("Found %d pending message file(s) for recovery", len(pending_files))
+
+    for pending_file in pending_files:
+        try:
+            # Extract session_id from filename: "session-id.pending.jsonl" -> "session-id"
+            session_id = pending_file.stem.replace(".pending", "")
+            if not session_id or session_id == "unknown":
+                logger.warning("Skipping pending file with invalid session_id: %s", pending_file.name)
+                continue
+
+            # Read all pending messages from the file
+            entries = []
+            with open(pending_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                        entries.append(entry)
+                    except json.JSONDecodeError as e:
+                        logger.warning("Skipping invalid JSON line in %s: %s", pending_file.name, e)
+                        continue
+
+            if not entries:
+                logger.debug("No valid messages in %s", pending_file.name)
+                continue
+
+            logger.info("Recovering %d message(s) for session %s", len(entries), session_id)
+
+            # Try to recover each message
+            for entry in entries:
+                try:
+                    # Support both formats: new wrapped {"_fallback_timestamp": t, "message": m}
+                    # and old plain message format
+                    msg_ts = None
+                    msg = None
+                    if isinstance(entry, dict) and "_fallback_timestamp" in entry and "message" in entry:
+                        msg_ts = entry.get("_fallback_timestamp")
+                        msg = entry.get("message")
+                    else:
+                        # Backward compatibility: old format is just the message
+                        msg = entry
+
+                    if not isinstance(msg, dict):
+                        logger.warning("Skipping invalid message entry: %s", type(msg))
+                        continue
+
+                    # Extract fields from message, similar to _flush_messages_to_session_db in run_agent.py
+                    role = msg.get("role", "unknown")
+                    content = msg.get("content")
+
+                    # Handle multimodal content - keep only text summary
+                    from agent.tool_dispatch_helpers import (
+                        _is_multimodal_tool_result,
+                        _multimodal_text_summary,
+                    )
+                    if _is_multimodal_tool_result(content):
+                        content = _multimodal_text_summary(content)
+                    elif isinstance(content, list):
+                        # OpenAI-style content parts - keep only text
+                        txt_parts = []
+                        for p in content:
+                            if isinstance(p, dict) and p.get("type") == "text":
+                                txt_parts.append(str(p.get("text", "")))
+                            elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
+                                txt_parts.append("[screenshot]")
+                        content = "\n".join(txt_parts) if txt_parts else None
+
+                    tool_name = msg.get("tool_name")
+                    tool_calls = msg.get("tool_calls")
+                    tool_call_id = msg.get("tool_call_id")
+                    finish_reason = msg.get("finish_reason")
+
+                    # Extract reasoning fields (only for assistant messages)
+                    reasoning = msg.get("reasoning") if role == "assistant" else None
+                    reasoning_content = msg.get("reasoning_content") if role == "assistant" else None
+                    reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
+                    codex_reasoning_items = msg.get("codex_reasoning_items") if role == "assistant" else None
+                    codex_message_items = msg.get("codex_message_items") if role == "assistant" else None
+
+                    # Append the message to session DB with original timestamp
+                    session_db.append_message(
+                        session_id=session_id,
+                        role=role,
+                        content=content,
+                        tool_name=tool_name,
+                        tool_calls=tool_calls,
+                        tool_call_id=tool_call_id,
+                        finish_reason=finish_reason,
+                        reasoning=reasoning,
+                        reasoning_content=reasoning_content,
+                        reasoning_details=reasoning_details,
+                        codex_reasoning_items=codex_reasoning_items,
+                        codex_message_items=codex_message_items,
+                        timestamp=msg_ts,
+                    )
+                    recovered_count += 1
+                except Exception as e:
+                    logger.warning("Failed to recover message for session %s: %s", session_id, e)
+                    continue
+
+            # Rename the file instead of deleting (for dev/test safety)
+            try:
+                archived_file = pending_file.with_name(pending_file.name + ".recovered")
+                # Add a unique suffix if the archived file already exists
+                counter = 1
+                while archived_file.exists():
+                    archived_file = pending_file.with_name(f"{pending_file.name}.recovered.{counter}")
+                    counter += 1
+                pending_file.rename(archived_file)
+                logger.info("Archived pending file to %s", archived_file.name)
+            except Exception as e:
+                logger.warning("Failed to archive pending file %s: %s", pending_file.name, e)
+
+        except Exception as e:
+            logger.warning("Failed to process pending file %s: %s", pending_file.name, e)
+            continue
+
+    if recovered_count > 0:
+        logger.info("Successfully recovered %d pending message(s)", recovered_count)
+    return recovered_count
+
+
 def _gateway_provider_error_reply(text: str) -> str:
     """Map raw provider/API errors to a short user-safe Telegram reply."""
     if _GATEWAY_AUTH_ERROR_RE.search(text):
@@ -2385,10 +2537,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # DM pairing store for code-based user authorization
         from gateway.pairing import PairingStore
         self.pairing_store = PairingStore()
-        
+
         # Event hook system
         from gateway.hooks import HookRegistry
         self.hooks = HookRegistry()
+
+        # Recover pending messages from *.pending.jsonl files
+        try:
+            profile = os.environ.get("HERMES_PROFILE")
+            _recover_pending_messages(self._session_db, profile=profile)
+        except Exception as e:
+            logger.warning("Pending message recovery failed: %s", e)
 
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2557,7 +2557,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # session search without this.  The underlying cause (usually
             # "locking protocol" from NFS) is now also captured by
             # hermes_state.get_last_init_error() for slash-command error strings.
-            logger.warning("SQLite session store not available: %s", e)
+            err_lower = str(e).lower()
+            if "locked" in err_lower or "busy" in err_lower:
+                logger.warning(
+                    "SQLite session store init failed — DB lock contention: %s", e,
+                )
+            else:
+                logger.warning("SQLite session store not available: %s", e)
 
         # Opportunistic state.db maintenance: prune ended sessions older
         # than sessions.retention_days + optional VACUUM. Tracks last-run

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -468,18 +468,12 @@ def _recover_pending_messages(session_db, profile: Optional[str] = None) -> int:
                     logger.warning("Failed to recover message for session %s: %s", session_id, e)
                     continue
 
-            # Rename the file instead of deleting (for dev/test safety)
+            # Delete the pending file after successful recovery
             try:
-                archived_file = pending_file.with_name(pending_file.name + ".recovered")
-                # Add a unique suffix if the archived file already exists
-                counter = 1
-                while archived_file.exists():
-                    archived_file = pending_file.with_name(f"{pending_file.name}.recovered.{counter}")
-                    counter += 1
-                pending_file.rename(archived_file)
-                logger.info("Archived pending file to %s", archived_file.name)
+                pending_file.unlink()
+                logger.info("Removed pending file %s", pending_file.name)
             except Exception as e:
-                logger.warning("Failed to archive pending file %s: %s", pending_file.name, e)
+                logger.warning("Failed to remove pending file %s: %s", pending_file.name, e)
 
         except Exception as e:
             logger.warning("Failed to process pending file %s: %s", pending_file.name, e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -350,35 +350,47 @@ def _recover_pending_messages(session_db, profile: Optional[str] = None) -> int:
             db_msgs = session_db.get_messages(session_id)
             overlap = 0  # number of pending entries that match DB suffix
             if db_msgs:
-                # Normalize both sides to comparable keys.  Comparison uses
-                # (role, content, tool_name, tool_calls_json, tool_call_id)
-                # — NOT timestamp — so the match is content-stable and won't
-                # false-negative across clock skew or recovery delays.
+                # Normalize both sides to comparable keys.  Uses
+                # (role, content, tool_name, tool_calls, tool_call_id,
+                # timestamp) so that the shared flush timestamp (set
+                # in _flush_messages_to_session_db) anchors the match:
+                # if append succeeded but _session_db_failed was still
+                # set (false alarm), the DB row and the fallback entry
+                # carry the SAME timestamp — they match exactly.
+                # Two genuine "继续" messages get different timestamps
+                # and won't collide.
                 import json as _json
-                def _mk_key(m):
+                def _mk_key(m, ts=None):
                     if not isinstance(m, dict):
                         return None
                     tc = m.get("tool_calls")
                     tc_str = _json.dumps(tc, sort_keys=True) if tc else None
+                    ts_val = ts if ts is not None else m.get("timestamp")
                     return (
                         m.get("role"),
                         m.get("content"),
                         m.get("tool_name"),
                         tc_str,
                         m.get("tool_call_id"),
+                        ts_val,
                     )
 
                 db_keys = [_mk_key(m) for m in db_msgs if _mk_key(m) is not None]
 
-                # Build pending keys from the unwrapped messages
+                # Build pending keys from the unwrapped messages, threading
+                # the wrapper's _fallback_timestamp into the comparison key.
                 pending_keys = []
                 for entry in entries:
                     msg = None
+                    entry_ts = None
                     if isinstance(entry, dict) and "_fallback_timestamp" in entry and "message" in entry:
                         msg = entry.get("message")
+                        entry_ts = entry.get("_fallback_timestamp")
                     else:
                         msg = entry
-                    pending_keys.append(_mk_key(msg) if isinstance(msg, dict) else None)
+                    pending_keys.append(
+                        _mk_key(msg, ts=entry_ts) if isinstance(msg, dict) else None
+                    )
 
                 # Find maximum overlap: db_msgs[-N:] == pending_keys[:N]
                 max_possible = min(len(db_keys), len(pending_keys))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -340,8 +340,64 @@ def _recover_pending_messages(session_db, profile: Optional[str] = None) -> int:
 
             logger.info("Recovering %d message(s) for session %s", len(entries), session_id)
 
-            # Try to recover each message
-            for entry in entries:
+            # ── Deduplication: find max-overlap prefix with existing DB messages ──
+            # JSONL fallback files are always append-only, written from
+            # messages[_last_flushed_db_idx:].  If DB writes partially
+            # succeeded before the fallback (or succeeded in a later turn
+            # after recovery), the pending file's PREFIX may overlap with
+            # the DB's SUFFIX.  Find that overlap so we only insert truly
+            # new messages.
+            db_msgs = session_db.get_messages(session_id)
+            overlap = 0  # number of pending entries that match DB suffix
+            if db_msgs:
+                # Normalize both sides to comparable keys.  Comparison uses
+                # (role, content, tool_name, tool_calls_json, tool_call_id)
+                # — NOT timestamp — so the match is content-stable and won't
+                # false-negative across clock skew or recovery delays.
+                import json as _json
+                def _mk_key(m):
+                    if not isinstance(m, dict):
+                        return None
+                    tc = m.get("tool_calls")
+                    tc_str = _json.dumps(tc, sort_keys=True) if tc else None
+                    return (
+                        m.get("role"),
+                        m.get("content"),
+                        m.get("tool_name"),
+                        tc_str,
+                        m.get("tool_call_id"),
+                    )
+
+                db_keys = [_mk_key(m) for m in db_msgs if _mk_key(m) is not None]
+
+                # Build pending keys from the unwrapped messages
+                pending_keys = []
+                for entry in entries:
+                    msg = None
+                    if isinstance(entry, dict) and "_fallback_timestamp" in entry and "message" in entry:
+                        msg = entry.get("message")
+                    else:
+                        msg = entry
+                    pending_keys.append(_mk_key(msg) if isinstance(msg, dict) else None)
+
+                # Find maximum overlap: db_msgs[-N:] == pending_keys[:N]
+                max_possible = min(len(db_keys), len(pending_keys))
+                overlap = 0
+                for n in range(max_possible, 0, -1):
+                    if db_keys[-n:] == pending_keys[:n]:
+                        overlap = n
+                        break
+
+                if overlap > 0:
+                    logger.info(
+                        "Skipping %d already-persisted message(s) for session %s (overlap found)",
+                        overlap, session_id,
+                    )
+            # ── End deduplication ──
+
+            # Try to recover only non-overlapping entries
+            new_entries = entries[overlap:]
+            for entry in new_entries:
                 try:
                     # Support both formats: new wrapped {"_fallback_timestamp": t, "message": m}
                     # and old plain message format

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2379,6 +2379,7 @@ class SessionDB:
         codex_message_items: Any = None,
         platform_message_id: str = None,
         observed: bool = False,
+        timestamp: float = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -2429,7 +2430,7 @@ class SessionDB:
                     tool_call_id,
                     tool_calls_json,
                     tool_name,
-                    time.time(),
+                    timestamp if timestamp is not None else time.time(),
                     token_count,
                     finish_reason,
                     reasoning,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -907,7 +907,7 @@ class SessionDB:
                 return result
             except sqlite3.OperationalError as exc:
                 err_msg = str(exc).lower()
-                if "locked" in err_msg or "busy" in err_msg:
+                if "locked" in err_msg or "busy" in err_msg or "readonly" in err_msg or "read-only" in err_msg:
                     last_err = exc
                     if attempt < self._WRITE_MAX_RETRIES - 1:
                         jitter = random.uniform(

--- a/run_agent.py
+++ b/run_agent.py
@@ -523,9 +523,8 @@ class AIAgent:
                 cwd=_launch_cwd_for_session(source),
             )
             self._session_db_created = True
-            if self._session_db_failed:
+            if self._session_db_create_fail_count:
                 failed_count = self._session_db_create_fail_count
-                self._session_db_failed = False
                 self._session_db_create_fail_count = 0
                 logger.info("Session DB creation recovered after %d failures",
                             failed_count)
@@ -533,7 +532,6 @@ class AIAgent:
             # Transient failure (e.g. SQLite lock). Keep _session_db alive —
             # _session_db_created stays False so next run_conversation() retries.
             self._session_db_create_fail_count += 1
-            self._session_db_failed = True
             logger.error(
                 "Session DB creation failed (#%d consecutive): %s",
                 self._session_db_create_fail_count, e
@@ -1496,33 +1494,11 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
-        # If DB persistence is degraded, immediately write JSONL fallback
-        # for unflushed messages only — avoid duplicating already-persisted rows.
-        if (self._session_db_failed or not self._session_db) and messages:
-            try:
-                from hermes_constants import get_hermes_home
-                sid = getattr(self, 'session_id', 'unknown')
-                base = Path(get_hermes_home())
-                profile = os.environ.get("HERMES_PROFILE")
-                if profile and profile != "default":
-                    base = base / "profiles" / profile
-                fb_dir = base / "sessions"
-                fb_dir.mkdir(parents=True, exist_ok=True)
-                fb_path = fb_dir / f"{sid}.pending.jsonl"
-                unflushed = messages[self._last_flushed_db_idx:]
-                now_ts = time.time()
-                with open(fb_path, "a") as f:
-                    for msg in unflushed:
-                        # Save message with timestamp for later recovery
-                        # Use msg.get("timestamp") if available, otherwise current time
-                        msg_ts = msg.get("_flush_timestamp", now_ts)
-                        wrapped = {
-                            "_fallback_timestamp": msg_ts,
-                            "message": msg,
-                        }
-                        f.write(json.dumps(wrapped, ensure_ascii=False) + "\n")
-            except Exception:
-                pass  # Last-resort fallback — if even this fails, nothing more we can do
+        # When SessionDB is entirely absent (e.g. SQLite init failed),
+        # _flush_messages_to_session_db returns early. Write ALL messages
+        # to the pending file so they can be recovered on next startup.
+        if not self._session_db and messages:
+            self._write_pending_fallback(messages, 0)
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
@@ -1582,6 +1558,37 @@ class AIAgent:
         from agent.agent_runtime_helpers import repair_message_sequence
         return repair_message_sequence(self, messages)
 
+    def _write_pending_fallback(self, messages: List[Dict], start_idx: int) -> None:
+        """Write messages[start_idx:] to a per-session pending JSONL file.
+
+        Called immediately when a DB append fails, so unflushed messages are
+        preserved without relying on a sticky flag.
+        """
+        if start_idx >= len(messages):
+            return
+        try:
+            from hermes_constants import get_hermes_home
+            sid = getattr(self, 'session_id', 'unknown')
+            base = Path(get_hermes_home())
+            profile = os.environ.get("HERMES_PROFILE")
+            if profile and profile != "default":
+                base = base / "profiles" / profile
+            fb_dir = base / "sessions"
+            fb_dir.mkdir(parents=True, exist_ok=True)
+            fb_path = fb_dir / f"{sid}.pending.jsonl"
+            unflushed = messages[start_idx:]
+            now_ts = time.time()
+            with open(fb_path, "a") as f:
+                for msg in unflushed:
+                    msg_ts = msg.get("_flush_timestamp", now_ts)
+                    wrapped = {
+                        "_fallback_timestamp": msg_ts,
+                        "message": msg,
+                    }
+                    f.write(json.dumps(wrapped, ensure_ascii=False) + "\n")
+        except Exception:
+            pass  # Last-resort — if even the fallback fails, nothing more we can do
+
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
 
@@ -1624,7 +1631,6 @@ class AIAgent:
             }
 
             last_successful_idx = self._last_flushed_db_idx
-            flush_ok = True
             for idx, msg in enumerate(messages):
                 if not isinstance(msg, dict):
                     continue
@@ -1679,15 +1685,12 @@ class AIAgent:
                     flushed_ids.add(msg_id)
                     last_successful_idx = idx + 1
                 except Exception:
-                    self._session_db_failed = True
-                    flush_ok = False
+                    self._write_pending_fallback(messages, last_successful_idx)
                     break
             self._last_flushed_db_idx = last_successful_idx
-            if flush_ok:
-                self._session_db_failed = False
         except Exception as e:
-            self._session_db_failed = True
             logger.error("Session DB flush failed: %s", e)
+            self._write_pending_fallback(messages, 0)
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """

--- a/run_agent.py
+++ b/run_agent.py
@@ -1510,9 +1510,17 @@ class AIAgent:
                 fb_dir.mkdir(parents=True, exist_ok=True)
                 fb_path = fb_dir / f"{sid}.pending.jsonl"
                 unflushed = messages[self._last_flushed_db_idx:]
+                now_ts = time.time()
                 with open(fb_path, "a") as f:
                     for msg in unflushed:
-                        f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                        # Save message with timestamp for later recovery
+                        # Use msg.get("timestamp") if available, otherwise current time
+                        msg_ts = msg.get("timestamp", now_ts)
+                        wrapped = {
+                            "_fallback_timestamp": msg_ts,
+                            "message": msg,
+                        }
+                        f.write(json.dumps(wrapped, ensure_ascii=False) + "\n")
             except Exception:
                 pass  # Last-resort fallback — if even this fails, nothing more we can do
 
@@ -1615,7 +1623,8 @@ class AIAgent:
                 if isinstance(item, dict)
             }
 
-            for msg in messages:
+            last_successful_idx = self._last_flushed_db_idx
+            for idx, msg in enumerate(messages):
                 if not isinstance(msg, dict):
                     continue
                 msg_id = id(msg)
@@ -1623,6 +1632,7 @@ class AIAgent:
                     continue
                 if msg_id in history_ids:
                     flushed_ids.add(msg_id)
+                    last_successful_idx = idx + 1
                     continue
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
@@ -1660,10 +1670,11 @@ class AIAgent:
                         codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                     )
                     flushed_ids.add(msg_id)
+                    last_successful_idx = idx + 1
                 except Exception:
                     self._session_db_failed = True
                     break
-            self._last_flushed_db_idx = len(messages)
+            self._last_flushed_db_idx = last_successful_idx
         except Exception as e:
             self._session_db_failed = True
             logger.error("Session DB flush failed: %s", e)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1643,9 +1643,13 @@ class AIAgent:
                     continue
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
+                # Persist multimodal tool results as their text summary only —
+                # base64 images would bloat the session DB and aren't useful
+                # for cross-session replay.
                 if _is_multimodal_tool_result(content):
                     content = _multimodal_text_summary(content)
                 elif isinstance(content, list):
+                    # List of OpenAI-style content parts: strip images, keep text.
                     _txt = []
                     for p in content:
                         if isinstance(p, dict) and p.get("type") == "text":

--- a/run_agent.py
+++ b/run_agent.py
@@ -523,12 +523,20 @@ class AIAgent:
                 cwd=_launch_cwd_for_session(source),
             )
             self._session_db_created = True
+            if self._session_db_failed:
+                failed_count = self._session_db_create_fail_count
+                self._session_db_failed = False
+                self._session_db_create_fail_count = 0
+                logger.info("Session DB creation recovered after %d failures",
+                            failed_count)
         except Exception as e:
             # Transient failure (e.g. SQLite lock). Keep _session_db alive —
             # _session_db_created stays False so next run_conversation() retries.
+            self._session_db_create_fail_count += 1
             self._session_db_failed = True
             logger.error(
-                "Session DB creation failed (will retry next turn): %s", e
+                "Session DB creation failed (#%d consecutive): %s",
+                self._session_db_create_fail_count, e
             )
 
     def _transition_context_engine_session(

--- a/run_agent.py
+++ b/run_agent.py
@@ -526,7 +526,8 @@ class AIAgent:
         except Exception as e:
             # Transient failure (e.g. SQLite lock). Keep _session_db alive —
             # _session_db_created stays False so next run_conversation() retries.
-            logger.warning(
+            self._session_db_failed = True
+            logger.error(
                 "Session DB creation failed (will retry next turn): %s", e
             )
 
@@ -1487,6 +1488,26 @@ class AIAgent:
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
+        # If DB persistence is degraded, immediately write JSONL fallback
+        # for unflushed messages only — avoid duplicating already-persisted rows.
+        if self._session_db_failed and messages:
+            try:
+                from hermes_constants import get_hermes_home
+                sid = getattr(self, 'session_id', 'unknown')
+                base = Path(get_hermes_home())
+                profile = os.environ.get("HERMES_PROFILE")
+                if profile:
+                    base = base / "profiles" / profile
+                fb_dir = base / "sessions"
+                fb_dir.mkdir(parents=True, exist_ok=True)
+                fb_path = fb_dir / f"{sid}.pending.jsonl"
+                unflushed = messages[self._last_flushed_db_idx:]
+                with open(fb_path, "a") as f:
+                    for msg in unflushed:
+                        f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+            except Exception:
+                pass  # Last-resort fallback — if even this fails, nothing more we can do
+
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
 
@@ -1597,13 +1618,9 @@ class AIAgent:
                     continue
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
-                # Persist multimodal tool results as their text summary only —
-                # base64 images would bloat the session DB and aren't useful
-                # for cross-session replay.
                 if _is_multimodal_tool_result(content):
                     content = _multimodal_text_summary(content)
                 elif isinstance(content, list):
-                    # List of OpenAI-style content parts: strip images, keep text.
                     _txt = []
                     for p in content:
                         if isinstance(p, dict) and p.get("type") == "text":
@@ -1619,24 +1636,29 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
-                self._session_db.append_message(
-                    session_id=self.session_id,
-                    role=role,
-                    content=content,
-                    tool_name=msg.get("tool_name"),
-                    tool_calls=tool_calls_data,
-                    tool_call_id=msg.get("tool_call_id"),
-                    finish_reason=msg.get("finish_reason"),
-                    reasoning=msg.get("reasoning") if role == "assistant" else None,
-                    reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
-                    reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
-                    codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
-                    codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
-                )
-                flushed_ids.add(msg_id)
+                try:
+                    self._session_db.append_message(
+                        session_id=self.session_id,
+                        role=role,
+                        content=content,
+                        tool_name=msg.get("tool_name"),
+                        tool_calls=tool_calls_data,
+                        tool_call_id=msg.get("tool_call_id"),
+                        finish_reason=msg.get("finish_reason"),
+                        reasoning=msg.get("reasoning") if role == "assistant" else None,
+                        reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
+                        reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                        codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
+                        codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                    )
+                    flushed_ids.add(msg_id)
+                except Exception:
+                    self._session_db_failed = True
+                    break
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
-            logger.warning("Session DB append_message failed: %s", e)
+            self._session_db_failed = True
+            logger.error("Session DB flush failed: %s", e)
 
     def _get_messages_up_to_last_assistant(self, messages: List[Dict]) -> List[Dict]:
         """

--- a/run_agent.py
+++ b/run_agent.py
@@ -1515,7 +1515,7 @@ class AIAgent:
                     for msg in unflushed:
                         # Save message with timestamp for later recovery
                         # Use msg.get("timestamp") if available, otherwise current time
-                        msg_ts = msg.get("timestamp", now_ts)
+                        msg_ts = msg.get("_flush_timestamp", now_ts)
                         wrapped = {
                             "_fallback_timestamp": msg_ts,
                             "message": msg,
@@ -1655,6 +1655,11 @@ class AIAgent:
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
                 try:
+                    # Generate timestamp ONCE — shared between DB append and
+                    # JSONL fallback so recovery can dedup by (role, content,
+                    # timestamp) without false-matching on genuine repeats.
+                    flush_ts = time.time()
+                    msg["_flush_timestamp"] = flush_ts
                     self._session_db.append_message(
                         session_id=self.session_id,
                         role=role,
@@ -1668,6 +1673,7 @@ class AIAgent:
                         reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
                         codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                         codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
+                        timestamp=flush_ts,
                     )
                     flushed_ids.add(msg_id)
                     last_successful_idx = idx + 1

--- a/run_agent.py
+++ b/run_agent.py
@@ -1498,13 +1498,13 @@ class AIAgent:
 
         # If DB persistence is degraded, immediately write JSONL fallback
         # for unflushed messages only — avoid duplicating already-persisted rows.
-        if self._session_db_failed and messages:
+        if (self._session_db_failed or not self._session_db) and messages:
             try:
                 from hermes_constants import get_hermes_home
                 sid = getattr(self, 'session_id', 'unknown')
                 base = Path(get_hermes_home())
                 profile = os.environ.get("HERMES_PROFILE")
-                if profile:
+                if profile and profile != "default":
                     base = base / "profiles" / profile
                 fb_dir = base / "sessions"
                 fb_dir.mkdir(parents=True, exist_ok=True)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1624,6 +1624,7 @@ class AIAgent:
             }
 
             last_successful_idx = self._last_flushed_db_idx
+            flush_ok = True
             for idx, msg in enumerate(messages):
                 if not isinstance(msg, dict):
                     continue
@@ -1679,8 +1680,11 @@ class AIAgent:
                     last_successful_idx = idx + 1
                 except Exception:
                     self._session_db_failed = True
+                    flush_ok = False
                     break
             self._last_flushed_db_idx = last_successful_idx
+            if flush_ok:
+                self._session_db_failed = False
         except Exception as e:
             self._session_db_failed = True
             logger.error("Session DB flush failed: %s", e)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1688,7 +1688,8 @@ class AIAgent:
                     )
                     flushed_ids.add(msg_id)
                     last_successful_idx = idx + 1
-                except Exception:
+                except Exception as e:
+                    logger.warning("append_message failed (pending fallback): %s", e)
                     self._write_pending_fallback(messages, last_successful_idx)
                     break
             self._last_flushed_db_idx = last_successful_idx

--- a/tests/run_agent/test_session_db_failed_fallback.py
+++ b/tests/run_agent/test_session_db_failed_fallback.py
@@ -103,8 +103,11 @@ class TestJsonlFallback:
             assert len(fb_files) == 1
             pending = [json.loads(line) for line in fb_files[0].read_text().splitlines() if line.strip()]
             assert len(pending) == 2
-            assert pending[0]["content"] == "new-one"
-            assert pending[1]["content"] == "new-two"
+            # Check wrapped format with timestamp
+            assert "_fallback_timestamp" in pending[0]
+            assert "message" in pending[0]
+            assert pending[0]["message"]["content"] == "new-one"
+            assert pending[1]["message"]["content"] == "new-two"
 
     def test_no_fallback_when_flag_false(self):
         """_session_db_failed=False → no .pending.jsonl created."""

--- a/tests/run_agent/test_session_db_failed_fallback.py
+++ b/tests/run_agent/test_session_db_failed_fallback.py
@@ -1,4 +1,9 @@
-"""Tests for _session_db_failed flag and JSONL fallback behaviour."""
+"""Tests for JSONL fallback when session DB persistence fails.
+
+After removing the sticky _session_db_failed flag, pending fallback is
+written directly in _flush_messages_to_session_db when an append fails,
+or in _persist_session when _session_db is None entirely.
+"""
 
 import json
 import os
@@ -29,25 +34,11 @@ def _make_message(role, content):
     return {"role": role, "content": content}
 
 
-# ── _ensure_db_session failure sets _session_db_failed ──────────────────
-
-def test_ensure_db_session_failure_sets_flag():
-    """When create_session raises, _session_db_failed must be True."""
-    db = MagicMock()
-    db.create_session.side_effect = RuntimeError("locking protocol")
-    agent = _make_agent(db)
-    agent._session_db_created = False
-
-    agent._ensure_db_session()
-
-    assert agent._session_db_failed is True
-
-
-# ── append_message failure preserves idx and sets flag ──────────────────
+# ── append_message failure preserves idx and writes pending ─────────────
 
 class TestFlushPartialFailure:
     def test_failure_preserves_idx(self):
-        """Single append failure: idx stays at last success, flag set."""
+        """Single append failure: idx stays at last success, pending written."""
         db = MagicMock()
         # First 3 appends succeed, 4th fails
         db.append_message.side_effect = [None, None, None, RuntimeError("wal locked")]
@@ -58,10 +49,9 @@ class TestFlushPartialFailure:
         agent._flush_messages_to_session_db(messages)
 
         assert agent._last_flushed_db_idx == 3
-        assert agent._session_db_failed is True
 
-    def test_all_succeed_no_flag(self):
-        """Normal path: flag stays False, idx = len(messages)."""
+    def test_all_succeed_no_fallback(self):
+        """Normal path: idx = len(messages), no pending file created."""
         with tempfile.TemporaryDirectory() as tmpdir:
             from hermes_state import SessionDB
             db_path = Path(tmpdir) / "test.db"
@@ -71,10 +61,13 @@ class TestFlushPartialFailure:
             agent._ensure_db_session()
 
             messages = [_make_message("user", "a"), _make_message("assistant", "b")]
-            agent._flush_messages_to_session_db(messages)
+            with patch("hermes_constants.get_hermes_home", return_value=Path(tmpdir)):
+                agent._flush_messages_to_session_db(messages)
 
-            assert agent._session_db_failed is False
             assert agent._last_flushed_db_idx == 2
+            # No pending file should be created
+            fb_dir = Path(tmpdir) / "sessions"
+            assert not fb_dir.exists() or not list(fb_dir.glob("*.pending.jsonl"))
 
 
 # ── JSONL fallback ─────────────────────────────────────────────────────
@@ -83,7 +76,7 @@ class TestJsonlFallback:
     def test_writes_only_unflushed(self):
         """Only messages[_last_flushed_db_idx:] appear in fallback file."""
         db = MagicMock()
-        # Make append_message fail so _flush cannot reset _last_flushed_db_idx
+        # Make append_message fail so _flush writes pending directly
         db.append_message.side_effect = RuntimeError("locked")
         agent = _make_agent(db, "test-sid")
         agent._session_db_created = True
@@ -103,25 +96,46 @@ class TestJsonlFallback:
             assert len(fb_files) == 1
             pending = [json.loads(line) for line in fb_files[0].read_text().splitlines() if line.strip()]
             assert len(pending) == 2
-            # Check wrapped format with timestamp
             assert "_fallback_timestamp" in pending[0]
             assert "message" in pending[0]
             assert pending[0]["message"]["content"] == "new-one"
             assert pending[1]["message"]["content"] == "new-two"
 
-    def test_no_fallback_when_flag_false(self):
-        """_session_db_failed=False → no .pending.jsonl created."""
-        db = MagicMock()
-        agent = _make_agent(db, "sid")
-        agent._session_db_failed = False
-        agent._save_session_log = MagicMock()
-
+    def test_no_fallback_when_all_succeed(self):
+        """All appends succeed → no pending file created."""
         with tempfile.TemporaryDirectory() as tmpdir:
+            from hermes_state import SessionDB
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = _make_agent(db, "sid")
+            agent._ensure_db_session()
+
+            messages = [_make_message("user", "hello")]
             with patch("hermes_constants.get_hermes_home", return_value=Path(tmpdir)):
-                agent._persist_session([_make_message("user", "hello")])
+                agent._persist_session(messages)
 
             fb_dir = Path(tmpdir) / "sessions"
             assert not fb_dir.exists() or not list(fb_dir.glob("*.pending.jsonl"))
+
+
+# ── DB-None fallback ───────────────────────────────────────────────────
+
+def test_fallback_when_session_db_is_none():
+    """When _session_db is None, all messages go to pending."""
+    agent = _make_agent(None, "sid")
+    agent._save_session_log = MagicMock()
+
+    messages = [_make_message("user", "a"), _make_message("assistant", "b")]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with patch("hermes_constants.get_hermes_home", return_value=Path(tmpdir)):
+            agent._persist_session(messages)
+
+        fb_dir = Path(tmpdir) / "sessions"
+        fb_files = list(fb_dir.glob("*.pending.jsonl"))
+        assert len(fb_files) == 1
+        pending = [json.loads(line) for line in fb_files[0].read_text().splitlines() if line.strip()]
+        assert len(pending) == 2
 
 
 # ── Profile isolation ──────────────────────────────────────────────────
@@ -130,7 +144,7 @@ def test_profile_isolation():
     """HERMES_PROFILE=myprof → fallback in profiles/myprof/sessions/."""
     with tempfile.TemporaryDirectory() as tmpdir:
         db = MagicMock()
-        # Make append_message fail so _session_db_failed stays set after flush
+        # Make append_message fail so pending is written directly
         db.append_message.side_effect = RuntimeError("locked")
 
         agent = _make_agent(db, "test-sid")
@@ -147,34 +161,3 @@ def test_profile_isolation():
 
         default_dir = Path(tmpdir) / "sessions"
         assert not default_dir.exists() or not list(default_dir.glob("*.pending.jsonl"))
-
-
-# ── agent_persisted logic ──────────────────────────────────────────────
-
-def test_agent_persisted_false_when_failed():
-    """agent_persisted must be False when _session_db_failed is True."""
-    db = MagicMock()
-    agent = _make_agent(db)
-    agent._session_db_failed = True
-
-    result = (
-        agent._session_db is not None
-        and agent._session_db_created
-        and not agent._session_db_failed
-    )
-    assert result is False
-
-
-def test_agent_persisted_true_when_all_ok():
-    """agent_persisted must be True when DB exists, created, and not failed."""
-    db = MagicMock()
-    agent = _make_agent(db)
-    agent._session_db_created = True
-    agent._session_db_failed = False
-
-    result = (
-        agent._session_db is not None
-        and agent._session_db_created
-        and not agent._session_db_failed
-    )
-    assert result is True

--- a/tests/run_agent/test_session_db_failed_fallback.py
+++ b/tests/run_agent/test_session_db_failed_fallback.py
@@ -1,0 +1,178 @@
+"""Tests for _session_db_failed flag and JSONL fallback behaviour."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+import pytest
+
+
+def _make_agent(session_db, session_id="test-sid"):
+    """Create a minimal AIAgent for testing persistence paths."""
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def _make_message(role, content):
+    return {"role": role, "content": content}
+
+
+# ── _ensure_db_session failure sets _session_db_failed ──────────────────
+
+def test_ensure_db_session_failure_sets_flag():
+    """When create_session raises, _session_db_failed must be True."""
+    db = MagicMock()
+    db.create_session.side_effect = RuntimeError("locking protocol")
+    agent = _make_agent(db)
+    agent._session_db_created = False
+
+    agent._ensure_db_session()
+
+    assert agent._session_db_failed is True
+
+
+# ── append_message failure preserves idx and sets flag ──────────────────
+
+class TestFlushPartialFailure:
+    def test_failure_preserves_idx(self):
+        """Single append failure: idx stays at last success, flag set."""
+        db = MagicMock()
+        # First 3 appends succeed, 4th fails
+        db.append_message.side_effect = [None, None, None, RuntimeError("wal locked")]
+        agent = _make_agent(db, "sid")
+        agent._ensure_db_session()
+
+        messages = [_make_message("user", f"msg{i}") for i in range(5)]
+        agent._flush_messages_to_session_db(messages)
+
+        assert agent._last_flushed_db_idx == 3
+        assert agent._session_db_failed is True
+
+    def test_all_succeed_no_flag(self):
+        """Normal path: flag stays False, idx = len(messages)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from hermes_state import SessionDB
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = _make_agent(db, "sid")
+            agent._ensure_db_session()
+
+            messages = [_make_message("user", "a"), _make_message("assistant", "b")]
+            agent._flush_messages_to_session_db(messages)
+
+            assert agent._session_db_failed is False
+            assert agent._last_flushed_db_idx == 2
+
+
+# ── JSONL fallback ─────────────────────────────────────────────────────
+
+class TestJsonlFallback:
+    def test_writes_only_unflushed(self):
+        """Only messages[_last_flushed_db_idx:] appear in fallback file."""
+        db = MagicMock()
+        # Make append_message fail so _flush cannot reset _last_flushed_db_idx
+        db.append_message.side_effect = RuntimeError("locked")
+        agent = _make_agent(db, "test-sid")
+        agent._session_db_created = True
+        agent._last_flushed_db_idx = 1  # msg[0] already in DB
+        agent._save_session_log = MagicMock()
+
+        messages = [_make_message("user", "already-done"),
+                     _make_message("assistant", "new-one"),
+                     _make_message("user", "new-two")]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("hermes_constants.get_hermes_home", return_value=Path(tmpdir)):
+                agent._persist_session(messages)
+
+            fb_dir = Path(tmpdir) / "sessions"
+            fb_files = list(fb_dir.glob("*.pending.jsonl"))
+            assert len(fb_files) == 1
+            pending = [json.loads(line) for line in fb_files[0].read_text().splitlines() if line.strip()]
+            assert len(pending) == 2
+            assert pending[0]["content"] == "new-one"
+            assert pending[1]["content"] == "new-two"
+
+    def test_no_fallback_when_flag_false(self):
+        """_session_db_failed=False → no .pending.jsonl created."""
+        db = MagicMock()
+        agent = _make_agent(db, "sid")
+        agent._session_db_failed = False
+        agent._save_session_log = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("hermes_constants.get_hermes_home", return_value=Path(tmpdir)):
+                agent._persist_session([_make_message("user", "hello")])
+
+            fb_dir = Path(tmpdir) / "sessions"
+            assert not fb_dir.exists() or not list(fb_dir.glob("*.pending.jsonl"))
+
+
+# ── Profile isolation ──────────────────────────────────────────────────
+
+def test_profile_isolation():
+    """HERMES_PROFILE=myprof → fallback in profiles/myprof/sessions/."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        from hermes_state import SessionDB
+        db_path = Path(tmpdir) / "test.db"
+        db = SessionDB(db_path=db_path)
+
+        agent = _make_agent(db, "test-sid")
+        agent._ensure_db_session()
+        agent._session_db_failed = True
+        agent._last_flushed_db_idx = 0
+
+        messages = [_make_message("user", "x")]
+        with patch("hermes_constants.get_hermes_home", return_value=Path(tmpdir)):
+            with patch.dict(os.environ, {"HERMES_PROFILE": "myprof"}):
+                agent._persist_session(messages)
+
+        prof_dir = Path(tmpdir) / "profiles" / "myprof" / "sessions"
+        assert len(list(prof_dir.glob("*.pending.jsonl"))) == 1
+
+        default_dir = Path(tmpdir) / "sessions"
+        assert not default_dir.exists() or not list(default_dir.glob("*.pending.jsonl"))
+
+
+# ── agent_persisted logic ──────────────────────────────────────────────
+
+def test_agent_persisted_false_when_failed():
+    """agent_persisted must be False when _session_db_failed is True."""
+    db = MagicMock()
+    agent = _make_agent(db)
+    agent._session_db_failed = True
+
+    result = (
+        agent._session_db is not None
+        and agent._session_db_created
+        and not agent._session_db_failed
+    )
+    assert result is False
+
+
+def test_agent_persisted_true_when_all_ok():
+    """agent_persisted must be True when DB exists, created, and not failed."""
+    db = MagicMock()
+    agent = _make_agent(db)
+    agent._session_db_created = True
+    agent._session_db_failed = False
+
+    result = (
+        agent._session_db is not None
+        and agent._session_db_created
+        and not agent._session_db_failed
+    )
+    assert result is True

--- a/tests/run_agent/test_session_db_failed_fallback.py
+++ b/tests/run_agent/test_session_db_failed_fallback.py
@@ -129,13 +129,12 @@ class TestJsonlFallback:
 def test_profile_isolation():
     """HERMES_PROFILE=myprof → fallback in profiles/myprof/sessions/."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        from hermes_state import SessionDB
-        db_path = Path(tmpdir) / "test.db"
-        db = SessionDB(db_path=db_path)
+        db = MagicMock()
+        # Make append_message fail so _session_db_failed stays set after flush
+        db.append_message.side_effect = RuntimeError("locked")
 
         agent = _make_agent(db, "test-sid")
         agent._ensure_db_session()
-        agent._session_db_failed = True
         agent._last_flushed_db_idx = 0
 
         messages = [_make_message("user", "x")]


### PR DESCRIPTION
## Problem

When `append_message()` fails (WAL lock contention, disk full, SQLITE_READONLY, etc.), messages accumulate in `messages[]` and `_last_flushed_db_idx` is never advanced. On agent eviction, context compression, or process restart, those unflushed messages are silently lost. The Gateway also blindly trusts `agent_persisted` — it assumes DB writes succeeded as long as `_session_db is not None`, never verifying the agent actually committed anything.

Additionally, SQLITE_READONLY (not just LOCKED/BUSY) was not retried in `_execute_write`, causing transient WAL-readonly states to permanently fail. And background review agents ran without a `session_db` handle, so their writes went nowhere when the session DB had been recovered from a previous failure.

## Changes (12 commits, rebased on main)

### Pending Fallback — Direct, No Sticky Flag

**`run_agent.py` — `_flush_messages_to_session_db`**
Per-message try/except. Each successful `append_message` advances `_last_flushed_db_idx`. On failure, immediately calls `_write_pending_fallback(messages, last_successful_idx)` to dump unflushed messages to `sessions/<sid>.pending.jsonl` — no sticky flag, no deferred write.

**`run_agent.py` — `_persist_session`**
Added a catch: when `_session_db is None` (SQLite init never succeeded), writes ALL messages to pending fallback via `_write_pending_fallback(messages, 0)`.

**`run_agent.py` — `_write_pending_fallback`**
New method. Wraps each message with its `_flush_timestamp` as `{"_fallback_timestamp": t, "message": m}` and appends to `<sid>.pending.jsonl`, respecting `HERMES_PROFILE` isolation.

### Shared Flush Timestamp for Safe Dedup

Every `append_message` in `_flush_messages_to_session_db` now generates a timestamp ONCE and passes it to both the DB write (via the new `timestamp=` param of `SessionDB.append_message`) and the message dict as `_flush_timestamp`. This anchors the dedup comparison: if a DB write succeeded but the fallback was still written (false alarm), both carry the same timestamp and won't be double-inserted during recovery.

Deduplication is based on `(role, content, tool_name, tool_calls, tool_call_id, timestamp)` — max-overlap suffix-vs-prefix match between existing DB messages and pending entries.

### SQLITE_READONLY Retry

**`hermes_state.py` — `_execute_write`**
Added `"readonly"` and `"read-only"` to the retry-eligible error string set. Previously only `"locked"` and `"busy"` were retried — WAL-mode readonly states were fatal on first attempt.

### Background Review Agent Gets session_db

**`agent/background_review.py`**
Pass `session_db=getattr(agent, "_session_db", None)` to review agents so their writes land in the correct session store.

### Gateway Startup Recovery

**`gateway/run.py` — `_recover_pending_messages`**
New function, called in `GatewayRunner.__init__`. Scans `<hermes_home>/sessions/*.pending.jsonl`, reads wrapped + plain messages, deduplicates against existing DB rows, replays new ones via `SessionDB.append_message` (with original timestamps, multimodal handling, reasoning fields), and deletes the pending file on success.

### Hardening & Cleanup

- **Log append_message failure reason** before triggering pending fallback (was silently swallowed)
- **Clear `_session_db_create_fail_count`** on successful recovery so consecutive-failure logging starts fresh
- **Restore accidentally removed comments** in `_flush_messages_to_session_db` that documented the cursor-tracking pattern
- **Delete pending files after recovery** instead of renaming (simpler, safer)
- **Add `_session_db_create_fail_count` init** in `agent_init.py`

## Design Principle

Memory is the most unsafe place. When DB persistence fails, get messages to disk immediately — JSONL fallback is the last line of defense before data loss. Dedup via shared timestamp guarantees safe replay on restart.

## Related work

- **#45966** — `fix(gateway): invalidate agent cache on cross-process session writes`
  Directly related: addresses the same cross-process session DB coordination problem from the Gateway side (agent writes to DB → Gateway cache was stale). This PR complements it by ensuring writes actually land before the Gateway ever has to invalidate.

- **#44837** — `fix(agent): clamp flush cursor after repair_message_sequence compaction`
  Related but not identical: manages `_last_flushed_db_idx` correctness during message sequence repair — the same cursor this PR tracks per-message.

- **#46071** — `fix(agent): persist repaired-turn responses`
  Related: touches the same `_persist_session` / `_flush_messages_to_session_db` path to ensure repaired messages are persisted, not just held in memory.

- **#43149** — `fix(state.db): recover from malformed sqlite_master`
  Related: another state.db resilience fix — covers the `sqlite_master` corruption case while this PR covers the runtime write-failure case.

- **#42123** — `fix(agent): clear _session_messages in AIAgent.close()`
  Related: session message lifecycle — prevents stale references from surviving agent teardown.

- **#40946 / #46968** — `feat/fix(delegation): async background subagents`
  Related: the background review agent path that this PR fixes (was missing `session_db`).

- **#47113** — extracted from this PR: standalone fix that passes `session_db` to background review agents.
- **8905ee6b8** — `fix(agent): rewind flush cursor exactly when repair compacts before the cursor`
  Follow-up to #44837, already on main. A `min()` clamp only fixes cursor overshoot past the new end of the list. When `repair_message_sequence` drops/merges messages at indexes below the cursor, the clamp leaves the cursor pointing past unflushed rows and the turn-end flush silently skips them. This PR's per-message cursor tracking (`last_successful_idx`) avoids the entire class of cursor healing bugs.

- **8e4c447e5** — `fix(gateway): prevent duplicate user messages in state.db`
  Related: Gateway-side dedup for user messages. When the agent has its own `_session_db`, `_flush_messages_to_session_db()` persists user messages to SQLite. Two Gateway fallback paths also wrote the same user message without `skip_db=True`. Same problem domain — this PR adds dedup on recovery.

- **46b2caf56** — `fix(state): use TRUNCATE WAL checkpoint to prevent unbounded WAL growth`
  Related: WAL management. Unbounded WAL growth can trigger readonly states in concurrent writer scenarios — exactly the class of `SQLITE_READONLY` errors that this PR's `_execute_write` retry now handles.

- **#41708** — `fix(compression): disable compression on background-review fork to prevent cross-turn stale-parent fork`
  Related: background review fork isolation. The review fork's lifecycle edge case (stale parent state across turns) mirrors the missing `session_db` issue that #47113 fixes.
