### PR TITLE
fix: avoid dashboard status false positives

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6232,6 +6232,101 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     return True
 
 
+def _get_parent_pid(pid: int) -> int | None:
+    """Return the parent PID for ``pid``, or ``None`` when unavailable.
+
+    Dashboard status/stop scans run from short-lived CLI wrapper processes.
+    Excluding only ``os.getpid()`` is not enough — the invoking shell or
+    parent ``hermes`` process can also contain ``hermes dashboard`` in its
+    command line and be mistaken for a live dashboard. We therefore need the
+    full ancestor chain, not just self.
+    """
+    if pid <= 1:
+        return None
+    try:
+        import psutil  # type: ignore
+        return psutil.Process(pid).ppid() or None
+    except ImportError:
+        pass
+    except Exception:
+        return None
+
+    if not shutil.which("ps"):
+        return None
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    if not raw:
+        return None
+    try:
+        parent_pid = int(raw.splitlines()[-1].strip())
+    except ValueError:
+        return None
+    return parent_pid if parent_pid > 0 else None
+
+
+def _get_ancestor_pids() -> set[int]:
+    """Return the current process plus its ancestor chain.
+
+    This matches the gateway status behavior: process-table scans must exclude
+    the calling CLI process AND any parent shell/wrapper that launched it.
+    Otherwise ``hermes dashboard --status`` can report a non-dashboard shell as
+    a running dashboard purely because its command line contains that phrase.
+    """
+    ancestors: set[int] = set()
+    pid = os.getpid()
+    for _ in range(64):
+        ancestors.add(pid)
+        parent = _get_parent_pid(pid)
+        if parent is None or parent <= 0 or parent in ancestors:
+            break
+        pid = parent
+    return ancestors
+
+
+def _get_process_cmdline(pid: int) -> str:
+    """Best-effort full command line for ``pid``.
+
+    Linux exposes ``/proc/<pid>/cmdline``; on macOS and other POSIX hosts, fall
+    back to ``ps`` so dashboard status can still disambiguate PIDs.
+    """
+    try:
+        if sys.platform != "win32":
+            cmdline_path = f"/proc/{pid}/cmdline"
+            if os.path.exists(cmdline_path):
+                with open(cmdline_path, "rb") as f:
+                    return (
+                        f.read()
+                        .replace(b"\x00", b" ")
+                        .decode("utf-8", errors="replace")
+                        .strip()
+                    )
+    except (OSError, ValueError):
+        pass
+
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return (result.stdout or "").strip()
+
+
 def _find_stale_dashboard_pids() -> list[int]:
     """Return PIDs of ``hermes dashboard`` processes other than ourselves.
 
@@ -6254,7 +6349,7 @@ def _find_stale_dashboard_pids() -> list[int]:
         "hermes_cli.main dashboard",
         "hermes_cli/main.py dashboard",
     ]
-    self_pid = os.getpid()
+    exclude_pids = _get_ancestor_pids()
     dashboard_pids: list[int] = []
 
     try:
@@ -6283,14 +6378,13 @@ def _find_stale_dashboard_pids() -> list[int]:
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    if (
-                        any(p in current_cmd for p in patterns)
-                        and int(pid_str) != self_pid
-                    ):
+                    if any(p in current_cmd for p in patterns):
                         try:
-                            dashboard_pids.append(int(pid_str))
+                            pid = int(pid_str)
                         except ValueError:
-                            pass
+                            continue
+                        if pid not in exclude_pids:
+                            dashboard_pids.append(pid)
         else:
             # Linux / macOS: scan the process table via ps and match against
             # the same explicit patterns list used on Windows.  Using ps
@@ -6317,7 +6411,7 @@ def _find_stale_dashboard_pids() -> list[int]:
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if any(p in command for p in patterns) and pid not in exclude_pids:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
@@ -10144,20 +10238,7 @@ def _report_dashboard_status() -> int:
     print(f"{len(pids)} hermes dashboard process(es) running:")
     for pid in pids:
         # Best-effort: show the full cmdline so users can tell profiles apart.
-        cmdline = ""
-        try:
-            if sys.platform != "win32":
-                cmdline_path = f"/proc/{pid}/cmdline"
-                if os.path.exists(cmdline_path):
-                    with open(cmdline_path, "rb") as f:
-                        cmdline = (
-                            f.read()
-                            .replace(b"\x00", b" ")
-                            .decode("utf-8", errors="replace")
-                            .strip()
-                        )
-        except (OSError, ValueError):
-            pass
+        cmdline = _get_process_cmdline(pid)
         if cmdline:
             print(f"    PID {pid}: {cmdline}")
         else:

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -15,7 +15,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from hermes_cli.main import cmd_dashboard, _report_dashboard_status
+from hermes_cli.main import cmd_dashboard, _report_dashboard_status, _get_process_cmdline
 
 
 def _ns(**kw):
@@ -41,14 +41,16 @@ class TestDashboardStatus:
     def test_status_with_processes(self, capsys):
         with patch("hermes_cli.main._find_stale_dashboard_pids",
                    return_value=[12345, 12346]), \
+             patch("hermes_cli.main._get_process_cmdline",
+                   side_effect=["hermes dashboard --port 9119", "hermes dashboard --port 9120 --no-open"]), \
              pytest.raises(SystemExit) as exc:
             cmd_dashboard(_ns(status=True))
         # Status is informational — always exits 0.
         assert exc.value.code == 0
         out = capsys.readouterr().out
         assert "2 hermes dashboard process(es) running" in out
-        assert "PID 12345" in out
-        assert "PID 12346" in out
+        assert "PID 12345: hermes dashboard --port 9119" in out
+        assert "PID 12346: hermes dashboard --port 9120 --no-open" in out
 
     def test_status_does_not_try_to_import_fastapi(self):
         """`--status` must not require dashboard runtime deps — it's a
