### PR TITLE
feat(memory): migrate legacy memories to holographic store

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -172,6 +172,17 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+PINCHER_FIRST_GUIDANCE = (
+    "[Pincher Router — code navigation directive]\n"
+    "For ALL code lookups, follow this order:\n"
+    "  1. mcp_pincher_search   — find a symbol by name or keyword\n"
+    "  2. mcp_pincher_context  — read a symbol + its imports before editing\n"
+    "  3. mcp_pincher_trace    — check callers before changing a signature\n"
+    "  4. mcp_pincher_changes  — blast-radius check before finalising edits\n"
+    "Do NOT call Read / Grep / Glob for code navigation until Pincher returns no result. "
+    "Every Pincher call generates a routing signal that reduces your cost per turn."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -34,6 +34,7 @@ from agent.prompt_builder import (
     KANBAN_GUIDANCE,
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
+    PINCHER_FIRST_GUIDANCE,
     PLATFORM_HINTS,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
@@ -108,6 +109,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
+    if any(name.startswith("mcp_pincher_") for name in agent.valid_tool_names):
+        tool_guidance.append(PINCHER_FIRST_GUIDANCE)
     # Kanban worker/orchestrator lifecycle — only present when the
     # dispatcher spawned this process (kanban_show check_fn gates on
     # HERMES_KANBAN_TASK env var). Normal chat sessions never see

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from pathlib import Path
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -179,6 +180,8 @@ class HolographicMemoryProvider(MemoryProvider):
             hrr_dim=hrr_dim,
         )
         self._session_id = session_id
+        if self._config.get("migrate_legacy_files", True):
+            self._migrate_legacy_memory_files(Path(_hermes_home))
 
     def system_prompt_block(self) -> str:
         if not self._store:
@@ -243,12 +246,60 @@ class HolographicMemoryProvider(MemoryProvider):
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes as facts."""
-        if action == "add" and self._store and content:
+        if action in {"add", "replace"} and self._store and content:
             try:
                 category = "user_pref" if target == "user" else "general"
-                self._store.add_fact(content, category=category)
+                self._store.add_fact(content, category=category, tags="legacy-memory-write")
             except Exception as e:
                 logger.debug("Holographic memory_write mirror failed: %s", e)
+
+    def _migrate_legacy_memory_files(self, hermes_home: Path) -> None:
+        """Backfill built-in MEMORY.md / USER.md entries into holographic facts.
+
+        The built-in memory files remain the always-on compact prompt source. This
+        migration makes those same entries available to fact_store's search/probe/
+        reason path and relies on MemoryStore.add_fact's content-level UNIQUE
+        constraint for idempotency.
+        """
+        if not self._store:
+            return
+        memory_dir = hermes_home / "memories"
+        sources = (
+            (memory_dir / "USER.md", "user_pref"),
+            (memory_dir / "MEMORY.md", "general"),
+        )
+        migrated = 0
+        for path, category in sources:
+            try:
+                text = path.read_text(encoding="utf-8-sig")
+            except FileNotFoundError:
+                continue
+            except Exception as exc:
+                logger.debug("Could not read legacy memory file %s: %s", path, exc)
+                continue
+            for entry in self._iter_legacy_memory_entries(text):
+                try:
+                    self._store.add_fact(
+                        entry,
+                        category=category,
+                        tags="legacy-memory-migration",
+                    )
+                    migrated += 1
+                except Exception as exc:
+                    logger.debug("Legacy memory migration failed for %s: %s", path, exc)
+        if migrated:
+            logger.info("Migrated %d legacy memory entries into holographic memory", migrated)
+
+    @staticmethod
+    def _iter_legacy_memory_entries(text: str) -> list[str]:
+        """Return durable fact entries from a built-in memory markdown file."""
+        entries: list[str] = []
+        for raw in re.split(r"\n\s*§\s*\n", text):
+            entry = raw.strip()
+            if not entry:
+                continue
+            entries.append(entry)
+        return entries
 
     def shutdown(self) -> None:
         self._store = None

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -923,6 +923,52 @@ class TestOnMemoryWriteBridge:
         mgr.on_memory_write("replace", "user", "updated pref")
         assert p.memory_writes == [("replace", "user", "updated pref")]
 
+    def test_holographic_provider_migrates_legacy_memory_files(self, tmp_path, monkeypatch):
+        """Holographic memory backfills current MEMORY.md / USER.md into facts."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+        import hermes_constants
+
+        hermes_home = tmp_path / "home"
+        memory_dir = hermes_home / "memories"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "USER.md").write_text("User prefers concise updates.\n§\nUser likes Pincher-first work.", encoding="utf-8")
+        (memory_dir / "MEMORY.md").write_text("Project uses pytest.\n§\nTool quirk: ddgs is search-only.", encoding="utf-8")
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: hermes_home)
+
+        provider = HolographicMemoryProvider({"db_path": str(tmp_path / "memory_store.db")})
+        provider.initialize("session-1")
+        assert provider._store is not None
+
+        user_facts = provider._store.list_facts(category="user_pref", min_trust=0.0, limit=10)
+        general_facts = provider._store.list_facts(category="general", min_trust=0.0, limit=10)
+        assert {fact["content"] for fact in user_facts} == {
+            "User prefers concise updates.",
+            "User likes Pincher-first work.",
+        }
+        assert {fact["content"] for fact in general_facts} == {
+            "Project uses pytest.",
+            "Tool quirk: ddgs is search-only.",
+        }
+
+        # Re-initialization is idempotent via MemoryStore.add_fact's UNIQUE content constraint.
+        provider.initialize("session-2")
+        assert provider._store.list_facts(min_trust=0.0, limit=20)
+        assert len(provider._store.list_facts(min_trust=0.0, limit=20)) == 4
+
+    def test_holographic_on_memory_write_mirrors_replacements(self, tmp_path):
+        """The live write hook mirrors both add and replace into fact_store."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+
+        provider = HolographicMemoryProvider({"db_path": str(tmp_path / "memory_store.db")})
+        provider.initialize("session-1")
+        assert provider._store is not None
+        provider.on_memory_write("replace", "user", "User now prefers default Codex over Qwen fallback.")
+
+        facts = provider._store.list_facts(category="user_pref", min_trust=0.0, limit=10)
+        assert [fact["content"] for fact in facts] == [
+            "User now prefers default Codex over Qwen fallback."
+        ]
+
     def test_on_memory_write_remove_not_bridged(self):
         """The bridge intentionally skips 'remove' — only add/replace notify."""
         # This tests the contract that run_agent.py checks:

--- a/tests/run_agent/test_pincher_first_prompt_guidance.py
+++ b/tests/run_agent/test_pincher_first_prompt_guidance.py
@@ -1,0 +1,64 @@
+"""Regression tests for Pincher-first prompt guidance injection."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list[dict]:
+    """Build minimal tool definitions accepted by AIAgent.__init__."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent_with_tools(*tool_names: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def test_pincher_first_guidance_injected_when_pincher_mcp_tools_loaded():
+    agent = _make_agent_with_tools(
+        "mcp_pincher_search",
+        "mcp_pincher_context",
+        "mcp_pincher_trace",
+        "mcp_pincher_changes",
+        "read_file",
+    )
+
+    prompt = agent._build_system_prompt()
+
+    assert "mcp_pincher_search" in prompt
+    assert "mcp_pincher_context" in prompt
+    assert "mcp_pincher_trace" in prompt
+    assert "mcp_pincher_changes" in prompt
+    assert "Do NOT call Read / Grep / Glob for code navigation until Pincher returns no result" in prompt
+
+
+def test_pincher_first_guidance_not_injected_without_pincher_mcp_tools():
+    agent = _make_agent_with_tools("read_file", "search_files", "terminal")
+
+    prompt = agent._build_system_prompt()
+
+    assert "mcp_pincher_search" not in prompt
+    assert "Do NOT call Read / Grep / Glob for code navigation until Pincher returns no result" not in prompt


### PR DESCRIPTION
## Summary
- inject Pincher-first guidance into the system prompt when Pincher MCP tools are loaded
- migrate legacy `MEMORY.md` / `USER.md` entries into the holographic `fact_store` so deep recall has the same durable facts
- add regression coverage for Pincher-first prompt injection and holographic legacy-memory migration/idempotency

## Verification
- `scripts/run_tests.sh tests/run_agent/test_pincher_first_prompt_guidance.py tests/agent/test_memory_provider.py::TestOnMemoryWriteBridge`
- `scripts/run_tests.sh tests/agent/test_memory_provider.py tests/run_agent/test_run_agent.py tests/gateway/test_agent_cache.py tests/tools/test_kanban_tools.py`
- Pincher blast-radius: `mcp_pincher_changes scope=base:origin/main depth=3` → 5 changed files, 18 changed symbols, 46 impacted callers, 37 suggested tests

## Notes
- Direct push to upstream `origin/main` failed with GitHub 403 for `kwad77`, so this PR is opened from the `kwad77` fork branch.
