### PR TITLE
[codex] recover from SDK NoneType stream errors

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,6 +107,12 @@ from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_
 logger = logging.getLogger(__name__)
 
 
+def _is_none_iterable_type_error(exc: TypeError) -> bool:
+    """Return true for the OpenAI SDK stream bug seen after valid Codex output."""
+    msg = str(exc)
+    return "NoneType" in msg and "iterable" in msg
+
+
 def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
     """Return False instead of raising when a patched symbol is not a type."""
     try:
@@ -791,13 +797,48 @@ class _CodexCompletionsAdapter:
             collected_output_items: List[Any] = []
             collected_text_deltas: List[str] = []
             has_function_calls = False
+            def _synthesize_final(reason: str):
+                synthesized_output = list(collected_output_items)
+                assembled = "".join(collected_text_deltas)
+                if not synthesized_output and assembled and not has_function_calls:
+                    synthesized_output = [SimpleNamespace(
+                        type="message", role="assistant", status="completed",
+                        content=[SimpleNamespace(type="output_text", text=assembled)],
+                    )]
+                if not synthesized_output:
+                    return None
+                logger.debug(
+                    "Codex auxiliary: synthesized final response after %s "
+                    "(%d items, %d chars)",
+                    reason, len(synthesized_output), len(assembled),
+                )
+                return SimpleNamespace(
+                    output=synthesized_output,
+                    output_text=assembled,
+                    status="completed",
+                    model=resp_kwargs.get("model"),
+                    usage=None,
+                )
+
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
             with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
+                stream_type_error = None
+                iterator = iter(stream)
+                while True:
+                    try:
+                        _event = next(iterator)
+                    except StopIteration:
+                        break
+                    except TypeError as exc:
+                        if not _is_none_iterable_type_error(exc):
+                            raise
+                        stream_type_error = exc
+                        break
+
                     _check_cancelled()
                     _etype = getattr(_event, "type", "")
                     if _etype == "response.output_item.done":
@@ -811,7 +852,19 @@ class _CodexCompletionsAdapter:
                     elif "function_call" in _etype:
                         has_function_calls = True
                 _check_cancelled()
-                final = stream.get_final_response()
+                if stream_type_error is not None:
+                    final = _synthesize_final("SDK stream iteration TypeError")
+                    if final is None:
+                        raise stream_type_error
+                else:
+                    try:
+                        final = stream.get_final_response()
+                    except TypeError as exc:
+                        if not _is_none_iterable_type_error(exc):
+                            raise
+                        final = _synthesize_final("SDK finalization TypeError")
+                        if final is None:
+                            raise
 
             # Backfill empty output from collected stream events
             _output = getattr(final, "output", None)

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,12 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _is_none_iterable_type_error(exc: TypeError) -> bool:
+    """Return true for the OpenAI SDK stream bug seen after valid Codex output."""
+    msg = str(exc)
+    return "NoneType" in msg and "iterable" in msg
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -193,8 +199,45 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
         try:
+            def _synthesize_final_response(reason: str):
+                synthesized_output = list(collected_output_items)
+                assembled = "".join(agent._codex_streamed_text_parts)
+                if not synthesized_output and assembled and not has_tool_calls:
+                    synthesized_output = [SimpleNamespace(
+                        type="message",
+                        role="assistant",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text=assembled)],
+                    )]
+                if not synthesized_output:
+                    return None
+                logger.debug(
+                    "Codex stream: synthesized final response after %s "
+                    "(%d items, %d chars)",
+                    reason, len(synthesized_output), len(assembled),
+                )
+                return SimpleNamespace(
+                    output=synthesized_output,
+                    output_text=assembled,
+                    status="completed",
+                    model=api_kwargs.get("model"),
+                    usage=None,
+                )
+
             with active_client.responses.stream(**api_kwargs) as stream:
