### PR TITLE
fix: apply default kanban notification subscriptions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1652,6 +1652,12 @@ DEFAULT_CONFIG = {
         # worker process (if still running host-locally) is terminated
         # before the reclaim.  0 disables stale detection entirely.
         "dispatch_stale_timeout_seconds": 14400,
+        # Optional gateway notification subscriptions applied by the DB layer
+        # to every newly-created task, regardless of whether it was created
+        # from the CLI, dashboard, gateway, worker tools, scripts, or swarm
+        # helpers. Each entry accepts platform, chat_id, optional thread_id,
+        # optional user_id, and optional notifier_profile.
+        "default_notify_subscriptions": [],
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1714,9 +1714,7 @@ def create_task(
             (idempotency_key,),
         ).fetchone()
         if row:
-            existing_id = row["id"]
-            _apply_default_notify_subscriptions(conn, existing_id)
-            return existing_id
+            return row["id"]
 
     now = int(time.time())
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1524,6 +1524,74 @@ def _canonical_assignee(assignee: Optional[str]) -> Optional[str]:
     return normalize_profile_name(assignee)
 
 
+def _default_notify_subscriptions() -> list[dict[str, Optional[str]]]:
+    """Return configured subscriptions applied to every newly-created task.
+
+    ``kanban.default_notify_subscriptions`` is intentionally evaluated in
+    the DB layer instead of the CLI/gateway/tool wrappers so all creation
+    paths (CLI, scripts, worker tools, dashboard, swarm/decompose helpers)
+    get the same durable notification default.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        raw_entries = cfg.get("kanban", {}).get("default_notify_subscriptions") or []
+    except Exception:
+        return []
+
+    if isinstance(raw_entries, dict):
+        raw_entries = [raw_entries]
+    if not isinstance(raw_entries, list):
+        return []
+
+    out: list[dict[str, Optional[str]]] = []
+    for raw in raw_entries:
+        if not isinstance(raw, dict):
+            continue
+        platform = str(raw.get("platform") or "").strip().lower()
+        chat_id = str(raw.get("chat_id") or "").strip()
+        if not platform or not chat_id:
+            continue
+
+        def _optional_text(key: str) -> Optional[str]:
+            value = raw.get(key)
+            if value is None:
+                return None
+            text = str(value).strip()
+            return text or None
+
+        out.append({
+            "platform": platform,
+            "chat_id": chat_id,
+            "thread_id": _optional_text("thread_id"),
+            "user_id": _optional_text("user_id"),
+            "notifier_profile": _optional_text("notifier_profile"),
+        })
+    return out
+
+
+def _apply_default_notify_subscriptions(conn: sqlite3.Connection, task_id: str) -> None:
+    """Attach configured default gateway notifications to ``task_id``."""
+    for sub in _default_notify_subscriptions():
+        try:
+            add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform=sub["platform"] or "",
+                chat_id=sub["chat_id"] or "",
+                thread_id=sub.get("thread_id"),
+                user_id=sub.get("user_id"),
+                notifier_profile=sub.get("notifier_profile"),
+            )
+        except Exception as exc:  # pragma: no cover - defensive, best effort
+            _log.warning(
+                "failed to apply default kanban notify subscription to %s: %s",
+                task_id,
+                exc,
+            )
+
+
 def create_task(
     conn: sqlite3.Connection,
     *,
@@ -1646,7 +1714,9 @@ def create_task(
             (idempotency_key,),
         ).fetchone()
         if row:
-            return row["id"]
+            existing_id = row["id"]
+            _apply_default_notify_subscriptions(conn, existing_id)
+            return existing_id
 
     now = int(time.time())
 
@@ -1750,6 +1820,7 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                     },
                 )
+            _apply_default_notify_subscriptions(conn, task_id)
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -59,6 +59,47 @@ def test_create_task_applies_default_notify_subscriptions(kanban_home, monkeypat
     }]
 
 
+def test_idempotent_create_does_not_reapply_default_notify_subscriptions(kanban_home, monkeypatch):
+    """Idempotent retries should not undo an intentional unsubscribe."""
+    default_subs = [{
+        "platform": "telegram",
+        "chat_id": "235856371",
+        "thread_id": None,
+        "user_id": None,
+        "notifier_profile": "default",
+    }]
+    monkeypatch.setattr(kb, "_default_notify_subscriptions", lambda: default_subs)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="notify once",
+            assignee="worker1",
+            idempotency_key="same-task",
+        )
+        assert kb.list_notify_subs(conn, tid)
+        assert kb.remove_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="235856371",
+        )
+
+        same_tid = kb.create_task(
+            conn,
+            title="notify once",
+            assignee="worker1",
+            idempotency_key="same-task",
+        )
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert same_tid == tid
+    assert subs == []
+
+
 @pytest.mark.asyncio
 async def test_notifier_unsubs_after_completed_event(kanban_home):
     """

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -26,6 +26,39 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def test_create_task_applies_default_notify_subscriptions(kanban_home, monkeypatch):
+    """Configured default subscriptions should attach at the DB create layer."""
+    monkeypatch.setattr(
+        kb,
+        "_default_notify_subscriptions",
+        lambda: [{
+            "platform": "telegram",
+            "chat_id": "235856371",
+            "thread_id": None,
+            "user_id": None,
+            "notifier_profile": "default",
+        }],
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="notify by default", assignee="worker1")
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert subs == [{
+        "task_id": tid,
+        "platform": "telegram",
+        "chat_id": "235856371",
+        "thread_id": "",
+        "user_id": None,
+        "notifier_profile": "default",
+        "created_at": subs[0]["created_at"],
+        "last_event_id": 0,
+    }]
+
+
 @pytest.mark.asyncio
 async def test_notifier_unsubs_after_completed_event(kanban_home):
     """

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -673,9 +673,21 @@ This is the whole point of the separation:
 - You spot a card that needs human context → `/kanban comment t_xyz "use the 2026 schema, not 2025"` lands on the task thread and the *next* run of that task will read it in `kanban_show()`.
 - You want to know what your fleet is doing without stopping the orchestrator → `/kanban list --mine` or `/kanban stats` inspects the board without touching your main conversation.
 
-### Auto-subscribe on `/kanban create` (gateway only)
+### Auto-subscribe on task creation
 
 When you create a task from the gateway with `/kanban create "…"`, the originating chat (platform + chat id + thread id) is automatically subscribed to that task's terminal events (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`). You'll get one message back per terminal event — including the first line of the worker's result summary on `completed` — without having to poll or remember the task id.
+
+Installations that want every task to notify a fixed home channel — including tasks created by CLI commands, scripts, worker tools, dashboard actions, or swarm/decompose helpers — can configure DB-layer defaults:
+
+```yaml
+kanban:
+  default_notify_subscriptions:
+    - platform: telegram
+      chat_id: "12345678"
+      notifier_profile: default
+```
+
+These defaults are applied by `kanban_db.create_task`, so they cover all creation paths. Remove the config entry, or remove a single row with `hermes kanban notify-unsubscribe`, to opt out.
 
 ```
 you> /kanban create "transcribe today's podcast" --assignee transcriber
@@ -731,7 +743,7 @@ Workers receive `$HERMES_TENANT` and namespace their memory writes by prefix. Th
 
 ## Gateway notifications
 
-When you run `/kanban create …` from the gateway (Telegram, Discord, Slack, etc.), the originating chat is automatically subscribed to the new task. The gateway's background notifier polls `task_events` every few seconds and delivers one message per terminal event (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`) to that chat. Completed tasks also send the first line of the worker's `--result` so you see the outcome without having to `/kanban show`.
+When you run `/kanban create …` from the gateway (Telegram, Discord, Slack, etc.), the originating chat is automatically subscribed to the new task. The gateway's background notifier polls `task_events` every few seconds and delivers one message per terminal event (`completed`, `blocked`, `gave_up`, `crashed`, `timed_out`) to that chat. Completed tasks also send the first line of the worker's `--result` so you see the outcome without having to `/kanban show`. If `kanban.default_notify_subscriptions` is configured, those fixed subscriptions are added to every new task as well, including non-gateway creation paths.
 
 You can manage subscriptions explicitly from the CLI — useful when a script / cron job wants to notify a chat it didn't originate from:
 


### PR DESCRIPTION
## Summary\n- add kanban.default_notify_subscriptions config support at the DB create_task layer\n- apply configured subscriptions to tasks created through CLI, scripts, worker tools, dashboard, and swarm/decompose helpers\n- document fixed home-channel defaults and add regression coverage\n\n## Tests\n- python -m pytest tests/hermes_cli/test_kanban_notify.py tests/tools/test_kanban_tools.py -q -o 'addopts='\n\n## Local verification\n- configured default Telegram subscription for this VPS: telegram:235856371, notifier_profile=default\n- created a blocked dry-run task and confirmed notify-list contained the Telegram subscription immediately, then archived it