### PR TITLE
fix: guard codex responses when output is null

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -245,7 +245,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -324,6 +324,17 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 logger.debug(
                     "Responses stream %s; falling back to create(stream=True). %s err=%s",
                     "rejected before response.created" if prelude_error else "did not emit response.completed",
+                    agent._client_log_context(),
+                    err_text,
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
+        except TypeError as exc:
+            err_text = str(exc)
+            null_output_error = "'NoneType' object is not iterable" in err_text
+            if null_output_error:
+                logger.debug(
+                    "Responses stream returned null output; falling back to create(stream=True). %s err=%s",
                     agent._client_log_context(),
                     err_text,
                 )
@@ -408,7 +419,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -157,9 +157,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -168,7 +169,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -447,6 +448,80 @@ def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(mon
     assert calls["stream"] == 2
     assert calls["create"] == 1
     assert response.output[0].content[0].text == "create fallback ok"
+
+
+def test_run_codex_stream_null_output_typeerror_falls_back_to_create_stream(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(final_error=TypeError("'NoneType' object is not iterable"))
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("null output recovered")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert calls["stream"] == 1
+    assert calls["create"] == 1
+    assert response.output[0].content[0].text == "null output recovered"
+
+
+def test_run_codex_stream_backfills_null_output_from_stream_items(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text="from primary stream null output")],
+    )
+    final_response = SimpleNamespace(output=None, status="completed")
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            final_response=final_response,
+            events=[SimpleNamespace(type="response.output_item.done", item=output_item)],
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.output[0].content[0].text == "from primary stream null output"
+
+
+def test_run_codex_create_stream_fallback_backfills_null_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        content=[SimpleNamespace(type="output_text", text="from null output fallback")],
+    )
+    terminal_response = SimpleNamespace(output=None, status="completed")
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.output_item.done", item=output_item),
+            SimpleNamespace(type="response.completed", response=terminal_response),
+        ]
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=lambda **kwargs: create_stream,
+        )
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert create_stream.closed is True
+    assert response.output[0].content[0].text == "from null output fallback"
 
 
 def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):


### PR DESCRIPTION
## Summary
- guard Codex Responses output parsing when a completed response returns null output
- suppress the user-visible auxiliary title-generation failure caused by iterating None
- add regression coverage for null-output responses

## Testing
- python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o addopts=''