### PR TITLE
fix(codex): handle output=null in response.completed from chatgpt.com backend

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -194,64 +194,83 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         collected_output_items: list = []
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
-                for event in stream:
-                    # Mark stream activity for the TTFB watchdog in
-                    # interruptible_api_call. The Codex backend can accept the
-                    # connection but never emit a single event; this timestamp
-                    # staying None tells the watchdog no bytes are flowing.
-                    agent._codex_stream_last_event_ts = time.time()
-                    agent._touch_activity("receiving stream response")
-                    if agent._interrupt_requested:
-                        break
-                    event_type = getattr(event, "type", "")
-                    # Fire callbacks on text content deltas (suppress during tool calls)
-                    if "output_text.delta" in event_type or event_type == "response.output_text.delta":
-                        delta_text = getattr(event, "delta", "")
-                        if delta_text:
-                            agent._codex_streamed_text_parts.append(delta_text)
-                        if delta_text and not has_tool_calls:
-                            if not first_delta_fired:
-                                first_delta_fired = True
-                                if on_first_delta:
-                                    try:
-                                        on_first_delta()
-                                    except Exception:
-                                        pass
-                            agent._fire_stream_delta(delta_text)
-                    # Track tool calls to suppress text streaming
-                    elif "function_call" in event_type:
-                        has_tool_calls = True
-                    # Fire reasoning callbacks
-                    elif "reasoning" in event_type and "delta" in event_type:
-                        reasoning_text = getattr(event, "delta", "")
-                        if reasoning_text:
-                            agent._fire_reasoning_delta(reasoning_text)
-                    # Collect completed output items — some backends
-                    # (chatgpt.com/backend-api/codex) stream valid items
-                    # via response.output_item.done but the SDK's
-                    # get_final_response() returns an empty output list.
-                    elif event_type == "response.output_item.done":
-                        done_item = getattr(event, "item", None)
-                        if done_item is not None:
-                            collected_output_items.append(done_item)
-                    # Log non-completed terminal events for diagnostics
-                    elif event_type in {"response.incomplete", "response.failed"}:
-                        resp_obj = getattr(event, "response", None)
-                        status = getattr(resp_obj, "status", None) if resp_obj else None
-                        incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
-                        logger.warning(
-                            "Codex Responses stream received terminal event %s "
-                            "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
-                            event_type, status, incomplete_details,
-                            sum(len(p) for p in agent._codex_streamed_text_parts),
-                            agent._client_log_context(),
-                        )
-                final_response = stream.get_final_response()
+                try:
+                    for event in stream:
+                        # Mark stream activity for the TTFB watchdog in
+                        # interruptible_api_call. The Codex backend can accept the
+                        # connection but never emit a single event; this timestamp
+                        # staying None tells the watchdog no bytes are flowing.
+                        agent._codex_stream_last_event_ts = time.time()
+                        agent._touch_activity("receiving stream response")
+                        if agent._interrupt_requested:
+                            break
+                        event_type = getattr(event, "type", "")
+                        # Fire callbacks on text content deltas (suppress during tool calls)
+                        if "output_text.delta" in event_type or event_type == "response.output_text.delta":
+                            delta_text = getattr(event, "delta", "")
+                            if delta_text:
+                                agent._codex_streamed_text_parts.append(delta_text)
+                            if delta_text and not has_tool_calls:
+                                if not first_delta_fired:
+                                    first_delta_fired = True
+                                    if on_first_delta:
+                                        try:
+                                            on_first_delta()
+                                        except Exception:
+                                            pass
+                                agent._fire_stream_delta(delta_text)
+                        # Track tool calls to suppress text streaming
+                        elif "function_call" in event_type:
+                            has_tool_calls = True
+                        # Fire reasoning callbacks
+                        elif "reasoning" in event_type and "delta" in event_type:
+                            reasoning_text = getattr(event, "delta", "")
+                            if reasoning_text:
+                                agent._fire_reasoning_delta(reasoning_text)
+                        # Collect completed output items — some backends
+                        # (chatgpt.com/backend-api/codex) stream valid items
+                        # via response.output_item.done but the SDK's
+                        # get_final_response() returns an empty output list.
+                        elif event_type == "response.output_item.done":
+                            done_item = getattr(event, "item", None)
+                            if done_item is not None:
+                                collected_output_items.append(done_item)
+                        # Log non-completed terminal events for diagnostics
+                        elif event_type in {"response.incomplete", "response.failed"}:
+                            resp_obj = getattr(event, "response", None)
+                            status = getattr(resp_obj, "status", None) if resp_obj else None
+                            incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
+                            logger.warning(
+                                "Codex Responses stream received terminal event %s "
+                                "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
+                                event_type, status, incomplete_details,
+                                sum(len(p) for p in agent._codex_streamed_text_parts),
+                                agent._client_log_context(),
+                            )
+                except TypeError as _stream_te:
+                    # The chatgpt.com backend occasionally sends a
+                    # response.completed event with output=null instead of
+                    # output=[]. The OpenAI SDK's parse_response() iterates
+                    # response.output without a null-guard, raising TypeError.
+                    # Swallow it here so collected items can be used for backfill.
+                    logger.debug(
+                        "Codex stream: TypeError during event iteration "
+                        "(chatgpt.com sent output=null in response.completed); "
+                        "falling back to collected items. error=%s",
+                        _stream_te,
+                    )
+                try:
+                    final_response = stream.get_final_response()
+                except RuntimeError:
+                    # No response.completed was fully processed (TypeError
+                    # interrupted it). Synthesize a bare response so the
+                    # backfill below can recover from collected items.
+                    final_response = SimpleNamespace(output=None, output_text=None)
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if not isinstance(_out, list) or not _out:
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -414,7 +433,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if not isinstance(_out, list) or not _out:
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(


### PR DESCRIPTION
## Problem

The `chatgpt.com/backend-api/codex` endpoint recently changed behavior: it now sends `response.completed` stream events with `output: null` instead of `output: []`.

The OpenAI SDK's `parse_response()` does:
```python
for output in response.output:  # TypeError when output is null
```

This `TypeError: 'NoneType' object is not iterable` bubbled up through `run_codex_stream` and was caught by the outer error handler, which correctly classifies `TypeError` as a non-retryable local programming bug. The result: **every message to gpt-5.5 via chatgpt.com fails immediately** — both interactive sessions and cron jobs, even with a single-message context.

## Root Cause

`is_given(None)` returns `True` in the SDK, so `None` passes the "was a value provided?" check but then crashes anything that iterates it. The `response.output_item.done` events streaming the actual output items arrive **before** `response.completed`, so the content is already in `collected_output_items` — it just never gets backfilled because the TypeError kills the stream before reaching the backfill code.

## Fix

Three changes to `agent/codex_runtime.py`:

1. **Wrap `for event in stream:` in `try/except TypeError`** — absorbs the SDK crash gracefully. The already-collected `collected_output_items` and `_codex_streamed_text_parts` remain usable.

2. **Wrap `stream.get_final_response()` in `try/except RuntimeError`** — when the `response.completed` handler was interrupted by TypeError, `_completed_response` is never set, so `get_final_response()` raises `RuntimeError("Didn't receive a response.completed event.")`. Fall back to a bare `SimpleNamespace` so the backfill below can take over.

3. **Extend both backfill conditions** from `isinstance(_out, list) and not _out` → `not isinstance(_out, list) or not _out` — handles `output=null` the same way as `output=[]` in both `run_codex_stream` and `run_codex_create_stream_fallback`.

## Verification

Confirmed fix on gpt-5.5 via `chatgpt.com/backend-api/codex`:
- Error was reliably reproducible on every message (both 139-message sessions and fresh single-message cron jobs)
- After applying this fix locally, responses are processed correctly using the `collected_output_items` backfill path