### PR TITLE
Enable fallback on 500 and 502 errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -780,7 +780,11 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
-        return result_fn(FailoverReason.server_error, retryable=True)
+        return result_fn(
+            FailoverReason.server_error,
+            retryable=True,
+            should_fallback=True,
+        )
 
     if status_code in {503, 529}:
         return result_fn(FailoverReason.overloaded, retryable=True)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -277,11 +277,13 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.server_error
         assert result.retryable is True
+        assert result.should_fallback is True
 
     def test_502_server_error(self):
         e = MockAPIError("Bad Gateway", status_code=502)
         result = classify_api_error(e)
         assert result.reason == FailoverReason.server_error
+        assert result.should_fallback is True
 
     def test_503_overloaded(self):
         e = MockAPIError("Service Unavailable", status_code=503)


### PR DESCRIPTION
## Summary
- mark non-validation HTTP 500/502 classifications as `should_fallback=True`
- keep the existing request-validation fast-fail branch unchanged
- extend error-classifier tests to assert fallback behavior for 500/502 server errors

## Testing
- pytest -q -o addopts= tests/agent/test_error_classifier.py
- ruff check agent/error_classifier.py tests/agent/test_error_classifier.py
- git diff --check

Closes #32961