### PR TITLE
fix(gateway): notify Telegram user when clarify button taps a dead entry

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3380,22 +3380,42 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.error("[%s] resolve_gateway_clarify failed: %s", self.name, exc)
                     resolved = False
 
-                await query.answer(text=f"✓ {resolved_text[:60]}")
-                try:
-                    await query.edit_message_text(
-                        text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
-                        parse_mode=ParseMode.HTML,
-                        reply_markup=None,
-                    )
-                except Exception:
-                    pass
-
                 if resolved:
+                    await query.answer(text=f"✓ {resolved_text[:60]}")
+                    try:
+                        await query.edit_message_text(
+                            text=f"❓ {_html.escape(query.message.text or '')}\n\n<b>{_html.escape(user_display)}:</b> {_html.escape(resolved_text)}",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
                     logger.info(
                         "Telegram clarify button resolved (id=%s, choice=%r, user=%s)",
                         clarify_id, resolved_text, user_display,
                     )
                 else:
+                    # The clarify entry was already gone when the button was
+                    # tapped: the gateway restarted (in-memory clarify state
+                    # lost) or the agent's clarify_timeout evicted the entry
+                    # before the user replied.  Without this branch the
+                    # message would be edited to show the user's choice as if
+                    # accepted while the agent never receives it and stays
+                    # stuck on "running: clarify" (issue #32762).  Surface the
+                    # dead tap to the user instead of silently dropping it.
+                    await query.answer(text="⚠️ This question expired — please /retry.")
+                    try:
+                        await query.edit_message_text(
+                            text=(
+                                f"❓ {_html.escape(query.message.text or '')}\n\n"
+                                "<i>⚠️ This question expired or the session reset — "
+                                "please /retry.</i>"
+                            ),
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
                     logger.warning(
                         "Telegram clarify button: resolve_gateway_clarify returned False (id=%s)",
                         clarify_id,

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -309,6 +309,46 @@ class TestTelegramClarifyCallback:
         assert "already" in query.answer.call_args[1]["text"].lower()
 
     @pytest.mark.asyncio
+    async def test_expired_entry_notifies_user(self):
+        """Tap on a button whose clarify entry is gone (timeout-evicted or
+        lost to a gateway restart) must surface an 'expired' notice instead
+        of editing the message to show the choice as accepted (issue #32762).
+        """
+        adapter = _make_adapter()
+        # The adapter still tracks the prompt (state survives a timeout
+        # eviction), but the clarify primitive entry has already been
+        # removed — so resolve_gateway_clarify returns False.
+        adapter._clarify_state["cidE"] = "sk-exp"
+
+        query = AsyncMock()
+        query.data = "cl:cidE:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.text = "Pick"
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, context)
+
+        # State popped, user told the prompt expired, and the message edited
+        # to the expired notice — NOT to a faux-accepted choice.
+        assert "cidE" not in adapter._clarify_state
+        query.answer.assert_called_once()
+        assert "expired" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_called_once()
+        edited_text = query.edit_message_text.call_args[1]["text"].lower()
+        assert "expired" in edited_text
+        assert "retry" in edited_text
+
+    @pytest.mark.asyncio
     async def test_unauthorized_user_rejected(self):
         from tools import clarify_gateway as cm
 


### PR DESCRIPTION
Notify the user when a Telegram clarify button is tapped after its pending entry is gone, instead of silently faking acceptance.

## What does this PR do?

In gateway mode, `tools.clarify_gateway` holds pending clarify requests in module-level state. When a clarify entry is no longer present — the agent's `clarify_timeout` already evicted it in `wait_for_response`, or the gateway restarted (SIGTERM) and lost in-memory state — `resolve_gateway_clarify(clarify_id, response)` returns `False`.

The Telegram `cl:` callback ignored that `False`: it had already edited the message to show the user's choice as accepted, then merely logged a warning. From the user's side the button looked successful, but the agent never received the answer and stayed stuck on `running: clarify` until `max_iterations`.

This PR makes the callback branch on the resolve result. On success it behaves exactly as before. On `False` it answers with an `⚠️ This question expired — please /retry.` toast, edits the original message to an expired/session-reset notice, and removes the inline buttons — so the dead tap is surfaced rather than dropped.

This is the issue's suggested **fix #2** ("notify the user on expired tap"), the smallest-scope item the reporter offered. It is a UX fix only: it does not restore the lost clarify state, so the deeper persistence (#1) and timeout-eviction grace-window (#4) work is intentionally left for follow-ups. Because this resolves only one of the four suggested acceptance criteria, the PR uses `Refs #32762` rather than a closing trailer.

## Related Issue

Refs #32762

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: in the `cl:` clarify callback, branch on the `resolve_gateway_clarify` return value. Keep the existing accepted-choice message edit + `✓` toast on success; on `False`, answer with an expired toast, edit the message to an expired/`/retry` notice, drop the inline keyboard, and keep the existing warning log.
- `tests/gateway/test_telegram_clarify_buttons.py`: add `test_expired_entry_notifies_user`, which taps a button whose primitive entry is gone and asserts the user gets an `expired`/`retry` notice (toast + message edit) rather than a faux-accepted choice.

## What changed and why

- **Why:** a tapped clarify button on an evicted/restart-lost entry silently dropped the user's reply and left the agent frozen on `running: clarify`. The message even showed the choice as accepted, so the failure was invisible to the user.
- **What:** the callback now distinguishes a resolved tap from a dead one and tells the user to `/retry` instead of pretending the answer landed.

## How to Test

1. Set `agent.clarify_timeout: 5` in config (to force quick eviction), start the gateway, and run an agent task that ends in a `clarify` with buttons over Telegram.
2. Wait past the timeout so `wait_for_response` evicts the entry, then tap a choice button.
3. Observe the message is replaced with `⚠️ This question expired or the session reset — please /retry.` and the buttons are removed (previously: the message showed your choice as accepted while the agent hung).
4. Automated: `pytest tests/gateway/test_telegram_clarify_buttons.py -q` — the new `test_expired_entry_notifies_user` covers the dead-entry path; the existing resolve/other/auth tests confirm the happy path is unchanged.

## What platforms tested on

- macOS on darwin-arm64 (local): `pytest tests/gateway/test_telegram_clarify_buttons.py tests/tools/test_clarify_gateway.py -q` → 28 passed; `ruff check` clean on the changed files.
- Change is pure async/Python string + control-flow with no process, signal, path, or subprocess work, so no platform-specific behavior is involved; cross-platform CI covers Linux/Windows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the gateway/clarify suites; full suite trusted to CI)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

<!-- autocontrib:worker-id=issue-new-61196032 kind=pr-open -->