### PR TITLE
fix(codex): recover from null-output stream snapshots

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,36 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _codex_partial_response_from_stream(
+    agent,
+    *,
+    collected_output_items: list,
+    has_tool_calls: bool,
+) -> Any:
+    """Build a minimal response from items/text already observed on a stream."""
+    if collected_output_items:
+        return SimpleNamespace(
+            output=list(collected_output_items),
+            status="completed",
+            model=getattr(agent, "model", None),
+        )
+    if agent._codex_streamed_text_parts and not has_tool_calls:
+        assembled = "".join(agent._codex_streamed_text_parts)
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text=assembled)],
+                )
+            ],
+            status="completed",
+            model=getattr(agent, "model", None),
+        )
+    return None
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -271,6 +301,24 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            err_text = str(exc)
+            if "'NoneType' object is not iterable" in err_text:
+                partial_response = _codex_partial_response_from_stream(
+                    agent,
+                    collected_output_items=collected_output_items,
+                    has_tool_calls=has_tool_calls,
+                )
+                if partial_response is not None:
+                    logger.warning(
+                        "Codex Responses stream parser received terminal response with output=None; "
+                        "recovered from %d collected item(s), streamed_chars=%d. %s",
+                        len(collected_output_items),
+                        sum(len(p) for p in agent._codex_streamed_text_parts),
+                        agent._client_log_context(),
+                    )
+                    return partial_response
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -186,6 +186,26 @@ class _FakeCreateStream:
         self.closed = True
 
 
+class _FakeResponsesStreamRaisesWhileIterating:
+    def __init__(self, events, error):
+        self._events = list(events)
+        self._error = error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+        raise self._error
+
+    def get_final_response(self):  # pragma: no cover - iterator raises first
+        raise AssertionError("get_final_response should not be reached")
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -482,6 +502,30 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_when_completed_snapshot_has_null_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    done_item = SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text="stream recovered")],
+    )
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStreamRaisesWhileIterating(
+            [SimpleNamespace(type="response.output_item.done", item=done_item)],
+            TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.output == [done_item]
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary
- recover Codex Responses streams when the OpenAI SDK crashes parsing a terminal response snapshot with output=None
- reuse collected response.output_item.done items or streamed text instead of failing over through every model
- add a regression test for the SDK TypeError path

## Validation
- /home/peter/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts="-m 'not integration'" tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_recovers_when_completed_snapshot_has_null_output tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_fallback_parses_create_stream_events -q
- Real Hermes Codex one-shot returned OK locally after patch