### PR TITLE
[codex] Recover Responses streams with null output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -115,6 +115,10 @@ def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
         return False
 
 
+def _is_response_output_none_iterable_error(exc: BaseException) -> bool:
+    return isinstance(exc, TypeError) and "'NoneType' object is not iterable" in str(exc)
+
+
 def _extract_url_query_params(url: str):
     """Extract query params from URL, return (clean_url, default_query dict or None)."""
     parsed = urlparse(url)
@@ -872,6 +876,65 @@ class _CodexCompletionsAdapter:
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc
+            if _is_response_output_none_iterable_error(exc):
+                if collected_output_items:
+                    def _recovered_get(obj: Any, key: str, default: Any = None) -> Any:
+                        val = getattr(obj, key, None)
+                        if val is None and isinstance(obj, dict):
+                            val = obj.get(key, default)
+                        return val if val is not None else default
+
+                    recovered_text_parts: List[str] = []
+                    recovered_tool_calls: List[Any] = []
+                    for item in collected_output_items:
+                        item_type = _recovered_get(item, "type")
+                        if item_type == "message":
+                            for part in (_recovered_get(item, "content") or []):
+                                ptype = _recovered_get(part, "type")
+                                if ptype in {"output_text", "text"}:
+                                    recovered_text_parts.append(_recovered_get(part, "text", ""))
+                        elif item_type == "function_call":
+                            recovered_tool_calls.append(SimpleNamespace(
+                                id=_recovered_get(item, "call_id", ""),
+                                type="function",
+                                function=SimpleNamespace(
+                                    name=_recovered_get(item, "name", ""),
+                                    arguments=_recovered_get(item, "arguments", "{}"),
+                                ),
+                            ))
+                    message = SimpleNamespace(
+                        role="assistant",
+                        content="".join(recovered_text_parts).strip() or None,
+                        tool_calls=recovered_tool_calls or None,
+                    )
+                    return SimpleNamespace(
+                        choices=[SimpleNamespace(
+                            index=0,
+                            message=message,
+                            finish_reason="tool_calls" if recovered_tool_calls else "stop",
+                        )],
+                        model=model,
+                        usage=None,
+                    )
+                elif collected_text_deltas and not has_function_calls:
+                    assembled = "".join(collected_text_deltas)
+                    logger.warning(
+                        "Codex auxiliary Responses stream final parse failed with output=None; "
+                        "recovering from %d text delta(s).",
+                        len(collected_text_deltas),
+                    )
+                    message = SimpleNamespace(
+                        role="assistant",
+                        content=assembled.strip() or None,
+                        tool_calls=None,
+                    )
+                    return SimpleNamespace(
+                        choices=[SimpleNamespace(index=0, message=message, finish_reason="stop")],
+                        model=model,
+                        usage=None,
+                    )
+                else:
+                    raise
             logger.debug("Codex auxiliary Responses API call failed: %s", exc)
             raise
         finally:

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -872,6 +872,18 @@ def _extract_responses_reasoning_text(item: Any) -> str:
     return ""
 
 
+def _safe_response_output_text(response: Any) -> str:
+    """Read Responses output_text without letting SDK property errors escape."""
+    try:
+        out_text = getattr(response, "output_text", None)
+    except Exception:
+        logger.debug("Could not read Responses output_text property", exc_info=True)
+        return ""
+    if isinstance(out_text, str):
+        return out_text.strip()
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Full response normalization
 # ---------------------------------------------------------------------------
@@ -883,15 +895,15 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         # The Codex backend can return empty output when the answer was
         # delivered entirely via stream events. Check output_text as a
         # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
-        if isinstance(out_text, str) and out_text.strip():
+        out_text = _safe_response_output_text(response)
+        if out_text:
             logger.debug(
                 "Codex response has empty output but output_text is present (%d chars); "
-                "synthesizing output item.", len(out_text.strip()),
+                "synthesizing output item.", len(out_text),
             )
             output = [SimpleNamespace(
                 type="message", role="assistant", status="completed",
-                content=[SimpleNamespace(type="output_text", text=out_text.strip())],
+                content=[SimpleNamespace(type="output_text", text=out_text)],
             )]
             response.output = output
         else:
@@ -917,6 +929,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     message_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
+    saw_message_item = False
     saw_commentary_phase = False
     saw_final_answer_phase = False
 
@@ -932,6 +945,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             has_incomplete_items = True
 
         if item_type == "message":
+            saw_message_item = True
             item_phase = getattr(item, "phase", None)
             normalized_phase = None
             if isinstance(item_phase, str):
@@ -1024,10 +1038,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
-        out_text = getattr(response, "output_text", "")
-        if isinstance(out_text, str):
-            final_text = out_text.strip()
+    if not final_text:
+        final_text = _safe_response_output_text(response)
 
     # ── Tool-call leak recovery ──────────────────────────────────
     # gpt-5.x on the Codex Responses API sometimes degenerates and emits
@@ -1075,6 +1087,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     elif leaked_tool_call_text:
         finish_reason = "incomplete"
     elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase):
