### PR TITLE
fix(agent): inject turn-level current time context

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+from hermes_time import current_time_context
 from agent.error_classifier import FailoverReason
 from agent.gemini_native_adapter import is_native_gemini_base_url
 from agent.model_metadata import is_local_endpoint
@@ -1681,14 +1682,19 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         "without calling any more tools."
     )
     messages.append({"role": "user", "content": summary_request})
+    summary_user_idx = len(messages) - 1
 
     try:
         # Build API messages, stripping internal-only fields
         # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
         _needs_sanitize = agent._should_sanitize_tool_calls()
         api_messages = []
-        for msg in messages:
+        for idx, msg in enumerate(messages):
             api_msg = msg.copy()
+            if idx == summary_user_idx and msg.get("role") == "user":
+                _time_context = current_time_context()
+                if _time_context and isinstance(api_msg.get("content"), str):
+                    api_msg["content"] = api_msg["content"] + "\n\n" + _time_context
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                 api_msg.pop(internal_field, None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -68,6 +68,7 @@ from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
+from hermes_time import current_time_context
 from tools.skill_provenance import set_current_write_origin
 from utils import base_url_host_matches, env_var_enabled
 
@@ -800,6 +801,9 @@ def run_conversation(
             # never mutated, so nothing leaks into session persistence.
             if idx == current_turn_user_idx and msg.get("role") == "user":
                 _injections = []
+                _time_context = current_time_context()
+                if _time_context:
+                    _injections.append(_time_context)
                 if _ext_prefetch_cache:
                     _fenced = build_memory_context_block(_ext_prefetch_cache)
                     if _fenced:
@@ -808,8 +812,17 @@ def run_conversation(
                     _injections.append(_plugin_user_context)
                 if _injections:
                     _base = api_msg.get("content", "")
+                    _injected_text = "\n\n".join(_injections)
                     if isinstance(_base, str):
-                        api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                        api_msg["content"] = _base + "\n\n" + _injected_text
+                    elif isinstance(_base, list):
+                        # Copy the list before appending so the API-only part
+                        # cannot leak into canonical/persisted history through
+                        # the shallow ``msg.copy()`` above.
+                        api_msg["content"] = [
+                            *_base,
+                            {"type": "text", "text": _injected_text},
+                        ]
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -133,3 +133,23 @@ def now() -> datetime:
     return datetime.now().astimezone()
 
 
+def current_time_context() -> str:
+    """Return a compact per-turn current-time context string for LLM calls.
+
+    This is intended for API-call-time user-message context, not for the
+    cached system prompt.  The formatter never surfaces an invalid configured
+    timezone name; if validation fails, ``now()`` has already fallen back to
+    the server-local timezone and we label that instead.
+    """
+    current = now()
+    tz = get_timezone()
+    if tz is not None and _cached_tz_name:
+        tz_label = _cached_tz_name
+    else:
+        tz_label = current.tzname() or current.strftime("%z") or "local"
+    return (
+        f"[Current time: {current.strftime('%Y-%m-%d %H:%M')} "
+        f"{tz_label} {current.strftime('%A')}]"
+    )
+
+

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3761,6 +3761,26 @@ class TestHandleMaxIterations:
         assert messages[2]["tool_name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
+    def test_summary_injects_turn_level_current_time_context(self, agent):
+        resp = _mock_response(content="Summary")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+        messages = [{"role": "user", "content": "do stuff"}]
+
+        with patch(
+            "agent.chat_completion_helpers.current_time_context",
+            return_value="[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]",
+        ):
+            result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        sent_msgs = kwargs.get("messages", [])
+        summary_msg = sent_msgs[-1]
+        assert summary_msg["role"] == "user"
+        assert "[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]" in summary_msg["content"]
+        assert "[Current time:" not in messages[-1]["content"]
+
     def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
         agent.base_url = "https://api.openai.com/v1"
         agent._base_url_lower = agent.base_url.lower()
@@ -3983,6 +4003,74 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_injects_turn_level_current_time_context_into_user_message(self, agent):
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch(
+                "agent.conversation_loop.current_time_context",
+                return_value="[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]",
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Final answer"
+        assert result["completed"] is True
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        sent_messages = kwargs["messages"]
+        assert "[Current time:" not in sent_messages[0]["content"]
+        user_message = next(m for m in sent_messages if m.get("role") == "user")
+        assert user_message["content"] == (
+            "hello\n\n[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]"
+        )
+        assert result["messages"][0]["content"] == "hello"
+
+    def test_injects_turn_level_current_time_context_into_multimodal_user_message(self, agent):
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+        multimodal_content = [
+            {"type": "text", "text": "What is in this image?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+        ]
+
+        with (
+            patch(
+                "agent.conversation_loop.current_time_context",
+                return_value="[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]",
+            ),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_model_supports_vision", return_value=True),
+        ):
+            result = agent.run_conversation(multimodal_content)
+
+        assert result["final_response"] == "Final answer"
+        assert result["completed"] is True
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        user_message = next(m for m in kwargs["messages"] if m.get("role") == "user")
+        assert user_message["content"] == [
+            *multimodal_content,
+            {
+                "type": "text",
+                "text": "[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]",
+            },
+        ]
+        assert result["messages"][0]["content"] == multimodal_content
+        assert all(
+            "[Current time:" not in str(part)
+            for part in result["messages"][0]["content"]
+        )
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"
@@ -4066,7 +4154,12 @@ class TestRunConversation:
         ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
         assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
-        assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
+        first_user_msg = next(
+            msg for msg in pre_request_calls[0]["request_messages"]
+            if msg.get("role") == "user"
+        )
+        assert first_user_msg.get("content", "").startswith("search something")
+        assert "[Current time:" in first_user_msg.get("content", "")
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -896,6 +896,81 @@ def test_copilot_final_preflight_sanitizes_both_middleware_layers(monkeypatch):
     ]
 
 
+def test_run_conversation_codex_injects_turn_level_current_time_context(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent._cached_system_prompt = "You are Hermes."
+    captured = {}
+    monkeypatch.setattr(
+        "agent.conversation_loop.current_time_context",
+        lambda: "[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]",
+    )
+
+    def _capture_api_call(api_kwargs):
+        captured["api_kwargs"] = api_kwargs
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+
+    result = agent.run_conversation("Say OK")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "OK"
+    assert "You are Hermes." in captured["api_kwargs"]["instructions"]
+    assert "[Current time:" not in captured["api_kwargs"]["instructions"]
+    assert "[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]" in str(
+        captured["api_kwargs"]["input"]
+    )
+    assert result["messages"][0]["content"] == "Say OK"
+
+
+def test_run_conversation_codex_injects_time_into_multimodal_user_content(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    captured = {}
+    multimodal_content = [
+        {"type": "text", "text": "What is in this image?"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        },
+    ]
+    monkeypatch.setattr(
+        "agent.conversation_loop.current_time_context",
+        lambda: "[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]",
+    )
+
+    def _capture_api_call(api_kwargs):
+        captured["api_kwargs"] = api_kwargs
+        return _codex_message_response("OK")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _capture_api_call)
+
+    result = agent.run_conversation(multimodal_content)
+
+    assert result["completed"] is True
+    assert result["final_response"] == "OK"
+    assert captured["api_kwargs"]["input"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "What is in this image?"},
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,AAAA",
+                },
+                {
+                    "type": "input_text",
+                    "text": "[Current time: 2026-05-27 09:30 Asia/Shanghai Wednesday]",
+                },
+            ],
+        }
+    ]
+    assert result["messages"][0]["content"] == multimodal_content
+    assert all(
+        "[Current time:" not in str(part)
+        for part in result["messages"][0]["content"]
+    )
+
+
 def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):
     """Regression: empty response.output + valid output_text should succeed,
     not trigger retry/fallback. The validation stage must defer to

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -103,6 +103,32 @@ class TestHermesTimeNow:
         assert r2.utcoffset() == timedelta(hours=5, minutes=30)
 
 
+class TestCurrentTimeContext:
+    """Test the LLM-facing current-time context formatter."""
+
+    def setup_method(self):
+        _reset_hermes_time_cache()
+
+    def teardown_method(self):
+        _reset_hermes_time_cache()
+        os.environ.pop("HERMES_TIMEZONE", None)
+
+    def test_uses_configured_timezone_label(self):
+        os.environ["HERMES_TIMEZONE"] = "Asia/Kolkata"
+        context = hermes_time.current_time_context()
+
+        assert context.startswith("[Current time: ")
+        assert "Asia/Kolkata" in context
+        assert context.endswith("]")
+
+    def test_invalid_timezone_label_not_exposed(self):
+        os.environ["HERMES_TIMEZONE"] = "Mars/Olympus_Mons"
+        context = hermes_time.current_time_context()
+
+        assert "[Current time: " in context
+        assert "Mars/Olympus_Mons" not in context
+
+
 class TestGetTimezone:
     """Test get_timezone()."""
 


### PR DESCRIPTION
## Summary
- add built-in turn-level current-time context via the existing API-only user-message injection path
- keep the cached system prompt stable so prompt caching is not invalidated by live time
- cover chat-completions, Codex Responses, and max-iterations summary paths

Fixes #10421.

## Tests
- uv run --extra dev pytest tests/test_timezone.py tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_summary_injects_turn_level_current_time_context tests/run_agent/test_run_agent.py::TestRunConversation::test_injects_turn_level_current_time_context_into_user_message tests/run_agent/test_run_agent.py::TestRunConversation::test_request_scoped_api_hooks_fire_for_each_api_call tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_injects_turn_level_current_time_context
- uv run --extra dev pytest tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py
- uv run --extra dev ruff check hermes_time.py agent/conversation_loop.py agent/chat_completion_helpers.py tests/test_timezone.py tests/run_agent/test_run_agent.py tests/run_agent/test_run_agent_codex_responses.py