### PR TITLE
fix(gateway): heartbeat runtime status while idle

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18279,6 +18279,28 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     except Exception as _mm_exc:
         logger.debug("Failed to start memory monitor: %s", _mm_exc)
 
+    # Periodic runtime-status heartbeat (gateway only). Refreshes the
+    # gateway_state.json timestamp during quiet periods so external
+    # health checks can tell "idle" from "dead".
+    try:
+        from gateway import status_heartbeat as _status_heartbeat
+
+        _sh_cfg = {}
+        try:
+            from hermes_cli.config import load_config as _load_cli_config
+
+            _sh_cfg = (_load_cli_config() or {}).get("logging", {}).get("status_heartbeat", {}) or {}
+        except Exception:
+            _sh_cfg = {}
+        if _sh_cfg.get("enabled", True):
+            try:
+                _sh_interval = float(_sh_cfg.get("interval_seconds", 60))
+            except (TypeError, ValueError):
+                _sh_interval = 60.0
+            _status_heartbeat.start_status_heartbeat(interval_seconds=_sh_interval)
+    except Exception as _sh_exc:
+        logger.debug("Failed to start status heartbeat: %s", _sh_exc)
+
     # Optional stderr handler — level driven by -v/-q flags on the CLI.
     # verbosity=None (-q/--quiet): no stderr output
     # verbosity=0    (default):    WARNING and above
@@ -18517,6 +18539,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         from gateway import memory_monitor as _memory_monitor
 
         _memory_monitor.stop_memory_monitoring(timeout=2.0)
+    except Exception:
+        pass
+
+    try:
+        from gateway import status_heartbeat as _status_heartbeat
+
+        _status_heartbeat.stop_status_heartbeat(timeout=2.0)
     except Exception:
         pass
 

