### PR TITLE
[codex] fix openai-codex null stream output recovery

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -174,6 +174,85 @@ def run_codex_app_server_turn(
     }
 
 
+def _synthetic_codex_response_from_stream(
+    collected_output_items: list,
+    text_parts: list,
+    *,
+    has_tool_calls: bool = False,
+    log_label: str = "Codex stream",
+):
+    """Build a terminal response from already-consumed stream events.
+
+    The ChatGPT Codex backend can emit complete output via
+    ``response.output_item.done`` / text deltas, then send a terminal
+    ``response.completed`` whose aggregate ``response.output`` is null. The
+    OpenAI SDK currently tries to iterate that null before Hermes can inspect
+    the final response. This helper preserves the stream output we already saw.
+    """
+    if collected_output_items:
+        output_text = "".join(text_parts) if text_parts else None
+        logger.debug(
+            "%s: synthesized terminal response from %d output items after null final output",
+            log_label,
+            len(collected_output_items),
+        )
+        return SimpleNamespace(
+            status="completed",
+            output=list(collected_output_items),
+            output_text=output_text,
+            usage=None,
+        )
+
+    if text_parts and not has_tool_calls:
+        assembled = "".join(text_parts)
+        logger.debug(
+            "%s: synthesized terminal response from %d text deltas (%d chars) after null final output",
+            log_label,
+            len(text_parts),
+            len(assembled),
+        )
+        return SimpleNamespace(
+            status="completed",
+            output=[SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )],
+            output_text=assembled,
+            usage=None,
+        )
+
+    return None
+
+
+def _backfill_codex_response_output(
+    response,
+    collected_output_items: list,
+    text_parts: list,
+    *,
+    has_tool_calls: bool = False,
+    log_label: str = "Codex stream",
+):
+    _out = getattr(response, "output", None)
+    if isinstance(_out, list) and _out:
+        return response
+    if _out is None or (isinstance(_out, list) and not _out):
+        synthetic = _synthetic_codex_response_from_stream(
+            collected_output_items,
+            text_parts,
+            has_tool_calls=has_tool_calls,
+            log_label=log_label,
+        )
+        if synthetic is not None:
+            response.output = synthetic.output
+            if getattr(response, "status", None) is None:
+                response.status = synthetic.status
+            if getattr(response, "output_text", None) is None and getattr(synthetic, "output_text", None):
+                response.output_text = synthetic.output_text
+    return response
+
+
 
 
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
@@ -250,27 +329,13 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
-                _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        final_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex stream: backfilled %d output items from stream events",
-                            len(collected_output_items),
-                        )
-                    elif agent._codex_streamed_text_parts and not has_tool_calls:
-                        assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex stream: synthesized output from %d text deltas (%d chars)",
-                            len(agent._codex_streamed_text_parts), len(assembled),
-                        )
-                return final_response
+                return _backfill_codex_response_output(
+                    final_response,
+                    collected_output_items,
+                    agent._codex_streamed_text_parts,
+                    has_tool_calls=has_tool_calls,
+                    log_label="Codex stream",
+                )
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(
@@ -334,6 +399,24 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     err_text,
                 )
                 return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
+        except TypeError as exc:
+            err_text = str(exc)
+            null_output_parse_error = "NoneType" in err_text and "not iterable" in err_text
+            if null_output_parse_error:
+                synthetic = _synthetic_codex_response_from_stream(
+                    collected_output_items,
+                    agent._codex_streamed_text_parts,
+                    has_tool_calls=has_tool_calls,
+                    log_label="Codex stream",
+                )
+                if synthetic is not None:
+                    logger.debug(
+                        "Codex stream SDK parse failed on null final output; returning synthesized response. %s err=%s",
+                        agent._client_log_context(),
+                        err_text,
+                    )
+                    return synthetic
             raise
 
 
@@ -412,27 +495,29 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is None and isinstance(event, dict):
                 terminal_response = event.get("response")
             if terminal_response is not None:
