### PR TITLE
fix: address 13 minor bugs, typos, and inconsistencies

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,7 +25,7 @@ import ssl
 import threading
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from agent.anthropic_adapter import _is_oauth_token
 from agent.auxiliary_client import set_runtime_main
@@ -266,7 +266,7 @@ def run_conversation(
     system_message: str = None,
     conversation_history: List[Dict[str, Any]] = None,
     task_id: str = None,
-    stream_callback: Optional[callable] = None,
+    stream_callback: Optional[Callable] = None,
     persist_user_message: Optional[str] = None,
 ) -> Dict[str, Any]:
     """

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1010,7 +1010,7 @@ class BatchRunner:
             checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
-            print(f"âš ï¸  Warning: Failed to save final checkpoint: {ckpt_err}")
+            print(f"⚠️  Warning: Failed to save final checkpoint: {ckpt_err}")
         
         # Calculate success rates
         for tool_name in total_tool_stats:

--- a/cli.py
+++ b/cli.py
@@ -2832,7 +2832,7 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
     return parsed
 
 
-def save_config_value(key_path: str, value: any) -> bool:
+def save_config_value(key_path: str, value: Any) -> bool:
     """
     Save a value to the active config file at the specified key path.
     

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -88,6 +88,14 @@ def get_timezone() -> Optional[ZoneInfo]:
     return _cached_tz
 
 
+def reset_cache() -> None:
+    """Clear the cached timezone so the next ``get_timezone()`` call re-resolves."""
+    global _cached_tz, _cached_tz_name, _cache_resolved
+    _cached_tz = None
+    _cached_tz_name = None
+    _cache_resolved = False
+
+
 def now() -> datetime:
     """
     Return the current time as a timezone-aware datetime.

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -26,7 +26,7 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
     from hermes_constants import get_hermes_home
@@ -340,7 +340,7 @@ def quick() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def deep(
-    confirm: Optional[callable] = None,
+    confirm: Optional[Callable] = None,
 ) -> Dict[str, Any]:
     """Deep cleanup.
 

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -437,7 +437,7 @@ class MemoryStore:
         """
         # Exact name match
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id FROM entities WHERE LOWER(name) = LOWER(?)", (name,)
         ).fetchone()
         if row is not None:
             return int(row["entity_id"])

--- a/run_agent.py
+++ b/run_agent.py
@@ -1250,7 +1250,7 @@ class AIAgent:
         a raw ``tool`` message and the next user turn lands as
         ``...tool, user, user`` — a protocol-invalid sequence that most
         providers silently reject (returns empty content), causing the
-        empty-retry loop to fire forever. See #<TBD>.
+        empty-retry loop to fire forever.
         """
         # Pass 1: strip the flagged scaffolding messages themselves.
         dropped_scaffolding = False
@@ -2283,7 +2283,7 @@ class AIAgent:
             self._todo_store.write(last_todo_response, merge=False)
             if not self.quiet_mode:
                 self._vprint(f"{self.log_prefix}📋 Restored {len(last_todo_response)} todo item(s) from history")
