### PR TITLE
fix(codex): handle gpt-5.5 null output in stream events

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -287,6 +287,34 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+        except TypeError as exc:
+            # The OpenAI SDK's parse_response() does ``for output in
+            # response.output`` — if gpt-5.5 (or another Codex backend)
+            # emits a streaming event where ``output`` is JSON null, the
+            # SDK raises TypeError: 'NoneType' object is not iterable.
+            # This is a transient provider-side quirk, not a Hermes bug.
+            # Retry like other recoverable stream failures; fall back to
+            # the create(stream=True) path when retries are exhausted.
+            err_text = str(exc)
+            if "NoneType" in err_text or "is not iterable" in err_text:
+                if attempt < max_stream_retries:
+                    logger.debug(
+                        "Codex stream: SDK TypeError (null output in stream event) "
+                        "(attempt %s/%s); retrying. %s error=%s",
+                        attempt + 1,
+                        max_stream_retries + 1,
+                        agent._client_log_context(),
+                        exc,
+                    )
+                    continue
+                logger.debug(
+                    "Codex stream: SDK TypeError exhausted retries; "
+                    "falling back to create(stream=True). %s error=%s",
+                    agent._client_log_context(),
+                    exc,
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
         except RuntimeError as exc:
             err_text = str(exc)
             missing_completed = "response.completed" in err_text

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3556,9 +3556,12 @@ def run_conversation(
                 # Refund the iteration if the ONLY tool(s) called were
                 # execute_code (programmatic tool calling).  These are
                 # cheap RPC-style calls that shouldn't eat the budget.
-                _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
-                if _tc_names == {"execute_code"}:
-                    agent.iteration_budget.refund()
+                # Guard against None tool_calls (codex transport returns None
+                # when no tool calls are present, not an empty list).
+                if assistant_message.tool_calls:
+                    _tc_names = {tc.function.name for tc in assistant_message.tool_calls}
+                    if _tc_names == {"execute_code"}:
+                        agent.iteration_budget.refund()
                 
                 # Use real token counts from the API response to decide
                 # compression.  prompt_tokens + completion_tokens is the


### PR DESCRIPTION
## Problem

gpt-5.5 intermittently emits SSE stream events where `response.output` is JSON `null`. The OpenAI SDK's `parse_response()` does `for output in response.output` — crashing with `TypeError: 'NoneType' object is not iterable`.

Hermes classified `TypeError` as a non-retryable local programming bug, so every affected request failed permanently with no retry. Sessions using `openai-codex` / `gpt-5.5` became completely unresponsive.

## Fix

**`agent/codex_runtime.py`** — catch `TypeError` with null-output fingerprint (`'NoneType'` or `'is not iterable'`) in the stream loop. Retry up to `max_stream_retries`, then fall back to `_run_codex_create_stream_fallback()`. Mirrors existing handling for `RuntimeError` and transport errors.

**`agent/conversation_loop.py`** — guard `tool_calls` set-comprehension against `None`. The codex transport returns `tool_calls=None` (not `[]`) when no tools were called; iterating it raised the same `TypeError` class.

## Reproduction

Any `openai-codex` session on `gpt-5.5` hitting the intermittent null-output backend behavior — every message fails with `⚠️ 'NoneType' object is not iterable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)