+        finish_reason = "incomplete"
+    elif saw_message_item and not final_text:
         finish_reason = "incomplete"
     elif reasoning_items_raw and not final_text:
         # Response contains only reasoning (encrypted thinking state) with

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,25 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _is_response_output_none_iterable_error(exc: BaseException) -> bool:
+    return isinstance(exc, TypeError) and "'NoneType' object is not iterable" in str(exc)
+
+
+def _synthesize_text_response_from_deltas(text_parts: list, *, model: Any = None) -> Any:
+    assembled = "".join(text_parts)
+    return SimpleNamespace(
+        output=[SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text=assembled)],
+        )],
+        usage=None,
+        status="completed",
+        model=model,
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -271,6 +290,33 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            if _is_response_output_none_iterable_error(exc):
+                if collected_output_items:
+                    logger.warning(
+                        "Codex Responses stream final parse failed with output=None; "
+                        "recovering from %d collected output item(s). %s",
+                        len(collected_output_items),
+                        agent._client_log_context(),
+                    )
+                    return SimpleNamespace(
+                        output=list(collected_output_items),
+                        usage=None,
+                        status="completed",
+                        model=api_kwargs.get("model"),
+                    )
+                if agent._codex_streamed_text_parts and not has_tool_calls:
+                    logger.warning(
+                        "Codex Responses stream final parse failed with output=None; "
+                        "recovering from %d text delta(s). %s",
+                        len(agent._codex_streamed_text_parts),
+                        agent._client_log_context(),
+                    )
+                    return _synthesize_text_response_from_deltas(
+                        agent._codex_streamed_text_parts,
+                        model=api_kwargs.get("model"),
+                    )
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2515,6 +2515,38 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert fake_client.responses.kwargs["timeout"] == 12.5
         assert response.choices[0].message.content == "summary"
 
+    def test_recovers_text_delta_when_final_response_output_none_crashes(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter([
+                    SimpleNamespace(type="response.created"),
+                    SimpleNamespace(type="response.output_text.delta", delta="O"),
+                    SimpleNamespace(type="response.output_text.delta", delta="K"),
+                ])
+
+            def get_final_response(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "say ok"}],
+            timeout=12.5,
+        )
+
+        assert response.choices[0].message.content == "OK"
+
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
         class SlowAliveStream:
             def __enter__(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -166,7 +167,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -448,6 +449,34 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
     assert response.output[0].content[0].text == "create fallback ok"
 
 
+def test_run_codex_stream_synthesizes_text_when_final_response_output_none_crashes(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.created"),
+                SimpleNamespace(type="response.output_text.delta", delta="O"),
+                SimpleNamespace(type="response.output_text.delta", delta="K"),
+            ],
+            final_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls["stream"] == 1
+    assert response.output[0].content[0].text == "OK"
+
+
 def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"stream": 0, "create": 0}
@@ -517,6 +546,36 @@ def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):
 
     assert result["completed"] is True
     assert result["final_response"] == "Hello from Codex"
+
+
+def test_normalize_codex_response_ignores_broken_output_text_property(monkeypatch):
+    """Some SDK response objects raise while computing output_text."""
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    class BrokenOutputTextResponse:
+        status = "completed"
+        model = "gpt-5-codex"
+
+        def __init__(self):
+            self.output = [
+                SimpleNamespace(
+                    type="message",
+                    status="completed",
+                    content=None,
+                )
+            ]
+
+        @property
+        def output_text(self):
+            for item in self.output:
+                for part in item.content:
+                    return getattr(part, "text", "")
+            return ""
+
+    assistant_message, finish_reason = _normalize_codex_response(BrokenOutputTextResponse())
+
+    assert assistant_message.content == ""
+    assert finish_reason == "incomplete"
 
 
 def test_run_conversation_codex_empty_output_no_output_text_retries(monkeypatch):


### PR DESCRIPTION
## Summary

This PR hardens the Codex Responses streaming path against providers that stream valid `response.output_text.delta` events but send a final `response.completed` payload whose `output` is `null`.

The OpenAI SDK can raise `TypeError: 'NoneType' object is not iterable` while parsing `stream.get_final_response()` in that case, before Hermes reaches the normal Responses normalization layer. This causes gateway/Discord turns and auxiliary vision/compression calls to fail even though usable text deltas were already received.

Changes:

- Recover main Codex Responses streams in `agent/codex_runtime.py` by synthesizing a message response from collected output items or text deltas when this specific SDK parse failure occurs.
- Apply the same recovery to the auxiliary Codex adapter in `agent/auxiliary_client.py`.
- Keep a defensive normalization guard in `agent/codex_responses_adapter.py` for broken `output_text` properties on final response objects.
- Add regression coverage for both main agent streaming and auxiliary streaming recovery.

## Validation

- `/Users/brisbane/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q` -> `67 passed, 1 warning`
- `/Users/brisbane/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_streaming.py -q` -> `40 passed, 1 warning`
- `/Users/brisbane/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q` -> `177 passed, 1 warning`
- Local smoke test: `hermes -z '只回复 OK 两个字母，不要调用工具。' --ignore-rules` returned `OK`.