### PR TITLE
fix(codex): recover streams after SDK NoneType finalizer errors

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -841,15 +841,20 @@ def _preflight_codex_api_kwargs(
 def _extract_responses_message_text(item: Any) -> str:
     """Extract assistant text from a Responses message output item."""
     content = getattr(item, "content", None)
+    if content is None and isinstance(item, dict):
+        content = item.get("content")
     if not isinstance(content, list):
         return ""
 
     chunks: List[str] = []
     for part in content:
         ptype = getattr(part, "type", None)
+        text = getattr(part, "text", None)
+        if isinstance(part, dict):
+            ptype = ptype or part.get("type")
+            text = text if text is not None else part.get("text")
         if ptype not in {"output_text", "text"}:
             continue
-        text = getattr(part, "text", None)
         if isinstance(text, str) and text:
             chunks.append(text)
     return "".join(chunks).strip()
@@ -922,7 +927,11 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
 
     for item in output:
         item_type = getattr(item, "type", None)
+        if item_type is None and isinstance(item, dict):
+            item_type = item.get("type")
         item_status = getattr(item, "status", None)
+        if item_status is None and isinstance(item, dict):
+            item_status = item.get("status")
         if isinstance(item_status, str):
             item_status = item_status.strip().lower()
         else:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -277,7 +277,40 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    # OpenAI SDK 2.24 can raise ``TypeError: 'NoneType' object is not iterable``
+                    # against chatgpt.com/backend-api/codex even after a healthy stream
+                    # emitted output_item.done / output_text.delta events.  Treat that as
+                    # a broken SDK finalizer, not a provider failure, and synthesize the
+                    # Responses object from the events we already collected.
+                    if "NoneType" not in str(exc) or (
+                        not collected_output_items and not agent._codex_streamed_text_parts
+                    ):
+                        raise
+                    assembled = "".join(agent._codex_streamed_text_parts)
+                    output_items = list(collected_output_items)
+                    if not output_items and assembled and not has_tool_calls:
+                        output_items = [SimpleNamespace(
+                            type="message",
+                            role="assistant",
+                            status="completed",
+                            content=[SimpleNamespace(type="output_text", text=assembled)],
+                        )]
+                    final_response = SimpleNamespace(
+                        id=None,
+                        object="response",
+                        status="completed",
+                        output=output_items,
+                        output_text=assembled,
+                        usage=None,
+                    )
+                    logger.warning(
+                        "Codex stream: recovered from SDK get_final_response TypeError "
+                        "using %d output items and %d streamed chars. %s",
+                        len(output_items), len(assembled), agent._client_log_context(),
+                    )
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -10,6 +10,7 @@ sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
 import run_agent
+from agent.codex_responses_adapter import _normalize_codex_response
 
 
 @pytest.fixture(autouse=True)
@@ -155,9 +156,11 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None, iter_error=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
+        self._iter_error = iter_error
 
     def __enter__(self):
         return self
@@ -166,7 +169,10 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        for event in self._events:
+            yield event
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -537,6 +543,50 @@ def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(mo
     assert calls["stream"] == 1
     assert response.output == [output_item]
     assert response.status == "completed"
+
+
+def test_run_codex_stream_recovers_text_deltas_when_sdk_raises_nonetype(monkeypatch):
+    """Recover from text deltas if the SDK raises after streaming content."""
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="O"),
+                SimpleNamespace(type="response.output_text.delta", delta="K"),
+            ],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback should not run"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response is not None
+    assert response.status == "completed"
+    assert response.output[0].content[0].text == "OK"
+
+
+def test_normalize_codex_response_accepts_dict_message_items():
+    response = SimpleNamespace(
+        output=[
+            {
+                "type": "message",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "dict ok"}],
+            }
+        ],
+        status="completed",
+        usage=None,
+    )
+
+    msg, finish_reason = _normalize_codex_response(response)
+    assert finish_reason == "stop"
+    assert msg.content == "dict ok"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

This PR makes the Codex Responses streaming path more tolerant of a failure mode seen with the ChatGPT Codex backend, where the model has already streamed usable output but the OpenAI SDK later raises:

```text
TypeError: 'NoneType' object is not iterable
```

When that happens after Hermes has collected `response.output_item.done` events or text deltas, we now recover the already-streamed content instead of failing the turn.

## What changed

- Recover from the SDK `NoneType` stream parsing error in `run_codex_stream` when output items or text deltas were already received.
- Backfill a minimal completed Responses-like object from the collected stream events.
- Keep the existing fallback behavior when there is no recoverable streamed output.
- Allow dict-shaped Codex message items/content parts during response normalization, in addition to SDK model objects.
- Add regression coverage for the stream-iteration failure case and dict-shaped response items.

## Why

The ChatGPT Codex backend can emit valid events such as:

```text
response.output_text.delta
response.output_item.done
```

and then the SDK may fail while parsing a terminal response whose `output` is `None`. Prior to this change, Hermes treated that as a non-retryable provider error even though the useful answer had already arrived in the stream.

The recovery is intentionally narrow: it only applies to this `NoneType` iterable error and only when Hermes has already collected stream output. If there is no collected output, the original error is still raised or the existing fallback path is used.

## Test plan

- [x] `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`
- [x] `python -m pytest tests/run_agent/test_codex_xai_oauth_recovery.py tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`

After rebasing onto current `upstream/main`, the local results were:

```text
68 passed, 1 warning
105 passed, 1 warning
```

I also smoke-tested the original failure path locally with `openai-codex` / `gpt-5.5` and confirmed that a simple prompt now completes instead of aborting with the `NoneType` error.
