### PR TITLE
Fix SELinux-blocked gateway system service installs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1386,6 +1386,13 @@ class SystemScopeRequiresRootError(RuntimeError):
         return self.args[0] if self.args else ""
 
 
+class SystemScopeSelinuxExecError(RuntimeError):
+    """Raised when SELinux would block a system service ExecStart path."""
+
+    def __str__(self) -> str:
+        return self.args[0] if self.args else ""
+
+
 def _user_dbus_socket_path() -> Path:
     """Return the expected per-user D-Bus socket path (regardless of existence)."""
     xdg = os.environ.get("XDG_RUNTIME_DIR") or f"/run/user/{os.getuid()}"  # windows-footgun: ok — POSIX systemd helper, never invoked on Windows
@@ -1868,6 +1875,17 @@ def install_linux_gateway_from_setup(force: bool = False, enable_on_startup: boo
 
     if scope == "system":
         run_as_user = _default_system_service_user()
+        if run_as_user:
+            conflict = _system_service_selinux_exec_conflict(run_as_user)
+            if conflict:
+                username, _home_dir, _python_path = conflict
+                print_warning("  System service install is not supported for this Hermes checkout while SELinux is enforcing.")
+                print_info("  Hermes' current virtualenv lives under the target user's home directory,")
+                print_info("  and a systemd system service would fail with status 203/EXEC on Fedora/RHEL-style hosts.")
+                print_info("  Use a user service instead: hermes gateway install")
+                print_info("  Or reinstall Hermes into a trusted system path such as /opt/hermes, then run:")
+                print_info(f"    sudo hermes gateway install --system --run-as-user {username}")
+                return scope, False
         if os.geteuid() != 0:  # windows-footgun: ok — Linux systemd install wizard, never invoked on Windows
             print_warning("  System service install requires sudo, so Hermes can't create it from this user session.")
             if run_as_user:
@@ -2018,6 +2036,83 @@ def get_python_path() -> str:
         if venv_python.exists():
             return str(venv_python)
     return sys.executable
+
+
+def _selinux_is_enforcing() -> bool:
+    """Return True when SELinux is active and enforcing on this host."""
+    if not is_linux() or is_termux():
+        return False
+
+    enforce_path = Path("/sys/fs/selinux/enforce")
+    try:
+        if enforce_path.exists():
+            return enforce_path.read_text(encoding="utf-8").strip() == "1"
+    except OSError:
+        pass
+
+    getenforce = shutil.which("getenforce")
+    if not getenforce:
+        return False
+
+    try:
+        result = subprocess.run(
+            [getenforce],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except Exception:
+        return False
+
+    return result.returncode == 0 and result.stdout.strip().lower() == "enforcing"
+
+
+def _system_service_selinux_exec_conflict(
+    run_as_user: str | None = None,
+) -> tuple[str, str, str] | None:
+    """Return conflict details when SELinux would block the system ExecStart."""
+    if not _selinux_is_enforcing():
+        return None
+
+    username, _group_name, home_dir = _system_service_identity(run_as_user)
+    python_path = _remap_path_for_user(get_python_path(), home_dir)
+
+    try:
+        Path(python_path).expanduser().relative_to(Path(home_dir).expanduser())
+    except ValueError:
+        return None
+
+    return username, home_dir, python_path
+
+
+def _raise_if_system_service_selinux_exec_conflicts(
+    run_as_user: str | None = None,
+) -> None:
+    conflict = _system_service_selinux_exec_conflict(run_as_user)
+    if not conflict:
+        return
+
+    username, home_dir, python_path = conflict
+    raise SystemScopeSelinuxExecError(
+        textwrap.dedent(
+            f"""
+            SELinux is enforcing and the Hermes system service for user '{username}'
+            would execute '{python_path}' from inside '{home_dir}'.
+
+            System-level systemd services on SELinux hosts cannot exec Hermes'
+            virtualenv interpreter from a home directory, so this install would
+            fail with status 203/EXEC.
+
+            Use a user service instead:
+              hermes gateway install
+
+            Or reinstall Hermes into a trusted system path such as /opt/hermes,
+            then rerun:
+              sudo hermes gateway install --system --run-as-user {username}
+            """
+        ).strip()
+    )
 
 
 # =============================================================================
@@ -2467,6 +2562,7 @@ def systemd_install(
 ):
     if system:
         _require_root_for_system_service("install")
+        _raise_if_system_service_selinux_exec_conflicts(run_as_user)
 
     # Offer to remove legacy units (hermes.service from pre-rename installs)
     # before installing the new hermes-gateway.service. If both remain, they
@@ -5147,6 +5243,9 @@ def gateway_command(args):
         # intercept the same condition with friendlier guidance before the
         # error is raised.
         print(str(e))
+        sys.exit(1)
+    except SystemScopeSelinuxExecError as e:
+        print_error(str(e))
         sys.exit(1)
 
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -492,6 +492,26 @@ def test_install_linux_gateway_from_setup_system_choice_without_root_prints_foll
     assert "sudo hermes gateway start --system" in out
 
 
+def test_install_linux_gateway_from_setup_system_choice_warns_on_selinux_home_exec(monkeypatch, capsys):
+    monkeypatch.setattr(gateway, "prompt_linux_gateway_install_scope", lambda: "system")
+    monkeypatch.setattr(gateway.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(gateway, "_default_system_service_user", lambda: "alice")
+    monkeypatch.setattr(
+        gateway,
+        "_system_service_selinux_exec_conflict",
+        lambda run_as_user=None: ("alice", "/home/alice", "/home/alice/.hermes/hermes-agent/venv/bin/python"),
+    )
+    monkeypatch.setattr(gateway, "systemd_install", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not install")))
+
+    scope, did_install = gateway.install_linux_gateway_from_setup(force=False)
+
+    out = capsys.readouterr().out
+    assert (scope, did_install) == ("system", False)
+    assert "status 203/EXEC" in out
+    assert "hermes gateway install" in out
+    assert "sudo hermes gateway install --system --run-as-user alice" in out
+
+
 def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeypatch):
     monkeypatch.setattr(gateway, "prompt_linux_gateway_install_scope", lambda: "system")
     monkeypatch.setattr(gateway.os, "geteuid", lambda: 0)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2409,6 +2409,38 @@ class TestSystemScopeRequiresRootError:
         assert not isinstance(err, SystemExit)
 
 
+class TestSystemScopeSelinuxExecError:
+    def test_systemd_install_raises_when_selinux_blocks_home_exec(self, monkeypatch, tmp_path):
+        unit_path = tmp_path / "etc" / "systemd" / "system" / "hermes-gateway.service"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "_require_root_for_system_service", lambda action: None)
+        monkeypatch.setattr(gateway_cli, "_selinux_is_enforcing", lambda: True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_python_path",
+            lambda: "/home/alice/.hermes/hermes-agent/venv/bin/python",
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: calls.append(args) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        with pytest.raises(gateway_cli.SystemScopeSelinuxExecError) as excinfo:
+            gateway_cli.systemd_install(force=False, system=True, run_as_user="alice")
+
+        assert "status 203/EXEC" in str(excinfo.value)
+        assert not unit_path.exists()
+        assert calls == []
+
+
 class TestSystemScopeWizardPreCheck:
     """Tests for _system_scope_wizard_would_need_root — the guard the
     wizard uses to detect the dead-end BEFORE prompting the user to start
@@ -2533,3 +2565,32 @@ class TestGatewayCommandCatchesSystemScopeError:
         # Renders the message, NOT the ``('msg', 'action')`` tuple repr
         assert "System gateway start requires root. Re-run with sudo." in out
         assert "('" not in out  # no tuple repr leaking through
+
+    def test_system_install_selinux_exec_error_exits_one_with_clean_message(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_managed", lambda: False)
+        monkeypatch.setattr(gateway_cli, "prompt_yes_no", lambda *args, **kwargs: True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "systemd_install",
+            lambda force=False, system=False, run_as_user=None, enable_on_startup=True: (_ for _ in ()).throw(
+                gateway_cli.SystemScopeSelinuxExecError("status 203/EXEC")
+            ),
+        )
+
+        args = SimpleNamespace(
+            gateway_command="install",
+            force=False,
+            system=True,
+            run_as_user="alice",
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            gateway_cli.gateway_command(args)
+
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert "status 203/EXEC" in out


### PR DESCRIPTION
## Summary
- detect SELinux enforcing hosts where the system gateway would exec a home-directory virtualenv interpreter
- refuse that broken `--system` install path with actionable guidance toward user services or a trusted install path
- cover the setup warning and direct CLI failure paths with focused gateway tests

## Testing
- pytest -q -o addopts= tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py -k "selinux or system_choice_without_root_prints_followup or system_choice_warns_on_selinux_home_exec or SystemScopeSelinuxExecError or system_install_selinux_exec_error_exits_one_with_clean_message"
- ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_service.py
- git diff --check

Closes #32932