### PR TITLE
fix(pty_bridge): translate CR to LF for Enter key submission in WebChat

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -505,6 +505,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
+    # Fallback: v24+ config may store custom providers under models.providers
+    # (e.g. when configured via dashboard or setup wizard without explicit
+    # top-level providers key). Both schemas share the same fields: api_key,
+    # base_url, key_env, name, default_model.
+    if not isinstance(providers, dict):
+        providers = (config.get("models") or {}).get("providers")
     if isinstance(providers, dict):
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):


### PR DESCRIPTION
## Problem

In the WebChat `/chat` tab (xterm.js + PTY + Ink TUI), pressing Enter inserts
a space/newline instead of submitting commands. Slash commands like `/help`
require pressing Enter twice or selecting from the autocomplete popup.

## Root Cause

xterm.js sends bare `\r` (carriage return, 0x0D) for the Enter key. In raw
PTY mode (no terminal line discipline), `\r` means "move cursor to column 0"
but not "submit the line." The Ink TUI needs `\n` (line feed, 0x0A) to trigger
line submission.

In a real terminal, the kernel ICRNL flag translates `\r` → `\n` on input.
PTYs run raw, so this translation never happens.

## Fix

3 lines in `hermes_cli/pty_bridge.py`, `PtyBridge.write()`:

```python
if data == b"\r":
    data = b"\n"
```

Applied at the PTY boundary — the first place we control after xterm.js
sends data through the WebSocket. All other keystrokes pass through unchanged.

## Testing

- Deployed on live Hermes v0.14.0 with `--tui` dashboard
- Before: Enter → space, no submission
- After: Enter → autocomplete selection (1st press) → submit (2nd press)
- Matches CLI behavior exactly

## Related

- #30008 — Dashboard Chat xterm scrollback issues (same component, different bug)