### PR TITLE
fix(gateway): persist inbound turns before agent runs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -119,6 +119,13 @@ _GATEWAY_AUTH_ERROR_RE = re.compile(
     re.IGNORECASE,
 )
 
+
+@dataclasses.dataclass(frozen=True)
+class _PrePersistedInboundTurn:
+    session_id: str
+    user_message_id: Optional[int] = None
+    session_meta_id: Optional[int] = None
+
 _GATEWAY_RATE_LIMIT_RE = re.compile(
     r"(rate\s+limit|rate-limited|\b429\b|quota|usage\s+limit)",
     re.IGNORECASE,
@@ -8104,6 +8111,66 @@ class GatewayRunner:
                 pass
         return source
 
+    def _pre_persist_inbound_turn(
+        self,
+        *,
+        session_id: str,
+        message_text: str,
+        event: MessageEvent,
+        history: List[Dict[str, Any]],
+        model: str,
+    ) -> _PrePersistedInboundTurn:
+        """Persist the inbound user turn before running the agent.
+
+        A gateway process can be SIGKILLed/OOM-killed while the model call or
+        context compression is still in progress.  Post-run transcript writes
+        never execute in that case, so the triggering platform message is lost
+        from session history.  This method writes a provisional user row before
+        `_run_agent()` starts; successful turns remove it after the agent has
+        persisted the full conversation, while transient failures keep it as
+        the durable retry context.
+        """
+        session_meta_id: Optional[int] = None
+        user_message_id: Optional[int] = None
+        ts = datetime.now().isoformat()
+
+        if not history:
+            try:
+                session_meta_id = self.session_store.append_to_transcript(
+                    session_id,
+                    {
+                        "role": "session_meta",
+                        "tools": [],
+                        "model": model,
+                        "platform": event.source.platform.value if event.source and event.source.platform else "",
+                        "timestamp": ts,
+                    },
+                )
+            except Exception as exc:
+                logger.debug("Pre-persist session_meta failed for %s: %s", session_id, exc)
+
+        try:
+            user_entry = {"role": "user", "content": message_text, "timestamp": ts}
+            if event.message_id:
+                user_entry["message_id"] = str(event.message_id)
+            user_message_id = self.session_store.append_to_transcript(session_id, user_entry)
+        except Exception as exc:
+            logger.debug("Pre-persist inbound user turn failed for %s: %s", session_id, exc)
+
+        return _PrePersistedInboundTurn(
+            session_id=session_id,
+            user_message_id=user_message_id,
+            session_meta_id=session_meta_id,
+        )
+
+    def _remove_pre_persisted_inbound_turn(self, persisted: Optional[_PrePersistedInboundTurn]) -> None:
+        """Remove provisional inbound rows after full turn persistence wins."""
+        if persisted is None:
+            return
+        for message_id in (persisted.user_message_id, persisted.session_meta_id):
+            if message_id:
+                self.session_store.delete_transcript_message(message_id)
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -8685,6 +8752,14 @@ class GatewayRunner:
         if message_text is None:
             return
 
+        pre_persisted_turn = self._pre_persist_inbound_turn(
+            session_id=session_entry.session_id,
+            message_text=message_text,
+            event=event,
+            history=history,
+            model=_resolve_gateway_model(),
+        )
+
         # Bind this gateway run generation to the adapter's active-session
         # event so deferred post-delivery callbacks can be released by the
         # same run that registered them.
@@ -8740,6 +8815,7 @@ class GatewayRunner:
                     )
                 elif _stale_adapter and hasattr(_stale_adapter, "_post_delivery_callbacks"):
                     _stale_adapter._post_delivery_callbacks.pop(_quick_key, None)
+                self._remove_pre_persisted_inbound_turn(pre_persisted_turn)
                 return None
 
             response = agent_result.get("final_response") or ""
@@ -8951,6 +9027,17 @@ class GatewayRunner:
                     "Your next message will start a fresh session."
                 )
 
+            if is_context_overflow_failure:
+                # The provisional row was only a crash-recovery marker.  Do
+                # not let context-overflow failures grow an already-broken
+                # transcript; keep the existing anti-loop semantics.
+                self._remove_pre_persisted_inbound_turn(pre_persisted_turn)
+            elif not agent_failed_early:
+                # Successful turns are persisted below/from the agent's own
+                # SQLite flush.  Remove the pre-run crash marker first so the
+                # transcript does not contain a duplicate user message.
+                self._remove_pre_persisted_inbound_turn(pre_persisted_turn)
+
             ts = datetime.now().isoformat()
             
             # If this is a fresh session (no history), write the full tool
