### PR TITLE
fix(telegram): render media captions as MarkdownV2 so Detailed Analysis stops leaking raw markdown on mobile (#32839)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3839,7 +3839,10 @@ class TelegramAdapter(BasePlatformAdapter):
             opened_files: List[Any] = []
             try:
                 for image_url, alt_text in chunk:
-                    caption = alt_text[:1024] if alt_text else None
+                    # Match the markdown-aware caption handling that
+                    # _send_media_with_caption_fallback applies to single
+                    # photos so album members render the same way (#32839).
+                    caption_kwargs = self._caption_send_kwargs(alt_text)
                     if image_url.startswith("file://"):
                         local_path = _unquote(image_url[7:])
                         if not os.path.exists(local_path):
@@ -3850,9 +3853,9 @@ class TelegramAdapter(BasePlatformAdapter):
                             continue
                         fh = open(local_path, "rb")
                         opened_files.append(fh)
-                        media.append(InputMediaPhoto(media=fh, caption=caption))
+                        media.append(InputMediaPhoto(media=fh, **caption_kwargs))
                     else:
-                        media.append(InputMediaPhoto(media=image_url, caption=caption))
+                        media.append(InputMediaPhoto(media=image_url, **caption_kwargs))
 
                 if not media:
                     continue

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3712,19 +3712,19 @@ class TelegramAdapter(BasePlatformAdapter):
                         reply_to_message_id=reply_to_id,
                         reply_to_mode=self._reply_to_mode
                     )
-                    msg = await self._send_with_dm_topic_reply_anchor_retry(
+                    msg = await self._send_media_with_caption_fallback(
                         self._bot.send_voice,
                         {
                             "chat_id": int(chat_id),
                             "voice": audio_file,
-                            "caption": caption[:1024] if caption else None,
                             "reply_to_message_id": reply_to_id,
                             **voice_thread_kwargs,
                             **self._notification_kwargs(metadata),
                         },
-                        metadata,
-                        reply_to_id,
-                        "voice",
+                        caption=caption,
+                        metadata=metadata,
+                        reply_to_message_id=reply_to_id,
+                        media_label="voice",
                         reset_media=lambda: audio_file.seek(0),
                     )
                 elif ext in {".mp3", ".m4a"}:
@@ -3738,19 +3738,19 @@ class TelegramAdapter(BasePlatformAdapter):
                         reply_to_message_id=reply_to_id,
                         reply_to_mode=self._reply_to_mode
                     )
-                    msg = await self._send_with_dm_topic_reply_anchor_retry(
+                    msg = await self._send_media_with_caption_fallback(
                         self._bot.send_audio,
                         {
                             "chat_id": int(chat_id),
                             "audio": audio_file,
-                            "caption": caption[:1024] if caption else None,
                             "reply_to_message_id": reply_to_id,
                             **audio_thread_kwargs,
                             **self._notification_kwargs(metadata),
                         },
-                        metadata,
-                        reply_to_id,
-                        "audio",
+                        caption=caption,
+                        metadata=metadata,
+                        reply_to_message_id=reply_to_id,
+                        media_label="audio",
                         reset_media=lambda: audio_file.seek(0),
                     )
                 else:
@@ -3935,19 +3935,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_mode=self._reply_to_mode
             )
             with open(image_path, "rb") as image_file:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
