### PR TITLE
fix(agent): recover Codex streams with null final output

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -173,7 +173,59 @@ def run_codex_app_server_turn(
         "codex_turn_id": turn.turn_id,
     }
 
+def _build_recovered_codex_stream_response(
+    *,
+    api_kwargs: dict,
+    collected_output_items: list,
+    streamed_text_parts: list,
+    has_tool_calls: bool,
+    terminal_status: str | None = None,
+    final_response: Any = None,
+    reason: str,
+):
+    status = terminal_status or getattr(final_response, "status", None) or "completed"
+    model = getattr(final_response, "model", None) or api_kwargs.get("model")
+    usage = getattr(final_response, "usage", None)
 
+    if collected_output_items:
+        logger.debug(
+            "Codex stream: recovered %d output items after %s",
+            len(collected_output_items),
+            reason,
+        )
+        return SimpleNamespace(
+            status=status,
+            model=model,
+            usage=usage,
+            output=list(collected_output_items),
+            output_text="".join(streamed_text_parts) or None,
+        )
+
+    if terminal_status in {"failed", "cancelled", "incomplete"}:
+        return None
+
+    if streamed_text_parts and not has_tool_calls:
+        assembled = "".join(streamed_text_parts)
+        logger.debug(
+            "Codex stream: recovered from %d text deltas after %s (%d chars)",
+            len(streamed_text_parts),
+            reason,
+            len(assembled),
+        )
+        return SimpleNamespace(
+            status=status,
+            model=model,
+            usage=usage,
+            output=[SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )],
+            output_text=assembled,
+        )
+
+    return None
 
 
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
@@ -188,13 +240,38 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     # returns empty output (e.g. chatgpt.com backend-api sends
     # response.incomplete instead of response.completed).
     agent._codex_streamed_text_parts: list = []
+
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        terminal_status: str | None = None
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
-                for event in stream:
+                stream_iter = iter(stream)
+                while True:
+                    try:
+                        event = next(stream_iter)
+                    except StopIteration:
+                        break
+                    except TypeError as exc:
+                        err_text = str(exc)
+                        # ChatGPT Codex can stream valid output and then send a
+                        # terminal response with output=None. openai-python may
+                        # raise while parsing that final SSE frame; recover only
+                        # if we already captured usable streamed content.
+                        if "'NoneType' object is not iterable" in err_text:
+                            recovered = _build_recovered_codex_stream_response(
+                                api_kwargs=api_kwargs,
+                                collected_output_items=collected_output_items,
+                                streamed_text_parts=agent._codex_streamed_text_parts,
+                                has_tool_calls=has_tool_calls,
+                                terminal_status=terminal_status,
+                                reason="SDK stream parser saw response.output=None",
+                            )
+                            if recovered is not None:
+                                return recovered
+                        raise
                     # Mark stream activity for the TTFB watchdog in
                     # interruptible_api_call. The Codex backend can accept the
                     # connection but never emit a single event; this timestamp
@@ -238,6 +315,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     elif event_type in {"response.incomplete", "response.failed"}:
                         resp_obj = getattr(event, "response", None)
                         status = getattr(resp_obj, "status", None) if resp_obj else None
+                        terminal_status = status or event_type.removeprefix("response.")
                         incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
                         logger.warning(
                             "Codex Responses stream received terminal event %s "
@@ -252,24 +330,19 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
                 if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        final_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex stream: backfilled %d output items from stream events",
-                            len(collected_output_items),
-                        )
-                    elif agent._codex_streamed_text_parts and not has_tool_calls:
-                        assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex stream: synthesized output from %d text deltas (%d chars)",
-                            len(agent._codex_streamed_text_parts), len(assembled),
-                        )
+                    recovered = _build_recovered_codex_stream_response(
+                        api_kwargs=api_kwargs,
+                        collected_output_items=collected_output_items,
+                        streamed_text_parts=agent._codex_streamed_text_parts,
+                        has_tool_calls=has_tool_calls,
+                        terminal_status=terminal_status,
+                        final_response=final_response,
+                        reason="empty final response output",
+                    )
+                    if recovered is not None:
+                        final_response.output = recovered.output
+                        if getattr(final_response, "output_text", None) is None:
+                            final_response.output_text = recovered.output_text
                 return final_response
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -173,6 +173,10 @@ def run_codex_app_server_turn(
         "codex_turn_id": turn.turn_id,
     }
 
