### PR TITLE
fix(agent): recover Responses streams with null output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,6 +107,50 @@ from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_
 logger = logging.getLogger(__name__)
 
 
+def _is_null_output_parse_error(exc: TypeError) -> bool:
+    return "NoneType" in str(exc) and "iterable" in str(exc)
+
+
+def _backfill_responses_output(
+    final: Any,
+    collected_output_items: List[Any],
+    collected_text_deltas: List[str],
+    *,
+    has_function_calls: bool,
+    label: str,
+) -> Any:
+    if final is None:
+        final = SimpleNamespace(status="completed", output=[])
+
+    output = getattr(final, "output", None)
+    if isinstance(output, list) and output:
+        return final
+
+    if collected_output_items:
+        final.output = list(collected_output_items)
+        logger.debug(
+            "%s: backfilled %d output items from stream events",
+            label,
+            len(collected_output_items),
+        )
+    elif collected_text_deltas and not has_function_calls:
+        assembled = "".join(collected_text_deltas)
+        final.output = [SimpleNamespace(
+            type="message", role="assistant", status="completed",
+            content=[SimpleNamespace(type="output_text", text=assembled)],
+        )]
+        logger.debug(
+            "%s: synthesized from %d deltas (%d chars)",
+            label,
+            len(collected_text_deltas),
+            len(assembled),
+        )
+    elif not isinstance(output, list):
+        final.output = []
+
+    return final
+
+
 def _safe_isinstance(obj: Any, maybe_type: Any) -> bool:
     """Return False instead of raising when a patched symbol is not a type."""
     try:
@@ -791,6 +835,7 @@ class _CodexCompletionsAdapter:
             collected_output_items: List[Any] = []
             collected_text_deltas: List[str] = []
             has_function_calls = False
+            terminal_response = None
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
@@ -810,31 +855,31 @@ class _CodexCompletionsAdapter:
                             collected_text_deltas.append(_delta)
                     elif "function_call" in _etype:
                         has_function_calls = True
+                    elif _etype in {"response.completed", "response.incomplete", "response.failed"}:
+                        terminal_response = getattr(_event, "response", None)
                 _check_cancelled()
-                final = stream.get_final_response()
+                try:
+                    final = stream.get_final_response()
+                except TypeError as exc:
+                    if not _is_null_output_parse_error(exc) or (
+                        not terminal_response
+                        and not collected_output_items
+                        and not collected_text_deltas
+                    ):
+                        raise
+                    logger.debug(
+                        "Codex auxiliary: recovering from null terminal output parse error",
+                        exc_info=True,
+                    )
+                    final = terminal_response
 
-            # Backfill empty output from collected stream events
-            _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
-                if collected_output_items:
-                    final.output = list(collected_output_items)
-                    logger.debug(
-                        "Codex auxiliary: backfilled %d output items from stream events",
-                        len(collected_output_items),
-                    )
-                elif collected_text_deltas and not has_function_calls:
-                    # Only synthesize text when no tool calls were streamed —
-                    # a function_call response with incidental text should not
-                    # be collapsed into a plain-text message.
-                    assembled = "".join(collected_text_deltas)
-                    final.output = [SimpleNamespace(
-                        type="message", role="assistant", status="completed",
-                        content=[SimpleNamespace(type="output_text", text=assembled)],
-                    )]
-                    logger.debug(
-                        "Codex auxiliary: synthesized from %d deltas (%d chars)",
-                        len(collected_text_deltas), len(assembled),
-                    )
+            final = _backfill_responses_output(
+                final,
+                collected_output_items,
+                collected_text_deltas,
+                has_function_calls=has_function_calls,
+                label="Codex auxiliary",
+            )
 
             # Extract text and tool calls from the Responses output.
             # Items may be SDK objects (attrs) or dicts (raw/fallback paths),
@@ -869,6 +914,47 @@ class _CodexCompletionsAdapter:
                     completion_tokens=getattr(resp_usage, "output_tokens", 0),
                     total_tokens=getattr(resp_usage, "total_tokens", 0),
                 )
