### PR TITLE
fix: recover Codex streams with null output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -784,6 +784,10 @@ class _CodexCompletionsAdapter:
                 # new failure mode for auxiliary calls.
                 pass
 
+        def _is_tool_call_event(event_type: Any) -> bool:
+            text = str(event_type or "")
+            return "function_call" in text or "tool_call" in text
+
         try:
             # Collect output items and text deltas during streaming —
             # the Codex backend can return empty response.output from
@@ -796,22 +800,60 @@ class _CodexCompletionsAdapter:
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
-            with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
+            try:
+                with self._client.responses.stream(**resp_kwargs) as stream:
+                    for _event in stream:
+                        _check_cancelled()
+                        _etype = getattr(_event, "type", "")
+                        if _etype == "response.output_item.done":
+                            _done = getattr(_event, "item", None)
+                            if _done is not None:
+                                collected_output_items.append(_done)
+                        elif "output_text.delta" in _etype:
+                            _delta = getattr(_event, "delta", "")
+                            if _delta:
+                                collected_text_deltas.append(_delta)
+                        elif _is_tool_call_event(_etype):
+                            has_function_calls = True
                     _check_cancelled()
-                    _etype = getattr(_event, "type", "")
-                    if _etype == "response.output_item.done":
-                        _done = getattr(_event, "item", None)
-                        if _done is not None:
-                            collected_output_items.append(_done)
-                    elif "output_text.delta" in _etype:
-                        _delta = getattr(_event, "delta", "")
-                        if _delta:
-                            collected_text_deltas.append(_delta)
-                    elif "function_call" in _etype:
-                        has_function_calls = True
-                _check_cancelled()
-                final = stream.get_final_response()
+                    final = stream.get_final_response()
+            except TypeError as exc:
+                if "'NoneType' object is not iterable" not in str(exc):
+                    raise
+                if collected_output_items:
+                    final = SimpleNamespace(
+                        output=list(collected_output_items),
+                        status="completed",
+                        model=model,
+                        usage=None,
+                    )
+                    logger.warning(
+                        "Codex auxiliary stream parser returned output=null; "
+                        "recovered %d output item(s) from streamed events.",
+                        len(collected_output_items),
+                    )
+                elif collected_text_deltas and not has_function_calls:
+                    assembled = "".join(collected_text_deltas)
+                    final = SimpleNamespace(
+                        output=[
+                            SimpleNamespace(
+                                type="message",
+                                role="assistant",
+                                status="completed",
+                                content=[SimpleNamespace(type="output_text", text=assembled)],
+                            )
+                        ],
+                        status="completed",
+                        model=model,
+                        usage=None,
+                    )
+                    logger.warning(
+                        "Codex auxiliary stream parser returned output=null; "
+                        "synthesized output from %d text delta(s).",
+                        len(collected_text_deltas),
+                    )
+                else:
+                    raise
 
             # Backfill empty output from collected stream events
             _output = getattr(final, "output", None)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,55 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _is_null_output_parse_error(exc: BaseException) -> bool:
+    """OpenAI SDK parser crash for Codex final events with output=null."""
+    return isinstance(exc, TypeError) and "'NoneType' object is not iterable" in str(exc)
+
+
+def _is_codex_tool_call_event(event_type: Any) -> bool:
+    """Return true for Responses events that represent tool-call activity."""
+    text = str(event_type or "")
+    return "function_call" in text or "tool_call" in text
+
+
+def _synthesize_codex_stream_response(
+    *,
+    api_kwargs: dict,
+    collected_output_items: List[Any],
+    collected_text_deltas: List[str],
+    has_tool_calls: bool,
+    source: str,
+) -> Any:
+    """Recover a Responses object from items already received on the stream."""
+    output_items = list(collected_output_items)
+    if not output_items and collected_text_deltas and not has_tool_calls:
+        assembled = "".join(collected_text_deltas)
+        output_items = [
+            SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )
+        ]
+
+    if not output_items:
+        return None
+
+    logger.warning(
+        "Codex %s stream parser returned output=null; recovered %d output item(s) "
+        "from streamed events.",
+        source,
+        len(output_items),
+    )
+    return SimpleNamespace(
+        output=output_items,
+        status="completed",
+        model=api_kwargs.get("model"),
+        usage=None,
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -219,7 +268,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                                         pass
                             agent._fire_stream_delta(delta_text)
                     # Track tool calls to suppress text streaming
-                    elif "function_call" in event_type:
+                    elif _is_codex_tool_call_event(event_type):
                         has_tool_calls = True
                     # Fire reasoning callbacks
                     elif "reasoning" in event_type and "delta" in event_type:
@@ -335,6 +384,18 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 )
                 return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             raise
