### PR TITLE
fix(codex-runtime): pin hermes-tools MCP launch context

### DIFF
--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -563,13 +563,15 @@ def _hermes_tools_python_executable(source_root: Path, fallback: Optional[str] =
     server has Hermes' optional deps (notably mcp), then fall back to the
     current interpreter for packaged installs.
     """
+    # ``.venv`` is the documented checkout environment (AGENTS.md); keep it
+    # ahead of the legacy ``venv`` directory when both happen to exist.
     candidates = [
-        source_root / "venv" / "bin" / "python3",
         source_root / ".venv" / "bin" / "python3",
-        source_root / "venv" / "bin" / "python",
         source_root / ".venv" / "bin" / "python",
-        source_root / "venv" / "Scripts" / "python.exe",
         source_root / ".venv" / "Scripts" / "python.exe",
+        source_root / "venv" / "bin" / "python3",
+        source_root / "venv" / "bin" / "python",
+        source_root / "venv" / "Scripts" / "python.exe",
     ]
     for candidate in candidates:
         if candidate.is_file():

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
@@ -554,18 +555,41 @@ def _looks_like_test_tempdir(path: str) -> bool:
     return any(needle in normalized for needle in needles)
 
 
+def _hermes_tools_python_executable(source_root: Path, fallback: Optional[str] = None) -> str:
+    """Choose a Python that can run Hermes' hermes-tools MCP server.
+
+    The migration can be invoked from helper scripts running under a generic
+    system Python. Prefer the checkout's venv when present so the spawned MCP
+    server has Hermes' optional deps (notably mcp), then fall back to the
+    current interpreter for packaged installs.
+    """
+    candidates = [
+        source_root / "venv" / "bin" / "python3",
+        source_root / ".venv" / "bin" / "python3",
+        source_root / "venv" / "bin" / "python",
+        source_root / ".venv" / "bin" / "python",
+        source_root / "venv" / "Scripts" / "python.exe",
+        source_root / ".venv" / "Scripts" / "python.exe",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return fallback or sys.executable
+
+
 def _build_hermes_tools_mcp_entry() -> dict:
     """Build the codex stdio-transport entry that launches Hermes' own
     tool surface as an MCP server. Codex's subprocess will call back into
     this for browser/web/delegate_task/vision/memory/skills tools.
 
-    The command runs the worktree's Python via the current sys.executable
-    so a hermes installed under /opt/, /usr/local/, or a venv all work.
-    HERMES_HOME and PYTHONPATH are passed through so the spawned process
-    sees the same config + module layout the user is running."""
-    import sys
+    Prefer the checkout venv Python when present, otherwise fall back to the
+    current interpreter so packaged installs still work. HERMES_HOME and
+    PYTHONPATH are passed through so the spawned process sees the same config
+    + module layout the user is running.
+    """
 
     env: dict[str, str] = {}
+
     # HERMES_HOME passes through IF SET so the MCP subprocess sees the same
     # config / auth / sessions DB as the parent CLI. Read from os.environ
     # (not get_hermes_home()) on purpose: when the env var is unset we want
@@ -584,18 +608,26 @@ def _build_hermes_tools_mcp_entry() -> dict:
         hermes_home = ""
     if hermes_home:
         env["HERMES_HOME"] = hermes_home
+    source_root = Path(__file__).resolve().parent.parent
     # PYTHONPATH passes through so a worktree-launched hermes finds the
-    # branch's modules instead of the installed package.
+    # branch's modules instead of the installed package. Always prepend the
+    # current source root too: Codex may launch this MCP server from an
+    # arbitrary project directory, and Hermes may have been invoked through a
+    # generic /usr/bin/python where -m agent.transports... is not otherwise
+    # importable.
+    pythonpath_parts = [str(source_root)]
     pythonpath = os.environ.get("PYTHONPATH")
     if pythonpath:
-        env["PYTHONPATH"] = pythonpath
+        pythonpath_parts.extend(p for p in pythonpath.split(os.pathsep) if p)
+    env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(pythonpath_parts))
     # Quiet mode + redaction defaults so the MCP wire stays clean.
     env["HERMES_QUIET"] = "1"
     env["HERMES_REDACT_SECRETS"] = env.get("HERMES_REDACT_SECRETS", "true")
 
     out: dict[str, Any] = {
-        "command": sys.executable,
+        "command": _hermes_tools_python_executable(source_root),
         "args": ["-m", "agent.transports.hermes_tools_mcp_server"],
+        "cwd": str(source_root),
     }
     if env:
         out["env"] = env

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -128,9 +128,22 @@ class TestTranslateOneServer:
 
 
 class TestHermesToolsPythonExecutable:
-    def test_prefers_repo_venv_python_over_current_interpreter(self, tmp_path):
+    def test_prefers_dot_venv_when_both_checkout_environments_exist(self, tmp_path):
         root = tmp_path / "hermes-agent"
-        venv_python = root / "venv" / "bin" / "python3"
+        dot_venv_python = root / ".venv" / "bin" / "python3"
+        legacy_venv_python = root / "venv" / "bin" / "python3"
+        dot_venv_python.parent.mkdir(parents=True)
+        legacy_venv_python.parent.mkdir(parents=True)
+        dot_venv_python.write_text("#!/bin/sh\n")
+        legacy_venv_python.write_text("#!/bin/sh\n")
+
+        chosen = _hermes_tools_python_executable(root, fallback="/usr/bin/python")
+
+        assert chosen == str(dot_venv_python)
+
+    def test_prefers_dot_venv_python_over_current_interpreter(self, tmp_path):
+        root = tmp_path / "hermes-agent"
+        venv_python = root / ".venv" / "bin" / "python3"
         venv_python.parent.mkdir(parents=True)
         venv_python.write_text("#!/bin/sh\n")
 

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 
 import pytest
 