+                msg = await self._send_media_with_caption_fallback(
                     self._bot.send_photo,
                     {
                         "chat_id": int(chat_id),
                         "photo": image_file,
-                        "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },
-                    metadata,
-                    reply_to_id,
-                    "photo",
+                    caption=caption,
+                    metadata=metadata,
+                    reply_to_message_id=reply_to_id,
+                    media_label="photo",
                     reset_media=lambda: image_file.seek(0),
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
@@ -4031,20 +4031,20 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
             with open(file_path, "rb") as f:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
+                msg = await self._send_media_with_caption_fallback(
                     self._bot.send_document,
                     {
                         "chat_id": int(chat_id),
                         "document": f,
                         "filename": display_name,
-                        "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },
-                    metadata,
-                    reply_to_id,
-                    "document",
+                    caption=caption,
+                    metadata=metadata,
+                    reply_to_message_id=reply_to_id,
+                    media_label="document",
                     reset_media=lambda: f.seek(0),
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
@@ -4079,19 +4079,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_mode=self._reply_to_mode
             )
             with open(video_path, "rb") as f:
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
+                msg = await self._send_media_with_caption_fallback(
                     self._bot.send_video,
                     {
                         "chat_id": int(chat_id),
                         "video": f,
-                        "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },
-                    metadata,
-                    reply_to_id,
-                    "video",
+                    caption=caption,
+                    metadata=metadata,
+                    reply_to_message_id=reply_to_id,
+                    media_label="video",
                     reset_media=lambda: f.seek(0),
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
@@ -4131,19 +4131,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            msg = await self._send_with_dm_topic_reply_anchor_retry(
+            msg = await self._send_media_with_caption_fallback(
                 self._bot.send_photo,
                 {
                     "chat_id": int(chat_id),
                     "photo": image_url,
-                    "caption": caption[:1024] if caption else None,
                     "reply_to_message_id": reply_to_id,
                     **photo_thread_kwargs,
                     **self._notification_kwargs(metadata),
                 },
-                metadata,
-                reply_to_id,
-                "URL photo",
+                caption=caption,
+                metadata=metadata,
+                reply_to_message_id=reply_to_id,
+                media_label="URL photo",
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -4168,19 +4168,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_message_id=reply_to_id,
                     reply_to_mode=self._reply_to_mode
                 )
-                msg = await self._send_with_dm_topic_reply_anchor_retry(
+                msg = await self._send_media_with_caption_fallback(
                     self._bot.send_photo,
                     {
                         "chat_id": int(chat_id),
                         "photo": image_data,
-                        "caption": caption[:1024] if caption else None,
                         "reply_to_message_id": reply_to_id,
                         **upload_thread_kwargs,
                         **self._notification_kwargs(metadata),
                     },
-                    metadata,
-                    reply_to_id,
-                    "uploaded photo",
+                    caption=caption,
+                    metadata=metadata,
+                    reply_to_message_id=reply_to_id,
+                    media_label="uploaded photo",
                 )
                 return SendResult(success=True, message_id=str(msg.message_id))
             except Exception as e2:
@@ -4215,19 +4215,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=reply_to_id,
                 reply_to_mode=self._reply_to_mode
             )
-            msg = await self._send_with_dm_topic_reply_anchor_retry(
+            msg = await self._send_media_with_caption_fallback(
                 self._bot.send_animation,
                 {
                     "chat_id": int(chat_id),
                     "animation": animation_url,
-                    "caption": caption[:1024] if caption else None,
                     "reply_to_message_id": reply_to_id,
                     **animation_thread_kwargs,
                     **self._notification_kwargs(metadata),
                 },
-                metadata,
-                reply_to_id,
-                "animation",
+                caption=caption,
+                metadata=metadata,
+                reply_to_message_id=reply_to_id,
+                media_label="animation",
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -748,6 +748,119 @@ class TelegramAdapter(BasePlatformAdapter):
                 return True
         return False
 
+    # ── Media caption MarkdownV2 fallback (#32839) ────────────────────────
+    #
+    # ``send_message`` runs the agent's text through :meth:`format_message` and
+    # sends it with ``parse_mode=MARKDOWN_V2`` so headers, bold, lists, etc.
+    # render on every Telegram client.  Historically the media send_* helpers
+    # forwarded ``caption`` raw with no ``parse_mode``, so markdown attached
+    # to a photo/document/video (e.g. an analysis report rendered alongside
+    # a screenshot) appeared as literal ``### Heading`` / ``**bold**`` on
+    # mobile.  The helpers below give every media path the same
+    # markdown-then-plain-text fallback the text path enjoys.
+
+    @staticmethod
+    def _is_markdown_parse_error(exc: BaseException) -> bool:
+        """Return True when *exc* is a Telegram BadRequest about parse_mode.
+
+        Telegram raises ``BadRequest: Can't parse entities: ...`` (and a few
+        ``Can't find end of the entity``-style variants) when MarkdownV2
+        input is invalid.  Match on the error text so we don't have to import
+        the SDK exception class here.
+        """
+        text = str(exc).lower()
+        return (
+            "can't parse" in text
+            or "cant parse" in text
+            or "can't find end of" in text
+            or "unsupported start tag" in text
+            or "byte offset" in text
+            or "entity" in text and "parse" in text
+        )
+
+    def _caption_send_kwargs(self, caption: Optional[str]) -> Dict[str, Any]:
+        """Build ``caption`` + ``parse_mode`` kwargs for a media send call.
+
+        Mirrors :meth:`send`'s markdown handling so callers can render
+        headers/bold/inline-code in captions instead of leaking raw markdown
+        to clients.  Returns ``{"caption": None}`` for empty input so the
+        result can be ``**``-unpacked unconditionally.
+
+        Telegram caps captions at 1024 UTF-16 code units.  MarkdownV2 escape
+        backslashes can inflate the formatted text past that ceiling for
+        special-char-heavy inputs; we fall back to the raw (truncated) text
+        in that case rather than emitting an over-length caption that
+        Telegram would reject outright.
+        """
+        if not caption:
+            return {"caption": None}
+        raw = caption[:1024]
+        formatted = self.format_message(raw)
+        if utf16_len(formatted) > 1024:
+            return {"caption": raw, "parse_mode": None}
+        return {"caption": formatted, "parse_mode": ParseMode.MARKDOWN_V2}
+
+    async def _send_media_with_caption_fallback(
+        self,
+        send_fn: Any,
+        base_kwargs: Dict[str, Any],
+        *,
+        caption: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+        reply_to_message_id: Optional[int],
+        media_label: str,
+        reset_media: Optional[Any] = None,
+    ) -> Any:
+        """Send a media call with MarkdownV2 caption + plain-text fallback.
+
+        Wraps :meth:`_send_with_dm_topic_reply_anchor_retry` so the existing
+        anchor-retry semantics still apply, then catches MarkdownV2 parse
+        errors and retries once with the formatting stripped.  Without this,
+        a caption whose markdown survives :meth:`format_message` but trips
+        the Bot API parser (rare, but observed when long analysis reports
+        mix tables, headers, and code) would either fail the whole send or
+        leave the user staring at raw ``### Heading`` / ``**bold**``.
+        """
+        caption_kwargs = self._caption_send_kwargs(caption)
+        send_kwargs = {**base_kwargs, **caption_kwargs}
+        try:
+            return await self._send_with_dm_topic_reply_anchor_retry(
+                send_fn,
+                send_kwargs,
+                metadata,
+                reply_to_message_id,
+                media_label,
+                reset_media=reset_media,
+            )
+        except Exception as md_error:
+            if (
+                not caption
+                or caption_kwargs.get("parse_mode") is None
+                or not self._is_markdown_parse_error(md_error)
+            ):
+                raise
+            logger.warning(
+                "[%s] MarkdownV2 caption parse failed for %s, "
+                "falling back to plain text: %s",
+                self.name,
+                media_label,
+                md_error,
+            )
+            plain_caption = _strip_mdv2(caption_kwargs["caption"])
+            plain_kwargs = {
+                **base_kwargs,
+                "caption": plain_caption,
+                "parse_mode": None,
+            }
+            return await self._send_with_dm_topic_reply_anchor_retry(
+                send_fn,
+                plain_kwargs,
+                metadata,
+                reply_to_message_id,
+                media_label,
+                reset_media=reset_media,
+            )
+
     async def _send_with_dm_topic_reply_anchor_retry(
         self,
         send_fn: Any,

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -133,7 +133,7 @@ class TestTelegramMultiImage:
         import telegram
         images = [(f"https://x.com/{i}.png", f"alt{i}") for i in range(3)]
         # Make InputMediaPhoto a concrete class that records its args
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media, "caption": caption})
+        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None, **_: {"media": media, "caption": caption})
 
         _run(adapter.send_multiple_images("12345", images))
 
@@ -146,7 +146,7 @@ class TestTelegramMultiImage:
         """15 photos → two send_media_group calls (10 + 5)."""
         import telegram
         images = [(f"https://x.com/{i}.png", "") for i in range(15)]
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media})
+        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None, **_: {"media": media})
 
         _run(adapter.send_multiple_images("12345", images))
 
@@ -157,7 +157,7 @@ class TestTelegramMultiImage:
     def test_animations_routed_to_send_animation(self, adapter):
         """GIFs are peeled off and sent individually via send_animation."""
         import telegram
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media})
+        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None, **_: {"media": media})
         adapter.send_animation = AsyncMock()
         # 2 photos + 1 gif
         images = [
@@ -175,7 +175,7 @@ class TestTelegramMultiImage:
     def test_fallback_to_per_image_on_send_media_group_failure(self, adapter):
         """If send_media_group raises, each photo falls back to send_image."""
         import telegram
-        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None: {"media": media})
+        telegram.InputMediaPhoto = MagicMock(side_effect=lambda media, caption=None, **_: {"media": media})
         adapter._bot.send_media_group = AsyncMock(side_effect=Exception("boom"))
         adapter.send_image = AsyncMock(return_value=MagicMock(success=True))
         adapter.send_animation = AsyncMock(return_value=MagicMock(success=True))

