### PR TITLE
feat(provider): add Xiaomi Token Plan as first-class provider

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -328,7 +328,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek-chat",
         "deepseek-reasoner",
     ],
-    "xiaomi": [
+"xiaomi": [
+        "mimo-v2.5-pro",
+        "mimo-v2.5",
+        "mimo-v2-pro",
+        "mimo-v2-omni",
+        "mimo-v2-flash",
+    ],
+    "xiaomi-token-plan": [
         "mimo-v2.5-pro",
         "mimo-v2.5",
         "mimo-v2-pro",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -186,6 +186,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="XIAOMI_BASE_URL",
     ),
+    "xiaomi-token-plan": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="XIAOMI_TOKEN_BASE_URL",
+    ),
     "tencent-tokenhub": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="TOKENHUB_BASE_URL",
@@ -334,9 +338,12 @@ ALIASES: Dict[str, str] = {
     "novita-ai": "novita",
     "novitaai": "novita",
 
-    # xiaomi
+# xiaomi
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
+    "xiaomi-token": "xiaomi-token-plan",
+    "mimo-token": "xiaomi-token-plan",
+    "xiaomi-token-plan-europe": "xiaomi-token-plan",
 
     # tencent
     "tencent": "tencent-tokenhub",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -338,12 +338,11 @@ ALIASES: Dict[str, str] = {
     "novita-ai": "novita",
     "novitaai": "novita",
 
-# xiaomi
+    # xiaomi
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
     "xiaomi-token": "xiaomi-token-plan",
     "mimo-token": "xiaomi-token-plan",
-    "xiaomi-token-plan-europe": "xiaomi-token-plan",
 
     # tencent
     "tencent": "tencent-tokenhub",

--- a/plugins/model-providers/xiaomi-token-plan/__init__.py
+++ b/plugins/model-providers/xiaomi-token-plan/__init__.py
@@ -1,0 +1,21 @@
+"""Xiaomi Token Plan (Europe) provider profile.
+
+Separate from the standard `xiaomi` profile because it hits a different
+endpoint (token-plan-ams.xiaomimimo.com/v1) with a dedicated token plan.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+xiaomi_token = ProviderProfile(
+    name="xiaomi-token-plan",
+    aliases=("xiaomi-token", "mimo-token", "xiaomi-token-plan-europe"),
+    display_name="Xiaomi Token Plan (Europe)",
+    description="Xiaomi MiMo Token Plan — Europe endpoint",
+    signup_url="https://platform.xiaomimimo.com/#/docs",
+    env_vars=("XIAOMI_API_KEY",),
+    base_url="https://token-plan-ams.xiaomimimo.com/v1",
+    auth_type="api_key",
+)
+
+register_provider(xiaomi_token)

--- a/plugins/model-providers/xiaomi-token-plan/__init__.py
+++ b/plugins/model-providers/xiaomi-token-plan/__init__.py
@@ -1,7 +1,11 @@
-"""Xiaomi Token Plan (Europe) provider profile.
+"""Xiaomi Token Plan provider profile.
 
-Separate from the standard `xiaomi` profile because it hits a different
-endpoint (token-plan-ams.xiaomimimo.com/v1) with a dedicated token plan.
+Region-neutral: defaults to the Singapore endpoint. Users on other regions
+can override via the XIAOMI_TOKEN_BASE_URL env var:
+
+  Europe (Amsterdam): https://token-plan-ams.xiaomimimo.com/v1
+  Singapore:          https://token-plan-sgp.xiaomimimo.com/v1
+  China:              https://token-plan-cn.xiaomimimo.com/v1
 """
 
 from providers import register_provider
@@ -9,12 +13,12 @@ from providers.base import ProviderProfile
 
 xiaomi_token = ProviderProfile(
     name="xiaomi-token-plan",
-    aliases=("xiaomi-token", "mimo-token", "xiaomi-token-plan-europe"),
-    display_name="Xiaomi Token Plan (Europe)",
-    description="Xiaomi MiMo Token Plan — Europe endpoint",
+    aliases=("xiaomi-token", "mimo-token"),
+    display_name="Xiaomi Token Plan",
+    description="Xiaomi MiMo Token Plan — region-selectable via XIAOMI_TOKEN_BASE_URL",
     signup_url="https://platform.xiaomimimo.com/#/docs",
     env_vars=("XIAOMI_API_KEY",),
-    base_url="https://token-plan-ams.xiaomimimo.com/v1",
+    base_url="https://token-plan-sgp.xiaomimimo.com/v1",
     auth_type="api_key",
 )
 

--- a/plugins/model-providers/xiaomi-token-plan/plugin.yaml
+++ b/plugins/model-providers/xiaomi-token-plan/plugin.yaml
@@ -1,0 +1,5 @@
+name: xiaomi-token-plan-provider
+kind: model-provider
+version: 1.0.0
+description: Xiaomi MiMo Token Plan (Europe)
+author: tuancookiez-hub

--- a/plugins/model-providers/xiaomi-token-plan/plugin.yaml
+++ b/plugins/model-providers/xiaomi-token-plan/plugin.yaml
@@ -1,5 +1,5 @@
 name: xiaomi-token-plan-provider
 kind: model-provider
 version: 1.0.0
-description: Xiaomi MiMo Token Plan (Europe)
+description: Xiaomi MiMo Token Plan (region-selectable)
 author: tuancookiez-hub


### PR DESCRIPTION
## Summary

Adds Xiaomi MiMo Token Plan as a built-in provider, following the same pattern as `alibaba-coding-plan` and `stepfun` for coding/plan providers.

## Region Selection

The provider defaults to the **Singapore** endpoint. Users on other regions can override via the `XIAOMI_TOKEN_BASE_URL` env var:

| Region | Endpoint |
|--------|----------|
| Singapore (default) | `https://token-plan-sgp.xiaomimimo.com/v1` |
| Europe (Amsterdam) | `https://token-plan-ams.xiaomimimo.com/v1` |
| China | `https://token-plan-cn.xiaomimimo.com/v1` |

Example in `.env`:
```
XIAOMI_TOKEN_BASE_URL=https://token-plan-ams.xiaomimimo.com/v1
```

## Changes

| File | Change |
|------|--------|
| `plugins/model-providers/xiaomi-token-plan/__init__.py` | **New** — ProviderProfile with Singapore default, env var override for regions |
| `plugins/model-providers/xiaomi-token-plan/plugin.yaml` | **New** — Plugin manifest |
| `hermes_cli/providers.py` | Add `HERMES_OVERLAYS` entry + 2 aliases (`xiaomi-token`, `mimo-token`) |
| `hermes_cli/models.py` | Add static model catalog |

## Provider Details

- **Default Endpoint:** `https://token-plan-sgp.xiaomimimo.com/v1`
- **Region Override:** `XIAOMI_TOKEN_BASE_URL` env var
- **Auth env var:** `XIAOMI_API_KEY`
- **Models:** `mimo-v2.5-pro`, `mimo-v2.5`, `mimo-v2-pro`, `mimo-v2-omni`, `mimo-v2-flash`