### PR TITLE
Diagnose malformed Codex Responses at the provider boundary

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -634,6 +634,12 @@ class _CodexCompletionsAdapter:
         self._client = real_client
         self._model = model
 
+    def _client_log_context(self, model: Optional[str] = None) -> str:
+        return (
+            f"provider=openai-codex base_url={getattr(self._client, 'base_url', 'unknown')} "
+            f"model={model or self._model}"
+        )
+
     def create(self, **kwargs) -> Any:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
@@ -791,6 +797,10 @@ class _CodexCompletionsAdapter:
             collected_output_items: List[Any] = []
             collected_text_deltas: List[str] = []
             has_function_calls = False
+            from agent.codex_runtime import (
+                CodexMalformedResponseError,
+                _is_none_iterable_type_error,
+            )
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
@@ -813,28 +823,39 @@ class _CodexCompletionsAdapter:
                 _check_cancelled()
                 final = stream.get_final_response()
 
-            # Backfill empty output from collected stream events
+            # Backfill/validate output before any caller or SDK helper touches
+            # .output_text.  chatgpt.com/backend-api/codex can return
+            # response.output=None, which openai-python otherwise exposes as
+            # the opaque: 'NoneType' object is not iterable.
             _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
-                if collected_output_items:
-                    final.output = list(collected_output_items)
-                    logger.debug(
-                        "Codex auxiliary: backfilled %d output items from stream events",
-                        len(collected_output_items),
-                    )
-                elif collected_text_deltas and not has_function_calls:
-                    # Only synthesize text when no tool calls were streamed —
-                    # a function_call response with incidental text should not
-                    # be collapsed into a plain-text message.
-                    assembled = "".join(collected_text_deltas)
-                    final.output = [SimpleNamespace(
-                        type="message", role="assistant", status="completed",
-                        content=[SimpleNamespace(type="output_text", text=assembled)],
-                    )]
-                    logger.debug(
-                        "Codex auxiliary: synthesized from %d deltas (%d chars)",
-                        len(collected_text_deltas), len(assembled),
-                    )
+            if isinstance(_output, list) and _output:
+                pass
+            elif collected_output_items:
+                final.output = list(collected_output_items)
+                logger.debug(
+                    "Codex auxiliary: backfilled %d output items from stream events",
+                    len(collected_output_items),
+                )
+            elif collected_text_deltas and not has_function_calls:
+                # Only synthesize text when no tool calls were streamed —
+                # a function_call response with incidental text should not
+                # be collapsed into a plain-text message.
+                assembled = "".join(collected_text_deltas)
+                final.output = [SimpleNamespace(
+                    type="message", role="assistant", status="completed",
+                    content=[SimpleNamespace(type="output_text", text=assembled)],
+                )]
+                logger.debug(
+                    "Codex auxiliary: synthesized from %d deltas (%d chars)",
+                    len(collected_text_deltas), len(assembled),
+                )
+            else:
+                output_desc = "empty" if isinstance(_output, list) else type(_output).__name__
+                raise CodexMalformedResponseError(
+                    f"auxiliary response.output was {output_desc}",
+                    phase="auxiliary responses.stream final_response",
+                    context=self._client_log_context(model),
+                )
 
             # Extract text and tool calls from the Responses output.
             # Items may be SDK objects (attrs) or dicts (raw/fallback paths),
@@ -869,6 +890,21 @@ class _CodexCompletionsAdapter:
                     completion_tokens=getattr(resp_usage, "output_tokens", 0),
                     total_tokens=getattr(resp_usage, "total_tokens", 0),
                 )