+        except TypeError as exc:
+            if not _is_null_output_parse_error(exc) or (
+                not terminal_response
+                and not collected_output_items
+                and not collected_text_deltas
+            ):
+                raise
+            logger.debug(
+                "Codex auxiliary: recovering from null streamed output parse error",
+                exc_info=True,
+            )
+            final = _backfill_responses_output(
+                terminal_response,
+                collected_output_items,
+                collected_text_deltas,
+                has_function_calls=has_function_calls,
+                label="Codex auxiliary",
+            )
+
+            def _item_get(obj: Any, key: str, default: Any = None) -> Any:
+                val = getattr(obj, key, None)
+                if val is None and isinstance(obj, dict):
+                    val = obj.get(key, default)
+                return val if val is not None else default
+
+            for item in getattr(final, "output", []):
+                item_type = _item_get(item, "type")
+                if item_type == "message":
+                    for part in (_item_get(item, "content") or []):
+                        ptype = _item_get(part, "type")
+                        if ptype in {"output_text", "text"}:
+                            text_parts.append(_item_get(part, "text", ""))
+                elif item_type == "function_call":
+                    tool_calls_raw.append(SimpleNamespace(
+                        id=_item_get(item, "call_id", ""),
+                        type="function",
+                        function=SimpleNamespace(
+                            name=_item_get(item, "name", ""),
+                            arguments=_item_get(item, "arguments", "{}"),
+                        ),
+                    ))
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,52 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _is_null_output_parse_error(exc: TypeError) -> bool:
+    return "NoneType" in str(exc) and "iterable" in str(exc)
+
+
+def _backfill_responses_output(
+    final_response: Any,
+    collected_output_items: list,
+    collected_text_parts: list,
+    *,
+    has_tool_calls: bool,
+    label: str,
+):
+    if final_response is None:
+        final_response = SimpleNamespace(status="completed", output=[])
+
+    output = getattr(final_response, "output", None)
+    if isinstance(output, list) and output:
+        return final_response
+
+    if collected_output_items:
+        final_response.output = list(collected_output_items)
+        logger.debug(
+            "%s: backfilled %d output items from stream events",
+            label,
+            len(collected_output_items),
+        )
+    elif collected_text_parts and not has_tool_calls:
+        assembled = "".join(collected_text_parts)
+        final_response.output = [SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text=assembled)],
+        )]
+        logger.debug(
+            "%s: synthesized output from %d text deltas (%d chars)",
+            label,
+            len(collected_text_parts),
+            len(assembled),
+        )
+    elif not isinstance(output, list):
+        final_response.output = []
+
+    return final_response
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -192,6 +238,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        terminal_response = None
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
                 for event in stream:
@@ -234,9 +281,12 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         done_item = getattr(event, "item", None)
                         if done_item is not None:
                             collected_output_items.append(done_item)
+                    elif event_type == "response.completed":
+                        terminal_response = getattr(event, "response", None)
                     # Log non-completed terminal events for diagnostics
                     elif event_type in {"response.incomplete", "response.failed"}:
                         resp_obj = getattr(event, "response", None)
