### PR TITLE
fix(cli): keep slash confirmation modal on app loop

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7141,25 +7141,13 @@ class HermesCLI:
         choices visible and lets the normal Enter key binding submit the typed
         or highlighted choice.
 
-        **Platform note (Windows dead-lock — issue #30768):**
-        The queue-based modal relies on prompt_toolkit key bindings receiving
-        keyboard events and calling ``_submit_slash_confirm_response``.  On
-        Windows (PowerShell / Windows Terminal) the prompt_toolkit input
-        channel can become unresponsive when the modal is entered from the
-        ``process_loop`` daemon thread, causing a dead-lock: the user sees the
-        confirmation panel but keystrokes never reach the key bindings and the
-        ``response_queue.get()`` blocks until the 120-second timeout expires.
-
-        To avoid this, we fall back to ``_prompt_text_input`` (a simple
-        ``input()``-based prompt) when any of these conditions hold:
-
-        * ``sys.platform == "win32"`` — native Windows console (ConPTY /
-          win32_input) does not support the modal reliably.
-        * Called from a non-main thread — the prompt_toolkit event loop only
-          runs on the main thread; key bindings can't fire from a daemon
-          thread (same rationale as the ``_prompt_text_input`` thread guard
-          in PR #23454).
-        * ``self._app`` is not set — unit tests / non-interactive contexts.
+        Slash commands are processed by ``process_loop`` on a worker thread,
+        while prompt_toolkit owns stdin on the main application loop.  On POSIX
+        terminals the worker must schedule modal open/close work onto the app
+        loop and then block on the modal response queue; falling back to raw
+        ``input()`` from the worker wedges because prompt_toolkit consumes the
+        user's keystrokes first.  Native Windows keeps the simple stdin fallback
+        for issue #30768, where the modal key bindings can fail to fire.
         """
         import threading
         import time as _time
@@ -7167,9 +7155,11 @@ class HermesCLI:
         if not choices:
             return None
 
+        app = getattr(self, "_app", None)
+
         # If prompt_toolkit is not running (unit tests / non-interactive calls),
         # keep the simple stdin fallback.
-        if not getattr(self, "_app", None):
+        if not app:
             return self._prompt_text_input("Choice [1/2/3]: ")
 
         # On Windows the prompt_toolkit input channel can deadlock when the
@@ -7180,33 +7170,75 @@ class HermesCLI:
         if sys.platform == "win32":
             return self._prompt_text_input("Choice [1/2/3]: ")
 
-        # Mirror the thread-aware guard from _prompt_text_input (PR #23454):
-        # run_in_terminal and the modal queue both depend on the main-thread
-        # event loop.  From a daemon thread the modal key bindings never fire.
-        if threading.current_thread() is not threading.main_thread():
-            return self._prompt_text_input("Choice [1/2/3]: ")
-
         response_queue = queue.Queue()
-        self._capture_modal_input_snapshot()
-        self._slash_confirm_state = {
-            "title": title,
-            "detail": detail,
-            "choices": choices,
-            "selected": 0,
-            "response_queue": response_queue,
-        }
-        self._slash_confirm_deadline = _time.monotonic() + timeout
-        self._invalidate()
+        modal_opened = False
+
+        def _open_modal() -> None:
+            nonlocal modal_opened
+            self._capture_modal_input_snapshot()
+            self._slash_confirm_state = {
+                "title": title,
+                "detail": detail,
+                "choices": choices,
+                "selected": 0,
+                "response_queue": response_queue,
+            }
+            self._slash_confirm_deadline = _time.monotonic() + timeout
+            modal_opened = True
+            self._invalidate()
+
+        def _close_modal() -> None:
+            nonlocal modal_opened
+            if not modal_opened:
+                return
+            self._slash_confirm_state = None
+            self._slash_confirm_deadline = 0
+            self._restore_modal_input_snapshot()
+            modal_opened = False
+            self._invalidate()
+
+        def _run_on_app_loop(callback, *, wait_timeout: float = 5.0) -> bool:
+            loop = getattr(app, "loop", None)
+            if loop is None or not hasattr(loop, "call_soon_threadsafe"):
+                return False
+
+            done = threading.Event()
+            errors: list[BaseException] = []
+
+            def _wrapped() -> None:
+                try:
+                    callback()
+                except BaseException as exc:  # best-effort UI modal cleanup path
+                    errors.append(exc)
+                finally:
+                    done.set()
+
+            try:
+                loop.call_soon_threadsafe(_wrapped)
+            except Exception:
+                return False
+
+            if not done.wait(wait_timeout):
+                return False
+            return not errors
+
+        in_main_thread = threading.current_thread() is threading.main_thread()
+        if in_main_thread:
+            _open_modal()
+        elif not _run_on_app_loop(_open_modal):
+            # Do not fall back to raw input() while prompt_toolkit owns stdin;
+            # that is the freeze this modal path is designed to avoid.
+            return None
 
         _last_countdown_refresh = _time.monotonic()
         try:
             while True:
                 try:
                     result = response_queue.get(timeout=1)
-                    self._slash_confirm_state = None
-                    self._slash_confirm_deadline = 0
-                    self._restore_modal_input_snapshot()
-                    self._invalidate()
+                    if in_main_thread:
+                        _close_modal()
+                    elif not _run_on_app_loop(_close_modal):
+                        _close_modal()
                     return result
                 except queue.Empty:
                     remaining = self._slash_confirm_deadline - _time.monotonic()
@@ -7217,11 +7249,11 @@ class HermesCLI:
                         _last_countdown_refresh = now
                         self._invalidate()
         finally:
-            if self._slash_confirm_state is not None:
-                self._slash_confirm_state = None
-                self._slash_confirm_deadline = 0
-                self._restore_modal_input_snapshot()
-                self._invalidate()
+            if modal_opened:
+                if in_main_thread:
+                    _close_modal()
+                elif not _run_on_app_loop(_close_modal):
+                    _close_modal()
         return None
 
     def _submit_slash_confirm_response(self, value: str | None) -> None:
@@ -7273,10 +7305,14 @@ class HermesCLI:
         if not state:
             return []
 
-        title = state.get("title") or "Confirm action"
-        detail = state.get("detail") or ""
-        choices = state.get("choices") or []
-        selected = state.get("selected", 0)
+        title = str(state.get("title") or "Confirm action")
+        detail = str(state.get("detail") or "")
+        raw_choices = state.get("choices") or []
+        choices: list[tuple[str, str, str]] = list(raw_choices)
+        try:
+            selected = int(state.get("selected", 0))
+        except (TypeError, ValueError):
+            selected = 0
 
         def _panel_box_width(title_text: str, content_lines: list[str], min_width: int = 56, max_width: int = 86) -> int:
             term_cols = shutil.get_terminal_size((100, 20)).columns

--- a/tests/cli/test_slash_confirm_windows.py
+++ b/tests/cli/test_slash_confirm_windows.py
@@ -1,14 +1,15 @@
-"""Regression tests for issue #30768: /reset and /new freeze on Windows.
+"""Regression tests for destructive slash confirmations.
 
 ``_prompt_text_input_modal`` uses a queue-based modal that relies on
-prompt_toolkit key bindings receiving keyboard events.  On Windows the
-prompt_toolkit input channel can deadlock when the modal is entered from
-the ``process_loop`` daemon thread.  The fix falls back to the simpler
-``_prompt_text_input`` (stdin-based) prompt on Windows and non-main threads.
+prompt_toolkit key bindings receiving keyboard events.  The modal must not
+fall back to raw ``input()`` while the prompt_toolkit app owns stdin on POSIX;
+that wedges /reset and /new because keystrokes are consumed by the app instead
+of the worker thread's ``input()`` call.  Native Windows keeps a stdin fallback
+for issue #30768, where the modal key bindings can fail to fire.
 
 These tests verify:
 1. Windows detection triggers the stdin fallback
-2. Non-main thread detection triggers the stdin fallback
+2. Non-main POSIX calls schedule the modal on the app loop
 3. macOS/Linux main-thread path still uses the modal (no regression)
 4. No-app path still uses the stdin fallback (existing behavior)
 5. Empty choices returns None (existing behavior)
@@ -66,28 +67,54 @@ class TestModalWindowsFallback:
         mock_stdin.assert_called_once_with("Choice [1/2/3]: ")
         assert result == "1"
 
-    def test_non_main_thread_falls_back_to_stdin(self):
-        """Off the main thread, _prompt_text_input_modal should use stdin fallback."""
+    def test_non_main_thread_with_running_app_schedules_modal_on_app_loop(self):
+        """Off the main thread on POSIX, use the live modal, not raw stdin.
+
+        ``process_loop`` handles slash commands on a worker thread while
+        prompt_toolkit still owns terminal input on the main app loop. A raw
+        ``input()`` fallback wedges there because prompt_toolkit consumes the
+        user's keystrokes. The worker must publish modal state on the app loop
+        and then wait for the normal key bindings to submit the response.
+        """
         cli = _make_cli()
+        scheduled = queue.Queue()
         result_holder = {}
+
+        class FakeLoop:
+            def call_soon_threadsafe(self, callback, *args):
+                scheduled.put((callback, args))
+
+        setattr(cli._app, "loop", FakeLoop())
 
         def run_on_daemon():
             # Patch platform to "linux" so the Windows check doesn't short-circuit.
-            with patch.object(sys, "platform", "linux"), \
-                 patch.object(cli, "_prompt_text_input", return_value="2") as mock_stdin:
+            with patch.object(sys, "platform", "linux"):
                 result_holder["result"] = cli._prompt_text_input_modal(
                     title="⚠️  /reset",
                     detail="This starts a fresh session.",
                     choices=_SAMPLE_CHOICES,
+                    timeout=5,
                 )
-                result_holder["stdin_called"] = mock_stdin.called
 
-        t = threading.Thread(target=run_on_daemon, daemon=True)
-        t.start()
-        t.join(timeout=2.0)
-        assert not t.is_alive(), "daemon thread hung — modal deadlocked"
-        assert result_holder["stdin_called"] is True
-        assert result_holder["result"] == "2"
+        with patch.object(cli, "_prompt_text_input", return_value="2") as mock_stdin, \
+             patch.object(cli, "_capture_modal_input_snapshot"), \
+             patch.object(cli, "_restore_modal_input_snapshot"), \
+             patch.object(cli, "_invalidate"):
+            t = threading.Thread(target=run_on_daemon, daemon=True)
+            t.start()
+
+            callback, args = scheduled.get(timeout=1.0)
+            callback(*args)
+            assert cli._slash_confirm_state is not None
+            cli._submit_slash_confirm_response("once")
+
+            callback, args = scheduled.get(timeout=1.0)
+            callback(*args)
+            t.join(timeout=2.0)
+
+        assert not t.is_alive(), "daemon thread hung waiting for modal response"
+        mock_stdin.assert_not_called()
+        assert result_holder["result"] == "once"
 
     def test_main_thread_non_windows_uses_modal(self):
         """On macOS/Linux main thread, the queue-based modal is still used."""
@@ -182,29 +209,38 @@ class TestModalWindowsFallback:
 
         assert cli._slash_confirm_state is None
 
-    def test_non_main_thread_fallback_does_not_set_modal_state(self):
-        """Verify daemon-thread fallback doesn't leave modal state set."""
+    def test_non_main_thread_app_loop_failure_does_not_call_stdin(self):
+        """If POSIX app-loop scheduling fails, cancel instead of raw stdin."""
         cli = _make_cli()
         errors = []
+        result_holder = {}
+
+        class FailingLoop:
+            def call_soon_threadsafe(self, callback, *args):
+                raise RuntimeError("loop unavailable")
+
+        setattr(cli._app, "loop", FailingLoop())
 
         def run_on_daemon():
             try:
                 with patch.object(sys, "platform", "linux"), \
-                     patch.object(cli, "_prompt_text_input", return_value="1"):
-                    cli._prompt_text_input_modal(
+                     patch.object(cli, "_prompt_text_input", return_value="1") as mock_stdin:
+                    result_holder["result"] = cli._prompt_text_input_modal(
                         title="⚠️  /new",
                         detail="This starts a fresh session.",
                         choices=_SAMPLE_CHOICES,
                     )
-                if cli._slash_confirm_state is not None:
-                    errors.append("_slash_confirm_state should be None")
+                    result_holder["stdin_called"] = mock_stdin.called
             except Exception as exc:
                 errors.append(str(exc))
 
         t = threading.Thread(target=run_on_daemon, daemon=True)
         t.start()
         t.join(timeout=2.0)
+        assert not t.is_alive(), "daemon thread hung after app-loop scheduling failure"
         assert not errors, f"unexpected errors: {errors}"
+        assert result_holder["result"] is None
+        assert result_holder["stdin_called"] is False
         assert cli._slash_confirm_state is None
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the destructive slash confirmation modal for `/clear`, `/new`, `/reset`, and `/undo` when those commands are processed from the CLI worker thread on POSIX terminals.

The existing code falls back to raw `input()` whenever `_prompt_text_input_modal()` is called off the main thread. That is the broken path in #22958: prompt_toolkit still owns stdin, so `1`, `2`, or `3` can leak into the composer instead of reaching the confirmation prompt.

This keeps the Windows stdin fallback for #30768, but on POSIX with a running prompt_toolkit app it schedules modal open and close work onto `app.loop.call_soon_threadsafe(...)` and waits on the existing modal response queue.

This is intentionally narrower than #25404. That PR changes `_prompt_text_input()` in a mixed-scope branch, but does not fix the worker-thread `_prompt_text_input_modal()` fallback that handles destructive slash confirmations.

## Related Issue

Fixes #22958

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [X] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Keeps no-app and native Windows paths on the existing stdin fallback.
  - Removes the POSIX worker-thread raw `input()` fallback while prompt_toolkit owns stdin.
  - Schedules slash confirmation modal open and close work on the prompt_toolkit app loop via `call_soon_threadsafe`.
  - Adds small normalization in the modal display renderer for `title`, `detail`, `choices`, and `selected` values used by the modal state.
- `tests/cli/test_slash_confirm_windows.py`
  - Updates the non-main POSIX regression to assert that the worker schedules modal work on the app loop and does not call raw stdin.
  - Keeps Windows stdin fallback coverage.
  - Keeps main-thread modal, no-app fallback, empty choices, and destructive slash normalization coverage.
  - Adds coverage for app-loop scheduling failure returning `None` without falling back to raw stdin.

## How to Test

1. Run the focused regression tests:
   - `/home/w0lf/hermes-agent/venv/bin/python -m pytest tests/cli/test_slash_confirm_windows.py tests/cli/test_destructive_slash_inline_skip_e2e.py -q -o 'addopts='`
2. Compile the changed Python files:
   - `/home/w0lf/hermes-agent/venv/bin/python -m py_compile cli.py tests/cli/test_slash_confirm_windows.py`
3. Check whitespace:
   - `git diff --check`
4. Check Windows footguns on changed files:
   - `/home/w0lf/hermes-agent/venv/bin/python scripts/check-windows-footguns.py cli.py tests/cli/test_slash_confirm_windows.py`
5. Manual PTY smoke:
   - Start Hermes in a tmux session from this branch with a temporary `HERMES_HOME`.
   - Enter `/new`.
   - Verify the modal renders.
   - Enter `1`.
   - Verify the CLI starts a new session and `1` does not appear as a chat message.

Local validation performed on Linux:

```text
/home/w0lf/hermes-agent/venv/bin/python -m pytest tests/cli/test_slash_confirm_windows.py tests/cli/test_destructive_slash_inline_skip_e2e.py -q -o 'addopts='
12 passed, 1 warning in 0.74s

/home/w0lf/hermes-agent/venv/bin/python -m py_compile cli.py tests/cli/test_slash_confirm_windows.py
passed, emitted pre-existing SyntaxWarning: cli.py:10857: 'return' in a 'finally' block

git diff --check
passed

/home/w0lf/hermes-agent/venv/bin/python scripts/check-windows-footguns.py cli.py tests/cli/test_slash_confirm_windows.py
✓ No Windows footguns found (2 file(s) scanned).

tmux PTY smoke with temporary HERMES_HOME
/new modal rendered, choice 1 submitted, CLI printed "New session started!", and the composer was clean afterward.
```

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: Linux 7.0.9-arch2-1, tmux PTY smoke

### Documentation & Housekeeping

- [X] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [X] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [X] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
│ ❯ [1] Approve Once — proceed this time only                            │
│   [2] Always Approve — proceed and silence this prompt permanently     │
│   [3] Cancel — keep current conversation                               │
│                                                                        │
│ Type 1/2/3 or use ↑/↓ then Enter. ESC/Ctrl+C cancels.                  │
╰────────────────────────────────────────────────────────────────────────╯

⚙️  /new
(^_^)v New session started!
❯
```
