### PR TITLE
fix(config): warn when memory.provider is set alongside memory_enabled=false

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3847,6 +3847,35 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 f"Move '{key}' under the appropriate section",
             ))
 
+    # ── memory: external provider is loaded independently of the in-prompt flags ──
+    # `memory.provider` controls whether an external memory plugin is loaded
+    # (watchdog, recall, capture, persona writes). `memory_enabled` /
+    # `user_profile_enabled` only control whether the LLM is told about the
+    # built-in memory tool in the system prompt. Users (and assistant agents
+    # asked to "disable memory") routinely assume `memory_enabled: false`
+    # turns off the whole subsystem; it doesn't.
+    memory_cfg = config.get("memory")
+    if isinstance(memory_cfg, dict):
+        provider_name = memory_cfg.get("provider")
+        if isinstance(provider_name, str) and provider_name.strip():
+            mem_enabled = memory_cfg.get("memory_enabled", True)
+            user_profile_enabled = memory_cfg.get("user_profile_enabled", True)
+            if mem_enabled is False or user_profile_enabled is False:
+                disabled_flags = []
+                if mem_enabled is False:
+                    disabled_flags.append("memory_enabled")
+                if user_profile_enabled is False:
+                    disabled_flags.append("user_profile_enabled")
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"memory.provider='{provider_name.strip()}' is set but "
+                    f"{'/'.join(disabled_flags)}=false — the plugin still "
+                    "loads (watchdog, recall, capture, persona writes) but "
+                    "the LLM is not told it has memory tools",
+                    "To fully disable the memory plugin, set "
+                    "memory.provider: \"\" (empty string)",
+                ))
+
     return issues
 
 

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -192,6 +192,92 @@ class TestMissingModelSection:
         assert not any("no 'model' section" in i.message for i in issues)
 
 
+class TestMemoryProviderTrap:
+    """memory.provider gates plugin loading independently of memory_enabled / user_profile_enabled.
+
+    Users who set memory_enabled=false expecting the whole subsystem to turn off
+    (watchdog, recall, capture, persona writes) silently keep paying the plugin
+    cost. Warn loudly when this config shape is present. See issue #32624 Trap 1.
+    """
+
+    def test_provider_set_and_memory_enabled_false_warns(self):
+        issues = validate_config_structure({
+            "memory": {
+                "provider": "memory_tencentdb",
+                "memory_enabled": False,
+                "user_profile_enabled": True,
+            },
+        })
+        warnings = [i for i in issues if i.severity == "warning"]
+        match = [i for i in warnings if "memory.provider" in i.message and "memory_enabled" in i.message]
+        assert len(match) == 1, f"Expected one memory-provider warning, got: {warnings}"
+        assert "memory_tencentdb" in match[0].message
+        assert "memory.provider: \"\"" in match[0].hint
+
+    def test_provider_set_and_user_profile_enabled_false_warns(self):
+        issues = validate_config_structure({
+            "memory": {
+                "provider": "honcho",
+                "memory_enabled": True,
+                "user_profile_enabled": False,
+            },
+        })
+        match = [i for i in issues if i.severity == "warning" and "user_profile_enabled" in i.message]
+        assert len(match) == 1
+        assert "honcho" in match[0].message
+
+    def test_provider_set_with_both_flags_false_warns_once(self):
+        issues = validate_config_structure({
+            "memory": {
+                "provider": "mem0",
+                "memory_enabled": False,
+                "user_profile_enabled": False,
+            },
+        })
+        match = [i for i in issues if i.severity == "warning" and "memory.provider" in i.message]
+        # Single combined warning listing both flags — not one per flag.
+        assert len(match) == 1, f"Expected one combined warning, got: {match}"
+        assert "memory_enabled" in match[0].message
+        assert "user_profile_enabled" in match[0].message
+
+    def test_provider_empty_no_warning(self):
+        """The recommended remediation — provider unset — produces no warning."""
+        issues = validate_config_structure({
+            "memory": {
+                "provider": "",
+                "memory_enabled": False,
+                "user_profile_enabled": False,
+            },
+        })
+        assert not any("memory.provider" in i.message for i in issues)
+
+    def test_provider_set_with_both_flags_true_no_warning(self):
+        """Healthy config — provider active and flags on — produces no warning."""
+        issues = validate_config_structure({
+            "memory": {
+                "provider": "hindsight",
+                "memory_enabled": True,
+                "user_profile_enabled": True,
+            },
+        })
+        assert not any("memory.provider" in i.message for i in issues)
+
+    def test_provider_whitespace_only_no_warning(self):
+        """Whitespace-only provider is treated as unset (matches plugin loader)."""
+        issues = validate_config_structure({
+            "memory": {
+                "provider": "   ",
+                "memory_enabled": False,
+            },
+        })
+        assert not any("memory.provider" in i.message for i in issues)
+
+    def test_memory_section_missing_no_crash(self):
+        """No memory section at all — no warning, no crash."""
+        issues = validate_config_structure({})
+        assert not any("memory.provider" in i.message for i in issues)
+
+
 class TestConfigIssueDataclass:
     """ConfigIssue should be a proper dataclass."""
 