+        except TypeError as exc:
+            if timed_out.is_set():
+                raise TimeoutError(_timeout_message()) from exc
+            if _is_none_iterable_type_error(exc):
+                logger.exception(
+                    "Codex auxiliary Responses parser raised a local TypeError. %s",
+                    self._client_log_context(model),
+                )
+                raise CodexMalformedResponseError(
+                    str(exc),
+                    phase="auxiliary responses.stream",
+                    context=self._client_log_context(model),
+                ) from exc
+            logger.debug("Codex auxiliary Responses API call failed: %s", exc)
+            raise
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,98 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+class CodexMalformedResponseError(TypeError):
+    """OpenAI SDK/Codex Responses parser failed after a non-HTTP response.
+
+    The chatgpt.com Codex backend can occasionally return a stream shape that
+    the OpenAI SDK collapses into a local ``TypeError`` such as
+    ``'NoneType' object is not iterable``.  Surface that as a provider/SDK
+    diagnostic instead of a bare Python error with ``HTTP None``.
+    """
+
+    def __init__(self, message: str, *, phase: str, context: str = "") -> None:
+        detail = (
+            "Codex Responses parser failed after the HTTP request was accepted: "
+            f"{message}. Phase: {phase}."
+        )
+        if context:
+            detail += f" {context}"
+        detail += (
+            " This usually means the Codex backend returned a streaming event "
+            "shape that this Hermes/OpenAI SDK build cannot parse; switching "
+            "provider/model or updating Hermes/OpenAI SDK is the practical "
+            "mitigation."
+        )
+        super().__init__(detail)
+        self.phase = phase
+        self.status_code = None
+        self.body = {"error": {"message": detail, "type": "codex_malformed_response"}}
+
+
+def _is_none_iterable_type_error(exc: BaseException) -> bool:
+    return isinstance(exc, TypeError) and "NoneType" in str(exc) and "iterable" in str(exc)
+
+
+def _ensure_response_output_or_raise(
+    response: Any,
+    *,
+    phase: str,
+    agent: Any,
+    collected_output_items: list | None = None,
+    collected_text_deltas: list | None = None,
+    suppress_text_synthesis: bool = False,
+) -> Any:
+    """Validate/backfill Codex Responses output before callers touch .output_text.
+
+    openai-python's ``Response.output_text`` property assumes ``output`` is
+    iterable.  The chatgpt.com Codex backend sometimes yields a terminal
+    response with ``output=None``; if we let that object escape, callers get the
+    opaque ``'NoneType' object is not iterable`` again.
+    """
+    output = getattr(response, "output", None)
+    if isinstance(output, list) and output:
+        return response
+
+    collected_output_items = collected_output_items or []
+    collected_text_deltas = collected_text_deltas or []
+    if collected_output_items:
+        response.output = list(collected_output_items)
+        logger.debug(
+            "Codex %s: backfilled %d output items",
+            phase,
+            len(collected_output_items),
+        )
+        return response
+
+    if collected_text_deltas and not suppress_text_synthesis:
+        assembled = "".join(collected_text_deltas)
+        response.output = [SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text=assembled)],
+        )]
+        logger.debug(
+            "Codex %s: synthesized output from %d text deltas (%d chars)",
+            phase,
+            len(collected_text_deltas),
+            len(assembled),
+        )
+        return response
+
+    if isinstance(output, list):
+        raise CodexMalformedResponseError(
+            "response.output was empty",
+            phase=phase,
+            context=agent._client_log_context(),
+        )
+    raise CodexMalformedResponseError(
+        f"response.output was {type(output).__name__}",
+        phase=phase,
+        context=agent._client_log_context(),
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -248,29 +340,15 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         )
                 final_response = stream.get_final_response()
                 # PATCH: ChatGPT Codex backend streams valid output items