-        _set_interrupt(False)
+        _set_interrupt(False, self._execution_thread_id)
 
     @property
     def is_interrupted(self) -> bool:

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -80,7 +80,7 @@ def register_credential_file(
     host_path = hermes_home / relative_path
 
     # Resolve symlinks and normalise ``..`` before the containment check so
-    # that traversal like ``../. ssh/id_rsa`` cannot escape HERMES_HOME.
+    # that traversal like ``../.ssh/id_rsa`` cannot escape HERMES_HOME.
     from tools.path_security import validate_within_dir
 
     containment_error = validate_within_dir(host_path, hermes_home)

--- a/tools/fuzzy_match.py
+++ b/tools/fuzzy_match.py
@@ -6,15 +6,16 @@ Implements a multi-strategy matching chain to robustly find and replace text,
 accommodating variations in whitespace, indentation, and escaping common
 in LLM-generated code.
 
-The 8-strategy chain (inspired by OpenCode), tried in order:
+The 9-strategy chain (inspired by OpenCode), tried in order:
 1. Exact match - Direct string comparison
 2. Line-trimmed - Strip leading/trailing whitespace per line
 3. Whitespace normalized - Collapse multiple spaces/tabs to single space
 4. Indentation flexible - Ignore indentation differences entirely
 5. Escape normalized - Convert \\n literals to actual newlines
 6. Trimmed boundary - Trim first/last line whitespace only
-7. Block anchor - Match first+last lines, use similarity for middle
-8. Context-aware - 50% line similarity threshold
+7. Unicode normalized - Normalize unicode representations
+8. Block anchor - Match first+last lines, use similarity for middle
+9. Context-aware - 50% line similarity threshold
 
 Multi-occurrence matching is handled via the replace_all flag.
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -17,7 +17,7 @@ Entry delimiter: § (section sign). Entries can be multiline.
 Character limits (not tokens) because char counts are model-independent.
 
 Design:
-- Single `memory` tool with action parameter: add, replace, remove, read
+- Single `memory` tool with action parameter: add, replace, remove
 - replace/remove use short unique substring matching (not full text or IDs)
 - Behavioral guidance lives in the tool schema description
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -45,11 +45,11 @@ DISTRIBUTIONS = {
     "image_gen": {
         "description": "Heavy focus on image generation with vision and web support",
         "toolsets": {
-            "image_gen": 90,  # 80% chance of image generation tools
-            "vision": 90,      # 60% chance of vision tools
-            "web": 55,         # 40% chance of web tools
+            "image_gen": 90,  # 90% chance of image generation tools
+            "vision": 90,      # 90% chance of vision tools
+            "web": 55,         # 55% chance of web tools
             "terminal": 45,
-            "moa": 10          # 20% chance of reasoning tools
+            "moa": 10          # 10% chance of reasoning tools
         }
     },
     
@@ -198,10 +198,10 @@ DISTRIBUTIONS = {
         "toolsets": {
             "terminal": 97,   # 97% - terminal almost always available
             "file": 97,       # 97% - file tools almost always available
-            "web": 97,        # 15% - web search/scrape for documentation
-            "browser": 75,    # 10% - browser occasionally for web interaction
-            "vision": 50,      # 8% - vision analysis rarely
-            "image_gen": 10    # 3% - image generation very rarely
+            "web": 97,        # 97% - web search/scrape for documentation
+            "browser": 75,    # 75% - browser occasionally for web interaction
+            "vision": 50,      # 50% - vision analysis
+            "image_gen": 10    # 10% - image generation rarely
         }
     },
     
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## Summary
- Fix wrong percentage comments in `toolset_distributions.py` (image_gen and terminal_tasks distributions)
- Add missing `reset_cache()` function in `hermes_time.py` (referenced in docstring but never defined)
- Fix stale docstring in `tools/memory_tool.py` (removed non-existent `read` action)
- Fix strategy count and list in `tools/fuzzy_match.py` (8 -> 9, add Unicode normalized strategy)
- Use exact matching (`LOWER(name) = LOWER(?)`) instead of `LIKE` in `plugins/memory/holographic/store.py`
- Add missing `thread_id` argument to `_set_interrupt(False)` call in `run_agent.py`
- Fix corrupted Unicode emoji (mojibake) in `batch_runner.py`
- Fix lowercase `any` type annotations to `Any` in `toolset_distributions.py` and `cli.py`
- Fix lowercase `callable` type annotations to `Callable` in `plugins/disk-cleanup/disk_cleanup.py` and `agent/conversation_loop.py`
- Remove `#<TBD>` placeholder comment in `run_agent.py`
- Fix typo `../. ssh/id_rsa` -> `../.ssh/id_rsa` in `tools/credential_files.py`
## Test plan
- [ ] Verify `reset_cache()` clears timezone cache and next `get_timezone()` re-resolves
- [ ] Verify holographic store entity lookup still matches names case-insensitively
- [ ] Verify `_set_interrupt(False, thread_id)` does not raise with the additional argument
- [ ] Verify type annotations pass mypy/pyright checks
- [ ] Grep for any remaining lowercase `any`/`callable` type annotations
Fixes #32848

