### PR TITLE
feat: add qwen3.7-max to alibaba and provider model lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -393,6 +393,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        "qwen3.7-max",
         "qwen3.6-plus",
         "kimi-k2.5",
         "qwen3.5-plus",
@@ -406,6 +407,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Alibaba Coding Plan — same platform as alibaba (DashScope coding-intl),
     # separate provider ID with its own base_url_env_var.
     "alibaba-coding-plan": [
+        "qwen3.7-max",
         "qwen3.6-plus",
         "qwen3.5-plus",
         "qwen3-coder-plus",


### PR DESCRIPTION
## Summary

Add `qwen3.7-max` to the Alibaba provider model catalogs that still lacked it.

## Context

#32809 already added `qwen/qwen3.7-max` to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`. Main has also changed since this PR was opened, so this PR is now intentionally narrowed to only the remaining Alibaba provider catalogs.

## Changes

- Add `qwen3.7-max` to `_PROVIDER_MODELS["alibaba"]`
- Add `qwen3.7-max` to `_PROVIDER_MODELS["alibaba-coding-plan"]`

## Testing

```bash
./venv/bin/pytest tests/hermes_cli/test_model_validation.py -q --tb=short -o 'addopts='
# 81 passed in 0.77s
```

## Related

- #32809 added OpenRouter/Nous entries
- #33109 adds a dedicated `alibaba-token-plan` provider for Token Plan users
