### PR TITLE
feat: add pfSense, TrueNAS Scale, and UnRAID monitoring skills (optional-skills)

### DIFF
--- a/optional-skills/devops/pfsense-monitoring/SKILL.md
+++ b/optional-skills/devops/pfsense-monitoring/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: pfsense-monitoring
-description: Query pfSense firewalls/gateways via REST API using curl — read-only monitoring for interfaces, gateways, services, firewall rules, DHCP, ARP, DNS, VPNs, routing, logs, and CARP status.
-version: 1.0.0
-author: Mert Özkan
+description: Monitor pfSense firewalls via REST API.
+version: 1.1.0
+author: Mert Özkan (@47Hunter47)
 license: MIT
 platforms: [linux, macos]
+required_environment_variables:
+  - name: PFSENSE_API_KEY
+    prompt: pfSense REST API token (Services → REST API → API Tokens)
+    help: "https://github.com/pfrest/pfSense-pkg-RESTAPI — generate in pfSense Web UI → Services → REST API → API Tokens"
+  - name: PFSENSE_URL
+    prompt: pfSense base URL (e.g., https://10.0.0.1:8443)
+    help: "Base HTTPS URL of the pfSense web interface with REST API enabled."
 metadata:
   hermes:
-    tags: [pfsense, firewall, gateway, network, monitoring, devops, infrastructure]
-    category: devops
-    requires_toolsets: [terminal]
+    tags: [pfsense, firewall, gateway, network, monitoring, devops]
+    related_skills: [truenas-monitoring, unraid-monitoring]
+    config:
+      PFSENSE_URL: "https://10.0.0.1"
 ---
 
-# pfSense Monitoring
+# pfSense Monitoring Skill
 
-Query a pfSense firewall/gateway using its REST API (pfSense-pkg-RESTAPI by pfrest). Uses `curl` via the terminal tool — no custom tool needed.
+Read-only monitoring of pfSense firewalls/gateways via the [pfSense-pkg-RESTAPI](https://github.com/pfrest/pfSense-pkg-RESTAPI) package. Interfaces, gateways, services, firewall rules, DHCP, ARP, DNS, VPNs, routing, logs, and CARP status — all via `curl` + `jq`.
+
+Does not modify firewall rules, change settings, or perform write operations.
 
 ## When to Use
 
@@ -27,115 +37,106 @@ Query a pfSense firewall/gateway using its REST API (pfSense-pkg-RESTAPI by pfre
 
 ## Prerequisites
 
-- **pfSense REST API package** installed (pfrest/pfSense-pkg-RESTAPI)
-- **PFSENSE_URL** and **PFSENSE_API_KEY** environment variables set
-- `curl` available in the terminal
+1. **pfSense REST API package** installed (pfrest/pfSense-pkg-RESTAPI):
+   ```bash
+   # SSH into pfSense as root
+   fetch -q "https://github.com/pfrest/pfSense-pkg-RESTAPI/releases/download/v2.8.0/pfSense-2.8.1-pkg-RESTAPI.pkg"
+   pkg add -f pfSense-2.8.1-pkg-RESTAPI.pkg
+   ```
+   Then: Web UI → Services → REST API → Settings → set port (e.g. 8443) if nginx conflicts with 443.
 
-### Installing REST API on pfSense
+2. **Environment variables** in `${HERMES_HOME:-~/.hermes}/.env`:
+   ```
+   PFSENSE_URL=https://<firewall-ip>[:port]
+   PFSENSE_API_KEY=<your-token>
+   ```
 
-SSH into pfSense as root and run:
+3. `curl` and `jq` available in terminal.
+
+## Quick Reference
+
 ```bash
-fetch -q "https://github.com/pfrest/pfSense-pkg-RESTAPI/releases/download/v2.8.0/pfSense-2.8.1-pkg-RESTAPI.pkg"
-pkg add -f pfSense-2.8.1-pkg-RESTAPI.pkg
-```
-
-After install: pfSense Web UI → Services → REST API → Settings → set a different port (e.g. 8443) if nginx can't bind 443.
-
-## Env Vars Required
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PFSENSE_URL` | `https://10.0.0.1` | pfSense hostname/IP |
-| `PFSENSE_API_KEY` | — | API token from Services → REST API → API Tokens |
-
-## Available Queries
-
-Each query is a `terminal()` call with `curl`. Always use `-k` (self-signed certs) and `-s` (silent). Pipe through `jq` for pretty output when available.
-
-### Summary
-```bash
+# Status summary
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/system"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/interfaces"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/gateways"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/services"
-```
 
-### Interfaces
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/interfaces" | jq '.data[] | {name: .if, ip: .ipaddr, status: .status, in: .inpkts, out: .outpkts}'
-```
+# Interfaces detail
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/interfaces" \
+  | jq '.data[] | {name: .if, ip: .ipaddr, status: .status, in: .inpkts, out: .outpkts}'
 
-### Gateways
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/gateways" | jq '.data[] | {name: .name, ip: .gateway, status: .status, delay: .delay, loss: .loss}'
-```
+# Gateways
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/gateways" \
+  | jq '.data[] | {name: .name, ip: .gateway, status: .status, delay: .delay, loss: .loss}'
 
-### Services
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/services" | jq '.data[] | {name: .name, running: .running}'
-```
+# Services
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/services" \
+  | jq '.data[] | {name: .name, running: .running}'
 
-### Firewall Rules
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/firewall/rules" | jq '.data[] | {number: .number, type: .type, interface: .interface, protocol: .protocol, source: .source, destination: .destination, action: .action}'
-```
+# Firewall rules
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/firewall/rules" \
+  | jq '.data[] | {number: .number, type: .type, interface: .interface, protocol: .protocol, source: .source, destination: .destination, action: .action}'
 
-### DHCP Leases
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/dhcp_server/leases" | jq '.data[] | {ip: .ip, mac: .mac, hostname: .hostname, online: .online}'
-```
+# DHCP leases
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/dhcp_server/leases" \
+  | jq '.data[] | {ip: .ip, mac: .mac, hostname: .hostname, online: .online}'
 
-### ARP Table
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/diagnostics/arp_table" | jq '.data[] | {ip: .ip_address, mac: .mac_address, interface: .interface}'
-```
+# ARP table
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/diagnostics/arp_table" \
+  | jq '.data[] | {ip: .ip_address, mac: .mac_address, interface: .interface}'
 
-### DNS Resolver
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/services/dns_resolver/settings" | jq '.data'
-```
+# DNS resolver settings
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/services/dns_resolver/settings" \
+  | jq '.data'
 
-### OpenVPN
-```bash
+# OpenVPN
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/openvpn/servers"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/openvpn/clients"
-```
 
-### IPsec
-```bash
-curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/ipsec/sas" | jq '.data[] | {name: .name, status: .status, local: .local, remote: .remote}'
-```
+# IPsec
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/ipsec/sas" \
+  | jq '.data[] | {name: .name, status: .status, local: .local, remote: .remote}'
 
-### Routes
-```bash
+# Routing
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/routing/gateways"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/routing/static_route"
-```
 
-### CARP Status
-```bash
+# CARP/HA
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/carp"
-```
 
-### Logs
-```bash
+# Logs
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/system"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/firewall"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/dhcp"
 curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/auth"
 ```
 
+## Procedure
+
+1. Verify env vars are set: `echo $PFSENSE_URL $PFSENSE_API_KEY`
+2. Health check: `curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/system"`
+3. Run the relevant query from Quick Reference above
+4. If response is HTML or 404, try `/api/v1/` prefix as fallback
+
 ## Pitfalls
 
-- **Auth header**: v2 API uses `X-API-Key` header. Wrong header (e.g. `Authorization: Bearer`) produces HTTP 401.
-- **IP ban**: Repeated failed auth → pfSense bans the source IP via pfTables (native firewall state table). Symptoms: ping works, SSH/HTTPS timeout. Fix: pfSense Web UI → Diagnostics → pfTables → delete your IP.
-- **Self-signed cert**: Always use `-k` with curl (pfSense uses self-signed by default).
-- **API fallback**: v2 is primary; if you get HTML/404, try `/api/v1/` prefix instead.
-- **Port conflict**: REST API nginx may conflict with webConfigurator (lighttpd) on ports 80/443. Set a different port in REST API settings.
-- **No REST API package**: If all calls return connection refused, the package isn't installed.
-- **SSH timeout**: pfSense can be slow — use `ConnectTimeout=30` for SSH commands.
+1. **Auth header**: v2 API uses `X-API-Key` header. Using `Authorization: ***` returns HTTP 401.
+2. **IP ban**: Repeated failed auth → pfSense bans source IP via pfTables. Symptoms: ping works, HTTPS times out. Fix: Web UI → Diagnostics → pfTables → delete your IP.
+3. **Self-signed cert**: Always use `-k` with curl (pfSense uses self-signed by default).
+4. **API version**: v2 is primary; if you get HTML/404, try `/api/v1/` prefix.
+5. **Port conflict**: REST API nginx may conflict with webConfigurator (lighttpd) on 80/443. Set a different port in REST API settings.
+6. **Package not installed**: All calls return connection refused = package missing.
+7. **Slow SSH**: pfSense can be slow — use `ConnectTimeout=30` for SSH commands.
 
-## Sister Skills
+## Verification
 
-- `truenas-monitoring` — TrueNAS Scale monitoring via curl + REST API
-- `unraid-monitoring` — UnRAID monitoring via curl + GraphQL API
+- [ ] `PFSENSE_URL` and `PFSENSE_API_KEY` are set in `.env`
+- [ ] Health check returns valid JSON (not HTML)
+- [ ] Auth header is `X-API-Key` (not `Authorization`)
+- [ ] Self-signed cert flag `-k` is used on all curl calls
+
+## Related Skills
+
+- `truenas-monitoring` — TrueNAS Scale via REST API
+- `unraid-monitoring` — UnRAID via GraphQL API

--- a/optional-skills/devops/pfsense-monitoring/SKILL.md
+++ b/optional-skills/devops/pfsense-monitoring/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: pfsense-monitoring
+description: Query pfSense firewalls/gateways via REST API using curl — read-only monitoring for interfaces, gateways, services, firewall rules, DHCP, ARP, DNS, VPNs, routing, logs, and CARP status.
+version: 1.0.0
+author: Mert Özkan
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [pfsense, firewall, gateway, network, monitoring, devops, infrastructure]
+    category: devops
+    requires_toolsets: [terminal]
+---
+
+# pfSense Monitoring
+
+Query a pfSense firewall/gateway using its REST API (pfSense-pkg-RESTAPI by pfrest). Uses `curl` via the terminal tool — no custom tool needed.
+
+## When to Use
+
+- User asks about pfSense firewall/gateway status
+- Check interfaces, gateways, services, or firewall rules
+- List DHCP leases, ARP table, or DNS resolver status
+- Check VPN connections (OpenVPN, IPsec)
+- View routing table or CARP/HA failover status
+- Read system, firewall, or auth logs
+
+## Prerequisites
+
+- **pfSense REST API package** installed (pfrest/pfSense-pkg-RESTAPI)
+- **PFSENSE_URL** and **PFSENSE_API_KEY** environment variables set
+- `curl` available in the terminal
+
+### Installing REST API on pfSense
+
+SSH into pfSense as root and run:
+```bash
+fetch -q "https://github.com/pfrest/pfSense-pkg-RESTAPI/releases/download/v2.8.0/pfSense-2.8.1-pkg-RESTAPI.pkg"
+pkg add -f pfSense-2.8.1-pkg-RESTAPI.pkg
+```
+
+After install: pfSense Web UI → Services → REST API → Settings → set a different port (e.g. 8443) if nginx can't bind 443.
+
+## Env Vars Required
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PFSENSE_URL` | `https://10.0.0.1` | pfSense hostname/IP |
+| `PFSENSE_API_KEY` | — | API token from Services → REST API → API Tokens |
+
+## Available Queries
+
+Each query is a `terminal()` call with `curl`. Always use `-k` (self-signed certs) and `-s` (silent). Pipe through `jq` for pretty output when available.
+
+### Summary
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/system"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/interfaces"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/gateways"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/services"
+```
+
+### Interfaces
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/interfaces" | jq '.data[] | {name: .if, ip: .ipaddr, status: .status, in: .inpkts, out: .outpkts}'
+```
+
+### Gateways
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/gateways" | jq '.data[] | {name: .name, ip: .gateway, status: .status, delay: .delay, loss: .loss}'
+```
+
+### Services
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/services" | jq '.data[] | {name: .name, running: .running}'
+```
+
+### Firewall Rules
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/firewall/rules" | jq '.data[] | {number: .number, type: .type, interface: .interface, protocol: .protocol, source: .source, destination: .destination, action: .action}'
+```
+
+### DHCP Leases
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/dhcp_server/leases" | jq '.data[] | {ip: .ip, mac: .mac, hostname: .hostname, online: .online}'
+```
+
+### ARP Table
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/diagnostics/arp_table" | jq '.data[] | {ip: .ip_address, mac: .mac_address, interface: .interface}'
+```
+
+### DNS Resolver
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/services/dns_resolver/settings" | jq '.data'
+```
+
+### OpenVPN
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/openvpn/servers"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/openvpn/clients"
+```
+
+### IPsec
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/ipsec/sas" | jq '.data[] | {name: .name, status: .status, local: .local, remote: .remote}'
+```
+
+### Routes
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/routing/gateways"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/routing/static_route"
+```
+
+### CARP Status
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/carp"
+```
+
+### Logs
+```bash
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/system"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/firewall"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/dhcp"
+curl -sk -H "X-API-Key: $PFSENSE_API_KEY" "$PFSENSE_URL/api/v2/status/logs/auth"
+```
+
+## Pitfalls
+
+- **Auth header**: v2 API uses `X-API-Key` header. Wrong header (e.g. `Authorization: Bearer`) produces HTTP 401.
+- **IP ban**: Repeated failed auth → pfSense bans the source IP via pfTables (native firewall state table). Symptoms: ping works, SSH/HTTPS timeout. Fix: pfSense Web UI → Diagnostics → pfTables → delete your IP.
+- **Self-signed cert**: Always use `-k` with curl (pfSense uses self-signed by default).
+- **API fallback**: v2 is primary; if you get HTML/404, try `/api/v1/` prefix instead.
+- **Port conflict**: REST API nginx may conflict with webConfigurator (lighttpd) on ports 80/443. Set a different port in REST API settings.
+- **No REST API package**: If all calls return connection refused, the package isn't installed.
+- **SSH timeout**: pfSense can be slow — use `ConnectTimeout=30` for SSH commands.
+
+## Sister Skills
+
+- `truenas-monitoring` — TrueNAS Scale monitoring via curl + REST API
+- `unraid-monitoring` — UnRAID monitoring via curl + GraphQL API

--- a/optional-skills/devops/truenas-monitoring/SKILL.md
+++ b/optional-skills/devops/truenas-monitoring/SKILL.md
@@ -1,20 +1,32 @@
 ---
 name: truenas-monitoring
-description: Query TrueNAS Scale systems via REST API using curl — read-only monitoring for pools, disks, shares, alerts, services, and system info.
-version: 1.0.0
-author: Mert Özkan
+description: Monitor TrueNAS Scale systems via REST API.
+version: 1.1.0
+author: Mert Özkan (@47Hunter47)
 license: MIT
 platforms: [linux, macos]
+required_environment_variables:
+  - name: TRUENAS_API_KEY
+    prompt: TrueNAS API key (Settings → API Keys)
+    help: "TrueNAS Web UI → Settings → API Keys — create a key with read access."
+  - name: TRUENAS_URL
+    prompt: TrueNAS base URL (e.g., https://truenas.local)
+    help: "Base HTTPS URL of the TrueNAS web interface."
 metadata:
   hermes:
-    tags: [truenas, nas, storage, zfs, monitoring, devops, infrastructure]
-    category: devops
-    requires_toolsets: [terminal]
+    tags: [truenas, nas, storage, zfs, monitoring, devops]
+    related_skills: [pfsense-monitoring, unraid-monitoring]
+    config:
+      TRUENAS_URL: "https://truenas.local"
 ---
 
-# TrueNAS Monitoring
+# TrueNAS Monitoring Skill
 
-Query a TrueNAS Scale system using its REST API v2.0. Uses `curl` via the terminal tool — no custom tool needed.
+Read-only monitoring of TrueNAS Scale systems via REST API v2.0. ZFS pool health, disk inventory, SMB/NFS shares, alerts, services, and system info — all via `curl` + `jq`.
+
+Does not modify pool configuration, create shares, or change system settings.
+
+> **Note:** REST API is deprecated in TrueNAS v25.10+ and will be removed in v26.04. After that, use WebSocket JSON-RPC 2.0.
 
 ## When to Use
 
@@ -28,76 +40,92 @@ Query a TrueNAS Scale system using its REST API v2.0. Uses `curl` via the termin
 
 ## Prerequisites
 
-- **TRUENAS_URL** and **TRUENAS_API_KEY** environment variables set
-- `curl` and `jq` available in the terminal
-- API key from TrueNAS Web UI → Settings → API Keys
-- Note: REST API is deprecated in TrueNAS v25.10+ and will be removed in v26.04
+1. **Environment variables** in `${HERMES_HOME:-~/.hermes}/.env`:
+   ```
+   TRUENAS_URL=https://<truenas-ip-or-hostname>
+   TRUENAS_API_KEY=<your-api-key>
+   ```
+   API key from TrueNAS Web UI → Settings → API Keys.
 
-## Env Vars Required
+2. `curl` and `jq` available in terminal.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `TRUENAS_URL` | `https://truenas.local` | TrueNAS hostname/IP |
-| `TRUENAS_API_KEY` | — | API key from Settings → API Keys |
+## Quick Reference
 
-## Available Queries
-
-All queries use `terminal()` with curl. Always use `-k` (self-signed certs) and pipe to `jq` for readable output.
-
-### Summary (multiple calls)
 ```bash
+# Status summary
 curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/system/info"
 curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/pool"
 curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/disk"
 curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/alert/list"
+
+# Pools
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/pool" \
+  | jq '.[] | {name: .name, status: .status, healthy: .healthy, size: .size, used: .used, available: .available}'
+
+# Disks
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/disk" \
+  | jq '.[] | {name: .name, serial: .serial, model: .model, size: .size, type: .type}'
+
+# SMB shares
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/smb" \
+  | jq '.[] | {name: .name, path: .path, comment: .comment, enabled: .enabled}'
+
+# NFS shares
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/nfs" \
+  | jq '.[] | {name: .name, path: .path, networks: .networks, enabled: .enabled}'
+
+# Alerts
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/alert/list" \
+  | jq '.[] | {level: .level, message: .message, dismissed: .dismissed, node: .node}'
+
+# Services
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/service" \
+  | jq '.[] | {name: .name, state: .state, pids: .pids, enable: .enable}'
 ```
 
-### Pools
-```bash
-curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/pool" | jq '.[] | {name: .name, status: .status, healthy: .healthy, size: .size, used: .used, available: .available}'
-```
+## Procedure
 
-### Disks
-```bash
-curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/disk" | jq '.[] | {name: .name, serial: .serial, model: .model, size: .size, type: .type}'
-```
-
-### Shares (SMB + NFS)
-```bash
-curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/smb" | jq '.[] | {name: .name, path: .path, comment: .comment, enabled: .enabled}'
-curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/nfs" | jq '.[] | {name: .name, path: .path, networks: .networks, enabled: .enabled}'
-```
-
-### Alerts
-```bash
-curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/alert/list" | jq '.[] | {level: .level, message: .message, dismissed: .dismissed, node: .node}'
-```
-
-### Services
-```bash
-curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/service" | jq '.[] | {name: .name, state: .state, pids: .pids, enable: .enable}'
-```
+1. Verify env vars: `echo $TRUENAS_URL $TRUENAS_API_KEY`
+2. Health check: `curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/system/info"`
+3. Run the relevant query from Quick Reference above
 
 ## Security Audit
 
 When auditing TrueNAS, always check:
 
-1. **NFS share restrictions**: `curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/nfs" | jq '.[] | {name: .name, networks: .networks}'` — empty networks = critical (any host can mount).
+1. **NFS share restrictions**:
+   ```bash
+   curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/nfs" \
+     | jq '.[] | {name: .name, networks: .networks}'
+   ```
+   Empty `networks` = critical (any host can mount).
 
-2. **SSH password auth**: If SSH service is running, check `curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/ssh" | jq '{password_auth: .passwordauth}'` — `true` = high risk.
+2. **SSH password auth**:
+   ```bash
+   curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/ssh" \
+     | jq '{password_auth: .passwordauth}'
+   ```
+   `true` = high risk.
 
 3. **Unnecessary services**: Flag NFS, iSCSI, FTP, SNMP if running but not needed.
 
 ## Pitfalls
 
-- **Auth**: TrueNAS uses `Authorization: Bearer` header (not X-API-Key).
-- **Self-signed cert**: Always use `-k` with curl.
-- **Deprecated API**: REST API is deprecated since TrueNAS v25.10; will be removed in v26.04. After that, use WebSocket JSON-RPC 2.0.
-- **HTTP 401**: Invalid or expired API key — regenerate in TrueNAS Web UI.
-- **Alert noise**: The deprecated REST API triggers a warning alert after 24h — cosmetic only.
-- **REST API deprecation alert**: If you see `RESTAPIUsage` alerts, they're from this query itself — harmless.
+1. **Auth header**: TrueNAS uses `Authorization: Bearer ***` (not `X-API-Key`).
+2. **Self-signed cert**: Always use `-k` with curl.
+3. **Deprecated API**: REST API deprecated since v25.10; removed in v26.04. Plan migration to WebSocket JSON-RPC 2.0.
+4. **HTTP 401**: Invalid or expired API key — regenerate in Web UI.
+5. **Alert noise**: Deprecated REST API triggers a warning alert after 24h — cosmetic only.
+6. **RESTAPIUsage alerts**: From this query itself — harmless.
 
-## Sister Skills
+## Verification
 
-- `unraid-monitoring` — UnRAID monitoring via curl + GraphQL API
-- `pfsense-monitoring` — pfSense monitoring via curl + REST API
+- [ ] `TRUENAS_URL` and `TRUENAS_API_KEY` are set in `.env`
+- [ ] Health check returns valid JSON (not HTML)
+- [ ] Auth header is `Authorization: Bearer` (not `X-API-Key`)
+- [ ] Self-signed cert flag `-k` is used on all curl calls
+
+## Related Skills
+
+- `pfsense-monitoring` — pfSense via REST API
+- `unraid-monitoring` — UnRAID via GraphQL API

--- a/optional-skills/devops/truenas-monitoring/SKILL.md
+++ b/optional-skills/devops/truenas-monitoring/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: truenas-monitoring
+description: Query TrueNAS Scale systems via REST API using curl — read-only monitoring for pools, disks, shares, alerts, services, and system info.
+version: 1.0.0
+author: Mert Özkan
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [truenas, nas, storage, zfs, monitoring, devops, infrastructure]
+    category: devops
+    requires_toolsets: [terminal]
+---
+
+# TrueNAS Monitoring
+
+Query a TrueNAS Scale system using its REST API v2.0. Uses `curl` via the terminal tool — no custom tool needed.
+
+## When to Use
+
+- User asks about TrueNAS system status
+- Check ZFS pool health, capacity, vdev topology
+- List physical disks with serial, model, size
+- Check SMB/NFS shares
+- View active alerts and warnings
+- Check service status (SMB, NFS, SSH, etc.)
+- Run a network security audit on TrueNAS
+
+## Prerequisites
+
+- **TRUENAS_URL** and **TRUENAS_API_KEY** environment variables set
+- `curl` and `jq` available in the terminal
+- API key from TrueNAS Web UI → Settings → API Keys
+- Note: REST API is deprecated in TrueNAS v25.10+ and will be removed in v26.04
+
+## Env Vars Required
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRUENAS_URL` | `https://truenas.local` | TrueNAS hostname/IP |
+| `TRUENAS_API_KEY` | — | API key from Settings → API Keys |
+
+## Available Queries
+
+All queries use `terminal()` with curl. Always use `-k` (self-signed certs) and pipe to `jq` for readable output.
+
+### Summary (multiple calls)
+```bash
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/system/info"
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/pool"
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/disk"
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/alert/list"
+```
+
+### Pools
+```bash
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/pool" | jq '.[] | {name: .name, status: .status, healthy: .healthy, size: .size, used: .used, available: .available}'
+```
+
+### Disks
+```bash
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/disk" | jq '.[] | {name: .name, serial: .serial, model: .model, size: .size, type: .type}'
+```
+
+### Shares (SMB + NFS)
+```bash
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/smb" | jq '.[] | {name: .name, path: .path, comment: .comment, enabled: .enabled}'
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/nfs" | jq '.[] | {name: .name, path: .path, networks: .networks, enabled: .enabled}'
+```
+
+### Alerts
+```bash
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/alert/list" | jq '.[] | {level: .level, message: .message, dismissed: .dismissed, node: .node}'
+```
+
+### Services
+```bash
+curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/service" | jq '.[] | {name: .name, state: .state, pids: .pids, enable: .enable}'
+```
+
+## Security Audit
+
+When auditing TrueNAS, always check:
+
+1. **NFS share restrictions**: `curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/sharing/nfs" | jq '.[] | {name: .name, networks: .networks}'` — empty networks = critical (any host can mount).
+
+2. **SSH password auth**: If SSH service is running, check `curl -sk -H "Authorization: Bearer $TRUENAS_API_KEY" "$TRUENAS_URL/api/v2.0/ssh" | jq '{password_auth: .passwordauth}'` — `true` = high risk.
+
+3. **Unnecessary services**: Flag NFS, iSCSI, FTP, SNMP if running but not needed.
+
+## Pitfalls
+
+- **Auth**: TrueNAS uses `Authorization: Bearer` header (not X-API-Key).
+- **Self-signed cert**: Always use `-k` with curl.
+- **Deprecated API**: REST API is deprecated since TrueNAS v25.10; will be removed in v26.04. After that, use WebSocket JSON-RPC 2.0.
+- **HTTP 401**: Invalid or expired API key — regenerate in TrueNAS Web UI.
+- **Alert noise**: The deprecated REST API triggers a warning alert after 24h — cosmetic only.
+- **REST API deprecation alert**: If you see `RESTAPIUsage` alerts, they're from this query itself — harmless.
+
+## Sister Skills
+
+- `unraid-monitoring` — UnRAID monitoring via curl + GraphQL API
+- `pfsense-monitoring` — pfSense monitoring via curl + REST API

--- a/optional-skills/devops/unraid-monitoring/SKILL.md
+++ b/optional-skills/devops/unraid-monitoring/SKILL.md
@@ -1,20 +1,30 @@
 ---
 name: unraid-monitoring
-description: Query UnRAID servers via GraphQL API using curl — read-only monitoring for system info, disks, Docker containers, and alerts.
-version: 1.0.0
-author: Mert Özkan
+description: Monitor UnRAID servers via GraphQL API.
+version: 1.1.0
+author: Mert Özkan (@47Hunter47)
 license: MIT
 platforms: [linux, macos]
+required_environment_variables:
+  - name: UNRAID_API_KEY
+    prompt: UnRAID API key (Settings → API Keys, READ_ANY permissions)
+    help: "UnRAID Web UI → Settings → API Keys — create a key with READ_ANY data permissions."
+  - name: UNRAID_URL
+    prompt: UnRAID base URL (e.g., https://unraid.local)
+    help: "Base HTTPS URL of the UnRAID web interface."
 metadata:
   hermes:
-    tags: [unraid, nas, docker, storage, monitoring, devops, infrastructure]
-    category: devops
-    requires_toolsets: [terminal]
+    tags: [unraid, nas, docker, storage, monitoring, devops]
+    related_skills: [pfsense-monitoring, truenas-monitoring]
+    config:
+      UNRAID_URL: "https://unraid.local"
 ---
 
-# UnRAID Monitoring
+# UnRAID Monitoring Skill
 
-Query an UnRAID server using its GraphQL API. Uses `curl` via the terminal tool — no custom tool needed.
+Read-only monitoring of UnRAID servers via GraphQL API (`/graphql`). System info, disk inventory, Docker containers, and alerts — all via `curl` + `jq`.
+
+Does not start/stop containers, modify disks, or change system settings.
 
 ## When to Use
 
@@ -27,81 +37,91 @@ Query an UnRAID server using its GraphQL API. Uses `curl` via the terminal tool 
 
 ## Prerequisites
 
-- **UNRAID_URL** and **UNRAID_API_KEY** environment variables set
-- `curl` and `jq` available in the terminal
-- API key from UnRAID Web UI → Settings → API Keys (with READ_ANY data permissions)
-- Note: UnRAID GraphQL is at `/graphql` endpoint
+1. **Environment variables** in `${HERMES_HOME:-~/.hermes}/.env`:
+   ```
+   UNRAID_URL=https://<unraid-ip-or-hostname>
+   UNRAID_API_KEY=<your-api-key>
+   ```
+   API key from UnRAID Web UI → Settings → API Keys (must have `READ_ANY` data permissions).
 
-## Env Vars Required
+2. `curl` and `jq` available in terminal.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `UNRAID_URL` | `https://unraid.local` | UnRAID hostname/IP |
-| `UNRAID_API_KEY` | — | API key with READ_ANY permissions |
+3. GraphQL endpoint: `$UNRAID_URL/graphql`
 
-## Available Queries
+## Quick Reference
 
-All queries use `terminal()` with curl posting GraphQL JSON. Always use `-k` (self-signed certs).
-
-Single reusable curl wrapper:
+Reusable curl wrapper:
 ```bash
-UNRAID_QUERY() { curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" -d "{\"query\":\"$1\"}" "$UNRAID_URL/graphql"; }
+UNRAID_QUERY() {
+  curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"query\":\"$1\"}" "$UNRAID_URL/graphql"
+}
 ```
 
-### Summary
+### System info
 ```bash
-UNRAID_QUERY='{ info { cpu { model cores threads } os { hostname distro kernel uptime } } disks { name size type serialNum temperature smartStatus } docker { containers { names image status } } notifications { warningsAndAlerts { id } } }'
-curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
-  -d "{\"query\":\"$UNRAID_QUERY\"}" "$UNRAID_URL/graphql" | jq '.data'
-```
-
-### System Info
-```bash
-curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
-  -d '{"query":"{ info { cpu { model cores threads } os { hostname distro kernel uptime } } }"}' \
-  "$UNRAID_URL/graphql" | jq '.data.info'
+UNRAID_QUERY '{ info { cpu { model cores threads } os { hostname distro kernel uptime } } }' \
+  | jq '.data.info'
 ```
 
 ### Disks
 ```bash
-curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
-  -d '{"query":"{ disks { name size type serialNum temperature smartStatus } }"}' \
-  "$UNRAID_URL/graphql" | jq '.data.disks'
+UNRAID_QUERY '{ disks { name size type serialNum temperature smartStatus } }' \
+  | jq '.data.disks'
 ```
 
-### Docker Containers
+### Docker containers
 ```bash
-curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
-  -d '{"query":"{ docker { containers { names image status } } }"}' \
-  "$UNRAID_URL/graphql" | jq '.data.docker.containers'
+UNRAID_QUERY '{ docker { containers { names image status } } }' \
+  | jq '.data.docker.containers'
 ```
 
 ### Alerts
 ```bash
-curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
-  -d '{"query":"{ notifications { warningsAndAlerts { id } } }"}' \
-  "$UNRAID_URL/graphql" | jq '.data.notifications.warningsAndAlerts'
+UNRAID_QUERY '{ notifications { warningsAndAlerts { id } } }' \
+  | jq '.data.notifications.warningsAndAlerts'
 ```
+
+### Full summary
+```bash
+UNRAID_QUERY '{ info { cpu { model cores threads } os { hostname distro kernel uptime } } disks { name size type serialNum temperature smartStatus } docker { containers { names image status } } notifications { warningsAndAlerts { id } } }' \
+  | jq '.data'
+```
+
+## Procedure
+
+1. Verify env vars: `echo $UNRAID_URL $UNRAID_API_KEY`
+2. Define `UNRAID_QUERY` shell function in terminal
+3. Run the relevant query from Quick Reference above
+4. Always check the `errors` field in response JSON (GraphQL returns 200 even on errors)
 
 ## Security Audit
 
 When auditing UnRAID, check Docker containers for high-risk services:
 
-1. **Risky containers**: Flag Apache Guacamole, Open WebUI, or any `:latest` tag containers.
+1. **Risky containers**: Flag Apache Guacamole, Open WebUI, or any `:latest` tag.
 2. **Host networking**: Containers using `--net=host` bypass UnRAID firewall entirely.
-3. **Pinned versions**: Prefer pinned versions (e.g. `linuxserver/plex:1.41.0`) over `:latest`.
+3. **Pinned versions**: Prefer `linuxserver/plex:1.41.0` over `:latest`.
 
 ## Pitfalls
 
-- **Auth**: UnRAID uses `Authorization: Bearer` header (not API keys in URL or body).
-- **Self-signed cert**: Always use `-k` with curl.
-- **GraphQL errors**: UnRAID returns HTTP 200 even on errors — always check the `errors` field in response JSON.
-- **Missing permissions**: "Invalid API key format" = key lacks READ_ANY data permissions.
-- **Disk size quirk**: Some disks may report incorrect sizes (e.g. 2TB as "1.8 PB") — API display issue.
-- **Memory**: Not accessible via GraphQL API.
-- **The UNRAID_QUERY shell function** is useful for multi-field queries — define it in terminal before use.
+1. **Auth header**: UnRAID uses `Authorization: Bearer ***` (not `X-API-Key` or URL params).
+2. **Self-signed cert**: Always use `-k` with curl.
+3. **GraphQL errors**: UnRAID returns HTTP 200 even on errors — always check the `errors` field.
+4. **Missing permissions**: "Invalid API key format" = key lacks `READ_ANY` data permissions.
+5. **Disk size quirk**: Some disks report incorrect sizes (e.g., 2TB as "1.8 PB") — API display issue.
+6. **Memory**: Not accessible via GraphQL API.
 
-## Sister Skills
+## Verification
 
-- `truenas-monitoring` — TrueNAS Scale monitoring via curl + REST API
-- `pfsense-monitoring` — pfSense monitoring via curl + REST API
+- [ ] `UNRAID_URL` and `UNRAID_API_KEY` are set in `.env`
+- [ ] API key has `READ_ANY` data permissions
+- [ ] Query returns valid JSON with no `errors` field
+- [ ] Auth header is `Authorization: Bearer` (not `X-API-Key`)
+- [ ] Self-signed cert flag `-k` is used on all curl calls
+
+## Related Skills
+
+- `pfsense-monitoring` — pfSense via REST API
+- `truenas-monitoring` — TrueNAS Scale via REST API

--- a/optional-skills/devops/unraid-monitoring/SKILL.md
+++ b/optional-skills/devops/unraid-monitoring/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: unraid-monitoring
+description: Query UnRAID servers via GraphQL API using curl — read-only monitoring for system info, disks, Docker containers, and alerts.
+version: 1.0.0
+author: Mert Özkan
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [unraid, nas, docker, storage, monitoring, devops, infrastructure]
+    category: devops
+    requires_toolsets: [terminal]
+---
+
+# UnRAID Monitoring
+
+Query an UnRAID server using its GraphQL API. Uses `curl` via the terminal tool — no custom tool needed.
+
+## When to Use
+
+- User asks about UnRAID system status
+- Check system info (hostname, OS, kernel, CPU, uptime)
+- List physical disks with serial, size, temperature, SMART status
+- List Docker containers with names, images, and status
+- View active notifications and warnings
+- Run a network security audit on UnRAID Docker exposure
+
+## Prerequisites
+
+- **UNRAID_URL** and **UNRAID_API_KEY** environment variables set
+- `curl` and `jq` available in the terminal
+- API key from UnRAID Web UI → Settings → API Keys (with READ_ANY data permissions)
+- Note: UnRAID GraphQL is at `/graphql` endpoint
+
+## Env Vars Required
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `UNRAID_URL` | `https://unraid.local` | UnRAID hostname/IP |
+| `UNRAID_API_KEY` | — | API key with READ_ANY permissions |
+
+## Available Queries
+
+All queries use `terminal()` with curl posting GraphQL JSON. Always use `-k` (self-signed certs).
+
+Single reusable curl wrapper:
+```bash
+UNRAID_QUERY() { curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" -d "{\"query\":\"$1\"}" "$UNRAID_URL/graphql"; }
+```
+
+### Summary
+```bash
+UNRAID_QUERY='{ info { cpu { model cores threads } os { hostname distro kernel uptime } } disks { name size type serialNum temperature smartStatus } docker { containers { names image status } } notifications { warningsAndAlerts { id } } }'
+curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
+  -d "{\"query\":\"$UNRAID_QUERY\"}" "$UNRAID_URL/graphql" | jq '.data'
+```
+
+### System Info
+```bash
+curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
+  -d '{"query":"{ info { cpu { model cores threads } os { hostname distro kernel uptime } } }"}' \
+  "$UNRAID_URL/graphql" | jq '.data.info'
+```
+
+### Disks
+```bash
+curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
+  -d '{"query":"{ disks { name size type serialNum temperature smartStatus } }"}' \
+  "$UNRAID_URL/graphql" | jq '.data.disks'
+```
+
+### Docker Containers
+```bash
+curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
+  -d '{"query":"{ docker { containers { names image status } } }"}' \
+  "$UNRAID_URL/graphql" | jq '.data.docker.containers'
+```
+
+### Alerts
+```bash
+curl -sk -H "Authorization: Bearer $UNRAID_API_KEY" -H "Content-Type: application/json" \
+  -d '{"query":"{ notifications { warningsAndAlerts { id } } }"}' \
+  "$UNRAID_URL/graphql" | jq '.data.notifications.warningsAndAlerts'
+```
+
+## Security Audit
+
+When auditing UnRAID, check Docker containers for high-risk services:
+
+1. **Risky containers**: Flag Apache Guacamole, Open WebUI, or any `:latest` tag containers.
+2. **Host networking**: Containers using `--net=host` bypass UnRAID firewall entirely.
+3. **Pinned versions**: Prefer pinned versions (e.g. `linuxserver/plex:1.41.0`) over `:latest`.
+
+## Pitfalls
+
+- **Auth**: UnRAID uses `Authorization: Bearer` header (not API keys in URL or body).
+- **Self-signed cert**: Always use `-k` with curl.
+- **GraphQL errors**: UnRAID returns HTTP 200 even on errors — always check the `errors` field in response JSON.
+- **Missing permissions**: "Invalid API key format" = key lacks READ_ANY data permissions.
+- **Disk size quirk**: Some disks may report incorrect sizes (e.g. 2TB as "1.8 PB") — API display issue.
+- **Memory**: Not accessible via GraphQL API.
+- **The UNRAID_QUERY shell function** is useful for multi-field queries — define it in terminal before use.
+
+## Sister Skills
+
+- `truenas-monitoring` — TrueNAS Scale monitoring via curl + REST API
+- `pfsense-monitoring` — pfSense monitoring via curl + REST API

--- a/tests/skills/test_nas_firewall_monitoring_skills.py
+++ b/tests/skills/test_nas_firewall_monitoring_skills.py
@@ -1,0 +1,211 @@
+"""Frontmatter contract tests for optional monitoring skills:
+pfsense-monitoring, truenas-monitoring, unraid-monitoring.
+
+Validates:
+- Frontmatter parses as YAML
+- name and description present
+- description <= 60 chars, one sentence, ends with period
+- required_environment_variables declared
+- Modern section headers present
+- No env var table in body (redundant with frontmatter declaration)
+"""
+
+import re
+
+import pytest
+import yaml
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS = [
+    {
+        "path": "optional-skills/devops/pfsense-monitoring/SKILL.md",
+        "name": "pfsense-monitoring",
+        "env_vars": ["PFSENSE_API_KEY", "PFSENSE_URL"],
+        "related": ["truenas-monitoring", "unraid-monitoring"],
+    },
+    {
+        "path": "optional-skills/devops/truenas-monitoring/SKILL.md",
+        "name": "truenas-monitoring",
+        "env_vars": ["TRUENAS_API_KEY", "TRUENAS_URL"],
+        "related": ["pfsense-monitoring", "unraid-monitoring"],
+    },
+    {
+        "path": "optional-skills/devops/unraid-monitoring/SKILL.md",
+        "name": "unraid-monitoring",
+        "env_vars": ["UNRAID_API_KEY", "UNRAID_URL"],
+        "related": ["pfsense-monitoring", "truenas-monitoring"],
+    },
+]
+
+MODERN_SECTIONS = [
+    "## When to Use",
+    "## Prerequisites",
+    "## Quick Reference",
+    "## Pitfalls",
+    "## Verification",
+]
+
+
+@pytest.fixture(params=SKILLS, ids=lambda s: s["name"])
+def skill(request):
+    return request.param
+
+
+def _load(skill):
+    """Read SKILL.md and return (content, frontmatter dict)."""
+    path = REPO_ROOT / skill["path"]
+    content = path.read_text()
+    assert content.startswith("---"), "Frontmatter must start at byte 0"
+    # Extract frontmatter between first --- and second ---
+    m = re.search(r"\n---\s*\n", content[3:])
+    assert m, "Frontmatter closing --- not found"
+    fm = yaml.safe_load(content[3 : m.start() + 3])
+    assert isinstance(fm, dict), "Frontmatter is not a YAML mapping"
+    body = content[m.end():]
+    # Strip any leftover dashes/newlines from YAML closing fence
+    body = body.lstrip("-\n ")
+    return content, fm, body
+
+
+class TestFrontmatterContract:
+    def test_name_present(self, skill):
+        _, fm, _ = _load(skill)
+        assert "name" in fm, "Frontmatter must have 'name'"
+        assert fm["name"] == skill["name"]
+
+    def test_description_present(self, skill):
+        _, fm, _ = _load(skill)
+        assert "description" in fm, "Frontmatter must have 'description'"
+
+    def test_description_max_60_chars(self, skill):
+        _, fm, _ = _load(skill)
+        desc = fm["description"]
+        assert len(desc) <= 60, (
+            f"Description is {len(desc)} chars (max 60): '{desc}'"
+        )
+
+    def test_description_ending(self, skill):
+        _, fm, _ = _load(skill)
+        desc = fm["description"]
+        assert desc.endswith("."), "Description must end with a period"
+
+    def test_description_one_sentence(self, skill):
+        """Description should be a single sentence — at most one terminal period."""
+        _, fm, _ = _load(skill)
+        desc = fm["description"]
+        # Count periods not part of abbreviations (e.g., 'v2.0')
+        periods = re.findall(r'(?<![a-zA-Z0-9])\.(?!\w)', desc.rstrip("."))
+        assert len(periods) <= 1, (
+            f"Description has {len(periods)} sentence-ending periods: '{desc}'"
+        )
+
+    def test_description_no_marketing_words(self, skill):
+        _, fm, _ = _load(skill)
+        desc = fm["description"].lower()
+        marketing = ["powerful", "comprehensive", "seamless", "advanced"]
+        for word in marketing:
+            assert word not in desc, f"Marketing word '{word}' in description"
+
+    def test_version_present(self, skill):
+        _, fm, _ = _load(skill)
+        assert "version" in fm, "Frontmatter should have 'version'"
+
+    def test_author_present(self, skill):
+        _, fm, _ = _load(skill)
+        assert "author" in fm, "Frontmatter should have 'author'"
+        # Author should be the human contributor, not 'Hermes Agent'
+        assert "Hermes Agent" not in fm["author"], (
+            "Author should credit the human contributor, not 'Hermes Agent'"
+        )
+
+    def test_license_present(self, skill):
+        _, fm, _ = _load(skill)
+        assert "license" in fm, "Frontmatter should have 'license'"
+
+
+class TestRequiredEnvVars:
+    def test_required_env_vars_declared(self, skill):
+        _, fm, _ = _load(skill)
+        req = fm.get("required_environment_variables", [])
+        assert isinstance(req, list), "required_environment_variables must be a list"
+        names = [e.get("name") for e in req]
+        for expected in skill["env_vars"]:
+            assert expected in names, (
+                f"Missing required_environment_variables entry for {expected}"
+            )
+
+    def test_api_key_has_prompt(self, skill):
+        _, fm, _ = _load(skill)
+        req = fm.get("required_environment_variables", [])
+        keys = [e for e in req if "API_KEY" in e.get("name", "")]
+        for k in keys:
+            assert k.get("prompt"), f"{k['name']} must have a 'prompt'"
+            assert k.get("help"), f"{k['name']} must have a 'help'"
+
+    def test_no_env_var_table_in_body(self, skill):
+        """Env vars documented in a markdown table are redundant with
+        required_environment_variables frontmatter — the table does not
+        trigger the setup/passthrough flow."""
+        _, _, body = _load(skill)
+        assert "| Variable" not in body and "| `Variable" not in body, (
+            "Remove env var markdown table — required_environment_variables "
+            "in frontmatter is the source of truth"
+        )
+
+    def test_url_in_config_not_required(self, skill):
+        """Non-secret appliance URLs belong in metadata.hermes.config,
+        not in required_environment_variables (they have defaults)."""
+        _, fm, _ = _load(skill)
+        # The URL var should be in required_environment_variables (for
+        # passthrough) or in metadata.hermes.config — either is fine.
+        req_names = [e.get("name") for e in fm.get("required_environment_variables", [])]
+        config = (fm.get("metadata") or {}).get("hermes") or {}
+        config_keys = list((config.get("config") or {}).keys())
+        url_var = [v for v in skill["env_vars"] if "URL" in v][0]
+        assert url_var in req_names or url_var in config_keys, (
+            f"{url_var} should be in required_environment_variables or "
+            "metadata.hermes.config"
+        )
+
+
+class TestModernSections:
+    def test_has_modern_sections(self, skill):
+        _, _, body = _load(skill)
+        for section in MODERN_SECTIONS:
+            assert section in body, f"Missing required section: {section}"
+
+    def test_has_title(self, skill):
+        _, _, body = _load(skill)
+        assert body.lstrip().startswith("# "), "Body must start with '# <Title>'"
+
+    def test_no_env_vars_required_section(self, skill):
+        """The old '## Env Vars Required' section is redundant when
+        required_environment_variables is in frontmatter."""
+        _, _, body = _load(skill)
+        assert "## Env Vars Required" not in body, (
+            "Remove '## Env Vars Required' — use required_environment_variables "
+            "in frontmatter instead"
+        )
+
+
+class TestRelatedSkills:
+    def test_related_skills_in_metadata(self, skill):
+        _, fm, _ = _load(skill)
+        meta = (fm.get("metadata") or {}).get("hermes") or {}
+        related = meta.get("related_skills", [])
+        assert isinstance(related, list)
+        for sibling in skill["related"]:
+            assert sibling in related, (
+                f"Should list {sibling} in metadata.hermes.related_skills"
+            )
+
+
+class TestBodyLength:
+    def test_body_not_empty(self, skill):
+        _, _, body = _load(skill)
+        assert len(body.strip()) > 50, "Body must have substantial content"
+
+    def test_total_under_limit(self, skill):
+        content, _, _ = _load(skill)
+        assert len(content) <= 100_000, "SKILL.md must be under 100,000 chars"


### PR DESCRIPTION
## Summary

Add three read-only infrastructure monitoring skills for commonly-used self-hosted devices, placed under `optional-skills/devops/` since not every user runs these systems.

### Skills added

| Skill | System | API | Actions |
|-------|--------|-----|---------|
| `pfsense-monitoring` | pfSense firewalls/gateways | REST API v2 (pfSense-pkg-RESTAPI) | summary, interfaces, gateways, services, firewall_rules, dhcp_leases, arp_table, dns_resolver, openvpn, ipsec, routes, carp, logs |
| `truenas-monitoring` | TrueNAS Scale NAS | REST API v2.0 | summary, pools, disks, shares, alerts, services |
| `unraid-monitoring` | UnRAID servers | GraphQL API | summary, info, disks, docker, alerts |

### Design

All three follow the same pattern:
- **No custom Python tools** — uses `terminal()` tool with `curl` for API calls. Follows the ["make it a skill"](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-it-be-a-skill-or-a-tool) guidance.
- **Read-only** — all queries are GET requests (or GraphQL queries with no mutations).
- **Env-var gated** — each skill only activates when the corresponding URL and API key env vars are set (e.g. `PFSENSE_URL` + `PFSENSE_API_KEY`).
- **Self-signed certs** — all devices use self-signed SSL by default; curl commands use `-k`.
- **Security audit sections** — each skill includes vulnerability checks relevant to its platform (NFS network restrictions, SSH password auth, Docker host networking exposure).
- **Sister skill references** — each skill links to the other two for multi-system workflows.

### Files changed

- `optional-skills/devops/pfsense-monitoring/SKILL.md`
- `optional-skills/devops/truenas-monitoring/SKILL.md`
- `optional-skills/devops/unraid-monitoring/SKILL.md`

### Testing

All three skills were tested against live production systems. Each curl command and endpoint was verified to return correct data.

Closes #32800 (superseded — was tool PR, now skill PR)
Closes #32865 (superseded — was tool PR, now skill PR)