### PR TITLE
chore(release): map WaefreBeorn bounty email

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -91,6 +91,7 @@ AUTHOR_MAP = {
     "3153586+xzessmedia@users.noreply.github.com": "xzessmedia",
     "AdamPlatin123@outlook.com": "AdamPlatin123",
     "32711803+waefrebeorn@users.noreply.github.com": "waefrebeorn",
+    "wubu.bounty.hunter@users.noreply.github.com": "waefrebeorn",
     "32869278+dusterbloom@users.noreply.github.com": "dusterbloom",
     "liuhao1024@users.noreply.github.com": "liuhao1024",
     "kylekahraman@users.noreply.github.com": "kylekahraman",


### PR DESCRIPTION
## Summary
- Add AUTHOR_MAP entry for wubu.bounty.hunter@users.noreply.github.com -> waefrebeorn
- Fixes the contributor attribution check failure on #32835

## Test Plan
- python3 -m py_compile scripts/release.py
- verified mapping string is present on a clean origin/main-based branch