### PR TITLE
fix(tools): surface dropped MEDIA attachments in send_message result

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -412,6 +412,68 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_dropped_media_surfaces_warning_not_clean_success(self, tmp_path, monkeypatch):
+        """A MEDIA path rejected by the safety filter must not be reported as a
+        clean success — the result has to carry a warning so the model/user
+        learns the attachment never went out (issue #32644)."""
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+        config, _telegram_cfg = _make_config()
+        archived = tmp_path / "voice-episodes" / "teaser.ogg"
+        archived.parent.mkdir(parents=True)
+        archived.write_bytes(b"OggS")
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": f"[[audio_as_voice]]\nteaser published\nMEDIA:{archived}",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        warnings = result.get("warnings", [])
+        assert any("1 MEDIA attachment(s) were blocked" in w for w in warnings), warnings
+        assert any("HERMES_MEDIA_ALLOW_DIRS" in w for w in warnings), warnings
+
+    def test_safe_media_send_has_no_dropped_warning(self, tmp_path, monkeypatch):
+        """A MEDIA path the filter accepts must not trigger the dropped-media
+        warning — guards against false positives from the issue #32644 fix."""
+        extra_root = tmp_path / "operator-media"
+        archived = extra_root / "teaser.ogg"
+        archived.parent.mkdir(parents=True)
+        archived.write_bytes(b"OggS")
+        monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(extra_root))
+        config, _telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": f"[[audio_as_voice]]\nteaser published\nMEDIA:{archived}",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert not any(
+            "blocked" in w for w in result.get("warnings", [])
+        ), result.get("warnings")
+        _, kwargs = send_mock.await_args
+        assert kwargs["media_files"] == [(str(archived.resolve()), True)]
+
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()
         leaked = "very-secret-query-token-123456"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -251,7 +251,13 @@ def _handle_send(args):
     force_document_attachments = "[[as_document]]" in message
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
+    requested_media_count = len(media_files)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    # MEDIA paths the safety filter rejected (resolved outside the allowed
+    # media roots). The text portion still sends, but the attachment silently
+    # vanishes — so the count is surfaced on the result rather than reporting an
+    # unqualified success the user reads as "attachment delivered" (issue #32644).
+    dropped_media_count = requested_media_count - len(media_files)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
@@ -313,6 +319,18 @@ def _handle_send(args):
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+
+        # Surface dropped attachments so a text-only send isn't reported as a
+        # clean success when the user asked for a media attachment (issue #32644).
+        if dropped_media_count and isinstance(result, dict) and result.get("success"):
+            warnings = list(result.get("warnings", []))
+            warnings.append(
+                f"{dropped_media_count} MEDIA attachment(s) were blocked and NOT "
+                "delivered: the resolved path is outside the allowed media roots, "
+                "so only the text was sent. Move the file under a Hermes media "
+                "cache or add its directory to HERMES_MEDIA_ALLOW_DIRS, then resend."
+            )
+            result["warnings"] = warnings
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:


### PR DESCRIPTION
## What does this PR do?

Fixes the Telegram `MEDIA:<path>` false-success in the `send_message` tool path. When a MEDIA directive resolves to a path outside the allowed media roots, `filter_media_delivery_paths` drops it (logging `Skipping unsafe MEDIA directive path outside allowed roots`), but the text portion still sends — so the tool returned an unqualified `{"success": true}` while the user received no attachment. The model/user had no signal that the attachment was silently dropped.

The fix records how many MEDIA paths the safety filter rejected and, when the send otherwise succeeds, appends a clear `warnings` entry to the result. The text still delivers (so it isn't a hard error), but the result no longer masquerades as a successful attachment delivery, and it tells the operator how to fix it (move the file under a Hermes media cache or add its directory to `HERMES_MEDIA_ALLOW_DIRS`).

Scope note: this addresses the false-success regression and adds regression coverage. The issue also asks for an operator-facing real-`sendVoice`/`sendAudio` smoke-test script and broader auditing of the gateway auto-delivery path — those are **deferred** to a follow-up, hence `Refs` rather than `Fixes` below.

## Related Issue

Refs #32644

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py`: in `_handle_send`, capture the requested MEDIA count before filtering, compute how many paths the safety filter dropped, and append a warning to a successful result when any were dropped.
- `tests/tools/test_send_message_tool.py`: add `test_dropped_media_surfaces_warning_not_clean_success` (rejected archive path produces a warning) and `test_safe_media_send_has_no_dropped_warning` (an allowlisted path still delivers with no false-positive warning).

## How to Test

1. With recency-trust disabled, send a Telegram message whose body contains `[[audio_as_voice]]` plus a `MEDIA:<path>` pointing outside the allowed media roots (e.g. an archived `~/.hermes/voice-episodes/.../teaser.ogg` not on the allowlist).
2. Confirm the returned result is still `success: true` for the text but now carries a `warnings` entry stating the attachment was blocked and not delivered.
3. Add the archive directory to `HERMES_MEDIA_ALLOW_DIRS` (or move the file under a Hermes media cache) and resend; confirm the attachment is delivered and no dropped-media warning appears.
4. Run the regression tests: `pytest tests/tools/test_send_message_tool.py -k "media or dropped or safe_media" -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_send_message_tool.py -q` and the relevant tests pass (24 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS on darwin-arm64 (local)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is pure Python string/count logic, `scripts/check-windows-footguns.py` clean

<!-- autocontrib:worker-id=issue-new-e74e17a1 kind=pr-open -->