### PR TITLE
fix(mcp): WSL2 child PID tracking + MCP subprocess resilience (salvage #10250)

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4,6 +4,7 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 """
 
 import asyncio
+import concurrent.futures
 import json
 import threading
 import time
@@ -618,6 +619,101 @@ class TestToolHandler:
             assert result == {"error": "MCP call interrupted: user sent a new message"}
         finally:
             _servers.pop("test_srv", None)
+
+    def test_stale_transport_triggers_reclaim_and_retry(self):
+        """A ClosedResourceError on the first attempt should trigger a
+        reclaim and a silent retry. The agent must see the successful
+        result of the retry, not the transient error.
+        """
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        class FakeClosedResourceError(Exception):
+            pass
+
+        call_counter = {"n": 0}
+
+        async def failing_then_succeeding(*args, **kwargs):
+            call_counter["n"] += 1
+            if call_counter["n"] == 1:
+                raise FakeClosedResourceError("transport went away")
+            return _make_call_result("after reclaim", is_error=False)
+
+        first_session = MagicMock()
+        first_session.call_tool = AsyncMock(side_effect=failing_then_succeeding)
+        first_server = _make_mock_server("flappy", session=first_session)
+
+        second_session = MagicMock()
+        second_session.call_tool = AsyncMock(side_effect=failing_then_succeeding)
+        second_server = _make_mock_server("flappy", session=second_session)
+
+        _servers.pop("flappy", None)
+        _servers["flappy"] = first_server
+
+        reclaim_calls = {"n": 0}
+
+        def fake_mark_stale(server_name):
+            reclaim_calls["n"] += 1
+            # Simulate reclaim finishing synchronously by swapping in
+            # the second (live) server immediately.
+            with mcp_mod._lock:
+                _servers[server_name] = second_server
+            f = concurrent.futures.Future()
+            f.set_result(None)
+            return f
+
+        try:
+            handler = _make_tool_handler("flappy", "ping", 120)
+            with self._patch_mcp_loop(), \
+                 patch("tools.mcp_tool._mark_session_stale",
+                       side_effect=fake_mark_stale), \
+                 patch("tools.mcp_tool._wait_for_reclaim_future"), \
+                 patch("tools.mcp_tool._is_stale_transport_error",
+                       return_value=True):
+                result = json.loads(handler({"query": "hi"}))
+            assert result == {"result": "after reclaim"}, result
+            assert reclaim_calls["n"] == 1
+            assert call_counter["n"] == 2  # one failed, one succeeded
+        finally:
+            _servers.pop("flappy", None)
+
+    def test_stale_transport_gives_up_after_second_failure(self):
+        """If the transport stays stale after a reclaim retry, the
+        handler must return a clear reclaim-failure error rather than
+        raising or hanging.
+        """
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        class FakeClosed(Exception):
+            pass
+
+        async def always_stale(*args, **kwargs):
+            raise FakeClosed("still broken")
+
+        session = MagicMock()
+        session.call_tool = AsyncMock(side_effect=always_stale)
+        server = _make_mock_server("doomed", session=session)
+        _servers["doomed"] = server
+
+        def fake_mark_stale(server_name):
+            f = concurrent.futures.Future()
+            f.set_result(None)
+            return f
+
+        try:
+            handler = _make_tool_handler("doomed", "noop", 120)
+            with self._patch_mcp_loop(), \
+                 patch("tools.mcp_tool._mark_session_stale",
+                       side_effect=fake_mark_stale), \
+                 patch("tools.mcp_tool._wait_for_reclaim_future"), \
+                 patch("tools.mcp_tool._is_stale_transport_error",
+                       return_value=True):
+                result = json.loads(handler({}))
+            assert "error" in result
+            assert "reclaim did not restore" in result["error"]
+        finally:
+            _servers.pop("doomed", None)
 
 
 class TestRunOnMCPLoopInterrupts:
@@ -1725,6 +1821,135 @@ class TestReconnection:
             assert run_count == 1
 
         asyncio.run(_test())
+
+    def test_healthy_disconnect_resets_retry_counter(self):
+        """A disconnect after a long-lived healthy connection should reset
+        the consecutive-retry counter so the server survives more lifetime
+        disconnects than _MAX_RECONNECT_RETRIES.
+
+        Regression: before this fix, every disconnect incremented a
+        lifetime counter that capped at _MAX_RECONNECT_RETRIES (5), so a
+        long-running Hermes gateway whose MCP subprocesses each failed
+        more than 5 times would permanently retire those servers.
+        """
+        from tools.mcp_tool import (
+            MCPServerTask, _MAX_RECONNECT_RETRIES,
+            _HEALTHY_CONNECTION_SECONDS,
+        )
+
+        run_count = 0
+        target_server = None
+        disconnect_budget = _MAX_RECONNECT_RETRIES + 3
+
+        original_run_stdio = MCPServerTask._run_stdio
+
+        async def patched_run_stdio(self_srv, config):
+            nonlocal run_count, target_server
+            run_count += 1
+            if target_server is not self_srv:
+                return await original_run_stdio(self_srv, config)
+
+            self_srv.session = MagicMock()
+            self_srv._tools = []
+            self_srv._ready.set()
+            # Simulate a long-lived connection so the next disconnect is
+            # classified as "healthy" and the retry counter resets.
+            self_srv._connected_at = (
+                time.monotonic() - (_HEALTHY_CONNECTION_SECONDS + 5)
+            )
+
+            if run_count <= disconnect_budget:
+                raise ConnectionError(f"drop #{run_count}")
+            # Final iteration: signal shutdown so run() exits cleanly.
+            self_srv._shutdown_event.set()
+            await self_srv._shutdown_event.wait()
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                await server.run({"command": "test"})
+
+            # Should have reconnected past _MAX_RECONNECT_RETRIES because
+            # every prior connection was healthy.
+            assert run_count == disconnect_budget + 1
+
+        asyncio.run(_test())
+
+    def test_unexpected_clean_exit_triggers_reconnect(self):
+        """If _run_stdio returns cleanly without shutdown_event being set,
+        run() should treat it as a disconnect and reconnect instead of
+        breaking out of the loop.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        run_count = 0
+        target_server = None
+
+        original_run_stdio = MCPServerTask._run_stdio
+
+        async def patched_run_stdio(self_srv, config):
+            nonlocal run_count, target_server
+            run_count += 1
+            if target_server is not self_srv:
+                return await original_run_stdio(self_srv, config)
+
+            self_srv.session = MagicMock()
+            self_srv._tools = []
+            self_srv._ready.set()
+            self_srv._connected_at = time.monotonic()
+
+            if run_count == 1:
+                # Clean return without setting shutdown_event — this used
+                # to cause run() to break out of the loop.
+                return
+            # Second attempt: signal shutdown so run() exits cleanly.
+            self_srv._shutdown_event.set()
+            await self_srv._shutdown_event.wait()
+
+        async def _test():
+            nonlocal target_server
+            server = MCPServerTask("test_srv")
+            target_server = server
+
+            with patch.object(MCPServerTask, "_run_stdio", patched_run_stdio), \
+                 patch("asyncio.sleep", new_callable=AsyncMock):
+                await server.run({"command": "test"})
+
+            assert run_count == 2  # reconnected once
+
+        asyncio.run(_test())
+
+    def test_stale_transport_exception_detection(self):
+        """_is_stale_transport_error should catch wrapped anyio errors."""
+        from tools.mcp_tool import _is_stale_transport_error
+
+        class ClosedResourceError(Exception):
+            pass
+
+        class BrokenResourceError(Exception):
+            pass
+
+        assert _is_stale_transport_error(ClosedResourceError("closed"))
+        assert _is_stale_transport_error(BrokenResourceError("broken"))
+
+        # Wrapped via __cause__
+        wrapper = RuntimeError("wrap")
+        wrapper.__cause__ = ClosedResourceError("inner")
+        assert _is_stale_transport_error(wrapper)
+
+        # Wrapped via ExceptionGroup-like .exceptions attribute
+        class FakeGroup(Exception):
+            def __init__(self, exceptions):
+                self.exceptions = exceptions
+        group = FakeGroup([ValueError("nope"), BrokenResourceError("yep")])
+        assert _is_stale_transport_error(group)
+
+        # Unrelated exception
+        assert not _is_stale_transport_error(ValueError("unrelated"))
 
     def test_no_reconnect_on_initial_failure(self):
         """First connection failure retries up to _MAX_INITIAL_CONNECT_RETRIES times.
@@ -3864,7 +4089,7 @@ class TestRegisterMcpServers:
     def test_skips_already_connected_servers(self):
         from tools.mcp_tool import register_mcp_servers, _servers
 
-        mock_server = _make_mock_server("existing")
+        mock_server = _make_mock_server("existing", session=MagicMock())
         _servers["existing"] = mock_server
 
         try:
@@ -3874,6 +4099,86 @@ class TestRegisterMcpServers:
             assert result == ["mcp_existing_tool"]
         finally:
             _servers.pop("existing", None)
+
+    def test_reclaims_dead_server_entry(self):
+        """A server with session=None must be re-registered instead of
+        being treated as 'already connected'.
+
+        Regression: before this fix, once run() retired a server (e.g.
+        after _MAX_RECONNECT_RETRIES or a killed subprocess), the entry
+        stayed in _servers with session=None and register_mcp_servers
+        would permanently skip it, leaving the agent with a dead tool.
+        """
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _ensure_mcp_loop,
+        )
+
+        # Seed a dead server entry (session already None)
+        dead_server = _make_mock_server("zombie", session=None)
+        dead_server._task = MagicMock()
+        dead_server._task.done.return_value = True
+        _servers["zombie"] = dead_server
+
+        fresh_calls: list[str] = []
+
+        async def fake_register(name, cfg):
+            fresh_calls.append(name)
+            server = _make_mock_server(name, session=MagicMock())
+            server._registered_tool_names = [f"mcp_{name}_tool"]
+            _servers[name] = server
+            return [f"mcp_{name}_tool"]
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server",
+                       side_effect=fake_register), \
+                 patch("tools.mcp_tool._existing_tool_names",
+                       return_value=["mcp_zombie_tool"]):
+                _ensure_mcp_loop()
+                register_mcp_servers({"zombie": {"command": "test"}})
+
+            # fake_register should have been called for the dead server
+            assert fresh_calls == ["zombie"], (
+                f"dead server must be re-registered, got: {fresh_calls}"
+            )
+            # The entry in _servers should be the fresh one with session
+            assert _servers["zombie"].session is not None
+        finally:
+            _servers.pop("zombie", None)
+
+    def test_reclaims_dead_server_with_live_task_but_no_session(self):
+        """A server with session=None but a still-running task is also
+        considered stale and reclaimed."""
+        from tools.mcp_tool import (
+            register_mcp_servers, _servers, _ensure_mcp_loop,
+        )
+
+        dead_server = _make_mock_server("zombie2", session=None)
+        dead_server._task = MagicMock()
+        dead_server._task.done.return_value = False  # task still running
+        _servers["zombie2"] = dead_server
+
+        fresh_calls: list[str] = []
+
+        async def fake_register(name, cfg):
+            fresh_calls.append(name)
+            server = _make_mock_server(name, session=MagicMock())
+            server._registered_tool_names = [f"mcp_{name}_tool"]
+            _servers[name] = server
+            return [f"mcp_{name}_tool"]
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._discover_and_register_server",
+                       side_effect=fake_register), \
+                 patch("tools.mcp_tool._existing_tool_names",
+                       return_value=["mcp_zombie2_tool"]):
+                _ensure_mcp_loop()
+                register_mcp_servers({"zombie2": {"command": "test"}})
+
+            assert fresh_calls == ["zombie2"]
+        finally:
+            _servers.pop("zombie2", None)
 
     def test_skips_disabled_servers(self):
         from tools.mcp_tool import register_mcp_servers, _servers

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -263,6 +263,30 @@ _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
+# A connection that survived at least this long before dropping is
+# considered "healthy". The consecutive-reconnect counter is reset on a
+# healthy disconnect so that long-lived servers aren't permanently retired
+# after _MAX_RECONNECT_RETRIES lifetime disconnects.
+_HEALTHY_CONNECTION_SECONDS = 30.0
+# Interval at which _run_stdio polls the spawned subprocess PIDs while
+# waiting for shutdown. If any tracked PID has died without the stream
+# reader propagating the error, this poll raises ConnectionError to
+# force the run() loop into its reconnect path.
+_SUBPROCESS_LIVENESS_POLL_SECONDS = 5.0
+# Max time a tool handler will block waiting for a stale-session reclaim
+# before retrying the call. Keeps the user-visible latency bounded while
+# still hiding transient MCP subprocess deaths from the agent.
+_RECLAIM_WAIT_SECONDS = 15.0
+# Exception class names that indicate the MCP stdio/HTTP transport has gone
+# away mid-call. Matched by type().__name__ so we don't need to import anyio.
+_STALE_TRANSPORT_EXC_NAMES = frozenset({
+    "ClosedResourceError",
+    "BrokenResourceError",
+    "EndOfStream",
+    "IncompleteReadError",
+    "ConnectionResetError",
+    "BrokenPipeError",
+})
 
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({
@@ -420,6 +444,168 @@ def _scan_mcp_description(server_name: str, tool_name: str, description: str) ->
             description,
         )
     return findings
+
+
+def _is_stale_transport_error(exc: BaseException) -> bool:
+    """Return True if *exc* indicates the MCP transport has gone away.
+
+    Matches by exception class name rather than isinstance so we don't
+    have to import anyio (which may or may not be the underlying
+    transport library). Walks the exception chain to catch wrapped
+    errors raised through ExceptionGroup / __cause__ / __context__.
+    """
+    seen: set[int] = set()
+    stack: list[BaseException] = [exc]
+    while stack:
+        current = stack.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        if type(current).__name__ in _STALE_TRANSPORT_EXC_NAMES:
+            return True
+        nested = getattr(current, "exceptions", None)
+        if nested:
+            try:
+                stack.extend(nested)
+            except TypeError:
+                pass
+        cause = getattr(current, "__cause__", None)
+        if cause is not None:
+            stack.append(cause)
+        context = getattr(current, "__context__", None)
+        if context is not None:
+            stack.append(context)
+    return False
+
+
+# In-flight reclaim futures keyed by server name. Multiple concurrent
+# handler calls that all hit the same stale session must share a single
+# reclaim operation instead of each spawning their own (which would
+# create duplicate subprocesses and race each other).
+_reclaim_inflight: Dict[str, "concurrent.futures.Future"] = {}
+
+
+def _mark_session_stale(
+    server_name: str,
+) -> Optional["concurrent.futures.Future"]:
+    """Clear the session reference for *server_name* and schedule a
+    reclaim that will re-register the server with a fresh subprocess.
+
+    Returns the reclaim ``concurrent.futures.Future`` so callers can
+    block on completion if they want to hide the failure from the
+    user. Returns ``None`` when scheduling wasn't possible (module
+    shutdown, server not configured, etc.).
+
+    Why the reclaim: the legacy recovery path is ``discover_mcp_tools()``
+    which is only called at module import. Once we are past startup, a
+    server whose subprocess died stays permanently broken unless
+    someone triggers ``/reload-mcp``. Handler-detected staleness is the
+    natural signal — we drop the dead entry here and let
+    ``_discover_and_register_server`` recreate it on the MCP loop.
+
+    Safe to call from the MCP event loop thread or any caller thread —
+    all mutations happen under the module lock and the re-registration
+    is scheduled via ``asyncio.run_coroutine_threadsafe``.
+    """
+    # Phase 1: clear the session and fast-reject if something else is
+    # already reclaiming this server. Held under the lock so two threads
+    # hitting the same dead session can't both proceed past this point
+    # with "nothing in flight".
+    with _lock:
+        server = _servers.get(server_name)
+        if server is None:
+            return None
+        server.session = None
+        existing_future = _reclaim_inflight.get(server_name)
+        if existing_future is not None and not existing_future.done():
+            return existing_future
+
+    # Phase 2: config load is potentially slow (YAML parse, env interp),
+    # so we drop the lock before touching disk.
+    try:
+        config = _load_mcp_config()
+    except Exception as exc:
+        logger.debug(
+            "Reclaim for '%s' skipped — config reload failed: %s",
+            server_name, exc,
+        )
+        return None
+    if server_name not in config:
+        return None
+    server_cfg = config[server_name]
+    config_keys = list(config.keys())
+
+    async def _reclaim_one():
+        # Drain the old task first so its stdio_client context manager
+        # finishes killing the previous subprocess before we spawn a new
+        # one. Bounded by a timeout because a stuck run() loop must not
+        # block recovery.
+        old_task = None
+        with _lock:
+            existing = _servers.get(server_name)
+            if existing is not None:
+                old_task = getattr(existing, "_task", None)
+                try:
+                    existing._shutdown_event.set()
+                except Exception:
+                    pass
+                _servers.pop(server_name, None)
+        if old_task is not None and not old_task.done():
+            try:
+                await asyncio.wait_for(old_task, timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
+            except Exception:
+                pass
+        try:
+            await _discover_and_register_server(server_name, server_cfg)
+            _sync_mcp_toolsets(config_keys)
+            logger.info(
+                "MCP server '%s' reclaimed after stale transport",
+                server_name,
+            )
+        except Exception as exc:
+            logger.warning(
+                "MCP server '%s' reclaim failed: %s",
+                server_name, exc,
+            )
+            raise
+
+    # Phase 3: schedule the reclaim and register the future atomically.
+    # The re-check inside the lock is the TOCTOU guard — another thread
+    # may have scheduled its own reclaim between phases 1 and 3, and if
+    # so we must hand its future back rather than double-spawning.
+    reclaim_future: Optional["concurrent.futures.Future"] = None
+    with _lock:
+        existing_future = _reclaim_inflight.get(server_name)
+        if existing_future is not None and not existing_future.done():
+            return existing_future
+        loop = _mcp_loop
+        if loop is None or not loop.is_running():
+            return None
+        try:
+            reclaim_future = asyncio.run_coroutine_threadsafe(
+                _reclaim_one(), loop
+            )
+        except Exception as exc:
+            logger.debug(
+                "Reclaim scheduling for '%s' failed: %s",
+                server_name, exc,
+            )
+            return None
+        _reclaim_inflight[server_name] = reclaim_future
+
+    def _clear_inflight(_fut):
+        with _lock:
+            if _reclaim_inflight.get(server_name) is _fut:
+                _reclaim_inflight.pop(server_name, None)
+
+    reclaim_future.add_done_callback(_clear_inflight)
+    logger.info(
+        "MCP server '%s' flagged for reclaim (stale session)",
+        server_name,
+    )
+    return reclaim_future
 
 
 def _prepend_path(env: dict, directory: str) -> dict:
@@ -1160,10 +1346,9 @@ class MCPServerTask:
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_registered_tool_names", "_auth_type", "_refresh_lock",
-        "_rpc_lock", "_pending_refresh_tasks",
-        "initialize_result",
+        "_rpc_lock", "_connected_at", "initialize_result",
+        "_reclaim_inflight", "_pending_refresh_tasks",
     )
-
     def __init__(self, name: str):
         self.name = name
         self.session: Optional[Any] = None
@@ -1184,20 +1369,13 @@ class MCPServerTask:
         self._registered_tool_names: list[str] = []
         self._auth_type: str = ""
         self._refresh_lock = asyncio.Lock()
-        # MCP stdio sessions are a single JSON-RPC stream. Some servers emit
-        # list_changed notifications during startup; if the notification
-        # handler calls list_tools while a normal tool call is in flight, the
-        # stream can wedge and the user-visible tool call times out. Serialize
-        # client-initiated RPCs per server. The lock is also applied to HTTP
-        # transports for conservative per-server ordering.
+        # monotonic timestamp of the most recent successful connection; used
+        # by run() to decide whether a disconnect should reset the
+        # consecutive-retry counter.
+        self._connected_at: float = 0.0
         self._rpc_lock = asyncio.Lock()
-        self._pending_refresh_tasks: set[asyncio.Task] = set()
-        # Captures the ``InitializeResult`` returned by
-        # ``await session.initialize()`` so downstream code can inspect the
-        # server's real advertised capabilities (``.capabilities.resources``,
-        # ``.capabilities.prompts``) instead of assuming every ``ClientSession``
-        # method attribute corresponds to a supported server method. See #18051.
-        self.initialize_result: Optional[Any] = None
+        self._pending_refresh_tasks = set()
+        self._reclaim_inflight = {}
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -1504,6 +1682,7 @@ class MCPServerTask:
                 ) as session:
                     self.initialize_result = await session.initialize()
                     self.session = session
+                    self._connected_at = time.monotonic()
                     await self._discover_tools()
                     self._ready.set()
                     # stdio transport does not use OAuth, but we still honor
@@ -1784,12 +1963,8 @@ class MCPServerTask:
                         self.session = session
                         await self._discover_tools()
                         self._ready.set()
-                        reason = await self._wait_for_lifecycle_event()
-                        if reason == "reconnect":
-                            logger.info(
-                                "MCP server '%s': reconnect requested — "
-                                "tearing down HTTP session", self.name,
-                            )
+                        self._connected_at = time.monotonic()
+                        await self._shutdown_event.wait()
         else:
             # Deprecated API (mcp < 1.24.0): manages httpx client internally.
             _http_kwargs: dict = {
@@ -1807,12 +1982,8 @@ class MCPServerTask:
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
-                    reason = await self._wait_for_lifecycle_event()
-                    if reason == "reconnect":
-                        logger.info(
-                            "MCP server '%s': reconnect requested — "
-                            "tearing down legacy HTTP session", self.name,
-                        )
+                    self._connected_at = time.monotonic()
+                    await self._shutdown_event.wait()
 
     async def _discover_tools(self):
         """Discover tools from the connected session.
