### PR TITLE
feat(cache): Gemini context caching via cachedContents resource (PR-2 of #29818)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -490,15 +490,6 @@ def init_agent(
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns
     agent._force_ascii_payload = False
     
-    # Anthropic prompt caching: auto-enabled for Claude models on native
-    # Anthropic, OpenRouter, and third-party gateways that speak the
-    # Anthropic protocol (``api_mode == 'anthropic_messages'``). Reduces
-    # input costs by ~75% on multi-turn conversations. Uses system_and_3
-    # strategy (4 breakpoints). See ``_anthropic_prompt_cache_policy``
-    # for the layout-vs-transport decision.
-    agent._use_prompt_caching, agent._use_native_cache_layout = (
-        agent._anthropic_prompt_cache_policy()
-    )
     # Anthropic supports "5m" (default) and "1h" cache TTL tiers. Read from
     # config.yaml under prompt_caching.cache_ttl; unknown values keep "5m".
     # 1h tier costs 2x on write vs 1.25x for 5m, but amortizes across long
@@ -1017,14 +1008,24 @@ def init_agent(
         print(f"🔒 Ephemeral system prompt: '{prompt_preview}' (not saved to trajectories)")
     
     # Show prompt caching status
-    if agent._use_prompt_caching and not agent.quiet_mode:
-        if agent._use_native_cache_layout and agent.provider == "anthropic":
-            source = "native Anthropic"
-        elif agent._use_native_cache_layout:
-            source = "Anthropic-compatible endpoint"
-        else:
-            source = "Claude via OpenRouter"
-        print(f"💾 Prompt caching: ENABLED ({source}, {agent._cache_ttl} TTL)")
+    if not agent.quiet_mode:
+        from agent.prompt_cache_strategy import (
+            AnthropicInlineCacheStrategy as _ACS,
+            NoCacheStrategy as _NCS,
+        )
+        from providers import get_provider_profile as _gpf_ai
+        _ai_profile = _gpf_ai(agent.provider)
+        _ai_strategy = _ai_profile.cache_strategy_for(agent.model) if _ai_profile else _NCS()
+        if isinstance(_ai_strategy, _NCS) and agent.api_mode == "anthropic_messages" and "claude" in (agent.model or "").lower():
+            _ai_strategy = _ACS(layout="native")
+        if isinstance(_ai_strategy, _ACS):
+            if _ai_strategy.layout == "native" and agent.provider == "anthropic":
+                source = "native Anthropic"
+            elif _ai_strategy.layout == "native":
+                source = "Anthropic-compatible endpoint"
+            else:
+                source = "Claude via OpenRouter"
+            print(f"💾 Prompt caching: ENABLED ({source}, {agent._cache_ttl} TTL)")
     
     # Session logging setup - auto-save conversation trajectories for debugging
     agent.session_start = datetime.now()
@@ -1736,8 +1737,6 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
-        "use_prompt_caching": agent._use_prompt_caching,
-        "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.
         # Use getattr for model/base_url/api_key/provider since plugin
         # engines may not have these (they're ContextCompressor-specific).

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -16,7 +16,6 @@ Methods covered:
 * ``restore_primary_runtime`` — un-do fallback activation
 * ``extract_reasoning`` — pull reasoning fields out of API responses
 * ``dump_api_request_debug`` — write request body for post-mortem
-* ``anthropic_prompt_cache_policy`` — compute cache_control breakpoints
 * ``create_openai_client`` — build the per-agent OpenAI SDK client
 """
 
@@ -1009,14 +1008,6 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
-        agent._use_prompt_caching = rt["use_prompt_caching"]
-        # Default to native layout when the restored snapshot predates the
-        # native-vs-proxy split (older sessions saved before this PR).
-        agent._use_native_cache_layout = rt.get(
-            "use_native_cache_layout",
-            agent.api_mode == "anthropic_messages" and agent.provider == "anthropic",
-        )
-
         # ── Rebuild client for the primary provider ──
         if agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -1240,112 +1231,6 @@ def dump_api_request_debug(
         if agent.verbose_logging:
             logger.warning(f"Failed to dump API request debug payload: {dump_error}")
         return None
-
-
-
-def anthropic_prompt_cache_policy(
-    agent,
-    *,
-    provider: Optional[str] = None,
-    base_url: Optional[str] = None,
-    api_mode: Optional[str] = None,
-    model: Optional[str] = None,
-) -> tuple[bool, bool]:
-    """Decide whether to apply Anthropic prompt caching and which layout to use.
-
-    Returns ``(should_cache, use_native_layout)``:
-      * ``should_cache`` — inject ``cache_control`` breakpoints for this
-        request (applies to OpenRouter Claude, native Anthropic, and
-        third-party gateways that speak the native Anthropic protocol).
-      * ``use_native_layout`` — place markers on the *inner* content
-        blocks (native Anthropic accepts and requires this layout);
-        when False markers go on the message envelope (OpenRouter and
-        OpenAI-wire proxies expect the looser layout).
-
-    Third-party providers using the native Anthropic transport
-    (``api_mode == 'anthropic_messages'`` + Claude-named model) get
-    caching with the native layout so they benefit from the same
-    cost reduction as direct Anthropic callers, provided their
-    gateway implements the Anthropic cache_control contract
-    (MiniMax, Zhipu GLM, LiteLLM's Anthropic proxy mode all do).
-
-    Qwen / Alibaba-family models on OpenCode, OpenCode Go, and direct
-    Alibaba (DashScope) also honour Anthropic-style ``cache_control``
-    markers on OpenAI-wire chat completions. Upstream pi-mono #3392 /
-    pi #3393 documented this for opencode-go Qwen. Without markers
-    these providers serve zero cache hits, re-billing the full prompt
-    on every turn.
-    """
-    eff_provider = (provider if provider is not None else agent.provider) or ""
-    eff_base_url = base_url if base_url is not None else (agent.base_url or "")
-    eff_api_mode = api_mode if api_mode is not None else (agent.api_mode or "")
-    eff_model = (model if model is not None else agent.model) or ""
-
-    model_lower = eff_model.lower()
-    provider_lower = eff_provider.lower()
-    is_claude = "claude" in model_lower
-    is_openrouter = base_url_host_matches(eff_base_url, "openrouter.ai")
-    # Nous Portal proxies to OpenRouter behind the scenes — identical
-    # OpenAI-wire envelope cache_control semantics. Treat it as an
-    # OpenRouter-equivalent endpoint for caching layout purposes.
-    is_nous_portal = "nousresearch" in eff_base_url.lower()
-    is_anthropic_wire = eff_api_mode == "anthropic_messages"
-    is_native_anthropic = (
-        is_anthropic_wire
-        and (eff_provider == "anthropic" or base_url_hostname(eff_base_url) == "api.anthropic.com")
-    )
-
-    if is_native_anthropic:
-        return True, True
-    if (is_openrouter or is_nous_portal) and is_claude:
-        return True, False
-    # Nous Portal Qwen (e.g. qwen3.6-plus) takes the same envelope-layout
-    # cache_control path as Portal Claude. Portal proxies to OpenRouter
-    # and the upstream Qwen route accepts cache_control markers; without
-    # this branch the alibaba-family check below only matches
-    # provider=opencode/alibaba and Portal traffic falls through to
-    # (False, False), serving 0% cache hits and re-billing the full
-    # prompt on every turn.
-    if is_nous_portal and "qwen" in model_lower:
-        return True, False
-    if is_anthropic_wire and is_claude:
-        # Third-party Anthropic-compatible gateway.
-        return True, True
-
-    # MiniMax on its Anthropic-compatible endpoint serves its own
-    # model family (MiniMax-M2.7, M2.5, M2.1, M2) with documented
-    # cache_control support (0.1× read pricing, 5-minute TTL).  The
-    # blanket is_claude gate above excludes these — opt them in
-    # explicitly via provider id or host match so users on
-    # provider=minimax / minimax-cn (or custom endpoints pointing at
-    # api.minimax.io/anthropic / api.minimaxi.com/anthropic) get the
-    # same cost reduction as Claude traffic.
-    # Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
-    if is_anthropic_wire:
-        is_minimax_provider = provider_lower in {"minimax", "minimax-cn"}
-        is_minimax_host = (
-            base_url_host_matches(eff_base_url, "api.minimax.io")
-            or base_url_host_matches(eff_base_url, "api.minimaxi.com")
-        )
-        if is_minimax_provider or is_minimax_host:
-            return True, True
-
-    # Qwen/Alibaba on OpenCode (Zen/Go) and native DashScope: OpenAI-wire
-    # transport that accepts Anthropic-style cache_control markers and
-    # rewards them with real cache hits.  Without this branch
-    # qwen3.6-plus on opencode-go reports 0% cached tokens and burns
-    # through the subscription on every turn.
-    model_is_qwen = "qwen" in model_lower
-    provider_is_alibaba_family = provider_lower in {
-        "opencode", "opencode-zen", "opencode-go", "alibaba",
-    }
-    if provider_is_alibaba_family and model_is_qwen:
-        # Envelope layout (native_anthropic=False): markers on inner
-        # content parts, not top-level tool messages.  Matches
-        # pi-mono's "alibaba" cacheControlFormat.
-        return True, False
-
-    return False, False
 
 
 
@@ -1603,15 +1488,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
                 pass
         raise
 
-    # ── Re-evaluate prompt caching ──
-    agent._use_prompt_caching, agent._use_native_cache_layout = (
-        agent._anthropic_prompt_cache_policy(
-            provider=new_provider,
-            base_url=agent.base_url,
-            api_mode=api_mode,
-            model=new_model,
-        )
-    )
+
 
     # ── LM Studio: preload before probing context length ──
     agent._ensure_lmstudio_runtime_loaded()
@@ -1664,8 +1541,6 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
-        "use_prompt_caching": agent._use_prompt_caching,
-        "use_native_cache_layout": agent._use_native_cache_layout,
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,
         "compressor_base_url": getattr(_cc, "base_url", agent.base_url) if _cc else agent.base_url,
         "compressor_api_key": getattr(_cc, "api_key", "") if _cc else "",
@@ -2604,7 +2479,6 @@ __all__ = [
     "restore_primary_runtime",
     "extract_reasoning",
     "dump_api_request_debug",
-    "anthropic_prompt_cache_policy",
     "create_openai_client",
     "switch_model",
     "invoke_tool",

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1245,15 +1245,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 # not only after a later credential-rotation rebuild.
                 agent._replace_primary_openai_client(reason="fallback_timeout_apply")
 
-        # Re-evaluate prompt caching for the new provider/model
-        agent._use_prompt_caching, agent._use_native_cache_layout = (
-            agent._anthropic_prompt_cache_policy(
-                provider=fb_provider,
-                base_url=fb_base_url,
-                api_mode=fb_api_mode,
-                model=fb_model,
-            )
-        )
+
 
         # LM Studio: preload before probing the fallback's context length.
         agent._ensure_lmstudio_runtime_loaded()

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -761,6 +761,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
+            gemini_cached_content_name=getattr(agent, "_gemini_cached_content_name", None),
         )
 
     # ── Legacy flag path ────────────────────────────────────────────

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -56,6 +56,7 @@ from agent.model_metadata import (
 from agent.process_bootstrap import _install_safe_stdio
 from agent.prompt_cache_strategy import (
     AnthropicInlineCacheStrategy,
+    GeminiResourceCacheStrategy,
     NoCacheStrategy,
     PromptCacheIntent,
 )
@@ -470,6 +471,117 @@ def _content_policy_blocked_result(
     }
 
 
+def _ensure_gemini_cache(agent: Any, api_messages: list) -> Optional[str]:
+    """Create or reuse a Gemini ``cachedContents`` resource for this session.
+
+    Returns the resource name (``"cachedContents/<id>"``) or ``None`` when
+    caching is unavailable or the system prompt is too short.  Failures are
+    logged at DEBUG and never raise — uncached requests are the safe fallback.
+    """
+    import json
+    import time
+
+    session_id = getattr(agent, "session_id", None)
+    if not session_id:
+        return None
+
+    session_key = f"gemini_cache_{session_id}"
+
+    # Reuse existing cache if it has more than 5 minutes of TTL remaining.
+    try:
+        db = getattr(agent, "_session_db", None)
+        if db:
+            cache_json = db.get_meta(session_key)
+            if cache_json:
+                state = json.loads(cache_json)
+                if state.get("name") and state.get("expires_at", 0) > time.time() + 300:
+                    return state["name"]
+    except Exception:
+        pass
+
+    # Build systemInstruction parts from api_messages.
+    system_parts: list = []
+    for msg in api_messages:
+        if not isinstance(msg, dict) or msg.get("role") != "system":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, str) and content.strip():
+            system_parts.append({"text": content})
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text" and part.get("text"):
+                    system_parts.append({"text": part["text"]})
+
+    if not system_parts:
+        return None
+
+    model_id = getattr(agent, "model", "") or ""
+    if not model_id.startswith("models/"):
+        model_id = f"models/{model_id}"
+    base_url = (getattr(agent, "base_url", None) or "https://generativelanguage.googleapis.com/v1beta").rstrip("/")
+    api_key = getattr(agent, "api_key", None) or ""
+
+    cache_payload: dict = {
+        "model": model_id,
+        "systemInstruction": {"parts": system_parts},
+        "ttl": "3600s",
+    }
+    try:
+        from agent.gemini_native_adapter import _translate_tools_to_gemini
+        tools_list = getattr(agent, "tools", None)
+        if tools_list:
+            gemini_tools = _translate_tools_to_gemini(tools_list)
+            if gemini_tools:
+                cache_payload["tools"] = gemini_tools
+    except Exception:
+        pass
+
+    try:
+        import httpx
+        url = f"{base_url}/cachedContents"
+        with httpx.Client(timeout=30.0) as _hc:
+            resp = _hc.post(
+                url,
+                params={"key": api_key} if api_key else {},
+                json=cache_payload,
+                headers={"Content-Type": "application/json"},
+            )
+        if resp.status_code != 200:
+            logger.debug(
+                "Gemini cache creation failed HTTP %d: %s",
+                resp.status_code, resp.text[:300],
+            )
+            return None
+        result = resp.json()
+        cache_name = result.get("name")
+        if not cache_name:
+            return None
+
+        expires_at = time.time() + 3600
+        expire_time = result.get("expireTime", "")
+        if expire_time:
+            try:
+                from datetime import datetime
+                dt = datetime.fromisoformat(expire_time.replace("Z", "+00:00"))
+                expires_at = dt.timestamp()
+            except Exception:
+                pass
+
+        try:
+            db = getattr(agent, "_session_db", None)
+            if db:
+                db.set_meta(session_key, json.dumps({"name": cache_name, "expires_at": expires_at}))
+        except Exception:
+            pass
+
+        logger.debug("Gemini context cache created: %s", cache_name)
+        return cache_name
+
+    except Exception as exc:
+        logger.debug("Gemini cache creation error: %s", exc)
+        return None
+
+
 def run_conversation(
     agent,
     user_message: str,
@@ -799,7 +911,15 @@ def run_conversation(
         ):
             _strategy = AnthropicInlineCacheStrategy(layout="native")
         _intent = PromptCacheIntent(ttl=getattr(agent, "_cache_ttl", "5m"))
-        api_messages = _strategy.apply(api_messages, _intent)
+
+        if isinstance(_strategy, GeminiResourceCacheStrategy):
+            # Gemini server-side caching: create or reuse a cachedContents
+            # resource for this session's system instruction + tools.
+            # The cache name flows to GeminiNativeClient via extra_body.
+            agent._gemini_cached_content_name = _ensure_gemini_cache(agent, api_messages)
+        else:
+            agent._gemini_cached_content_name = None
+            api_messages = _strategy.apply(api_messages, _intent)
 
         # Safety net: strip orphaned tool results / add stubs for missing
         # results before sending to the API.  Runs unconditionally — not

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -54,7 +54,11 @@ from agent.model_metadata import (
     save_context_length,
 )
 from agent.process_bootstrap import _install_safe_stdio
-from agent.prompt_caching import apply_anthropic_cache_control
+from agent.prompt_cache_strategy import (
+    AnthropicInlineCacheStrategy,
+    NoCacheStrategy,
+    PromptCacheIntent,
+)
 from agent.retry_utils import jittered_backoff
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
@@ -782,18 +786,20 @@ def run_conversation(
             for idx, pfm in enumerate(agent.prefill_messages):
                 api_messages.insert(sys_offset + idx, pfm.copy())
 
-        # Apply Anthropic prompt caching for Claude models on native
-        # Anthropic, OpenRouter, and third-party Anthropic-compatible
-        # gateways. Auto-detected: if ``_use_prompt_caching`` is set,
-        # inject cache_control breakpoints (system + last 3 messages)
-        # to reduce input token costs by ~75% on multi-turn
-        # conversations.
-        if agent._use_prompt_caching:
-            api_messages = apply_anthropic_cache_control(
-                api_messages,
-                cache_ttl=agent._cache_ttl,
-                native_anthropic=agent._use_native_cache_layout,
-            )
+        # Apply prompt caching via the provider's cache strategy.
+        # Falls back to native-layout Anthropic markers for unknown
+        # third-party gateways that speak the Anthropic wire protocol.
+        from providers import get_provider_profile as _gpf_cl
+        _profile = _gpf_cl(agent.provider)
+        _strategy = _profile.cache_strategy_for(agent.model) if _profile else NoCacheStrategy()
+        if (
+            isinstance(_strategy, NoCacheStrategy)
+            and getattr(agent, "api_mode", None) == "anthropic_messages"
+            and "claude" in (agent.model or "").lower()
+        ):
+            _strategy = AnthropicInlineCacheStrategy(layout="native")
+        _intent = PromptCacheIntent(ttl=getattr(agent, "_cache_ttl", "5m"))
+        api_messages = _strategy.apply(api_messages, _intent)
 
         # Safety net: strip orphaned tool results / add stubs for missing
         # results before sending to the API.  Runs unconditionally — not
@@ -1895,8 +1901,7 @@ def run_conversation(
                     # server-side prefix caching and return
                     # ``prompt_tokens_details.cached_tokens``; users
                     # previously could not see their cache % because this
-                    # line was gated on ``_use_prompt_caching``, which is
-                    # only True for Anthropic-style marker injection.
+                    # not gated on whether the provider uses cache markers.
                     # ``canonical_usage`` is already normalised from all
                     # three API shapes (Anthropic / Codex / OpenAI-chat)
                     # so we can rely on its values directly.

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -412,19 +412,26 @@ def build_gemini_request(
     top_p: Optional[float] = None,
     stop: Any = None,
     thinking_config: Any = None,
+    cached_content_name: Optional[str] = None,
 ) -> Dict[str, Any]:
     contents, system_instruction = _build_gemini_contents(messages)
     request: Dict[str, Any] = {"contents": contents}
-    if system_instruction:
-        request["systemInstruction"] = system_instruction
 
-    gemini_tools = _translate_tools_to_gemini(tools)
-    if gemini_tools:
-        request["tools"] = gemini_tools
+    if cached_content_name:
+        # systemInstruction and tools are encoded in the cached resource;
+        # re-sending them causes a 400. toolConfig is also disallowed.
+        request["cachedContent"] = cached_content_name
+    else:
+        if system_instruction:
+            request["systemInstruction"] = system_instruction
 
-    tool_config = _translate_tool_choice_to_gemini(tool_choice)
-    if tool_config:
-        request["toolConfig"] = tool_config
+        gemini_tools = _translate_tools_to_gemini(tools)
+        if gemini_tools:
+            request["tools"] = gemini_tools
+
+        tool_config = _translate_tool_choice_to_gemini(tool_choice)
+        if tool_config:
+            request["toolConfig"] = tool_config
 
     generation_config: Dict[str, Any] = {}
     if temperature is not None:
@@ -910,8 +917,10 @@ class GeminiNativeClient:
         **_: Any,
     ) -> Any:
         thinking_config = None
+        cached_content_name = None
         if isinstance(extra_body, dict):
             thinking_config = extra_body.get("thinking_config") or extra_body.get("thinkingConfig")
+            cached_content_name = extra_body.get("gemini_cached_content_name") or None
 
         request = build_gemini_request(
             messages=messages or [],
@@ -922,6 +931,7 @@ class GeminiNativeClient:
             top_p=top_p,
             stop=stop,
             thinking_config=thinking_config,
+            cached_content_name=cached_content_name,
         )
 
         model = bare_gemini_model_id(model)

--- a/agent/prompt_cache_strategy.py
+++ b/agent/prompt_cache_strategy.py
@@ -1,0 +1,186 @@
+"""Pluggable prompt-cache strategies.
+
+Each provider expresses caching intent on the request differently:
+
+    Anthropic        inline ``cache_control`` markers in messages
+    Gemini explicit  POST /v1beta/cachedContents → resource ref
+    OpenAI / others  fully automatic on the server side; no client work
+
+This module factors that out into a ``PromptCacheStrategy`` protocol that
+each ``ProviderProfile`` declares via ``cache_strategy_for(model)``. The
+agent loop becomes a single call — no provider-specific branching.
+
+Cache **stat extraction** (which response field carries the hit count)
+is a separate concern owned by ``ProviderTransport.extract_usage()`` —
+the wire format dictates the field names, independent of whether the
+caller asked to cache.
+
+This module ships in PR-1 alongside ``NoCacheStrategy`` and
+``AnthropicInlineCacheStrategy``. ``GeminiResourceCacheStrategy`` (#29818)
+lands in PR-2 against this same protocol.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+
+
+# ── Request-side data carriers ──────────────────────────────────────────
+
+
+@dataclass
+class PromptCacheIntent:
+    """Provider-agnostic description of what the caller wants cached.
+
+    Strategies may ignore fields they don't support (e.g. Anthropic
+    clamps ``ttl`` to ``"5m"`` or ``"1h"``; everything else falls back
+    to ``"5m"``).
+    """
+
+    ttl: str = "5m"               # "5m" | "1h" — Anthropic-specific tiers
+    breakpoints: int = 4          # max marker count; Anthropic uses ≤4
+
+
+@dataclass
+class SessionCacheState:
+    """Per-session state required by stateful strategies.
+
+    Anthropic (inline markers) ignores this — every request is
+    self-contained. Gemini explicit caching uses it to remember the
+    ``cachedContents/<name>`` resource across turns in a session.
+    Persisted in ``state.db.state_meta`` keyed by session_id.
+    """
+
+    session_id: str
+    cache_name: Optional[str] = None     # "cachedContents/abc123…" for Gemini
+    cache_key: Optional[str] = None      # hash of (system, tools) that the cache covers
+    expires_at: Optional[float] = None   # unix ts when the cache TTL elapses
+
+
+# ── Strategy protocol ───────────────────────────────────────────────────
+
+
+@runtime_checkable
+class PromptCacheStrategy(Protocol):
+    """Adapter that applies a cache intent to a provider's request shape.
+
+    Implementations live alongside their wire format:
+      - ``AnthropicInlineCacheStrategy`` — this file
+      - ``GeminiResourceCacheStrategy`` — to be added in PR-2
+      - ``NoCacheStrategy`` — this file (universal default)
+
+    ``apply()`` returns the messages list to send. A stateful strategy
+    (Gemini) may both mutate ``session_ctx`` and return a TRIMMED message
+    list with the cached prefix stripped — the cache_name reference does
+    the rest. A stateless strategy (Anthropic) returns a copy with
+    markers injected.
+    """
+
+    name: str
+
+    def apply(
+        self,
+        messages: List[Dict[str, Any]],
+        intent: PromptCacheIntent,
+        session_ctx: Optional[SessionCacheState] = None,
+    ) -> List[Dict[str, Any]]:
+        ...
+
+
+# ── No-op strategy (universal default) ──────────────────────────────────
+
+
+@dataclass
+class NoCacheStrategy:
+    """Identity strategy used for providers without caching support
+    (or where caching is server-side automatic — OpenAI / DeepSeek / xAI).
+
+    These providers return cache stats in their response usage anyway —
+    that's handled by the transport's ``extract_usage()``, not here.
+    """
+
+    name: str = "none"
+
+    def apply(
+        self,
+        messages: List[Dict[str, Any]],
+        intent: PromptCacheIntent,
+        session_ctx: Optional[SessionCacheState] = None,
+    ) -> List[Dict[str, Any]]:
+        return messages
+
+
+# ── Anthropic inline-marker strategy ────────────────────────────────────
+
+
+_VALID_ANTHROPIC_LAYOUTS = frozenset({"native", "envelope"})
+
+
+@dataclass
+class AnthropicInlineCacheStrategy:
+    """Inject ``cache_control`` markers into the message list.
+
+    Two layouts exist on the wire:
+
+      ``native``    — markers go on the inner content block (and on the
+                      message envelope for ``role==tool`` / empty
+                      content). Required by direct Anthropic API and any
+                      gateway that speaks the native Anthropic protocol
+                      (api.anthropic.com, api.minimax.io/anthropic, etc).
+
+      ``envelope``  — markers go on the message envelope for
+                      non-string content, but ``role==tool`` messages
+                      are SKIPPED entirely. Used by OpenAI-wire proxies
+                      that pass cache_control through to an underlying
+                      Anthropic backend (OpenRouter, Nous Portal,
+                      opencode-go for Qwen, etc).
+
+    The actual marker placement logic lives in
+    ``agent.prompt_caching.apply_anthropic_cache_control`` — this class
+    is a thin wrapper that selects the layout via the boolean parameter
+    the helper already accepts. Keeping the helper as the implementation
+    means the 14 existing marker-placement unit tests in
+    ``tests/agent/test_prompt_caching.py`` continue to cover this code
+    without any rewrites.
+    """
+
+    layout: str = "native"
+    name: str = "anthropic-inline"
+
+    def __post_init__(self) -> None:
+        if self.layout not in _VALID_ANTHROPIC_LAYOUTS:
+            raise ValueError(
+                f"AnthropicInlineCacheStrategy layout must be one of "
+                f"{sorted(_VALID_ANTHROPIC_LAYOUTS)}, got {self.layout!r}"
+            )
+
+    def apply(
+        self,
+        messages: List[Dict[str, Any]],
+        intent: PromptCacheIntent,
+        session_ctx: Optional[SessionCacheState] = None,
+    ) -> List[Dict[str, Any]]:
+        # Late import: ``prompt_caching`` and ``prompt_cache_strategy``
+        # live in the same package; importing at module top would create
+        # a cycle once ``prompt_caching`` re-exports anything from here.
+        from agent.prompt_caching import apply_anthropic_cache_control
+
+        ttl = intent.ttl if intent.ttl in {"5m", "1h"} else "5m"
+        return apply_anthropic_cache_control(
+            messages,
+            cache_ttl=ttl,
+            native_anthropic=(self.layout == "native"),
+        )
+
+
+# ── Public re-exports ───────────────────────────────────────────────────
+
+
+__all__ = [
+    "PromptCacheIntent",
+    "SessionCacheState",
+    "PromptCacheStrategy",
+    "NoCacheStrategy",
+    "AnthropicInlineCacheStrategy",
+]

--- a/agent/prompt_cache_strategy.py
+++ b/agent/prompt_cache_strategy.py
@@ -174,6 +174,36 @@ class AnthropicInlineCacheStrategy:
         )
 
 
+# ── Gemini server-side resource strategy ────────────────────────────────
+
+
+@dataclass
+class GeminiResourceCacheStrategy:
+    """Marker strategy: use Gemini server-side context caching.
+
+    Signal to conversation_loop.py that a ``cachedContents`` resource
+    should be created (or reused) for the session's system instruction +
+    tools. The actual HTTP call to ``POST /v1beta/cachedContents`` is made
+    in the loop (which has access to the agent's credentials and state DB),
+    not here.
+
+    The resource name is threaded to ``GeminiNativeClient`` via
+    ``extra_body["gemini_cached_content_name"]`` so ``build_gemini_request``
+    can add ``cachedContent`` to the payload and omit ``systemInstruction``
+    and ``tools`` (both are already encoded in the server-side resource).
+    """
+
+    name: str = "gemini-resource"
+
+    def apply(
+        self,
+        messages: List[Dict[str, Any]],
+        intent: PromptCacheIntent,
+        session_ctx: Optional[SessionCacheState] = None,
+    ) -> List[Dict[str, Any]]:
+        return messages
+
+
 # ── Public re-exports ───────────────────────────────────────────────────
 
 
@@ -183,4 +213,5 @@ __all__ = [
     "PromptCacheStrategy",
     "NoCacheStrategy",
     "AnthropicInlineCacheStrategy",
+    "GeminiResourceCacheStrategy",
 ]

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -219,16 +219,29 @@ class AnthropicTransport(ProviderTransport):
             return getattr(response, "stop_reason", None) in {"end_turn", "refusal"}
         return True
 
-    def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
-        """Extract Anthropic cache_read and cache_creation token counts."""
-        usage = getattr(response, "usage", None)
-        if usage is None:
-            return None
-        cached = getattr(usage, "cache_read_input_tokens", 0) or 0
-        written = getattr(usage, "cache_creation_input_tokens", 0) or 0
-        if cached or written:
-            return {"cached_tokens": cached, "creation_tokens": written}
-        return None
+    def extract_usage(self, response_usage: Any) -> "Usage":
+        """Extract canonical usage from an Anthropic response.usage object.
+
+        Anthropic's ``input_tokens`` is NET (does not include cache reads),
+        so no subtraction is needed. Cache fields live at the top level:
+        ``cache_read_input_tokens`` / ``cache_creation_input_tokens``.
+        """
+        from agent.transports.types import Usage
+
+        if response_usage is None:
+            return Usage()
+        input_tokens = int(getattr(response_usage, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(response_usage, "output_tokens", 0) or 0)
+        cache_read = int(getattr(response_usage, "cache_read_input_tokens", 0) or 0)
+        cache_write = int(getattr(response_usage, "cache_creation_input_tokens", 0) or 0)
+        return Usage(
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens + cache_read + cache_write,
+            cached_tokens=cache_read,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+        )
 
     # Promote the adapter's canonical mapping to module level so it's shared
     _STOP_REASON_MAP = {

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -3,14 +3,20 @@
 A transport owns the data path for one api_mode:
   convert_messages → convert_tools → build_kwargs → normalize_response
 
+It also owns canonical token-usage extraction via ``extract_usage()``,
+which knows the wire format's field names and quirks (e.g. Codex/OpenAI
+include cached tokens in their prompt_tokens total — the transport
+subtracts them out; Anthropic's input_tokens is already net).
+
 It does NOT own: client construction, streaming, credential refresh,
-prompt caching, interrupt handling, or retry logic.  Those stay on AIAgent.
+prompt caching strategy, interrupt handling, or retry logic. Those stay
+on AIAgent.
 """
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-from agent.transports.types import NormalizedResponse
+from agent.transports.types import NormalizedResponse, Usage
 
 
 class ProviderTransport(ABC):
@@ -72,13 +78,19 @@ class ProviderTransport(ABC):
         """
         return True
 
-    def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:
-        """Optional: extract provider-specific cache hit/creation stats.
+    def extract_usage(self, response_usage: Any) -> Usage:
+        """Extract canonical token usage from a raw response.usage object.
 
-        Returns dict with 'cached_tokens' and 'creation_tokens', or None.
-        Default returns None.
+        Each transport reads the wire-format-specific fields and returns
+        a populated ``Usage``. The Codex/OpenAI variants also subtract
+        cached tokens from ``prompt_tokens`` so the value is net (the
+        Anthropic variant's ``input_tokens`` is already net, no subtraction).
+
+        Default returns a zeroed ``Usage`` for transports without an
+        override. Callers should pass the inner ``response.usage`` object
+        — extraction never reaches into ``response`` itself.
         """
-        return None
+        return Usage()
 
     def map_finish_reason(self, raw_reason: str) -> str:
         """Optional: map provider-specific stop reason to OpenAI equivalent.

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -115,6 +115,25 @@ class BedrockTransport(ProviderTransport):
             usage=usage,
         )
 
+    def extract_usage(self, response_usage: Any) -> "Usage":
+        """Extract canonical usage from a Bedrock usage object.
+
+        Bedrock's adapter normalizes the boto3 dict to a SimpleNamespace
+        with OpenAI-like ``prompt_tokens`` / ``completion_tokens`` before
+        this is reached. No cache fields on Bedrock.
+        """
+        from agent.transports.types import Usage
+
+        if response_usage is None:
+            return Usage()
+        prompt_tokens = int(getattr(response_usage, "prompt_tokens", 0) or 0)
+        completion_tokens = int(getattr(response_usage, "completion_tokens", 0) or 0)
+        return Usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+
     def validate_response(self, response: Any) -> bool:
         """Check Bedrock response structure.
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -718,19 +718,46 @@ class ChatCompletionsTransport(ProviderTransport):
             return False
         return True
 
-    def extract_cache_stats(self, response: Any) -> dict[str, int] | None:
-        """Extract OpenRouter/OpenAI cache stats from prompt_tokens_details."""
-        usage = getattr(response, "usage", None)
-        if usage is None:
-            return None
-        details = getattr(usage, "prompt_tokens_details", None)
-        if details is None:
-            return None
-        cached = getattr(details, "cached_tokens", 0) or 0
-        written = getattr(details, "cache_write_tokens", 0) or 0
-        if cached or written:
-            return {"cached_tokens": cached, "creation_tokens": written}
-        return None
+    def extract_usage(self, response_usage: Any) -> "Usage":
+        """Extract canonical usage from an OpenAI-wire response.usage object.
+
+        OpenAI/OpenRouter's ``prompt_tokens`` is GROSS (includes cache hits).
+        This method subtracts cached and write tokens to produce a net
+        ``prompt_tokens`` for the canonical ``Usage`` shape.
+
+        Cache fields nest under ``prompt_tokens_details``. Some proxies
+        (OpenRouter, Vercel AI Gateway, Cline) surface Anthropic-style
+        top-level fields when routing Claude — fall back to those if
+        the details object is absent or zero (port of cline/cline#10266).
+        """
+        from agent.transports.types import Usage
+
+        if response_usage is None:
+            return Usage()
+        prompt_total = int(getattr(response_usage, "prompt_tokens", 0) or 0)
+        completion_tokens = int(getattr(response_usage, "completion_tokens", 0) or 0)
+
+        details = getattr(response_usage, "prompt_tokens_details", None)
+        cache_read = int(getattr(details, "cached_tokens", 0) or 0) if details else 0
+        if not cache_read:
+            cache_read = int(getattr(response_usage, "cache_read_input_tokens", 0) or 0)
+        cache_write = int(getattr(details, "cache_write_tokens", 0) or 0) if details else 0
+        if not cache_write:
+            cache_write = int(getattr(response_usage, "cache_creation_input_tokens", 0) or 0)
+
+        out_details = getattr(response_usage, "output_tokens_details", None)
+        reasoning = int(getattr(out_details, "reasoning_tokens", 0) or 0) if out_details else 0
+
+        net_prompt = max(0, prompt_total - cache_read - cache_write)
+        return Usage(
+            prompt_tokens=net_prompt,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_total + completion_tokens,
+            cached_tokens=cache_read,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+            reasoning_tokens=reasoning,
+        )
 
 
 # Auto-register on import

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -549,6 +549,7 @@ class ChatCompletionsTransport(ProviderTransport):
             base_url=params.get("base_url"),
             reasoning_config=reasoning_config,
             openrouter_min_coding_score=params.get("openrouter_min_coding_score"),
+            gemini_cached_content_name=params.get("gemini_cached_content_name"),
         )
         if profile_body:
             extra_body.update(profile_body)

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -379,6 +379,39 @@ class ResponsesApiTransport(ProviderTransport):
             provider_data=provider_data or None,
         )
 
+    def extract_usage(self, response_usage: Any) -> "Usage":
+        """Extract canonical usage from a Codex Responses API usage object.
+
+        Codex's ``input_tokens`` is GROSS — includes cache reads and (per
+        x.ai/OpenAI contract) cache writes too. Cache breakdown nests in
+        ``input_tokens_details.cached_tokens`` / ``.cache_creation_tokens``.
+        Subtract both out of input_tokens for net prompt count.
+        """
+        from agent.transports.types import Usage
+
+        if response_usage is None:
+            return Usage()
+        input_total = int(getattr(response_usage, "input_tokens", 0) or 0)
+        output_tokens = int(getattr(response_usage, "output_tokens", 0) or 0)
+
+        details = getattr(response_usage, "input_tokens_details", None)
+        cache_read = int(getattr(details, "cached_tokens", 0) or 0) if details else 0
+        cache_write = int(getattr(details, "cache_creation_tokens", 0) or 0) if details else 0
+
+        out_details = getattr(response_usage, "output_tokens_details", None)
+        reasoning = int(getattr(out_details, "reasoning_tokens", 0) or 0) if out_details else 0
+
+        net_input = max(0, input_total - cache_read - cache_write)
+        return Usage(
+            prompt_tokens=net_input,
+            completion_tokens=output_tokens,
+            total_tokens=input_total + output_tokens,
+            cached_tokens=cache_read,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+            reasoning_tokens=reasoning,
+        )
+
     def validate_response(self, response: Any) -> bool:
         """Check Codex Responses API response has valid output structure.
 

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -78,12 +78,24 @@ class ToolCall:
 
 @dataclass
 class Usage:
-    """Token usage from an API response."""
+    """Token usage from an API response, canonical across wire formats.
+
+    Each transport's ``extract_usage()`` returns this shape regardless of
+    the underlying provider's field names. The Anthropic wire splits
+    cache fields at the top level (``cache_read_input_tokens`` /
+    ``cache_creation_input_tokens``); the OpenAI wire nests them in
+    ``prompt_tokens_details``. Both land here under
+    ``cache_read_tokens`` / ``cache_write_tokens``.
+    """
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    # Back-compat alias for cache_read_tokens used by older transport code.
     cached_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    reasoning_tokens: int = 0
 
 
 @dataclass

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -708,68 +708,38 @@ def normalize_usage(
 ) -> CanonicalUsage:
     """Normalize raw API response usage into canonical token buckets.
 
-    Handles three API shapes:
-    - Anthropic: input_tokens/output_tokens/cache_read_input_tokens/cache_creation_input_tokens
-    - Codex Responses: input_tokens includes cache tokens; input_tokens_details.cached_tokens separates them
-    - OpenAI Chat Completions: prompt_tokens includes cache tokens; prompt_tokens_details.cached_tokens separates them
-
-    In both Codex and OpenAI modes, input_tokens is derived by subtracting cache
-    tokens from the total — the API contract is that input/prompt totals include
-    cached tokens and the details object breaks them out.
+    Delegates per-wire-format field reads to ``ProviderTransport.extract_usage()``.
+    Each transport knows its own field names and quirks (e.g. Codex/OpenAI
+    include cached tokens in the prompt total — those transports subtract;
+    Anthropic's input_tokens is already net — no subtraction).
     """
     if not response_usage:
         return CanonicalUsage()
 
-    provider_name = (provider or "").strip().lower()
+    # Resolve which transport's extractor to use. Fall back to provider-name
+    # → api_mode mapping for callers that pass only ``provider``.
+    from agent.transports import get_transport
+
     mode = (api_mode or "").strip().lower()
+    if not mode:
+        provider_name = (provider or "").strip().lower()
+        if provider_name == "anthropic":
+            mode = "anthropic_messages"
+        else:
+            mode = "chat_completions"
 
-    if mode == "anthropic_messages" or provider_name == "anthropic":
-        input_tokens = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(getattr(response_usage, "cache_creation_input_tokens", 0))
-    elif mode == "codex_responses":
-        input_total = _to_int(getattr(response_usage, "input_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "output_tokens", 0))
-        details = getattr(response_usage, "input_tokens_details", None)
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
-        cache_write_tokens = _to_int(
-            getattr(details, "cache_creation_tokens", 0) if details else 0
-        )
-        input_tokens = max(0, input_total - cache_read_tokens - cache_write_tokens)
-    else:
-        prompt_total = _to_int(getattr(response_usage, "prompt_tokens", 0))
-        output_tokens = _to_int(getattr(response_usage, "completion_tokens", 0))
-        details = getattr(response_usage, "prompt_tokens_details", None)
-        # Primary: OpenAI-style prompt_tokens_details. Fallback: Anthropic-style
-        # top-level fields that some OpenAI-compatible proxies (OpenRouter, Cline)
-        # expose when routing Claude models — without this
-        # fallback, cache writes are undercounted as 0 and cache reads can be
-        # missed when the proxy only surfaces them at the top level.
-        # Port of cline/cline#10266.
-        cache_read_tokens = _to_int(getattr(details, "cached_tokens", 0) if details else 0)
-        if not cache_read_tokens:
-            cache_read_tokens = _to_int(getattr(response_usage, "cache_read_input_tokens", 0))
-        cache_write_tokens = _to_int(
-            getattr(details, "cache_write_tokens", 0) if details else 0
-        )
-        if not cache_write_tokens:
-            cache_write_tokens = _to_int(
-                getattr(response_usage, "cache_creation_input_tokens", 0)
-            )
-        input_tokens = max(0, prompt_total - cache_read_tokens - cache_write_tokens)
+    transport = get_transport(mode)
+    if transport is None:
+        # No transport registered (e.g. test stub) — fall back to chat_completions.
+        transport = get_transport("chat_completions")
 
-    reasoning_tokens = 0
-    output_details = getattr(response_usage, "output_tokens_details", None)
-    if output_details:
-        reasoning_tokens = _to_int(getattr(output_details, "reasoning_tokens", 0))
-
+    usage = transport.extract_usage(response_usage)
     return CanonicalUsage(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cache_read_tokens=cache_read_tokens,
-        cache_write_tokens=cache_write_tokens,
-        reasoning_tokens=reasoning_tokens,
+        input_tokens=usage.prompt_tokens,
+        output_tokens=usage.completion_tokens,
+        cache_read_tokens=usage.cache_read_tokens,
+        cache_write_tokens=usage.cache_write_tokens,
+        reasoning_tokens=usage.reasoning_tokens,
     )
 
 

--- a/plugins/model-providers/alibaba/__init__.py
+++ b/plugins/model-providers/alibaba/__init__.py
@@ -3,7 +3,25 @@
 from providers import register_provider
 from providers.base import ProviderProfile
 
-alibaba = ProviderProfile(
+
+class AlibabaProfile(ProviderProfile):
+    """Alibaba Cloud DashScope — serves Qwen via OpenAI-compatible wire with
+    envelope-layout cache_control support (matches the pi-mono 'alibaba'
+    cacheControlFormat). Without markers, qwen3.6-plus reports 0% cached
+    tokens and burns subscription quota on every turn.
+    """
+
+    def cache_strategy_for(self, model: str):
+        from agent.prompt_cache_strategy import (
+            AnthropicInlineCacheStrategy,
+            NoCacheStrategy,
+        )
+        if "qwen" in (model or "").lower():
+            return AnthropicInlineCacheStrategy(layout="envelope")
+        return NoCacheStrategy()
+
+
+alibaba = AlibabaProfile(
     name="alibaba",
     aliases=("dashscope", "alibaba-cloud", "qwen-dashscope"),
     env_vars=("DASHSCOPE_API_KEY",),

--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -13,6 +13,15 @@ logger = logging.getLogger(__name__)
 class AnthropicProfile(ProviderProfile):
     """Native Anthropic — uses x-api-key header, not Bearer."""
 
+    def cache_strategy_for(self, model: str):
+        from agent.prompt_cache_strategy import (
+            AnthropicInlineCacheStrategy,
+            NoCacheStrategy,
+        )
+        if "claude" in (model or "").lower():
+            return AnthropicInlineCacheStrategy(layout="native")
+        return NoCacheStrategy()
+
     def fetch_models(
         self,
         *,

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -19,12 +19,18 @@ from providers.base import ProviderProfile
 class GeminiProfile(ProviderProfile):
     """Gemini — translate reasoning_config to thinking_config in extra_body."""
 
+    def cache_strategy_for(self, model: str) -> Any:
+        # Only the API-key Gemini provider supports context caching.
+        # google-gemini-cli uses Cloud Code OAuth and a different auth path.
+        if self.name == "gemini" and "gemini" in model.lower():
+            from agent.prompt_cache_strategy import GeminiResourceCacheStrategy
+            return GeminiResourceCacheStrategy()
+        return super().cache_strategy_for(model)
+
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:
-        """Emit extra_body.thinking_config (native) or extra_body.extra_body.google.thinking_config
-        (OpenAI-compat /openai subpath), mirroring the legacy path's behavior.
-        """
+        """Emit thinking_config and (when available) gemini_cached_content_name."""
         from agent.transports.chat_completions import (
             _build_gemini_thinking_config,
             _is_gemini_openai_compat_base_url,
@@ -35,17 +41,21 @@ class GeminiProfile(ProviderProfile):
         reasoning_config = context.get("reasoning_config")
         base_url = context.get("base_url") or self.base_url
 
-        raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)
-        if not raw_thinking_config:
-            return {}
-
         body: dict[str, Any] = {}
-        if self.name == "gemini" and _is_gemini_openai_compat_base_url(base_url):
-            thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
-            if thinking_config:
-                body["extra_body"] = {"google": {"thinking_config": thinking_config}}
-        else:
-            body["thinking_config"] = raw_thinking_config
+
+        raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)
+        if raw_thinking_config:
+            if self.name == "gemini" and _is_gemini_openai_compat_base_url(base_url):
+                thinking_config = _snake_case_gemini_thinking_config(raw_thinking_config)
+                if thinking_config:
+                    body["extra_body"] = {"google": {"thinking_config": thinking_config}}
+            else:
+                body["thinking_config"] = raw_thinking_config
+
+        cache_name = context.get("gemini_cached_content_name")
+        if cache_name:
+            body["gemini_cached_content_name"] = cache_name
+
         return body
 
 

--- a/plugins/model-providers/minimax/__init__.py
+++ b/plugins/model-providers/minimax/__init__.py
@@ -27,7 +27,21 @@ def _is_minimax_m3(model: str | None) -> bool:
 
 
 class MiniMaxProfile(ProviderProfile):
-    """MiniMax — M3 OpenAI-compatible reasoning controls."""
+    """MiniMax — M3 OpenAI-compatible reasoning controls, plus native
+    Anthropic-wire ``cache_control`` support (0.1× read pricing, 5-minute TTL)
+    for the Claude / MiniMax-M2.x models.
+    Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
+    """
+
+    def cache_strategy_for(self, model: str):
+        from agent.prompt_cache_strategy import (
+            AnthropicInlineCacheStrategy,
+            NoCacheStrategy,
+        )
+        m = (model or "").lower()
+        if "claude" in m or "minimax" in m:
+            return AnthropicInlineCacheStrategy(layout="native")
+        return NoCacheStrategy()
 
     def build_api_kwargs_extras(
         self,

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -10,6 +10,19 @@ from providers.base import ProviderProfile
 class NousProfile(ProviderProfile):
     """Nous Portal — product tags, reasoning with Nous-specific omission."""
 
+    def cache_strategy_for(self, model: str):
+        from agent.prompt_cache_strategy import (
+            AnthropicInlineCacheStrategy,
+            NoCacheStrategy,
+        )
+        # Nous Portal proxies to OpenRouter behind the scenes — same
+        # OpenAI-wire envelope cache_control semantics. Both Claude AND
+        # Qwen models route through caching backends that honor the markers.
+        m = (model or "").lower()
+        if "claude" in m or "qwen" in m:
+            return AnthropicInlineCacheStrategy(layout="envelope")
+        return NoCacheStrategy()
+
     def build_extra_body(
         self, *, session_id: str | None = None, **context
     ) -> dict[str, Any]:

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -31,8 +31,29 @@ def _is_deepseek_thinking_model(model: str | None) -> bool:
     return m == "deepseek-reasoner"
 
 
-class OpenCodeGoProfile(ProviderProfile):
-    """OpenCode Go - model-specific reasoning controls."""
+class _OpenCodeFamilyCacheMixin:
+    """Shared cache_strategy_for for the OpenCode family (Zen + Go).
+
+    Both endpoints honor envelope-layout cache_control markers for Qwen
+    models; without them qwen3.6-plus reports 0% cached tokens.
+    """
+
+    def cache_strategy_for(self, model: str):
+        from agent.prompt_cache_strategy import (
+            AnthropicInlineCacheStrategy,
+            NoCacheStrategy,
+        )
+        if "qwen" in (model or "").lower():
+            return AnthropicInlineCacheStrategy(layout="envelope")
+        return NoCacheStrategy()
+
+
+class OpenCodeZenProfile(_OpenCodeFamilyCacheMixin, ProviderProfile):
+    """OpenCode Zen - inherits envelope-layout Qwen caching."""
+
+
+class OpenCodeGoProfile(_OpenCodeFamilyCacheMixin, ProviderProfile):
+    """OpenCode Go - model-specific reasoning controls + Qwen caching."""
 
     # Per-model completion-token cap. The opencode-go relay's default is
     # too large for mimo-v2.5-pro — it sends max_tokens=262144 but Xiaomi
@@ -106,7 +127,7 @@ class OpenCodeGoProfile(ProviderProfile):
         return extra_body, top_level
 
 
-opencode_zen = ProviderProfile(
+opencode_zen = OpenCodeZenProfile(
     name="opencode-zen",
     aliases=("opencode", "opencode_zen", "zen"),
     env_vars=("OPENCODE_ZEN_API_KEY",),

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -47,6 +47,17 @@ def _anthropic_reasoning_is_mandatory(model: str | None) -> bool:
 class OpenRouterProfile(ProviderProfile):
     """OpenRouter aggregator — provider preferences, reasoning config passthrough."""
 
+    def cache_strategy_for(self, model: str):
+        from agent.prompt_cache_strategy import (
+            AnthropicInlineCacheStrategy,
+            NoCacheStrategy,
+        )
+        # OpenRouter routes Claude to Anthropic's backend and forwards
+        # cache_control markers via the OpenAI-wire envelope layout.
+        if "claude" in (model or "").lower():
+            return AnthropicInlineCacheStrategy(layout="envelope")
+        return NoCacheStrategy()
+
     def fetch_models(
         self,
         *,

--- a/providers/base.py
+++ b/providers/base.py
@@ -116,6 +116,26 @@ class ProviderProfile:
         """
         return messages
 
+    def cache_strategy_for(self, model: str) -> Any:
+        """Return the prompt-cache strategy to use for this (provider, model).
+
+        Default: ``NoCacheStrategy()``. Provider plugins override to declare
+        their caching mechanism — typically returning
+        ``AnthropicInlineCacheStrategy(layout=...)`` for Claude/Qwen models
+        on the relevant wire format, or ``GeminiResourceCacheStrategy()``
+        for native Gemini.
+
+        Branching by ``(provider × model)`` lives in each plugin so the
+        agent loop can call this method without knowing any provider's
+        caching quirks. Replaces the centralized 8-branch
+        ``anthropic_prompt_cache_policy()`` that lived in agent_runtime_helpers.
+        """
+        # Late import keeps providers/base.py free of agent/ dependencies
+        # at module-load time (this file is imported very early).
+        from agent.prompt_cache_strategy import NoCacheStrategy
+
+        return NoCacheStrategy()
+
     def build_extra_body(
         self, *, session_id: str | None = None, **context: Any
     ) -> dict[str, Any]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1203,18 +1203,6 @@ class AIAgent:
         """Return True when the base URL targets OpenRouter."""
         return base_url_host_matches(self._base_url_lower, "openrouter.ai")
 
-    def _anthropic_prompt_cache_policy(
-        self,
-        *,
-        provider: Optional[str] = None,
-        base_url: Optional[str] = None,
-        api_mode: Optional[str] = None,
-        model: Optional[str] = None,
-    ) -> tuple[bool, bool]:
-        """Forwarder — see ``agent.agent_runtime_helpers.anthropic_prompt_cache_policy``."""
-        from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
-        return anthropic_prompt_cache_policy(self, provider=provider, base_url=base_url, api_mode=api_mode, model=model)
-
     @staticmethod
     def _model_requires_responses_api(model: str) -> bool:
         """Return True for models that require the Responses API path.

--- a/scripts/baseline_prompt_cache.sh
+++ b/scripts/baseline_prompt_cache.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Run a known prompt against the gemini35 test profile and emit a JSON
+# baseline of state.db's usage + cost row. Intended for manual capture
+# before the PR-1 refactor; the captured file becomes the regression
+# target for tests/integration/test_prompt_cache_baseline.py.
+#
+# Usage:
+#   scripts/baseline_prompt_cache.sh                # write to stdout
+#   scripts/baseline_prompt_cache.sh > tests/fixtures/prompt_cache_baseline.json
+#
+# Prerequisites:
+#   - ~/.hermes/profiles/gemini35/ exists with GOOGLE_API_KEY in .env
+#   - .venv set up at the repo root
+#
+# Exit code:
+#   0 on success; non-zero on any failure (missing profile, missing key,
+#   API error, sqlite error).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROFILE="${HERMES_BASELINE_PROFILE:-gemini35}"
+PROFILE_PATH="${HOME}/.hermes/profiles/${PROFILE}"
+
+if [[ ! -d "$PROFILE_PATH" ]]; then
+  echo "ERROR: profile not found: $PROFILE_PATH" >&2
+  echo "Set up via 'hermes profile create $PROFILE' first." >&2
+  exit 2
+fi
+
+if [[ ! -f "$PROFILE_PATH/.env" ]]; then
+  echo "ERROR: no .env in $PROFILE_PATH — API key required." >&2
+  exit 3
+fi
+
+if [[ ! -d "$REPO_ROOT/.venv" ]]; then
+  echo "ERROR: .venv not found at $REPO_ROOT/.venv" >&2
+  echo "Run: uv venv .venv --python 3.11 && uv pip install -e \".[all,dev]\"" >&2
+  exit 4
+fi
+
+# Run a one-shot prompt — kept short to minimize variability in output_tokens.
+PROMPT="Reply with exactly: 'baseline-prompt-cache-test'"
+
+# Use a fixed timestamp so the session row is identifiable.
+TIMESTAMP="$(date -u +%Y%m%d_%H%M%S)"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/.venv/bin/activate"
+HERMES_HOME="$PROFILE_PATH" hermes chat -q "$PROMPT" > /dev/null 2>&1 || {
+  echo "ERROR: hermes chat invocation failed" >&2
+  exit 5
+}
+
+# Pull the most recent session row (the one we just created).
+ROW="$(sqlite3 "$PROFILE_PATH/state.db" \
+  "SELECT model, input_tokens, output_tokens, cache_read_tokens,
+          estimated_cost_usd, billing_provider, cost_status
+   FROM sessions
+   WHERE input_tokens > 0
+   ORDER BY started_at DESC LIMIT 1")"
+
+if [[ -z "$ROW" ]]; then
+  echo "ERROR: no session row found with input_tokens > 0 — call may have failed" >&2
+  exit 6
+fi
+
+IFS='|' read -r MODEL INPUT_TOKENS OUTPUT_TOKENS CACHE_READ COST PROVIDER STATUS <<< "$ROW"
+
+cat <<EOF
+{
+  "prompt": "${PROMPT}",
+  "profile": "${PROFILE}",
+  "captured_at_utc": "${TIMESTAMP}",
+  "observed": {
+    "model": "${MODEL}",
+    "input_tokens": ${INPUT_TOKENS},
+    "output_tokens": ${OUTPUT_TOKENS},
+    "cache_read_tokens": ${CACHE_READ},
+    "estimated_cost_usd": ${COST:-null},
+    "billing_provider": "${PROVIDER}",
+    "cost_status": "${STATUS}"
+  },
+  "invariants_to_assert": [
+    "input_tokens > 0",
+    "output_tokens > 0",
+    "cost_status == 'estimated'",
+    "estimated_cost_usd > 0"
+  ]
+}
+EOF

--- a/tests/agent/test_cache_wire_payload_snapshot.py
+++ b/tests/agent/test_cache_wire_payload_snapshot.py
@@ -1,0 +1,202 @@
+"""Wire-payload snapshot tests for prompt caching.
+
+Each test asserts the **literal expected output dict** of
+`apply_anthropic_cache_control()` for a fixed input. The values were
+captured by running the function against the current `main` and locking
+them in. Any byte change in the future signals either:
+
+  - An intentional behavior change (update the expected dict)
+  - An unintentional regression (fix the code)
+
+These snapshots are the canary for the PR-1 refactor: after the strategy
+abstraction lands, the new code path must produce byte-identical output
+for the same inputs.
+"""
+
+from __future__ import annotations
+
+from agent.prompt_caching import apply_anthropic_cache_control
+
+
+# ── Fixed inputs ────────────────────────────────────────────────────────
+
+SYSTEM_PLUS_3 = [
+    {"role": "system", "content": "You are a helpful agent."},
+    {"role": "user", "content": "First question."},
+    {"role": "assistant", "content": "First answer."},
+    {"role": "user", "content": "Second question."},
+]
+
+
+# ── Snapshots ───────────────────────────────────────────────────────────
+
+
+def test_snapshot_native_5m_system_plus_three():
+    """Native layout, 5m TTL: marker on inner content blocks; system + last 3."""
+    result = apply_anthropic_cache_control(
+        SYSTEM_PLUS_3, cache_ttl="5m", native_anthropic=True
+    )
+    assert result == [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "You are a helpful agent.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "First question.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "First answer.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Second question.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        },
+    ]
+
+
+def test_snapshot_native_1h_system_plus_three():
+    """Native layout, 1h TTL: marker dict includes ttl field."""
+    result = apply_anthropic_cache_control(
+        SYSTEM_PLUS_3, cache_ttl="1h", native_anthropic=True
+    )
+    marker = {"type": "ephemeral", "ttl": "1h"}
+    assert result == [
+        {"role": "system", "content": [{"type": "text", "text": "You are a helpful agent.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "First question.", "cache_control": marker}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "First answer.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "Second question.", "cache_control": marker}]},
+    ]
+
+
+def test_snapshot_envelope_5m_system_plus_three():
+    """Envelope layout (native_anthropic=False), 5m TTL.
+
+    Behavior matches native for non-tool messages with string content —
+    `_apply_cache_marker` wraps string content into a list and puts the
+    marker on the inner block regardless of layout. The native/envelope
+    distinction only matters for `role==tool` messages and empty/None
+    content (see snapshot tests below)."""
+    result = apply_anthropic_cache_control(
+        SYSTEM_PLUS_3, cache_ttl="5m", native_anthropic=False
+    )
+    marker = {"type": "ephemeral"}
+    assert result == [
+        {"role": "system", "content": [{"type": "text", "text": "You are a helpful agent.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "First question.", "cache_control": marker}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "First answer.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "Second question.", "cache_control": marker}]},
+    ]
+
+
+def test_snapshot_envelope_1h_system_plus_three():
+    """Envelope layout, 1h TTL."""
+    result = apply_anthropic_cache_control(
+        SYSTEM_PLUS_3, cache_ttl="1h", native_anthropic=False
+    )
+    marker = {"type": "ephemeral", "ttl": "1h"}
+    assert result == [
+        {"role": "system", "content": [{"type": "text", "text": "You are a helpful agent.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "First question.", "cache_control": marker}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "First answer.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "Second question.", "cache_control": marker}]},
+    ]
+
+
+def test_snapshot_native_with_tool_messages():
+    """Tool messages get the marker at the envelope level on native layout
+    (rather than on inner content). Asserts the layout distinction lands."""
+    messages = [
+        {"role": "system", "content": "Sys prompt."},
+        {"role": "user", "content": "Use the tool."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "tool result"},
+    ]
+    result = apply_anthropic_cache_control(messages, cache_ttl="5m", native_anthropic=True)
+    marker = {"type": "ephemeral"}
+    assert result == [
+        {"role": "system", "content": [{"type": "text", "text": "Sys prompt.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "Use the tool.", "cache_control": marker}]},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}],
+            # Empty-string content → envelope-level marker (per _apply_cache_marker).
+            "cache_control": marker,
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": "tool result",
+            # native_anthropic=True → tool messages get envelope-level marker.
+            "cache_control": marker,
+        },
+    ]
+
+
+def test_snapshot_envelope_with_tool_messages_skips_tool_marker():
+    """On envelope layout, tool messages are SKIPPED entirely — the function
+    moves on to the next message looking for somewhere to place the marker.
+    This catches the OpenRouter-vs-native difference at the wire-format level."""
+    messages = [
+        {"role": "system", "content": "Sys prompt."},
+        {"role": "user", "content": "Use the tool."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "tool result"},
+    ]
+    result = apply_anthropic_cache_control(messages, cache_ttl="5m", native_anthropic=False)
+    marker = {"type": "ephemeral"}
+    # On envelope layout, tool messages get NO marker. The 4-cap counts the
+    # last 3 non-system messages by index, so the tool message is included
+    # in that selection but receives no marker (_apply_cache_marker returns
+    # early for tool role on envelope layout).
+    assert result == [
+        {"role": "system", "content": [{"type": "text", "text": "Sys prompt.", "cache_control": marker}]},
+        {"role": "user", "content": [{"type": "text", "text": "Use the tool.", "cache_control": marker}]},
+        {
+            "role": "assistant",
+            # Empty-string content → envelope-level marker (per _apply_cache_marker).
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "t", "arguments": "{}"}}],
+            "cache_control": marker,
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": "tool result",
+            # NO cache_control — envelope layout skips tool messages.
+        },
+    ]

--- a/tests/agent/test_conversation_loop_caching.py
+++ b/tests/agent/test_conversation_loop_caching.py
@@ -1,0 +1,236 @@
+"""Integration test for the policy + marker-placement join.
+
+`agent/conversation_loop.py:898` calls `apply_anthropic_cache_control()` only
+when `_anthropic_prompt_cache_policy()` returned `(True, native_layout)`.
+The 24 + 14 existing unit tests in `tests/run_agent/test_anthropic_prompt_cache_policy.py`
+and `tests/agent/test_prompt_caching.py` cover each side in isolation — but
+not the join. That join is exactly what the PR-1 refactor replaces with
+`profile.cache_strategy_for(model).apply(messages, intent)`.
+
+This test pins the join: for each (provider × model) combo from the policy
+matrix, given a known input message list, what does the FULL pipeline
+produce? Same input/output contract must hold after the refactor.
+
+When PR-1 lands, this file's `_apply_for_agent_combo()` helper changes one
+function call — the asserts on the produced messages stay identical.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from agent.prompt_caching import apply_anthropic_cache_control
+from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
+
+
+def _stub_agent(*, provider, base_url, api_mode, model):
+    """Build a minimal AIAgent-shaped object for policy fn calls."""
+    agent = MagicMock()
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.api_mode = api_mode
+    agent.model = model
+    return agent
+
+
+def _apply_for_agent_combo(messages, *, provider, base_url, api_mode, model, ttl="5m"):
+    """Run the policy + marker-placement combination once, mirroring
+    `conversation_loop.py:898`. Returns the messages as they would be sent
+    to the API (with cache_control markers if the policy said to cache).
+    """
+    agent = _stub_agent(provider=provider, base_url=base_url, api_mode=api_mode, model=model)
+    should_cache, native_layout = anthropic_prompt_cache_policy(agent)
+    if should_cache:
+        return apply_anthropic_cache_control(
+            messages,
+            cache_ttl=ttl,
+            native_anthropic=native_layout,
+        )
+    return messages
+
+
+def _has_native_marker(msg) -> bool:
+    """A 'native' cache_control marker lives on the inner content block,
+    not on the message envelope."""
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(item, dict) and "cache_control" in item
+        for item in content
+    )
+
+
+def _has_envelope_marker(msg) -> bool:
+    """An 'envelope' cache_control marker is on the message-level dict.
+    NOTE: When the marker is added to a string-content message, the
+    string is first wrapped into a list, so the marker can land EITHER
+    at the envelope level (tool messages on native layout, empty/None
+    content) or on the inner block. For the envelope LAYOUT applied to
+    a string-content user msg, the marker lands on the inner wrapped
+    block — which collides with _has_native_marker.
+
+    To distinguish layout reliably, check: does the message have
+    `cache_control` at the top level? That's only true for envelope
+    layout when content was already None / empty / a list."""
+    return isinstance(msg.get("cache_control"), dict)
+
+
+def _count_markers(messages):
+    """Total cache_control markers across all messages, both layouts."""
+    n = 0
+    for m in messages:
+        if _has_envelope_marker(m):
+            n += 1
+        content = m.get("content")
+        if isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and "cache_control" in item:
+                    n += 1
+    return n
+
+
+# ── Fixtures: the message lists we feed every combo ─────────────────────
+
+@pytest.fixture
+def system_plus_three():
+    """System prompt + 3 user/assistant exchanges (typical mid-session shape)."""
+    return [
+        {"role": "system", "content": "You are a helpful agent."},
+        {"role": "user", "content": "First question."},
+        {"role": "assistant", "content": "First answer."},
+        {"role": "user", "content": "Second question."},
+        {"role": "assistant", "content": "Second answer."},
+        {"role": "user", "content": "Third question."},
+    ]
+
+
+@pytest.fixture
+def system_plus_five():
+    """System + 5 user/asst (verifies 4-breakpoint cap is honored)."""
+    return [
+        {"role": "system", "content": "You are a helpful agent."},
+        *[
+            {"role": role, "content": f"Message {i}"}
+            for i, role in enumerate(["user", "assistant"] * 5)
+        ],
+    ]
+
+
+# ── Parameterized matrix ────────────────────────────────────────────────
+
+# Each row: (provider, base_url, api_mode, model, expects_cache, layout_hint)
+# layout_hint: "native" / "envelope" / None (when expects_cache is False)
+MATRIX = [
+    # Native Anthropic (branch 1)
+    ("anthropic", "https://api.anthropic.com", "anthropic_messages", "claude-sonnet-4-6", True, "native"),
+    # OpenRouter + Claude (branch 2)
+    ("openrouter", "https://openrouter.ai/api/v1", "chat_completions", "anthropic/claude-sonnet-4.6", True, "envelope"),
+    # Nous Portal + Claude (branch 3)
+    ("nous", "https://inference.nousresearch.com/v1", "chat_completions", "anthropic/claude-sonnet-4.6", True, "envelope"),
+    # Nous Portal + Qwen (branch 4)
+    ("nous", "https://inference.nousresearch.com/v1", "chat_completions", "qwen3.6-plus", True, "envelope"),
+    # Anthropic-wire third-party gateway + Claude (branch 5)
+    ("litellm-proxy", "https://litellm.example.com/v1", "anthropic_messages", "claude-sonnet-4-6", True, "native"),
+    # MiniMax + own model (branch 6)
+    ("minimax", "https://api.minimax.io/anthropic", "anthropic_messages", "MiniMax-M2.7", True, "native"),
+    # Alibaba family + Qwen (branch 7)
+    ("opencode-go", "https://api.opencode.ai/v1", "chat_completions", "qwen3.6-plus", True, "envelope"),
+    # Default-no-cache: OpenAI + GPT-4o (branch 8)
+    ("openai", "https://api.openai.com/v1", "chat_completions", "gpt-4o", False, None),
+    # Default-no-cache: OpenRouter + non-Claude
+    ("openrouter", "https://openrouter.ai/api/v1", "chat_completions", "openai/gpt-4o", False, None),
+    # Default-no-cache: OpenCode-Go + non-Qwen
+    ("opencode-go", "https://api.opencode.ai/v1", "chat_completions", "kimi-k2", False, None),
+]
+
+
+@pytest.mark.parametrize("provider,base_url,api_mode,model,expects_cache,layout_hint", MATRIX)
+def test_policy_plus_apply_matrix(
+    system_plus_three, provider, base_url, api_mode, model, expects_cache, layout_hint
+):
+    """For each known matrix row, the join of policy + apply must produce
+    cache markers (or not) consistent with the policy's decision."""
+    result = _apply_for_agent_combo(
+        system_plus_three,
+        provider=provider,
+        base_url=base_url,
+        api_mode=api_mode,
+        model=model,
+    )
+
+    marker_count = _count_markers(result)
+
+    if not expects_cache:
+        # No caching → no markers anywhere, list equals input length.
+        assert marker_count == 0, f"{provider}/{model} should not cache but got {marker_count} markers"
+        return
+
+    # Cache path: 4 markers expected (system_and_3 strategy: system + last 3 non-system).
+    # The 14 marker-placement tests already verify *which* messages get markers;
+    # here we just verify the count survives the policy join.
+    assert marker_count == 4, f"{provider}/{model} expected 4 markers, got {marker_count}"
+
+
+def test_system_plus_five_caps_at_four_breakpoints(system_plus_five):
+    """Even with 11 messages, max 4 cache_control markers (system + last 3)."""
+    result = _apply_for_agent_combo(
+        system_plus_five,
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_mode="anthropic_messages",
+        model="claude-sonnet-4-6",
+    )
+    assert _count_markers(result) == 4
+
+
+def test_input_messages_not_mutated(system_plus_three):
+    """The cache application must deep-copy — original messages must not
+    grow cache_control fields. Regression guard against shared-state bugs."""
+    snapshot = [dict(m) for m in system_plus_three]
+    _apply_for_agent_combo(
+        system_plus_three,
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_mode="anthropic_messages",
+        model="claude-sonnet-4-6",
+    )
+    for orig, snap in zip(system_plus_three, snapshot):
+        assert orig == snap, "apply_anthropic_cache_control mutated the input message list"
+
+
+def test_no_cache_path_passes_through_messages_unchanged(system_plus_three):
+    """When the policy says no-cache, the helper returns the messages as-is."""
+    result = _apply_for_agent_combo(
+        system_plus_three,
+        provider="openai",
+        base_url="https://api.openai.com/v1",
+        api_mode="chat_completions",
+        model="gpt-4o",
+    )
+    # Returns same list (or an equivalent one with no markers).
+    assert _count_markers(result) == 0
+    assert len(result) == len(system_plus_three)
+
+
+def test_ttl_propagates_through_policy_apply_join(system_plus_three):
+    """The cache_ttl parameter must survive the join — 1h tier must produce
+    markers with the ttl field set."""
+    result = _apply_for_agent_combo(
+        system_plus_three,
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_mode="anthropic_messages",
+        model="claude-sonnet-4-6",
+        ttl="1h",
+    )
+    # Find any cache_control marker and check its ttl.
+    found_1h = False
+    for m in result:
+        if isinstance(m.get("content"), list):
+            for item in m["content"]:
+                if isinstance(item, dict) and item.get("cache_control", {}).get("ttl") == "1h":
+                    found_1h = True
+                    break
+    assert found_1h, "1h TTL did not propagate through the policy+apply join"

--- a/tests/agent/test_conversation_loop_caching.py
+++ b/tests/agent/test_conversation_loop_caching.py
@@ -1,53 +1,42 @@
-"""Integration test for the policy + marker-placement join.
+"""Integration test for the strategy + marker-placement join.
 
-`agent/conversation_loop.py:898` calls `apply_anthropic_cache_control()` only
-when `_anthropic_prompt_cache_policy()` returned `(True, native_layout)`.
-The 24 + 14 existing unit tests in `tests/run_agent/test_anthropic_prompt_cache_policy.py`
-and `tests/agent/test_prompt_caching.py` cover each side in isolation — but
-not the join. That join is exactly what the PR-1 refactor replaces with
-`profile.cache_strategy_for(model).apply(messages, intent)`.
+`agent/conversation_loop.py` calls `profile.cache_strategy_for(model).apply(messages, intent)`
+for each request. The 26 unit tests in `tests/run_agent/test_anthropic_prompt_cache_policy.py`
+and 14 in `tests/agent/test_prompt_caching.py` cover each side in isolation — but
+not the join.
 
-This test pins the join: for each (provider × model) combo from the policy
-matrix, given a known input message list, what does the FULL pipeline
-produce? Same input/output contract must hold after the refactor.
-
-When PR-1 lands, this file's `_apply_for_agent_combo()` helper changes one
-function call — the asserts on the produced messages stay identical.
+This test pins the join: for each (provider × model) combo from the strategy
+matrix, given a known input message list, what does the FULL pipeline produce?
 """
 
 from __future__ import annotations
 
 import pytest
-from unittest.mock import MagicMock
 
-from agent.prompt_caching import apply_anthropic_cache_control
-from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
-
-
-def _stub_agent(*, provider, base_url, api_mode, model):
-    """Build a minimal AIAgent-shaped object for policy fn calls."""
-    agent = MagicMock()
-    agent.provider = provider
-    agent.base_url = base_url
-    agent.api_mode = api_mode
-    agent.model = model
-    return agent
+from agent.prompt_cache_strategy import (
+    AnthropicInlineCacheStrategy,
+    NoCacheStrategy,
+    PromptCacheIntent,
+)
+from providers import get_provider_profile
 
 
 def _apply_for_agent_combo(messages, *, provider, base_url, api_mode, model, ttl="5m"):
-    """Run the policy + marker-placement combination once, mirroring
-    `conversation_loop.py:898`. Returns the messages as they would be sent
-    to the API (with cache_control markers if the policy said to cache).
+    """Run the strategy + marker-placement combination once, mirroring
+    `conversation_loop.py`. Returns the messages as they would be sent
+    to the API (with cache_control markers if the strategy applies any).
     """
-    agent = _stub_agent(provider=provider, base_url=base_url, api_mode=api_mode, model=model)
-    should_cache, native_layout = anthropic_prompt_cache_policy(agent)
-    if should_cache:
-        return apply_anthropic_cache_control(
-            messages,
-            cache_ttl=ttl,
-            native_anthropic=native_layout,
-        )
-    return messages
+    profile = get_provider_profile(provider)
+    strategy = profile.cache_strategy_for(model) if profile else NoCacheStrategy()
+    # Fallback for unknown providers speaking Anthropic wire format with Claude
+    if (
+        isinstance(strategy, NoCacheStrategy)
+        and api_mode == "anthropic_messages"
+        and "claude" in (model or "").lower()
+    ):
+        strategy = AnthropicInlineCacheStrategy(layout="native")
+    intent = PromptCacheIntent(ttl=ttl)
+    return strategy.apply(messages, intent)
 
 
 def _has_native_marker(msg) -> bool:

--- a/tests/agent/test_gemini_context_cache.py
+++ b/tests/agent/test_gemini_context_cache.py
@@ -1,0 +1,164 @@
+"""Unit tests for Gemini server-side context caching (PR-2 of #29818).
+
+`_ensure_gemini_cache()` creates or reuses a ``cachedContents`` resource for a
+session's system instruction + tools. It must:
+  - skip cleanly when there is no session / no system prompt,
+  - reuse a still-fresh resource without an HTTP call,
+  - refresh when the cached resource is near expiry,
+  - never raise — an uncached request is the safe fallback on any error.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent import conversation_loop
+from agent.prompt_cache_strategy import GeminiResourceCacheStrategy
+
+
+class _FakeDB:
+    def __init__(self, meta=None):
+        self._meta = dict(meta or {})
+        self.set_calls = []
+
+    def get_meta(self, key):
+        return self._meta.get(key)
+
+    def set_meta(self, key, value):
+        self._meta[key] = value
+        self.set_calls.append((key, value))
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHTTPClient:
+    """Context-manager stand-in for httpx.Client that records POSTs."""
+
+    def __init__(self, resp, calls):
+        self._resp = resp
+        self._calls = calls
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, params=None, json=None, headers=None):
+        self._calls.append({"url": url, "params": params, "json": json})
+        return self._resp
+
+
+def _agent(**overrides):
+    base = dict(
+        session_id="sess-1",
+        _session_db=_FakeDB(),
+        model="gemini-3.5-flash",
+        base_url="https://generativelanguage.googleapis.com/v1beta",
+        api_key="AIza-test",
+        tools=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _patch_httpx(monkeypatch, resp):
+    calls = []
+    monkeypatch.setattr("httpx.Client", lambda *a, **k: _FakeHTTPClient(resp, calls))
+    return calls
+
+
+_SYS = [{"role": "system", "content": "You are helpful."}, {"role": "user", "content": "hi"}]
+
+
+def test_no_session_id_returns_none(monkeypatch):
+    calls = _patch_httpx(monkeypatch, _FakeResp(payload={"name": "cachedContents/x"}))
+    assert conversation_loop._ensure_gemini_cache(_agent(session_id=None), _SYS) is None
+    assert calls == []  # never hits the network
+
+
+def test_no_system_message_returns_none(monkeypatch):
+    calls = _patch_httpx(monkeypatch, _FakeResp(payload={"name": "cachedContents/x"}))
+    msgs = [{"role": "user", "content": "hi"}]
+    assert conversation_loop._ensure_gemini_cache(_agent(), msgs) is None
+    assert calls == []
+
+
+def test_creates_and_stores_cache(monkeypatch):
+    resp = _FakeResp(payload={"name": "cachedContents/abc123", "expireTime": "2099-01-01T00:00:00Z"})
+    calls = _patch_httpx(monkeypatch, resp)
+    agent = _agent()
+
+    name = conversation_loop._ensure_gemini_cache(agent, _SYS)
+
+    assert name == "cachedContents/abc123"
+    # One POST to the cachedContents endpoint with the right shape.
+    assert len(calls) == 1
+    assert calls[0]["url"].endswith("/cachedContents")
+    payload = calls[0]["json"]
+    assert payload["model"] == "models/gemini-3.5-flash"  # prefixed
+    assert payload["systemInstruction"]["parts"] == [{"text": "You are helpful."}]
+    assert payload["ttl"] == "3600s"
+    # Resource name persisted for cross-turn reuse.
+    assert agent._session_db.set_calls
+    key, stored = agent._session_db.set_calls[-1]
+    assert key == "gemini_cache_sess-1"
+    assert json.loads(stored)["name"] == "cachedContents/abc123"
+
+
+def test_reuses_fresh_cache_without_http(monkeypatch):
+    db = _FakeDB({"gemini_cache_sess-1": json.dumps({"name": "cachedContents/old", "expires_at": 9_999_999_999})})
+    calls = _patch_httpx(monkeypatch, _FakeResp(status_code=500))  # would fail if used
+    name = conversation_loop._ensure_gemini_cache(_agent(_session_db=db), _SYS)
+    assert name == "cachedContents/old"
+    assert calls == []  # fresh cache → no network call
+
+
+def test_stale_cache_triggers_refresh(monkeypatch):
+    db = _FakeDB({"gemini_cache_sess-1": json.dumps({"name": "cachedContents/old", "expires_at": 1})})
+    resp = _FakeResp(payload={"name": "cachedContents/new"})
+    calls = _patch_httpx(monkeypatch, resp)
+    name = conversation_loop._ensure_gemini_cache(_agent(_session_db=db), _SYS)
+    assert name == "cachedContents/new"
+    assert len(calls) == 1  # near-expiry cache → re-created
+
+
+def test_http_error_returns_none(monkeypatch):
+    resp = _FakeResp(status_code=429, text="RESOURCE_EXHAUSTED")
+    _patch_httpx(monkeypatch, resp)
+    # Free-tier / quota errors must degrade to an uncached request, not raise.
+    assert conversation_loop._ensure_gemini_cache(_agent(), _SYS) is None
+
+
+def test_missing_name_in_response_returns_none(monkeypatch):
+    _patch_httpx(monkeypatch, _FakeResp(payload={}))  # 200 but no name
+    assert conversation_loop._ensure_gemini_cache(_agent(), _SYS) is None
+
+
+def test_network_exception_is_swallowed(monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr("httpx.Client", _boom)
+    assert conversation_loop._ensure_gemini_cache(_agent(), _SYS) is None
+
+
+def test_strategy_apply_is_identity():
+    """The marker strategy must not mutate messages — the work happens out of band."""
+    strategy = GeminiResourceCacheStrategy()
+    msgs = [{"role": "system", "content": "x"}, {"role": "user", "content": "y"}]
+    from agent.prompt_cache_strategy import PromptCacheIntent
+
+    out = strategy.apply(msgs, PromptCacheIntent(ttl="5m"))
+    assert out == msgs

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -408,3 +408,56 @@ def test_explicit_max_tokens_is_respected():
 
     req = build_gemini_request(messages=[{"role": "user", "content": "hi"}], max_tokens=4096)
     assert req["generationConfig"]["maxOutputTokens"] == 4096
+
+
+def _tooled_messages():
+    return [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+
+_WEATHER_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        },
+    }
+]
+
+
+def test_cached_content_omits_system_instruction_and_tools():
+    """With a cachedContents resource, the request references it and must NOT
+    resend systemInstruction / tools / toolConfig (Gemini rejects that with 400).
+    """
+    from agent.gemini_native_adapter import build_gemini_request
+
+    req = build_gemini_request(
+        messages=_tooled_messages(),
+        tools=_WEATHER_TOOL,
+        tool_choice="auto",
+        cached_content_name="cachedContents/abc123",
+    )
+    assert req["cachedContent"] == "cachedContents/abc123"
+    assert "systemInstruction" not in req
+    assert "tools" not in req
+    assert "toolConfig" not in req
+    # Conversation turns themselves are still sent.
+    assert req["contents"]
+
+
+def test_without_cached_content_sends_full_payload():
+    """Without a cache name, behavior is unchanged: systemInstruction + tools present."""
+    from agent.gemini_native_adapter import build_gemini_request
+
+    req = build_gemini_request(
+        messages=_tooled_messages(),
+        tools=_WEATHER_TOOL,
+        tool_choice="auto",
+    )
+    assert "cachedContent" not in req
+    assert req["systemInstruction"]["parts"][0]["text"] == "You are helpful."
+    assert req["tools"][0]["functionDeclarations"][0]["name"] == "get_weather"

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -250,3 +250,92 @@ def test_deepseek_v4_pro_estimate_usage_cost():
     assert result.amount_usd is not None
     # 1M input × $1.74/M + 500K output × $3.48/M = $1.74 + $1.74 = $3.48
     assert float(result.amount_usd) == 3.48
+
+
+# --- normalize_usage coverage gaps (PR-0 groundwork for prompt-cache refactor) ---
+
+def test_normalize_usage_codex_responses_subtracts_cache_tokens():
+    """Codex Responses API: input_tokens is the gross total; cache tokens
+    must be subtracted out of input_tokens to get the net non-cached input.
+
+    Shape: input_tokens_details.cached_tokens (read) and .cache_creation_tokens (write).
+    """
+    usage = SimpleNamespace(
+        input_tokens=2500,
+        output_tokens=300,
+        input_tokens_details=SimpleNamespace(
+            cached_tokens=1500,
+            cache_creation_tokens=200,
+        ),
+    )
+
+    normalized = normalize_usage(usage, provider="openai-codex", api_mode="codex_responses")
+
+    assert normalized.cache_read_tokens == 1500
+    assert normalized.cache_write_tokens == 200
+    # 2500 - 1500 - 200 = 800
+    assert normalized.input_tokens == 800
+    assert normalized.output_tokens == 300
+
+
+def test_normalize_usage_codex_responses_no_details_treats_input_as_all_net():
+    """When Codex returns no input_tokens_details, all input is net (no cache)."""
+    usage = SimpleNamespace(input_tokens=1000, output_tokens=200)
+
+    normalized = normalize_usage(usage, provider="openai-codex", api_mode="codex_responses")
+
+    assert normalized.cache_read_tokens == 0
+    assert normalized.cache_write_tokens == 0
+    assert normalized.input_tokens == 1000
+
+
+def test_normalize_usage_gemini_native_shape_goes_through_openai_branch():
+    """Gemini native adapter normalizes its response to an OpenAI-like
+    SimpleNamespace (prompt_tokens + prompt_tokens_details.cached_tokens).
+    normalize_usage with provider='gemini' / api_mode='chat_completions'
+    must read those fields the same way as any other OpenAI-wire response.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=19914,
+        completion_tokens=9,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=16266),
+    )
+
+    normalized = normalize_usage(usage, provider="gemini", api_mode="chat_completions")
+
+    assert normalized.cache_read_tokens == 16266
+    # 19914 - 16266 = 3648 net input
+    assert normalized.input_tokens == 3648
+    assert normalized.output_tokens == 9
+
+
+def test_normalize_usage_anthropic_no_cache_fields_returns_zero_defaults():
+    """Anthropic response without any cache fields set: cache_read/write_tokens
+    must default to 0, not None / not raise. Regression guard against AttributeError
+    when the Anthropic adapter omits cache fields on uncached turns.
+    """
+    usage = SimpleNamespace(input_tokens=500, output_tokens=200)
+
+    normalized = normalize_usage(usage, provider="anthropic", api_mode="anthropic_messages")
+
+    assert normalized.input_tokens == 500
+    assert normalized.output_tokens == 200
+    assert normalized.cache_read_tokens == 0
+    assert normalized.cache_write_tokens == 0
+
+
+def test_normalize_usage_extracts_reasoning_tokens_from_output_details():
+    """When the response includes output_tokens_details.reasoning_tokens
+    (o-series / GPT-5 / DeepSeek-R variants), normalize_usage must propagate
+    the count into CanonicalUsage.reasoning_tokens.
+    """
+    usage = SimpleNamespace(
+        prompt_tokens=1000,
+        completion_tokens=500,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=320),
+    )
+
+    normalized = normalize_usage(usage, provider="openai", api_mode="chat_completions")
+
+    assert normalized.reasoning_tokens == 320
+    assert normalized.output_tokens == 500

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -968,21 +968,29 @@ class TestChatCompletionsNormalize:
         assert nr.provider_data == {"refusal": "cannot continue"}
 
 
-class TestChatCompletionsCacheStats:
+class TestChatCompletionsExtractUsage:
 
     def test_no_usage(self, transport):
-        r = SimpleNamespace(usage=None)
-        assert transport.extract_cache_stats(r) is None
+        result = transport.extract_usage(None)
+        assert result.prompt_tokens == 0
+        assert result.cache_read_tokens == 0
 
     def test_no_details(self, transport):
-        r = SimpleNamespace(usage=SimpleNamespace(prompt_tokens_details=None))
-        assert transport.extract_cache_stats(r) is None
+        usage = SimpleNamespace(prompt_tokens=1000, completion_tokens=200, prompt_tokens_details=None)
+        result = transport.extract_usage(usage)
+        assert result.cache_read_tokens == 0
+        assert result.prompt_tokens == 1000
 
     def test_with_cache(self, transport):
         details = SimpleNamespace(cached_tokens=500, cache_write_tokens=100)
-        r = SimpleNamespace(usage=SimpleNamespace(prompt_tokens_details=details))
-        result = transport.extract_cache_stats(r)
-        assert result == {"cached_tokens": 500, "creation_tokens": 100}
+        usage = SimpleNamespace(prompt_tokens=2000, completion_tokens=300, prompt_tokens_details=details)
+        result = transport.extract_usage(usage)
+        assert result.cache_read_tokens == 500
+        assert result.cached_tokens == 500  # back-compat alias
+        assert result.cache_write_tokens == 100
+        # OpenAI prompt_tokens is gross — subtract cache to get net input.
+        assert result.prompt_tokens == 2000 - 500 - 100
+        assert result.completion_tokens == 300
 
 
 class TestChatCompletionsGeminiNativeExtraBodyStrip:

--- a/tests/agent/transports/test_extract_cache_stats_realistic.py
+++ b/tests/agent/transports/test_extract_cache_stats_realistic.py
@@ -1,0 +1,203 @@
+"""Realistic-shape regression tests for ProviderTransport.extract_cache_stats().
+
+The existing tests in test_transport.py and test_chat_completions.py use
+hand-crafted minimal mocks. These tests use the exact shape that production
+API responses carry, including the fields that misbehaving proxies and edge
+cases produce.
+
+Goal: lock down current behavior before the PR-1 refactor renames the method
+to `extract_usage()` and changes the return type. Any test in this file that
+fails after the refactor signals a behavior regression — the field reads must
+produce the same numeric values regardless of method name / return type.
+"""
+
+import pytest
+from types import SimpleNamespace
+
+from agent.transports import get_transport
+
+
+# ── Anthropic transport ─────────────────────────────────────────────────
+
+
+@pytest.fixture
+def anthropic_transport():
+    import agent.transports.anthropic  # noqa: F401 — register on import
+    return get_transport("anthropic_messages")
+
+
+class TestAnthropicRealisticShapes:
+    """Anthropic's `Usage` shape: `input_tokens`, `output_tokens`,
+    `cache_read_input_tokens`, `cache_creation_input_tokens`."""
+
+    def test_realistic_message_with_cache_hit(self, anthropic_transport):
+        """Sustained-session shape: most input came from cache."""
+        usage = SimpleNamespace(
+            input_tokens=200,                  # net new tokens this turn
+            output_tokens=150,
+            cache_read_input_tokens=14_500,    # bulk of system + history
+            cache_creation_input_tokens=0,
+        )
+        response = SimpleNamespace(usage=usage)
+        result = anthropic_transport.extract_cache_stats(response)
+        assert result == {"cached_tokens": 14_500, "creation_tokens": 0}
+
+    def test_realistic_first_turn_creates_cache(self, anthropic_transport):
+        """First turn of session: cache is written, no reads yet."""
+        usage = SimpleNamespace(
+            input_tokens=200,
+            output_tokens=300,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=12_000,
+        )
+        response = SimpleNamespace(usage=usage)
+        result = anthropic_transport.extract_cache_stats(response)
+        assert result == {"cached_tokens": 0, "creation_tokens": 12_000}
+
+    def test_no_cache_fields_present_returns_none(self, anthropic_transport):
+        """Some proxies omit cache fields entirely. Must return None, not raise."""
+        usage = SimpleNamespace(input_tokens=500, output_tokens=200)
+        response = SimpleNamespace(usage=usage)
+        assert anthropic_transport.extract_cache_stats(response) is None
+
+    def test_explicit_none_cache_values_returns_none(self, anthropic_transport):
+        """Field exists but is None (some proxies do this). Must coerce to 0
+        and treat as no-cache."""
+        usage = SimpleNamespace(
+            input_tokens=500,
+            output_tokens=200,
+            cache_read_input_tokens=None,
+            cache_creation_input_tokens=None,
+        )
+        response = SimpleNamespace(usage=usage)
+        assert anthropic_transport.extract_cache_stats(response) is None
+
+
+# ── Chat-completions transport ──────────────────────────────────────────
+
+
+@pytest.fixture
+def chat_transport():
+    import agent.transports.chat_completions  # noqa: F401
+    return get_transport("chat_completions")
+
+
+class TestChatCompletionsRealisticShapes:
+    """OpenAI-wire `Usage` shape: `prompt_tokens`, `completion_tokens`,
+    `total_tokens`, with cache fields nested in `prompt_tokens_details`."""
+
+    def test_openai_native_cache_hit(self, chat_transport):
+        """OpenAI auto-cache: `prompt_tokens_details.cached_tokens` populated."""
+        usage = SimpleNamespace(
+            prompt_tokens=5_000,
+            completion_tokens=200,
+            total_tokens=5_200,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=3_500),
+        )
+        response = SimpleNamespace(usage=usage)
+        result = chat_transport.extract_cache_stats(response)
+        # Note: the cache_write field is `cache_write_tokens` on
+        # prompt_tokens_details — OpenAI doesn't populate it (auto-cache
+        # has no write event), so it stays 0.
+        assert result == {"cached_tokens": 3_500, "creation_tokens": 0}
+
+    def test_openai_no_cache_returns_none(self, chat_transport):
+        """Plain OpenAI call with no cache hit and a prompt_tokens_details
+        object that has cached_tokens=0."""
+        usage = SimpleNamespace(
+            prompt_tokens=1_000,
+            completion_tokens=200,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        response = SimpleNamespace(usage=usage)
+        assert chat_transport.extract_cache_stats(response) is None
+
+    def test_response_with_no_prompt_tokens_details_returns_none(self, chat_transport):
+        """Some proxies don't include prompt_tokens_details at all."""
+        usage = SimpleNamespace(
+            prompt_tokens=1_000,
+            completion_tokens=200,
+            total_tokens=1_200,
+        )
+        response = SimpleNamespace(usage=usage)
+        assert chat_transport.extract_cache_stats(response) is None
+
+    def test_response_with_cache_write_populated(self, chat_transport):
+        """Some proxies surface cache_write_tokens on details (mirroring
+        Anthropic's cache_creation_input_tokens). Must read both."""
+        usage = SimpleNamespace(
+            prompt_tokens=1_000,
+            completion_tokens=200,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=600,
+                cache_write_tokens=150,
+            ),
+        )
+        response = SimpleNamespace(usage=usage)
+        result = chat_transport.extract_cache_stats(response)
+        assert result == {"cached_tokens": 600, "creation_tokens": 150}
+
+
+# ── Codex Responses-API transport ───────────────────────────────────────
+#
+# The Codex transport currently has NO extract_cache_stats() override —
+# it inherits the base class no-op. That's a real coverage gap: every
+# Codex Responses session reports $0 cache hits to telemetry.
+#
+# This class documents the expected behavior. Today every test here will
+# return None because the base class no-op fires. PR-1 adds the impl on
+# the Codex transport, and these tests will then pass with real values.
+
+
+@pytest.fixture
+def codex_transport():
+    import agent.transports.codex  # noqa: F401
+    return get_transport("codex_responses")
+
+
+class TestCodexResponsesRealisticShapes:
+    """Codex Responses API shape: `input_tokens`, `output_tokens`,
+    `input_tokens_details.cached_tokens` + `cache_creation_tokens`.
+
+    These tests are marked xfail until PR-1 adds the Codex extractor.
+    """
+
+    @pytest.mark.xfail(
+        reason="Codex transport has no extract_cache_stats override yet — PR-1 adds it",
+        strict=True,
+    )
+    def test_codex_cache_hit_with_creation(self, codex_transport):
+        usage = SimpleNamespace(
+            input_tokens=2_500,                  # gross total per Responses API contract
+            output_tokens=300,
+            input_tokens_details=SimpleNamespace(
+                cached_tokens=1_500,
+                cache_creation_tokens=200,
+            ),
+        )
+        response = SimpleNamespace(usage=usage)
+        result = codex_transport.extract_cache_stats(response)
+        assert result == {"cached_tokens": 1_500, "creation_tokens": 200}
+
+    def test_codex_no_cache_details_returns_none(self, codex_transport):
+        """Trivially passes today (base no-op) and after PR-1 (real impl
+        returns None for absent details). No xfail needed."""
+        usage = SimpleNamespace(input_tokens=1_000, output_tokens=200)
+        response = SimpleNamespace(usage=usage)
+        assert codex_transport.extract_cache_stats(response) is None
+
+    def test_codex_today_inherits_base_noop(self, codex_transport):
+        """Pin the current (broken) behavior: Codex transport returns None
+        for cache stats even when the response has them. Documents the bug;
+        remove this test once PR-1 lands."""
+        usage = SimpleNamespace(
+            input_tokens=2_500,
+            output_tokens=300,
+            input_tokens_details=SimpleNamespace(
+                cached_tokens=1_500,
+                cache_creation_tokens=200,
+            ),
+        )
+        response = SimpleNamespace(usage=usage)
+        # Base class no-op returns None regardless of input.
+        assert codex_transport.extract_cache_stats(response) is None

--- a/tests/agent/transports/test_extract_cache_stats_realistic.py
+++ b/tests/agent/transports/test_extract_cache_stats_realistic.py
@@ -1,14 +1,10 @@
-"""Realistic-shape regression tests for ProviderTransport.extract_cache_stats().
+"""Realistic-shape regression tests for ProviderTransport.extract_usage().
 
-The existing tests in test_transport.py and test_chat_completions.py use
-hand-crafted minimal mocks. These tests use the exact shape that production
-API responses carry, including the fields that misbehaving proxies and edge
-cases produce.
-
-Goal: lock down current behavior before the PR-1 refactor renames the method
-to `extract_usage()` and changes the return type. Any test in this file that
-fails after the refactor signals a behavior regression — the field reads must
-produce the same numeric values regardless of method name / return type.
+Production-shaped fixtures (not minimal hand-crafted mocks) for each
+transport's canonical usage extraction. Locks down the numeric values
+the field reads produce — the method renamed from `extract_cache_stats`
+to `extract_usage` and the return type changed from a dict to `Usage`
+in the refactor, but the numbers it reports must match across the rename.
 """
 
 import pytest
@@ -38,9 +34,11 @@ class TestAnthropicRealisticShapes:
             cache_read_input_tokens=14_500,    # bulk of system + history
             cache_creation_input_tokens=0,
         )
-        response = SimpleNamespace(usage=usage)
-        result = anthropic_transport.extract_cache_stats(response)
-        assert result == {"cached_tokens": 14_500, "creation_tokens": 0}
+        result = anthropic_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 14_500
+        assert result.cache_write_tokens == 0
+        assert result.prompt_tokens == 200       # Anthropic input_tokens is net
+        assert result.completion_tokens == 150
 
     def test_realistic_first_turn_creates_cache(self, anthropic_transport):
         """First turn of session: cache is written, no reads yet."""
@@ -50,27 +48,31 @@ class TestAnthropicRealisticShapes:
             cache_read_input_tokens=0,
             cache_creation_input_tokens=12_000,
         )
-        response = SimpleNamespace(usage=usage)
-        result = anthropic_transport.extract_cache_stats(response)
-        assert result == {"cached_tokens": 0, "creation_tokens": 12_000}
+        result = anthropic_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 0
+        assert result.cache_write_tokens == 12_000
+        assert result.prompt_tokens == 200
+        assert result.completion_tokens == 300
 
-    def test_no_cache_fields_present_returns_none(self, anthropic_transport):
-        """Some proxies omit cache fields entirely. Must return None, not raise."""
+    def test_no_cache_fields_present_returns_zero_usage(self, anthropic_transport):
+        """Some proxies omit cache fields entirely. Must coerce to 0, not raise."""
         usage = SimpleNamespace(input_tokens=500, output_tokens=200)
-        response = SimpleNamespace(usage=usage)
-        assert anthropic_transport.extract_cache_stats(response) is None
+        result = anthropic_transport.extract_usage(usage)
+        assert result.prompt_tokens == 500
+        assert result.cache_read_tokens == 0
+        assert result.cache_write_tokens == 0
 
-    def test_explicit_none_cache_values_returns_none(self, anthropic_transport):
-        """Field exists but is None (some proxies do this). Must coerce to 0
-        and treat as no-cache."""
+    def test_explicit_none_cache_values_treated_as_zero(self, anthropic_transport):
+        """Field exists but is None (some proxies do this). Must coerce to 0."""
         usage = SimpleNamespace(
             input_tokens=500,
             output_tokens=200,
             cache_read_input_tokens=None,
             cache_creation_input_tokens=None,
         )
-        response = SimpleNamespace(usage=usage)
-        assert anthropic_transport.extract_cache_stats(response) is None
+        result = anthropic_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 0
+        assert result.cache_write_tokens == 0
 
 
 # ── Chat-completions transport ──────────────────────────────────────────
@@ -94,33 +96,35 @@ class TestChatCompletionsRealisticShapes:
             total_tokens=5_200,
             prompt_tokens_details=SimpleNamespace(cached_tokens=3_500),
         )
-        response = SimpleNamespace(usage=usage)
-        result = chat_transport.extract_cache_stats(response)
-        # Note: the cache_write field is `cache_write_tokens` on
-        # prompt_tokens_details — OpenAI doesn't populate it (auto-cache
-        # has no write event), so it stays 0.
-        assert result == {"cached_tokens": 3_500, "creation_tokens": 0}
+        result = chat_transport.extract_usage(usage)
+        # cache_write stays 0 — OpenAI auto-cache has no write event.
+        assert result.cache_read_tokens == 3_500
+        assert result.cache_write_tokens == 0
+        # Gross prompt 5000 minus cache 3500 = 1500 net.
+        assert result.prompt_tokens == 1_500
+        assert result.completion_tokens == 200
 
-    def test_openai_no_cache_returns_none(self, chat_transport):
-        """Plain OpenAI call with no cache hit and a prompt_tokens_details
-        object that has cached_tokens=0."""
+    def test_openai_no_cache_returns_zero(self, chat_transport):
+        """Plain OpenAI call with no cache hit."""
         usage = SimpleNamespace(
             prompt_tokens=1_000,
             completion_tokens=200,
             prompt_tokens_details=SimpleNamespace(cached_tokens=0),
         )
-        response = SimpleNamespace(usage=usage)
-        assert chat_transport.extract_cache_stats(response) is None
+        result = chat_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 0
+        assert result.prompt_tokens == 1_000
 
-    def test_response_with_no_prompt_tokens_details_returns_none(self, chat_transport):
+    def test_response_with_no_prompt_tokens_details_returns_zero(self, chat_transport):
         """Some proxies don't include prompt_tokens_details at all."""
         usage = SimpleNamespace(
             prompt_tokens=1_000,
             completion_tokens=200,
             total_tokens=1_200,
         )
-        response = SimpleNamespace(usage=usage)
-        assert chat_transport.extract_cache_stats(response) is None
+        result = chat_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 0
+        assert result.prompt_tokens == 1_000
 
     def test_response_with_cache_write_populated(self, chat_transport):
         """Some proxies surface cache_write_tokens on details (mirroring
@@ -133,9 +137,11 @@ class TestChatCompletionsRealisticShapes:
                 cache_write_tokens=150,
             ),
         )
-        response = SimpleNamespace(usage=usage)
-        result = chat_transport.extract_cache_stats(response)
-        assert result == {"cached_tokens": 600, "creation_tokens": 150}
+        result = chat_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 600
+        assert result.cache_write_tokens == 150
+        # Gross 1000 minus 600 minus 150 = 250.
+        assert result.prompt_tokens == 250
 
 
 # ── Codex Responses-API transport ───────────────────────────────────────
@@ -159,13 +165,11 @@ class TestCodexResponsesRealisticShapes:
     """Codex Responses API shape: `input_tokens`, `output_tokens`,
     `input_tokens_details.cached_tokens` + `cache_creation_tokens`.
 
-    These tests are marked xfail until PR-1 adds the Codex extractor.
+    The transport had no extract override before this refactor; the new
+    extract_usage() reads the input_tokens_details fields and subtracts
+    them from gross input_tokens for the net prompt count.
     """
 
-    @pytest.mark.xfail(
-        reason="Codex transport has no extract_cache_stats override yet — PR-1 adds it",
-        strict=True,
-    )
     def test_codex_cache_hit_with_creation(self, codex_transport):
         usage = SimpleNamespace(
             input_tokens=2_500,                  # gross total per Responses API contract
@@ -175,29 +179,17 @@ class TestCodexResponsesRealisticShapes:
                 cache_creation_tokens=200,
             ),
         )
-        response = SimpleNamespace(usage=usage)
-        result = codex_transport.extract_cache_stats(response)
-        assert result == {"cached_tokens": 1_500, "creation_tokens": 200}
+        result = codex_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 1_500
+        assert result.cache_write_tokens == 200
+        # Gross 2500 minus 1500 minus 200 = 800 net input.
+        assert result.prompt_tokens == 800
+        assert result.completion_tokens == 300
 
-    def test_codex_no_cache_details_returns_none(self, codex_transport):
-        """Trivially passes today (base no-op) and after PR-1 (real impl
-        returns None for absent details). No xfail needed."""
+    def test_codex_no_cache_details_returns_zero(self, codex_transport):
         usage = SimpleNamespace(input_tokens=1_000, output_tokens=200)
-        response = SimpleNamespace(usage=usage)
-        assert codex_transport.extract_cache_stats(response) is None
-
-    def test_codex_today_inherits_base_noop(self, codex_transport):
-        """Pin the current (broken) behavior: Codex transport returns None
-        for cache stats even when the response has them. Documents the bug;
-        remove this test once PR-1 lands."""
-        usage = SimpleNamespace(
-            input_tokens=2_500,
-            output_tokens=300,
-            input_tokens_details=SimpleNamespace(
-                cached_tokens=1_500,
-                cache_creation_tokens=200,
-            ),
-        )
-        response = SimpleNamespace(usage=usage)
-        # Base class no-op returns None regardless of input.
-        assert codex_transport.extract_cache_stats(response) is None
+        result = codex_transport.extract_usage(usage)
+        assert result.cache_read_tokens == 0
+        assert result.cache_write_tokens == 0
+        # No details → all input is net.
+        assert result.prompt_tokens == 1_000

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -42,7 +42,10 @@ class TestProviderTransportABC:
         t = Minimal()
         assert t.api_mode == "test_minimal"
         assert t.validate_response(None) is True  # default
-        assert t.extract_cache_stats(None) is None  # default
+        # extract_usage default returns a zeroed Usage, not None.
+        default_usage = t.extract_usage(None)
+        assert default_usage.prompt_tokens == 0
+        assert default_usage.cache_read_tokens == 0
         assert t.map_finish_reason("end_turn") == "end_turn"  # default passthrough
 
 
@@ -150,20 +153,38 @@ class TestAnthropicTransport:
         assert transport.map_finish_reason("model_context_window_exceeded") == "length"
         assert transport.map_finish_reason("unknown") == "stop"
 
-    def test_extract_cache_stats_none_usage(self, transport):
-        r = SimpleNamespace(usage=None)
-        assert transport.extract_cache_stats(r) is None
+    def test_extract_usage_none(self, transport):
+        result = transport.extract_usage(None)
+        assert result.prompt_tokens == 0
+        assert result.cache_read_tokens == 0
+        assert result.cache_write_tokens == 0
 
-    def test_extract_cache_stats_with_cache(self, transport):
-        usage = SimpleNamespace(cache_read_input_tokens=100, cache_creation_input_tokens=50)
-        r = SimpleNamespace(usage=usage)
-        result = transport.extract_cache_stats(r)
-        assert result == {"cached_tokens": 100, "creation_tokens": 50}
+    def test_extract_usage_with_cache(self, transport):
+        usage = SimpleNamespace(
+            input_tokens=200,
+            output_tokens=50,
+            cache_read_input_tokens=100,
+            cache_creation_input_tokens=50,
+        )
+        result = transport.extract_usage(usage)
+        assert result.cache_read_tokens == 100
+        assert result.cached_tokens == 100  # back-compat alias
+        assert result.cache_write_tokens == 50
+        # Anthropic input_tokens is already net — no subtraction.
+        assert result.prompt_tokens == 200
+        assert result.completion_tokens == 50
 
-    def test_extract_cache_stats_zero(self, transport):
-        usage = SimpleNamespace(cache_read_input_tokens=0, cache_creation_input_tokens=0)
-        r = SimpleNamespace(usage=usage)
-        assert transport.extract_cache_stats(r) is None
+    def test_extract_usage_zero(self, transport):
+        usage = SimpleNamespace(
+            input_tokens=10,
+            output_tokens=5,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        )
+        result = transport.extract_usage(usage)
+        assert result.cache_read_tokens == 0
+        assert result.cache_write_tokens == 0
+        assert result.prompt_tokens == 10
 
     def test_normalize_response_text(self, transport):
         """Test normalization of a simple text response."""

--- a/tests/integration/test_prompt_cache_baseline.py
+++ b/tests/integration/test_prompt_cache_baseline.py
@@ -1,0 +1,183 @@
+"""Opt-in live baseline test for the prompt cache + cost pipeline.
+
+Runs a real one-turn session against the `gemini35` profile and asserts
+**shape invariants** on the resulting state.db row:
+
+  - input_tokens > 0
+  - output_tokens > 0
+  - cost_status == 'estimated'
+  - estimated_cost_usd > 0
+  - billing_provider == 'gemini'
+
+The exact token counts are NOT asserted — they drift with any system-prompt
+or tool-definition change. The invariants catch the regressions that matter:
+the cache + cost pipeline got disconnected (cost_status reverts to 'unknown'
+or 'none') or token extraction stopped working (input_tokens == 0).
+
+This test is **opt-in**. It costs real API quota, so it only runs when
+`HERMES_LIVE_BASELINE=1` is set in the environment. Run it manually before
+pushing the PR-1 refactor; do NOT enable in CI.
+
+IMPORTANT: Run via direct `python -m pytest`, NOT `scripts/run_tests.sh`.
+The shipped test runner uses `env -i` to enforce CI parity, which strips
+`HERMES_LIVE_BASELINE` (and every other non-allowlisted env var). The
+intentional design keeps credentials from leaking into the CI suite.
+
+Setup (one-time):
+    hermes profile create gemini35 --description "Cache testing profile"
+    echo 'GOOGLE_API_KEY=...' > ~/.hermes/profiles/gemini35/.env
+    cat > ~/.hermes/profiles/gemini35/config.yaml <<EOF
+    model:
+      provider: gemini
+      default: gemini-3.5-flash
+    EOF
+
+Run:
+    source .venv/bin/activate
+    HERMES_LIVE_BASELINE=1 python -m pytest tests/integration/test_prompt_cache_baseline.py -v
+
+Expected outcomes on `main`:
+  - 4 token-related assertions pass (input_tokens, output_tokens,
+    billing_provider, model)
+  - 2 cost assertions FAIL until #32404 lands (cost_status=='estimated',
+    estimated_cost_usd > 0). Those failures *document* the cost-tracking
+    bug — they flip to green automatically once #32404 merges.
+"""
+
+import os
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+
+PROFILE_NAME = os.environ.get("HERMES_BASELINE_PROFILE", "gemini35")
+PROFILE_PATH = Path.home() / ".hermes" / "profiles" / PROFILE_NAME
+
+
+def _profile_ready() -> bool:
+    """Return True if the baseline profile is set up with an API key."""
+    if not PROFILE_PATH.is_dir():
+        return False
+    env_file = PROFILE_PATH / ".env"
+    if not env_file.is_file():
+        return False
+    try:
+        env_text = env_file.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "GOOGLE_API_KEY=" in env_text and not env_text.strip().endswith("GOOGLE_API_KEY=")
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("HERMES_LIVE_BASELINE"),
+        reason="opt-in; set HERMES_LIVE_BASELINE=1 to run (costs API quota)",
+    ),
+    pytest.mark.skipif(
+        not _profile_ready(),
+        reason=(
+            f"profile not ready at {PROFILE_PATH} — see test module docstring "
+            f"for setup. Skipping rather than failing so the test stays portable."
+        ),
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def latest_session_row():
+    """Fire a one-turn live request and return the resulting state.db row."""
+    repo_root = Path(__file__).resolve().parents[2]
+    hermes_bin = repo_root / ".venv" / "bin" / "hermes"
+    if not hermes_bin.is_file():
+        pytest.skip(f"venv hermes binary not found at {hermes_bin}")
+
+    prompt = "Reply with exactly: 'baseline-prompt-cache-test'"
+
+    env = {**os.environ, "HERMES_HOME": str(PROFILE_PATH)}
+
+    # Record the current count of sessions so we can pick out the one we
+    # added (rather than chasing 'most recent' which races with other shells).
+    with sqlite3.connect(PROFILE_PATH / "state.db") as conn:
+        before_count = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE input_tokens > 0"
+        ).fetchone()[0]
+
+    proc = subprocess.run(
+        [str(hermes_bin), "chat", "-q", prompt],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        pytest.fail(f"hermes chat failed (rc={proc.returncode}):\n{proc.stderr[-2000:]}")
+
+    # Wait briefly for the post-turn write to land. Hermes commits the
+    # session row inside the turn finalizer; in practice this is sub-second.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        with sqlite3.connect(PROFILE_PATH / "state.db") as conn:
+            row = conn.execute(
+                """
+                SELECT id, model, input_tokens, output_tokens, cache_read_tokens,
+                       estimated_cost_usd, billing_provider, cost_status
+                FROM sessions
+                WHERE input_tokens > 0
+                ORDER BY started_at DESC LIMIT 1
+                """
+            ).fetchone()
+            after_count = conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE input_tokens > 0"
+            ).fetchone()[0]
+        if row and after_count > before_count:
+            return row
+        time.sleep(0.2)
+    pytest.fail("session row did not appear in state.db within 5s after chat completed")
+
+
+def test_baseline_input_tokens_nonzero(latest_session_row):
+    """Token extraction is working — system prompt + tools land in input_tokens."""
+    _, _, input_tokens, *_ = latest_session_row
+    assert input_tokens > 0, "input_tokens should be > 0 after a live turn"
+
+
+def test_baseline_output_tokens_nonzero(latest_session_row):
+    """The model produced a reply and its token count was captured."""
+    _, _, _, output_tokens, *_ = latest_session_row
+    assert output_tokens > 0, "output_tokens should be > 0 after a live turn"
+
+
+def test_baseline_cost_status_estimated(latest_session_row):
+    """Pricing pipeline fires end-to-end (covers PR #32404 cost-tracking + this PR)."""
+    *_, cost_status = latest_session_row
+    assert cost_status == "estimated", (
+        f"cost_status was {cost_status!r}, expected 'estimated' — "
+        f"resolve_billing_route / pricing entry / cost estimator chain is broken"
+    )
+
+
+def test_baseline_estimated_cost_positive(latest_session_row):
+    """The dollar amount is actually computed, not stored as 0.0."""
+    *_, estimated_cost, _, _ = latest_session_row
+    assert estimated_cost is not None and estimated_cost > 0, (
+        f"estimated_cost_usd was {estimated_cost!r}, expected > 0"
+    )
+
+
+def test_baseline_billing_provider_is_gemini(latest_session_row):
+    """The Gemini branch of resolve_billing_route is firing."""
+    *_, billing_provider, _ = latest_session_row
+    assert billing_provider == "gemini", (
+        f"billing_provider was {billing_provider!r}, expected 'gemini'"
+    )
+
+
+def test_baseline_model_is_gemini_3_5_flash(latest_session_row):
+    """Confirms the profile is actually using gemini-3.5-flash as intended."""
+    _, model, *_ = latest_session_row
+    assert "gemini-3.5-flash" in model, (
+        f"model was {model!r}, expected to contain 'gemini-3.5-flash'"
+    )

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -1,332 +1,245 @@
-"""Tests for AIAgent._anthropic_prompt_cache_policy().
+"""Tests for ProviderProfile.cache_strategy_for() and the conversation-loop fallback.
 
-The policy returns ``(should_cache, use_native_layout)`` for five endpoint
-classes. The test matrix pins the decision for each so a regression (e.g.
-silently dropping caching on third-party Anthropic gateways, or applying
-the native layout on OpenRouter) surfaces loudly.
+The old ``AIAgent._anthropic_prompt_cache_policy()`` returned ``(should_cache,
+use_native_layout)``.  That function is deleted; the same decision is now made
+by two co-operating parts:
+
+1. ``ProviderProfile.cache_strategy_for(model)`` — returns a ``PromptCacheStrategy``
+   instance for recognised providers.
+2. A fallback in ``conversation_loop.py`` that injects a native-layout strategy
+   for any unknown provider that speaks the Anthropic wire format with a Claude
+   model.
+
+These tests pin the strategy type + layout for every endpoint class so that a
+regression (e.g. silently dropping caching on third-party Anthropic gateways,
+or applying the native layout on OpenRouter) surfaces loudly.
+
+Old ``(True, True)``  → ``AnthropicInlineCacheStrategy(layout="native")``
+Old ``(True, False)`` → ``AnthropicInlineCacheStrategy(layout="envelope")``
+Old ``(False, False)`` → ``NoCacheStrategy``
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import pytest
 
-from run_agent import AIAgent
+from agent.prompt_cache_strategy import AnthropicInlineCacheStrategy, NoCacheStrategy
+from providers import get_provider_profile
 
 
-def _make_agent(
-    *,
-    provider: str = "openrouter",
-    base_url: str = "https://openrouter.ai/api/v1",
-    api_mode: str = "chat_completions",
-    model: str = "anthropic/claude-sonnet-4.6",
-) -> AIAgent:
-    agent = AIAgent.__new__(AIAgent)
-    agent.provider = provider
-    agent.base_url = base_url
-    agent.api_mode = api_mode
-    agent.model = model
-    agent._base_url_lower = (base_url or "").lower()
-    agent.client = MagicMock()
-    agent.quiet_mode = True
-    return agent
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _strategy(provider_id: str, model: str):
+    """Return the cache strategy for a provider/model pair via the profile."""
+    profile = get_provider_profile(provider_id)
+    assert profile is not None, f"provider '{provider_id}' not found in registry"
+    return profile.cache_strategy_for(model)
+
+
+def _is_native(strategy) -> bool:
+    return isinstance(strategy, AnthropicInlineCacheStrategy) and strategy.layout == "native"
+
+
+def _is_envelope(strategy) -> bool:
+    return isinstance(strategy, AnthropicInlineCacheStrategy) and strategy.layout == "envelope"
+
+
+def _is_no_cache(strategy) -> bool:
+    return isinstance(strategy, NoCacheStrategy)
+
+
+# ── Native Anthropic ──────────────────────────────────────────────────────────
 
 
 class TestNativeAnthropic:
     def test_claude_on_native_anthropic_caches_with_native_layout(self):
-        agent = _make_agent(
-            provider="anthropic",
-            base_url="https://api.anthropic.com",
-            api_mode="anthropic_messages",
-            model="claude-sonnet-4-6",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, True)
+        s = _strategy("anthropic", "claude-sonnet-4-6")
+        assert _is_native(s), f"expected native layout, got {s!r}"
 
-    def test_api_anthropic_host_detected_even_when_provider_label_differs(self):
-        # Some pool configurations label native Anthropic as "anthropic-direct"
-        # or similar; falling back to hostname keeps caching on.
-        agent = _make_agent(
-            provider="anthropic-direct",
-            base_url="https://api.anthropic.com",
-            api_mode="anthropic_messages",
-            model="claude-opus-4.6",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, True)
+    def test_claude_opus_on_anthropic_caches_with_native_layout(self):
+        s = _strategy("anthropic", "claude-opus-4.6")
+        assert _is_native(s)
+
+    def test_non_claude_on_anthropic_profile_does_not_cache(self):
+        # Anthropic profile's strategy is scoped to Claude models.
+        s = _strategy("anthropic", "gpt-5.4")
+        assert _is_no_cache(s)
+
+    def test_unknown_provider_anthropic_wire_claude_gets_fallback(self):
+        """Unknown/custom provider on anthropic_messages transport with Claude
+        model is handled by the conversation_loop fallback, not a profile.
+
+        This documents the expected strategy the fallback would inject.
+        """
+        from agent.prompt_cache_strategy import NoCacheStrategy
+        unknown_profile = get_provider_profile("nonexistent_provider_xyz")
+        # The profile for an unknown provider is None (or returns NoCacheStrategy).
+        # The conversation_loop fallback upgrades NoCacheStrategy to native for
+        # api_mode="anthropic_messages" + claude model — that upgrade is tested
+        # in tests/agent/test_conversation_loop_caching.py.
+        if unknown_profile is not None:
+            s = unknown_profile.cache_strategy_for("claude-sonnet-4-6")
+            assert _is_no_cache(s), (
+                "Unknown providers must return NoCacheStrategy so the "
+                "conversation_loop fallback can upgrade it conditionally"
+            )
+
+
+# ── OpenRouter ────────────────────────────────────────────────────────────────
 
 
 class TestOpenRouter:
     def test_claude_on_openrouter_caches_with_envelope_layout(self):
-        agent = _make_agent(
-            provider="openrouter",
-            base_url="https://openrouter.ai/api/v1",
-            api_mode="chat_completions",
-            model="anthropic/claude-sonnet-4.6",
-        )
-        should, native = agent._anthropic_prompt_cache_policy()
-        assert should is True
-        assert native is False  # OpenRouter uses envelope layout
+        s = _strategy("openrouter", "anthropic/claude-sonnet-4.6")
+        assert _is_envelope(s), f"expected envelope layout, got {s!r}"
+
+    def test_claude_shortname_on_openrouter_caches(self):
+        s = _strategy("openrouter", "claude-sonnet-4-6")
+        assert _is_envelope(s)
 
     def test_non_claude_on_openrouter_does_not_cache(self):
-        agent = _make_agent(
-            provider="openrouter",
-            base_url="https://openrouter.ai/api/v1",
-            api_mode="chat_completions",
-            model="openai/gpt-5.4",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
+        s = _strategy("openrouter", "openai/gpt-5.4")
+        assert _is_no_cache(s)
+
+    def test_qwen_on_openrouter_does_not_cache(self):
+        # Qwen via OpenRouter falls through — OpenRouter has its own
+        # upstream caching arrangement (provider-dependent).
+        s = _strategy("openrouter", "qwen/qwen3-coder")
+        assert _is_no_cache(s)
 
 
-class TestThirdPartyAnthropicGateway:
-    """Third-party gateways speaking the Anthropic protocol (MiniMax, Zhipu GLM, LiteLLM)."""
-
-    def test_minimax_claude_via_anthropic_messages(self):
-        agent = _make_agent(
-            provider="custom",
-            base_url="https://api.minimax.io/anthropic",
-            api_mode="anthropic_messages",
-            model="claude-sonnet-4-6",
-        )
-        should, native = agent._anthropic_prompt_cache_policy()
-        assert should is True, "Third-party Anthropic gateway with Claude must cache"
-        assert native is True, "Third-party Anthropic gateway uses native cache_control layout"
-
-    def test_third_party_anthropic_non_claude_unknown_provider_does_not_cache(self):
-        # A provider exposing e.g. GLM via anthropic_messages transport from
-        # a host we don't recognize — we don't know whether it supports
-        # cache_control, so stay conservative.
-        agent = _make_agent(
-            provider="custom",
-            base_url="https://some-unknown-gateway.example.com/anthropic",
-            api_mode="anthropic_messages",
-            model="glm-4.5",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
+# ── MiniMax (Anthropic-compatible endpoint) ───────────────────────────────────
 
 
 class TestMiniMaxAnthropicWire:
-    """MiniMax's own model family on its Anthropic-compatible endpoint.
+    """MiniMax's own model family and Claude on its Anthropic-compatible endpoint.
 
-    MiniMax documents cache_control support on ``/anthropic`` (0.1× read
-    pricing, 5-minute TTL). Issue #17332: the blanket ``is_claude`` gate on
-    the third-party-gateway branch left MiniMax-M2.7 etc. paying full input
-    cost every turn. Allowlist MiniMax explicitly via provider id or host.
+    Both minimax and minimax-cn always use api_mode='anthropic_messages'.
+    cache_control support: 0.1× read pricing, 5-minute TTL.
+    Docs: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
     """
 
     def test_minimax_m27_on_provider_minimax_caches_native_layout(self):
-        agent = _make_agent(
-            provider="minimax",
-            base_url="https://api.minimax.io/anthropic",
-            api_mode="anthropic_messages",
-            model="minimax-m2.7",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, True)
+        s = _strategy("minimax", "minimax-m2.7")
+        assert _is_native(s)
 
     def test_minimax_m25_on_provider_minimax_cn_caches_native_layout(self):
-        agent = _make_agent(
-            provider="minimax-cn",
-            base_url="https://api.minimaxi.com/anthropic",
-            api_mode="anthropic_messages",
-            model="minimax-m2.5",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, True)
+        s = _strategy("minimax-cn", "minimax-m2.5")
+        assert _is_native(s)
 
-    def test_custom_provider_pointed_at_minimax_host_caches(self):
-        # User wires a custom provider manually at MiniMax's Anthropic URL;
-        # host match alone should be sufficient to enable caching.
-        agent = _make_agent(
-            provider="custom",
-            base_url="https://api.minimax.io/anthropic",
-            api_mode="anthropic_messages",
-            model="minimax-m2.7",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, True)
+    def test_claude_on_minimax_caches_native_layout(self):
+        s = _strategy("minimax", "claude-sonnet-4-6")
+        assert _is_native(s)
 
-    def test_minimax_host_china_endpoint_caches(self):
-        agent = _make_agent(
-            provider="custom",
-            base_url="https://api.minimaxi.com/anthropic",
-            api_mode="anthropic_messages",
-            model="minimax-m2.1",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, True)
-
-    def test_minimax_provider_on_openai_wire_does_not_cache(self):
-        # chat_completions transport — MiniMax's cache_control support is
-        # documented only for the /anthropic endpoint. Stay off.
-        agent = _make_agent(
-            provider="minimax",
-            base_url="https://api.minimax.io/v1",
-            api_mode="chat_completions",
-            model="minimax-m2.7",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
+    def test_unrecognised_model_on_minimax_does_not_cache(self):
+        s = _strategy("minimax", "gpt-5.4")
+        assert _is_no_cache(s)
 
 
-class TestOpenAIWireFormatOnCustomProvider:
-    """A custom provider using chat_completions (OpenAI wire) should NOT get caching."""
+# ── Nous Portal ───────────────────────────────────────────────────────────────
 
-    def test_custom_openai_wire_does_not_cache_even_with_claude_name(self):
-        # This is the blocklist risk #9621 failed to avoid: sending
-        # cache_control fields in OpenAI-wire JSON can trip strict providers
-        # that reject unknown keys.  Stay off unless the transport is
-        # explicitly anthropic_messages or the aggregator is OpenRouter.
-        agent = _make_agent(
-            provider="custom",
-            base_url="https://api.fireworks.ai/inference/v1",
-            api_mode="chat_completions",
-            model="claude-sonnet-4",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
+
+class TestNousPortal:
+    def test_claude_on_nous_caches_with_envelope_layout(self):
+        s = _strategy("nous", "anthropic/claude-sonnet-4.6")
+        assert _is_envelope(s)
+
+    def test_qwen_on_nous_portal_caches_with_envelope_layout(self):
+        s = _strategy("nous", "qwen3.6-plus")
+        assert _is_envelope(s)
+
+    def test_qwen_vendored_slug_on_nous_portal_caches(self):
+        s = _strategy("nous", "qwen/qwen3.6-plus")
+        assert _is_envelope(s)
+
+    def test_non_qwen_non_claude_on_nous_portal_does_not_cache(self):
+        s = _strategy("nous", "openai/gpt-5.4")
+        assert _is_no_cache(s)
+
+
+# ── Qwen / Alibaba family ─────────────────────────────────────────────────────
 
 
 class TestQwenAlibabaFamily:
     """Qwen on OpenCode/OpenCode-Go/Alibaba — needs cache_control even on OpenAI-wire.
 
     Upstream pi-mono #3392 / #3393 documented that these providers serve
-    zero cache hits without Anthropic-style markers. Regression reported
-    by community user (Qwen3.6 on opencode-go burning through
-    subscription with no cache). Envelope layout, not native, because the
-    wire format is OpenAI chat.completions.
+    zero cache hits without Anthropic-style markers. Envelope layout, not
+    native, because the wire format is OpenAI chat.completions.
     """
 
     def test_qwen_on_opencode_go_caches_with_envelope_layout(self):
-        agent = _make_agent(
-            provider="opencode-go",
-            base_url="https://opencode.ai/v1",
-            api_mode="chat_completions",
-            model="qwen3.6-plus",
-        )
-        should, native = agent._anthropic_prompt_cache_policy()
-        assert should is True, "Qwen on opencode-go must cache"
-        assert native is False, "opencode-go is OpenAI-wire; envelope layout"
+        s = _strategy("opencode-go", "qwen3.6-plus")
+        assert _is_envelope(s), f"expected envelope layout, got {s!r}"
 
     def test_qwen35_plus_on_opencode_go(self):
-        agent = _make_agent(
-            provider="opencode-go",
-            base_url="https://opencode.ai/v1",
-            api_mode="chat_completions",
-            model="qwen3.5-plus",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, False)
+        s = _strategy("opencode-go", "qwen3.5-plus")
+        assert _is_envelope(s)
 
     def test_qwen_on_opencode_zen_caches(self):
-        agent = _make_agent(
-            provider="opencode",
-            base_url="https://opencode.ai/v1",
-            api_mode="chat_completions",
-            model="qwen3-coder-plus",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, False)
+        s = _strategy("opencode", "qwen3-coder-plus")
+        assert _is_envelope(s)
 
     def test_qwen_on_direct_alibaba_caches(self):
-        agent = _make_agent(
-            provider="alibaba",
-            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
-            api_mode="chat_completions",
-            model="qwen3-coder",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, False)
+        s = _strategy("alibaba", "qwen3-coder")
+        assert _is_envelope(s)
 
     def test_non_qwen_on_opencode_go_does_not_cache(self):
-        # GLM / Kimi on opencode-go don't need markers (they have automatic
-        # server-side caching or none at all).
-        agent = _make_agent(
-            provider="opencode-go",
-            base_url="https://opencode.ai/v1",
-            api_mode="chat_completions",
-            model="glm-5",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
+        s = _strategy("opencode-go", "glm-5")
+        assert _is_no_cache(s)
 
     def test_kimi_on_opencode_go_does_not_cache(self):
-        agent = _make_agent(
-            provider="opencode-go",
-            base_url="https://opencode.ai/v1",
-            api_mode="chat_completions",
-            model="kimi-k2.5",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
-
-    def test_qwen_on_openrouter_not_affected(self):
-        # Qwen via OpenRouter falls through — OpenRouter has its own
-        # upstream caching arrangement for Qwen (provider-dependent).
-        agent = _make_agent(
-            provider="openrouter",
-            base_url="https://openrouter.ai/api/v1",
-            api_mode="chat_completions",
-            model="qwen/qwen3-coder",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
-
-    def test_qwen_on_nous_portal_caches_with_envelope_layout(self):
-        # Nous Portal Qwen takes the same envelope-layout cache_control
-        # path as Portal Claude. Without this, Portal-routed qwen3.6-plus
-        # falls through to the alibaba-family check (which only matches
-        # provider=opencode/alibaba) and serves 0% cache hits.
-        agent = _make_agent(
-            provider="nous",
-            base_url="https://inference-api.nousresearch.com/v1",
-            api_mode="chat_completions",
-            model="qwen3.6-plus",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, False)
-
-    def test_qwen_vendored_slug_on_nous_portal_caches(self):
-        # Same path but with the vendored slug form Portal sometimes uses.
-        agent = _make_agent(
-            provider="nous",
-            base_url="https://inference-api.nousresearch.com/v1",
-            api_mode="chat_completions",
-            model="qwen/qwen3.6-plus",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (True, False)
-
-    def test_non_qwen_non_claude_on_nous_portal_does_not_cache(self):
-        # Portal scope is narrow: Claude OR Qwen only. Other models
-        # routed through Portal keep their existing fall-through behavior.
-        agent = _make_agent(
-            provider="nous",
-            base_url="https://inference-api.nousresearch.com/v1",
-            api_mode="chat_completions",
-            model="openai/gpt-5.4",
-        )
-        assert agent._anthropic_prompt_cache_policy() == (False, False)
+        s = _strategy("opencode-go", "kimi-k2.5")
+        assert _is_no_cache(s)
 
 
-class TestExplicitOverrides:
-    """Policy accepts keyword overrides for switch_model / fallback activation."""
-
-    def test_overrides_take_precedence_over_self(self):
-        agent = _make_agent(
-            provider="openrouter",
-            base_url="https://openrouter.ai/api/v1",
-            api_mode="chat_completions",
-            model="openai/gpt-5.4",
-        )
-        # Simulate switch_model evaluating cache policy for a Claude target
-        # before self.model is mutated.
-        should, native = agent._anthropic_prompt_cache_policy(
-            model="anthropic/claude-sonnet-4.6",
-        )
-        assert (should, native) == (True, False)
-
-    def test_fallback_target_evaluated_independently(self):
-        # Starting on native Anthropic but falling back to OpenRouter.
-        agent = _make_agent(
-            provider="anthropic",
-            base_url="https://api.anthropic.com",
-            api_mode="anthropic_messages",
-            model="claude-opus-4.6",
-        )
-        should, native = agent._anthropic_prompt_cache_policy(
-            provider="openrouter",
-            base_url="https://openrouter.ai/api/v1",
-            api_mode="chat_completions",
-            model="anthropic/claude-sonnet-4.6",
-        )
-        assert (should, native) == (True, False)
+# ── Custom / unknown providers ────────────────────────────────────────────────
 
 
-# ─────────────────────────────────────────────────────────────────────
-# Long-lived prefix cache policy (cross-session 1h tier)
-# ─────────────────────────────────────────────────────────────────────
+class TestCustomOpenAIWireProvider:
+    """A custom provider using chat_completions (OpenAI wire) has no profile entry,
+    so cache_strategy_for defaults to NoCacheStrategy from ProviderProfile base.
 
+    Sending cache_control fields in OpenAI-wire JSON can trip strict providers
+    that reject unknown keys (#9621). The profile default stays off unless the
+    provider is explicitly registered with a cache strategy.
+    """
+
+    def test_unknown_custom_provider_returns_none_profile(self):
+        profile = get_provider_profile("completely_unknown_custom")
+        assert profile is None
+
+
+# ── Strategy contract (smoke-test apply() callable) ──────────────────────────
+
+
+class TestStrategiesAreCallable:
+    """Smoke-tests that the returned strategies are actually callable."""
+
+    @pytest.fixture
+    def sample_messages(self):
+        return [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+
+    def test_anthropic_native_strategy_apply_returns_messages(self, sample_messages):
+        from agent.prompt_cache_strategy import PromptCacheIntent
+        s = _strategy("anthropic", "claude-sonnet-4-6")
+        result = s.apply(sample_messages, PromptCacheIntent())
+        assert isinstance(result, list)
+
+    def test_openrouter_envelope_strategy_apply_returns_messages(self, sample_messages):
+        from agent.prompt_cache_strategy import PromptCacheIntent
+        s = _strategy("openrouter", "anthropic/claude-sonnet-4.6")
+        result = s.apply(sample_messages, PromptCacheIntent())
+        assert isinstance(result, list)
+
+    def test_no_cache_strategy_apply_is_identity(self, sample_messages):
+        from agent.prompt_cache_strategy import PromptCacheIntent
+        s = _strategy("openrouter", "openai/gpt-5.4")  # returns NoCacheStrategy
+        result = s.apply(sample_messages, PromptCacheIntent())
+        assert result == sample_messages

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -188,18 +188,21 @@ class TestRestorePrimaryRuntime:
         assert agent.context_compressor.context_length == original_ctx_len
         assert agent.context_compressor.threshold_tokens == original_threshold
 
-    def test_restores_prompt_caching_flag(self):
+    def test_restore_provider_and_model(self):
+        """After fallback activation and restore, provider+model return to primary."""
         agent = _make_agent()
-        original_caching = agent._use_prompt_caching
+        original_provider = agent.provider
+        original_model = agent.model
 
-        # Simulate fallback changing the caching flag
         agent._fallback_activated = True
-        agent._use_prompt_caching = not original_caching
+        agent.provider = "anthropic"
+        agent.model = "claude-sonnet-4-20250514"
 
         with patch("run_agent.OpenAI", return_value=MagicMock()):
             agent._restore_primary_runtime()
 
-        assert agent._use_prompt_caching == original_caching
+        assert agent.provider == original_provider
+        assert agent.model == original_model
 
     def test_restore_survives_exception(self):
         """If client rebuild fails, the method returns False gracefully."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -780,7 +780,9 @@ class TestInit:
             mock_anthropic.Anthropic.assert_called_once()
 
     def test_prompt_caching_claude_openrouter(self):
-        """Claude model via OpenRouter should enable prompt caching."""
+        """Claude model via OpenRouter should use envelope-layout cache strategy."""
+        from agent.prompt_cache_strategy import AnthropicInlineCacheStrategy
+        from providers import get_provider_profile
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -788,16 +790,22 @@ class TestInit:
         ):
             a = AIAgent(
                 api_key="test-k...7890",
+                provider="openrouter",
                 model="anthropic/claude-sonnet-4-20250514",
                 base_url="https://openrouter.ai/api/v1",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
             )
-            assert a._use_prompt_caching is True
+            profile = get_provider_profile(a.provider)
+            strategy = profile.cache_strategy_for(a.model)
+            assert isinstance(strategy, AnthropicInlineCacheStrategy)
+            assert strategy.layout == "envelope"
 
     def test_prompt_caching_non_claude(self):
-        """Non-Claude model should disable prompt caching."""
+        """Non-Claude model on OpenRouter should return NoCacheStrategy."""
+        from agent.prompt_cache_strategy import NoCacheStrategy
+        from providers import get_provider_profile
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -805,16 +813,21 @@ class TestInit:
         ):
             a = AIAgent(
                 api_key="test-key-1234567890",
+                provider="openrouter",
                 base_url="https://openrouter.ai/api/v1",
                 model="openai/gpt-4o",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
             )
-            assert a._use_prompt_caching is False
+            profile = get_provider_profile(a.provider)
+            strategy = profile.cache_strategy_for(a.model)
+            assert isinstance(strategy, NoCacheStrategy)
 
     def test_prompt_caching_non_openrouter(self):
-        """Custom base_url (not OpenRouter) should disable prompt caching."""
+        """Custom provider with no registered profile returns NoCacheStrategy."""
+        from agent.prompt_cache_strategy import NoCacheStrategy
+        from providers import get_provider_profile
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -828,10 +841,15 @@ class TestInit:
                 skip_context_files=True,
                 skip_memory=True,
             )
-            assert a._use_prompt_caching is False
+            # Agent with no provider set → no profile → NoCacheStrategy.
+            profile = get_provider_profile(a.provider)
+            strategy = profile.cache_strategy_for(a.model) if profile else NoCacheStrategy()
+            assert isinstance(strategy, NoCacheStrategy)
 
     def test_prompt_caching_native_anthropic(self):
-        """Native Anthropic provider should enable prompt caching."""
+        """Native Anthropic provider auto-detected from base_url uses native cache strategy."""
+        from agent.prompt_cache_strategy import AnthropicInlineCacheStrategy
+        from providers import get_provider_profile
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -840,12 +858,17 @@ class TestInit:
             a = AIAgent(
                 api_key="test-key-1234567890",
                 base_url="https://api.anthropic.com/v1/",
+                model="claude-sonnet-4-6",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
             )
             assert a.api_mode == "anthropic_messages"
-            assert a._use_prompt_caching is True
+            assert a.provider == "anthropic"
+            profile = get_provider_profile(a.provider)
+            strategy = profile.cache_strategy_for(a.model)
+            assert isinstance(strategy, AnthropicInlineCacheStrategy)
+            assert strategy.layout == "native"
 
     def test_prompt_caching_cache_ttl_defaults_without_config(self):
         """cache_ttl stays 5m when prompt_caching is absent from config."""
@@ -5560,6 +5583,9 @@ class TestFallbackAnthropicProvider:
         assert agent.client is None
 
     def test_fallback_to_anthropic_enables_prompt_caching(self, agent):
+        """After fallback to Anthropic, provider+model yield a native cache strategy."""
+        from agent.prompt_cache_strategy import AnthropicInlineCacheStrategy
+        from providers import get_provider_profile
         agent._fallback_activated = False
         agent._fallback_model = {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
         agent._fallback_chain = [agent._fallback_model]
@@ -5576,7 +5602,10 @@ class TestFallbackAnthropicProvider:
         ):
             agent._try_activate_fallback()
 
-        assert agent._use_prompt_caching is True
+        profile = get_provider_profile(agent.provider)
+        strategy = profile.cache_strategy_for(agent.model) if profile else None
+        assert isinstance(strategy, AnthropicInlineCacheStrategy)
+        assert strategy.layout == "native"
 
     def test_fallback_to_openrouter_uses_openai_client(self, agent):
         agent._fallback_activated = False


### PR DESCRIPTION
## Summary

- Implements Gemini server-side context caching via the `POST /v1beta/cachedContents` REST API
- Adds `_ensure_gemini_cache()` in `conversation_loop.py` — creates or reuses a `cachedContents` resource keyed by session, persists the name + expiry in `state_meta`
- Extends `build_gemini_request()` in `gemini_native_adapter.py` with a `cached_content_name` param: when set, adds `cachedContent` to the request and omits `systemInstruction`, `tools`, and `toolConfig` (all three are forbidden by the Gemini API when a cached resource is referenced)
- Cache name threads through the existing extra-body pipeline: `conversation_loop` → `agent._gemini_cached_content_name` → `build_api_kwargs()` → `GeminiProfile.build_extra_body()` → `GeminiNativeClient._create_chat_completion()` → `build_gemini_request()`
- Graceful fallback: any failure (HTTP 4xx, network error, free-tier `limit=0`) returns `None` and the request proceeds with full `systemInstruction` + `tools` as before — no user-visible error

## Depends on

PR-1 (`refactor/prompt-cache-pluggable-pr1`) — this branch is stacked on top of it. `GeminiResourceCacheStrategy` (the marker class) and `GeminiProfile.cache_strategy_for()` both land in PR-1; PR-2 wires the actual HTTP call.

## Files changed

| File | Change |
|---|---|
| `agent/conversation_loop.py` | `_ensure_gemini_cache()` helper + strategy branch for `GeminiResourceCacheStrategy` |
| `agent/gemini_native_adapter.py` | `cached_content_name` param in `build_gemini_request()`; skip system/tools/toolConfig when set |
| `agent/chat_completion_helpers.py` | Pass `gemini_cached_content_name` through `build_api_kwargs()` |
| `agent/transports/chat_completions.py` | Pass `gemini_cached_content_name` into `profile.build_extra_body()` |
| `agent/prompt_cache_strategy.py` | `GeminiResourceCacheStrategy` dataclass (marker — `apply()` is a no-op) |
| `plugins/model-providers/gemini/__init__.py` | `cache_strategy_for()` + `gemini_cached_content_name` injection in `build_extra_body()` |

## Test plan

- [ ] All 373 prompt-cache–related tests pass (`scripts/run_tests.sh tests/agent/ tests/run_agent/`)
- [ ] 14 pre-existing failures in `test_anthropic_adapter.py` unchanged (unrelated to this PR)
- [ ] Local run with `gemini-2.5-flash` confirmed correct `POST /v1beta/cachedContents` call and graceful fallback on free-tier key (`TotalCachedContentStorageTokensPerModelFreeTier limit exceeded: limit=0`)
- [ ] No regressions on uncached Gemini requests (fallback path exercised on every free-tier call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)