### PR TITLE
fix(approval): preserve flag case during dangerous-pattern matching

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -130,6 +130,20 @@ class TestSafeCommand:
         assert desc is None
 
 
+class TestGitBranchForceDelete:
+    def test_force_delete_uppercase_gated(self):
+        is_dangerous, key, desc = detect_dangerous_command("git branch -D feature")
+        assert is_dangerous is True
+        assert key is not None
+        assert "force delete" in desc.lower()
+
+    def test_safe_delete_lowercase_not_gated(self):
+        is_dangerous, key, desc = detect_dangerous_command("git branch -d feature")
+        assert is_dangerous is False
+        assert key is None
+        assert desc is None
+
+
 def _clear_session(key):
     """Replace for removed clear_session() — directly clear internal state."""
     approval_module._session_approved.pop(key, None)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -265,7 +265,7 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     """
     if "SUDO_PASSWORD" in os.environ:
         return (False, None)
-    normalized = _normalize_command_for_detection(command).lower()
+    normalized = _lower_except_flags(_normalize_command_for_detection(command))
     if _SUDO_STDIN_RE.search(normalized):
         return (True, "sudo password guessing via stdin (sudo -S)")
     return (False, None)
@@ -277,7 +277,7 @@ def detect_hardline_command(command: str) -> tuple:
     Returns:
         (is_hardline, description) or (False, None)
     """
-    normalized = _normalize_command_for_detection(command).lower()
+    normalized = _lower_except_flags(_normalize_command_for_detection(command))
     for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
         if pattern_re.search(normalized):
             return (True, description)
@@ -454,6 +454,21 @@ def _approval_key_aliases(pattern_key: str) -> set[str]:
 # Detection
 # =========================================================================
 
+def _lower_except_flags(s: str) -> str:
+    """Lowercase command words but preserve flag case (-D stays -D, not -d).
+
+    This is important because patterns like ``git branch -D`` (force delete)
+    are intentionally case-sensitive: ``-D`` is destructive while ``-d`` is a
+    safe merged-branch-only delete.  Calling ``.lower()`` on the full command
+    string before pattern matching collapses that distinction.
+    """
+    return re.sub(
+        r'\S+',
+        lambda m: m.group(0) if m.group(0).startswith('-') else m.group(0).lower(),
+        s,
+    )
+
+
 def _normalize_command_for_detection(command: str) -> str:
     """Normalize a command string before dangerous-pattern matching.
 
@@ -478,7 +493,7 @@ def detect_dangerous_command(command: str) -> tuple:
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
-    command_lower = _normalize_command_for_detection(command).lower()
+    command_lower = _lower_except_flags(_normalize_command_for_detection(command))
     for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
         if pattern_re.search(command_lower):
             pattern_key = description

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -393,7 +393,10 @@ DANGEROUS_PATTERNS = [
     (r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
     (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
-    (r'\bgit\s+branch\s+-D\b', "git branch force delete"),
+    # Scoped (?-i:-D) overrides the module-wide re.IGNORECASE so the safe
+    # merged-only `-d` delete does not match the force-delete `-D`. Relies on
+    # _lower_except_flags() preserving flag case at the detection call sites.
+    (r'\bgit\s+branch\s+(?-i:-D)\b', "git branch force delete"),
     # Script execution after chmod +x — catches the two-step pattern where
     # a script is first made executable then immediately run. The script
     # content may contain dangerous commands that individual patterns miss.


### PR DESCRIPTION
## Problem

`detect_dangerous_command`, `detect_hardline_command`, and `_check_sudo_stdin_guard` all call `_normalize_command_for_detection(command).lower()` before running regex pattern matching. The `.lower()` collapses case distinctions across the entire command string, including flags.

The concrete victim: the `git branch` force-delete pattern. The safe merged-only delete (`-d`) and the true force-delete (`-D`) become indistinguishable, so users get a gate prompt on the safe variant. That erodes trust in the gate and trains people to dismiss approvals.

## Fix

This takes two pieces that only work together:

**1. Preserve flag case in the input.** `_lower_except_flags()` lowercases every token **except** those starting with `-`, and replaces the chained `.lower()` at all three call sites. Command names and subcommands are still lowercased; only flag tokens keep their original casing.

```python
def _lower_except_flags(s: str) -> str:
    """Lowercase command words but preserve flag case (-D stays -D, not -d)."""
    return re.sub(
        r'\S+',
        lambda m: m.group(0) if m.group(0).startswith('-') else m.group(0).lower(),
        s,
    )
```

**2. Make the pattern case-sensitive.** Preserving the input case is not enough on its own: the patterns are compiled with a module-wide `re.IGNORECASE` (`_RE_FLAGS = re.IGNORECASE | re.DOTALL`), so `-D` in the pattern still matches `-d` regardless of the input. The git-branch pattern now scopes the flag off:

```python
(r'\bgit\s+branch\s+(?-i:-D)\b', "git branch force delete"),
```

Both halves are required:
- Without `_lower_except_flags`, the input is already lowercased to `-d` and `(?-i:-D)` would **miss the real force-delete** (false negative).
- Without `(?-i:-D)`, `re.IGNORECASE` re-collapses the cases and the safe `-d` **still trips the gate** (the original false positive).

`git branch -D` is currently the only case-sensitive uppercase-flag pattern, but `_lower_except_flags` keeps the door open for any future flag-case-dependent pattern (`-R` vs `-r`, `-F` vs `-f`, etc.).

## Testing

New `TestGitBranchForceDelete`:
- `git branch -D <branch>` still triggers the "git branch force delete" gate
- `git branch -d <branch>` no longer triggers it

All existing hardline and dangerous patterns are unaffected (none other than `git branch -D` rely on flag case).
