### PR TITLE
fix(gateway): respect explicit global unauthorized_dm_behavior: pair when allowlists are configured

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -484,6 +484,11 @@ class GatewayConfig:
 
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
+    _global_unauthorized_dm_behavior_explicit: bool = field(
+        default=False,
+        repr=False,
+        compare=False,
+    )
 
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
@@ -669,6 +674,13 @@ class GatewayConfig:
                 )
         return self.unauthorized_dm_behavior
 
+    def has_explicit_global_unauthorized_dm_behavior(self) -> bool:
+        """Return whether the global unauthorized-DM policy was explicitly set."""
+        return (
+            self._global_unauthorized_dm_behavior_explicit
+            or self.unauthorized_dm_behavior != "pair"
+        )
+
     def get_notice_delivery(self, platform: Optional[Platform] = None) -> str:
         """Return the effective notice-delivery mode for a platform."""
         if platform:
@@ -693,6 +705,7 @@ def load_gateway_config() -> GatewayConfig:
     """
     _home = get_hermes_home()
     gw_data: dict = {}
+    explicit_global_unauthorized_dm_behavior = False
 
     # Legacy fallback: gateway.json provides the base layer.
     # config.yaml keys always win when both specify the same setting.
@@ -758,6 +771,7 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
 
             if "unauthorized_dm_behavior" in yaml_cfg:
+                explicit_global_unauthorized_dm_behavior = True
                 gw_data["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(
                     yaml_cfg.get("unauthorized_dm_behavior"),
                     "pair",
@@ -1128,6 +1142,7 @@ def load_gateway_config() -> GatewayConfig:
         )
 
     config = GatewayConfig.from_dict(gw_data)
+    config._global_unauthorized_dm_behavior_explicit = explicit_global_unauthorized_dm_behavior
 
     # Override with environment variables
     _apply_env_overrides(config)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6610,7 +6610,7 @@ class GatewayRunner:
 
         # Check for an explicit global config override.
         if config and hasattr(config, "unauthorized_dm_behavior"):
-            if config.unauthorized_dm_behavior != "pair":  # non-default → explicit override
+            if config.has_explicit_global_unauthorized_dm_behavior():
                 return config.unauthorized_dm_behavior
 
         # No explicit override.  Fall back to allowlist-aware default:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -102,6 +102,7 @@ AUTHOR_MAP = {
     "30312689+aashizpoudel@users.noreply.github.com": "aashizpoudel",
     "oleksii.lisikh@gmail.com": "olisikh",
     "jithendranaidunara@gmail.com": "JithendraNara",
+    "byquenox@gmail.com": "quen0xi",
     "jeremy@geocaching.com": "outdoorsea",
     "54763683+thedavidmurray@users.noreply.github.com": "thedavidmurray",
     "leone.parise@gmail.com": "leoneparise",

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.config import GatewayConfig, Platform, PlatformConfig, load_gateway_config
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionSource
 
@@ -720,6 +720,28 @@ def test_explicit_pair_config_overrides_allowlist_default(monkeypatch):
     runner, _adapter = _make_runner(Platform.SIGNAL, config)
 
     # The per-platform explicit config should beat the allowlist-derived default
+    behavior = runner._get_unauthorized_dm_behavior(Platform.SIGNAL)
+    assert behavior == "pair"
+
+
+def test_global_pair_config_yaml_overrides_allowlist_default(monkeypatch, tmp_path):
+    """Top-level config.yaml pair override beats the allowlist-derived ignore."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SIGNAL_ALLOWED_USERS", "+15550000001")
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "unauthorized_dm_behavior: pair\n"
+        "signal:\n"
+        "  enabled: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    config = load_gateway_config()
+    runner, _adapter = _make_runner(Platform.SIGNAL, config)
+
     behavior = runner._get_unauthorized_dm_behavior(Platform.SIGNAL)
     assert behavior == "pair"
 


### PR DESCRIPTION
## Summary

Fixes a gateway auth-policy regression where an explicitly configured global `unauthorized_dm_behavior: pair` was ignored when allowlists were configured.

Previously, `_get_unauthorized_dm_behavior()` inferred whether the global policy was explicit by checking the value itself. Because `"pair"` is also the default, an explicit top-level setting of:

    unauthorized_dm_behavior: pair

was treated as implicit and could be overridden by the allowlist-derived default of `"ignore"`.

## Why this is merge-worthy

This bug broke the documented precedence rules in `configuration.md`. Operators who explicitly opted back into pairing could still get `"ignore"` behavior whenever allowlists were present.

## Scope of changes

- `gateway/config.py`
  - Track whether the global `unauthorized_dm_behavior` was explicitly set in `config.yaml`
- `gateway/run.py`
  - Use that explicitness signal in `_get_unauthorized_dm_behavior()` instead of relying on `!= "pair"`
- `tests/gateway/test_unauthorized_dm_behavior.py`
  - Add regression coverage for explicit global `pair` with allowlists

## Verified tests

Targeted test runs passed:

- `tests/gateway/test_unauthorized_dm_behavior.py`
  - `test_explicit_pair_config_overrides_allowlist_default`
  - `test_global_pair_config_yaml_overrides_allowlist_default`
  - `test_allowlist_authorized_user_returns_ignore_for_unauthorized`
  - `test_get_unauthorized_dm_behavior_no_allowlist_returns_pair`
  - Result: `4 passed, 27 deselected`

- `tests/gateway/test_config.py`
  - `test_bridges_unauthorized_dm_behavior_from_config_yaml`
  - Result: `1 passed, 47 deselected`