+def _is_codex_null_output_type_error(exc: TypeError) -> bool:
+    return "'NoneType' object is not iterable" in str(exc)
+
+
 def _build_recovered_codex_stream_response(
     *,
     api_kwargs: dict,
@@ -255,12 +259,11 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     except StopIteration:
                         break
                     except TypeError as exc:
-                        err_text = str(exc)
                         # ChatGPT Codex can stream valid output and then send a
                         # terminal response with output=None. openai-python may
                         # raise while parsing that final SSE frame; recover only
                         # if we already captured usable streamed content.
-                        if "'NoneType' object is not iterable" in err_text:
+                        if _is_codex_null_output_type_error(exc):
                             recovered = _build_recovered_codex_stream_response(
                                 api_kwargs=api_kwargs,
                                 collected_output_items=collected_output_items,
@@ -324,12 +327,29 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    # Some SDK versions defer final Responses object parsing
+                    # until get_final_response(), so the same output=None
+                    # terminal payload can fail here after iteration ends.
+                    if _is_codex_null_output_type_error(exc):
+                        recovered = _build_recovered_codex_stream_response(
+                            api_kwargs=api_kwargs,
+                            collected_output_items=collected_output_items,
+                            streamed_text_parts=agent._codex_streamed_text_parts,
+                            has_tool_calls=has_tool_calls,
+                            terminal_status=terminal_status,
+                            reason="SDK final response parser saw response.output=None",
+                        )
+                        if recovered is not None:
+                            return recovered
+                    raise
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     recovered = _build_recovered_codex_stream_response(
                         api_kwargs=api_kwargs,
                         collected_output_items=collected_output_items,

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -219,6 +219,24 @@ class _FakeResponsesStreamTypeErrorInFinalResponse:
         raise TypeError("'NoneType' object is not iterable")
 
 
+class _FakeResponsesStreamFinalResponseAfterEvents:
+    def __init__(self, events, final_response):
+        self._events = list(events)
+        self._final_response = final_response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_response(self):
+        return self._final_response
+
+
 class _FakeResponsesStreamTypeErrorInCallback:
     def __enter__(self):
         return self
@@ -249,6 +267,22 @@ class _FakeResponsesForFinalNone:
     def create(self, **kwargs):
         self.create_calls += 1
         raise AssertionError("create fallback should not run after recoverable stream output")
+
+
+class _FakeResponsesForFinalResponse:
+    def __init__(self, events, final_response):
+        self.events = list(events)
+        self.final_response = final_response
+        self.stream_calls = 0
+        self.create_calls = 0
+
+    def stream(self, **kwargs):
+        self.stream_calls += 1
+        return _FakeResponsesStreamFinalResponseAfterEvents(self.events, self.final_response)
+
+    def create(self, **kwargs):
+        self.create_calls += 1
+        raise AssertionError("create fallback should not run after final response backfill")
 
 
 class _FakeCreateStream:
@@ -616,6 +650,37 @@ def test_run_codex_stream_recovers_when_get_final_response_sees_none_output(monk
     assert fake_responses.create_calls == 0
     assert response.status == "completed"
     assert response.output[0].content[0].text == "Hello from final"
+
+
+@pytest.mark.parametrize("final_output", [None, []])
+def test_run_codex_stream_recovers_when_final_response_output_is_empty_after_deltas(
+    monkeypatch, final_output
+):
+    agent = _build_agent(monkeypatch)
+    final_response = SimpleNamespace(
+        output=final_output,
+        output_text=None,
+        usage=SimpleNamespace(input_tokens=4, output_tokens=2, total_tokens=6),
+        status="completed",
+        model="gpt-5-codex",
+    )
+    fake_responses = _FakeResponsesForFinalResponse(
+        [
+            SimpleNamespace(type="response.output_text.delta", delta="Hello "),
+            SimpleNamespace(type="response.output_text.delta", delta="from empty final"),
+        ],
+        final_response,
+    )
+    agent.client = SimpleNamespace(responses=fake_responses)
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert fake_responses.stream_calls == 1
+    assert fake_responses.create_calls == 0
+    assert response is final_response
+    assert response.status == "completed"
+    assert response.output_text == "Hello from empty final"
+    assert response.output[0].content[0].text == "Hello from empty final"
 
 
 def test_run_codex_stream_does_not_synthesize_text_after_tool_call(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -154,6 +154,15 @@ def _codex_ack_message_response(text: str):
     )
 
 
+def _codex_message_item(text: str):
+    return SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text=text)],
+    )
+
+
 class _FakeResponsesStream:
     def __init__(self, *, final_response=None, final_error=None):
         self._final_response = final_response
@@ -172,6 +181,54 @@ class _FakeResponsesStream:
         if self._final_error is not None:
             raise self._final_error
         return self._final_response
+
+
+class _FakeResponsesStreamTypeErrorAfterEvents:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+        raise TypeError("'NoneType' object is not iterable")
+
+    def get_final_response(self):
+        raise AssertionError("should recover before get_final_response()")
+
+
+class _FakeResponsesStreamTypeErrorInCallback:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        yield SimpleNamespace(type="response.output_text.delta", delta="Hello")
+
+    def get_final_response(self):
+        return _codex_message_response("unused")
+
+
+class _FakeResponsesForFinalNone:
+    def __init__(self, events):
+        self.events = list(events)
+        self.stream_calls = 0
+        self.create_calls = 0
+
+    def stream(self, **kwargs):
+        self.stream_calls += 1
+        return _FakeResponsesStreamTypeErrorAfterEvents(self.events)
+
+    def create(self, **kwargs):
+        self.create_calls += 1
+        raise AssertionError("create fallback should not run after recoverable stream output")
 
 
 class _FakeCreateStream:
@@ -482,6 +539,92 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+@pytest.mark.parametrize(
+    ("events", "expected_text"),
+    [
+        (
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="Hello "),
+                SimpleNamespace(type="response.output_text.delta", delta="world"),
+            ],
+            "Hello world",
+        ),
+        (
+            [
+                SimpleNamespace(
+                    type="response.output_item.done",
+                    item=_codex_message_item("done item text"),
+                )
+            ],
+            "done item text",
+        ),
+    ],
+)
+def test_run_codex_stream_recovers_when_sdk_final_parser_sees_none_output(
+    monkeypatch, events, expected_text
+):
+    agent = _build_agent(monkeypatch)
+    fake_responses = _FakeResponsesForFinalNone(events)
+    agent.client = SimpleNamespace(responses=fake_responses)
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert fake_responses.stream_calls == 1
+    assert fake_responses.create_calls == 0
+    assert response.status == "completed"
+    assert response.model == "gpt-5-codex"
+    assert response.output[0].type == "message"
+    assert response.output[0].content[0].text == expected_text
+
+
+def test_run_codex_stream_does_not_synthesize_text_after_tool_call(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    fake_responses = _FakeResponsesForFinalNone(
+        [
+            SimpleNamespace(type="response.output_item.added"),
+            SimpleNamespace(type="response.function_call_arguments.delta", delta="{}"),
+            SimpleNamespace(type="response.output_text.delta", delta="tool text"),
+        ]
+    )
+    agent.client = SimpleNamespace(responses=fake_responses)
+
+    with pytest.raises(TypeError, match="NoneType"):
+        agent._run_codex_stream(_codex_request_kwargs())
+
+    assert fake_responses.create_calls == 0
+
+
+def test_run_codex_stream_does_not_recover_without_streamed_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    fake_responses = _FakeResponsesForFinalNone([SimpleNamespace(type="response.created")])
+    agent.client = SimpleNamespace(responses=fake_responses)
+
+    with pytest.raises(TypeError, match="NoneType"):
+        agent._run_codex_stream(_codex_request_kwargs())
+
+    assert fake_responses.create_calls == 0
+
+
+def test_run_codex_stream_does_not_hide_callback_type_errors(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStreamTypeErrorInCallback(),
+            create=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("create fallback should not run")
+            ),
+        )
+    )
+
+    def _raise_callback(*_args, **_kwargs):
+        raise TypeError("'NoneType' object is not iterable")
+
+    agent._fire_stream_delta = _raise_callback
+
+    with pytest.raises(TypeError, match="NoneType"):
+        agent._run_codex_stream(_codex_request_kwargs())
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -202,6 +202,23 @@ class _FakeResponsesStreamTypeErrorAfterEvents:
         raise AssertionError("should recover before get_final_response()")
 
 
