### PR TITLE
fix(kanban): require tool evidence before worker completion

### DIFF
--- a/.paperclip_artifacts/quality-gate/proof-bb4703c761ea6687b6399aa2e61e0a08fabd3ca3.json
+++ b/.paperclip_artifacts/quality-gate/proof-bb4703c761ea6687b6399aa2e61e0a08fabd3ca3.json
@@ -1,0 +1,25 @@
+{
+  "branch": "fix/32746-kanban-tool-evidence",
+  "worktree_path": "/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/fix-32746-kanban-tool-evidence",
+  "head": "bb4703c761ea6687b6399aa2e61e0a08fabd3ca3",
+  "fetched_origin_main_sha": "bb4703c761ea6687b6399aa2e61e0a08fabd3ca3",
+  "latest_fetch_timestamp": "2026-05-27T02:00:52Z",
+  "gate_scope": "lightweight_targeted",
+  "targeted_commands": [
+    {
+      "cmd": "uv run --frozen --extra dev pytest tests/tools/test_kanban_tools.py -q",
+      "exit_code": 0
+    },
+    {
+      "cmd": "uv run --frozen --extra dev ruff check hermes_cli/kanban_db.py tools/kanban_tools.py tests/tools/test_kanban_tools.py",
+      "exit_code": 0
+    },
+    {
+      "cmd": "git diff --check",
+      "exit_code": 0
+    }
+  ],
+  "exception_only_commands": [],
+  "attribution_note": "No overlapping linked PR or keyword-overlap PR was present at final pre-push check; local proof is green for the touched kanban completion gate path.",
+  "green_for_push": true
+}

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3398,6 +3398,64 @@ def block_task(
         return True
 
 
+def block_task_for_protocol_violation(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    expected_run_id: Optional[int] = None,
+    details: Optional[dict] = None,
+) -> bool:
+    """Auto-block a worker and emit a ``protocol_violation`` event."""
+    payload = {"reason": reason}
+    if isinstance(details, dict) and details:
+        payload.update(details)
+    with write_txn(conn):
+        if expected_run_id is None:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'blocked',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                """,
+                (task_id,),
+            )
+        else:
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status       = 'blocked',
+                       claim_lock   = NULL,
+                       claim_expires= NULL,
+                       worker_pid   = NULL
+                 WHERE id = ?
+                   AND status IN ('running', 'ready')
+                   AND current_run_id = ?
+                """,
+                (task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id,
+            outcome="blocked", status="blocked",
+            summary=reason,
+        )
+        if run_id is None and reason:
+            run_id = _synthesize_ended_run(
+                conn, task_id,
+                outcome="blocked",
+                summary=reason,
+            )
+        _append_event(conn, task_id, "protocol_violation", payload, run_id=run_id)
+        _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
+        return True
+
+
 
 def promote_task(
     conn: sqlite3.Connection,

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -14,6 +14,29 @@ import os
 import pytest
 
 
+def _seed_worker_session(session_id: str, tool_names: list[str]) -> None:
+    from hermes_state import SessionDB
+
+    db = SessionDB()
+    try:
+        db.create_session(session_id=session_id, source="cli")
+        db.append_message(
+            session_id,
+            role="assistant",
+            content="",
+            tool_calls=[
+                {
+                    "id": f"call-{idx}",
+                    "type": "function",
+                    "function": {"name": name, "arguments": "{}"},
+                }
+                for idx, name in enumerate(tool_names, start=1)
+            ],
+        )
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # Gating
 # ---------------------------------------------------------------------------
@@ -168,6 +191,9 @@ def worker_env(monkeypatch, tmp_path):
     finally:
         conn.close()
     monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    session_id = "sess-worker-default"
+    monkeypatch.setenv("HERMES_SESSION_ID", session_id)
+    _seed_worker_session(session_id, ["read_file"])
     return tid
 
 
@@ -306,7 +332,10 @@ def test_complete_happy_path(worker_env):
         run = kb.latest_run(conn, worker_env)
         assert run.outcome == "completed"
         assert run.summary == "got the thing done"
-        assert run.metadata == {"files": 2}
+        assert run.metadata == {
+            "files": 2,
+            "worker_session_id": "sess-worker-default",
+        }
     finally:
         conn.close()
 
@@ -334,13 +363,17 @@ def test_complete_metadata_round_trips_through_show(worker_env):
     shown = json.loads(show_out)
     assert shown["task"]["status"] == "done"
     assert shown["runs"][-1]["summary"] == "finished with structured evidence"
-    assert shown["runs"][-1]["metadata"] == handoff
+    assert shown["runs"][-1]["metadata"] == {
+        **handoff,
+        "worker_session_id": "sess-worker-default",
+    }
 
 
 def test_complete_stamps_worker_session_id_from_env(monkeypatch, worker_env):
     from tools import kanban_tools as kt
 
     monkeypatch.setenv("HERMES_SESSION_ID", "session-trusted")
+    _seed_worker_session("session-trusted", ["read_file"])
     metadata = {"files": 2, "worker_session_id": "user-spoof"}
 
     out = kt._handle_complete({
@@ -494,6 +527,32 @@ def test_complete_rejects_non_dict_metadata(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_complete({"summary": "x", "metadata": [1, 2, 3]})
     assert json.loads(out).get("error")
+
+
+def test_complete_auto_blocks_without_non_kanban_tool_evidence(worker_env, monkeypatch):
+    from hermes_cli import kanban_db as kb
+    from hermes_state import SessionDB
+    from tools import kanban_tools as kt
+
+    session_id = "sess-kanban-only"
+    monkeypatch.setenv("HERMES_SESSION_ID", session_id)
+    _seed_worker_session(session_id, ["kanban_show", "kanban_complete"])
+
+    out = json.loads(kt._handle_complete({"summary": "fabricated completion"}))
+    err = out.get("error", "")
+    assert "non-kanban tool calls" in err
+    assert "protocol_violation" in err
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task.status == "blocked"
+        events = kb.list_events(conn, worker_env)
+        kinds = [e.kind for e in events]
+        assert "protocol_violation" in kinds
+        assert "blocked" in kinds
+    finally:
+        conn.close()
 
 
 def test_complete_phantom_card_message_advertises_retry(worker_env):
@@ -1063,7 +1122,10 @@ def test_worker_lifecycle_through_tools(worker_env):
         assert parent.current_run_id is None
         run = kb.latest_run(conn, worker_env)
         assert run.outcome == "completed"
-        assert run.metadata == {"child_task": child_out["task_id"]}
+        assert run.metadata == {
+            "child_task": child_out["task_id"],
+            "worker_session_id": "sess-worker-default",
+        }
         # Child is todo (parent just finished, but recompute_ready may
         # have promoted it — complete_task runs recompute internally).
         child = kb.get_task(conn, child_out["task_id"])
@@ -1312,9 +1374,11 @@ def test_worker_unblock_rejects_foreign_task_id(worker_env):
         conn.close()
 
 
-def test_worker_complete_own_task_still_works(worker_env):
+def test_worker_complete_own_task_still_works(worker_env, monkeypatch):
     """The ownership check doesn't break the normal own-task happy path."""
     from tools import kanban_tools as kt
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-own-task")
+    _seed_worker_session("session-own-task", ["read_file"])
     # Both implicit (no task_id arg) and explicit (matching env) must work.
     out = kt._handle_complete({"task_id": worker_env, "summary": "explicit own"})
     d = json.loads(out)
@@ -1325,6 +1389,9 @@ def test_worker_complete_rejects_stale_run_id(worker_env, monkeypatch):
     """A retried worker cannot complete the task using an old run token."""
     from hermes_cli import kanban_db as kb
     import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-stale-run")
+    _seed_worker_session("session-stale-run", ["read_file"])
 
     conn = kb.connect()
     try:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -176,6 +176,45 @@ def _connect(board: Optional[str] = None):
     return kb, kb.connect(board=board)
 
 
+def _worker_non_kanban_tool_evidence() -> tuple[str, list[str], list[str]]:
+    """Return current-session non-kanban tool-call evidence for a worker."""
+    from gateway.session_context import get_session_env
+    from hermes_state import SessionDB
+
+    session_id = (
+        os.environ.get("HERMES_SESSION_ID", "").strip()
+        or get_session_env("HERMES_SESSION_ID", "").strip()
+    )
+    if not session_id:
+        return "", [], []
+
+    db = SessionDB()
+    try:
+        messages = db.get_messages(session_id)
+    finally:
+        db.close()
+
+    all_tool_calls: list[str] = []
+    non_kanban_calls: list[str] = []
+    for msg in messages:
+        tool_calls = msg.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            continue
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                continue
+            fn = call.get("function")
+            if not isinstance(fn, dict):
+                continue
+            name = str(fn.get("name") or "").strip()
+            if not name:
+                continue
+            all_tool_calls.append(name)
+            if not name.startswith("kanban_"):
+                non_kanban_calls.append(name)
+    return session_id, non_kanban_calls, all_tool_calls
+
+
 def _ok(**fields: Any) -> str:
     return json.dumps({"ok": True, **fields})
 
@@ -469,6 +508,48 @@ def _handle_complete(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
+            if os.environ.get("HERMES_KANBAN_TASK") == tid:
+                session_id, non_kanban_calls, all_tool_calls = (
+                    _worker_non_kanban_tool_evidence()
+                )
+                if not non_kanban_calls:
+                    reason = (
+                        "worker attempted kanban_complete without any prior "
+                        "non-kanban tool calls in this session"
+                    )
+                    detail = (
+                        f" session_id={session_id}."
+                        if session_id else
+                        " session_id unavailable."
+                    )
+                    observed = (
+                        ", ".join(all_tool_calls)
+                        if all_tool_calls else
+                        "(none recorded)"
+                    )
+                    blocked = kb.block_task_for_protocol_violation(
+                        conn, tid,
+                        reason=reason + detail,
+                        expected_run_id=_worker_run_id(tid),
+                        details={
+                            "session_id": session_id or None,
+                            "observed_tool_calls": all_tool_calls,
+                            "non_kanban_tool_calls": non_kanban_calls,
+                        },
+                    )
+                    if not blocked:
+                        return tool_error(
+                            f"kanban_complete blocked: {reason}{detail} "
+                            f"Observed tool calls: {observed}. Task state "
+                            f"could not be updated because the run is no "
+                            f"longer current."
+                        )
+                    return tool_error(
+                        f"kanban_complete blocked: {reason}{detail} "
+                        f"Observed tool calls: {observed}. The task was "
+                        f"auto-blocked with a protocol_violation event; do "
+                        f"real tool work before retrying."
+                    )
             try:
                 ok = kb.complete_task(
                     conn, tid,


### PR DESCRIPTION
## Summary
- auto-block dispatcher-scoped workers that call `kanban_complete` without any prior non-`kanban_*` tool calls in their recorded session
- emit a first-class `protocol_violation` event for that path so operators can distinguish fabricated completion from an ordinary block
- cover the new gate with targeted kanban tool tests and keep existing worker session stamping expectations explicit

Closes #32746

## Local proof
- `uv run --frozen --extra dev pytest tests/tools/test_kanban_tools.py -q`
- `uv run --frozen --extra dev ruff check hermes_cli/kanban_db.py tools/kanban_tools.py tests/tools/test_kanban_tools.py`
- `git diff --check`

## Notes
- direct push to `NousResearch/hermes-agent` returned 403 for `LeonSGP43`, so this PR is opened from the fork branch
- final pre-push overlap check found no assignee, no linked closing PR, and no keyword-overlap open PR for #32746
