### PR TITLE
fix: recover Codex stream final parse TypeError

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -188,6 +188,41 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
     # returns empty output (e.g. chatgpt.com backend-api sends
     # response.incomplete instead of response.completed).
     agent._codex_streamed_text_parts: list = []
+
+    def _synthesize_response_from_stream(exc: BaseException):
+        if collected_output_items:
+            logger.warning(
+                "Codex stream final parse failed (%s); using %d collected output item(s). %s",
+                exc,
+                len(collected_output_items),
+                agent._client_log_context(),
+            )
+            return SimpleNamespace(
+                status="completed",
+                output=list(collected_output_items),
+            )
+        if agent._codex_streamed_text_parts and not has_tool_calls:
+            assembled = "".join(agent._codex_streamed_text_parts)
+            logger.warning(
+                "Codex stream final parse failed (%s); synthesized response from "
+                "%d text delta(s), %d chars. %s",
+                exc,
+                len(agent._codex_streamed_text_parts),
+                len(assembled),
+                agent._client_log_context(),
+            )
+            return SimpleNamespace(
+                status="completed",
+                output=[SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text=assembled)],
+                )],
+                output_text=assembled,
+            )
+        raise exc
+
     for attempt in range(max_stream_retries + 1):
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
@@ -246,7 +281,12 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    if "'NoneType' object is not iterable" not in str(exc):
+                        raise
+                    final_response = _synthesize_response_from_stream(exc)
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
@@ -271,6 +311,10 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            if "'NoneType' object is not iterable" not in str(exc):
+                raise
+            return _synthesize_response_from_stream(exc)
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -166,7 +167,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -482,6 +483,97 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_conversation_recovers_when_codex_final_parse_typeerror_has_output_items(monkeypatch):
+    """Regression: chatgpt.com/backend-api/codex can stream valid output
+    items, then the SDK final parser raises ``'NoneType' object is not
+    iterable``. The user-visible turn should still complete with the streamed
+    assistant text instead of surfacing a non-retryable provider failure.
+    """
+    agent = _build_agent(monkeypatch)
+    calls = {"create": 0}
+    item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="stream item ok")],
+    )
+
+    def _unexpected_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("unexpected fallback")
+
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                events=[SimpleNamespace(type="response.output_item.done", item=item)],
+                final_error=TypeError("'NoneType' object is not iterable"),
+            ),
+            create=_unexpected_create,
+        )
+    )
+    agent._create_request_openai_client = lambda **kwargs: fake_client
+
+    result = agent.run_conversation("Say hello")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "stream item ok"
+    assert result["messages"][-1]["role"] == "assistant"
+    assert result["messages"][-1]["content"] == "stream item ok"
+    assert calls["create"] == 0
+
+
+def test_run_conversation_recovers_when_codex_final_parse_typeerror_has_text_deltas(monkeypatch):
+    """If the SDK final parser fails before producing output items, preserve
+    the already streamed assistant text as the final conversation response.
+    """
+    agent = _build_agent(monkeypatch)
+    calls = {"create": 0}
+
+    def _unexpected_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("unexpected fallback")
+
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                events=[
+                    SimpleNamespace(type="response.output_text.delta", delta="hello "),
+                    SimpleNamespace(type="response.output_text.delta", delta="world"),
+                ],
+                final_error=TypeError("'NoneType' object is not iterable"),
+            ),
+            create=_unexpected_create,
+        )
+    )
+    agent._create_request_openai_client = lambda **kwargs: fake_client
+
+    result = agent.run_conversation("Say hello")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "hello world"
+    assert result["messages"][-1]["role"] == "assistant"
+    assert result["messages"][-1]["content"] == "hello world"
+    assert calls["create"] == 0
+
+
+def test_run_codex_stream_reraises_unrelated_final_parse_typeerror(monkeypatch):
+    """Only the known SDK final-response parse failure is recoverable; other
+    TypeErrors should keep failing so unrelated bugs are not hidden.
+    """
+    agent = _build_agent(monkeypatch)
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                events=[SimpleNamespace(type="response.output_text.delta", delta="hello")],
+                final_error=TypeError("different parser failure"),
+            ),
+            create=lambda **kwargs: _codex_message_response("unexpected fallback"),
+        )
+    )
+
+    with pytest.raises(TypeError, match="different parser failure"):
+        agent._run_codex_stream(_codex_request_kwargs())
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes a Codex streaming edge case where the OpenAI SDK final response parser can raise:

```text
TypeError: 'NoneType' object is not iterable
```

This was observed with the `openai-codex` provider against `https://chatgpt.com/backend-api/codex`. The stream had already produced usable assistant output, but `stream.get_final_response()` failed while parsing the final response. Hermes then treated the turn as a non-retryable provider/client failure even though output was available.

## What changed

- Adds a recovery path around Codex `stream.get_final_response()` for the specific `NoneType` final parse error.
- If `response.output_item.done` events were collected, Hermes synthesizes a completed response from those output items.
- If no output items exist but text deltas were streamed and no tool calls are active, Hermes synthesizes a completed assistant message from the accumulated text deltas.
- Keeps unrelated `TypeError`s unchanged by re-raising them.

## Why

The Codex backend can stream valid output items/text before the SDK final parser fails. In that case, dropping the turn is worse than using the already streamed output, especially because the user may see the text but Hermes still marks the request as failed.

Observed log shape:

```text
API call failed (attempt 1/3): TypeError
Provider: openai-codex  Model: gpt-5.5
Endpoint: https://chatgpt.com/backend-api/codex
Error: 'NoneType' object is not iterable
Non-retryable client error: 'NoneType' object is not iterable
```

After the fix, the same failure mode is logged as a warning and Hermes continues with the collected streamed output.

## Tests

- `source venv/bin/activate && python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q`
  - 67 passed
- `source venv/bin/activate && python -m pytest tests/run_agent/test_streaming.py tests/run_agent/test_codex_xai_oauth_recovery.py -q`
  - 77 passed
