### PR TITLE
fix(codex): tolerate None output responses

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -815,7 +815,7 @@ class _CodexCompletionsAdapter:
 
             # Backfill empty output from collected stream events
             _output = getattr(final, "output", None)
-            if not isinstance(_output, list) or not _output:
+            if _output is None or (isinstance(_output, list) and not _output):
                 if collected_output_items:
                     final.output = list(collected_output_items)
                     logger.debug(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -815,7 +815,7 @@ class _CodexCompletionsAdapter:
 
             # Backfill empty output from collected stream events
             _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
+            if not isinstance(_output, list) or not _output:
                 if collected_output_items:
                     final.output = list(collected_output_items)
                     logger.debug(

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -838,6 +838,23 @@ def _preflight_codex_api_kwargs(
 # Response extraction helpers
 # ---------------------------------------------------------------------------
 
+def _safe_get_response_output_text(response: Any, default: str = "") -> str:
+    """Read SDK ``response.output_text`` without letting output=None crash.
+
+    Recent OpenAI SDK builds compute ``output_text`` by iterating
+    ``response.output``. Some terminal ChatGPT Codex responses carry
+    ``output=None``, so the property itself raises TypeError before Hermes can
+    classify the upstream response.
+    """
+    try:
+        out_text = getattr(response, "output_text", default)
+    except TypeError as exc:
+        if "'NoneType' object is not iterable" not in str(exc):
+            raise
+        return default
+    return out_text if isinstance(out_text, str) else default
+
+
 def _extract_responses_message_text(item: Any) -> str:
     """Extract assistant text from a Responses message output item."""
     content = getattr(item, "content", None)
@@ -883,7 +900,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         # The Codex backend can return empty output when the answer was
         # delivered entirely via stream events. Check output_text as a
         # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
+        out_text = _safe_get_response_output_text(response)
         if isinstance(out_text, str) and out_text.strip():
             logger.debug(
                 "Codex response has empty output but output_text is present (%d chars); "
@@ -1024,10 +1041,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
-        out_text = getattr(response, "output_text", "")
-        if isinstance(out_text, str):
-            final_text = out_text.strip()
+    if not final_text:
+        final_text = _safe_get_response_output_text(response).strip()
 
     # ── Tool-call leak recovery ──────────────────────────────────
     # gpt-5.x on the Codex Responses API sometimes degenerates and emits

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -251,7 +251,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if not isinstance(_out, list) or not _out:
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -330,6 +330,26 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 logger.debug(
                     "Responses stream %s; falling back to create(stream=True). %s err=%s",
                     "rejected before response.created" if prelude_error else "did not emit response.completed",
+                    agent._client_log_context(),
+                    err_text,
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
+        except TypeError as exc:
+            err_text = str(exc)
+            sdk_output_none = "'NoneType' object is not iterable" in err_text
+            if sdk_output_none and attempt < max_stream_retries:
+                logger.debug(
+                    "Responses stream parser hit output=None "
+                    "(attempt %s/%s); retrying. %s",
+                    attempt + 1,
+                    max_stream_retries + 1,
+                    agent._client_log_context(),
+                )
+                continue
+            if sdk_output_none:
+                logger.debug(
+                    "Responses stream parser hit output=None; falling back to create(stream=True). %s err=%s",
                     agent._client_log_context(),
                     err_text,
                 )
@@ -414,7 +434,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if not isinstance(_out, list) or not _out:
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,11 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _needs_output_backfill(output: Any) -> bool:
+    """Return true only for backend shapes known to lose streamed output."""
+    return output is None or (isinstance(output, list) and not output)
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -251,7 +256,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if not isinstance(_out, list) or not _out:
+                if _needs_output_backfill(_out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -337,7 +342,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             raise
         except TypeError as exc:
             err_text = str(exc)
-            sdk_output_none = "'NoneType' object is not iterable" in err_text
+            sdk_output_none = exc.args == ("'NoneType' object is not iterable",)
             if sdk_output_none and attempt < max_stream_retries:
                 logger.debug(
                     "Responses stream parser hit output=None "
@@ -434,7 +439,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if not isinstance(_out, list) or not _out:
+                if _needs_output_backfill(_out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -29,7 +29,10 @@ from typing import Any, Dict, List, Optional
 
 from agent.anthropic_adapter import _is_oauth_token
 from agent.auxiliary_client import set_runtime_main
-from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.codex_responses_adapter import (
+    _safe_get_response_output_text,
+    _summarize_user_message_for_log,
+)
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
@@ -1224,7 +1227,6 @@ def run_conversation(
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
-                                from agent.codex_responses_adapter import _safe_get_response_output_text
                                 _out_text = _safe_get_response_output_text(response)
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1224,7 +1224,8 @@ def run_conversation(
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
-                                _out_text = getattr(response, "output_text", None)
+                                from agent.codex_responses_adapter import _safe_get_response_output_text
+                                _out_text = _safe_get_response_output_text(response)
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:
                                     logger.debug(

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -101,10 +101,10 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
             ),
-            "tools": response_tools,
             "store": False,
         }
         if response_tools:
+            kwargs["tools"] = response_tools
             kwargs["tool_choice"] = "auto"
             kwargs["parallel_tool_calls"] = True
 

--- a/tests/agent/test_codex_runtime.py
+++ b/tests/agent/test_codex_runtime.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+import pytest
+
+
+class _StreamRaisesNoneOutputTypeError:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        raise TypeError("'NoneType' object is not iterable")
+
+
+class _StreamRaisesOtherTypeError:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        raise TypeError("different type error")
+
+
+class _FakeResponses:
+    def __init__(self, stream):
+        self._stream = stream
+
+    def stream(self, **kwargs):
+        return self._stream
+
+
+class _FakeAgent:
+    _interrupt_requested = False
+    _codex_streamed_text_parts = []
+
+    def __init__(self):
+        self.fallback_calls = []
+
+    def _touch_activity(self, *_args, **_kwargs):
+        pass
+
+    def _fire_stream_delta(self, *_args, **_kwargs):
+        pass
+
+    def _fire_reasoning_delta(self, *_args, **_kwargs):
+        pass
+
+    def _client_log_context(self):
+        return "provider=openai-codex"
+
+    def _run_codex_create_stream_fallback(self, api_kwargs, client=None):
+        self.fallback_calls.append((api_kwargs, client))
+        return SimpleNamespace(status="failed", output=None)
+
+
+def test_codex_stream_falls_back_when_sdk_parser_sees_output_none():
+    from agent.codex_runtime import run_codex_stream
+
+    agent = _FakeAgent()
+    client = SimpleNamespace(responses=_FakeResponses(_StreamRaisesNoneOutputTypeError()))
+    response = run_codex_stream(agent, {"model": "gpt-5.5"}, client=client)
+
+    assert response.status == "failed"
+    assert agent.fallback_calls == [({"model": "gpt-5.5"}, client)]
+
+
+def test_codex_stream_does_not_swallow_unrelated_type_error():
+    from agent.codex_runtime import run_codex_stream
+
+    agent = _FakeAgent()
+    client = SimpleNamespace(responses=_FakeResponses(_StreamRaisesOtherTypeError()))
+
+    with pytest.raises(TypeError, match="different type error"):
+        run_codex_stream(agent, {"model": "gpt-5.5"}, client=client)
+
+    assert agent.fallback_calls == []

--- a/tests/agent/test_codex_runtime.py
+++ b/tests/agent/test_codex_runtime.py
@@ -34,10 +34,9 @@ class _FakeResponses:
 
 
 class _FakeAgent:
-    _interrupt_requested = False
-    _codex_streamed_text_parts = []
-
     def __init__(self):
+        self._interrupt_requested = False
+        self._codex_streamed_text_parts = []
         self.fallback_calls = []
 
     def _touch_activity(self, *_args, **_kwargs):
@@ -78,3 +77,12 @@ def test_codex_stream_does_not_swallow_unrelated_type_error():
         run_codex_stream(agent, {"model": "gpt-5.5"}, client=client)
 
     assert agent.fallback_calls == []
+
+
+def test_output_backfill_keeps_non_empty_non_list_output():
+    from agent.codex_runtime import _needs_output_backfill
+
+    assert _needs_output_backfill(None)
+    assert _needs_output_backfill([])
+    assert not _needs_output_backfill([SimpleNamespace(type="message")])
+    assert not _needs_output_backfill((SimpleNamespace(type="message"),))

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -54,6 +54,20 @@ class TestCodexBuildKwargs:
         assert "input" in kw
         assert kw["store"] is False
 
+    def test_omits_tools_when_no_tools_are_available(self, transport):
+        messages = [{"role": "user", "content": "Hello"}]
+
+        assert "tools" not in transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=None,
+        )
+        assert "tools" not in transport.build_kwargs(
+            model="gpt-5.5",
+            messages=messages,
+            tools=[],
+        )
+
     def test_system_extracted_from_messages(self, transport):
         messages = [
             {"role": "system", "content": "Custom system prompt"},
@@ -397,6 +411,22 @@ class TestCodexNormalizeResponse:
         assert isinstance(nr, NormalizedResponse)
         assert nr.content == "Hello world"
         assert nr.finish_reason == "stop"
+
+    def test_output_none_does_not_crash_output_text_property(self, transport):
+        class ResponseWithSdkOutputTextProperty:
+            output = None
+            status = "completed"
+            incomplete_details = None
+            usage = None
+
+            @property
+            def output_text(self):
+                for _output in self.output:
+                    pass
+                return "unreachable"
+
+        with pytest.raises(RuntimeError, match="Responses API returned no output items"):
+            transport.normalize_response(ResponseWithSdkOutputTextProperty())
 
     def test_message_items_preserved_in_provider_data(self, transport):
         """Codex assistant message item ids/phases must survive transport normalization."""


### PR DESCRIPTION
## Summary
- omit null tools from Codex Responses kwargs so the OpenAI SDK does not iterate None
- route SDK output=None parser TypeErrors through the existing raw stream fallback
- safely read output_text when SDK response.output is None
- backfill stream output for both output=[] and output=None in main and auxiliary Codex paths

## Verification
- `venv/bin/python -m pytest tests/agent/transports/test_codex_transport.py tests/agent/test_codex_runtime.py tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout -q`
- Live smoke: Hermes `openai-codex`/`gpt-5.5` no longer aborts with `TypeError: 'NoneType' object is not iterable`; current upstream returns empty `response.output` and Hermes reports that as an invalid API response after retries instead of masking it as NoneType.
