### PR TITLE
fix(gateway): preserve relink path after restart

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -251,7 +251,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -271,6 +271,39 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            # OpenAI SDK ≤2.24 bug: parse_response() in the streaming state
+            # machine iterates response.output which can be None when the
+            # Codex backend sends response.completed with output=null.
+            # The SDK crashes with "'NoneType' object is not iterable" inside
+            # accumulate_event() before get_final_response() is ever reached.
+            # Recover from collected output items / streamed text deltas.
+            if "'NoneType' object is not iterable" in str(exc) or "not iterable" in str(exc):
+                logger.warning(
+                    "Codex stream: SDK parse_response() hit None output — "
+                    "recovering from %d collected items, %d text deltas. %s",
+                    len(collected_output_items),
+                    len(agent._codex_streamed_text_parts),
+                    agent._client_log_context(),
+                )
+                if collected_output_items:
+                    return SimpleNamespace(
+                        output=list(collected_output_items),
+                        status="completed",
+                    )
+                elif agent._codex_streamed_text_parts:
+                    assembled = "".join(agent._codex_streamed_text_parts)
+                    return SimpleNamespace(
+                        output=[SimpleNamespace(
+                            type="message",
+                            role="assistant",
+                            status="completed",
+                            content=[SimpleNamespace(type="output_text", text=assembled)],
+                        )],
+                        status="completed",
+                    )
+            # Not the SDK None-output bug — re-raise
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6466,6 +6466,7 @@ class GatewayRunner:
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.SLACK: "SLACK_ALLOW_BOTS",
         }
 
         # Plugin platforms: check the registry for auth env var names

--- a/tests/gateway/test_discord_bot_auth_bypass.py
+++ b/tests/gateway/test_discord_bot_auth_bypass.py
@@ -1,6 +1,6 @@
-"""Regression guard for #4466: DISCORD_ALLOW_BOTS works without DISCORD_ALLOWED_USERS.
+"""Regression guard for bot allow policies working without *_ALLOWED_USERS.
 
-The bug had two sequential gates both rejecting bot messages:
+The original #4466 bug had two sequential gates both rejecting bot messages:
 
   Gate 1 — `on_message` in gateway/platforms/discord.py ran the user-allowlist
   check BEFORE the bot filter, so bot senders were dropped with a warning
@@ -9,8 +9,8 @@ The bug had two sequential gates both rejecting bot messages:
   Gate 2 — `_is_user_authorized` in gateway/run.py rejected bots at the
   gateway level even if they somehow reached that layer.
 
-These tests assert both gates now pass a bot message through when
-DISCORD_ALLOW_BOTS permits it AND no user allowlist entry exists.
+These tests assert both gates now pass a bot message through when the platform's
+*_ALLOW_BOTS permits it AND no user allowlist entry exists.
 """
 
 import os
@@ -33,6 +33,9 @@ def _isolate_discord_env(monkeypatch):
         "DISCORD_ALLOWED_USERS",
         "DISCORD_ALLOWED_ROLES",
         "DISCORD_ALLOW_ALL_USERS",
+        "SLACK_ALLOW_BOTS",
+        "SLACK_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
         "GATEWAY_ALLOWED_USERS",
     ):
@@ -81,6 +84,17 @@ def _make_discord_human_source(user_id: str = "100200300"):
     )
 
 
+def _make_slack_bot_source(bot_id: str = "U0B13E9M3LZ"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="channel",
+        user_id=bot_id,
+        user_name="Storm",
+        is_bot=True,
+    )
+
+
 def test_discord_bot_authorized_when_allow_bots_mentions(monkeypatch):
     """DISCORD_ALLOW_BOTS=mentions must authorize a bot sender even when
     DISCORD_ALLOWED_USERS is set and the bot's ID is NOT in it.
@@ -108,6 +122,40 @@ def test_discord_bot_authorized_when_allow_bots_all(monkeypatch):
 
     source = _make_discord_bot_source()
     assert runner._is_user_authorized(source) is True
+
+
+def test_slack_bot_authorized_when_allow_bots_mentions(monkeypatch):
+    """SLACK_ALLOW_BOTS=mentions must authorize bot senders at the gateway
+    layer just like Discord/Feishu. The Slack adapter already enforces that the
+    message mentioned this bot before the event reaches _is_user_authorized.
+    """
+    runner = _make_bare_runner()
+
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U-human-only")
+
+    source = _make_slack_bot_source(bot_id="U0B13E9M3LZ")
+    assert runner._is_user_authorized(source) is True
+
+
+def test_slack_bot_authorized_when_allow_bots_all(monkeypatch):
+    runner = _make_bare_runner()
+
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U-human-only")
+
+    source = _make_slack_bot_source()
+    assert runner._is_user_authorized(source) is True
+
+
+def test_slack_bot_NOT_authorized_when_allow_bots_none(monkeypatch):
+    runner = _make_bare_runner()
+
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "none")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U-human-only")
+
+    source = _make_slack_bot_source()
+    assert runner._is_user_authorized(source) is False
 
 
 def test_discord_bot_NOT_authorized_when_allow_bots_none(monkeypatch):

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -862,6 +862,41 @@ class TestCodexStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == 3
 
+    def test_codex_stream_none_output_typeerror_recovers_from_text_deltas(self):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        def broken_sdk_iter():
+            yield SimpleNamespace(type="response.output_text.delta", delta="partial answer")
+            raise TypeError("'NoneType' object is not iterable")
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.__iter__ = MagicMock(return_value=broken_sdk_iter())
+        mock_stream.get_final_response.side_effect = AssertionError(
+            "SDK crashed before final response was available"
+        )
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = mock_stream
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response.status == "completed"
+        assert response.output[0].type == "message"
+        assert response.output[0].content[0].text == "partial answer"
+
     def test_codex_remote_protocol_error_falls_back_to_create_stream(self):
         from run_agent import AIAgent
         import httpx


### PR DESCRIPTION
## Summary
- allow Slack bot senders through the gateway auth layer when `SLACK_ALLOW_BOTS` explicitly permits bot mentions/all, matching Discord and Feishu behavior
- harden Codex Responses streaming against the OpenAI SDK `output=None` TypeError path by reconstructing a completed response from collected items/text deltas
- add regression coverage for Slack bot authorization and Codex stream recovery

## Test Plan
- `scripts/run_tests.sh tests/run_agent/test_streaming.py tests/gateway/test_discord_bot_auth_bypass.py tests/gateway/test_restart_resume_pending.py tests/gateway/test_clean_shutdown_marker.py`
