### PR TITLE
fix(cron): guard against null deliver/repeat/schedule in cron list

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -58,16 +58,16 @@ def cron_list(show_all: bool = False):
     for job in jobs:
         job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
-        schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
+        schedule = job.get("schedule_display") or (job.get("schedule") or {}).get("value", "?")
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
 
-        repeat_info = job.get("repeat", {})
+        repeat_info = job.get("repeat") or {}
         repeat_times = repeat_info.get("times")
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)


### PR DESCRIPTION
## Fixes #32896

When a cron job has `null` `deliver`, `repeat`, or `schedule` fields (common when jobs are created without explicit delivery), `hermes cron list` crashes with:

```
TypeError: can only join an iterable
```

### Root Cause

`.get("key", default)` only applies the default when the key is **missing**. When the key **exists** with value `None` (null in JSON), `.get()` returns `None` and the default is ignored.

### Fix

Use `or default` pattern instead of `.get(key, default)`:
- `job.get("deliver", ["local"])` → `job.get("deliver") or ["local"]`
- `job.get("repeat", {})` → `job.get("repeat") or {}`
- `job.get("schedule_display", ...)` → `job.get("schedule_display") or (...)`

This ensures `None` values are also replaced with the default.

### Changes
- `hermes_cli/cron.py`: 3 lines changed