### PR TITLE
fix: quiet Copilot status probes

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -592,11 +592,11 @@ def _resolve_api_key_provider_secret(
         # Use the dedicated copilot auth module for proper token validation
         try:
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
-            token, source = resolve_copilot_token()
+            token, source = resolve_copilot_token(warn_invalid=False)
             if token:
                 return get_copilot_api_token(token), source
         except ValueError as exc:
-            logger.warning("Copilot token validation failed: %s", exc)
+            logger.debug("Copilot token validation failed during status probe: %s", exc)
         except Exception:
             pass
         return "", ""

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -64,11 +64,20 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
     return True, "OK"
 
 
-def resolve_copilot_token() -> tuple[str, str]:
+def resolve_copilot_token(
+    *,
+    warn_invalid: bool = True,
+    include_gh_cli: bool = True,
+) -> tuple[str, str]:
     """Resolve a GitHub token suitable for Copilot API use.
 
     Returns (token, source) where source describes where the token came from.
-    Raises ValueError if only a classic PAT is available.
+    Raises ValueError if only a classic PAT is available from ``gh auth token``.
+
+    ``warn_invalid=False`` is for provider-discovery/status probes: generic
+    ``GH_TOKEN`` / ``GITHUB_TOKEN`` often hold classic PATs for normal GitHub
+    workflows. Those tokens are valid for GitHub but not for Copilot, so probes
+    should not emit noisy warnings unless the user explicitly selects Copilot.
     """
     # 1. Check env vars in priority order
     for env_var in COPILOT_ENV_VARS:
@@ -76,13 +85,14 @@ def resolve_copilot_token() -> tuple[str, str]:
         if val:
             valid, msg = validate_copilot_token(val)
             if not valid:
-                logger.warning(
-                    "Token from %s is not supported: %s", env_var, msg
-                )
+                log = logger.warning if warn_invalid else logger.debug
+                log("Token from %s is not supported: %s", env_var, msg)
                 continue
             return val, env_var
 
     # 2. Fall back to gh auth token
+    if not include_gh_cli:
+        return "", ""
     token = _try_gh_cli_token()
     if token:
         valid, msg = validate_copilot_token(token)

--- a/tests/hermes_cli/test_copilot_status_probe_quiet.py
+++ b/tests/hermes_cli/test_copilot_status_probe_quiet.py
@@ -1,0 +1,44 @@
+"""Regression coverage for quiet Copilot status probes.
+
+Generic GitHub tokens (GH_TOKEN / GITHUB_TOKEN) are often classic PATs that are
+valid for normal GitHub workflows but unusable for Copilot. Provider discovery
+must not warn about them unless Copilot is explicitly selected.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+
+def test_resolve_copilot_token_quiet_probe_skips_classic_pat_without_warning(monkeypatch, caplog):
+    from hermes_cli.copilot_auth import resolve_copilot_token
+
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "ghp_classic_pat_for_regular_github")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_another_regular_github_pat")
+
+    with patch("hermes_cli.copilot_auth._try_gh_cli_token") as gh_cli, caplog.at_level(logging.WARNING):
+        token, source = resolve_copilot_token(warn_invalid=False, include_gh_cli=False)
+
+    assert token == ""
+    assert source == ""
+    gh_cli.assert_not_called()
+    assert "Token from GH_TOKEN is not supported" not in caplog.text
+    assert "Token from GITHUB_TOKEN is not supported" not in caplog.text
+
+
+def test_copilot_provider_status_probe_does_not_warn_on_ambient_classic_pats(monkeypatch, caplog):
+    from hermes_cli.auth import get_api_key_provider_status
+
+    monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "ghp_classic_pat_for_regular_github")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_another_regular_github_pat")
+
+    with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="ghp_cli_classic_pat") as gh_cli, caplog.at_level(logging.WARNING):
+        status = get_api_key_provider_status("copilot")
+
+    assert status["configured"] is False
+    assert status["logged_in"] is False
+    gh_cli.assert_called_once()
+    assert "Copilot token validation failed" not in caplog.text
+    assert "Classic Personal Access Tokens" not in caplog.text


### PR DESCRIPTION
## What does this PR do?

Provider status discovery may probe Copilot while generic `GH_TOKEN` / `GITHUB_TOKEN` values are set for normal GitHub automation. Classic PATs are valid for GitHub but not for Copilot, so a status probe should report Copilot as unconfigured without emitting warning noise.

This PR adds a quiet probe mode to Copilot token resolution and uses it from provider status discovery.

## Related Issue

No exact issue found during overlap scan.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/copilot_auth.py`: add `warn_invalid` / `include_gh_cli` options for probe-safe token resolution.
- `hermes_cli/auth.py`: use quiet Copilot token resolution during provider status checks.
- `tests/hermes_cli/test_copilot_status_probe_quiet.py`: regression coverage for ambient classic PATs.

## How to Test

1. `python3 -m py_compile hermes_cli/auth.py hermes_cli/copilot_auth.py tests/hermes_cli/test_copilot_status_probe_quiet.py`
2. `uv run --with pytest --with pytest-timeout --with pytest-asyncio python -m pytest tests/hermes_cli/test_copilot_status_probe_quiet.py -q`

Focused result: `2 passed`.

Full `pytest tests/ -q` was not run locally; this is a narrow CLI auth/status probe fix.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Behavior is covered by focused logging regression tests.