+import hermes_cli.codex_runtime_plugin_migration as migration
 from hermes_cli.codex_runtime_plugin_migration import (
     MIGRATION_MARKER,
     MIGRATION_END_MARKER,
     _build_hermes_tools_mcp_entry,
     _format_toml_value,
+    _hermes_tools_python_executable,
     _looks_like_test_tempdir,
     _strip_existing_managed_block,
     _strip_unmanaged_plugin_tables,
@@ -121,6 +125,55 @@ class TestTranslateOneServer:
     def test_non_dict_input(self):
         cfg, skipped = _translate_one_server("x", "notadict")  # type: ignore[arg-type]
         assert cfg is None
+
+
+class TestHermesToolsPythonExecutable:
+    def test_prefers_repo_venv_python_over_current_interpreter(self, tmp_path):
+        root = tmp_path / "hermes-agent"
+        venv_python = root / "venv" / "bin" / "python3"
+        venv_python.parent.mkdir(parents=True)
+        venv_python.write_text("#!/bin/sh\n")
+
+        chosen = _hermes_tools_python_executable(root, fallback="/usr/bin/python")
+
+        assert chosen == str(venv_python)
+
+    def test_falls_back_when_no_repo_venv_exists(self, tmp_path):
+        assert _hermes_tools_python_executable(tmp_path, fallback="/usr/bin/python") == "/usr/bin/python"
+
+    def test_ignores_non_file_venv_candidate(self, tmp_path):
+        root = tmp_path / "hermes-agent"
+        (root / "venv" / "bin" / "python3").mkdir(parents=True)
+        windows_python = root / "venv" / "Scripts" / "python.exe"
+        windows_python.parent.mkdir(parents=True)
+        windows_python.write_text("", encoding="utf-8")
+
+        chosen = _hermes_tools_python_executable(root, fallback="/usr/bin/python")
+
+        assert chosen == str(windows_python)
+
+
+class TestHermesToolsMcpEntry:
+    def test_entry_pins_source_root_cwd_and_pythonpath(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv(
+            "PYTHONPATH",
+            os.pathsep.join([
+                "/existing/path",
+                str(Path(migration.__file__).resolve().parent.parent),
+            ]),
+        )
+
+        entry = _build_hermes_tools_mcp_entry()
+
+        source_root = Path(migration.__file__).resolve().parent.parent
+        assert entry["args"] == ["-m", "agent.transports.hermes_tools_mcp_server"]
+        assert entry["cwd"] == str(source_root)
+        assert entry["command"] == _hermes_tools_python_executable(source_root)
+        assert entry["env"]["PYTHONPATH"].split(os.pathsep)[:2] == [
+            str(source_root),
+            "/existing/path",
+        ]
 
 
 # ---- TOML rendering ----
@@ -499,6 +552,11 @@ class TestMigrate:
         text = (tmp_path / "config.toml").read_text()
         assert "[mcp_servers.hermes-tools]" in text
         assert "hermes_tools_mcp_server" in text
+        # The callback must be launchable even when Hermes was invoked via
+        # /usr/bin/python and Codex starts the MCP server from an arbitrary
+        # project directory.
+        assert "cwd = " in text
+        assert "PYTHONPATH" in text
         # Must include startup + tool timeouts so codex doesn't give up
         assert "startup_timeout_sec" in text
         assert "tool_timeout_sec" in text

--- a/website/docs/user-guide/features/codex-app-server-runtime.md
+++ b/website/docs/user-guide/features/codex-app-server-runtime.md
@@ -354,6 +354,7 @@ Codex's built-in toolset covers shell/file ops/patches but doesn't have web sear
 [mcp_servers.hermes-tools]
 command = "/path/to/python"
 args = ["-m", "agent.transports.hermes_tools_mcp_server"]
+cwd = "/path/to/hermes-agent"
 env = { HERMES_HOME = "/your/.hermes", PYTHONPATH = "...", HERMES_QUIET = "1" }
 startup_timeout_sec = 30.0
 tool_timeout_sec = 600.0


### PR DESCRIPTION
## Summary
- pin the generated `hermes-tools` MCP server entry to the Hermes source root with `cwd`
- prepend the source root to `PYTHONPATH` so `python -m agent.transports.hermes_tools_mcp_server` remains importable when Codex starts MCP servers from arbitrary project directories
- prefer the checkout `venv`/`.venv` Python for the MCP subprocess, falling back to the current interpreter for packaged installs
- add regression coverage for venv selection, cwd/PYTHONPATH pinning, and migrated TOML output

## Why
Codex can launch configured MCP servers from a project working directory that is not the Hermes checkout. In that case the generated `hermes-tools` callback can fail before the MCP initialize response with `ModuleNotFoundError: No module named 'agent'`, surfacing only as a generic MCP handshake failure.

## Duplicate PR check
I searched open PRs for exact terms around `hermes_tools_mcp_server`, `hermes-tools`, `PYTHONPATH`, `cwd`, `codex_runtime_plugin_migration`, and the initialize-response startup failure. No open PR appears to fix this launch-context issue. Related but non-duplicate PRs include schema/tool-surface work (#26432, #31279), migration rerun behavior (#26532), and generic MCP startup/timeout handling (#29764, #29853, #24508).

## Tests
- `/home/dso2ng/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_codex_runtime_plugin_migration.py -q` (`71 passed`)
- `/home/dso2ng/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/codex_runtime_plugin_migration.py tests/hermes_cli/test_codex_runtime_plugin_migration.py`
