### PR TITLE
fix: trust local profile wrappers in tirith pipe checks

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -307,6 +307,7 @@ terminal:
 #   tirith_path: "tirith"       # Path to tirith binary (supports ~ expansion)
 #   tirith_timeout: 5           # Scan timeout in seconds
 #   tirith_fail_open: true      # Allow commands if tirith unavailable
+#   trusted_executable_dirs: [] # Extra local script dirs allowed to pipe into interpreters
 
 # =============================================================================
 # Browser Tool Configuration

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1569,6 +1569,7 @@ DEFAULT_CONFIG = {
         "tirith_path": "tirith",
         "tirith_timeout": 5,
         "tirith_fail_open": True,
+        "trusted_executable_dirs": [],
         "website_blocklist": {
             "enabled": False,
             "domains": [],
@@ -4629,6 +4630,7 @@ _SECURITY_COMMENT = """
 #   tirith_path: "tirith"
 #   tirith_timeout: 5
 #   tirith_fail_open: true
+#   trusted_executable_dirs: []
 """
 
 _FALLBACK_COMMENT = """

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -1229,7 +1229,8 @@ class TestSpawnWarningDedup:
 # ---------------------------------------------------------------------------
 
 _CFG = {"tirith_enabled": True, "tirith_path": "tirith",
-        "tirith_timeout": 5, "tirith_fail_open": True}
+        "tirith_timeout": 5, "tirith_fail_open": True,
+        "trusted_executable_dirs": []}
 
 
 class TestAppTldSuppression:
@@ -1342,3 +1343,67 @@ class TestIsAppTldFinding:
 
     def test_case_insensitive_match(self):
         assert self.fn({"rule_id": "lookalike_tld", "value": ".APP"})
+
+
+class TestTrustedLocalPipeToInterpreterSuppression:
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    @patch("tools.tirith_security._get_hermes_home")
+    def test_profile_wrapper_pipe_is_downgraded_to_allow(self, mock_home, mock_cfg, mock_run, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        wrapper = hermes_home / "profiles" / "worker" / "bin" / "my-wrapper"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        wrapper.chmod(0o755)
+
+        mock_home.return_value = str(hermes_home)
+        mock_cfg.return_value = dict(_CFG)
+        findings = [{"rule_id": "pipe_to_interpreter", "severity": "high"}]
+        mock_run.return_value = _mock_run(1, _json_stdout(findings, "pipe to interpreter"))
+
+        with patch("tools.tirith_security.shutil.which", return_value=str(wrapper)):
+            result = check_command_security("my-wrapper clients | python3 -c 'print(1)'")
+
+        assert result["action"] == "allow"
+        assert result["findings"] == []
+        assert result["summary"] == ""
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    @patch("tools.tirith_security._get_hermes_home")
+    def test_mixed_findings_preserve_block(self, mock_home, mock_cfg, mock_run, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        wrapper = hermes_home / "profiles" / "worker" / "bin" / "my-wrapper"
+        wrapper.parent.mkdir(parents=True)
+        wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        wrapper.chmod(0o755)
+
+        mock_home.return_value = str(hermes_home)
+        mock_cfg.return_value = dict(_CFG)
+        findings = [
+            {"rule_id": "pipe_to_interpreter", "severity": "high"},
+            {"rule_id": "homograph_url", "severity": "high"},
+        ]
+        mock_run.return_value = _mock_run(1, _json_stdout(findings, "mixed"))
+
+        with patch("tools.tirith_security.shutil.which", return_value=str(wrapper)):
+            result = check_command_security("my-wrapper clients | python3 -c 'print(1)'")
+
+        assert result["action"] == "block"
+        assert len(result["findings"]) == 2
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    @patch("tools.tirith_security._get_hermes_home")
+    def test_untrusted_system_binary_preserves_block(self, mock_home, mock_cfg, mock_run, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        mock_home.return_value = str(hermes_home)
+        mock_cfg.return_value = dict(_CFG)
+        findings = [{"rule_id": "pipe_to_interpreter", "severity": "high"}]
+        mock_run.return_value = _mock_run(1, _json_stdout(findings, "pipe to interpreter"))
+
+        with patch("tools.tirith_security.shutil.which", return_value="/usr/bin/curl"):
+            result = check_command_security("curl https://example.com | python3 -c 'print(1)'")
+
+        assert result["action"] == "block"
+        assert len(result["findings"]) == 1

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -25,6 +25,8 @@ import json
 import logging
 import os
 import platform
+from pathlib import Path
+import shlex
 import shutil
 import stat
 import subprocess
@@ -72,6 +74,7 @@ def _load_security_config() -> dict:
         "tirith_path": "tirith",
         "tirith_timeout": 5,
         "tirith_fail_open": True,
+        "trusted_executable_dirs": [],
     }
     try:
         from hermes_cli.config import load_config
@@ -84,6 +87,7 @@ def _load_security_config() -> dict:
         "tirith_path": os.getenv("TIRITH_BIN", cfg.get("tirith_path", defaults["tirith_path"])),
         "tirith_timeout": _env_int("TIRITH_TIMEOUT", cfg.get("tirith_timeout", defaults["tirith_timeout"])),
         "tirith_fail_open": _env_bool("TIRITH_FAIL_OPEN", cfg.get("tirith_fail_open", defaults["tirith_fail_open"])),
+        "trusted_executable_dirs": cfg.get("trusted_executable_dirs", defaults["trusted_executable_dirs"]) or [],
     }
 
 
@@ -771,6 +775,14 @@ def check_command_security(command: str) -> dict:
         elif action == "warn":
             summary = "security warning detected (details unavailable)"
 
+    # Suppress pipe-to-interpreter findings for trusted local executables such
+    # as profile-local wrapper scripts. These are already under the user's
+    # control and do not carry the remote-content risk that tirith is guarding.
+    if findings and _all_findings_are_trusted_local_pipe_to_interpreter(findings, command, cfg):
+        action = "allow"
+        findings = []
+        summary = ""
+
     # Suppress warn verdicts that consist solely of a lookalike_tld finding for
     # the .app TLD.  .app is a legitimate gTLD used by many production services
     # and the "can be confused with file extensions" heuristic generates false
@@ -801,3 +813,114 @@ def _is_app_tld_finding(finding: dict) -> bool:
         if val is not None and ".app" in str(val).lower():
             return True
     return False
+
+
+def _all_findings_are_trusted_local_pipe_to_interpreter(
+    findings: list[dict],
+    command: str,
+    cfg: dict,
+) -> bool:
+    """Return True when every finding is a trusted-local pipe_to_interpreter hit."""
+    if not findings:
+        return False
+    executable = _resolve_first_piped_executable(command)
+    if executable is None or not _is_trusted_local_executable(executable, cfg):
+        return False
+    return all(_is_pipe_to_interpreter_finding(finding) for finding in findings)
+
+
+def _is_pipe_to_interpreter_finding(finding: dict) -> bool:
+    return isinstance(finding, dict) and finding.get("rule_id") == "pipe_to_interpreter"
+
+
+def _resolve_first_piped_executable(command: str) -> Path | None:
+    """Resolve the left-hand executable in a single pipe command."""
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars="|")
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return None
+
+    if tokens.count("|") != 1:
+        return None
+
+    pipe_index = tokens.index("|")
+    if pipe_index <= 0:
+        return None
+
+    executable = tokens[0]
+    if "/" in executable:
+        candidate = Path(executable).expanduser()
+        try:
+            return candidate.resolve(strict=True)
+        except OSError:
+            return None
+
+    resolved = shutil.which(executable)
+    if not resolved:
+        return None
+    try:
+        return Path(resolved).resolve(strict=True)
+    except OSError:
+        return None
+
+
+def _is_trusted_local_executable(path: Path, cfg: dict) -> bool:
+    """Return True for user-owned executables in trusted local script dirs."""
+    try:
+        stat_result = path.stat()
+    except OSError:
+        return False
+
+    if not path.is_file() or not os.access(path, os.X_OK):
+        return False
+
+    getuid = getattr(os, "getuid", None)
+    if callable(getuid) and stat_result.st_uid != getuid():
+        return False
+
+    resolved = path.resolve()
+    if _is_under_directory(resolved, Path.home().resolve() / ".local" / "bin"):
+        return True
+
+    hermes_home = Path(_get_hermes_home()).expanduser().resolve()
+    if _is_under_directory(resolved, hermes_home / "bin"):
+        return True
+    if _is_under_profile_bin(resolved, hermes_home):
+        return True
+
+    configured_dirs = cfg.get("trusted_executable_dirs") or []
+    for directory in configured_dirs:
+        try:
+            trusted_dir = Path(os.path.expanduser(str(directory))).resolve()
+        except OSError:
+            continue
+        if _is_under_directory(resolved, trusted_dir):
+            return True
+
+    return False
+
+
+def _is_under_profile_bin(path: Path, hermes_home: Path) -> bool:
+    """Return True for executables in <root>/profiles/<name>/bin/."""
+    candidates = [hermes_home / "profiles"]
+    if hermes_home.parent.name == "profiles":
+        candidates.append(hermes_home.parent)
+
+    for profiles_root in candidates:
+        try:
+            rel = path.relative_to(profiles_root.resolve())
+        except ValueError:
+            continue
+        if len(rel.parts) >= 3 and rel.parts[1] == "bin":
+            return True
+    return False
+
+
+def _is_under_directory(path: Path, directory: Path) -> bool:
+    try:
+        path.relative_to(directory)
+        return True
+    except ValueError:
+        return False

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1565,6 +1565,7 @@ security:
   tirith_path: "tirith"          # Path to tirith binary (default: "tirith" in $PATH)
   tirith_timeout: 5              # Seconds to wait for tirith scan before timing out
   tirith_fail_open: true         # Allow command execution if tirith is unavailable
+  trusted_executable_dirs: []    # Extra local script dirs allowed to pipe into interpreters
   website_blocklist:             # See Website Blocklist section below
     enabled: false
     domains: []
@@ -1576,6 +1577,7 @@ security:
 - `tirith_path` — path to the tirith binary. Set this if tirith is installed in a non-standard location.
 - `tirith_timeout` — maximum seconds to wait for a tirith scan. Commands proceed if the scan times out.
 - `tirith_fail_open` — when `true` (default), commands are allowed to execute if tirith is unavailable or fails. Set to `false` to block commands when tirith cannot verify them.
+- `trusted_executable_dirs` — extra local directories whose user-owned executables are trusted when piping into interpreters. Hermes already trusts executables in profile `bin/` directories and `~/.local/bin`.
 
 ## Website Blocklist
 


### PR DESCRIPTION
Fixes #32737

## Summary
- suppress `pipe_to_interpreter` findings when every finding comes from piping a user-owned executable in trusted local script directories
- trust Hermes profile `bin/` directories and `~/.local/bin` by default, with optional `security.trusted_executable_dirs` overrides
- cover the new suppression path with targeted tirith wrapper tests and document the config knob

## Proof
- `pytest -o addopts='' tests/tools/test_tirith_security.py -q`
- `ruff check tools/tirith_security.py tests/tools/test_tirith_security.py`
- `git diff --check`

## Notes
- upstream direct push is not permitted for `LeonSGP43`, so this PR comes from the company fork
- retained worktree: `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-32737-trusted-local-pipe`
- proof artifact: `.paperclip_artifacts/quality-gate/proof-441af46a94475f11d67506ddd122a77d3353f34e.json`