-                # Backfill empty output from collected stream events
-                _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        terminal_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex fallback stream: backfilled %d output items",
-                            len(collected_output_items),
-                        )
-                    elif collected_text_deltas:
-                        assembled = "".join(collected_text_deltas)
-                        terminal_response.output = [SimpleNamespace(
-                            type="message", role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex fallback stream: synthesized from %d deltas (%d chars)",
-                            len(collected_text_deltas), len(assembled),
-                        )
-                return terminal_response
+                return _backfill_codex_response_output(
+                    terminal_response,
+                    collected_output_items,
+                    collected_text_deltas,
+                    log_label="Codex fallback stream",
+                )
+    except TypeError as exc:
+        err_text = str(exc)
+        null_output_parse_error = "NoneType" in err_text and "not iterable" in err_text
+        if null_output_parse_error:
+            synthetic = _synthetic_codex_response_from_stream(
+                collected_output_items,
+                collected_text_deltas,
+                log_label="Codex fallback stream",
+            )
+            if synthetic is not None:
+                logger.debug(
+                    "Codex fallback stream SDK parse failed on null final output; returning synthesized response. %s err=%s",
+                    agent._client_log_context(),
+                    err_text,
+                )
+                return synthetic
+        raise
     finally:
         close_fn = getattr(stream_or_response, "close", None)
         if callable(close_fn):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -484,6 +484,70 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert response.output[0].content[0].text == "streamed create ok"
 
 
+def test_run_codex_stream_synthesizes_when_sdk_final_output_is_null(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text="streamed ok")],
+    )
+    calls = {"stream": 0, "create": 0}
+
+    class _NullOutputResponsesStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            return iter([
+                SimpleNamespace(type="response.output_item.done", item=output_item),
+                SimpleNamespace(type="response.output_text.delta", delta="streamed ok"),
+            ])
+
+        def get_final_response(self):
+            raise TypeError("'NoneType' object is not iterable")
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _NullOutputResponsesStream()
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("should not use fallback")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls == {"stream": 1, "create": 0}
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "streamed ok"
+
+
+def test_create_stream_fallback_backfills_terminal_null_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text="fallback streamed ok")],
+    )
+    create_stream = _FakeCreateStream([
+        SimpleNamespace(type="response.output_item.done", item=output_item),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(status="completed", output=None)),
+    ])
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=lambda **kwargs: None, create=lambda **kwargs: create_stream)
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert create_stream.closed is True
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "fallback streamed ok"
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## What does this PR do?

Fixes a Codex Responses streaming crash where the backend streams valid `response.output_item.done` events or text deltas, then the terminal aggregate response has `output: null`. In that shape, openai-python raises `TypeError("'NoneType' object is not iterable")` before Hermes reaches its existing empty-output backfill logic, so the turn aborts as a non-retryable client error.

This PR keeps the existing empty-list recovery path and extends it to `output is None` / SDK final-parse failures by returning a synthetic terminal response from stream data Hermes has already collected.

This uses the existing issue to avoid opening another duplicate report. Related PRs already exist; this one is intentionally scoped to the current `agent/codex_runtime.py` path plus regression tests.

## Related Issue

Fixes #11179

Related: #32903, #32894, #32923, #32888

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_runtime.py`
  - Adds a small helper to build a synthetic Responses terminal object from collected `response.output_item.done` events, or from text deltas when no tool call was streamed.
  - Uses that helper for both normal `responses.stream()` finals and `responses.create(stream=True)` fallback finals when terminal `output` is `None` or empty.
  - Catches only the specific SDK `TypeError` shape caused by iterating `None`, and re-raises unrelated `TypeError`s unchanged.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - Adds regression coverage for SDK final parse failure after streamed output items.
  - Adds regression coverage for `create(stream=True)` fallback terminal responses with `output=None`.

## How to Test

1. `python -m py_compile agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py`
2. `uv run --extra dev python -m ruff check agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py`
3. `uv run --extra dev python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_synthesizes_when_sdk_final_output_is_null tests/run_agent/test_run_agent_codex_responses.py::test_create_stream_fallback_backfills_terminal_null_output tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_fallback_parses_create_stream_events -q`
4. `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py`
5. `uv run --extra dev python scripts/check-windows-footguns.py agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py`
6. `HOME=/tmp/hermes-agent-test-home scripts/run_tests.sh`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1; live hotfix also verified on Ubuntu hosts with `hermes -z "ping" --ignore-rules`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A; ran Windows footgun check on changed files
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted regression tests:

```text
3 passed in 3.87s
```

Related test file via project wrapper:

```text
=== Summary: 1 files, 67 tests passed, 0 failed (100% complete) in 23.7s (16 workers) ===
```

Full local suite after installing `.[all,dev]`:

```text
=== Summary: 1205 files, 26134 tests passed, 20 failed (100% complete) in 403.8s (16 workers) ===
```

The Codex Responses regression file passed in the full run:

```text
tests/run_agent/test_run_agent_codex_responses.py (67✓, 38.3s)
```

The 20 full-suite failures were outside this PR's changed files and clustered around local macOS/Linux service assumptions, browser-launch messaging, Anthropic OAuth keychain mocking, `systemctl` availability, and `/tmp` vs `/private/tmp` path normalization.