### PR TITLE
fix: rename list_distributions param to avoid shadowing imported function

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1156,7 +1156,7 @@ def main(
     num_workers: int = 4,
     resume: bool = False,
     verbose: bool = False,
-    list_distributions: bool = False,
+    show_distributions: bool = False,
     ephemeral_system_prompt: str = None,
     log_prefix_chars: int = 100,
     providers_allowed: str = None,
@@ -1184,7 +1184,7 @@ def main(
         num_workers (int): Number of parallel worker processes (default: 4)
         resume (bool): Resume from checkpoint if run was interrupted (default: False)
         verbose (bool): Enable verbose logging (default: False)
-        list_distributions (bool): List available toolset distributions and exit
+        show_distributions (bool): List available toolset distributions and exit
         ephemeral_system_prompt (str): System prompt used during agent execution but NOT saved to trajectories (optional)
         log_prefix_chars (int): Number of characters to show in log previews for tool calls/responses (default: 20)
         providers_allowed (str): Comma-separated list of OpenRouter providers to allow (e.g. "anthropic,openai")
@@ -1219,7 +1219,7 @@ def main(
         python batch_runner.py --list_distributions
     """
     # Handle list distributions
-    if list_distributions:
+    if show_distributions:
         from toolset_distributions import print_distribution_info
 
         print("📊 Available Toolset Distributions")


### PR DESCRIPTION
## Summary

The `main()` parameter `list_distributions: bool` in `batch_runner.py` shadows the module-level import `from toolset_distributions import list_distributions`, causing `--list_distributions` to crash with `TypeError: 'bool' object is not callable`.

Renamed the parameter to `show_distributions` so the imported function remains callable.

Fixes #32845

## Test plan

- [ ] Run `python batch_runner.py --show_distributions` and verify it lists distributions without crashing
- [ ] Confirm `list_distributions()` from `toolset_distributions` is correctly called on line 1228
- [ ] Verify normal batch runs (without the flag) are unaffected