### PR TITLE
feat(dashboard): opt-in LAN WebSocket access via HERMES_DASHBOARD_TRUST_LAN

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3303,6 +3303,7 @@ async def get_models_analytics(days: int = 30):
 
 import re
 import asyncio
+import ipaddress
 
 # PTY bridge is POSIX-only (depends on fcntl/termios/ptyprocess).  On native
 # Windows the import raises; catch and leave PtyBridge=None so the rest of
@@ -3326,16 +3327,40 @@ _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 # loopback so tests don't need to rewrite request scope.
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 
+_TRUST_LAN_ENV = "HERMES_DASHBOARD_TRUST_LAN"
+
+
+def _is_rfc1918_or_ula(host: str) -> bool:
+    """Return True if *host* parses as an RFC1918 (10/8, 172.16/12, 192.168/16)
+    or IPv6 ULA (fc00::/7) address.  Invalid input returns False."""
+    try:
+        ip = ipaddress.ip_address(host)
+    except (ValueError, TypeError):
+        return False
+    if isinstance(ip, ipaddress.IPv4Address):
+        return ip in ipaddress.ip_network("10.0.0.0/8") \
+            or ip in ipaddress.ip_network("172.16.0.0/12") \
+            or ip in ipaddress.ip_network("192.168.0.0/16")
+    return ip in ipaddress.ip_network("fc00::/7")
+
 
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
-    Allows loopback clients only.
+    Loopback is always allowed.  When the ``HERMES_DASHBOARD_TRUST_LAN``
+    environment variable is set to a truthy value (``1``/``true``/``yes``),
+    RFC1918 and IPv6 ULA clients are also allowed; this is intended for
+    reverse-proxy deployments where the dashboard sits behind a separate
+    LAN gateway.  Public addresses are always rejected.
     """
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return True
-    return client_host in _LOOPBACK_HOSTS
+    if client_host in _LOOPBACK_HOSTS:
+        return True
+    if os.environ.get(_TRUST_LAN_ENV, "").strip().lower() in {"1", "true", "yes"}:
+        return _is_rfc1918_or_ula(client_host)
+    return False
 
 
 def _ws_host_origin_is_allowed(ws: "WebSocket") -> bool:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2450,3 +2450,35 @@ class TestDashboardPluginStaticAssetAllowlist:
         # — never 200.
         assert resp.status_code in (403, 404)
 
+
+def test_ws_lan_client_rejected_by_default(monkeypatch):
+    from types import SimpleNamespace
+    from hermes_cli.web_server import _ws_client_is_allowed
+    monkeypatch.delenv("HERMES_DASHBOARD_TRUST_LAN", raising=False)
+    ws = SimpleNamespace(client=SimpleNamespace(host="192.168.1.10"))
+    assert _ws_client_is_allowed(ws) is False
+
+
+def test_ws_lan_client_allowed_with_trust_env(monkeypatch):
+    from types import SimpleNamespace
+    from hermes_cli.web_server import _ws_client_is_allowed
+    monkeypatch.setenv("HERMES_DASHBOARD_TRUST_LAN", "1")
+    ws = SimpleNamespace(client=SimpleNamespace(host="192.168.1.10"))
+    assert _ws_client_is_allowed(ws) is True
+
+
+def test_ws_public_client_rejected_even_with_trust_env(monkeypatch):
+    from types import SimpleNamespace
+    from hermes_cli.web_server import _ws_client_is_allowed
+    monkeypatch.setenv("HERMES_DASHBOARD_TRUST_LAN", "1")
+    ws = SimpleNamespace(client=SimpleNamespace(host="8.8.8.8"))
+    assert _ws_client_is_allowed(ws) is False
+
+
+def test_ws_loopback_always_allowed(monkeypatch):
+    from types import SimpleNamespace
+    from hermes_cli.web_server import _ws_client_is_allowed
+    monkeypatch.delenv("HERMES_DASHBOARD_TRUST_LAN", raising=False)
+    ws = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    assert _ws_client_is_allowed(ws) is True
+


### PR DESCRIPTION
## Summary
Allows opt-in LAN access to dashboard WebSocket endpoints via the new `HERMES_DASHBOARD_TRUST_LAN` environment variable. Default behavior is unchanged — strict loopback-only as introduced in #30741.

## Motivation
Reverse-proxy deployments where Hermes dashboard runs behind a separate gateway host (e.g. router/firewall doing TLS termination + auth on a different LAN machine) currently hit 4403 on all four WebSocket endpoints (`/api/events`, `/api/ws`, `/api/pty`, `/api/pub`) because `ws.client.host` is the proxy's LAN IP, not loopback. PR #18633 previously addressed this with `--insecure + 0.0.0.0`; PR #30741 tightened it back to loopback-only. This change re-enables the use case as an explicit opt-in without weakening the default.

## Behavior
- Env unset / `0` / `false` (default): unchanged — only loopback clients accepted, public IPs rejected.
- Env `1` / `true` / `yes`: RFC1918 (`10/8`, `172.16/12`, `192.168/16`) and ULA (`fc00::/7`) clients additionally accepted; public IPs still rejected.
- Loopback always allowed regardless of env.
- Host/Origin header check (`_ws_host_origin_is_allowed`) is unaffected.

## Security note
Operators enabling this **must** ensure their LAN segment is trusted and that the reverse proxy enforces authentication. This is opt-in precisely because LAN ≠ trusted in many deployments.

## Tests
Four new test cases cover loopback / LAN-default-reject / LAN-with-env-allow / public-IP-still-rejected.
