### PR TITLE
fix(gateway): do not interrupt active runs for internal events

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3304,6 +3304,26 @@ class BasePlatformAdapter(ABC):
 
         # Check if there's already an active handler for this session
         if session_key in self._active_sessions:
+            # Internal synthetic events (background process completion/watch
+            # notifications) are routed through the normal adapter so they can
+            # reuse session context, but they are not live user input. Queue
+            # them for the next turn without setting the interrupt guard or
+            # invoking the busy-session handler, otherwise the gateway can emit
+            # a bogus "Interrupting current task" ack and abort user work.
+            if getattr(event, "internal", False):
+                logger.debug(
+                    "[%s] Queuing internal event for active session %s without interrupt",
+                    self.name,
+                    session_key,
+                )
+                merge_pending_message_event(
+                    self._pending_messages,
+                    session_key,
+                    event,
+                    merge_text=True,
+                )
+                return
+
             # Certain commands must bypass the active-session guard and be
             # dispatched directly to the gateway runner.  Without this, they
             # are queued as pending messages and either:

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -47,6 +47,7 @@ def _make_event(
     user_id: str = "u1",
     user_name: str | None = None,
     thread_id: str | None = None,
+    internal: bool = False,
 ) -> MessageEvent:
     source = SessionSource(
         platform=Platform.TELEGRAM,
@@ -61,6 +62,7 @@ def _make_event(
         message_type=MessageType.TEXT,
         source=source,
         message_id=f"msg-{text[:8]}",
+        internal=internal,
     )
 
 
@@ -375,3 +377,32 @@ def test_busy_text_mode_respects_env_var_override(monkeypatch):
     adapter = _make_initialized_adapter()
     assert adapter._busy_text_mode == "interrupt"
     assert not adapter._is_queue_text_debounce_candidate(_make_event("test"))
+
+
+@pytest.mark.asyncio
+async def test_internal_followup_queues_without_interrupting_active_session():
+    """Synthetic process/watch events must not masquerade as live user input.
+
+    Background process notifications use ``MessageEvent.internal=True`` and may
+    arrive while the session they belong to is already processing a real user
+    turn. They should be queued for the next turn without setting the interrupt
+    guard; otherwise the gateway emits a bogus "Interrupting current task" ack
+    and aborts user work even though no user sent a new message.
+    """
+    adapter = _make_adapter()
+    first = _make_event("real user work")
+    session_key = build_session_key(first.source)
+
+    guard = asyncio.Event()
+    adapter._active_sessions[session_key] = guard
+    internal_event = _make_event(
+        '[IMPORTANT: Background process proc_x matched watch pattern "ready".]',
+        internal=True,
+    )
+
+    await adapter.handle_message(internal_event)
+
+    pending = adapter._pending_messages[session_key]
+    assert pending is internal_event
+    assert pending.internal is True
+    assert not guard.is_set(), "internal events must not interrupt the active user turn"


### PR DESCRIPTION
## What does this PR do?

Internal gateway events such as background process watch notifications can arrive while the target session is already running a real user turn. They are synthetic follow-up context, not live user input, so they should be queued for the next turn without tripping the active-session interrupt guard.

This PR queues `MessageEvent.internal=True` events into pending messages when the session is active and leaves the active run's interrupt event unset.

## Related Issue

Related to gateway background/watch notification reliability; no exact issue found during overlap scan.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: queue internal events for active sessions without invoking busy/interrupt handling.
- `tests/gateway/test_active_session_text_merge.py`: add regression coverage that internal follow-up events do not set the active run interrupt guard.

## How to Test

1. `python3 -m py_compile gateway/platforms/base.py tests/gateway/test_active_session_text_merge.py`
2. `uv run --with pytest --with pytest-timeout --with pytest-asyncio python -m pytest tests/gateway/test_active_session_text_merge.py::test_internal_followup_queues_without_interrupting_active_session -q`

Focused result: `1 passed`.

Full `pytest tests/ -q` was not run locally; this is a narrow gateway hotfix branch.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Behavior is covered by the focused regression test above.
