### PR TITLE
fix(cli): preserve Ctrl-J newline in CR/LF terminals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3133,16 +3133,19 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 )
 
 
-def _preserve_ctrl_enter_newline() -> bool:
-    """Detect environments where Ctrl+Enter must produce a newline, not submit.
+_RAW_LF_NEWLINE_TERM_PROGRAMS = {"WezTerm", "WarpTerminal"}
 
-    Windows Terminal, WSL, SSH sessions, Ghostty, and some modern terminals
-    deliver Ctrl+Enter/Ctrl+J as bare LF (c-j). On those terminals c-j must
-    NOT be bound to submit;
-    binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
-    submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
-    some thin PTYs without SSH) still need c-j bound to submit, so we keep
-    that binding for those.
+
+def _preserve_ctrl_enter_newline() -> bool:
+    """Detect environments where Ctrl+Enter/Ctrl+J must produce a newline, not submit.
+
+    Native Windows, WSL, SSH sessions, Windows Terminal, Ghostty, and several
+    modern local terminals (including WezTerm, Warp, and Kitty) send
+    Ctrl+Enter/Ctrl+J as bare LF (c-j). On those terminals c-j must NOT be
+    bound to submit; binding it to submit makes Ctrl+J / Ctrl+Enter (intended
+    as 'newline like Alt+Enter') submit instead. Local POSIX TTYs that deliver
+    Enter as LF (docker exec, some thin PTYs without SSH) still need c-j bound
+    to submit, so we keep that binding for unrecognized bare local terminals.
 
     See issue #22379.
     """
@@ -3157,6 +3160,10 @@ def _preserve_ctrl_enter_newline() -> bool:
     if os.environ.get("TERM", "").lower() == "xterm-ghostty":
         return True
     if os.environ.get("TERM_PROGRAM", "").lower() == "ghostty":
+        return True
+    if os.environ.get("TERM_PROGRAM") in _RAW_LF_NEWLINE_TERM_PROGRAMS:
+        return True
+    if os.environ.get("KITTY_WINDOW_ID"):
         return True
     if "microsoft" in os.environ.get("WSL_DISTRO_NAME", "").lower():
         return True

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -63,6 +63,20 @@ def test_ghostty_tmux_session_preserves_ctrl_j_newline():
             assert cli_mod._preserve_ctrl_enter_newline() is True
 
 
+def test_local_wezterm_preserves_newline():
+    import cli as cli_mod
+    with patch.object(sys, "platform", "linux"):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "WezTerm"}, clear=True):
+            assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_local_kitty_preserves_newline():
+    import cli as cli_mod
+    with patch.object(sys, "platform", "linux"):
+        with patch.dict(os.environ, {"KITTY_WINDOW_ID": "1"}, clear=True):
+            assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
 def test_pure_local_linux_does_not_preserve():
     """A bare local Linux TTY (no SSH/WSL/WT/Ghostty) keeps c-j → submit so docker exec
     style Enter-as-LF stays usable."""

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -70,6 +70,24 @@ def test_local_wezterm_preserves_newline():
             assert cli_mod._preserve_ctrl_enter_newline() is True
 
 
+def test_local_warp_terminal_preserves_newline_and_leaves_ctrl_j_unbound():
+    import cli as cli_mod
+    from prompt_toolkit.key_binding import KeyBindings
+
+    def submit_handler(event):
+        return None
+
+    with patch.object(sys, "platform", "linux"):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "WarpTerminal"}, clear=True):
+            assert cli_mod._preserve_ctrl_enter_newline() is True
+            kb = KeyBindings()
+            cli_mod._bind_prompt_submit_keys(kb, submit_handler)
+
+    bindings = {tuple(getattr(key, "value", key) for key in binding.keys): binding.handler for binding in kb.bindings}
+    assert bindings[("c-m",)] is submit_handler
+    assert ("c-j",) not in bindings
+
+
 def test_local_kitty_preserves_newline():
     import cli as cli_mod
     with patch.object(sys, "platform", "linux"):


### PR DESCRIPTION
## Summary
- preserve `c-j` as a newline key in known local terminals that distinguish Enter (CR) from Ctrl-J/Ctrl+Enter (LF)
- add TERM_PROGRAM-based coverage for WezTerm and WarpTerminal plus Kitty's `KITTY_WINDOW_ID`
- keep the existing fallback for unrecognized local POSIX/thin PTYs where plain Enter may arrive as LF and still needs to submit

## Why
On Linux WezTerm, Ctrl-J reaches prompt_toolkit as bare LF (`c-j`). Hermes currently binds `c-j` to submit on local POSIX terminals, so Ctrl-J submits the turn instead of inserting a newline.

The existing #22379 fix already avoids binding `c-j` to submit in Windows, WSL, SSH, and Windows Terminal environments where LF represents a distinct newline-intent keystroke. This PR extends that same environment-gated approach to known local CR/LF-distinguishing terminal environments instead of enabling blanket POSIX behavior.

## Related work
- Builds on the environment-gated approach from #22777 / #22379.
- Related to #23921, but generalizes the terminal detection beyond Warp while keeping the scope limited.
- Avoids the opposite failure mode in #9299 by leaving `c-j` submit enabled for unrecognized local thin PTYs.
- Not a duplicate of #18229: that PR is TUI / hermes-ink raw LF handling, while this PR is classic Python CLI / prompt_toolkit keybinding behavior.

## Test plan
- `python -m pytest tests/cli/test_ctrl_enter_newline.py -o addopts= -q`
