### PR TITLE
Fix Codex Responses crash when output is null

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -883,7 +883,14 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         # The Codex backend can return empty output when the answer was
         # delivered entirely via stream events. Check output_text as a
         # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
+        try:
+            out_text = getattr(response, "output_text", None)
+        except TypeError:
+            # The OpenAI SDK's Response.output_text property assumes
+            # response.output is iterable. chatgpt.com/backend-api/codex can
+            # return output=None, so treat the property as absent instead of
+            # leaking the SDK TypeError into the agent loop.
+            out_text = None
         if isinstance(out_text, str) and out_text.strip():
             logger.debug(
                 "Codex response has empty output but output_text is present (%d chars); "
@@ -1024,8 +1031,11 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
-        out_text = getattr(response, "output_text", "")
+    if not final_text:
+        try:
+            out_text = getattr(response, "output_text", "")
+        except TypeError:
+            out_text = ""
         if isinstance(out_text, str):
             final_text = out_text.strip()
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,10 +20,48 @@ import json
 import logging
 import os
 import time
+import traceback
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
+
+
+def _is_openai_responses_output_none_typeerror(exc: BaseException) -> bool:
+    """Detect the OpenAI SDK Responses parser crash for output=None events."""
+    if not isinstance(exc, TypeError):
+        return False
+    if "'NoneType' object is not iterable" not in str(exc):
+        return False
+    tb_text = "".join(traceback.format_tb(exc.__traceback__))
+    return (
+        "openai/lib/_parsing/_responses.py" in tb_text
+        or "openai/lib/streaming/responses/_responses.py" in tb_text
+    )
+
+
+def _codex_response_from_stream_backfill(
+    *,
+    collected_output_items: list,
+    collected_text_deltas: list,
+) -> Any:
+    if collected_output_items:
+        return SimpleNamespace(
+            status="completed",
+            output=list(collected_output_items),
+        )
+    if collected_text_deltas:
+        assembled = "".join(collected_text_deltas)
+        return SimpleNamespace(
+            status="completed",
+            output=[SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )],
+        )
+    return None
 
 
 def run_codex_app_server_turn(
@@ -251,7 +289,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -270,7 +308,37 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             "Codex stream: synthesized output from %d text deltas (%d chars)",
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
+                    elif _out is None:
+                        # Newer chatgpt.com/backend-api/codex streams can end
+                        # with a completed Response whose output is JSON null.
+                        # The SDK's output_text property assumes an iterable
+                        # output, so normalize null to an empty list here and
+                        # let the outer response-validation path retry/fallback
+                        # as a malformed empty response.
+                        final_response.output = []
                 return final_response
+        except TypeError as exc:
+            if not _is_openai_responses_output_none_typeerror(exc):
+                raise
+            backfilled = _codex_response_from_stream_backfill(
+                collected_output_items=collected_output_items,
+                collected_text_deltas=agent._codex_streamed_text_parts,
+            )
+            if backfilled is not None:
+                logger.debug(
+                    "Codex Responses stream SDK parser hit output=None; "
+                    "recovered response from %d output item(s), %d text delta(s). %s",
+                    len(collected_output_items),
+                    len(agent._codex_streamed_text_parts),
+                    agent._client_log_context(),
+                )
+                return backfilled
+            logger.debug(
+                "Codex Responses stream SDK parser hit output=None with no "
+                "recoverable stream content; falling back to create(stream=True). %s",
+                agent._client_log_context(),
+            )
+            return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(
@@ -348,6 +416,8 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
 
     # Compatibility shim for mocks or providers that still return a concrete response.
     if hasattr(stream_or_response, "output"):
+        if getattr(stream_or_response, "output", None) is None:
+            stream_or_response.output = []
         return stream_or_response
     if not hasattr(stream_or_response, "__iter__"):
         return stream_or_response
@@ -414,7 +484,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(
@@ -432,6 +502,8 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                             "Codex fallback stream: synthesized from %d deltas (%d chars)",
                             len(collected_text_deltas), len(assembled),
                         )
+                    elif _out is None:
+                        terminal_response.output = []
                 return terminal_response
     finally:
         close_fn = getattr(stream_or_response, "close", None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1224,7 +1224,10 @@ def run_conversation(
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
-                                _out_text = getattr(response, "output_text", None)
+                                try:
+                                    _out_text = getattr(response, "output_text", None)
+                                except TypeError:
+                                    _out_text = None
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:
                                     logger.debug(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -398,6 +398,20 @@ class TestCodexNormalizeResponse:
         assert nr.content == "Hello world"
         assert nr.finish_reason == "stop"
 
+    def test_output_none_with_sdk_output_text_property_error_raises_clean_runtimeerror(self, transport):
+        class _OutputNoneResponse:
+            output = None
+            status = "completed"
+            incomplete_details = None
+            usage = None
+
+            @property
+            def output_text(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        with pytest.raises(RuntimeError, match="Responses API returned no output items"):
+            transport.normalize_response(_OutputNoneResponse())
+
     def test_message_items_preserved_in_provider_data(self, transport):
         """Codex assistant message item ids/phases must survive transport normalization."""
         r = SimpleNamespace(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -484,6 +484,95 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert response.output[0].content[0].text == "streamed create ok"
 
 
+def test_run_codex_stream_recovers_text_delta_when_sdk_parser_sees_output_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr(
+        "agent.codex_runtime._is_openai_responses_output_none_typeerror",
+        lambda exc: True,
+    )
+
+    class _OutputNoneCrashStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            yield SimpleNamespace(type="response.output_text.delta", delta="hello")
+            raise TypeError("'NoneType' object is not iterable")
+
+    fallback_calls = {"n": 0}
+
+    def _fallback(*args, **kwargs):
+        fallback_calls["n"] += 1
+        return _codex_message_response("fallback")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _OutputNoneCrashStream(),
+            create=lambda **kwargs: _codex_message_response("unused"),
+        )
+    )
+    agent._run_codex_create_stream_fallback = _fallback
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.output[0].content[0].text == "hello"
+    assert fallback_calls["n"] == 0
+
+
+def test_run_codex_stream_falls_back_when_sdk_parser_sees_output_none_without_deltas(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    monkeypatch.setattr(
+        "agent.codex_runtime._is_openai_responses_output_none_typeerror",
+        lambda exc: True,
+    )
+
+    class _OutputNoneCrashStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            raise TypeError("'NoneType' object is not iterable")
+
+    fallback_response = _codex_message_response("fallback ok")
+    fallback_calls = {"n": 0}
+
+    def _fallback(*args, **kwargs):
+        fallback_calls["n"] += 1
+        return fallback_response
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _OutputNoneCrashStream(),
+            create=lambda **kwargs: _codex_message_response("unused"),
+        )
+    )
+    agent._run_codex_create_stream_fallback = _fallback
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response is fallback_response
+    assert fallback_calls["n"] == 1
+
+
+def test_codex_create_stream_fallback_normalizes_concrete_output_none(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    response = SimpleNamespace(output=None, status="completed")
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: response)
+    )
+
+    result = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert result is response
+    assert result.output == []
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary
- detect the OpenAI SDK Responses stream parser crash caused by `response.output = null`
- recover from streamed Codex output items or text deltas when available
- normalize remaining `output = null` cases into the existing malformed-response retry/fallback path
- guard `response.output_text` access because the SDK property can raise the same TypeError when `output` is null

## Tests
- `venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py`
- `venv/bin/python -m pytest tests/agent/transports/test_codex_transport.py`
- `venv/bin/python -m py_compile agent/codex_runtime.py agent/codex_responses_adapter.py agent/conversation_loop.py`