### PR TITLE
fix(codex): avoid tools=None TypeError on openai-codex when no tools are registered (#32892)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -176,11 +176,41 @@ def run_codex_app_server_turn(
 
 
 
+def _strip_sdk_none_iterables(api_kwargs: dict) -> dict:
+    """Drop keys whose ``None`` value would trip the openai SDK's
+    ``Iterable``-typed parameters.
+
+    The openai SDK's ``responses.stream()`` and ``responses.parse()``
+    call ``_make_tools(tools)`` eagerly, which iterates ``tools``
+    without a None guard.  Passing ``tools=None`` raises
+    ``TypeError: 'NoneType' object is not iterable`` before any HTTP
+    request is issued (openai==2.24.0, #32892).  Preflight already
+    strips ``tools=None``, but this defensive shim guarantees the
+    invariant even if a future code path bypasses preflight or a
+    plugin re-injects the key.  We mutate in-place rather than copy
+    so the dict the caller still holds matches what we sent.
+    """
+    if not isinstance(api_kwargs, dict):
+        return api_kwargs
+    # ``tools`` is the only param the SDK iterates eagerly enough to
+    # crash on None; the rest (``include``, ``reasoning``, etc.) flow
+    # through ``maybe_transform`` which tolerates None.
+    if api_kwargs.get("tools", "missing") is None:
+        api_kwargs.pop("tools", None)
+        # ``tool_choice`` / ``parallel_tool_calls`` are meaningless
+        # without tools and can themselves 400 on some backends, so
+        # drop them in lockstep.
+        api_kwargs.pop("tool_choice", None)
+        api_kwargs.pop("parallel_tool_calls", None)
+    return api_kwargs
+
+
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
     """Execute one streaming Responses API request and return the final response."""
     import httpx as _httpx
 
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
+    _strip_sdk_none_iterables(api_kwargs)
     max_stream_retries = 1
     has_tool_calls = False
     first_delta_fired = False
@@ -344,6 +374,11 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
     fallback_kwargs = dict(api_kwargs)
     fallback_kwargs["stream"] = True
     fallback_kwargs = agent._get_transport().preflight_kwargs(fallback_kwargs, allow_stream=True)
+    # Belt-and-braces: ``responses.create`` tolerates ``tools=None`` today,
+    # but the streaming fallback is the recovery path for an already-failing
+    # turn — keep the kwargs invariant identical to ``run_codex_stream`` so
+    # any future SDK tightening doesn't reintroduce #32892 here.
+    _strip_sdk_none_iterables(fallback_kwargs)
     stream_or_response = active_client.responses.create(**fallback_kwargs)
 
     # Compatibility shim for mocks or providers that still return a concrete response.
@@ -448,6 +483,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
 
 
 __all__ = [
+    "_strip_sdk_none_iterables",
     "run_codex_app_server_turn",
     "run_codex_stream",
     "run_codex_create_stream_fallback",

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -94,6 +94,14 @@ class ResponsesApiTransport(ProviderTransport):
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
         response_tools = _responses_tools(tools)
+        # ``tools`` MUST be omitted entirely when there are no functions to
+        # expose: the openai SDK's ``responses.stream()`` / ``responses.parse()``
+        # eagerly call ``_make_tools(tools)`` which does ``for tool in tools``
+        # without a None guard, so passing ``tools=None`` raises
+        # ``TypeError: 'NoneType' object is not iterable`` before any HTTP
+        # request is issued (openai==2.24.0).  Reported for the
+        # ``openai-codex`` / ``gpt-5.5`` combo on chatgpt.com/backend-api/codex
+        # (#32892) where the agent runs without external tools registered.
         kwargs = {
             "model": model,
             "instructions": instructions,
@@ -101,10 +109,10 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
             ),
-            "tools": response_tools,
             "store": False,
         }
         if response_tools:
+            kwargs["tools"] = response_tools
             kwargs["tool_choice"] = "auto"
             kwargs["parallel_tool_calls"] = True
 

--- a/tests/run_agent/test_codex_no_tools_nonetype.py
+++ b/tests/run_agent/test_codex_no_tools_nonetype.py
@@ -1,0 +1,379 @@
+"""Regression coverage for #32892.
+
+The openai SDK's ``responses.stream()`` / ``responses.parse()`` eagerly
+call ``_make_tools(tools)``, which iterates ``tools`` *without* a None
+guard.  Passing ``tools=None`` therefore raises::
+
+    TypeError: 'NoneType' object is not iterable
+
+…before any HTTP request is issued.  This trips the
+``openai-codex`` / ``gpt-5.5`` combo on ``chatgpt.com/backend-api/codex``
+whenever the user runs Hermes without external tools registered: the
+agent loop catches the TypeError, sees no HTTP status, classifies it as
+non-retryable, and aborts.
+
+These tests pin the two defences that together prevent the regression:
+
+1.  :func:`agent.transports.codex.ResponsesApiTransport.build_kwargs`
+    must never emit ``tools=None`` (only add the key when there are
+    function tools to expose).
+2.  :func:`agent.codex_runtime._strip_sdk_none_iterables` must strip
+    ``tools=None`` (and the meaningless ``tool_choice`` /
+    ``parallel_tool_calls`` partners) at the SDK boundary, so any code
+    path that bypasses preflight or re-injects the key still survives.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+
+# Stub optional deps the parent module imports at top level — keeps this
+# test file runnable in the same environment as the existing Codex tests.
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def transport():
+    """Fresh ``ResponsesApiTransport`` per test (it is stateless but
+    the import has side-effects on a global transport registry)."""
+    from agent.transports.codex import ResponsesApiTransport
+
+    return ResponsesApiTransport()
+
+
+@pytest.fixture
+def codex_messages() -> List[Dict[str, Any]]:
+    """Minimal Codex-shaped chat history mirroring the #32892 reproducer:
+    one system + one short user message, with no tool calls in history."""
+    return [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "Hey! What can I help you with?"},
+    ]
+
+
+def _build_kwargs_no_tools(transport, messages) -> Dict[str, Any]:
+    """Exercise the real ``build_kwargs`` for the codex backend with no tools."""
+    return transport.build_kwargs(
+        model="gpt-5.5",
+        messages=messages,
+        tools=None,
+        is_codex_backend=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_kwargs: the "tools=None" key must never appear
+# ---------------------------------------------------------------------------
+
+
+def test_build_kwargs_omits_tools_key_when_no_tools(transport, codex_messages):
+    """``build_kwargs`` must not place ``tools=None`` in the outgoing dict.
+
+    Putting ``tools=None`` reaches ``responses.stream()`` which calls
+    ``_make_tools(None)`` and crashes with the #32892 TypeError before any
+    request is sent.
+    """
+    kwargs = _build_kwargs_no_tools(transport, codex_messages)
+
+    assert "tools" not in kwargs, (
+        f"tools key must be omitted entirely when no tools are registered, "
+        f"got kwargs={sorted(kwargs)}"
+    )
+
+
+def test_build_kwargs_omits_tool_choice_and_parallel_when_no_tools(transport, codex_messages):
+    """``tool_choice`` / ``parallel_tool_calls`` are meaningless without
+    tools — and some backends 400 on them.  Confirm we never set them."""
+    kwargs = _build_kwargs_no_tools(transport, codex_messages)
+
+    assert "tool_choice" not in kwargs
+    assert "parallel_tool_calls" not in kwargs
+
+
+def test_build_kwargs_keeps_required_codex_fields_without_tools(transport, codex_messages):
+    """The toolless build must still emit the non-negotiable Codex fields
+    (model / instructions / input / store) — otherwise we'd just be moving
+    the bug from the SDK to preflight."""
+    kwargs = _build_kwargs_no_tools(transport, codex_messages)
+
+    assert kwargs["model"] == "gpt-5.5"
+    assert kwargs["instructions"] == "You are Hermes."
+    assert kwargs["store"] is False
+    assert isinstance(kwargs["input"], list)
+    assert kwargs["input"] and kwargs["input"][0]["role"] == "user"
+
+
+def test_build_kwargs_emits_tools_when_tools_present(transport, codex_messages):
+    """Sanity check the inverse: when tools ARE provided, they MUST appear
+    in the outgoing kwargs along with the related ``tool_choice`` /
+    ``parallel_tool_calls`` switches."""
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a shell command.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    kwargs = transport.build_kwargs(
+        model="gpt-5.5",
+        messages=codex_messages,
+        tools=tools,
+        is_codex_backend=True,
+    )
+
+    assert "tools" in kwargs and kwargs["tools"], "tools must be present when registered"
+    assert kwargs["tools"][0]["name"] == "terminal"
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["parallel_tool_calls"] is True
+
+
+def test_build_kwargs_drops_empty_tools_list(transport, codex_messages):
+    """``tools=[]`` collapses to ``None`` inside ``_responses_tools`` —
+    the resulting kwargs must therefore also omit the key."""
+    kwargs = transport.build_kwargs(
+        model="gpt-5.5",
+        messages=codex_messages,
+        tools=[],
+        is_codex_backend=True,
+    )
+
+    assert "tools" not in kwargs
+    assert "tool_choice" not in kwargs
+    assert "parallel_tool_calls" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# _strip_sdk_none_iterables: belt-and-braces guard at the SDK boundary
+# ---------------------------------------------------------------------------
+
+
+def test_strip_sdk_none_iterables_removes_tools_none():
+    """The defensive shim must drop ``tools=None`` before the SDK iterates it."""
+    from agent.codex_runtime import _strip_sdk_none_iterables
+
+    kwargs = {
+        "model": "gpt-5.5",
+        "instructions": "be helpful",
+        "input": [{"role": "user", "content": "hi"}],
+        "tools": None,
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+        "store": False,
+    }
+    result = _strip_sdk_none_iterables(kwargs)
+
+    # In-place mutation is documented in the helper's docstring so the
+    # caller's dict reflects what was actually sent.
+    assert result is kwargs
+    assert "tools" not in result
+    assert "tool_choice" not in result, (
+        "tool_choice is meaningless without tools and 400s on some backends"
+    )
+    assert "parallel_tool_calls" not in result
+    # Untouched fields stay put.
+    assert result["model"] == "gpt-5.5"
+    assert result["store"] is False
+
+
+def test_strip_sdk_none_iterables_preserves_real_tools():
+    """A populated ``tools`` list must pass through untouched."""
+    from agent.codex_runtime import _strip_sdk_none_iterables
+
+    real_tools = [{"type": "function", "name": "terminal"}]
+    kwargs = {
+        "model": "gpt-5.5",
+        "tools": real_tools,
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+    }
+    _strip_sdk_none_iterables(kwargs)
+
+    assert kwargs["tools"] is real_tools
+    assert kwargs["tool_choice"] == "auto"
+    assert kwargs["parallel_tool_calls"] is True
+
+
+def test_strip_sdk_none_iterables_noop_without_tools_key():
+    """When the key was never set, the helper must NOT add it."""
+    from agent.codex_runtime import _strip_sdk_none_iterables
+
+    kwargs = {"model": "gpt-5.5", "instructions": "x"}
+    _strip_sdk_none_iterables(kwargs)
+    assert "tools" not in kwargs
+    assert sorted(kwargs) == ["instructions", "model"]
+
+
+def test_strip_sdk_none_iterables_handles_non_dict():
+    """Defensive: a non-dict input must not raise."""
+    from agent.codex_runtime import _strip_sdk_none_iterables
+
+    assert _strip_sdk_none_iterables(None) is None
+    assert _strip_sdk_none_iterables("not a dict") == "not a dict"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: run_codex_stream must not crash when api_kwargs has tools=None
+# ---------------------------------------------------------------------------
+
+
+class _RecordingResponsesStream:
+    """Stand-in for the openai SDK's stream manager that records the kwargs
+    it was invoked with, so the test can assert ``tools=None`` was scrubbed
+    before reaching the SDK."""
+
+    def __init__(self, kwargs):
+        self.kwargs = kwargs
+        self._final = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="ok")],
+                )
+            ],
+            status="completed",
+            model="gpt-5.5",
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_response(self):
+        return self._final
+
+
+def _fake_codex_agent():
+    """Tiny stand-in for ``AIAgent`` exposing exactly the surface that
+    ``run_codex_stream`` touches.  Avoids the full bootstrap (~25 imports)
+    so the regression remains a unit test."""
+    agent = SimpleNamespace()
+    agent._interrupt_requested = False
+    agent._codex_streamed_text_parts = []
+    agent._codex_stream_last_event_ts = None
+    agent._client_log_context = lambda: ""
+    agent._touch_activity = lambda *_a, **_k: None
+    agent._fire_stream_delta = lambda *_a, **_k: None
+    agent._fire_reasoning_delta = lambda *_a, **_k: None
+    return agent
+
+
+def test_run_codex_stream_scrubs_tools_none_before_sdk_call():
+    """Even if a caller bypasses preflight, ``run_codex_stream`` must drop
+    ``tools=None`` so the openai SDK's ``_make_tools(None)`` never sees it.
+
+    This is the actual #32892 reproducer: ``api_kwargs`` contains
+    ``tools=None``, ``run_codex_stream`` is called, and the call must
+    succeed instead of raising ``TypeError: 'NoneType' object is not iterable``.
+    """
+    from agent.codex_runtime import run_codex_stream
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_stream(**kwargs):
+        captured.update(kwargs)
+        return _RecordingResponsesStream(kwargs)
+
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream)
+    )
+    agent = _fake_codex_agent()
+    api_kwargs = {
+        "model": "gpt-5.5",
+        "instructions": "be helpful",
+        "input": [{"role": "user", "content": "Hey! What can I help you with?"}],
+        "tools": None,
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+        "store": False,
+    }
+
+    # Must NOT raise TypeError.
+    response = run_codex_stream(agent, api_kwargs, client=fake_client)
+
+    assert response is not None
+    # The SDK call site never saw tools=None.
+    assert "tools" not in captured, (
+        f"tools=None leaked into responses.stream() kwargs: {captured}"
+    )
+    assert "tool_choice" not in captured
+    assert "parallel_tool_calls" not in captured
+    # And the caller's dict reflects the scrub (documented in-place
+    # mutation), so debug dumps / retries see what was actually sent.
+    assert "tools" not in api_kwargs
+
+
+def test_run_codex_stream_preserves_real_tools():
+    """The scrub must NOT remove a populated tools list — that would
+    silently break every tool-calling turn."""
+    from agent.codex_runtime import run_codex_stream
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_stream(**kwargs):
+        captured.update(kwargs)
+        return _RecordingResponsesStream(kwargs)
+
+    fake_client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream)
+    )
+    agent = _fake_codex_agent()
+    real_tools = [
+        {"type": "function", "name": "terminal", "parameters": {"type": "object"}},
+    ]
+    api_kwargs = {
+        "model": "gpt-5.5",
+        "instructions": "be helpful",
+        "input": [{"role": "user", "content": "ls"}],
+        "tools": real_tools,
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+        "store": False,
+    }
+
+    run_codex_stream(agent, api_kwargs, client=fake_client)
+
+    assert captured.get("tools") is real_tools
+    assert captured.get("tool_choice") == "auto"
+    assert captured.get("parallel_tool_calls") is True
+
+
+# ---------------------------------------------------------------------------
+# Direct openai SDK assertion: the bug is real (sanity-checks the fix target)
+# ---------------------------------------------------------------------------
+
+
+def test_openai_sdk_raises_typeerror_on_tools_none():
+    """Document the upstream behaviour the two defences guard against.
+
+    If the SDK ever fixes ``_make_tools(None)`` to return ``omit``
+    gracefully, this test will start failing — at which point the agent
+    defences become belt-only and this test should be flipped to an
+    ``xfail`` so we notice the upstream change.
+    """
+    from openai.resources.responses.responses import _make_tools
+
+    with pytest.raises(TypeError, match="NoneType.*not iterable"):
+        _make_tools(None)


### PR DESCRIPTION
## What does this PR do?

Fixes #32892 — every Hermes turn against `openai-codex` / `gpt-5.5`
(chatgpt.com/backend-api/codex) crashed before sending the request when
the agent was running without external tools registered, surfacing as:

```
⚠️  API call failed (attempt 1/3): TypeError
   🔌 Provider: openai-codex  Model: gpt-5.5
   🌐 Endpoint: https://chatgpt.com/backend-api/codex
   📝 Error: 'NoneType' object is not iterable
⚠️ Non-retryable error (HTTP None) — trying fallback...
❌ Non-retryable client error (HTTP None). Aborting.
```

### Root cause

`openai==2.24.0`'s `responses.stream()` (and `responses.parse()`) call
`_make_tools(tools)` eagerly:

```python
def _make_tools(tools):
    if not is_given(tools):
        return omit
    converted_tools = []
    for tool in tools:           # ← iterates without a None guard
        ...
```

`is_given(None)` returns `True`, so passing `tools=None` skips the
`omit` early-return and crashes with
`TypeError: 'NoneType' object is not iterable` before any HTTP request
is issued. The agent's outer loop catches the TypeError, sees no HTTP
status, classifies it as non-retryable and aborts.

Hermes' Codex transport was unconditionally placing `"tools":
response_tools` into the kwargs dict, so `response_tools=None`
(the "no tools registered" case) shipped `tools=None` straight into the
SDK.

### Fix (two defences, three small commits)

1. **`agent/transports/codex.py::build_kwargs`** — only attach `tools`
   (and the meaningless `tool_choice` / `parallel_tool_calls` partners)
   when the converted list is non-empty. Matches how the
   chat_completions transport already gates the same keys.
2. **`agent/codex_runtime.py::_strip_sdk_none_iterables`** — defensive
   shim called from `run_codex_stream` and
   `run_codex_create_stream_fallback` so any future code path that
   still ships `tools=None` (a custom transport, a plugin re-injecting
   the key, a future preflight regression) is scrubbed at the SDK
   boundary. Mutates in place so debug dumps / retries see exactly
   what was sent.
3. **`tests/run_agent/test_codex_no_tools_nonetype.py`** — 12 new
   tests covering both defences plus an end-to-end `run_codex_stream`
   reproducer.

## Related Issue

Fixes #32892

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/codex.py` — drop the unconditional
  `"tools": response_tools` slot; only add `tools` /
  `tool_choice` / `parallel_tool_calls` when there are real tools.
- `agent/codex_runtime.py` — add `_strip_sdk_none_iterables`, call
  from `run_codex_stream` and `run_codex_create_stream_fallback`,
  export from `__all__`.
- `tests/run_agent/test_codex_no_tools_nonetype.py` — **12 new tests**
  pinning build_kwargs, the strip helper, end-to-end through
  `run_codex_stream`, and an upstream SDK assertion so we notice if
  `_make_tools(None)` ever gets fixed.

## How to Test

```bash
# New regression suite — 12 tests, no network
python -m pytest tests/run_agent/test_codex_no_tools_nonetype.py -v

# Wider Codex surface — full existing suite must still pass
python -m pytest tests/run_agent/test_run_agent_codex_responses.py
# expected: 65 passed
```

Direct reproduction of the upstream bug (and confirmation of the fix):

```python
# BEFORE the fix:
>>> from openai import OpenAI
>>> c = OpenAI(api_key='x', base_url='https://chatgpt.com/backend-api/codex')
>>> c.responses.stream(model='gpt-5.5', input=[{'role':'user','content':'hi'}],
...                    instructions='ok', tools=None, store=False).__enter__()
TypeError: 'NoneType' object is not iterable

# AFTER the fix — build_kwargs never emits tools=None,
# and the strip helper guards the SDK call:
>>> from agent.transports.codex import ResponsesApiTransport
>>> kw = ResponsesApiTransport().build_kwargs(
...     model='gpt-5.5',
...     messages=[{'role':'system','content':'ok'},{'role':'user','content':'hi'}],
...     tools=None, is_codex_backend=True)
>>> 'tools' in kw
False
>>> c.responses.stream(**kw)   # reaches network normally
```

## Checklist

- [x] Conventional Commits (`fix(codex):`, `fix(codex):`, `test(codex):`)
- [x] 3 focused commits, single author (`xxxigm`)
- [x] 12 new tests pass; existing 65 codex_responses tests pass; the
      remaining failures in the broader run are pre-existing on
      `upstream/main` (missing optional `anthropic` SDK,
      `test_bundled_plugins_discovered` plugin-discovery flake) and
      unrelated to this PR.
- [x] Tested on macOS 15.6 (darwin 24.6.0), Python 3.12, openai==2.24.0
- [x] No new config keys, no breaking API change.
- [x] Backwards-compatible: when tools ARE registered the outgoing
      kwargs are byte-for-byte identical to before; only the toolless
      path changes shape.