### PR TITLE
fix(agent): recover Responses streams with null output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -784,13 +784,14 @@ class _CodexCompletionsAdapter:
                 # new failure mode for auxiliary calls.
                 pass
 
+        # Collect output items and text deltas during streaming —
+        # the Codex backend can return empty/null response.output from
+        # get_final_response(), or the SDK can raise TypeError while
+        # handling a terminal response whose output is null.
+        collected_output_items: List[Any] = []
+        collected_text_deltas: List[str] = []
+        has_function_calls = False
         try:
-            # Collect output items and text deltas during streaming —
-            # the Codex backend can return empty response.output from
-            # get_final_response() even when items were streamed.
-            collected_output_items: List[Any] = []
-            collected_text_deltas: List[str] = []
-            has_function_calls = False
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
@@ -813,28 +814,14 @@ class _CodexCompletionsAdapter:
                 _check_cancelled()
                 final = stream.get_final_response()
 
-            # Backfill empty output from collected stream events
-            _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
-                if collected_output_items:
-                    final.output = list(collected_output_items)
-                    logger.debug(
-                        "Codex auxiliary: backfilled %d output items from stream events",
-                        len(collected_output_items),
-                    )
-                elif collected_text_deltas and not has_function_calls:
-                    # Only synthesize text when no tool calls were streamed —
-                    # a function_call response with incidental text should not
-                    # be collapsed into a plain-text message.
-                    assembled = "".join(collected_text_deltas)
-                    final.output = [SimpleNamespace(
-                        type="message", role="assistant", status="completed",
-                        content=[SimpleNamespace(type="output_text", text=assembled)],
-                    )]
-                    logger.debug(
-                        "Codex auxiliary: synthesized from %d deltas (%d chars)",
-                        len(collected_text_deltas), len(assembled),
-                    )
+            from agent.codex_runtime import _backfill_responses_output
+            final = _backfill_responses_output(
+                final,
+                collected_output_items=collected_output_items,
+                collected_text_deltas=collected_text_deltas,
+                has_tool_calls=has_function_calls,
+                log_label="Codex auxiliary",
+            )
 
             # Extract text and tool calls from the Responses output.
             # Items may be SDK objects (attrs) or dicts (raw/fallback paths),
@@ -872,8 +859,45 @@ class _CodexCompletionsAdapter:
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
-            logger.debug("Codex auxiliary Responses API call failed: %s", exc)
-            raise
+            from agent.codex_runtime import _backfill_responses_output, _responses_null_output_typeerror
+            if _responses_null_output_typeerror(exc) and (collected_output_items or collected_text_deltas):
+                logger.debug(
+                    "Codex auxiliary Responses stream crashed on terminal output=None; "
+                    "recovering from streamed events"
+                )
+                final = _backfill_responses_output(
+                    SimpleNamespace(output=None),
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=collected_text_deltas,
+                    has_tool_calls=has_function_calls,
+                    log_label="Codex auxiliary",
+                )
+
+                def _item_get(obj: Any, key: str, default: Any = None) -> Any:
+                    val = getattr(obj, key, None)
+                    if val is None and isinstance(obj, dict):
+                        val = obj.get(key, default)
+                    return val if val is not None else default
+
+                for item in getattr(final, "output", []):
+                    item_type = _item_get(item, "type")
+                    if item_type == "message":
+                        for part in (_item_get(item, "content") or []):
+                            ptype = _item_get(part, "type")
+                            if ptype in {"output_text", "text"}:
+                                text_parts.append(_item_get(part, "text", ""))
+                    elif item_type == "function_call":
+                        tool_calls_raw.append(SimpleNamespace(
+                            id=_item_get(item, "call_id", ""),
+                            type="function",
+                            function=SimpleNamespace(
+                                name=_item_get(item, "name", ""),
+                                arguments=_item_get(item, "arguments", "{}"),
+                            ),
+                        ))
+            else:
+                logger.debug("Codex auxiliary Responses API call failed: %s", exc)
+                raise
         finally:
             if timeout_timer is not None:
                 timeout_timer.cancel()

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,53 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _responses_null_output_typeerror(exc: BaseException) -> bool:
+    """Return True for the SDK crash caused by terminal output=None."""
+    return isinstance(exc, TypeError) and "NoneType" in str(exc) and "not iterable" in str(exc)
+
+
+def _backfill_responses_output(
+    response: Any,
+    *,
+    collected_output_items: List[Any],
+    collected_text_deltas: List[str],
+    has_tool_calls: bool = False,
+    log_label: str,
+) -> Any:
+    """Backfill Responses output from stream events when terminal output is empty/null."""
+    if response is None:
+        response = SimpleNamespace(output=[])
+
+    current_output = getattr(response, "output", None)
+    if current_output is not None and not (isinstance(current_output, list) and not current_output):
+        return response
+
+    if collected_output_items:
+        response.output = list(collected_output_items)
+        logger.debug(
+            "%s: backfilled %d output items from stream events",
+            log_label,
+            len(collected_output_items),
+        )
+    elif collected_text_deltas and not has_tool_calls:
+        assembled = "".join(collected_text_deltas)
+        response.output = [SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text=assembled)],
+        )]
+        logger.debug(
+            "%s: synthesized output from %d text deltas (%d chars)",
+            log_label,
+            len(collected_text_deltas),
+            len(assembled),
+        )
+    else:
+        response.output = []
+    return response
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -192,6 +239,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        collected_text_deltas: list = []
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
                 for event in stream:
@@ -209,6 +257,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         delta_text = getattr(event, "delta", "")
                         if delta_text:
                             agent._codex_streamed_text_parts.append(delta_text)
+                            collected_text_deltas.append(delta_text)
                         if delta_text and not has_tool_calls:
                             if not first_delta_fired:
                                 first_delta_fired = True
@@ -247,30 +296,26 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             agent._client_log_context(),
                         )
                 final_response = stream.get_final_response()
-                # PATCH: ChatGPT Codex backend streams valid output items
-                # but get_final_response() can return an empty output list.
-                # Backfill from collected items or synthesize from deltas.
-                _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        final_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex stream: backfilled %d output items from stream events",
-                            len(collected_output_items),
-                        )
-                    elif agent._codex_streamed_text_parts and not has_tool_calls:
-                        assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex stream: synthesized output from %d text deltas (%d chars)",
-                            len(agent._codex_streamed_text_parts), len(assembled),
-                        )
-                return final_response
+                return _backfill_responses_output(
+                    final_response,
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=collected_text_deltas or agent._codex_streamed_text_parts,
+                    has_tool_calls=has_tool_calls,
+                    log_label="Codex stream",
+                )
+        except TypeError as exc:
+            if _responses_null_output_typeerror(exc) and (collected_output_items or collected_text_deltas):
+                logger.debug(
+                    "Codex Responses stream crashed on terminal output=None; recovering from streamed events"
+                )
+                return _backfill_responses_output(
+                    SimpleNamespace(output=None),
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=collected_text_deltas,
+                    has_tool_calls=has_tool_calls,
+                    log_label="Codex stream",
+                )
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(
@@ -413,26 +458,12 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                 terminal_response = event.get("response")
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
-                _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        terminal_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex fallback stream: backfilled %d output items",
-                            len(collected_output_items),
-                        )
-                    elif collected_text_deltas:
-                        assembled = "".join(collected_text_deltas)
-                        terminal_response.output = [SimpleNamespace(
-                            type="message", role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex fallback stream: synthesized from %d deltas (%d chars)",
-                            len(collected_text_deltas), len(assembled),
-                        )
-                return terminal_response
+                return _backfill_responses_output(
+                    terminal_response,
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=collected_text_deltas,
+                    log_label="Codex fallback stream",
+                )
     finally:
         close_fn = getattr(stream_or_response, "close", None)
         if callable(close_fn):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2315,6 +2315,54 @@ class TestCodexAdapterReasoningTranslation:
         assert "reasoning" not in captured
         assert "include" not in captured
 
+    def test_null_output_typeerror_recovers_from_text_deltas(self):
+        """Regression for Responses streams whose terminal response has output=None.
+
+        The OpenAI SDK raises TypeError while processing response.completed;
+        the adapter should still recover from text deltas already streamed.
+        """
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        class _FakeStream:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_text.delta", delta="hello ")
+                yield SimpleNamespace(type="response.output_text.delta", delta="again")
+                raise TypeError("'NoneType' object is not iterable")
+            def get_final_response(self):  # pragma: no cover - iteration raises first
+                raise AssertionError("get_final_response should not be reached")
+
+        real_client = MagicMock()
+        real_client.responses.stream = lambda **kwargs: _FakeStream()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.3-codex")
+
+        response = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        message = response.choices[0].message
+        assert message.content == "hello again"
+        assert message.tool_calls is None
+
+    def test_null_final_output_recovers_from_text_deltas(self):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        class _FakeStream:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_text.delta", delta="terminal ")
+                yield SimpleNamespace(type="response.output_text.delta", delta="null ok")
+            def get_final_response(self):
+                return SimpleNamespace(output=None, usage=None)
+
+        real_client = MagicMock()
+        real_client.responses.stream = lambda **kwargs: _FakeStream()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.3-codex")
+
+        response = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert response.choices[0].message.content == "terminal null ok"
+
     def test_extra_body_without_reasoning_key_is_noop(self):
         adapter, captured = self._build_adapter()
         adapter.create(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -186,6 +186,24 @@ class _FakeCreateStream:
         self.closed = True
 
 
+class _TypeErrorAfterEventsStream:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        yield from self._events
+        raise TypeError("'NoneType' object is not iterable")
+
+    def get_final_response(self):  # pragma: no cover - iteration raises first
+        raise AssertionError("get_final_response should not be reached")
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -482,6 +500,54 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_when_sdk_crashes_on_null_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _TypeErrorAfterEventsStream(
+            [
+                SimpleNamespace(type="response.output_text.delta", delta="null "),
+                SimpleNamespace(type="response.output_text.delta", delta="output ok"),
+            ]
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.output[0].content[0].text == "null output ok"
+
+
+def test_run_codex_create_stream_fallback_backfills_null_terminal_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.output_text.delta", delta="terminal "),
+            SimpleNamespace(type="response.output_text.delta", delta="null ok"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    output=None,
+                    usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+                    status="completed",
+                    model="gpt-5-codex",
+                ),
+            ),
+        ]
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: create_stream)
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert response.output[0].content[0].text == "terminal null ok"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

Recover Codex/OpenAI Responses streams when the terminal `response.output` is `null`/`None` even though earlier stream events already delivered output items or text deltas.

This is the same failure mode described in #11179 and the same direction as #11182, adapted to this fork's current runtime split where the main Codex Responses stream lives in `agent/codex_runtime.py` rather than directly in `run_agent.py`.

## Root Cause

Some Responses backends can emit valid `response.output_item.done` or `response.output_text.delta` events, then finish with a terminal response whose `output` field is `null`. The OpenAI SDK may raise `TypeError: 'NoneType' object is not iterable` while processing that terminal event, before Hermes can read the final response normally.

## Changes

- Add shared Responses output backfill helpers in `agent/codex_runtime.py`.
- Recover the main Codex Responses stream path from SDK `NoneType` iteration crashes using collected output items or text deltas.
- Treat terminal `output=None` the same as empty output in the `create(stream=True)` fallback.
- Apply the same recovery to the auxiliary Responses adapter used by compression, memory, and related side-LLM flows.
- Add regression coverage for SDK TypeError recovery and direct `output=None` terminal responses.

## Validation

- `uv run --with pytest --with pytest-timeout --with pytest-asyncio python -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py`
- Result: `245 passed in 65.41s`