@@ -66,6 +68,21 @@ class TestDashboardStatus:
              pytest.raises(SystemExit) as exc:
             cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
+
+
+class TestDashboardCmdlineHelpers:
+    def test_get_process_cmdline_falls_back_to_ps_when_proc_missing(self):
+        mock_result = MagicMock(returncode=0, stdout="python -m hermes_cli.main dashboard --port 9119\n")
+        with patch("os.path.exists", return_value=False), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            cmdline = _get_process_cmdline(12345)
+        assert cmdline == "python -m hermes_cli.main dashboard --port 9119"
+        mock_run.assert_called_once_with(
+            ["ps", "-o", "command=", "-p", "12345"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
 
 
 class TestDashboardStop:

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -118,7 +118,8 @@ class TestFindStaleDashboardPids:
             assert sorted(_find_stale_dashboard_pids()) == [12345, 12346, 12347]
 
     def test_self_pid_excluded(self):
-        with patch("subprocess.run") as mock_run:
+        with patch("subprocess.run") as mock_run, \
+             patch("hermes_cli.main._get_ancestor_pids", return_value={os.getpid()}):
             mock_run.return_value = MagicMock(
                 returncode=0,
                 stdout="\n".join([
@@ -130,6 +131,21 @@ class TestFindStaleDashboardPids:
             pids = _find_stale_dashboard_pids()
         assert os.getpid() not in pids
         assert 12345 in pids
+
+    def test_ancestor_pid_excluded(self):
+        with patch("subprocess.run") as mock_run, \
+             patch("hermes_cli.main._get_ancestor_pids", return_value={54321, os.getpid()}):
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(54321, "bash -lc hermes dashboard --status"),
+                    _ps_line(12345, "hermes dashboard --port 9119"),
+                ]) + "\n",
+                stderr="",
+            )
+            pids = _find_stale_dashboard_pids()
+        assert 54321 not in pids
+        assert pids == [12345]
 
     def test_ps_not_found_returns_empty(self):
         with patch("subprocess.run", side_effect=FileNotFoundError):


### PR DESCRIPTION
## Summary
- exclude the calling shell and full ancestor PID chain from dashboard process detection
- fall back to `ps` for dashboard cmdline lookup on macOS when `/proc/<pid>/cmdline` is unavailable
- add regression coverage for ancestor exclusion and cmdline fallback behavior

## Test Plan
- scripts/run_tests.sh tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_dashboard_lifecycle_flags.py -q