### PR TITLE
fix(codex): recover from null terminal output in Responses streams

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,48 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _is_null_output_stream_type_error(exc: TypeError) -> bool:
+    """Return True only for the SDK's terminal ``response.output is None`` crash."""
+    return str(exc) == "'NoneType' object is not iterable"
+
+
+def _synthesize_codex_stream_response_from_items(
+    *,
+    output_items: list,
+    model: Any = None,
+    status: str = "completed",
+):
+    """Build a minimal Responses-like object from already streamed items."""
+    return SimpleNamespace(
+        output=list(output_items),
+        status=status,
+        model=model,
+        usage=SimpleNamespace(input_tokens=0, output_tokens=0, total_tokens=0),
+    )
+
+
+def _synthesize_codex_stream_response_from_text(
+    *,
+    text_parts: list,
+    model: Any = None,
+    status: str = "completed",
+):
+    """Build a minimal Responses-like message response from streamed text deltas."""
+    assembled = "".join(text_parts)
+    return _synthesize_codex_stream_response_from_items(
+        output_items=[
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status=status,
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )
+        ],
+        model=model,
+        status=status,
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -251,7 +293,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -260,17 +302,55 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         )
                     elif agent._codex_streamed_text_parts and not has_tool_calls:
                         assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
+                        final_response.output = _synthesize_codex_stream_response_from_text(
+                            text_parts=agent._codex_streamed_text_parts,
+                            model=getattr(final_response, "model", api_kwargs.get("model")),
+                        ).output
                         logger.debug(
                             "Codex stream: synthesized output from %d text deltas (%d chars)",
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            if not _is_null_output_stream_type_error(exc):
+                raise
+            if collected_output_items:
+                logger.debug(
+                    "Codex Responses stream parser hit terminal null output; "
+                    "recovering from %d collected output items. %s",
+                    len(collected_output_items),
+                    agent._client_log_context(),
+                )
+                return _synthesize_codex_stream_response_from_items(
+                    output_items=collected_output_items,
+                    model=api_kwargs.get("model"),
+                )
+            if agent._codex_streamed_text_parts and not has_tool_calls:
+                logger.debug(
+                    "Codex Responses stream parser hit terminal null output; "
+                    "recovering from %d streamed text deltas. %s",
+                    len(agent._codex_streamed_text_parts),
+                    agent._client_log_context(),
+                )
+                return _synthesize_codex_stream_response_from_text(
+                    text_parts=agent._codex_streamed_text_parts,
+                    model=api_kwargs.get("model"),
+                )
+            if attempt < max_stream_retries:
+                logger.debug(
+                    "Codex Responses stream parser hit terminal null output "
+                    "with no recoverable stream payload (attempt %s/%s); retrying. %s",
+                    attempt + 1,
+                    max_stream_retries + 1,
+                    agent._client_log_context(),
+                )
+                continue
+            logger.debug(
+                "Codex Responses stream parser hit terminal null output with no "
+                "recoverable stream payload; falling back to create(stream=True). %s",
+                agent._client_log_context(),
+            )
+            return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(
@@ -414,7 +494,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(
@@ -423,11 +503,10 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                         )
                     elif collected_text_deltas:
                         assembled = "".join(collected_text_deltas)
-                        terminal_response.output = [SimpleNamespace(
-                            type="message", role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
+                        terminal_response.output = _synthesize_codex_stream_response_from_text(
+                            text_parts=collected_text_deltas,
+                            model=getattr(terminal_response, "model", api_kwargs.get("model")),
+                        ).output
                         logger.debug(
                             "Codex fallback stream: synthesized from %d deltas (%d chars)",
                             len(collected_text_deltas), len(assembled),

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,11 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None, iter_error=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
+        self._iter_error = iter_error
 
     def __enter__(self):
         return self
@@ -166,7 +168,10 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        for event in self._events:
+            yield event
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -482,6 +487,109 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_collected_items_after_null_output_typeerror(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+    streamed_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="recovered from item")],
+    )
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            events=[SimpleNamespace(type="response.output_item.done", item=streamed_item)],
+            final_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("should not use fallback")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response is not None
+    assert calls == {"stream": 1, "create": 0}
+    assert response.output == [streamed_item]
+    assert response.output[0].content[0].text == "recovered from item"
+
+
+def test_run_codex_stream_recovers_text_deltas_after_null_output_typeerror(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="hello "),
+                SimpleNamespace(type="response.output_text.delta", delta="world"),
+            ],
+            final_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("should not use fallback")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response is not None
+    assert calls == {"stream": 1, "create": 0}
+    assert response.output[0].content[0].text == "hello world"
+
+
+def test_run_codex_stream_falls_back_after_null_output_typeerror_without_recovery_payload(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            final_error=TypeError("'NoneType' object is not iterable")
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("create fallback after null output")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response is not None
+    assert calls == {"stream": 2, "create": 1}
+    assert response.output[0].content[0].text == "create fallback after null output"
+
+
+def test_run_codex_stream_reraises_unrelated_typeerror(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(final_error=TypeError("different local bug"))
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    with pytest.raises(TypeError, match="different local bug"):
+        agent._run_codex_stream(_codex_request_kwargs())
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

- recover Codex Responses streams when the SDK raises `TypeError: 'NoneType' object is not iterable` on a terminal null `response.output`
- synthesize the final response from already collected `response.output_item.done` events when possible
- synthesize plain assistant output from streamed text deltas when no tool calls were present
- retry once, then fall back to the existing raw `create(stream=True)` parser when no recoverable streamed payload exists
- add regression coverage for collected-item recovery, text-delta recovery, fallback behavior, and unrelated TypeError re-raising

## Why

The ChatGPT Codex backend can close a Responses stream with a terminal frame that has no output list. OpenAI Python SDK 2.24.0 raises while iterating that field, even though Hermes may already have received usable streamed output-item events. This made Hermes abort with a non-retryable client error.

## Tests

- `uv run --python 3.13 --with pytest pytest tests/run_agent/test_run_agent_codex_responses.py -o 'addopts=' -q`
- `uv run --python 3.13 python -m py_compile agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py`

Closes #32894