-                for event in stream:
+                stream_type_error = None
+                iterator = iter(stream)
+                while True:
+                    try:
+                        event = next(iterator)
+                    except StopIteration:
+                        break
+                    except TypeError as exc:
+                        if not _is_none_iterable_type_error(exc):
+                            raise
+                        stream_type_error = exc
+                        break
+
                     # Mark stream activity for the TTFB watchdog in
                     # interruptible_api_call. The Codex backend can accept the
                     # connection but never emit a single event; this timestamp
@@ -246,10 +289,22 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
-                # PATCH: ChatGPT Codex backend streams valid output items
-                # but get_final_response() can return an empty output list.
-                # Backfill from collected items or synthesize from deltas.
+                if stream_type_error is not None:
+                    final_response = _synthesize_final_response("SDK stream iteration TypeError")
+                    if final_response is None:
+                        raise stream_type_error
+                else:
+                    try:
+                        final_response = stream.get_final_response()
+                    except TypeError as exc:
+                        if not _is_none_iterable_type_error(exc):
+                            raise
+                        final_response = _synthesize_final_response("SDK finalization TypeError")
+                        if final_response is None:
+                            raise
+                # ChatGPT Codex can stream valid output items while the SDK
+                # final response has an empty output list. Recover from the
+                # stream events before response validation treats it as empty.
                 _out = getattr(final_response, "output", None)
                 if isinstance(_out, list) and not _out:
                     if collected_output_items:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2476,6 +2476,34 @@ class TestVisionAutoSkipsKimiCoding:
 
 
 class TestCodexAuxiliaryAdapterTimeout:
+    def test_recovers_from_iteration_nonetype_after_text_delta(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_text.delta", delta="summary")
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):
+                pytest.fail("final response should be synthesized from stream events")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "summarize this"}],
+        )
+
+        assert response.choices[0].message.content == "summary"
+
     def test_forwards_timeout_to_responses_stream(self):
         class FakeStream:
             def __enter__(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,11 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None, iter_error=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
+        self._iter_error = iter_error
 
     def __enter__(self):
         return self
@@ -166,7 +168,10 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        for event in self._events:
+            yield event
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -482,6 +487,62 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_from_iteration_nonetype_after_text_delta(monkeypatch):
+    """If the SDK iterator raises after streaming text, keep the usable output."""
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="OK"),
+            ],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: pytest.fail("create fallback should not run"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.status == "completed"
+    assert response.output_text == "OK"
+    assert response.output[0].content[0].text == "OK"
+
+
+def test_run_codex_stream_recovers_from_finalization_nonetype_after_output_item(monkeypatch):
+    """If finalization fails after output_item.done, keep the streamed item."""
+    agent = _build_agent(monkeypatch)
+    streamed_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="OK")],
+    )
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="OK"),
+                SimpleNamespace(type="response.output_item.done", item=streamed_item),
+            ],
+            final_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: pytest.fail("create fallback should not run"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.status == "completed"
+    assert response.output_text == "OK"
+    assert response.output == [streamed_item]
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes a Codex Responses streaming failure where the OpenAI SDK can raise `TypeError: 'NoneType' object is not iterable` after the ChatGPT Codex backend has already streamed usable output.

The main Codex runtime and auxiliary Codex adapter now recover only when stream content has already been collected. They synthesize the final response from streamed output items or text deltas so Hermes does not abort after a successful Codex generation.

## Root Cause

The `chatgpt.com/backend-api/codex` streaming path can emit valid `response.output_text.delta` / `response.output_item.done` events, but SDK stream iteration or finalization can still raise a `NoneType` iterable `TypeError`. Previously Hermes treated that as a non-retryable client error even though the model output was already available.

## Validation

- `./venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_recovers_from_iteration_nonetype_after_text_delta tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_recovers_from_finalization_nonetype_after_output_item tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_recovers_from_iteration_nonetype_after_text_delta -q`
- `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py`
- Live canary: `hermes chat -q "Reply exactly: OK" --provider openai-codex -m gpt-5.5 --ignore-rules -Q`

## Notes

The recovery remains narrow: unrelated `TypeError`s still propagate, and this path only synthesizes a completed response when Hermes has already observed usable streamed output.