### PR TITLE
Fix CI tests for update stream reloads and web plugin registry

### DIFF
--- a/tests/hermes_cli/test_update_hangup_protection.py
+++ b/tests/hermes_cli/test_update_hangup_protection.py
@@ -9,6 +9,7 @@ that ``hermes update`` survives a terminal disconnect mid-install
 from __future__ import annotations
 
 import io
+import importlib
 import os
 import signal
 import sys
@@ -22,6 +23,31 @@ from hermes_cli.main import (
     _finalize_update_output,
     _install_hangup_protection,
 )
+
+
+@pytest.fixture(autouse=True)
+def _refresh_bindings_against_live_module():
+    """Rebind module-level names to the *current* ``hermes_cli.main``.
+
+    Some CLI tests delete/reload ``hermes_cli.main`` in ``sys.modules``.
+    If that happens before these tests run in the same process, our
+    top-of-file ``from hermes_cli.main import ...`` bindings may point to a
+    stale module object (and a different ``_UpdateOutputStream`` class).
+    Refreshing the bindings makes ``isinstance(..., _UpdateOutputStream)``
+    robust under reloads.
+    """
+    global _UpdateOutputStream
+    global _finalize_update_output
+    global _install_hangup_protection
+
+    live = sys.modules.get("hermes_cli.main")
+    if live is None:
+        live = importlib.import_module("hermes_cli.main")
+
+    _UpdateOutputStream = live._UpdateOutputStream
+    _finalize_update_output = live._finalize_update_output
+    _install_hangup_protection = live._install_hangup_protection
+    yield
 
 
 # -----------------------------------------------------------------------------

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -78,6 +78,7 @@ class TestBundledPluginsRegister:
         from agent.web_search_registry import list_providers
 
         names = sorted(p.name for p in list_providers())
+        # All eight bundled providers should be present (including xai).
         assert names == [
             "brave-free",
             "ddgs",


### PR DESCRIPTION
## What does this PR do?

This PR fixes two CI test issues:

* Refreshes hangup protection test bindings against the live `hermes_cli.main` module to avoid stale `_UpdateOutputStream` class references when other CLI tests delete/reload `hermes_cli.main` in the same test process.
* Clarifies that the bundled web search provider registry now contains eight providers, including `xai`.

This is a test-only change. No production implementation code was changed.

## Related Issue

N/A — no linked issue.

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 🔒 Security fix
* [ ] 📝 Documentation update
* [x] ✅ Tests (adding or improving test coverage)
* [ ] ♻️ Refactor (no behavior change)
* [ ] 🎯 New skill (bundled or hub)

## Changes Made

* `tests/hermes_cli/test_update_hangup_protection.py`

  * Added an autouse fixture that refreshes `_UpdateOutputStream`, `_install_hangup_protection`, and `_finalize_update_output` from the current live `hermes_cli.main` module before each test.
  * This makes the test robust when other CLI tests reload `hermes_cli.main`.

* `tests/plugins/web/test_web_search_provider_plugins.py`

  * Added a comment clarifying that all eight bundled web search providers should be present, including `xai`.

## How to Test

1. Run the affected test files:

`scripts/run_tests.sh tests/hermes_cli/test_update_hangup_protection.py tests/plugins/web/test_web_search_provider_plugins.py`

2. Expected result:

`66 tests passed, 0 failed`

3. Verified locally on Ubuntu 24.04 under WSL2.

## Checklist

### Code

* [ ] I've read the [[Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
* [ ] My commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
* [ ] I searched for [[existing PRs](https://github.com/NousResearch/hermes-agent/pulls)](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
* [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
* [ ] I've run `pytest tests/ -q` and all tests pass
* [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
* [x] I've tested on my platform: Ubuntu 24.04 WSL2 on Windows 11

### Documentation & Housekeeping

* [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
* [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
* [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
* [x] I've considered cross-platform impact (Windows, macOS) per the [[compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
* [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add or modify a skill.

## Screenshots / Logs

`scripts/run_tests.sh tests/hermes_cli/test_update_hangup_protection.py tests/plugins/web/test_web_search_provider_plugins.py`

Result:

`=== Summary: 2 files, 66 tests passed, 0 failed (100% complete) in 2.0s (64 workers) ===`