--- a/gateway/status_heartbeat.py
+++ b/gateway/status_heartbeat.py
@@ -1,0 +1,92 @@
+"""Periodic gateway runtime-status heartbeat updates.
+
+Keeps ``gateway_state.json`` fresh during otherwise idle gateway periods so
+cross-container health checks can distinguish "alive but idle" from "stale".
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Optional
+
+from gateway.status import write_runtime_status
+
+logger = logging.getLogger(__name__)
+
+_heartbeat_thread: Optional[threading.Thread] = None
+_stop_event: Optional[threading.Event] = None
+_interval_seconds: float = 60.0
+_lock = threading.Lock()
+
+
+def heartbeat_once() -> None:
+    """Refresh gateway_state.json without changing any semantic fields."""
+    write_runtime_status()
+
+
+def _heartbeat_loop(stop_event: threading.Event, interval: float) -> None:
+    while not stop_event.wait(interval):
+        try:
+            heartbeat_once()
+        except Exception as exc:
+            logger.debug("Status heartbeat tick failed: %s", exc)
+
+
+def start_status_heartbeat(interval_seconds: float = 60.0) -> bool:
+    """Start a daemon thread that periodically refreshes runtime status."""
+    global _heartbeat_thread, _stop_event, _interval_seconds
+
+    with _lock:
+        if _heartbeat_thread is not None and _heartbeat_thread.is_alive():
+            return False
+
+        _interval_seconds = float(interval_seconds)
+        _stop_event = threading.Event()
+
+        # Emit an immediate baseline tick so fresh gateways start with a
+        # current timestamp instead of waiting one full interval.
+        try:
+            heartbeat_once()
+        except Exception as exc:
+            logger.debug("Status heartbeat baseline tick failed: %s", exc)
+
+        _heartbeat_thread = threading.Thread(
+            target=_heartbeat_loop,
+            args=(_stop_event, _interval_seconds),
+            name="gateway-status-heartbeat",
+            daemon=True,
+        )
+        _heartbeat_thread.start()
+
+        logger.info(
+            "[STATUS] Periodic runtime heartbeat started (interval: %ds)",
+            int(_interval_seconds),
+        )
+        return True
+
+
+def stop_status_heartbeat(timeout: float = 2.0) -> None:
+    """Stop the heartbeat thread if it is running."""
+    global _heartbeat_thread, _stop_event
+
+    with _lock:
+        if _stop_event is None or _heartbeat_thread is None:
+            return
+
+        _stop_event.set()
+        thread = _heartbeat_thread
+        _heartbeat_thread = None
+        _stop_event = None
+
+    try:
+        thread.join(timeout=timeout)
+    except Exception:
+        pass
+
+    logger.info("[STATUS] Periodic runtime heartbeat stopped")
+
+
+def is_running() -> bool:
+    """Whether the heartbeat thread is currently alive."""
+    return _heartbeat_thread is not None and _heartbeat_thread.is_alive()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1683,6 +1683,13 @@ DEFAULT_CONFIG = {
             "enabled": True,         # Flip to false to silence the periodic line
             "interval_seconds": 300, # Default: every 5 minutes
         },
+        # Periodic gateway runtime-status heartbeat. Refreshes
+        # gateway_state.json during otherwise idle periods so external
+        # health checks don't mistake "quiet" for "dead".
+        "status_heartbeat": {
+            "enabled": True,
+            "interval_seconds": 60,
+        },
     },
 
     # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -175,6 +175,69 @@ async def test_start_gateway_verbosity_imports_redacting_formatter(monkeypatch, 
 
 
 @pytest.mark.asyncio
+async def test_start_gateway_wires_status_heartbeat(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    calls = []
+
+    class _ShortRunRunner:
+        def __init__(self, config):
+            self.config = config
+            self.should_exit_cleanly = False
+            self.should_exit_with_failure = False
+            self.exit_reason = None
+            self.adapters = {}
+            self.exit_code = None
+            self._restart_requested = False
+            self._restart_via_service = False
+
+        async def start(self):
+            return True
+
+        async def wait_for_shutdown(self):
+            return None
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("tools.mcp_tool.discover_mcp_tools", lambda: None)
+    monkeypatch.setattr("tools.mcp_tool.shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _ShortRunRunner)
+    monkeypatch.setattr("gateway.run._start_cron_ticker", lambda stop_event, adapters=None, loop=None: stop_event.wait(0.01))
+    monkeypatch.setattr("gateway.memory_monitor.start_memory_monitoring", lambda interval_seconds=300.0: True)
+    monkeypatch.setattr("gateway.memory_monitor.stop_memory_monitoring", lambda timeout=2.0: None)
+    monkeypatch.setattr(
+        "gateway.status_heartbeat.start_status_heartbeat",
+        lambda interval_seconds=60.0: calls.append(("start", interval_seconds)) or True,
+    )
+    monkeypatch.setattr(
+        "gateway.status_heartbeat.stop_status_heartbeat",
+        lambda timeout=2.0: calls.append(("stop", timeout)),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "logging": {
+                "memory_monitor": {"enabled": False},
+                "status_heartbeat": {"enabled": True, "interval_seconds": 7},
+            }
+        },
+    )
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is True
+    assert ("start", 7.0) in calls
+    assert ("stop", 2.0) in calls
+
+
+@pytest.mark.asyncio
 async def test_start_gateway_replace_force_uses_terminate_pid(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/gateway/test_status_heartbeat.py
+++ b/tests/gateway/test_status_heartbeat.py
@@ -1,0 +1,99 @@
+"""Tests for gateway.status_heartbeat."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from gateway import status_heartbeat as sh
+
+
+@pytest.fixture(autouse=True)
+def _ensure_heartbeat_stopped():
+    sh.stop_status_heartbeat(timeout=1.0)
+    yield
+    sh.stop_status_heartbeat(timeout=1.0)
+
+
+def test_heartbeat_once_calls_write_runtime_status(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sh, "write_runtime_status", lambda: calls.append("tick"))
+
+    sh.heartbeat_once()
+
+    assert calls == ["tick"]
+
+
+def test_start_emits_immediate_tick_and_returns_true(monkeypatch, caplog):
+    calls = []
+    monkeypatch.setattr(sh, "write_runtime_status", lambda: calls.append("tick"))
+    caplog.set_level(logging.INFO, logger="gateway.status_heartbeat")
+
+    started = sh.start_status_heartbeat(interval_seconds=3600.0)
+
+    assert started is True
+    assert sh.is_running() is True
+    assert calls == ["tick"]
+    assert any("Periodic runtime heartbeat started" in r.getMessage() for r in caplog.records)
+
+
+def test_double_start_is_noop(monkeypatch):
+    monkeypatch.setattr(sh, "write_runtime_status", lambda: None)
+
+    assert sh.start_status_heartbeat(interval_seconds=3600.0) is True
+    assert sh.start_status_heartbeat(interval_seconds=3600.0) is False
+    assert sh.is_running() is True
+
+
+def test_stop_logs_shutdown(monkeypatch, caplog):
+    monkeypatch.setattr(sh, "write_runtime_status", lambda: None)
+    sh.start_status_heartbeat(interval_seconds=3600.0)
+    caplog.clear()
+    caplog.set_level(logging.INFO, logger="gateway.status_heartbeat")
+
+    sh.stop_status_heartbeat(timeout=1.0)
+
+    assert sh.is_running() is False
+    assert any("Periodic runtime heartbeat stopped" in r.getMessage() for r in caplog.records)
+
+
+def test_stop_without_start_is_noop():
+    sh.stop_status_heartbeat(timeout=0.5)
+    assert sh.is_running() is False
+
+
+def test_periodic_timer_fires(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sh, "write_runtime_status", lambda: calls.append(time.monotonic()))
+
+    sh.start_status_heartbeat(interval_seconds=0.1)
+    time.sleep(0.45)
+    sh.stop_status_heartbeat(timeout=1.0)
+
+    # Immediate baseline tick + at least 2 periodic ticks.
+    assert len(calls) >= 3, calls
+
+
+def test_thread_is_daemon(monkeypatch):
+    monkeypatch.setattr(sh, "write_runtime_status", lambda: None)
+
+    sh.start_status_heartbeat(interval_seconds=3600.0)
+
+    assert sh._heartbeat_thread is not None
+    assert sh._heartbeat_thread.daemon is True
+
+
+def test_tick_failure_is_logged_at_debug(monkeypatch, caplog):
+    def _boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(sh, "write_runtime_status", _boom)
+    caplog.set_level(logging.DEBUG, logger="gateway.status_heartbeat")
+
+    sh.start_status_heartbeat(interval_seconds=0.1)
+    time.sleep(0.15)
+    sh.stop_status_heartbeat(timeout=1.0)
+
+    assert any("Status heartbeat tick failed" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- add a lightweight `gateway.status_heartbeat` daemon that periodically calls `write_runtime_status()` so idle gateways keep `gateway_state.json.updated_at` fresh
- wire the heartbeat into `start_gateway()` with a new `logging.status_heartbeat` config block and clean shutdown teardown
- cover the new module and the gateway startup wiring with targeted tests

## Testing
- `pytest -q -o addopts='' tests/gateway/test_status_heartbeat.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_status.py`
- `ruff check gateway/status_heartbeat.py gateway/run.py hermes_cli/config.py tests/gateway/test_status_heartbeat.py tests/gateway/test_runner_startup_failures.py`
- `git diff --check`

## Notes
- Proof for pushed HEAD `dd35ec076c5975d0e9db169023d1e13e2cdc7fba` is recorded at `.paperclip_artifacts/quality-gate/proof-dd35ec076c5975d0e9db169023d1e13e2cdc7fba.json` in the retained worktree.
- Local test execution used `pytest -o addopts=''` because this machine's globally available pytest lacks the repo's optional timeout plugin, while the touched test scope remained unchanged.
