### PR TITLE
fix: handle Codex OAuth responses missing output

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -20,10 +20,87 @@ import json
 import logging
 import os
 import time
+from functools import wraps
 from types import SimpleNamespace
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
+
+
+def _coerce_completed_response_output(response: Any) -> bool:
+    """Normalize Codex completed events that omit ``output``.
+
+    ChatGPT's Codex backend can emit ``response.completed`` with the
+    ``output`` field omitted/null.  OpenAI SDK versions that assume the
+    field is iterable raise ``TypeError: 'NoneType' object is not
+    iterable`` before Hermes can fall back.  Only completed responses are
+    coerced; incomplete/failed responses keep their original shape.
+    """
+    if response is None or getattr(response, "output", None) is not None:
+        return False
+    if getattr(response, "status", None) != "completed":
+        return False
+    try:
+        response.output = []
+    except Exception:
+        try:
+            object.__setattr__(response, "output", [])
+        except Exception:
+            logger.debug(
+                "Unable to coerce missing output on completed Codex response",
+                exc_info=True,
+            )
+            return False
+    return True
+
+
+def _response_from_parse_args(args: tuple, kwargs: dict) -> Any:
+    response = kwargs.get("response")
+    if response is not None:
+        return response
+    # Current OpenAI SDK versions expose response as keyword-only, but this
+    # keeps the compatibility patch safe if a relay/vendor-pinned SDK uses a
+    # positional helper signature.
+    for arg in reversed(args):
+        if hasattr(arg, "output") and hasattr(arg, "status"):
+            return arg
+    return None
+
+
+def _install_openai_missing_output_patch() -> None:
+    """Patch OpenAI response parsing for Codex completed events missing output."""
+    try:
+        import openai.lib._parsing._responses as oai_parsing
+    except Exception:
+        logger.debug("OpenAI response parser unavailable for Codex output patch", exc_info=True)
+        return
+
+    original_parse_response = oai_parsing.parse_response
+    if getattr(original_parse_response, "_hermes_missing_output_patch", False):
+        return
+
+    @wraps(original_parse_response)
+    def patched_parse_response(*args, **kwargs):
+        _coerce_completed_response_output(_response_from_parse_args(args, kwargs))
+        return original_parse_response(*args, **kwargs)
+
+    patched_parse_response._hermes_missing_output_patch = True
+    oai_parsing.parse_response = patched_parse_response
+
+    for module_name in (
+        "openai.lib.streaming.responses._responses",
+        "openai.resources.responses.responses",
+    ):
+        try:
+            module = __import__(module_name, fromlist=["parse_response"])
+            if getattr(getattr(module, "parse_response", None), "_hermes_missing_output_patch", False):
+                continue
+            module.parse_response = patched_parse_response
+        except Exception:
+            logger.debug("Unable to patch %s.parse_response", module_name, exc_info=True)
+
+
+_install_openai_missing_output_patch()
 
 
 def run_codex_app_server_turn(
@@ -287,9 +364,9 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
-        except RuntimeError as exc:
+        except (RuntimeError, TypeError) as exc:
             err_text = str(exc)
-            missing_completed = "response.completed" in err_text
+            missing_completed = "response.completed" in err_text or "'NoneType' object is not iterable" in err_text
             # The OpenAI SDK's Responses streaming state machine raises
             # ``RuntimeError("Expected to have received `response.created`
             # before `<event-type>`")`` when the first SSE event from the

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -397,6 +397,33 @@ def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_mo
     assert "prompt_cache_key" not in kwargs
 
 
+def test_codex_parse_patch_only_coerces_completed_missing_output():
+    from agent.codex_runtime import _coerce_completed_response_output
+
+    completed = SimpleNamespace(status="completed", output=None)
+    incomplete = SimpleNamespace(status="incomplete", output=None)
+    failed = SimpleNamespace(status="failed", output=None)
+    populated = SimpleNamespace(status="completed", output=["already set"])
+
+    assert _coerce_completed_response_output(completed) is True
+    assert completed.output == []
+    assert _coerce_completed_response_output(incomplete) is False
+    assert incomplete.output is None
+    assert _coerce_completed_response_output(failed) is False
+    assert failed.output is None
+    assert _coerce_completed_response_output(populated) is False
+    assert populated.output == ["already set"]
+
+
+def test_codex_parse_patch_finds_keyword_and_positional_response():
+    from agent.codex_runtime import _response_from_parse_args
+
+    response = SimpleNamespace(status="completed", output=None)
+    assert _response_from_parse_args((), {"response": response}) is response
+    assert _response_from_parse_args((object(), response), {}) is response
+    assert _response_from_parse_args((object(),), {}) is None
+
+
 def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):
     agent = _build_agent(monkeypatch)
     calls = {"stream": 0}
@@ -429,6 +456,39 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
         calls["stream"] += 1
         return _FakeResponsesStream(
             final_error=RuntimeError("Didn't receive a `response.completed` event.")
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("create fallback ok")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert calls["stream"] == 2
+    assert calls["create"] == 1
+    assert response.output[0].content[0].text == "create fallback ok"
+
+
+def test_run_codex_stream_handles_none_output_completed_event_typeerror(monkeypatch):
+    """ChatGPT Codex can send response.completed with no output field.
+
+    Newer OpenAI SDK streaming parsers surface that as TypeError before
+    Hermes can inspect the final response, so treat it like a missing
+    response.completed postlude and use the existing retry/fallback path.
+    """
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            final_error=TypeError("'NoneType' object is not iterable")
         )
 
     def _fake_create(**kwargs):


### PR DESCRIPTION
## Summary
- Coerce completed OpenAI Responses objects with missing/null output to an empty output list before SDK parsing raises a TypeError
- Keep incomplete, failed, and already-populated responses untouched
- Treat the observed SDK TypeError as a Codex stream completion failure so Hermes can use the existing retry/fallback path
- Add regression coverage for the parser compatibility helper and streaming fallback

## Security / secrets check
- Scanned added lines and committed diff for hardcoded secret assignments and common API key/token patterns
- No API keys, OAuth tokens, or secrets were found in the diff
- The change does not log or transmit credentials; it only normalizes response object shape and uses existing fallback behavior

## Test Plan
- env -u PYTHONHOME -u PYTHONPATH PYTHONPATH="/c/Users/g_nan/AppData/Local/hermes/hermes-agent" ./venv/Scripts/python -m py_compile agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py
- env -u PYTHONHOME -u PYTHONPATH PYTHONPATH="/c/Users/g_nan/AppData/Local/hermes/hermes-agent" ./venv/Scripts/python -m pytest -o addopts= tests/run_agent/test_run_agent_codex_responses.py -q -p no:timeout