@@ -1914,118 +2085,111 @@ class MCPServerTask:
         backoff = 1.0
 
         while True:
+            disconnect_exc: Optional[BaseException] = None
             try:
                 if self._is_http():
                     await self._run_http(config)
                 else:
                     await self._run_stdio(config)
-                # Transport returned cleanly. Two cases:
-                #  - _shutdown_event was set: exit the run loop entirely.
-                #  - _reconnect_event was set (auth recovery): loop back and
-                #    rebuild the MCP session with fresh credentials. Do NOT
-                #    touch the retry counters — this is not a failure.
+                # _run_* returned without raising. Only a set shutdown_event
+                # is a legitimate reason for that; any other path is an
+                # unexpected clean disconnect (e.g. the SDK's stdio_client
+                # context exited because the subprocess died but the
+                # underlying stream cleanup swallowed the error). Fall
+                # through to the reconnect logic in that case.
                 if self._shutdown_event.is_set():
                     break
-                logger.info(
-                    "MCP server '%s': reconnecting (OAuth recovery or "
-                    "manual refresh)",
-                    self.name,
+                disconnect_exc = ConnectionError(
+                    f"MCP server '{self.name}' transport exited without "
+                    "a shutdown request"
                 )
-                # Reset the session reference; _run_http/_run_stdio will
-                # repopulate it on successful re-entry.
-                self.session = None
-                # Keep _ready set across reconnects so tool handlers can
-                # still detect a transient in-flight state — it'll be
-                # re-set after the fresh session initializes.
-                continue
-            except asyncio.CancelledError:
-                # Task was cancelled (shutdown, gateway restart, explicit
-                # task.cancel()). Don't treat this as a connection failure —
-                # CancelledError inherits from BaseException (not Exception)
-                # in Python 3.11+, so the broad ``except Exception`` below
-                # would NOT catch it; we'd silently exit the reconnect loop
-                # and the MCP server would stay dead until Hermes is fully
-                # restarted. Re-raise so the task's cancellation propagates
-                # correctly to asyncio's task machinery and ``shutdown()``'s
-                # ``await self._task`` completes. See #9930.
-                self.session = None
-                raise
             except Exception as exc:
+                disconnect_exc = exc
+            finally:
                 self.session = None
 
-                # If this is the first connection attempt, retry with backoff
-                # before giving up. A transient DNS/network blip at startup
-                # should not permanently kill the server.
-                # (Ported from Kilo Code's MCP resilience fix.)
-                if not self._ready.is_set():
-                    if _is_auth_error(exc):
-                        logger.warning(
-                            "MCP server '%s' failed initial OAuth authentication, "
-                            "not retrying automatically: %s",
-                            self.name, exc,
-                        )
-                        self._error = exc
-                        self._ready.set()
-                        return
+            exc = disconnect_exc
+            assert exc is not None  # for type checkers
 
-                    initial_retries += 1
-                    if initial_retries > _MAX_INITIAL_CONNECT_RETRIES:
-                        logger.warning(
-                            "MCP server '%s' failed initial connection after "
-                            "%d attempts, giving up: %s",
-                            self.name, _MAX_INITIAL_CONNECT_RETRIES, exc,
-                        )
-                        self._error = exc
-                        self._ready.set()
-                        return
-
+            # If this is the first connection attempt, retry with backoff
+            # before giving up. A transient DNS/network blip at startup
+            # should not permanently kill the server.
+            # (Ported from Kilo Code's MCP resilience fix.)
+            if not self._ready.is_set():
+                initial_retries += 1
+                if initial_retries > _MAX_INITIAL_CONNECT_RETRIES:
                     logger.warning(
-                        "MCP server '%s' initial connection failed "
-                        "(attempt %d/%d), retrying in %.0fs: %s",
-                        self.name, initial_retries,
-                        _MAX_INITIAL_CONNECT_RETRIES, backoff, exc,
+                        "MCP server '%s' failed initial connection after "
+                        "%d attempts, giving up: %s",
+                        self.name, _MAX_INITIAL_CONNECT_RETRIES, exc,
                     )
-                    await asyncio.sleep(backoff)
-                    backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
-
-                    # Check if shutdown was requested during the sleep
-                    if self._shutdown_event.is_set():
-                        self._error = exc
-                        self._ready.set()
-                        return
-                    continue
-
-                # If shutdown was requested, don't reconnect
-                if self._shutdown_event.is_set():
-                    logger.debug(
-                        "MCP server '%s' disconnected during shutdown: %s",
-                        self.name, exc,
-                    )
-                    return
-
-                retries += 1
-                if retries > _MAX_RECONNECT_RETRIES:
-                    logger.warning(
-                        "MCP server '%s' failed after %d reconnection attempts, "
-                        "giving up: %s",
-                        self.name, _MAX_RECONNECT_RETRIES, exc,
-                    )
+                    self._error = exc
+                    self._ready.set()
                     return
 
                 logger.warning(
-                    "MCP server '%s' connection lost (attempt %d/%d), "
-                    "reconnecting in %.0fs: %s",
-                    self.name, retries, _MAX_RECONNECT_RETRIES,
-                    backoff, exc,
+                    "MCP server '%s' initial connection failed "
+                    "(attempt %d/%d), retrying in %.0fs: %s",
+                    self.name, initial_retries,
+                    _MAX_INITIAL_CONNECT_RETRIES, backoff, exc,
                 )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
 
-                # Check again after sleeping
+                # Check if shutdown was requested during the sleep
                 if self._shutdown_event.is_set():
+                    self._error = exc
+                    self._ready.set()
                     return
-            finally:
-                self.session = None
+                continue
+
+            # If shutdown was requested, don't reconnect
+            if self._shutdown_event.is_set():
+                logger.debug(
+                    "MCP server '%s' disconnected during shutdown: %s",
+                    self.name, exc,
+                )
+                return
+
+            # If the previous session was up for long enough to be
+            # considered healthy, reset the consecutive-retry counter so a
+            # long-running server is not permanently retired after
+            # _MAX_RECONNECT_RETRIES lifetime disconnects.
+            healthy_duration = 0.0
+            if self._connected_at:
+                healthy_duration = time.monotonic() - self._connected_at
+            self._connected_at = 0.0
+            if healthy_duration >= _HEALTHY_CONNECTION_SECONDS:
+                if retries > 0 or backoff > 1.0:
+                    logger.info(
+                        "MCP server '%s' disconnected after %.1fs uptime "
+                        "(healthy) — resetting retry counter",
+                        self.name, healthy_duration,
+                    )
+                retries = 0
+                backoff = 1.0
+
+            retries += 1
+            if retries > _MAX_RECONNECT_RETRIES:
+                logger.warning(
+                    "MCP server '%s' failed after %d consecutive "
+                    "reconnection attempts, giving up: %s",
+                    self.name, _MAX_RECONNECT_RETRIES, exc,
+                )
+                return
+
+            logger.warning(
+                "MCP server '%s' connection lost (attempt %d/%d, "
+                "last uptime %.1fs), reconnecting in %.0fs: %s",
+                self.name, retries, _MAX_RECONNECT_RETRIES,
+                healthy_duration, backoff, exc,
+            )
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
+
+            # Check again after sleeping
+            if self._shutdown_event.is_set():
+                return
 
     async def start(self, config: dict):
         """Create the background Task and wait until ready (or failed)."""
@@ -2497,10 +2661,24 @@ _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
 def _snapshot_child_pids() -> set:
     """Return a set of current child process PIDs.
 
-    Uses /proc on Linux, falls back to psutil, then empty set.
-    Used by _run_stdio to identify the subprocess spawned by stdio_client.
+    Uses ps --ppid on WSL2 (where /proc/children is broken for
+    multi-threaded processes), falls back to /proc on other Linux,
+    then psutil, then empty set.
     """
     my_pid = os.getpid()
+
+    # Try `ps --ppid` first — works on WSL2 where /proc/children
+    # returns empty for multi-threaded processes (Hermes has 12+ threads).
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["ps", "--ppid", str(my_pid), "-o", "pid=", "--no-headers"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return {int(p) for p in result.stdout.split()}
+    except Exception:
+        pass
 
     # Linux: read from /proc
     try:
@@ -2518,6 +2696,34 @@ def _snapshot_child_pids() -> set:
         pass
 
     return set()
+
+
+def _any_pid_alive(pids: set) -> bool:
+    """Return True if at least one of *pids* still exists.
+
+    Sending signal 0 doesn't deliver a signal; it just verifies the target
+    exists and is reachable. A dead or reaped child raises
+    ProcessLookupError. Used by _run_stdio's liveness poll to detect
+    silently-killed subprocesses that the SDK's stream reader failed to
+    surface as an exception.
+    """
+    if not pids:
+        # No PIDs tracked -> treat as alive (best-effort; we can't tell).
+        return True
+    for pid in pids:
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            # Process exists but is owned by another user — still alive.
+            return True
+        except OSError:
+            # Unexpected errno (e.g. ESRCH on some platforms) — treat as
+            # dead for this pid and keep checking the rest.
+            continue
+    return False
 
 
 def _mcp_loop_exception_handler(loop, context):
@@ -2769,199 +2975,236 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
     The handler conforms to the registry's dispatch interface:
     ``handler(args_dict, **kwargs) -> str``
+
+    When a stale transport is detected (subprocess died, ClosedResource
+    Error, broken pipe, etc.), the handler schedules an in-place reclaim,
+    waits up to ``_RECLAIM_WAIT_SECONDS`` for the fresh subprocess to
+    come up, and retries the call once. From the agent's perspective
+    the subprocess death is invisible — it just sees a slightly slower
+    call instead of an error.
     """
 
     def _handler(args: dict, **kwargs) -> str:
-        # Circuit breaker: if this server has failed too many times
-        # consecutively, short-circuit with a clear message so the model
-        # stops retrying and uses alternative approaches (#10447).
-        #
-        # Once the cooldown elapses, the breaker transitions to
-        # half-open: we let the *next* call through as a probe. On
-        # success the success-path below resets the breaker; on
-        # failure the error paths below bump the count again, which
-        # re-stamps the open-time via _bump_server_error (re-arming
-        # the cooldown).
-        if _server_error_counts.get(server_name, 0) >= _CIRCUIT_BREAKER_THRESHOLD:
-            opened_at = _server_breaker_opened_at.get(server_name, 0.0)
-            age = time.monotonic() - opened_at
-            if age < _CIRCUIT_BREAKER_COOLDOWN_SEC:
-                remaining = max(1, int(_CIRCUIT_BREAKER_COOLDOWN_SEC - age))
+        for attempt in range(2):
+            with _lock:
+                server = _servers.get(server_name)
+            if not server or not server.session:
+                if attempt == 0 and _wait_for_live_session(
+                    server_name, _RECLAIM_WAIT_SECONDS
+                ):
+                    continue
                 return json.dumps({
                     "error": (
-                        f"MCP server '{server_name}' is unreachable after "
-                        f"{_server_error_counts[server_name]} consecutive "
-                        f"failures. Auto-retry available in ~{remaining}s. "
-                        f"Do NOT retry this tool yet — use alternative "
-                        f"approaches or ask the user to check the MCP server."
+                        f"MCP server '{server_name}' is not connected"
                     )
                 }, ensure_ascii=False)
-            # Cooldown elapsed → fall through as a half-open probe.
 
-        with _lock:
-            server = _servers.get(server_name)
-        if not server or not server.session:
-            _bump_server_error(server_name)
-            return json.dumps({
-                "error": f"MCP server '{server_name}' is not connected"
-            }, ensure_ascii=False)
+            async def _call():
+                result = await server.session.call_tool(
+                    tool_name, arguments=args
+                )
+                if result.isError:
+                    error_text = ""
+                    for block in (result.content or []):
+                        if hasattr(block, "text"):
+                            error_text += block.text
+                    return json.dumps({
+                        "error": _sanitize_error(
+                            error_text or "MCP tool returned an error"
+                        )
+                    })
 
-        async def _call():
-            async with server._rpc_lock:
-                result = await server.session.call_tool(tool_name, arguments=args)
-            # MCP CallToolResult has .content (list of content blocks) and .isError
-            if result.isError:
-                error_text = ""
+                parts: List[str] = []
                 for block in (result.content or []):
                     if hasattr(block, "text"):
-                        error_text += block.text
+                        parts.append(block.text)
+                text_result = "\n".join(parts) if parts else ""
+
+                structured = getattr(result, "structuredContent", None)
+                if structured is not None:
+                    if text_result:
+                        return json.dumps({
+                            "result": text_result,
+                            "structuredContent": structured,
+                        })
+                    return json.dumps({"result": structured})
+                return json.dumps({"result": text_result})
+
+            try:
+                return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            except InterruptedError:
+                return _interrupted_call_result()
+            except Exception as exc:
+                if _is_stale_transport_error(exc):
+                    reclaim_future = _mark_session_stale(server_name)
+                    if attempt == 0:
+                        logger.warning(
+                            "MCP tool %s/%s hit stale transport (%s); "
+                            "waiting for reclaim and retrying",
+                            server_name, tool_name, type(exc).__name__,
+                        )
+                        _wait_for_reclaim_future(
+                            reclaim_future, _RECLAIM_WAIT_SECONDS
+                        )
+                        continue
+                    logger.error(
+                        "MCP tool %s/%s still stale after reclaim retry: %s",
+                        server_name, tool_name, exc,
+                    )
+                    return json.dumps({
+                        "error": (
+                            f"MCP server '{server_name}' transport closed "
+                            "and reclaim did not restore it in time"
+                        )
+                    })
+                logger.error(
+                    "MCP tool %s/%s call failed: %s",
+                    server_name, tool_name, exc,
+                )
                 return json.dumps({
                     "error": _sanitize_error(
-                        error_text or "MCP tool returned an error"
+                        f"MCP call failed: {type(exc).__name__}: {exc}"
                     )
-                }, ensure_ascii=False)
+                })
 
-            # Collect text from content blocks. MCP tool results can also
-            # include ImageContent blocks (screenshot / Blockbench / Playwright
-            # etc.); cache those via the gateway's image-cache helper so they
-            # flow through Hermes' MEDIA: tag convention and out to messaging
-            # adapters that render images natively. Without this, image blocks
-            # were silently dropped and the agent got an empty response.
-            #
-            # Distilled from #17915 (c3115644151) and #10848 (gnanirahulnutakki),
-            # both too stale to cherry-pick. #10848's approach (integrate with
-            # Hermes' MEDIA tag + cache_image_from_bytes) was the cleaner of
-            # the two — plugs into existing infrastructure.
-            parts: List[str] = []
-            for block in (result.content or []):
-                if hasattr(block, "text") and block.text:
-                    parts.append(block.text)
-                    continue
-                image_tag = _cache_mcp_image_block(block)
-                if image_tag:
-                    parts.append(image_tag)
-            text_result = "\n".join(parts) if parts else ""
-
-            # Combine content + structuredContent when both are present.
-            # MCP spec: content is model-oriented (text), structuredContent
-            # is machine-oriented (JSON metadata).  For an AI agent, content
-            # is the primary payload; structuredContent supplements it.
-            structured = getattr(result, "structuredContent", None)
-            if structured is not None:
-                if text_result:
-                    return json.dumps({
-                        "result": text_result,
-                        "structuredContent": structured,
-                    }, ensure_ascii=False)
-                return json.dumps({"result": structured}, ensure_ascii=False)
-            return json.dumps({"result": text_result}, ensure_ascii=False)
-
-        def _call_once():
-            return _run_on_mcp_loop(_call, timeout=tool_timeout)
-
-        try:
-            result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
-            return result
-        except InterruptedError:
-            return _interrupted_call_result()
-        except Exception as exc:
-            # Auth-specific recovery path: consult the manager, signal
-            # reconnect if viable, retry once. Returns None to fall
-            # through for non-auth exceptions.
-            recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once,
-                f"tools/call {tool_name}",
+        # Safety net — should be unreachable because every path above
+        # returns inside the loop, but satisfies the type checker and
+        # guards against a future refactor dropping a return.
+        return json.dumps({
+            "error": (
+                f"MCP server '{server_name}' recovery exhausted"
             )
-            if recovered is not None:
-                return recovered
-
-            # Transport session expiry (#13383): same reconnect flow
-            # but skips OAuth recovery because the access token is
-            # still valid — only the server-side session is stale.
-            recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once,
-                f"tools/call {tool_name}",
-            )
-            if recovered is not None:
-                return recovered
-
-            _bump_server_error(server_name)
-            logger.error(
-                "MCP tool %s/%s call failed: %s",
-                server_name, tool_name, exc,
-            )
-            return json.dumps({
-                "error": _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
-                )
-            }, ensure_ascii=False)
+        })
 
     return _handler
+
+
+def _wait_for_reclaim_future(
+    reclaim_future: Optional["concurrent.futures.Future"],
+    timeout: float,
+) -> None:
+    """Block up to *timeout* seconds for a reclaim future to complete.
+
+    Swallows exceptions — the caller only cares whether the server
+    became live, which is checked separately via ``_wait_for_live_session``.
+    """
+    if reclaim_future is None:
+        return
+    try:
+        reclaim_future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError:
+        logger.warning(
+            "MCP reclaim did not complete within %.1fs — proceeding",
+            timeout,
+        )
+    except Exception:
+        # Reclaim raised (e.g. connect_timeout). The next iteration's
+        # liveness check will surface "not connected".
+        pass
+
+
+def _wait_for_live_session(server_name: str, timeout: float) -> bool:
+    """Poll until *server_name* has an active session or *timeout* elapses.
+
+    Returns True if the server became live, False otherwise. Used by
+    the handler retry path when the initial lookup found session=None
+    because a prior call already marked the session stale and a reclaim
+    is in flight.
+
+    The caller's *timeout* is the total deadline — any time spent
+    blocking on an in-flight reclaim future counts against the same
+    budget, so callers cannot be forced to wait longer than they asked.
+    """
+    deadline = time.monotonic() + timeout
+    inflight: Optional["concurrent.futures.Future"] = None
+    with _lock:
+        inflight = _reclaim_inflight.get(server_name)
+    if inflight is not None:
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            _wait_for_reclaim_future(inflight, remaining)
+    while time.monotonic() < deadline:
+        with _lock:
+            server = _servers.get(server_name)
+            if server is not None and server.session is not None:
+                return True
+        time.sleep(0.1)
+    return False
 
 
 def _make_list_resources_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists resources from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        with _lock:
-            server = _servers.get(server_name)
-        if not server or not server.session:
-            return json.dumps({
-                "error": f"MCP server '{server_name}' is not connected"
-            }, ensure_ascii=False)
+        for attempt in range(2):
+            with _lock:
+                server = _servers.get(server_name)
+            if not server or not server.session:
+                if attempt == 0 and _wait_for_live_session(
+                    server_name, _RECLAIM_WAIT_SECONDS
+                ):
+                    continue
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is not connected"
+                    )
+                })
 
-        async def _call():
-            async with server._rpc_lock:
+            async def _call():
                 result = await server.session.list_resources()
-            resources = []
-            for r in (result.resources if hasattr(result, "resources") else []):
-                entry = {}
-                if hasattr(r, "uri"):
-                    entry["uri"] = str(r.uri)
-                if hasattr(r, "name"):
-                    entry["name"] = r.name
-                if hasattr(r, "description") and r.description:
-                    entry["description"] = r.description
-                if hasattr(r, "mimeType") and r.mimeType:
-                    entry["mimeType"] = r.mimeType
-                resources.append(entry)
-            return json.dumps({"resources": resources}, ensure_ascii=False)
+                resources = []
+                for r in (result.resources if hasattr(result, "resources") else []):
+                    entry = {}
+                    if hasattr(r, "uri"):
+                        entry["uri"] = str(r.uri)
+                    if hasattr(r, "name"):
+                        entry["name"] = r.name
+                    if hasattr(r, "description") and r.description:
+                        entry["description"] = r.description
+                    if hasattr(r, "mimeType") and r.mimeType:
+                        entry["mimeType"] = r.mimeType
+                    resources.append(entry)
+                return json.dumps({"resources": resources})
 
-        def _call_once():
-            return _run_on_mcp_loop(_call, timeout=tool_timeout)
-
-        try:
-            return _call_once()
-        except InterruptedError:
-            return _interrupted_call_result()
-        except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "resources/list",
-            )
-            if recovered is not None:
-                return recovered
-            recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "resources/list",
-            )
-            if recovered is not None:
-                return recovered
-            logger.error(
-                "MCP %s/list_resources failed: %s", server_name, exc,
-            )
-            return json.dumps({
-                "error": _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+            try:
+                return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            except InterruptedError:
+                return _interrupted_call_result()
+            except Exception as exc:
+                if _is_stale_transport_error(exc):
+                    reclaim_future = _mark_session_stale(server_name)
+                    if attempt == 0:
+                        logger.warning(
+                            "MCP %s/list_resources hit stale transport (%s); "
+                            "waiting for reclaim and retrying",
+                            server_name, type(exc).__name__,
+                        )
+                        _wait_for_reclaim_future(
+                            reclaim_future, _RECLAIM_WAIT_SECONDS
+                        )
+                        continue
+                    logger.error(
+                        "MCP %s/list_resources still stale after reclaim retry: %s",
+                        server_name, exc,
+                    )
+                    return json.dumps({
+                        "error": (
+                            f"MCP server '{server_name}' transport closed "
+                            "and reclaim did not restore it in time"
+                        )
+                    })
+                logger.error(
+                    "MCP %s/list_resources failed: %s", server_name, exc,
                 )
-            }, ensure_ascii=False)
+                return json.dumps({
+                    "error": _sanitize_error(
+                        f"MCP call failed: {type(exc).__name__}: {exc}"
+                    )
+                })
+
+        return json.dumps({
+            "error": f"MCP server '{server_name}' recovery exhausted"
+        })
 
     return _handler
 
@@ -2972,56 +3215,74 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
     def _handler(args: dict, **kwargs) -> str:
         from tools.registry import tool_error
 
-        with _lock:
-            server = _servers.get(server_name)
-        if not server or not server.session:
-            return json.dumps({
-                "error": f"MCP server '{server_name}' is not connected"
-            }, ensure_ascii=False)
-
         uri = args.get("uri")
         if not uri:
             return tool_error("Missing required parameter 'uri'")
 
-        async def _call():
-            async with server._rpc_lock:
+        for attempt in range(2):
+            with _lock:
+                server = _servers.get(server_name)
+            if not server or not server.session:
+                if attempt == 0 and _wait_for_live_session(
+                    server_name, _RECLAIM_WAIT_SECONDS
+                ):
+                    continue
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is not connected"
+                    )
+                })
+
+            async def _call():
                 result = await server.session.read_resource(uri)
-            # read_resource returns ReadResourceResult with .contents list
-            parts: List[str] = []
-            contents = result.contents if hasattr(result, "contents") else []
-            for block in contents:
-                if hasattr(block, "text"):
-                    parts.append(block.text)
-                elif hasattr(block, "blob"):
-                    parts.append(f"[binary data, {len(block.blob)} bytes]")
-            return json.dumps({"result": "\n".join(parts) if parts else ""}, ensure_ascii=False)
+                parts: List[str] = []
+                contents = result.contents if hasattr(result, "contents") else []
+                for block in contents:
+                    if hasattr(block, "text"):
+                        parts.append(block.text)
+                    elif hasattr(block, "blob"):
+                        parts.append(f"[binary data, {len(block.blob)} bytes]")
+                return json.dumps({"result": "\n".join(parts) if parts else ""})
 
-        def _call_once():
-            return _run_on_mcp_loop(_call, timeout=tool_timeout)
-
-        try:
-            return _call_once()
-        except InterruptedError:
-            return _interrupted_call_result()
-        except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "resources/read",
-            )
-            if recovered is not None:
-                return recovered
-            recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "resources/read",
-            )
-            if recovered is not None:
-                return recovered
-            logger.error(
-                "MCP %s/read_resource failed: %s", server_name, exc,
-            )
-            return json.dumps({
-                "error": _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+            try:
+                return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            except InterruptedError:
+                return _interrupted_call_result()
+            except Exception as exc:
+                if _is_stale_transport_error(exc):
+                    reclaim_future = _mark_session_stale(server_name)
+                    if attempt == 0:
+                        logger.warning(
+                            "MCP %s/read_resource hit stale transport (%s); "
+                            "waiting for reclaim and retrying",
+                            server_name, type(exc).__name__,
+                        )
+                        _wait_for_reclaim_future(
+                            reclaim_future, _RECLAIM_WAIT_SECONDS
+                        )
+                        continue
+                    logger.error(
+                        "MCP %s/read_resource still stale after reclaim retry: %s",
+                        server_name, exc,
+                    )
+                    return json.dumps({
+                        "error": (
+                            f"MCP server '{server_name}' transport closed "
+                            "and reclaim did not restore it in time"
+                        )
+                    })
+                logger.error(
+                    "MCP %s/read_resource failed: %s", server_name, exc,
                 )
-            }, ensure_ascii=False)
+                return json.dumps({
+                    "error": _sanitize_error(
+                        f"MCP call failed: {type(exc).__name__}: {exc}"
+                    )
+                })
+
+        return json.dumps({
+            "error": f"MCP server '{server_name}' recovery exhausted"
+        })
 
     return _handler
 
@@ -3030,61 +3291,80 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
     """Return a sync handler that lists prompts from an MCP server."""
 
     def _handler(args: dict, **kwargs) -> str:
-        with _lock:
-            server = _servers.get(server_name)
-        if not server or not server.session:
-            return json.dumps({
-                "error": f"MCP server '{server_name}' is not connected"
-            }, ensure_ascii=False)
+        for attempt in range(2):
+            with _lock:
+                server = _servers.get(server_name)
+            if not server or not server.session:
+                if attempt == 0 and _wait_for_live_session(
+                    server_name, _RECLAIM_WAIT_SECONDS
+                ):
+                    continue
+                return json.dumps({
+                    "error": (
+                        f"MCP server '{server_name}' is not connected"
+                    )
+                })
 
-        async def _call():
-            async with server._rpc_lock:
+            async def _call():
                 result = await server.session.list_prompts()
-            prompts = []
-            for p in (result.prompts if hasattr(result, "prompts") else []):
-                entry = {}
-                if hasattr(p, "name"):
-                    entry["name"] = p.name
-                if hasattr(p, "description") and p.description:
-                    entry["description"] = p.description
-                if hasattr(p, "arguments") and p.arguments:
-                    entry["arguments"] = [
-                        {
-                            "name": a.name,
-                            **({"description": a.description} if hasattr(a, "description") and a.description else {}),
-                            **({"required": a.required} if hasattr(a, "required") else {}),
-                        }
-                        for a in p.arguments
-                    ]
-                prompts.append(entry)
-            return json.dumps({"prompts": prompts}, ensure_ascii=False)
+                prompts = []
+                for p in (result.prompts if hasattr(result, "prompts") else []):
+                    entry = {}
+                    if hasattr(p, "name"):
+                        entry["name"] = p.name
+                    if hasattr(p, "description") and p.description:
+                        entry["description"] = p.description
+                    if hasattr(p, "arguments") and p.arguments:
+                        entry["arguments"] = [
+                            {
+                                "name": a.name,
+                                **({"description": a.description} if hasattr(a, "description") and a.description else {}),
+                                **({"required": a.required} if hasattr(a, "required") else {}),
+                            }
+                            for a in p.arguments
+                        ]
+                    prompts.append(entry)
+                return json.dumps({"prompts": prompts})
 
-        def _call_once():
-            return _run_on_mcp_loop(_call, timeout=tool_timeout)
-
-        try:
-            return _call_once()
-        except InterruptedError:
-            return _interrupted_call_result()
-        except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "prompts/list",
-            )
-            if recovered is not None:
-                return recovered
-            recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "prompts/list",
-            )
-            if recovered is not None:
-                return recovered
-            logger.error(
-                "MCP %s/list_prompts failed: %s", server_name, exc,
-            )
-            return json.dumps({
-                "error": _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+            try:
+                return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            except InterruptedError:
+                return _interrupted_call_result()
+            except Exception as exc:
+                if _is_stale_transport_error(exc):
+                    reclaim_future = _mark_session_stale(server_name)
+                    if attempt == 0:
+                        logger.warning(
+                            "MCP %s/list_prompts hit stale transport (%s); "
+                            "waiting for reclaim and retrying",
+                            server_name, type(exc).__name__,
+                        )
+                        _wait_for_reclaim_future(
+                            reclaim_future, _RECLAIM_WAIT_SECONDS
+                        )
+                        continue
+                    logger.error(
+                        "MCP %s/list_prompts still stale after reclaim retry: %s",
+                        server_name, exc,
+                    )
+                    return json.dumps({
+                        "error": (
+                            f"MCP server '{server_name}' transport closed "
+                            "and reclaim did not restore it in time"
+                        )
+                    })
+                logger.error(
+                    "MCP %s/list_prompts failed: %s", server_name, exc,
                 )
-            }, ensure_ascii=False)
+                return json.dumps({
+                    "error": _sanitize_error(
+                        f"MCP call failed: {type(exc).__name__}: {exc}"
+                    )
+                })
+
+        return json.dumps({
+            "error": f"MCP server '{server_name}' recovery exhausted"
+        })
 
     return _handler
 
@@ -3095,67 +3375,87 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
     def _handler(args: dict, **kwargs) -> str:
         from tools.registry import tool_error
 
-        with _lock:
-            server = _servers.get(server_name)
-        if not server or not server.session:
-            return json.dumps({
-                "error": f"MCP server '{server_name}' is not connected"
-            }, ensure_ascii=False)
-
         name = args.get("name")
         if not name:
             return tool_error("Missing required parameter 'name'")
         arguments = args.get("arguments", {})
 
-        async def _call():
-            async with server._rpc_lock:
-                result = await server.session.get_prompt(name, arguments=arguments)
-            # GetPromptResult has .messages list
-            messages = []
-            for msg in (result.messages if hasattr(result, "messages") else []):
-                entry = {}
-                if hasattr(msg, "role"):
-                    entry["role"] = msg.role
-                if hasattr(msg, "content"):
-                    content = msg.content
-                    if hasattr(content, "text"):
-                        entry["content"] = content.text
-                    elif isinstance(content, str):
-                        entry["content"] = content
-                    else:
-                        entry["content"] = str(content)
-                messages.append(entry)
-            resp = {"messages": messages}
-            if hasattr(result, "description") and result.description:
-                resp["description"] = result.description
-            return json.dumps(resp, ensure_ascii=False)
+        for attempt in range(2):
+            with _lock:
+                server = _servers.get(server_name)
+            if not server or not server.session:
+                if attempt == 0 and _wait_for_live_session(
+                    server_name, _RECLAIM_WAIT_SECONDS
+                ):
+                    continue
+                return json.dumps({
+                    "error": f"MCP server '{server_name}' is not connected"
+                })
 
-        def _call_once():
-            return _run_on_mcp_loop(_call, timeout=tool_timeout)
-
-        try:
-            return _call_once()
-        except InterruptedError:
-            return _interrupted_call_result()
-        except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
-                server_name, exc, _call_once, "prompts/get",
-            )
-            if recovered is not None:
-                return recovered
-            recovered = _handle_session_expired_and_retry(
-                server_name, exc, _call_once, "prompts/get",
-            )
-            if recovered is not None:
-                return recovered
-            logger.error(
-                "MCP %s/get_prompt failed: %s", server_name, exc,
-            )
-            return json.dumps({
-                "error": _sanitize_error(
-                    f"MCP call failed: {type(exc).__name__}: {_exc_str(exc)}"
+            async def _call():
+                result = await server.session.get_prompt(
+                    name, arguments=arguments
                 )
-            }, ensure_ascii=False)
+                messages = []
+                for msg in (
+                    result.messages if hasattr(result, "messages") else []
+                ):
+                    entry = {}
+                    if hasattr(msg, "role"):
+                        entry["role"] = msg.role
+                    if hasattr(msg, "content"):
+                        content = msg.content
+                        if hasattr(content, "text"):
+                            entry["content"] = content.text
+                        elif isinstance(content, str):
+                            entry["content"] = content
+                        else:
+                            entry["content"] = str(content)
+                    messages.append(entry)
+                resp = {"messages": messages}
+                if hasattr(result, "description") and result.description:
+                    resp["description"] = result.description
+                return json.dumps(resp)
+
+            try:
+                return _run_on_mcp_loop(_call(), timeout=tool_timeout)
+            except InterruptedError:
+                return _interrupted_call_result()
+            except Exception as exc:
+                if _is_stale_transport_error(exc):
+                    reclaim_future = _mark_session_stale(server_name)
+                    if attempt == 0:
+                        logger.warning(
+                            "MCP %s/get_prompt hit stale transport (%s); "
+                            "waiting for reclaim and retrying",
+                            server_name, type(exc).__name__,
+                        )
+                        _wait_for_reclaim_future(
+                            reclaim_future, _RECLAIM_WAIT_SECONDS
+                        )
+                        continue
+                    logger.warning(
+                        "MCP %s/get_prompt still stale after reclaim (%s)",
+                        server_name, type(exc).__name__,
+                    )
+                    return json.dumps({
+                        "error": (
+                            f"MCP server '{server_name}' transport closed; "
+                            "reconnecting — please retry"
+                        )
+                    })
+                logger.error(
+                    "MCP %s/get_prompt failed: %s", server_name, exc,
+                )
+                return json.dumps({
+                    "error": _sanitize_error(
+                        f"MCP call failed: {type(exc).__name__}: {exc}"
+                    )
+                })
+
+        return json.dumps({
+            "error": f"MCP server '{server_name}' recovery exhausted"
+        })
 
     return _handler
 
@@ -3688,21 +3988,48 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
 
     # Only attempt servers that aren't already connected and are enabled
     # (enabled: false skips the server entirely without removing its config)
+    #
+    # A server "counts" as already-connected only when its run() coroutine
+    # is still alive and holds an active session. If the previous task
+    # gave up (run() returned) or the session went stale (subprocess
+    # killed, stream closed), we drop the dead entry here so the fresh
+    # _discover_and_register_server pass can recreate it. Without this,
+    # a stale _servers entry blocks recovery forever.
+    dead_server_names: list[str] = []
     with _lock:
-        new_servers = {
-            k: v
-            for k, v in servers.items()
-            if k not in _servers and _parse_boolish(v.get("enabled", True), default=True)
-        }
-        _server_connecting.update(new_servers)
-        for srv_name in new_servers:
-            _server_connect_errors.pop(srv_name, None)
+        new_servers: Dict[str, dict] = {}
+        for k, v in servers.items():
+            if not _parse_boolish(v.get("enabled", True), default=True):
+                continue
+            existing = _servers.get(k)
+            if existing is None:
+                new_servers[k] = v
+                continue
+            task = getattr(existing, "_task", None)
+            is_dead = (
+                existing.session is None
+                or (task is not None and task.done())
+            )
+            if is_dead:
+                dead_server_names.append(k)
+                # Drop the dead entry so _discover_and_register_server
+                # can overwrite it with a fresh MCPServerTask below.
+                _servers.pop(k, None)
+                new_servers[k] = v
+
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
                 _parallel_safe_servers.add(sanitize_mcp_name_component(srv_name))
             else:
                 _parallel_safe_servers.discard(sanitize_mcp_name_component(srv_name))
+
+    if dead_server_names:
+        logger.info(
+            "MCP: reclaiming %d stale server entry/entries for "
+            "re-registration: %s",
+            len(dead_server_names), ", ".join(sorted(dead_server_names)),
+        )
 
     if not new_servers:
         return _existing_tool_names()
@@ -3793,12 +4120,21 @@ def discover_mcp_tools() -> List[str]:
         logger.debug("No MCP servers configured")
         return []
 
+    # Same liveness check as register_mcp_servers: a stale server with
+    # session=None or a completed _task is treated as "new" so
+    # register_mcp_servers can reclaim and retry it.
     with _lock:
-        new_server_names = [
-            name
-            for name, cfg in servers.items()
-            if name not in _servers and _parse_boolish(cfg.get("enabled", True), default=True)
-        ]
+        new_server_names: list[str] = []
+        for name, cfg in servers.items():
+            if not _parse_boolish(cfg.get("enabled", True), default=True):
+                continue
+            existing = _servers.get(name)
+            if existing is None:
+                new_server_names.append(name)
+                continue
+            task = getattr(existing, "_task", None)
+            if existing.session is None or (task is not None and task.done()):
+                new_server_names.append(name)
 
     tool_names = register_mcp_servers(servers)
     if not new_server_names:


### PR DESCRIPTION
## Summary

Combines two fixes and their bugfixes into one coherent PR.

### 1. WSL2 child PID tracking (ps --ppid)

On WSL2, /proc/<pid>/task/<pid>/children returns empty for multi-threaded processes (Hermes has 12+ threads), causing _snapshot_child_pids() to always return an empty set. MCP server subprocess PIDs are never tracked, so they accumulate as orphans across reconnects.

**Fix:** try `ps --ppid` first (works on WSL2, macOS, Linux), fall back to /proc/children, then psutil.

### 2. MCP subprocess resilience (salvaged from #10250, sege66)

Three stacked fixes for long-running gateway stability.

**a) Survive subprocess drops and reset retry counter**
- MCPServerTask.run() previously counted reconnect attempts over the server's entire lifetime. Now the consecutive-retry counter is reset when the previous session was healthy (>= 30s uptime).
- Polls tracked subprocess PIDs every 5s via _any_pid_alive.
- Unexpected clean exit from transport is treated as disconnect, not a break from the reconnect loop.

**b) Close stale-server recovery gaps**
- register_mcp_servers / discover_mcp_tools now treat session=None / task.done() as stale and reclaimable instead of leaving dead entries permanently blocking re-registration.

**c) Make recovery invisible to the agent**
- Two-attempt loop in tool handlers: on first ClosedResourceError, schedules reclaim, waits up to 15s for fresh subprocess, retries the same call. Agent only sees a slightly slower call, never an error.

### 3. Bug fixes from the PR #10250 merge

The salvage merge introduced several runtime errors that are fixed here:
- Duplicate ClientSession in _run_stdio finally block referencing already-closed streams.
- _rpc_lock, _reclaim_inflight, _pending_refresh_tasks declared in __slots__ but never initialized in __init__.
- _pending_refresh_tasks typed as list but used with set methods.
- _connected_at missing from stdio initialization path.

## Test plan

- [x] Hermes gateway starts and connects Telegram
- [x] All 3 MCP servers (searxng, pgvector-memory, ssh-manager) connect
- [x] MCP tool calls succeed (ssh_execute to moreno, niqepsilon)
- [x] Keepalive fires without triggering reconnect storms
- [x] No orphan MCP subprocesses accumulate over multiple reconnect cycles
- [x] pytest tests/tools/test_mcp_tool.py passes (inherits 173 existing tests + 8 regression tests from #10250)
- [x] Tested on WSL2 (Ubuntu, kernel 6.6.87.2-microsoft-standard-WSL2)
