### PR TITLE
fix(cli): handle null `deliver` field in `cron list` legacy entries

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -67,7 +67,7 @@ def cron_list(show_all: bool = False):
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -5,7 +5,7 @@ from argparse import Namespace
 import pytest
 
 from cron.jobs import create_job, get_job, list_jobs
-from hermes_cli.cron import cron_command
+from hermes_cli.cron import cron_command, cron_list
 
 
 @pytest.fixture()
@@ -88,6 +88,24 @@ class TestCronCommandLifecycle:
 
         out = capsys.readouterr().out
         assert "Updated job" in out
+
+    def test_list_handles_null_deliver_in_legacy_job(self, tmp_cron_dir, monkeypatch, capsys):
+        legacy_job = {
+            "id": "legacy123",
+            "name": "Legacy job",
+            "schedule_display": "every 1h",
+            "deliver": None,
+        }
+        monkeypatch.setattr(
+            "cron.jobs.list_jobs",
+            lambda include_disabled=False: [legacy_job],
+        )
+
+        cron_list(show_all=True)
+
+        out = capsys.readouterr().out
+        assert "Legacy job" in out
+        assert "Deliver:   local" in out
 
     def test_create_with_multiple_skills(self, tmp_cron_dir, capsys):
         cron_command(


### PR DESCRIPTION
## What does this PR do?

`hermes cron list` crashes with `TypeError: can only join an iterable` on cron jobs whose `deliver` field is explicitly `null` rather than absent. `dict.get("deliver", ["local"])` only returns the default when the key is missing — an explicit `null` skips the default, yields `None`, and the subsequent `", ".join(None)` raises.

Switches to `dict.get("deliver") or ["local"]` so `None`, empty list, and empty string all fall back to the default deliver target.

## Related Issue

Fixes #32896

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/cron.py` — replace `job.get("deliver", ["local"])` with `job.get("deliver") or ["local"]` so an explicit `null` deliver value falls back to the default instead of crashing the join.
- `tests/hermes_cli/test_cron.py` — add `test_list_handles_null_deliver_in_legacy_job` which monkeypatches `cron.jobs.list_jobs` to return a legacy entry with `deliver: null` and asserts the listing renders with `Deliver:   local`.

## How to Test

1. Reproduce on `main`: a cron job with `deliver: null` in `jobs.json` makes `hermes cron list` exit with the issue's stack trace at `hermes_cli/cron.py:73`.
2. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_cron.py -v` → 4 passed.
3. Removing the one-line fix and rerunning the new test reproduces `TypeError: can only join an iterable` at `cron.py:73` — same fingerprint as the issue.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — fix is platform-agnostic Python dict handling
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- #23490 (`fix(cron): guard against None values in legacy job entries for cron list`, mtvgadgets) patches the `schedule` and `repeat` fields with the same defensive-`or` pattern but does not touch the `deliver` field that fingerprints in #32896's stack trace. This PR completes the same pattern for the one remaining field in `cron_list` that actually raises rather than just rendering oddly. The two PRs are orthogonal and either can land first.

> Audited siblings: confirmed every other `job.get(<field>, <default>)` in `cron_list` already uses `or` (e.g. `skills = job.get("skills") or ...`), returns a string default (`id`, `name`, `next_run_at` — these only render oddly, never crash), or is fully covered by #23490 (`schedule`, `repeat`). No widening needed beyond the `deliver` line.