### PR TITLE
fix(codex): tolerate response.output=None from ChatGPT Codex Responses stream

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -335,6 +335,26 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 )
                 return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             raise
+        except TypeError as exc:
+            # The OpenAI SDK Responses accumulator (parse_response) raises
+            # ``TypeError("'NoneType' object is not iterable")`` when a backend
+            # emits a stream event whose ``response.output`` is ``None`` rather
+            # than ``[]`` — observed on chatgpt.com/backend-api/codex with
+            # gpt-5.5.  ``parse_response`` runs ``for output in response.output``
+            # without guarding ``None``.  The raw ``create(stream=True)``
+            # fallback parses events manually and never calls the accumulator,
+            # so it recovers the real output.  Narrowly match the accumulator's
+            # message so genuine TypeErrors in our own callbacks still propagate
+            # (mirrors how the RuntimeError handler above re-raises unrelated
+            # errors).
+            if "is not iterable" not in str(exc):
+                raise
+            logger.debug(
+                "Responses stream accumulator raised TypeError (%s); "
+                "falling back to create(stream=True). %s",
+                exc, agent._client_log_context(),
+            )
+            return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
 
 
 
@@ -412,9 +432,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is None and isinstance(event, dict):
                 terminal_response = event.get("response")
             if terminal_response is not None:
