### PR TITLE
fix(credential-pool): treat token_invalidated/token_revoked as terminal

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -110,6 +110,17 @@ SUPPORTED_POOL_STRATEGIES = {
 EXHAUSTED_TTL_401_SECONDS = 5 * 60           # 5 minutes
 EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
+# Terminal OAuth failures (token_invalidated / token_revoked from the model
+# provider) cannot be recovered by waiting — the operator must re-auth.  A
+# 1-year cooldown keeps the credential out of rotation without introducing a
+# new state machine branch.  An explicit operator reset (e.g. `hermes auth`)
+# clears the entry's exhausted status the normal way.
+EXHAUSTED_TTL_TERMINAL_SECONDS = 365 * 24 * 60 * 60
+
+# Reasons that mark a credential as effectively dead.  Sourced from the
+# provider error body's `code` field — see ``extract_api_error_context`` in
+# ``agent.agent_runtime_helpers`` which normalises ``code`` into ``reason``.
+TERMINAL_FAILURE_REASONS = frozenset({"token_invalidated", "token_revoked"})
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
 # Custom endpoints all share provider='custom' but are keyed by their
@@ -245,8 +256,27 @@ def _is_manual_source(source: str) -> bool:
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
 
 
-def _exhausted_ttl(error_code: Optional[int]) -> int:
-    """Return cooldown seconds based on the HTTP status that caused exhaustion."""
+def _is_terminal_failure_reason(error_reason: Optional[str]) -> bool:
+    """True when the provider's error body marked the credential as dead."""
+    if not isinstance(error_reason, str):
+        return False
+    return error_reason.strip().lower() in TERMINAL_FAILURE_REASONS
+
+
+def _exhausted_ttl(
+    error_code: Optional[int],
+    error_reason: Optional[str] = None,
+) -> int:
+    """Return cooldown seconds based on the HTTP status that caused exhaustion.
+
+    ``token_invalidated`` / ``token_revoked`` reasons override the status-code
+    based default: a revoked OAuth token will never recover on its own, so a
+    5-minute (401) cooldown lets it rejoin rotation and fail again on the next
+    request.  Returning a 1-year cooldown effectively retires the entry until
+    the operator re-auths.
+    """
+    if _is_terminal_failure_reason(error_reason):
+        return EXHAUSTED_TTL_TERMINAL_SECONDS
     if error_code == 401:
         return EXHAUSTED_TTL_401_SECONDS
     if error_code == 429:
@@ -335,11 +365,21 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
 def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     if entry.last_status != STATUS_EXHAUSTED:
         return None
+    # Terminal OAuth failures cannot be recovered by waiting.  Honour the
+    # long cooldown regardless of any reset hint that may have been attached
+    # (token revocation responses occasionally inherit a Retry-After header
+    # from upstream proxies — that header is meaningless here).
+    if _is_terminal_failure_reason(entry.last_error_reason):
+        if entry.last_status_at is None:
+            return None
+        return entry.last_status_at + EXHAUSTED_TTL_TERMINAL_SECONDS
     reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
     if reset_at is not None:
         return reset_at
     if entry.last_status_at:
-        return entry.last_status_at + _exhausted_ttl(entry.last_error_code)
+        return entry.last_status_at + _exhausted_ttl(
+            entry.last_error_code, entry.last_error_reason
+        )
     return None
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -369,7 +369,8 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
     # long cooldown regardless of any reset hint that may have been attached
     # (token revocation responses occasionally inherit a Retry-After header
     # from upstream proxies — that header is meaningless here).
-    if _is_terminal_failure_reason(entry.last_error_reason):
+    error_reason = getattr(entry, "last_error_reason", None)
+    if _is_terminal_failure_reason(error_reason):
         if entry.last_status_at is None:
             return None
         return entry.last_status_at + EXHAUSTED_TTL_TERMINAL_SECONDS
@@ -378,7 +379,7 @@ def _exhausted_until(entry: PooledCredential) -> Optional[float]:
         return reset_at
     if entry.last_status_at:
         return entry.last_status_at + _exhausted_ttl(
-            entry.last_error_code, entry.last_error_reason
+            entry.last_error_code, error_reason
         )
     return None
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -296,6 +296,117 @@ def test_exhausted_401_entry_resets_after_five_minutes(tmp_path, monkeypatch):
     assert entry.last_status == "ok"
 
 
+def test_terminal_token_invalidated_does_not_reset_after_five_minutes(tmp_path, monkeypatch):
+    """A revoked OAuth token must not rejoin rotation on the 401 cooldown.
+
+    Regression for #32849 — a Codex 401 with ``code: token_invalidated`` used
+    to inherit the transient 5-minute cooldown, so the same dead credential
+    kept getting picked back up every TTL window.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    # Prevent auto-seeding from Codex CLI tokens on the host.
+    monkeypatch.setattr(
+        "hermes_cli.auth._import_codex_cli_tokens",
+        lambda: None,
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-revoked",
+                        "label": "Hermes Agent Codex",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "tok-revoked",
+                        "last_status": "exhausted",
+                        # Well past the 5-minute and 1-hour windows.
+                        "last_status_at": time.time() - 7 * 24 * 60 * 60,
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                    },
+                    {
+                        "id": "cred-healthy",
+                        "label": "secondary",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "tok-healthy",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+
+    # The healthy entry should be chosen — the revoked one must stay out of
+    # rotation regardless of how much time has passed.
+    assert entry is not None
+    assert entry.id == "cred-healthy"
+    # And the revoked entry should still be flagged as exhausted in the pool.
+    revoked = next(e for e in pool.entries() if e.id == "cred-revoked")
+    assert revoked.last_status == "exhausted"
+    assert revoked.last_error_reason == "token_invalidated"
+
+
+def test_terminal_token_revoked_blocks_pool_availability(tmp_path, monkeypatch):
+    """A single-credential pool with a ``token_revoked`` reason has nothing to offer."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "hermes_cli.auth._import_codex_cli_tokens",
+        lambda: None,
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "tok-1",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 30 * 24 * 60 * 60,
+                        "last_error_code": 401,
+                        "last_error_reason": "token_revoked",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.has_credentials() is True
+    assert pool.has_available() is False
+    assert pool.select() is None
+
+
+def test_terminal_failure_reason_check_is_case_insensitive():
+    """Defensive — provider casing varies between SDKs and reverse proxies."""
+    from agent.credential_pool import _is_terminal_failure_reason
+
+    assert _is_terminal_failure_reason("token_invalidated") is True
+    assert _is_terminal_failure_reason("Token_Invalidated") is True
+    assert _is_terminal_failure_reason("  token_revoked  ") is True
+    assert _is_terminal_failure_reason("invalid_api_key") is False
+    assert _is_terminal_failure_reason("device_code_exhausted") is False
+    assert _is_terminal_failure_reason(None) is False
+    assert _is_terminal_failure_reason("") is False
+
+
 def test_explicit_reset_timestamp_overrides_default_429_ttl(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     # Prevent auto-seeding from Codex CLI tokens on the host


### PR DESCRIPTION
## What does this PR do?

A revoked OAuth credential used to inherit the transient 5-minute 401 cooldown in `_exhausted_ttl`, so the same dead token kept rejoining rotation every TTL window and failing the very next request — surfacing for users as repeated `Failed to generate context summary: 401 token_invalidated` log lines and broken context-compression until the operator manually removed the credential via `hermes auth`.

Extends `_exhausted_ttl` to consult `last_error_reason` alongside the HTTP status code. When the reason is `token_invalidated` or `token_revoked` (the provider error body's `code` field, normalised by `extract_api_error_context` in `agent/agent_runtime_helpers.py`), the cooldown becomes 1 year — effectively dead until the operator re-auths. `_exhausted_until` also honours the long cooldown regardless of any `Retry-After` hint that may have been attached to the response (those headers are meaningless for permanently-revoked tokens).

This is the minimum behavioural fix — no new status field on `PooledCredential`, no operator-visible state machine change. An explicit `hermes auth` reset still clears the entry the normal way.

## Related Issue

Fixes #32849

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credential_pool.py` — adds `EXHAUSTED_TTL_TERMINAL_SECONDS` (1 year) and `TERMINAL_FAILURE_REASONS = {token_invalidated, token_revoked}`; introduces a small `_is_terminal_failure_reason` helper; `_exhausted_ttl` now takes the reason and short-circuits to the terminal cooldown; `_exhausted_until` mirrors the same short-circuit so a stale `last_error_reset_at` cannot pull a dead credential back into rotation early.
- `tests/agent/test_credential_pool.py` — three regression tests: (a) a `token_invalidated` entry sitting 7 days past the 5-minute 401 window is still skipped and a healthy sibling is selected instead, (b) a single-credential pool with a `token_revoked` reason reports `has_available() is False` and `select() is None` even 30 days later, (c) the helper is case- and whitespace-insensitive and rejects unrelated reasons (`invalid_api_key`, `device_code_exhausted`, `None`, empty).

> Audited siblings: confirmed every other call site of `_exhausted_ttl` / `_exhausted_until` flows through `extract_api_error_context` (or its `_pool_error_context` equivalent in `agent/auxiliary_client.py`), both of which already normalise the provider body's `code` into `error_context['reason']`. The fix covers every provider that exposes a terminal `code` on its 401 — Codex / OpenAI / Anthropic / OpenRouter / custom. No widening needed.

## How to Test

1. Reproduce the original bug on `main`:
   ```python
   import time
   from agent.credential_pool import _exhausted_until, PooledCredential
   entry = PooledCredential(
       provider="openai-codex", id="c", label="x", auth_type="oauth",
       priority=0, source="manual:device_code", access_token="x",
       last_status="exhausted",
       last_status_at=time.time() - 7 * 24 * 60 * 60,  # 7 days ago
       last_error_code=401,
       last_error_reason="token_invalidated",
   )
   # On main: _exhausted_until returns a timestamp 6d 23h 55m in the past
   # → credential is "available" again.
   # On this branch: returns ~1 year in the future → stays dead.
   ```
2. Focused test run:
   ```
   uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 \
       -m pytest tests/agent/test_credential_pool.py \
                 tests/agent/test_credential_pool_routing.py \
                 tests/tools/test_credential_pool_env_fallback.py -v
   ```
   Expected: 91 passed (88 existing + 3 new). All existing TTL/rotation tests continue to pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing string or config change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python state-machine change)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

_N/A._