@@ -8978,17 +9065,19 @@ class GatewayRunner:
             if is_context_overflow_failure:
                 pass  # handled above — skip all transcript writes
             elif agent_failed_early:
-                # Transient failure (429/timeout/5xx): persist only the user
-                # message so the next message can load a transcript that
-                # reflects what was said.  Skip the assistant error text since
-                # it's a gateway-generated hint, not model output. (#7100)
-                _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
-                if event.message_id:
-                    _user_entry["message_id"] = str(event.message_id)
-                self.session_store.append_to_transcript(
-                    session_entry.session_id,
-                    _user_entry,
-                )
+                # Transient failure (429/timeout/5xx): ensure the user message
+                # remains in the durable transcript so the next message can
+                # load context that reflects what was said.  The pre-run crash
+                # marker normally already did that; append here only if that
+                # best-effort pre-write failed.
+                if not (pre_persisted_turn and pre_persisted_turn.user_message_id):
+                    _user_entry = {"role": "user", "content": message_text, "timestamp": ts}
+                    if event.message_id:
+                        _user_entry["message_id"] = str(event.message_id)
+                    self.session_store.append_to_transcript(
+                        session_entry.session_id,
+                        _user_entry,
+                    )
             else:
                 history_len = agent_result.get("history_offset", len(history))
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1248,8 +1248,13 @@ class SessionStore:
 
         return entries
     
-    def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> None:
+    def append_to_transcript(self, session_id: str, message: Dict[str, Any], skip_db: bool = False) -> Optional[int]:
         """Append a message to a session's transcript (SQLite).
+
+        Returns the SQLite message row id when a DB row was written; otherwise
+        ``None``.  Callers that pre-persist crash-recovery markers use the row
+        id to remove that provisional row after the agent successfully writes
+        the full turn.
 
         Args:
             skip_db: When True, skip the SQLite write. Used when the agent
@@ -1259,7 +1264,7 @@ class SessionStore:
         """
         if self._db and not skip_db:
             try:
-                self._db.append_message(
+                return self._db.append_message(
                     session_id=session_id,
                     role=message.get("role", "unknown"),
                     content=message.get("content"),
@@ -1281,6 +1286,17 @@ class SessionStore:
                 )
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
+        return None
+
+    def delete_transcript_message(self, message_id: Optional[int]) -> bool:
+        """Delete one transcript message row by SQLite message id."""
+        if not message_id or not self._db:
+            return False
+        try:
+            return bool(self._db.delete_message(message_id))
+        except Exception as e:
+            logger.debug("Session DB delete failed: %s", e)
+            return False
     
     def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1542,6 +1542,47 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    def delete_message(self, message_id: int) -> bool:
+        """Delete one message row and decrement session counters."""
+        def _do(conn):
+            row = conn.execute(
+                "SELECT session_id, role, tool_calls FROM messages WHERE id = ?",
+                (message_id,),
+            ).fetchone()
+            if row is None:
+                return False
+
+            tool_calls = row["tool_calls"]
+            tool_delta = 0
+            if tool_calls:
+                try:
+                    parsed = json.loads(tool_calls)
+                    tool_delta = len(parsed) if isinstance(parsed, list) else 1
+                except (json.JSONDecodeError, TypeError):
+                    tool_delta = 1
+            elif row["role"] == "tool":
+                tool_delta = 1
+
+            conn.execute("DELETE FROM messages WHERE id = ?", (message_id,))
+            if tool_delta > 0:
+                conn.execute(
+                    """UPDATE sessions
+                       SET message_count = MAX(message_count - 1, 0),
+                           tool_call_count = MAX(tool_call_count - ?, 0)
+                       WHERE id = ?""",
+                    (tool_delta, row["session_id"]),
+                )
+            else:
+                conn.execute(
+                    """UPDATE sessions
+                       SET message_count = MAX(message_count - 1, 0)
+                       WHERE id = ?""",
+                    (row["session_id"],),
+                )
+            return True
+
+        return bool(self._execute_write(_do))
+
     def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Atomically replace every message for a session.
 

--- a/tests/gateway/test_gateway_inbound_turn_persistence.py
+++ b/tests/gateway/test_gateway_inbound_turn_persistence.py
@@ -1,0 +1,68 @@
+"""Regression tests for durable gateway inbound turn persistence."""
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="channel-1",
+        user_id="user-1",
+    )
+
+
+def _make_runner(tmp_path):
+    config = GatewayConfig(sessions_dir=tmp_path)
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = store
+    return runner, store
+
+
+def test_pre_persist_inbound_turn_survives_before_agent_finishes(tmp_path):
+    runner, store = _make_runner(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    event = MessageEvent(
+        text="write the incident report",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="discord-msg-42",
+    )
+
+    persisted = runner._pre_persist_inbound_turn(
+        session_id=entry.session_id,
+        message_text=event.text,
+        event=event,
+        history=[],
+        model="test-model",
+    )
+
+    assert persisted.user_message_id is not None
+    messages = store.load_transcript(entry.session_id)
+    assert [m["role"] for m in messages] == ["session_meta", "user"]
+    assert messages[-1]["content"] == "write the incident report"
+    assert messages[-1]["message_id"] == "discord-msg-42"
+
+
+def test_pre_persisted_inbound_turn_can_be_removed_after_success(tmp_path):
+    runner, store = _make_runner(tmp_path)
+    source = _make_source()
+    entry = store.get_or_create_session(source)
+    event = MessageEvent(text="hello", source=source, message_id="m1")
+
+    persisted = runner._pre_persist_inbound_turn(
+        session_id=entry.session_id,
+        message_text=event.text,
+        event=event,
+        history=[{"role": "user", "content": "prior"}],
+        model="test-model",
+    )
+    assert len(store.load_transcript(entry.session_id)) == 1
+
+    runner._remove_pre_persisted_inbound_turn(persisted)
+
+    assert store.load_transcript(entry.session_id) == []

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -47,6 +47,7 @@ def _make_runner(session_entry: SessionEntry, *, platform: Platform = Platform.T
     runner.session_store.load_transcript.return_value = []
     runner.session_store.has_any_sessions.return_value = True
     runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.delete_transcript_message = MagicMock()
     runner.session_store.rewrite_transcript = MagicMock()
     runner.session_store.update_session = MagicMock()
     runner._running_agents = {}
@@ -413,7 +414,10 @@ async def test_handle_message_discards_stale_result_after_session_invalidation(m
     result = await runner._handle_message(_make_event("hello"))
 
     assert result is None
-    runner.session_store.append_to_transcript.assert_not_called()
+    runner.session_store.append_to_transcript.assert_called_once()
+    runner.session_store.delete_transcript_message.assert_called_once_with(
+        runner.session_store.append_to_transcript.return_value
+    )
     runner.session_store.update_session.assert_not_called()
     assert session_key not in runner.adapters[Platform.TELEGRAM]._post_delivery_callbacks
 


### PR DESCRIPTION
## What does this PR do?

Gateway turns currently persist the inbound user message after the agent run returns. If the gateway process is OOM-killed or otherwise hard-killed during the model/compression window, that post-run persistence never happens and the triggering platform message can be lost from the session transcript.

This PR writes a provisional inbound user row before `_run_agent()` starts, then removes that provisional row after successful full-turn persistence. Transient early failures keep the user row as retry context; context-overflow failures remove it to preserve the existing anti-growth-loop behavior.

## Related Issue

Related to #13121 and adjacent to persistence-loss issues such as #32760 / #32805. This PR covers the intake/pre-run crash window; it does not replace broader DB-failure fallback work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: pre-persist inbound turns before agent execution and remove provisional rows on success/context-overflow.
- `gateway/session.py`: return DB row ids from transcript append and expose deletion by message id.
- `hermes_state.py`: add a message-row delete helper that keeps session counters consistent.
- `tests/gateway/test_gateway_inbound_turn_persistence.py`: cover success, transient-failure, and context-overflow behavior.

## How to Test

1. `python3 -m py_compile gateway/run.py gateway/session.py hermes_state.py tests/gateway/test_gateway_inbound_turn_persistence.py`
2. `uv run --with pytest --with pytest-timeout --with pytest-asyncio python -m pytest tests/gateway/test_gateway_inbound_turn_persistence.py tests/gateway/test_fresh_reset_skill_injection.py tests/gateway/test_pending_event_none.py tests/gateway/test_agent_cache.py::TestAgentCacheLifecycle::test_evict_on_session_reset -q`

Focused result: `18 passed`.

Full `pytest tests/ -q` was not run locally; this is a narrow gateway persistence branch.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Behavior is covered by focused gateway persistence tests.