-                # but get_final_response() can return an empty output list.
-                # Backfill from collected items or synthesize from deltas.
-                _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        final_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex stream: backfilled %d output items from stream events",
-                            len(collected_output_items),
-                        )
-                    elif agent._codex_streamed_text_parts and not has_tool_calls:
-                        assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex stream: synthesized output from %d text deltas (%d chars)",
-                            len(agent._codex_streamed_text_parts), len(assembled),
-                        )
-                return final_response
+                # but get_final_response() can return empty/None output.
+                return _ensure_response_output_or_raise(
+                    final_response,
+                    phase="responses.stream final_response",
+                    agent=agent,
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=agent._codex_streamed_text_parts,
+                    suppress_text_synthesis=has_tool_calls,
+                )
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(
@@ -287,6 +365,29 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+        except TypeError as exc:
+            if not _is_none_iterable_type_error(exc):
+                raise
+            logger.exception(
+                "Codex Responses stream parser raised a local TypeError. %s",
+                agent._client_log_context(),
+            )
+            if attempt < max_stream_retries:
+                continue
+            try:
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            except TypeError as fallback_exc:
+                if _is_none_iterable_type_error(fallback_exc):
+                    logger.exception(
+                        "Codex create(stream=True) fallback parser raised the same local TypeError. %s",
+                        agent._client_log_context(),
+                    )
+                    raise CodexMalformedResponseError(
+                        str(fallback_exc),
+                        phase="responses.create(stream=True) fallback",
+                        context=agent._client_log_context(),
+                    ) from fallback_exc
+                raise
         except RuntimeError as exc:
             err_text = str(exc)
             missing_completed = "response.completed" in err_text
@@ -344,11 +445,28 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
     fallback_kwargs = dict(api_kwargs)
     fallback_kwargs["stream"] = True
     fallback_kwargs = agent._get_transport().preflight_kwargs(fallback_kwargs, allow_stream=True)
-    stream_or_response = active_client.responses.create(**fallback_kwargs)
+    try:
+        stream_or_response = active_client.responses.create(**fallback_kwargs)
+    except TypeError as exc:
+        if _is_none_iterable_type_error(exc):
+            logger.exception(
+                "Codex create(stream=True) fallback failed before yielding events. %s",
+                agent._client_log_context(),
+            )
+            raise CodexMalformedResponseError(
+                str(exc),
+                phase="responses.create(stream=True)",
+                context=agent._client_log_context(),
+            ) from exc
+        raise
 
     # Compatibility shim for mocks or providers that still return a concrete response.
     if hasattr(stream_or_response, "output"):
-        return stream_or_response
+        return _ensure_response_output_or_raise(
+            stream_or_response,
+            phase="responses.create(stream=True) concrete_response",
+            agent=agent,
+        )
     if not hasattr(stream_or_response, "__iter__"):
         return stream_or_response
 
@@ -412,27 +530,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is None and isinstance(event, dict):
                 terminal_response = event.get("response")
             if terminal_response is not None:
-                # Backfill empty output from collected stream events
-                _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        terminal_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex fallback stream: backfilled %d output items",
-                            len(collected_output_items),
-                        )
-                    elif collected_text_deltas:
-                        assembled = "".join(collected_text_deltas)
-                        terminal_response.output = [SimpleNamespace(
-                            type="message", role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex fallback stream: synthesized from %d deltas (%d chars)",
-                            len(collected_text_deltas), len(assembled),
-                        )
-                return terminal_response
+                return _ensure_response_output_or_raise(
+                    terminal_response,
+                    phase="responses.create(stream=True) terminal_response",
+                    agent=agent,
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=collected_text_deltas,
+                )
     finally:
         close_fn = getattr(stream_or_response, "close", None)
         if callable(close_fn):
@@ -442,7 +546,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                 pass
 
     if terminal_response is not None:
-        return terminal_response
+        return _ensure_response_output_or_raise(
+            terminal_response,
+            phase="responses.create(stream=True) terminal_response",
+            agent=agent,
+            collected_output_items=collected_output_items,
+            collected_text_deltas=collected_text_deltas,
+        )
     raise RuntimeError("Responses create(stream=True) fallback did not emit a terminal response.")
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2870,7 +2870,8 @@ def run_conversation(
                 if is_client_error:
                     # Try fallback before aborting — a different provider
                     # may not have the same issue (rate limit, auth, etc.)
-                    agent._emit_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
+                    _status_label = f"HTTP {status_code}" if status_code is not None else "no HTTP status"
+                    agent._emit_status(f"⚠️ Non-retryable error ({_status_label}) — trying fallback...")
                     if agent._try_activate_fallback():
                         retry_count = 0
                         compression_attempts = 0
@@ -2881,10 +2882,10 @@ def run_conversation(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,
                         )
                     agent._emit_status(
-                        f"❌ Non-retryable error (HTTP {status_code}): "
+                        f"❌ Non-retryable error ({_status_label}): "
                         f"{agent._summarize_api_error(api_error)}"
                     )
-                    agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error (HTTP {status_code}). Aborting.", force=True)
+                    agent._vprint(f"{agent.log_prefix}❌ Non-retryable client error ({_status_label}). Aborting.", force=True)
                     agent._vprint(f"{agent.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     agent._vprint(f"{agent.log_prefix}   🌐 Endpoint: {_base}", force=True)
                     # Actionable guidance for common auth errors
@@ -2917,7 +2918,10 @@ def run_conversation(
                                 agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
                     else:
                         agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
-                    logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
+                    if is_local_validation_error:
+                        logger.exception("%sNon-retryable local/API response parsing error", agent.log_prefix)
+                    else:
+                        logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
                     # Skip session persistence when the error is likely
                     # context-overflow related (status 400 + large session).
                     # Persisting the failed user message would make the

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2515,6 +2515,68 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert fake_client.responses.kwargs["timeout"] == 12.5
         assert response.choices[0].message.content == "summary"
 
+    def test_rejects_none_output_with_diagnostic(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return SimpleNamespace(output=None, status="completed", usage=None)
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(
+            responses=FakeResponses(),
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        with pytest.raises(TypeError) as exc_info:
+            adapter.create(messages=[{"role": "user", "content": "title"}])
+
+        message = str(exc_info.value)
+        assert "Codex Responses parser failed" in message
+        assert "auxiliary response.output was NoneType" in message
+        assert "auxiliary responses.stream final_response" in message
+        assert "provider=openai-codex" in message
+
+    def test_wraps_stream_parser_none_iterable_typeerror(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(
+            responses=FakeResponses(),
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        with pytest.raises(TypeError) as exc_info:
+            adapter.create(messages=[{"role": "user", "content": "title"}])
+
+        message = str(exc_info.value)
+        assert "Codex Responses parser failed" in message
+        assert "auxiliary responses.stream" in message
+        assert "'NoneType' object is not iterable" in message
+
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
         class SlowAliveStream:
             def __enter__(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -484,6 +484,74 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert response.output[0].content[0].text == "streamed create ok"
 
 
+def test_run_codex_stream_wraps_none_iterable_typeerror_after_fallback(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(final_error=TypeError("'NoneType' object is not iterable"))
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        raise TypeError("'NoneType' object is not iterable")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    with pytest.raises(TypeError) as exc_info:
+        agent._run_codex_stream(_codex_request_kwargs())
+
+    message = str(exc_info.value)
+    assert "Codex Responses parser failed" in message
+    assert "HTTP request was accepted" in message
+    assert "responses.create(stream=True)" in message
+    assert "HTTP None" not in message
+    assert calls == {"stream": 2, "create": 1}
+
+
+
+def test_run_codex_stream_rejects_terminal_response_with_none_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(final_response=SimpleNamespace(output=None, status="completed"))
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return SimpleNamespace(output=None, status="completed")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create)
+    )
+
+    with pytest.raises(TypeError) as exc_info:
+        agent._run_codex_stream(_codex_request_kwargs())
+
+    message = str(exc_info.value)
+    assert "Codex Responses parser failed" in message
+    assert "response.output was NoneType" in message
+    assert "responses.stream final_response" in message
+    assert calls == {"stream": 1, "create": 0}
+
+def test_summarize_api_error_uses_structured_codex_parser_message():
+    from agent.codex_runtime import CodexMalformedResponseError
+
+    error = CodexMalformedResponseError(
+        "'NoneType' object is not iterable",
+        phase="responses.stream",
+        context="provider=openai-codex model=gpt-5.5",
+    )
+
+    summary = run_agent.AIAgent._summarize_api_error(error)
+
+    assert summary.startswith("Codex Responses parser failed")
+    assert "provider=openai-codex" in summary
+    assert "HTTP None" not in summary
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary

This PR makes Hermes diagnose malformed Codex/OpenAI Responses objects instead of surfacing raw SDK parser failures such as:

```text
'NoneType' object is not iterable
```

The observed failure mode is a terminal Responses object where `response.output` is `None`. That can currently escape through both main Codex generation and auxiliary title generation.

## Ontology / boundary

- **Cloud behavior:** the remote Codex endpoint may produce, or the SDK may construct, a terminal Responses object with `output = None`.
- **SDK invariant:** `openai-python` should not leak raw `TypeError` when parsing malformed Responses payloads.
- **Hermes containment:** Hermes should identify the provider boundary and report provider/model/endpoint/phase context to users.

This is intentionally not treated as an MCP startup issue; MCP failures are separate from this Codex Responses parser path.

## Changes

- Add `CodexMalformedResponseError` for malformed Codex Responses diagnostics.
- Validate/backfill Codex final responses before callers touch `output_text`.
- Wrap SDK `TypeError("'NoneType' object is not iterable")` from Responses streaming.
- Apply the same diagnostic containment to auxiliary title generation.
- Avoid misleading `HTTP None` wording for local parser/client failures.
- Add regressions for main and auxiliary malformed Responses paths.

## Verification

```text
venv/bin/python -m pytest -q \
  tests/agent/test_auxiliary_client.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/run_agent/test_codex_xai_oauth_recovery.py \
  tests/run_agent/test_streaming.py

323 passed, 1 warning
```
