### PR TITLE
fix(tools): reuse supervisor sessions for browser_cdp target_id

### DIFF
--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -403,6 +403,29 @@ def test_browser_cdp_frame_id_routes_via_supervisor(chrome_cdp, supervisor_regis
     assert value == 2, f"expected 2, got {value!r}"
 
 
+def test_browser_cdp_target_id_routes_via_supervisor(chrome_cdp, supervisor_registry):
+    """browser_cdp(target_id=...) reuses the live supervisor session."""
+    cdp_url, _port = chrome_cdp
+    sv = supervisor_registry.get_or_start(task_id="target-id-test", cdp_url=cdp_url)
+    assert sv.snapshot().active
+    assert sv._page_target_id
+
+    from tools.browser_cdp_tool import browser_cdp
+
+    result = browser_cdp(
+        method="Runtime.evaluate",
+        params={"expression": "1 + 2", "returnByValue": True},
+        target_id=sv._page_target_id,
+        task_id="target-id-test",
+    )
+    r = json.loads(result)
+    assert r.get("success") is True, f"expected success, got: {r}"
+    assert r.get("target_id") == sv._page_target_id
+    assert r.get("session_id") == sv._page_session_id
+    value = r.get("result", {}).get("result", {}).get("value")
+    assert value == 3, f"expected 3, got {value!r}"
+
+
 def test_browser_cdp_frame_id_real_oopif_smoke_documented():
     """Document that real-OOPIF E2E was manually verified — see PR #14540.
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -298,6 +298,71 @@ def _browser_cdp_via_supervisor(
     return json.dumps(payload, ensure_ascii=False)
 
 
+def _browser_cdp_target_via_supervisor(
+    task_id: str,
+    target_id: str,
+    method: str,
+    params: Optional[Dict[str, Any]],
+    timeout: float,
+) -> Optional[str]:
+    """Route a target-scoped CDP call through a live supervisor session.
+
+    Returns ``None`` when no suitable live supervisor/session exists so the
+    caller can fall back to the legacy stateless attach flow.
+    """
+    try:
+        from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
+    except Exception:
+        return None
+
+    supervisor = SUPERVISOR_REGISTRY.get(task_id)
+    if supervisor is None:
+        return None
+
+    session_id = supervisor.resolve_target_session(target_id)
+    if not session_id:
+        return None
+
+    loop = supervisor._loop  # type: ignore[attr-defined]
+    if loop is None or not loop.is_running():
+        return None
+
+    async def _do_cdp():
+        return await supervisor._cdp(  # type: ignore[attr-defined]
+            method,
+            params or {},
+            session_id=session_id,
+            timeout=timeout,
+        )
+
+    try:
+        from agent.async_utils import safe_schedule_threadsafe
+
+        fut = safe_schedule_threadsafe(_do_cdp(), loop)
+        if fut is None:
+            return tool_error(
+                "CDP call via supervisor failed: loop unavailable",
+                cdp_docs=CDP_DOCS_URL,
+            )
+        result_msg = fut.result(timeout=timeout + 2)
+    except Exception as exc:
+        return tool_error(
+            f"CDP call via supervisor failed: {type(exc).__name__}: {exc}",
+            cdp_docs=CDP_DOCS_URL,
+        )
+
+    return json.dumps(
+        {
+            "success": True,
+            "method": method,
+            "target_id": target_id,
+            "session_id": session_id,
+            "result": result_msg.get("result", {}),
+        },
+        ensure_ascii=False,
+    )
+
+
 def browser_cdp(
     method: str,
     params: Optional[Dict[str, Any]] = None,
@@ -340,6 +405,16 @@ def browser_cdp(
             params=params,
             timeout=timeout,
         )
+    if target_id:
+        routed = _browser_cdp_target_via_supervisor(
+            task_id=task_id or "default",
+            target_id=target_id,
+            method=method,
+            params=params,
+            timeout=timeout,
+        )
+        if routed is not None:
+            return routed
     del task_id  # stateless path below
 
     if not method or not isinstance(method, str):
@@ -457,6 +532,10 @@ BROWSER_CDP_SCHEMA: Dict[str, Any] = {
         "target_id and frame_id.\n"
         "- Page-level methods (Page.*, Runtime.*, DOM.*, Emulation.*, "
         "Network.* scoped to a tab): pass target_id from Target.getTargets.\n"
+        "- When the requested target_id belongs to the live browser "
+        "supervisor session, Hermes reuses that persistent CDP WebSocket "
+        "automatically; otherwise it falls back to a fresh stateless "
+        "attach for backward compatibility.\n"
         "- **Cross-origin iframe scope** (Runtime.evaluate inside an OOPIF, "
         "Page.* targeting a frame target, etc.): pass frame_id from the "
         "browser_snapshot frame_tree output. This routes through the CDP "

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -310,6 +310,7 @@ class CDPSupervisor:
         self._next_call_id = 1
         self._pending_calls: Dict[int, asyncio.Future] = {}
         self._ws: Optional[ClientConnection] = None
+        self._page_target_id: Optional[str] = None
         self._page_session_id: Optional[str] = None
         self._child_sessions: Dict[str, Dict[str, Any]] = {}  # session_id -> info
 
@@ -548,6 +549,22 @@ class CDPSupervisor:
 
         return {"ok": True, "result": value, "result_type": result_type}
 
+    def resolve_target_session(self, target_id: str) -> Optional[str]:
+        """Return the live supervisor session for a known CDP target id."""
+        if not target_id:
+            return None
+        with self._state_lock:
+            if target_id == self._page_target_id and self._page_session_id:
+                return self._page_session_id
+            frame = self._frames.get(target_id)
+            if frame and frame.cdp_session_id:
+                return frame.cdp_session_id
+            for session_id, meta in self._child_sessions.items():
+                info = meta.get("info") if isinstance(meta, dict) else None
+                if isinstance(info, dict) and info.get("targetId") == target_id:
+                    return session_id
+        return None
+
     # ── Supervisor loop internals ────────────────────────────────────────────
 
     def _thread_main(self) -> None:
@@ -618,6 +635,7 @@ class CDPSupervisor:
             try:
                 # Reset per-connection session state so stale ids don't hang
                 # around after a reconnect.
+                self._page_target_id = None
                 self._page_session_id = None
                 self._child_sessions.clear()
                 # We deliberately keep `_pending_dialogs` and `_frames` —
@@ -692,6 +710,7 @@ class CDPSupervisor:
             "Target.attachToTarget",
             {"targetId": target_id, "flatten": True},
         )
+        self._page_target_id = target_id
         self._page_session_id = attach["result"]["sessionId"]
         await self._cdp("Page.enable", session_id=self._page_session_id)
         await self._cdp("Runtime.enable", session_id=self._page_session_id)


### PR DESCRIPTION
## Summary
- reuse the live browser supervisor session when `browser_cdp` is called with a `target_id` that already belongs to the connected supervisor
- track the top-level page target id in `CDPSupervisor` and resolve target ids back to live session ids before falling back to the legacy stateless attach flow
- add a regression test covering `browser_cdp(target_id=...)` against the supervisor-backed path

Closes #32685.

## Verification
- `uv run --frozen --extra dev pytest tests/tools/test_browser_cdp_tool.py tests/tools/test_browser_supervisor.py -q`
- `source /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/activate && ruff check tools/browser_cdp_tool.py tools/browser_supervisor.py tests/tools/test_browser_supervisor.py`
- `git diff --check`
