### PR TITLE
fix: parenthesize or-expressions before slice truncation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7897,7 +7897,7 @@ class HermesCLI:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10582,7 +10582,7 @@ class GatewayRunner:
             lines.append(t("gateway.personality.none_option"))
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(t("gateway.personality.item", name=name, preview=preview))

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1584,7 +1584,7 @@ class SlashCommandCompleter(Completer):
             for name, prompt in personalities.items():
                 if name.startswith(sub_lower) and name != sub_lower:
                     if isinstance(prompt, dict):
-                        meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                        meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                     else:
                         meta = str(prompt)[:50]
                     yield Completion(

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1461,7 +1461,7 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
             detail = ""
             try:
                 err_body = response.json()
-                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+                detail = (err_body.get("error", {}).get("message", "") or response.text)[:300]
             except Exception:
                 detail = response.text[:300]
             return {

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1431,7 +1431,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         # Surface the API error message when present
         try:
             err = response.json().get("error", {})
-            detail = err.get("message") or response.text[:300]
+            detail = (err.get("message") or response.text)[:300]
         except Exception:
             detail = response.text[:300]
         raise RuntimeError(


### PR DESCRIPTION
## Summary

Python's slice operator `[:]` binds tighter than `or`, so:
```python
x or y[:50]   # → x or (y[:50])   — only truncates y
(x or y)[:50] # truncates the result of or
```

This causes long descriptions and error messages to leak untruncated, breaking display layouts and error surfaces.

### Fixed instances (5 files)

| File | Line | Context |
|------|------|--------|
| `hermes_cli/commands.py` | 1587 | Personality autocomplete preview |
| `cli.py` | 7900 | Personality list preview |
| `gateway/run.py` | 10585 | Gateway personality preview |
| `tools/tts_tool.py` | 1434 | TTS error detail truncation |
| `tools/transcription_tools.py` | 1464 | Transcription error detail |

### Pattern

Before:
```python
meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
```

After:
```python
meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
```

Each fix adds parentheses to ensure `[:N]` applies to the entire `or` expression, not just the right operand.