+                        terminal_response = resp_obj
                         status = getattr(resp_obj, "status", None) if resp_obj else None
                         incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
                         logger.warning(
@@ -246,31 +296,46 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
-                # PATCH: ChatGPT Codex backend streams valid output items
-                # but get_final_response() can return an empty output list.
-                # Backfill from collected items or synthesize from deltas.
-                _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        final_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex stream: backfilled %d output items from stream events",
-                            len(collected_output_items),
-                        )
-                    elif agent._codex_streamed_text_parts and not has_tool_calls:
-                        assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex stream: synthesized output from %d text deltas (%d chars)",
-                            len(agent._codex_streamed_text_parts), len(assembled),
-                        )
-                return final_response
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    if not _is_null_output_parse_error(exc) or (
+                        not terminal_response
+                        and not collected_output_items
+                        and not agent._codex_streamed_text_parts
+                    ):
+                        raise
+                    logger.debug(
+                        "Codex stream: recovering from null terminal output parse error",
+                        exc_info=True,
+                    )
+                    final_response = terminal_response
+
+                return _backfill_responses_output(
+                    final_response,
+                    collected_output_items,
+                    agent._codex_streamed_text_parts,
+                    has_tool_calls=has_tool_calls,
+                    label="Codex stream",
+                )
+        except TypeError as exc:
+            if not _is_null_output_parse_error(exc) or (
+                not terminal_response
+                and not collected_output_items
+                and not agent._codex_streamed_text_parts
+            ):
+                raise
+            logger.debug(
+                "Codex stream: recovering from null streamed output parse error",
+                exc_info=True,
+            )
+            return _backfill_responses_output(
+                terminal_response,
+                collected_output_items,
+                agent._codex_streamed_text_parts,
+                has_tool_calls=has_tool_calls,
+                label="Codex stream",
+            )
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(
@@ -412,27 +477,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is None and isinstance(event, dict):
                 terminal_response = event.get("response")
             if terminal_response is not None:
-                # Backfill empty output from collected stream events
-                _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        terminal_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex fallback stream: backfilled %d output items",
-                            len(collected_output_items),
-                        )
-                    elif collected_text_deltas:
-                        assembled = "".join(collected_text_deltas)
-                        terminal_response.output = [SimpleNamespace(
-                            type="message", role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex fallback stream: synthesized from %d deltas (%d chars)",
-                            len(collected_text_deltas), len(assembled),
-                        )
-                return terminal_response
+                return _backfill_responses_output(
+                    terminal_response,
+                    collected_output_items,
+                    collected_text_deltas,
+                    has_tool_calls=False,
+                    label="Codex fallback stream",
+                )
     finally:
         close_fn = getattr(stream_or_response, "close", None)
         if callable(close_fn):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2210,6 +2210,42 @@ class TestAuxiliaryPoolRotationRetry:
         mock_fallback.assert_not_called()
 
 
+class TestCodexAuxiliaryClientStreamRecovery:
+    def test_stream_parser_null_output_error_backfills_output_items(self):
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        streamed_item = SimpleNamespace(
+            type="message",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text="stream recovered")],
+        )
+
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=streamed_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):
+                raise AssertionError("stream iteration should fail before final parsing")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert response.choices[0].message.content == "stream recovered"
+
+
 class TestCodexAdapterReasoningTranslation:
     """Verify _CodexCompletionsAdapter translates extra_body.reasoning
     into the Responses API's top-level reasoning + include fields, matching

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -186,6 +186,24 @@ class _FakeCreateStream:
         self.closed = True
 
 
+class _FakeNullOutputCrashStream:
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        yield from self._events
+        raise TypeError("'NoneType' object is not iterable")
+
+    def get_final_response(self):
+        raise AssertionError("stream iteration should fail before final parsing")
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -482,6 +500,32 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_when_terminal_output_null_crashes_parser(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    streamed_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="stream recovered")],
+    )
+
+    def _fake_stream(**kwargs):
+        return _FakeNullOutputCrashStream([
+            SimpleNamespace(type="response.output_item.done", item=streamed_item),
+        ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert response.output == [streamed_item]
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a Responses streaming crash where an OpenAI-compatible endpoint streams valid `response.output_item.done` events, then the SDK raises while parsing a terminal response whose `response.output` is `null`.

Hermes already recovered when the final output was an empty list. This extends that recovery to the null-output parser failure path by backfilling from already-streamed output items, or synthesizing message output from text deltas when no tool call was streamed. The same recovery is applied to the main Codex Responses runtime and the auxiliary Codex adapter.

## Related Issue

Fixes #11179

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_runtime.py`
  - Adds shared output backfill for missing/null/empty Responses stream finals.
  - Recovers from the SDK `TypeError("'NoneType' object is not iterable")` during stream iteration or final parsing when streamed output is available.
  - Reuses the same backfill helper for the create(stream=True) fallback path.
- `agent/auxiliary_client.py`
  - Adds equivalent null-output recovery for the Codex auxiliary chat-completions adapter used by side tasks.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - Adds a fake-stream regression for SDK parser failure after `response.output_item.done`.
- `tests/agent/test_auxiliary_client.py`
  - Adds the same regression for the auxiliary adapter path.

## How to Test

1. Targeted regressions:

   ```bash
   python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_recovers_when_terminal_output_null_crashes_parser -q
   python -m pytest tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryClientStreamRecovery::test_stream_parser_null_output_error_backfills_output_items -q
   ```

2. Related files:

   ```bash
   python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q
   python -m pytest tests/agent/test_auxiliary_client.py -q
   ```

3. Static checks:

   ```bash
   python -m ruff check agent/auxiliary_client.py agent/codex_runtime.py tests/agent/test_auxiliary_client.py tests/run_agent/test_run_agent_codex_responses.py
   python -m py_compile agent/codex_runtime.py agent/auxiliary_client.py tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py
   ```

4. Local live smoke against `openai-codex + gpt-5.5`:

   ```bash
   hermes chat --provider openai-codex -m gpt-5.5 --ignore-rules --quiet --max-turns 1 -q "Reply with exactly: HERMES_55_OK"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15, Python 3.11.10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted related tests:

```text
tests/run_agent/test_run_agent_codex_responses.py: 66 passed, 1 warning in 31.46s
tests/agent/test_auxiliary_client.py: 177 passed, 1 warning in 8.24s
ruff: All checks passed
py_compile: passed
local live smoke: stdout HERMES_55_OK
```