### PR DESCRIPTION
## What does this PR do?

`memory.provider` controls whether an external memory plugin is loaded (watchdog, recall, capture, persona writes). `memory_enabled` / `user_profile_enabled` control only whether the LLM is told about the built-in memory tool in the **system prompt**. They do not gate the plugin loader — `plugins/memory/__init__.py:316-318` only reads `memory.provider`.

Users (and assistant agents asked to "disable memory") read `memory_enabled: false` as "turn the whole subsystem off" and observe the plugin watchdog, recall traffic, and persona writes continuing anyway. The reporter spent ~14h debugging exactly this in #32624 Trap 1 before locating the actual gating logic.

This PR implements **Option B** from the issue: an additive `validate_config_structure()` warning that fires when `memory.provider` is non-empty AND (`memory_enabled` is `false` OR `user_profile_enabled` is `false`). Pure warning, no behavior change.

> Audited siblings: `validate_config_structure()` is already wired into `print_config_warnings()` (called at CLI/gateway startup), so no extra plumbing is needed. Other config sections (`custom_providers`, `fallback_model`) follow the same `ConfigIssue` pattern — this addition mirrors them.

## Related Issue

Fixes #32624 (Trap 1 only — Traps 2 and 3 are cleanly separable per the reporter's note and belong in follow-up PRs).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`hermes_cli/config.py\` — extend \`validate_config_structure()\` with a memory-trap check. Warns when \`memory.provider\` is set but \`memory_enabled\` and/or \`user_profile_enabled\` is explicitly \`false\`. Single combined warning when both flags are off; whitespace-only provider treated as unset (matches the plugin loader).
- \`tests/hermes_cli/test_config_validation.py\` — \`TestMemoryProviderTrap\` covers the bug scenario (warns), the recommended remediation (\`provider: \"\"\` → no warning), the healthy default (both flags true → no warning), the both-flags-false case (one combined warning, not two), whitespace handling, and a missing-section guard.

## How to Test

1. \`uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_config_validation.py -v\`
2. Or set the bug-shape config in \`~/.hermes/config.yaml\`:
   \`\`\`yaml
   memory:
     provider: memory_tencentdb
     memory_enabled: false
   \`\`\`
3. Run \`hermes doctor\` or start any CLI command — the warning prints on stderr:
   \`\`\`
   ⚠ memory.provider='memory_tencentdb' is set but memory_enabled=false — the plugin still loads (watchdog, recall, capture, persona writes) but the LLM is not told it has memory tools
   \`\`\`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (\`fix(config):\`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass (28/28)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (warning text is self-documenting)
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — N/A (no new keys)
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure-Python config validator, no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Distinct from Burgunthy's open #30814 \`fix(memory): prevent dead writes when memory_enabled is false\`, which addresses runtime tool-dispatch for the **in-process** \`MemoryStore\` (Option C from the issue — behavior change at \`tool_executor\`). This PR is a purely additive config-load-time warning targeting the **external plugin loader** path the reporter actually hit (memory_tencentdb watchdog continuing for 14h despite \`memory_enabled: false\`). The two are complementary — both can land.