+        except TypeError as exc:
+            if _is_null_output_parse_error(exc):
+                recovered = _synthesize_codex_stream_response(
+                    api_kwargs=api_kwargs,
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=agent._codex_streamed_text_parts,
+                    has_tool_calls=has_tool_calls,
+                    source="Responses",
+                )
+                if recovered is not None:
+                    return recovered
+            raise
 
 
 
@@ -355,6 +416,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
     terminal_response = None
     collected_output_items: list = []
     collected_text_deltas: list = []
+    has_tool_calls = False
     try:
         for event in stream_or_response:
             agent._touch_activity("receiving stream response")
@@ -404,6 +466,8 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                     delta = event.get("delta", "")
                 if delta:
                     collected_text_deltas.append(delta)
+            elif event_type and _is_codex_tool_call_event(event_type):
+                has_tool_calls = True
 
             if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
                 continue
@@ -421,7 +485,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                             "Codex fallback stream: backfilled %d output items",
                             len(collected_output_items),
                         )
-                    elif collected_text_deltas:
+                    elif collected_text_deltas and not has_tool_calls:
                         assembled = "".join(collected_text_deltas)
                         terminal_response.output = [SimpleNamespace(
                             type="message", role="assistant",
@@ -433,6 +497,18 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                             len(collected_text_deltas), len(assembled),
                         )
                 return terminal_response
+    except TypeError as exc:
+        if _is_null_output_parse_error(exc):
+            recovered = _synthesize_codex_stream_response(
+                api_kwargs=fallback_kwargs,
+                collected_output_items=collected_output_items,
+                collected_text_deltas=collected_text_deltas,
+                has_tool_calls=has_tool_calls,
+                source="fallback Responses",
+            )
+            if recovered is not None:
+                return recovered
+        raise
     finally:
         close_fn = getattr(stream_or_response, "close", None)
         if callable(close_fn):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2515,6 +2515,63 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert fake_client.responses.kwargs["timeout"] == 12.5
         assert response.choices[0].message.content == "summary"
 
+    def test_recovers_when_sdk_stream_parser_crashes_on_null_output(self):
+        output_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="recovered auxiliary")],
+        )
+
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=output_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - crash happens during iteration
+                raise AssertionError("unreachable")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize"}])
+
+        assert response.choices[0].message.content == "recovered auxiliary"
+
+    def test_does_not_synthesize_text_after_custom_tool_call(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_text.delta", delta="incidental text")
+                yield SimpleNamespace(type="response.custom_tool_call.delta")
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - crash happens during iteration
+                raise AssertionError("unreachable")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        with pytest.raises(TypeError, match="NoneType"):
+            adapter.create(messages=[{"role": "user", "content": "summarize"}])
+
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
         class SlowAliveStream:
             def __enter__(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,11 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None, iter_error=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
+        self._iter_error = iter_error
 
     def __enter__(self):
         return self
@@ -166,7 +168,10 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        for event in self._events:
+            yield event
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -482,6 +487,60 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_when_sdk_parses_completed_null_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        role="assistant",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="Hello from stream")],
+    )
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.created"),
+                SimpleNamespace(type="response.in_progress"),
+                SimpleNamespace(type="response.output_item.done", item=output_item),
+            ],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.status == "completed"
+    assert response.output == [output_item]
+
+
+def test_run_codex_stream_does_not_synthesize_text_after_custom_tool_call(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="incidental text"),
+                SimpleNamespace(type="response.custom_tool_call.delta"),
+            ],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    with pytest.raises(TypeError, match="NoneType"):
+        agent._run_codex_stream(_codex_request_kwargs())
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary
- Recover Codex Responses streams when the OpenAI SDK crashes parsing a terminal payload with `output=null` after valid output items/text deltas were already streamed.
- Apply the same recovery path to auxiliary Codex streaming calls used by summarization/compression-style helpers.
- Guard against synthesizing plain text after any tool-call event, including custom tool calls.

## Test Plan
- `source venv/bin/activate && python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_recovers_when_sdk_parses_completed_null_output tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_does_not_synthesize_text_after_custom_tool_call tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_recovers_when_sdk_stream_parser_crashes_on_null_output tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_does_not_synthesize_text_after_custom_tool_call -q`
- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py`
