### PR TITLE
fix(codex): recover from NoneType crash when response.output is null on stream completion

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -335,6 +335,50 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 )
                 return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             raise
+        except TypeError as exc:
+            # OpenAI/Codex can stream valid output_item.done frames but
+            # omit response.output on response.completed.  openai-python
+            # then crashes parsing the completed frame before
+            # get_final_response() returns.  Recover from the items or
+            # deltas we already collected instead of surfacing a
+            # non-retryable TypeError to the caller.
+            err_text = str(exc)
+            if "'NoneType' object is not iterable" not in err_text:
+                raise
+            if collected_output_items:
+                logger.warning(
+                    "Codex stream completed without response.output; "
+                    "recovering from %d streamed output items. %s",
+                    len(collected_output_items),
+                    agent._client_log_context(),
+                )
+                return SimpleNamespace(
+                    output=list(collected_output_items),
+                    status="completed",
+                    model=api_kwargs.get("model"),
+                    usage=None,
+                )
+            if agent._codex_streamed_text_parts and not has_tool_calls:
+                assembled = "".join(agent._codex_streamed_text_parts)
+                logger.warning(
+                    "Codex stream completed without response.output; "
+                    "recovering from %d text deltas (%d chars). %s",
+                    len(agent._codex_streamed_text_parts),
+                    len(assembled),
+                    agent._client_log_context(),
+                )
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        role="assistant",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text=assembled)],
+                    )],
+                    status="completed",
+                    model=api_kwargs.get("model"),
+                    usage=None,
+                )
+            raise
 
 
 


### PR DESCRIPTION
OpenAI Codex can stream valid response.output_item.done frames but omit response.output on the final response.completed frame. openai-python then raises TypeError while parsing the completed frame — before Hermes can use the data it already received.

Because TypeError is classified as a local validation error (is_local_validation_error), the conversation loop treats it as non-retryable and aborts immediately instead of falling back.

This patch catches that specific TypeError in run_codex_stream and reassembles the response from collected_output_items (preferred) or _codex_streamed_text_parts (text-delta fallback) — the same recovery paths already used for empty response.output. Unrelated TypeErrors are re-raised unchanged.

Verified in production: logs show "Codex stream completed without response.output; recovering from N streamed output items" instead of hard failures.

Refs: #11179, #21444