### PR TITLE
Handle Responses streams with missing terminal output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -784,6 +784,30 @@ class _CodexCompletionsAdapter:
                 # new failure mode for auxiliary calls.
                 pass
 
+        def _item_get(obj: Any, key: str, default: Any = None) -> Any:
+            val = getattr(obj, key, None)
+            if val is None and isinstance(obj, dict):
+                val = obj.get(key, default)
+            return val if val is not None else default
+
+        def _collect_final_output(final_response: Any) -> None:
+            for item in getattr(final_response, "output", []):
+                item_type = _item_get(item, "type")
+                if item_type == "message":
+                    for part in (_item_get(item, "content") or []):
+                        ptype = _item_get(part, "type")
+                        if ptype in {"output_text", "text"}:
+                            text_parts.append(_item_get(part, "text", ""))
+                elif item_type == "function_call":
+                    tool_calls_raw.append(SimpleNamespace(
+                        id=_item_get(item, "call_id", ""),
+                        type="function",
+                        function=SimpleNamespace(
+                            name=_item_get(item, "name", ""),
+                            arguments=_item_get(item, "arguments", "{}"),
+                        ),
+                    ))
+
         try:
             # Collect output items and text deltas during streaming —
             # the Codex backend can return empty response.output from
@@ -811,7 +835,20 @@ class _CodexCompletionsAdapter:
                     elif "function_call" in _etype:
                         has_function_calls = True
                 _check_cancelled()
-                final = stream.get_final_response()
+                try:
+                    final = stream.get_final_response()
+                except TypeError as exc:
+                    from agent.codex_runtime import recover_responses_stream_output
+
+                    final = recover_responses_stream_output(
+                        exc,
+                        output_items=collected_output_items,
+                        text_parts=collected_text_deltas,
+                        has_tool_calls=has_function_calls,
+                        log_prefix="Codex auxiliary",
+                    )
+                    if final is None:
+                        raise
 
             # Backfill empty output from collected stream events
             _output = getattr(final, "output", None)
@@ -837,30 +874,8 @@ class _CodexCompletionsAdapter:
                     )
 
             # Extract text and tool calls from the Responses output.
-            # Items may be SDK objects (attrs) or dicts (raw/fallback paths),
-            # so use a helper that handles both shapes.
-            def _item_get(obj: Any, key: str, default: Any = None) -> Any:
-                val = getattr(obj, key, None)
-                if val is None and isinstance(obj, dict):
-                    val = obj.get(key, default)
-                return val if val is not None else default
-
-            for item in getattr(final, "output", []):
-                item_type = _item_get(item, "type")
-                if item_type == "message":
-                    for part in (_item_get(item, "content") or []):
-                        ptype = _item_get(part, "type")
-                        if ptype in {"output_text", "text"}:
-                            text_parts.append(_item_get(part, "text", ""))
-                elif item_type == "function_call":
-                    tool_calls_raw.append(SimpleNamespace(
-                        id=_item_get(item, "call_id", ""),
-                        type="function",
-                        function=SimpleNamespace(
-                            name=_item_get(item, "name", ""),
-                            arguments=_item_get(item, "arguments", "{}"),
-                        ),
-                    ))
+            # Items may be SDK objects (attrs) or dicts (raw/fallback paths).
+            _collect_final_output(final)
 
             resp_usage = getattr(final, "usage", None)
             if resp_usage:
@@ -872,8 +887,19 @@ class _CodexCompletionsAdapter:
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
-            logger.debug("Codex auxiliary Responses API call failed: %s", exc)
-            raise
+            from agent.codex_runtime import recover_responses_stream_output
+
+            final = recover_responses_stream_output(
+                exc,
+                output_items=collected_output_items,
+                text_parts=collected_text_deltas,
+                has_tool_calls=has_function_calls,
+                log_prefix="Codex auxiliary",
+            )
+            if final is None:
+                logger.debug("Codex auxiliary Responses API call failed: %s", exc)
+                raise
+            _collect_final_output(final)
         finally:
             if timeout_timer is not None:
                 timeout_timer.cancel()

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,59 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def recover_responses_stream_output(
+    exc: BaseException,
+    *,
+    output_items: List[Any],
+    text_parts: List[str],
+    has_tool_calls: bool,
+    log_prefix: str,
+    log_context: str = "",
+) -> Any | None:
+    """Recover a Responses result when the SDK rejects a malformed terminal event.
+
+    Some OpenAI-compatible Responses streams emit valid incremental events
+    (``response.output_item.done`` / text deltas) but omit ``response.output``
+    from the terminal ``response.completed`` event.  The OpenAI SDK parses that
+    final event while iterating the stream and raises ``TypeError: 'NoneType'
+    object is not iterable`` before callers can use ``get_final_response()``.
+    When prior streamed content is complete enough, synthesize the minimal
+    response object Hermes already expects.
+    """
+    if not isinstance(exc, TypeError):
+        return None
+    if "NoneType" not in str(exc) or "iterable" not in str(exc):
+        return None
+    if output_items:
+        logger.warning(
+            "%s: recovered from malformed terminal event with missing output "
+            "using %d streamed output item(s)%s",
+            log_prefix,
+            len(output_items),
+            f". {log_context}" if log_context else "",
+        )
+        return SimpleNamespace(output=list(output_items), usage=None)
+    if text_parts and not has_tool_calls:
+        assembled = "".join(text_parts)
+        logger.warning(
+            "%s: recovered from malformed terminal event with missing output "
+            "using %d streamed text chars%s",
+            log_prefix,
+            len(assembled),
+            f". {log_context}" if log_context else "",
+        )
+        return SimpleNamespace(
+            output=[SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )],
+            usage=None,
+        )
+    return None
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -246,7 +299,19 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    final_response = recover_responses_stream_output(
+                        exc,
+                        output_items=collected_output_items,
+                        text_parts=agent._codex_streamed_text_parts,
+                        has_tool_calls=has_tool_calls,
+                        log_prefix="Codex stream",
+                        log_context=agent._client_log_context(),
+                    )
+                    if final_response is None:
+                        raise
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
@@ -271,6 +336,18 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            recovered = recover_responses_stream_output(
+                exc,
+                output_items=collected_output_items,
+                text_parts=agent._codex_streamed_text_parts,
+                has_tool_calls=has_tool_calls,
+                log_prefix="Codex stream",
+                log_context=agent._client_log_context(),
+            )
+            if recovered is not None:
+                return recovered
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/tests/agent/test_codex_stream_recovery.py
+++ b/tests/agent/test_codex_stream_recovery.py
@@ -1,0 +1,76 @@
+"""Regression tests for malformed Responses streaming terminal events."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class _MalformedTerminalStream:
+    """Yields valid content, then fails like the SDK parser can on completion."""
+
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        yield from self._events
+        raise TypeError("'NoneType' object is not iterable")
+
+    def get_final_response(self):
+        raise AssertionError("iteration failure should recover before final response")
+
+
+def _message_item(text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text=text)],
+        role="assistant",
+    )
+
+
+def test_codex_stream_recovers_when_terminal_event_omits_output():
+    from agent.codex_runtime import run_codex_stream
+
+    item = _message_item("pong")
+    events = [SimpleNamespace(type="response.output_item.done", item=item)]
+    client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _MalformedTerminalStream(events)
+        )
+    )
+    agent = SimpleNamespace(
+        _interrupt_requested=False,
+        _codex_stream_last_event_ts=None,
+        _touch_activity=lambda *args, **kwargs: None,
+        _fire_stream_delta=lambda *args, **kwargs: None,
+        _fire_reasoning_delta=lambda *args, **kwargs: None,
+        _client_log_context=lambda: "provider=custom model=gpt-5.5",
+    )
+
+    response = run_codex_stream(agent, {"model": "gpt-5.5"}, client=client)
+
+    assert response.output == [item]
+
+
+def test_codex_auxiliary_recovers_when_terminal_event_omits_output():
+    from agent.auxiliary_client import _CodexCompletionsAdapter
+
+    item = _message_item("pong")
+    events = [SimpleNamespace(type="response.output_item.done", item=item)]
+    client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _MalformedTerminalStream(events)
+        )
+    )
+
+    response = _CodexCompletionsAdapter(client, "gpt-5.5").create(
+        messages=[{"role": "user", "content": "ping"}]
+    )
+
+    assert response.choices[0].message.content == "pong"


### PR DESCRIPTION
## Summary
- recover Responses streams when the terminal event omits response.output but earlier output_item.done/text deltas were already received
- share the recovery path between the main Codex stream runtime and the auxiliary Responses adapter
- add regression coverage for malformed terminal streaming events

## Why
Some OpenAI-compatible Responses endpoints emit valid incremental SSE events, then send a response.completed payload without an output field. OpenAI SDK parsing raises TypeError: 'NoneType' object is not iterable while iterating the stream, before Hermes can use the already streamed output. This makes the error look like a non-retryable client failure even though the assistant output was already available.

## Tests
- ./venv/bin/python -m py_compile agent/codex_runtime.py agent/auxiliary_client.py tests/agent/test_codex_stream_recovery.py
- ./venv/bin/python -m pytest tests/agent/test_codex_stream_recovery.py tests/agent/test_codex_ttfb_watchdog.py tests/agent/test_auxiliary_client.py -q