### PR TITLE
feat(session_context): add set/reset_current_turn_session_key public wrappers

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -36,36 +36,42 @@ needs to replace the import + call site:
     platform = get_session_env("HERMES_SESSION_PLATFORM", "")
 """
 
+from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from typing import Optional, cast
+from typing import Iterator, Optional
+
+class _UnsetType:
+    def __repr__(self) -> str:
+        return "<UNSET>"
+
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
 # When it holds "" (after clear_session_vars resets it), we return "" — no fallback.
-_UNSET: object = object()
+_UNSET = _UnsetType()
 
 # ---------------------------------------------------------------------------
 # Per-task session variables
 # ---------------------------------------------------------------------------
 
-_SESSION_PLATFORM: ContextVar[object] = ContextVar("HERMES_SESSION_PLATFORM", default=_UNSET)
-_SESSION_CHAT_ID: ContextVar[object] = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
-_SESSION_CHAT_NAME: ContextVar[object] = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
-_SESSION_THREAD_ID: ContextVar[object] = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
-_SESSION_USER_ID: ContextVar[object] = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
-_SESSION_USER_NAME: ContextVar[object] = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
-_SESSION_KEY: ContextVar[object] = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
-_SESSION_ID: ContextVar[object] = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+_SESSION_PLATFORM: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_PLATFORM", default=_UNSET)
+_SESSION_CHAT_ID: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
+_SESSION_CHAT_NAME: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
+_SESSION_THREAD_ID: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
+_SESSION_USER_ID: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
+_SESSION_USER_NAME: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
+_SESSION_KEY: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
+_SESSION_ID: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # ID of the message that triggered the current turn. Used as a reply anchor
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).
-_SESSION_MESSAGE_ID: ContextVar[object] = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
+_SESSION_MESSAGE_ID: ContextVar[str | _UnsetType] = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
-_CRON_AUTO_DELIVER_PLATFORM: ContextVar[object] = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
-_CRON_AUTO_DELIVER_CHAT_ID: ContextVar[object] = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
-_CRON_AUTO_DELIVER_THREAD_ID: ContextVar[object] = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
+_CRON_AUTO_DELIVER_PLATFORM: ContextVar[str | _UnsetType] = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
+_CRON_AUTO_DELIVER_CHAT_ID: ContextVar[str | _UnsetType] = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
+_CRON_AUTO_DELIVER_THREAD_ID: ContextVar[str | _UnsetType] = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -98,7 +104,7 @@ def set_current_session_id(session_id: str) -> None:
     _SESSION_ID.set(session_id)
 
 
-def set_current_turn_session_key(session_key: Optional[str]) -> Token[object]:
+def set_current_turn_session_key(session_key: Optional[str]) -> Token[str | _UnsetType]:
     """Bind the per-turn session-identity ContextVar to ``session_key``.
 
     Accepts ``None`` (treated as empty string) so server-initiated turns can
@@ -125,13 +131,23 @@ def set_current_turn_session_key(session_key: Optional[str]) -> Token[object]:
     return _SESSION_KEY.set(session_key or "")
 
 
-def reset_current_turn_session_key(token: Token[object]) -> None:
+def reset_current_turn_session_key(token: Token[str | _UnsetType]) -> None:
     """Reset the per-turn session-identity ContextVar.
 
     Pair with :func:`set_current_turn_session_key` in a ``finally``
     clause.
     """
     _SESSION_KEY.reset(token)