+class _FakeResponsesStreamTypeErrorInFinalResponse:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_response(self):
+        raise TypeError("'NoneType' object is not iterable")
+
+
 class _FakeResponsesStreamTypeErrorInCallback:
     def __enter__(self):
         return self
@@ -217,13 +234,16 @@ class _FakeResponsesStreamTypeErrorInCallback:
 
 
 class _FakeResponsesForFinalNone:
-    def __init__(self, events):
+    def __init__(self, events, *, fail_in_get_final_response: bool = False):
         self.events = list(events)
+        self.fail_in_get_final_response = fail_in_get_final_response
         self.stream_calls = 0
         self.create_calls = 0
 
     def stream(self, **kwargs):
         self.stream_calls += 1
+        if self.fail_in_get_final_response:
+            return _FakeResponsesStreamTypeErrorInFinalResponse(self.events)
         return _FakeResponsesStreamTypeErrorAfterEvents(self.events)
 
     def create(self, **kwargs):
@@ -577,6 +597,25 @@ def test_run_codex_stream_recovers_when_sdk_final_parser_sees_none_output(
     assert response.model == "gpt-5-codex"
     assert response.output[0].type == "message"
     assert response.output[0].content[0].text == expected_text
+
+
+def test_run_codex_stream_recovers_when_get_final_response_sees_none_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    fake_responses = _FakeResponsesForFinalNone(
+        [
+            SimpleNamespace(type="response.output_text.delta", delta="Hello "),
+            SimpleNamespace(type="response.output_text.delta", delta="from final"),
+        ],
+        fail_in_get_final_response=True,
+    )
+    agent.client = SimpleNamespace(responses=fake_responses)
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert fake_responses.stream_calls == 1
+    assert fake_responses.create_calls == 0
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "Hello from final"
 
 
 def test_run_codex_stream_does_not_synthesize_text_after_tool_call(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a Codex Responses streaming crash where the ChatGPT Codex backend can emit valid streamed output and then trip openai-python final parsing with:

```text
TypeError: 'NoneType' object is not iterable
```

Observed repro shape: `openai-codex` / `gpt-5.5` on `https://chatgpt.com/backend-api/codex` streamed `response.output_text.delta` chunks spelling the expected answer, then openai-python raised while parsing a final response whose `output` was null.

This PR preserves already-received streamed content instead of treating that SDK finalization failure as a fatal empty response. It handles both observed SDK failure points: during stream iteration and during `stream.get_final_response()`.

## Related Issue

Related to #21444, #19981, and #22986.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/codex_runtime.py`
  - Adds a narrow recovery helper for Codex streamed responses when openai-python hits the null-final-output parser path after Hermes already collected usable streamed output.
  - Recovers from `response.output_item.done` items first.
  - Synthesizes text from streamed deltas only when no function/tool call was observed.
  - Handles the null-output `TypeError` both from stream iteration and from `stream.get_final_response()`.
  - Preserves failure behavior when there is no streamed output, when a tool-call turn only has text deltas, or when the TypeError comes from Hermes-side callback/processing code.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - Adds regression coverage for recovered streamed deltas, recovered output items, finalization-time null output, no recovery without streamed output, no text synthesis after tool-call events, and no masking of unrelated callback TypeErrors.

## How to Test

1. Targeted canonical runner:

```bash
scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -- -q
```

Result in CT216 after the test follow-up commit: `73 tests passed`.

2. Direct pytest before the follow-up commit:

```bash
venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q
```

Result in CT216: `70 passed, 1 warning`.

3. Live validation against ChatGPT Codex backend:

```bash
hermes chat -Q --provider openai-codex -m gpt-5.5 -q "Reply exactly: LATEST_GPT55_FINAL_OK"
```

Result in CT216 after the earlier code follow-up commit:

```text
LATEST_GPT55_FINAL_OK
```

4. Partial full-suite run before the follow-up commit:

```bash
scripts/run_tests.sh -j 4
```

Stopped after confirming early progress because the full suite is 1205 files / 26435 tests in this CT. Progress before stop: `669 passed, 0 failed`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian/Linux LXC on Proxmox, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A; this is provider stream parsing logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Live validation output after the follow-up commit:

```text
session_id: 20260527_003011_c8f528
LATEST_GPT55_FINAL_OK
```


