### PR TITLE
fix(file-sync): preserve sync_back on Python 3.11

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -156,6 +156,7 @@ AUTHOR_MAP = {
     "aubrey@freeman-wisco.com": "Freeman-Consulting",
     "don.rhm@gmail.com": "rahimsais",
     "40222899+rahimsais@users.noreply.github.com": "rahimsais",
+    "byquenox@gmail.com": "quen0xi",
     "alfred@Alfreds-Mac-mini.local": "NivOO5",
     "231191380+NivOO5@users.noreply.github.com": "NivOO5",
     "jameshuang@gmail.com": "kjames2001",

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -6,12 +6,16 @@ import os
 import signal
 import tarfile
 import time
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-fcntl = pytest.importorskip("fcntl")
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
 
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -52,6 +56,31 @@ def _write_file(path: Path, content: bytes) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(content)
     return str(path)
+
+
+def _make_python311_extractall(original_extractall):
+    """Emulate Python 3.11 rejecting the ``filter=`` keyword."""
+    def python311_extractall(
+        self, path=".", members=None, *, numeric_owner=False, filter=None
+    ):
+        if filter is not None:
+            raise TypeError(
+                "TarFile.extractall() got an unexpected keyword argument 'filter'"
+            )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Python 3.14 will, by default, filter extracted tar archives",
+                category=DeprecationWarning,
+            )
+            return original_extractall(
+                self,
+                path=path,
+                members=members,
+                numeric_owner=numeric_owner,
+            )
+
+    return python311_extractall
 
 
 def _make_manager(
@@ -153,6 +182,34 @@ class TestSyncBackAppliesChanged:
         mgr.sync_back(hermes_home=tmp_path / ".hermes")
 
         assert host_file.read_bytes() == remote_content
+
+    @patch("tools.environments.file_sync._sleep")
+    def test_sync_back_applies_changed_file_with_python311_extractall(self, mock_sleep, tmp_path):
+        """Fallback extraction should preserve sync_back on Python 3.11."""
+        host_file = tmp_path / "host" / "skill.py"
+        original_content = b"print('v1')"
+        _write_file(host_file, original_content)
+
+        remote_path = "/root/.hermes/skill.py"
+        mapping = [(str(host_file), remote_path)]
+
+        remote_content = b"print('v2 - edited on remote')"
+        download_fn = _make_download_fn({
+            "root/.hermes/skill.py": remote_content,
+        })
+
+        mgr = _make_manager(tmp_path, file_mapping=mapping, bulk_download_fn=download_fn)
+        mgr._pushed_hashes[remote_path] = _sha256_bytes(original_content)
+
+        with patch.object(
+            tarfile.TarFile,
+            "extractall",
+            _make_python311_extractall(tarfile.TarFile.extractall),
+        ):
+            mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        assert host_file.read_bytes() == remote_content
+        assert mock_sleep.call_count == 0
 
 
 class TestSyncBackNewRemoteFile:
@@ -256,6 +313,45 @@ class TestSyncBackRetries:
         assert any("all" in r.message.lower() and "failed" in r.message.lower() for r in caplog.records)
 
 
+class TestSyncBackTarSafety:
+    """Fallback extraction should still reject unsafe archive members."""
+
+    @patch("tools.environments.file_sync._sleep")
+    def test_sync_back_python311_fallback_rejects_unsafe_member(
+        self, mock_sleep, tmp_path, caplog
+    ):
+        host_file = _write_file(tmp_path / "host_skill.md", b"original")
+        remote_path = "/root/.hermes/skill.md"
+
+        def download(dest: Path):
+            with tarfile.open(dest, "w") as tar:
+                info = tarfile.TarInfo("../../escape.txt")
+                data = b"pwned"
+                info.size = len(data)
+                tar.addfile(info, io.BytesIO(data))
+
+        mgr = _make_manager(
+            tmp_path,
+            file_mapping=[(host_file, remote_path)],
+            bulk_download_fn=download,
+        )
+        mgr._pushed_hashes[remote_path] = _sha256_bytes(b"original")
+
+        escape_path = tmp_path / "escape.txt"
+        with caplog.at_level(logging.WARNING, logger="tools.environments.file_sync"):
+            with patch.object(
+                tarfile.TarFile,
+                "extractall",
+                _make_python311_extractall(tarfile.TarFile.extractall),
+            ):
+                mgr.sync_back(hermes_home=tmp_path / ".hermes")
+
+        assert mock_sleep.call_count == _SYNC_BACK_MAX_RETRIES - 1
+        assert Path(host_file).read_bytes() == b"original"
+        assert not escape_path.exists()
+        assert any("unsafe" in r.message.lower() for r in caplog.records)
+
+
 class TestPushedHashesPopulated:
     """_pushed_hashes is populated during sync() and cleared on delete."""
 
@@ -308,6 +404,7 @@ class TestPushedHashesPopulated:
 class TestSyncBackFileLock:
     """Verify that fcntl.flock is used during sync-back."""
 
+    @pytest.mark.skipif(fcntl is None, reason="fcntl unavailable on Windows")
     @patch("tools.environments.file_sync.fcntl.flock")
     def test_sync_back_file_lock(self, mock_flock, tmp_path):
         download_fn = _make_download_fn({})

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -21,7 +21,7 @@ try:
     import fcntl
 except ImportError:
     fcntl = None  # Windows — file locking skipped
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable
 
 from hermes_constants import get_hermes_home
@@ -102,6 +102,42 @@ def _sha256_file(path: str) -> str:
 _SYNC_BACK_MAX_RETRIES = 3
 _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
+
+
+def _validate_sync_back_member(member: tarfile.TarInfo) -> None:
+    """Reject archive members that would be unsafe to extract without a filter."""
+    normalized_name = member.name.replace("\\", "/")
+    posix_path = PurePosixPath(normalized_name)
+    windows_path = PureWindowsPath(member.name)
+
+    if posix_path.is_absolute() or windows_path.is_absolute():
+        raise tarfile.TarError(f"unsafe sync_back tar member path: {member.name}")
+    if ".." in posix_path.parts:
+        raise tarfile.TarError(f"unsafe sync_back tar member path: {member.name}")
+    if not (member.isfile() or member.isdir()):
+        raise tarfile.TarError(
+            f"unsupported sync_back tar member type: {member.name}"
+        )
+
+
+def _extract_sync_back_tar(tar: tarfile.TarFile, dest: str) -> None:
+    """Extract a sync_back tar using ``filter='data'`` when available."""
+    try:
+        tar.extractall(dest, filter="data")  # type: ignore[call-arg]
+        return
+    except TypeError:
+        logger.debug(
+            "sync_back: tarfile filter='data' unavailable, using validated fallback"
+        )
+
+    for member in tar.getmembers():
+        _validate_sync_back_member(member)
+    tar.extractall(dest)
+
+
+def _normalize_remote_path(remote_path: str) -> PurePosixPath:
+    """Normalize remote container paths independently of host path rules."""
+    return PurePosixPath(remote_path.replace("\\", "/"))
 
 
 class FileSyncManager:
@@ -306,13 +342,15 @@ class FileSyncManager:
         except Exception:
             file_mapping = []
 
-        with tempfile.NamedTemporaryFile(suffix=".tar") as tf:
-            self._bulk_download_fn(Path(tf.name))
+        fd, temp_tar = tempfile.mkstemp(suffix=".tar")
+        os.close(fd)
+        try:
+            self._bulk_download_fn(Path(temp_tar))
 
             # Defensive size cap: a misbehaving sandbox could produce an
             # arbitrarily large tar. Refuse to extract if it exceeds the cap.
             try:
-                tar_size = os.path.getsize(tf.name)
+                tar_size = os.path.getsize(temp_tar)
             except OSError:
                 tar_size = 0
             if tar_size > _SYNC_BACK_MAX_BYTES:
@@ -323,14 +361,14 @@ class FileSyncManager:
                 return
 
             with tempfile.TemporaryDirectory(prefix="hermes-sync-back-") as staging:
-                with tarfile.open(tf.name) as tar:
-                    tar.extractall(staging, filter="data")
+                with tarfile.open(temp_tar) as tar:
+                    _extract_sync_back_tar(tar, staging)
 
                 applied = 0
                 for dirpath, _dirnames, filenames in os.walk(staging):
                     for fname in filenames:
                         staged_file = os.path.join(dirpath, fname)
-                        rel = os.path.relpath(staged_file, staging)
+                        rel = os.path.relpath(staged_file, staging).replace("\\", "/")
                         remote_path = "/" + rel
 
                         pushed_hash = self._pushed_hashes.get(remote_path)
@@ -372,13 +410,19 @@ class FileSyncManager:
                     logger.info("sync_back: applied %d changed file(s)", applied)
                 else:
                     logger.debug("sync_back: no remote changes detected")
+        finally:
+            try:
+                os.unlink(temp_tar)
+            except OSError:
+                pass
 
     def _resolve_host_path(self, remote_path: str,
                            file_mapping: list[tuple[str, str]] | None = None) -> str | None:
         """Find the host path for a known remote path from the file mapping."""
         mapping = file_mapping if file_mapping is not None else []
+        normalized_remote = _normalize_remote_path(remote_path)
         for host, remote in mapping:
-            if remote == remote_path:
+            if _normalize_remote_path(remote) == normalized_remote:
                 return host
         return None
 
@@ -393,10 +437,12 @@ class FileSyncManager:
         ``/root/.hermes/skills/b.md`` maps to ``~/.hermes/skills/b.md``.
         """
         mapping = file_mapping if file_mapping is not None else []
+        normalized_remote = _normalize_remote_path(remote_path)
         for host, remote in mapping:
-            remote_dir = str(Path(remote).parent)
-            if remote_path.startswith(remote_dir + "/"):
-                host_dir = str(Path(host).parent)
-                suffix = remote_path[len(remote_dir):]
-                return host_dir + suffix
+            remote_dir = _normalize_remote_path(remote).parent
+            try:
+                suffix = normalized_remote.relative_to(remote_dir)
+            except ValueError:
+                continue
+            return str(Path(host).parent.joinpath(*suffix.parts))
         return None


### PR DESCRIPTION
## Summary
Fixes `sync_back()` on Python 3.11 by avoiding an unconditional `tar.extractall(..., filter="data")` call, which only works on Python 3.12+.

## What Changed
- added a safe Python 3.11 fallback for tar extraction in `tools/environments/file_sync.py`
- preserved `filter="data"` on newer runtimes
- validated fallback tar members to reject unsafe paths and unsupported member types
- fixed temp tar handling for cross-platform sync-back execution
- normalized remote path handling so host-path inference stays consistent across platforms

## Tests
- `tests/tools/test_file_sync_back.py`

19 passed, 1 skipped in 0.47s