### PR TITLE
fix: add fallback return in _generate_summary when retries exhausted

### DIFF
--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -636,7 +636,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 else:
                     # Fallback: create a basic summary
                     return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"
-    
+
+        # All retries exhausted or max_retries=0
+        self.logger.warning("Summary generation failed after %d attempt(s); using placeholder", self.config.max_retries)
+        return self._ensure_summary_prefix(None)
+
     async def _generate_summary_async(self, content: str, metrics: TrajectoryMetrics) -> str:
         """
         Generate a summary of the compressed turns using OpenRouter (async version).
@@ -705,7 +709,11 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                 else:
                     # Fallback: create a basic summary
                     return "[CONTEXT SUMMARY]: [Summary generation failed - previous turns contained tool calls and responses that have been compressed to save context space.]"
-    
+
+        # All retries exhausted or max_retries=0
+        self.logger.warning("Async summary generation failed after %d attempt(s); using placeholder", self.config.max_retries)
+        return self._ensure_summary_prefix(None)
+
     def compress_trajectory(
         self,
         trajectory: List[Dict[str, str]]


### PR DESCRIPTION
## Summary

Both `_generate_summary()` and `_generate_summary_async()` in `trajectory_compressor.py` declare `-> str` return type but fall through to implicit `return None` when `max_retries` is 0 (the `for attempt in range(0)` loop body never executes). The `None` is then injected as conversation message content, causing downstream `TypeError` crashes.

Added a fallback after each for-loop that logs a warning and returns a safe placeholder string via `_ensure_summary_prefix(None)`.

Fixes #32847

## Test plan

- [ ] Set `max_retries=0` in `CompressionConfig` and run trajectory compression — verify no `TypeError` and placeholder summary is used
- [ ] Set `max_retries=1` with a failing summarization endpoint — verify the existing in-loop fallback still works
- [ ] Set `max_retries=3` with a working endpoint — verify normal summarization is unaffected