+
+
+@contextmanager
+def turn_session_key(session_key: Optional[str]) -> Iterator[None]:
+    """Context manager wrapper around the public per-turn session-key setters."""
+    token = set_current_turn_session_key(session_key)
+    try:
+        yield
+    finally:
+        reset_current_turn_session_key(token)
 
 
 def set_session_vars(
@@ -209,7 +225,7 @@ def get_session_env(name: str, default: str = "") -> str:
     var = _VAR_MAP.get(name)
     if var is not None:
         value = var.get()
-        if value is not _UNSET:
-            return cast(str, value)
+        if isinstance(value, str):
+            return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -37,7 +37,7 @@ needs to replace the import + call site:
 """
 
 from contextvars import ContextVar, Token
-from typing import Any
+from typing import Any, Optional
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
@@ -98,10 +98,12 @@ def set_current_session_id(session_id: str) -> None:
     _SESSION_ID.set(session_id)
 
 
-def set_current_turn_session_key(session_key: str) -> Token:
+def set_current_turn_session_key(session_key: Optional[str]) -> Token[str]:
     """Bind the per-turn session-identity ContextVar to ``session_key``.
 
-    Returns the :class:`contextvars.Token`; callers MUST pass it to
+    Accepts ``None`` (treated as empty string) so server-initiated turns can
+    pass through whatever they have without a pre-check; returns the
+    :class:`contextvars.Token` that callers MUST pass to
     :func:`reset_current_turn_session_key` in a ``finally`` clause.
 
     Public wrapper for the per-turn session-identity binding used by
@@ -109,20 +111,21 @@ def set_current_turn_session_key(session_key: str) -> Token:
     callers do not need to import ``_SESSION_KEY`` directly.
 
     Mirror of the pattern at ``tools/approval.py`` for the
-    approval-session ContextVar; intentionally NAMED DISTINCTLY
-    (``turn_session`` vs ``session``) because the two ContextVars
+    approval-session ContextVar; the public API here is intentionally
+    named with the ``turn_session_key`` suffix (and binds the
+    ``_SESSION_KEY`` ContextVar) because the two ContextVars
     carry different concerns:
 
     * approval-session: identifies the human/policy session that
       approves tool calls (``tools/approval.py:_approval_session_key``).
-    * per-turn session: identifies the agent turn / chat session for
-      downstream model-resolve, stream routing, and persistence
-      (this module's ``_SESSION_KEY``).
+    * per-turn session (``_SESSION_KEY`` in this module): identifies the
+      agent turn / chat session for downstream model-resolve, stream
+      routing, and persistence.
     """
     return _SESSION_KEY.set(session_key or "")
 
 
-def reset_current_turn_session_key(token: Token) -> None:
+def reset_current_turn_session_key(token: Token[str]) -> None:
     """Reset the per-turn session-identity ContextVar.
 
     Pair with :func:`set_current_turn_session_key` in a ``finally``

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -36,7 +36,7 @@ needs to replace the import + call site:
     platform = get_session_env("HERMES_SESSION_PLATFORM", "")
 """
 
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 from typing import Any
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
@@ -96,6 +96,39 @@ def set_current_session_id(session_id: str) -> None:
 
     os.environ["HERMES_SESSION_ID"] = session_id
     _SESSION_ID.set(session_id)
+
+
+def set_current_turn_session_key(session_key: str) -> Token:
+    """Bind the per-turn session-identity ContextVar to ``session_key``.
+
+    Returns the :class:`contextvars.Token`; callers MUST pass it to
+    :func:`reset_current_turn_session_key` in a ``finally`` clause.
+
+    Public wrapper for the per-turn session-identity binding used by
+    server-initiated agent turns (e.g. completion-time wakeups) so
+    callers do not need to import ``_SESSION_KEY`` directly.
+
+    Mirror of the pattern at ``tools/approval.py`` for the
+    approval-session ContextVar; intentionally NAMED DISTINCTLY
+    (``turn_session`` vs ``session``) because the two ContextVars
+    carry different concerns:
+
+    * approval-session: identifies the human/policy session that
+      approves tool calls (``tools/approval.py:_approval_session_key``).
+    * per-turn session: identifies the agent turn / chat session for
+      downstream model-resolve, stream routing, and persistence
+      (this module's ``_SESSION_KEY``).
+    """
+    return _SESSION_KEY.set(session_key or "")
+
+
+def reset_current_turn_session_key(token: Token) -> None:
+    """Reset the per-turn session-identity ContextVar.
+
+    Pair with :func:`set_current_turn_session_key` in a ``finally``
+    clause.
+    """
+    _SESSION_KEY.reset(token)
 
 
 def set_session_vars(

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -37,35 +37,35 @@ needs to replace the import + call site:
 """
 
 from contextvars import ContextVar, Token
-from typing import Any, Optional
+from typing import Optional, cast
 
 # Sentinel to distinguish "never set in this context" from "explicitly set to empty".
 # When a contextvar holds _UNSET, we fall back to os.environ (CLI/cron compat).
 # When it holds "" (after clear_session_vars resets it), we return "" — no fallback.
-_UNSET: Any = object()
+_UNSET: object = object()
 
 # ---------------------------------------------------------------------------
 # Per-task session variables
 # ---------------------------------------------------------------------------
 
-_SESSION_PLATFORM: ContextVar = ContextVar("HERMES_SESSION_PLATFORM", default=_UNSET)
-_SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
-_SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
-_SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
-_SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
-_SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
-_SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
-_SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+_SESSION_PLATFORM: ContextVar[object] = ContextVar("HERMES_SESSION_PLATFORM", default=_UNSET)
+_SESSION_CHAT_ID: ContextVar[object] = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
+_SESSION_CHAT_NAME: ContextVar[object] = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
+_SESSION_THREAD_ID: ContextVar[object] = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
+_SESSION_USER_ID: ContextVar[object] = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
+_SESSION_USER_NAME: ContextVar[object] = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
+_SESSION_KEY: ContextVar[object] = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
+_SESSION_ID: ContextVar[object] = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 # ID of the message that triggered the current turn. Used as a reply anchor
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).
-_SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
+_SESSION_MESSAGE_ID: ContextVar[object] = ContextVar("HERMES_SESSION_MESSAGE_ID", default=_UNSET)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
-_CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
-_CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
-_CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
+_CRON_AUTO_DELIVER_PLATFORM: ContextVar[object] = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
+_CRON_AUTO_DELIVER_CHAT_ID: ContextVar[object] = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
+_CRON_AUTO_DELIVER_THREAD_ID: ContextVar[object] = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -98,7 +98,7 @@ def set_current_session_id(session_id: str) -> None:
     _SESSION_ID.set(session_id)
 
 
-def set_current_turn_session_key(session_key: Optional[str]) -> Token[str]:
+def set_current_turn_session_key(session_key: Optional[str]) -> Token[object]:
     """Bind the per-turn session-identity ContextVar to ``session_key``.
 
     Accepts ``None`` (treated as empty string) so server-initiated turns can
@@ -125,7 +125,7 @@ def set_current_turn_session_key(session_key: Optional[str]) -> Token[str]:
     return _SESSION_KEY.set(session_key or "")
 
 
-def reset_current_turn_session_key(token: Token[str]) -> None:
+def reset_current_turn_session_key(token: Token[object]) -> None:
     """Reset the per-turn session-identity ContextVar.
 
     Pair with :func:`set_current_turn_session_key` in a ``finally``
@@ -210,6 +210,6 @@ def get_session_env(name: str, default: str = "") -> str:
     if var is not None:
         value = var.get()
         if value is not _UNSET:
-            return value
+            return cast(str, value)
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)

--- a/tests/test_session_context_public_turn_setters.py
+++ b/tests/test_session_context_public_turn_setters.py
@@ -9,8 +9,9 @@ ContextVar (``_approval_session_key`` in tools.approval).
 
 from gateway.session_context import (
     get_session_env,
-    set_current_turn_session_key,
     reset_current_turn_session_key,
+    set_current_turn_session_key,
+    turn_session_key,
 )
 
 
@@ -39,7 +40,7 @@ def test_nested_set_reset():
         reset_current_turn_session_key(outer)
 
 
-def test_empty_string_normalized():
+def test_empty_string_round_trip():
     token = set_current_turn_session_key("")
     try:
         assert get_session_env("HERMES_SESSION_KEY") == ""
@@ -47,10 +48,24 @@ def test_empty_string_normalized():
         reset_current_turn_session_key(token)
 
 
-def test_none_normalized_to_empty():
+def test_none_coerced_to_empty_string():
     # set_current_turn_session_key(None) should not raise; treat as "".
     token = set_current_turn_session_key(None)
     try:
         assert get_session_env("HERMES_SESSION_KEY") == ""
     finally:
         reset_current_turn_session_key(token)
+
+
+def test_turn_session_key_context_manager_restores_previous_value(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_KEY", "env-session")
+
+    with turn_session_key("session-xyz"):
+        assert get_session_env("HERMES_SESSION_KEY") == "session-xyz"
+
+    assert get_session_env("HERMES_SESSION_KEY") == "env-session"
+
+
+def test_turn_session_key_context_manager_none_coerces_to_empty_string():
+    with turn_session_key(None):
+        assert get_session_env("HERMES_SESSION_KEY") == ""

--- a/tests/test_session_context_public_turn_setters.py
+++ b/tests/test_session_context_public_turn_setters.py
@@ -15,15 +15,19 @@ from gateway.session_context import (
 
 
 def test_set_and_reset_round_trip():
+    # Capture the surrounding-context value BEFORE setting so the post-reset
+    # assertion is robust: an outer fixture / parent context could legitimately
+    # hold "session-abc" itself, in which case a `!=` check would flake.
+    previous = _SESSION_KEY.get()
     token = set_current_turn_session_key("session-abc")
     try:
         assert _SESSION_KEY.get() == "session-abc"
     finally:
         reset_current_turn_session_key(token)
-    # After reset, the value is no longer "session-abc". It either returns
-    # to the module-level default (the _UNSET sentinel) or to whatever the
-    # surrounding test context had set it to.
-    assert _SESSION_KEY.get() != "session-abc"
+    # After reset, the value returns to whatever it was before set() — the
+    # module-level default (the _UNSET sentinel) for a fresh context, or the
+    # surrounding context's value if one was already bound.
+    assert _SESSION_KEY.get() is previous
 
 
 def test_nested_set_reset():

--- a/tests/test_session_context_public_turn_setters.py
+++ b/tests/test_session_context_public_turn_setters.py
@@ -8,38 +8,33 @@ ContextVar (``_approval_session_key`` in tools.approval).
 """
 
 from gateway.session_context import (
-    _SESSION_KEY,
+    get_session_env,
     set_current_turn_session_key,
     reset_current_turn_session_key,
 )
 
 
-def test_set_and_reset_round_trip():
-    # Capture the surrounding-context value BEFORE setting so the post-reset
-    # assertion is robust: an outer fixture / parent context could legitimately
-    # hold "session-abc" itself, in which case a `!=` check would flake.
-    previous = _SESSION_KEY.get()
+def test_set_and_reset_round_trip(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_KEY", "env-session")
+    previous = get_session_env("HERMES_SESSION_KEY")
     token = set_current_turn_session_key("session-abc")
     try:
-        assert _SESSION_KEY.get() == "session-abc"
+        assert get_session_env("HERMES_SESSION_KEY") == "session-abc"
     finally:
         reset_current_turn_session_key(token)
-    # After reset, the value returns to whatever it was before set() — the
-    # module-level default (the _UNSET sentinel) for a fresh context, or the
-    # surrounding context's value if one was already bound.
-    assert _SESSION_KEY.get() is previous
+    assert get_session_env("HERMES_SESSION_KEY") == previous
 
 
 def test_nested_set_reset():
     outer = set_current_turn_session_key("outer")
     try:
-        assert _SESSION_KEY.get() == "outer"
+        assert get_session_env("HERMES_SESSION_KEY") == "outer"
         inner = set_current_turn_session_key("inner")
         try:
-            assert _SESSION_KEY.get() == "inner"
+            assert get_session_env("HERMES_SESSION_KEY") == "inner"
         finally:
             reset_current_turn_session_key(inner)
-        assert _SESSION_KEY.get() == "outer"
+        assert get_session_env("HERMES_SESSION_KEY") == "outer"
     finally:
         reset_current_turn_session_key(outer)
 
@@ -47,15 +42,15 @@ def test_nested_set_reset():
 def test_empty_string_normalized():
     token = set_current_turn_session_key("")
     try:
-        assert _SESSION_KEY.get() == ""
+        assert get_session_env("HERMES_SESSION_KEY") == ""
     finally:
         reset_current_turn_session_key(token)
 
 
 def test_none_normalized_to_empty():
     # set_current_turn_session_key(None) should not raise; treat as "".
-    token = set_current_turn_session_key(None)  # type: ignore[arg-type]
+    token = set_current_turn_session_key(None)
     try:
-        assert _SESSION_KEY.get() == ""
+        assert get_session_env("HERMES_SESSION_KEY") == ""
     finally:
         reset_current_turn_session_key(token)

--- a/tests/test_session_context_public_turn_setters.py
+++ b/tests/test_session_context_public_turn_setters.py
@@ -1,0 +1,57 @@
+"""Tests for public per-turn session-key setters in gateway.session_context.
+
+These wrappers mirror tools/approval.py's set_current_session_key /
+reset_current_session_key pattern but are deliberately named distinctly
+(``turn_session_key``) because they target a different ContextVar
+(``_SESSION_KEY`` in gateway.session_context) than the approval-session
+ContextVar (``_approval_session_key`` in tools.approval).
+"""
+
+from gateway.session_context import (
+    _SESSION_KEY,
+    set_current_turn_session_key,
+    reset_current_turn_session_key,
+)
+
+
+def test_set_and_reset_round_trip():
+    token = set_current_turn_session_key("session-abc")
+    try:
+        assert _SESSION_KEY.get() == "session-abc"
+    finally:
+        reset_current_turn_session_key(token)
+    # After reset, the value is no longer "session-abc". It either returns
+    # to the module-level default (the _UNSET sentinel) or to whatever the
+    # surrounding test context had set it to.
+    assert _SESSION_KEY.get() != "session-abc"
+
+
+def test_nested_set_reset():
+    outer = set_current_turn_session_key("outer")
+    try:
+        assert _SESSION_KEY.get() == "outer"
+        inner = set_current_turn_session_key("inner")
+        try:
+            assert _SESSION_KEY.get() == "inner"
+        finally:
+            reset_current_turn_session_key(inner)
+        assert _SESSION_KEY.get() == "outer"
+    finally:
+        reset_current_turn_session_key(outer)
+
+
+def test_empty_string_normalized():
+    token = set_current_turn_session_key("")
+    try:
+        assert _SESSION_KEY.get() == ""
+    finally:
+        reset_current_turn_session_key(token)
+
+
+def test_none_normalized_to_empty():
+    # set_current_turn_session_key(None) should not raise; treat as "".
+    token = set_current_turn_session_key(None)  # type: ignore[arg-type]
+    try:
+        assert _SESSION_KEY.get() == ""
+    finally:
+        reset_current_turn_session_key(token)


### PR DESCRIPTION
This adds public wrappers for the per-turn session-identity ContextVar in
`gateway.session_context`, mirroring the structural pattern that
`tools/approval.py` uses for the approval-session ContextVar.

Motivation
- hermes-webui PR #2968 (https://github.com/nesquena/hermes-webui/pull/2968)
  currently binds per-turn session identity by importing `_SESSION_KEY`
  and calling `.set(...)` directly inside `api/streaming.py`. The
  webui maintainer flagged the private-API touch and asked for a public
  setter to mirror `tools/approval.py:set_current_session_key`. This PR
  closes that gap.

What ships
- `gateway.session_context.set_current_turn_session_key(key: str) -> Token`
- `gateway.session_context.reset_current_turn_session_key(token: Token) -> None`
- Test coverage: round-trip, nested set+reset, empty-string normalization,
  None-normalized-to-empty.
- No change to `_SESSION_KEY` itself or to existing callers; the wrappers
  are additive.

Naming
- Deliberately distinct from `tools/approval.py`'s
  `set_current_session_key` — the two ContextVars carry different
  concerns and downstream callers may need to set both in the same
  scope. `turn_session` (this module) vs `session` (approval) keeps
  imports unambiguous.

Follow-up
- hermes-webui will land a small commit on PR #2968 replacing the
  private touch in `api/streaming.py:_set_turn_session_identity` with
  `set_current_turn_session_key` once this lands. No webui change is
  needed in this PR.

Refs
- nesquena/hermes-webui#2968 (webui side review comment)