--- a/tests/gateway/test_telegram_caption_markdown.py
+++ b/tests/gateway/test_telegram_caption_markdown.py
@@ -1,0 +1,447 @@
+"""Regression tests for Telegram media-caption MarkdownV2 rendering (#32839).
+
+Background
+----------
+``send_message`` runs the agent's response text through :meth:`format_message`
+and sends it with ``parse_mode=MARKDOWN_V2`` so headings, bold, and code spans
+render correctly on every Telegram client.  The media senders
+(``send_image_file``, ``send_document``, ``send_video``, ``send_image``,
+``send_voice``, ``send_animation``, ``send_multiple_images``) historically
+forwarded ``caption`` raw with no ``parse_mode``, so markdown attached to a
+photo or document (e.g. a research "Detailed Analysis" section sent alongside
+a screenshot) showed up as literal ``### Heading`` / ``**bold**`` on mobile.
+
+These tests pin the post-fix behaviour:
+
+* :meth:`_caption_send_kwargs` returns formatted caption + ``MARKDOWN_V2``.
+* :meth:`_send_media_with_caption_fallback` falls back to plain text only on
+  actual MarkdownV2 parse errors and leaves other failures alone.
+* Every media sender propagates the caption through the new pipeline.
+* ``send_multiple_images`` propagates ``parse_mode`` into each
+  ``InputMediaPhoto`` so album captions render too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Telegram package mock
+# ---------------------------------------------------------------------------
+
+
+def _ensure_telegram_mock() -> None:
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+from telegram.constants import ParseMode as _ParseMode  # noqa: E402
+
+# In environments where the real ``telegram`` package isn't installed the
+# stub above gives us a MagicMock whose ``ParseMode.MARKDOWN_V2`` auto-spawns
+# a sentinel.  Comparing against ``_MDV2_SENTINEL`` keeps the assertions
+# robust regardless of whether the real SDK or the mock supplies the value.
+_MDV2_SENTINEL = _ParseMode.MARKDOWN_V2
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(enabled=True, token="fake-token")
+    a = TelegramAdapter(config)
+    a._bot = MagicMock()
+    return a
+
+
+# ===========================================================================
+# _caption_send_kwargs (pure)
+# ===========================================================================
+
+
+class TestCaptionSendKwargs:
+    """Pin the contract of the caption-formatting helper."""
+
+    def test_none_returns_caption_only(self, adapter):
+        """Empty caption stays empty and skips parse_mode entirely so
+        callers can ``**``-unpack without overriding a default ``parse_mode``.
+        """
+        assert adapter._caption_send_kwargs(None) == {"caption": None}
+
+    def test_empty_string_returns_caption_only(self, adapter):
+        assert adapter._caption_send_kwargs("") == {"caption": None}
+
+    def test_plain_text_formats_and_sets_markdown_v2(self, adapter):
+        """Plain ASCII gets the MarkdownV2 parse_mode even when no formatting
+        is present — this guarantees Telegram never sees ``parse_mode=None``
+        for a non-empty caption that survives :meth:`format_message`.
+        """
+        out = adapter._caption_send_kwargs("hello world")
+        assert out["parse_mode"] == _MDV2_SENTINEL
+        assert out["caption"] == "hello world"
+
+    def test_markdown_headers_converted_to_bold(self, adapter):
+        """The regression case: a ``###`` heading must become MarkdownV2
+        bold so mobile clients render formatting instead of raw markdown.
+        """
+        out = adapter._caption_send_kwargs("### Detailed Analysis")
+        assert out["parse_mode"] == _MDV2_SENTINEL
+        assert "*Detailed Analysis*" in out["caption"]
+        assert "###" not in out["caption"]
+
+    def test_markdown_bold_converted(self, adapter):
+        out = adapter._caption_send_kwargs("**New Feature**")
+        assert out["parse_mode"] == _MDV2_SENTINEL
+        assert out["caption"] == "*New Feature*"
+
+    def test_raw_caption_truncated_to_1024_chars(self, adapter):
+        """Telegram caps captions at 1024 chars — the helper must enforce
+        this before formatting so the raw input length is bounded.
+        """
+        out = adapter._caption_send_kwargs("A" * 2000)
+        assert len(out["caption"]) == 1024
+        assert out["parse_mode"] == _MDV2_SENTINEL
+
+    def test_inflated_caption_falls_back_to_plain(self, adapter):
+        """When MarkdownV2 escape backslashes push the formatted text past
+        the 1024 ceiling, the helper drops parse_mode and returns the raw
+        (truncated) caption so the send isn't rejected by Telegram.
+        """
+        # 1000 dots → each becomes ``\.`` after escape ≈ 2000 chars formatted.
+        out = adapter._caption_send_kwargs("." * 1000)
+        assert out["parse_mode"] is None
+        assert out["caption"] == "." * 1000
+
+
+# ===========================================================================
+# _is_markdown_parse_error (pure)
+# ===========================================================================
+
+
+class TestIsMarkdownParseError:
+    def test_classic_parse_error_message(self, adapter):
+        exc = Exception("Bad Request: can't parse entities: Character '*' is reserved")
+        assert adapter._is_markdown_parse_error(exc)
+
+    def test_can_t_find_end_of_entity(self, adapter):
+        exc = Exception("Bad Request: can't find end of the entity starting at byte offset 12")
+        assert adapter._is_markdown_parse_error(exc)
+
+    def test_unrelated_error_is_not_parse_error(self, adapter):
+        exc = Exception("Connection reset by peer")
+        assert not adapter._is_markdown_parse_error(exc)
+
+    def test_chat_not_found_is_not_parse_error(self, adapter):
+        exc = Exception("Bad Request: chat not found")
+        assert not adapter._is_markdown_parse_error(exc)
+
+
+# ===========================================================================
+# _send_media_with_caption_fallback (integration)
+# ===========================================================================
+
+
+class TestSendMediaWithCaptionFallback:
+    def test_first_attempt_uses_markdown_v2(self, adapter):
+        """Happy path: success on the first attempt with MarkdownV2 set."""
+        send_fn = AsyncMock(return_value=MagicMock(message_id=1))
+        _run(
+            adapter._send_media_with_caption_fallback(
+                send_fn,
+                {"chat_id": 1},
+                caption="### Detailed Analysis",
+                metadata=None,
+                reply_to_message_id=None,
+                media_label="photo",
+            )
+        )
+        send_fn.assert_awaited_once()
+        kwargs = send_fn.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert "*Detailed Analysis*" in kwargs["caption"]
+
+    def test_parse_error_falls_back_to_plain(self, adapter):
+        """A Bad Request about parse_mode triggers exactly one retry without
+        parse_mode so the user still gets the photo, just without formatting.
+        """
+        calls = []
+
+        async def _flaky(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise Exception("Bad Request: can't parse entities at byte offset 5")
+            return MagicMock(message_id=2)
+
+        _run(
+            adapter._send_media_with_caption_fallback(
+                _flaky,
+                {"chat_id": 1},
+                caption="### Detailed Analysis",
+                metadata=None,
+                reply_to_message_id=None,
+                media_label="photo",
+            )
+        )
+        assert len(calls) == 2
+        assert calls[0]["parse_mode"] == _MDV2_SENTINEL
+        assert calls[1]["parse_mode"] is None
+        # The plain-text retry strips MarkdownV2 markers so the reader sees
+        # ``Detailed Analysis`` rather than the raw ``*Detailed Analysis*``.
+        assert calls[1]["caption"] == "Detailed Analysis"
+
+    def test_non_parse_error_is_not_retried(self, adapter):
+        """Network errors must propagate so existing retry logic upstream
+        keeps working — only MarkdownV2 parse errors deserve the fallback.
+        """
+        send_fn = AsyncMock(side_effect=Exception("Connection reset by peer"))
+        with pytest.raises(Exception, match="Connection reset"):
+            _run(
+                adapter._send_media_with_caption_fallback(
+                    send_fn,
+                    {"chat_id": 1},
+                    caption="### Heading",
+                    metadata=None,
+                    reply_to_message_id=None,
+                    media_label="photo",
+                )
+            )
+        send_fn.assert_awaited_once()
+
+    def test_empty_caption_skips_fallback(self, adapter):
+        """An empty caption can't trigger MarkdownV2 errors, so no retry
+        scaffolding runs even when the send raises something parse-like.
+        """
+        send_fn = AsyncMock(side_effect=Exception("can't parse"))
+        with pytest.raises(Exception, match="can't parse"):
+            _run(
+                adapter._send_media_with_caption_fallback(
+                    send_fn,
+                    {"chat_id": 1},
+                    caption=None,
+                    metadata=None,
+                    reply_to_message_id=None,
+                    media_label="photo",
+                )
+            )
+        send_fn.assert_awaited_once()
+
+
+# ===========================================================================
+# Per-method wiring
+# ===========================================================================
+
+
+class TestSendImageFileCaptionParseMode:
+    def test_sends_with_markdown_v2_caption(self, adapter, tmp_path):
+        """End-to-end: a markdown caption on send_image_file reaches
+        Telegram with ``parse_mode=MARKDOWN_V2`` and the formatted body.
+        """
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG" + b"\x00" * 50)
+        adapter._bot.send_photo = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(
+            adapter.send_image_file(
+                chat_id="12345",
+                image_path=str(img),
+                caption="### Detailed Analysis\n**New Feature**",
+            )
+        )
+
+        kwargs = adapter._bot.send_photo.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert "*Detailed Analysis*" in kwargs["caption"]
+        assert "*New Feature*" in kwargs["caption"]
+
+    def test_empty_caption_does_not_set_parse_mode(self, adapter, tmp_path):
+        """Avoid setting ``parse_mode`` for empty captions so we don't
+        confuse python-telegram-bot about a non-existent payload.
+        """
+        img = tmp_path / "shot.png"
+        img.write_bytes(b"\x89PNG" + b"\x00" * 50)
+        adapter._bot.send_photo = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(adapter.send_image_file(chat_id="12345", image_path=str(img)))
+
+        kwargs = adapter._bot.send_photo.call_args.kwargs
+        assert kwargs["caption"] is None
+        assert "parse_mode" not in kwargs
+
+
+class TestSendDocumentCaptionParseMode:
+    def test_document_caption_uses_markdown_v2(self, adapter, tmp_path):
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF-1.4\n")
+        adapter._bot.send_document = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(
+            adapter.send_document(
+                chat_id="12345",
+                file_path=str(doc),
+                caption="### Summary",
+            )
+        )
+
+        kwargs = adapter._bot.send_document.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert "*Summary*" in kwargs["caption"]
+
+
+class TestSendVideoCaptionParseMode:
+    def test_video_caption_uses_markdown_v2(self, adapter, tmp_path):
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 50)
+        adapter._bot.send_video = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(
+            adapter.send_video(
+                chat_id="12345",
+                video_path=str(video),
+                caption="**Demo**",
+            )
+        )
+
+        kwargs = adapter._bot.send_video.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert kwargs["caption"] == "*Demo*"
+
+
+class TestSendVoiceCaptionParseMode:
+    def test_voice_ogg_caption_uses_markdown_v2(self, adapter, tmp_path):
+        audio = tmp_path / "voice.ogg"
+        audio.write_bytes(b"OggS" + b"\x00" * 50)
+        adapter._bot.send_voice = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(
+            adapter.send_voice(
+                chat_id="12345",
+                audio_path=str(audio),
+                caption="### Voice Memo",
+            )
+        )
+
+        kwargs = adapter._bot.send_voice.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert "*Voice Memo*" in kwargs["caption"]
+
+    def test_audio_mp3_caption_uses_markdown_v2(self, adapter, tmp_path):
+        audio = tmp_path / "song.mp3"
+        audio.write_bytes(b"ID3" + b"\x00" * 50)
+        adapter._bot.send_audio = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(
+            adapter.send_voice(
+                chat_id="12345",
+                audio_path=str(audio),
+                caption="**Track One**",
+            )
+        )
+
+        kwargs = adapter._bot.send_audio.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert kwargs["caption"] == "*Track One*"
+
+
+class TestSendAnimationCaptionParseMode:
+    def test_animation_caption_uses_markdown_v2(self, adapter):
+        adapter._bot.send_animation = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(
+            adapter.send_animation(
+                chat_id="12345",
+                animation_url="https://example.com/funny.gif",
+                caption="### Reaction",
+            )
+        )
+
+        kwargs = adapter._bot.send_animation.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert "*Reaction*" in kwargs["caption"]
+
+
+class TestSendImageCaptionParseMode:
+    def test_url_image_caption_uses_markdown_v2(self, adapter):
+        adapter._bot.send_photo = AsyncMock(return_value=MagicMock(message_id=1))
+
+        _run(
+            adapter.send_image(
+                chat_id="12345",
+                image_url="https://example.com/img.png",
+                caption="**Wow**",
+            )
+        )
+
+        kwargs = adapter._bot.send_photo.call_args.kwargs
+        assert kwargs["parse_mode"] == _MDV2_SENTINEL
+        assert kwargs["caption"] == "*Wow*"
+
+
+class TestSendMultipleImagesCaptionParseMode:
+    def test_album_member_captions_set_parse_mode(self, adapter):
+        """Albums (``send_media_group``) build :class:`InputMediaPhoto`
+        objects per item; each must receive ``parse_mode`` so individual
+        captions render the same as standalone photos.
+        """
+        import telegram
+
+        captured: list[dict] = []
+
+        def _fake_input_media_photo(media, caption=None, parse_mode=None, **_):
+            captured.append({"caption": caption, "parse_mode": parse_mode})
+            return MagicMock()
+
+        telegram.InputMediaPhoto = MagicMock(side_effect=_fake_input_media_photo)
+        adapter._bot.send_media_group = AsyncMock(return_value=[MagicMock(message_id=1)])
+
+        images = [
+            ("https://x.com/a.png", "### First"),
+            ("https://x.com/b.png", "**Second**"),
+        ]
+        _run(adapter.send_multiple_images("12345", images))
+
+        assert len(captured) == 2
+        assert captured[0]["parse_mode"] == _MDV2_SENTINEL
+        assert "*First*" in captured[0]["caption"]
+        assert captured[1]["parse_mode"] == _MDV2_SENTINEL
+        assert captured[1]["caption"] == "*Second*"
+
+    def test_album_member_without_alt_text_omits_parse_mode(self, adapter):
+        """Empty alt-text must not leak a stray ``parse_mode=None`` kwarg
+        that would clobber a future Telegram default — keep parity with
+        the single-photo path.
+        """
+        import telegram
+
+        captured: list[dict] = []
+
+        def _fake_input_media_photo(media, caption=None, **kwargs):
+            captured.append({"caption": caption, **kwargs})
+            return MagicMock()
+
+        telegram.InputMediaPhoto = MagicMock(side_effect=_fake_input_media_photo)
+        adapter._bot.send_media_group = AsyncMock(return_value=[MagicMock(message_id=1)])
+
+        images = [("https://x.com/a.png", "")]
+        _run(adapter.send_multiple_images("12345", images))
+
+        assert captured == [{"caption": None}]


### PR DESCRIPTION
## What does this PR do?

Fixes #32839 — markdown in a Telegram media caption (photos, documents,
videos, voice/audio, GIFs, albums) used to ship raw to the Bot API with
no `parse_mode`, so a research "Detailed Analysis" section attached to a
screenshot rendered as literal `### 1. Introduction to Claude Code Workflows`
/ `**New Feature**` on every Telegram client — most visibly on mobile.

Three small additions wired together:

1. **Caption formatter helpers** (`gateway/platforms/telegram.py`) —
   - `_caption_send_kwargs(caption)` mirrors `send_message`: truncates to
     Telegram's 1024-char ceiling, runs the text through `format_message`
     (converting `### → *...*`, `**bold** → *bold*`, etc.), and returns
     `{"caption", "parse_mode"}` ready to `**`-unpack.  Falls back to the
     raw text when escape backslashes push the formatted caption past
     1024 chars.
   - `_is_markdown_parse_error(exc)` recognises Bot API `can't parse
     entities` / `can't find end of the entity` errors via message text.
   - `_send_media_with_caption_fallback(send_fn, ...)` wraps the existing
     `_send_with_dm_topic_reply_anchor_retry` and retries once with the
     formatting stripped if MarkdownV2 fails, so the media still lands.

2. **Wire every media send path** — `send_image_file`, `send_document`,
   `send_video`, `send_voice` (both `.ogg/.opus` voice and `.mp3/.m4a`
   audio call sites), `send_image` (URL + uploaded fallback), and
   `send_animation` route through the new helper.

3. **Album fix** — `send_multiple_images` builds `InputMediaPhoto` per
   member; each now uses `_caption_send_kwargs` so per-photo captions in
   `send_media_group` render the same way standalone photos do.

## Related Issue

Fixes #32839

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py` — three new helpers (`_is_markdown_parse_error`,
  `_caption_send_kwargs`, `_send_media_with_caption_fallback`), every
  media `send_*` re-routed through them, and album members built with
  the MarkdownV2-aware `caption`/`parse_mode` kwargs.
- `tests/gateway/test_send_multiple_images.py` — relax the
  `InputMediaPhoto` mock lambdas to accept the new `parse_mode` kwarg
  (signature change is intentional, not a behavioural regression).
- `tests/gateway/test_telegram_caption_markdown.py` — **25 new tests**
  pinning the helper contracts (`_caption_send_kwargs` truncation +
  inflation fallback, `_is_markdown_parse_error` matchers, fallback
  retry-once semantics) and the per-method wiring for every media
  sender, plus an album-member parse_mode assertion.

Backwards compatible: empty captions still send with `caption=None` and
no `parse_mode`; agent-authored ASCII without markdown still arrives
unchanged byte-for-byte (just with `parse_mode=MARKDOWN_V2` set so the
Bot API will render it the moment any formatting is introduced).

## How to Test

```bash
# New regression suite — 25 tests, no network, no real telegram SDK
.venv/bin/python -m pytest tests/gateway/test_telegram_caption_markdown.py -v

# Wider telegram surface — 168 tests, ensures no caption-related
# regression in send_image_file, send_multiple_images, or the
# format_message conversion pipeline.
.venv/bin/python -m pytest \
    tests/gateway/test_telegram_caption_markdown.py \
    tests/gateway/test_send_image_file.py \
    tests/gateway/test_send_multiple_images.py \
    tests/gateway/test_telegram_format.py
# expected: 168 passed
```

End-to-end behaviour after the fix:

```
# Before: agent attaches "### Detailed Analysis\n**New Feature**" as a
#         photo caption → Telegram receives raw markdown, mobile clients
#         show it literally:
#
#         ### Detailed Analysis
#         **New Feature**
#
# After:  the same caption is converted to MarkdownV2 and shipped with
#         parse_mode=MARKDOWN_V2 → mobile clients render:
#
#         Detailed Analysis        ← bold
#         New Feature              ← bold
#
# Edge case: a caption that survives format_message but trips the Bot
#            API parser (rare — long mixed table/header/code blocks) now
#            retries once with stripped markdown so the photo still
#            lands, with a single WARNING log line identifying the
#            offending send_* call instead of a dropped send.
```

## Checklist

- [x] Conventional Commits (`feat(telegram):`, `fix(telegram):`, `test(telegram):`)
- [x] 4 focused commits, single author (`xxxigm`)
- [x] 25 new tests pass; 143 existing telegram tests pass; pre-existing
      flake in `test_telegram_thread_fallback.py` (order-dependent state
      contamination) and a handful of unrelated test-contamination
      failures (`test_matrix.py`, `test_wecom_callback.py`,
      `test_telegram_approval_buttons.py`, `test_telegram_model_picker.py`,
      `test_telegram_slash_confirm.py`) confirmed unchanged on
      `upstream/main` — none are caused by this PR.
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12
- [x] No new config keys, no API change beyond `parse_mode` now being
      set on media-send call kwargs.
- [x] Backwards-compatible: empty / `None` captions take the same code
      path as before; existing send_* call sites need no caller changes.