-                # Backfill empty output from collected stream events
+                # Backfill empty output from collected stream events.
+                # The chatgpt.com/backend-api/codex backend can send
+                # ``output: null`` (not ``[]``) on the terminal event, so treat
+                # None like an empty list and synthesize from the items/deltas
+                # we collected above.
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/tests/run_agent/test_codex_responses_output_none.py
+++ b/tests/run_agent/test_codex_responses_output_none.py
@@ -1,0 +1,158 @@
+"""Regression tests for the ChatGPT Codex ``response.output = None`` crash.
+
+When Hermes uses the ``openai-codex`` provider against the ChatGPT backend
+(``https://chatgpt.com/backend-api/codex``), the OpenAI SDK's Responses
+streaming accumulator (``parse_response``) raises
+``TypeError("'NoneType' object is not iterable")`` because it runs
+``for output in response.output`` and that backend emits an event whose
+``response.output`` is ``None`` rather than ``[]``.
+
+``_run_codex_stream`` now treats that accumulator TypeError the same way it
+already treats the prelude/postlude RuntimeErrors — fall back to the manual
+``responses.create(stream=True)`` path, which never calls the accumulator.
+The match is narrow (``"is not iterable"``) so genuine TypeErrors in our own
+callbacks still propagate, mirroring
+``test_codex_stream_unrelated_runtimeerror_still_raises``.
+
+The fallback's empty-output backfill also now treats ``output is None`` like
+an empty list, so it synthesizes from collected items/deltas in that case too.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_codex_agent():
+    """Build a minimal AIAgent wired for codex_responses streaming tests."""
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://chatgpt.com/backend-api/codex",
+        model="gpt-5.5",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "codex_responses"
+    agent.provider = "openai-codex"
+    agent._interrupt_requested = False
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Change 1: accumulator TypeError -> create(stream=True) fallback
+# ---------------------------------------------------------------------------
+
+
+def test_codex_stream_accumulator_typeerror_falls_back_to_create_stream():
+    """The SDK accumulator's ``'NoneType' object is not iterable`` must route
+    to the non-stream fallback instead of surfacing as a non-retryable error."""
+    agent = _make_codex_agent()
+
+    accumulator_error = TypeError("'NoneType' object is not iterable")
+
+    mock_client = MagicMock()
+    mock_client.responses.stream.side_effect = accumulator_error
+
+    fallback_response = SimpleNamespace(
+        output=[SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="fallback ok")],
+        )],
+        status="completed",
+    )
+
+    with patch.object(
+        agent, "_run_codex_create_stream_fallback", return_value=fallback_response
+    ) as mock_fallback:
+        result = agent._run_codex_stream({}, client=mock_client)
+
+    assert result is fallback_response
+    mock_fallback.assert_called_once_with({}, client=mock_client)
+
+
+def test_codex_stream_unrelated_typeerror_still_raises():
+    """TypeErrors that aren't the accumulator's iterable error (e.g. a bug in
+    one of our own stream callbacks) must propagate, not be swallowed."""
+    agent = _make_codex_agent()
+
+    mock_client = MagicMock()
+    mock_client.responses.stream.side_effect = TypeError(
+        "build_api_kwargs() got an unexpected keyword argument"
+    )
+
+    with patch.object(agent, "_run_codex_create_stream_fallback") as mock_fallback:
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            agent._run_codex_stream({}, client=mock_client)
+
+    mock_fallback.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Change 2: fallback backfill treats output=None like an empty list
+# ---------------------------------------------------------------------------
+
+
+def _completed_event(response):
+    return SimpleNamespace(type="response.completed", response=response)
+
+
+# A request that satisfies the Codex Responses preflight validator
+# (model + instructions + input are required before the stream is opened).
+_VALID_CODEX_KWARGS = {
+    "model": "gpt-5.5",
+    "instructions": "be brief",
+    "input": [{"role": "user", "content": "ping"}],
+}
+
+
+def test_fallback_synthesizes_output_when_terminal_output_is_none():
+    """A terminal ``response.completed`` whose ``output`` is ``None`` must be
+    backfilled from the text deltas collected during the manual stream."""
+    agent = _make_codex_agent()
+
+    terminal_response = SimpleNamespace(output=None, status="completed")
+    events = [
+        SimpleNamespace(type="response.output_text.delta", delta="po"),
+        SimpleNamespace(type="response.output_text.delta", delta="ng"),
+        _completed_event(terminal_response),
+    ]
+
+    mock_client = MagicMock()
+    # create(stream=True) returns an iterable of events (no ``.output`` attr,
+    # so the compatibility shim does not short-circuit).
+    mock_client.responses.create.return_value = iter(events)
+
+    result = agent._run_codex_create_stream_fallback(_VALID_CODEX_KWARGS, client=mock_client)
+
+    assert result is terminal_response
+    assert isinstance(result.output, list) and result.output
+    assert result.output[0].content[0].text == "pong"
+
+
+def test_fallback_backfills_items_when_terminal_output_is_none():
+    """When output items arrived via ``response.output_item.done`` they take
+    precedence over synthesized deltas, even if terminal output is None."""
+    agent = _make_codex_agent()
+
+    done_item = SimpleNamespace(
+        type="message",
+        role="assistant",
+        content=[SimpleNamespace(type="output_text", text="real item")],
+    )
+    terminal_response = SimpleNamespace(output=None, status="completed")
+    events = [
+        SimpleNamespace(type="response.output_item.done", item=done_item),
+        _completed_event(terminal_response),
+    ]
+
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = iter(events)
+
+    result = agent._run_codex_create_stream_fallback(_VALID_CODEX_KWARGS, client=mock_client)
+
+    assert result is terminal_response
+    assert result.output == [done_item]


### PR DESCRIPTION
## Summary

Every turn on the `openai-codex` ChatGPT backend (`https://chatgpt.com/backend-api/codex`) currently aborts with `'NoneType' object is not iterable` and the user gets only an error fallback. This makes the Codex provider crash on `get_final_response()` / stream accumulation routable to the existing manual-stream recovery path instead of a non-retryable client error, so the turn completes normally.

## Root cause

The OpenAI SDK's Responses accumulator (`openai/lib/_parsing/_responses.py:61`) runs `for output in response.output:` without guarding `None`. The ChatGPT Codex backend emits a stream event whose `response.output` is `None` (not `[]`), so the SDK raises:

```
File ".../openai/lib/streaming/responses/_responses.py", line 360, in accumulate_event
    self._completed_response = parse_response(...)
File ".../openai/lib/_parsing/_responses.py", line 61, in parse_response
    for output in response.output:
TypeError: 'NoneType' object is not iterable
```

`run_codex_stream` already routes `httpx.*` transport errors and the SDK's prelude/postlude `RuntimeError` shapes to `_run_codex_create_stream_fallback` (which consumes the raw `responses.create(stream=True)` stream manually and never calls the accumulator). The accumulator's `TypeError` was simply not in that catch list, so it escalated as a non-retryable error (`conversation_loop` treats it as a local validation / programming bug).

This is **not** an auth/config/model problem: replaying the exact failing request body directly against the endpoint returns HTTP 200 with a complete, valid SSE stream. The failure is purely client-side stream parsing.

## Fix

`agent/codex_runtime.py`:

1. **`run_codex_stream`** — add a `TypeError` handler alongside the existing `RuntimeError` one. The crash can fire both *during* stream iteration (`accumulate_event`) and at `get_final_response()`; catching it for the whole `with ... as stream:` block covers both. The match is **narrow** (`if "is not iterable" not in str(exc): raise`) so genuine `TypeError`s from our own stream callbacks still propagate — mirroring how the `RuntimeError` handler re-raises unrelated shapes (locked by `test_codex_stream_unrelated_runtimeerror_still_raises`).

   ```python
   except TypeError as exc:
       if "is not iterable" not in str(exc):
           raise
       logger.debug(
           "Responses stream accumulator raised TypeError (%s); "
           "falling back to create(stream=True). %s",
           exc, agent._client_log_context(),
       )
       return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
   ```

2. **`run_codex_create_stream_fallback`** — treat a terminal `output is None` like an empty list, so the existing backfill (from `response.output_item.done` items / text deltas) also covers the `None` case, not just `[]`:

   ```diff
   - _out = getattr(terminal_response, "output", None)
   - if isinstance(_out, list) and not _out:
   + _out = getattr(terminal_response, "output", None)
   + if _out is None or (isinstance(_out, list) and not _out):
   ```

This matches Hermes' existing pattern of absorbing Codex backend stream quirks via the manual fallback, and fixes the crash without waiting on an upstream `openai` SDK release.

## How to Test

1. `hermes auth add openai-codex` (any ChatGPT-tier OAuth)
2. `hermes chat -q "say ok" --provider openai-codex -m gpt-5.5`
3. **Before:** `❌ Non-retryable client error: 'NoneType' object is not iterable`
4. **After:** the model's response is returned; `agent.log` shows a debug line `falling back to create(stream=True)`.

## Validation

New regression suite `tests/run_agent/test_codex_responses_output_none.py` — 4/4 pass against the real `AIAgent` + real Codex preflight:

```
test_codex_stream_accumulator_typeerror_falls_back_to_create_stream  PASSED
test_codex_stream_unrelated_typeerror_still_raises                   PASSED
test_fallback_synthesizes_output_when_terminal_output_is_none        PASSED
test_fallback_backfills_items_when_terminal_output_is_none           PASSED
```

No regression in the existing codex/streaming suites:

```
tests/run_agent/test_codex_xai_oauth_recovery.py
tests/run_agent/test_run_agent_codex_responses.py
tests/run_agent/test_streaming.py
                                            142 passed in 41.79s
```

**Not yet verified end-to-end:** that the live `chatgpt.com/backend-api/codex` backend's manual `create(stream=True)` terminal event carries the real, complete output. The unit tests fake the stream events; the in-place control flow is proven, but a live confirmation against the backend is the remaining gap.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Related issues & prior art

This crash is tracked by several issues — closest is #32908 (notes the existing backfill at `codex_runtime.py` is bypassed because the accumulator raises before it), plus #32892, #32894, #32903, #11179.

There are also open PRs targeting the same crash (e.g. #32919, #32939, #32921, #32890, #32884). This PR's angle: a **narrowly-matched** `TypeError` handler that reuses the existing `create(stream=True)` fallback to cover **both** crash sites (mid-iteration *and* `get_final_response()`), plus the `output is None` guard in the fallback backfill, with a focused regression suite. Happy to consolidate with whichever approach maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
