### PR TITLE
fix(codex): recover from response.completed with output=null on chatgpt.com backend

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -287,6 +287,53 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+        except TypeError as exc:
+            # The chatgpt.com/backend-api/codex backend intermittently
+            # sends ``response.completed`` SSE events whose ``response.output``
+            # field is ``null``.  The OpenAI SDK's ``parse_response()``
+            # then does ``for output in response.output:`` and raises
+            # ``TypeError: 'NoneType' object is not iterable``, which the
+            # outer conversation loop classifies as a non-retryable local
+            # validation error and aborts the turn.  We've already
+            # collected the streamed deltas / output items, so synthesize
+            # a response from them — the same recovery the post-stream
+            # backfill below performs when ``get_final_response()`` returns
+            # an empty output list.
+            err_text = str(exc)
+            if "NoneType" in err_text and "iterable" in err_text:
+                if collected_output_items or agent._codex_streamed_text_parts:
+                    synth_output: list = list(collected_output_items)
+                    assembled = "".join(agent._codex_streamed_text_parts)
+                    if not synth_output and assembled and not has_tool_calls:
+                        synth_output = [SimpleNamespace(
+                            type="message",
+                            role="assistant",
+                            status="completed",
+                            content=[SimpleNamespace(type="output_text", text=assembled)],
+                        )]
+                    logger.warning(
+                        "Codex response.completed had output=null; recovered from "
+                        "%d collected items / %d text deltas (%d chars). %s",
+                        len(collected_output_items),
+                        len(agent._codex_streamed_text_parts),
+                        len(assembled),
+                        agent._client_log_context(),
+                    )
+                    return SimpleNamespace(
+                        output=synth_output,
+                        output_text=assembled,
+                        usage=None,
+                        model=api_kwargs.get("model", ""),
+                        status="completed",
+                        incomplete_details=None,
+                    )
+                logger.debug(
+                    "Codex response.completed had output=null and no stream "
+                    "content was collected; falling back to create(stream=True). %s",
+                    agent._client_log_context(),
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
         except RuntimeError as exc:
             err_text = str(exc)
             missing_completed = "response.completed" in err_text

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2348,6 +2348,14 @@ def run_conversation(
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
                 _error_summary = agent._summarize_api_error(api_error)
+                # Local-validation errors (TypeError, ValueError) typically
+                # indicate a bug in our request building or in the upstream
+                # SDK's response parsing — keep the full traceback so we can
+                # actually fix them instead of just seeing the summary line.
+                _emit_tb = (
+                    isinstance(api_error, (TypeError, ValueError))
+                    and not isinstance(api_error, (UnicodeEncodeError, json.JSONDecodeError))
+                )
                 logger.warning(
                     "API call failed (attempt %s/%s) error_type=%s %s summary=%s",
                     retry_count,
@@ -2355,6 +2363,7 @@ def run_conversation(
                     error_type,
                     agent._client_log_context(),
                     _error_summary,
+                    exc_info=api_error if _emit_tb else False,
                 )
 
                 _provider = getattr(agent, "provider", "unknown")

--- a/tests/run_agent/test_codex_stream_null_output_recovery.py
+++ b/tests/run_agent/test_codex_stream_null_output_recovery.py
@@ -1,0 +1,163 @@
+"""Regression test for the May 2026 ``response.completed`` ``output=null`` bug.
+
+The ``chatgpt.com/backend-api/codex`` endpoint started intermittently sending
+``response.completed`` SSE events whose ``response.output`` field is ``null``
+(observed on ``gpt-5.5``).  The OpenAI SDK's ``parse_response()`` then does
+``for output in response.output:`` and raises::
+
+    TypeError: 'NoneType' object is not iterable
+
+The outer conversation loop classifies that as a non-retryable local
+validation error and aborts the turn — the user sees a generic
+"I encountered an error" line instead of the model's actual answer, even
+though every text delta was already streamed to us.
+
+``run_codex_stream`` now catches that specific ``TypeError`` and recovers
+by synthesizing a response from the deltas / output items it already
+collected, the same backfill the post-stream path runs when
+``get_final_response()`` returns an empty output list.  When nothing was
+collected we fall back to ``run_codex_create_stream_fallback``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_codex_agent():
+    """Build a minimal AIAgent wired for codex_responses streaming tests."""
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        model="gpt-5.5",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "codex_responses"
+    agent.provider = "openai-codex"
+    agent._interrupt_requested = False
+    return agent
+
+
+class _StreamWithTypeError:
+    """Context manager that yields deltas, then raises the SDK's TypeError.
+
+    Mirrors what the OpenAI SDK does when the Codex backend sends
+    ``response.completed`` with ``output=null`` — the SDK iterates the
+    null output inside its own event loop, so the TypeError surfaces
+    from inside our ``for event in stream:`` loop, after we've already
+    consumed delta events.
+    """
+
+    def __init__(self, deltas):
+        self._deltas = deltas
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        for delta_text in self._deltas:
+            yield SimpleNamespace(
+                type="response.output_text.delta",
+                delta=delta_text,
+            )
+        raise TypeError("'NoneType' object is not iterable")
+
+
+def test_codex_stream_recovers_from_null_output_using_collected_deltas():
+    """When the backend sends response.completed with output=null, recover
+    by synthesizing a response from the text deltas already streamed.
+
+    The synthesized response carries the text the model actually produced
+    so the agent can continue the turn instead of aborting with a
+    "non-retryable client error" and showing the user a generic error.
+    """
+    agent = _make_codex_agent()
+
+    mock_client = MagicMock()
+    mock_client.responses.stream.return_value = _StreamWithTypeError(
+        ["Hello, ", "world!"]
+    )
+
+    # If we accidentally fall back to create(stream=True), the test should
+    # fail loudly — recovery from in-stream deltas should not need a 2nd call.
+    with patch.object(
+        agent, "_run_codex_create_stream_fallback",
+        side_effect=AssertionError("must not fall back when deltas are present"),
+    ):
+        result = agent._run_codex_stream(
+            {"model": "gpt-5.5"}, client=mock_client,
+        )
+
+    assert getattr(result, "status", None) == "completed"
+    assert getattr(result, "output_text", None) == "Hello, world!"
+    output = getattr(result, "output", None)
+    assert isinstance(output, list) and len(output) == 1
+    synthesized = output[0]
+    assert synthesized.type == "message"
+    assert synthesized.role == "assistant"
+    assert synthesized.content[0].type == "output_text"
+    assert synthesized.content[0].text == "Hello, world!"
+
+
+def test_codex_stream_null_output_with_no_content_falls_back():
+    """When the backend sends output=null AND no deltas were collected,
+    fall back to create(stream=True) so we still get a chance at a real
+    response or a surfaced provider error.
+    """
+    agent = _make_codex_agent()
+
+    mock_client = MagicMock()
+    # No deltas, just the immediate TypeError — same shape as a Codex
+    # response.completed with output=null and no prior text events.
+    mock_client.responses.stream.return_value = _StreamWithTypeError([])
+
+    fallback_response = SimpleNamespace(
+        output=[SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="fallback ok")],
+        )],
+        status="completed",
+    )
+    with patch.object(
+        agent, "_run_codex_create_stream_fallback", return_value=fallback_response,
+    ) as mock_fallback:
+        result = agent._run_codex_stream(
+            {"model": "gpt-5.5"}, client=mock_client,
+        )
+
+    assert result is fallback_response
+    mock_fallback.assert_called_once()
+
+
+def test_codex_stream_unrelated_typeerror_still_raises():
+    """Only the specific ``'NoneType' object is not iterable`` message
+    should trigger recovery — unrelated TypeErrors must propagate so we
+    don't mask real bugs."""
+    agent = _make_codex_agent()
+
+    class _StreamWithUnrelatedTypeError:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def __iter__(self):
+            raise TypeError("unrelated programming bug")
+
+    mock_client = MagicMock()
+    mock_client.responses.stream.return_value = _StreamWithUnrelatedTypeError()
+
+    with patch.object(agent, "_run_codex_create_stream_fallback") as mock_fallback:
+        with pytest.raises(TypeError, match="unrelated programming bug"):
+            agent._run_codex_stream({"model": "gpt-5.5"}, client=mock_client)
+
+    mock_fallback.assert_not_called()


### PR DESCRIPTION
## Summary

The chatgpt.com/backend-api/codex endpoint intermittently sends `response.completed` SSE events whose `response.output` field is `null` (observed on gpt-5.5, May 2026). The OpenAI SDK 2.24.0's `parse_response()` then does `for output in response.output:` at [`openai/lib/_parsing/_responses.py:61`](https://github.com/openai/openai-python/blob/v2.24.0/src/openai/lib/_parsing/_responses.py#L61) and raises:

```
TypeError: 'NoneType' object is not iterable
```

The outer conversation loop classifies that as a non-retryable local-validation error and aborts the turn. The user sees a generic "I encountered an error" message instead of the model's actual answer — even though every text delta was already streamed to us and accumulated in `agent._codex_streamed_text_parts`.

Existing protection in `run_codex_stream` for empty-output responses only runs *after* `stream.get_final_response()` returns. The TypeError fires *inside* `for event in stream:` (during the `response.completed` accumulation), so the post-stream backfill never gets a chance.

## Changes

- `agent/codex_runtime.py:run_codex_stream` — catch the specific `TypeError: 'NoneType' object is not iterable` from `parse_response()` and recover by synthesizing a response from the deltas/items already collected (same shape as the existing post-stream backfill). When nothing was collected, fall back to `_run_codex_create_stream_fallback` — mirrors how the existing `RuntimeError(\"Expected to have received \`response.completed\`\")` branch handles broken Responses backends like xAI OAuth, codex-lb relays, and custom Responses relays.
- `agent/conversation_loop.py` — when an API call fails with `TypeError`/`ValueError` (excluding `UnicodeEncodeError` / `json.JSONDecodeError`, which are handled elsewhere), log the full traceback via `exc_info=`. Without this the original bug was undiagnosable from the logs — only the one-line summary `'NoneType' object is not iterable` reached `errors.log`, with no stack frame to point at `parse_response`.
- `tests/run_agent/test_codex_stream_null_output_recovery.py` — three regression tests:
  - Recovery from streamed deltas synthesizes a `completed` response with the assembled text.
  - When no content was collected, fall back to `_run_codex_create_stream_fallback`.
  - Unrelated `TypeError` messages still propagate (so we don't mask real bugs).

## Test plan

- [x] `scripts/run_tests.sh tests/run_agent/test_codex_stream_null_output_recovery.py` — 3 passed
- [x] `scripts/run_tests.sh tests/run_agent/test_codex_xai_oauth_recovery.py tests/agent/test_codex_ttfb_watchdog.py tests/run_agent/test_run_agent_codex_responses.py` — 105 passed, no regressions in adjacent Codex paths
- [x] Manual: gateway running with patch applied, the message that previously failed with `'NoneType' object is not iterable` now succeeds and emits the new `Codex response.completed had output=null; recovered from N collected items / M text deltas` warning in `agent.log`.
- [x] Platform: tested on macOS (Darwin 25.2.0, Python 3.11)

## Notes

- The recovery is a true fix for the user-visible symptom (an aborted turn becomes a successful response carrying the streamed text), but the upstream Codex backend should not be sending `response.completed` with `output=null` in the first place — worth reporting to OpenAI separately. The OpenAI SDK could also defensively handle this case in `parse_response()`.
- The diagnostic `exc_info` change is small but worth keeping — it catches an entire class of failures (any future SDK-side iteration bug, request-building bug, or backend payload-shape regression) that would otherwise reach `errors.log` with no traceback.