### PR TITLE
fix(hindsight): guard missing cloud client dependency

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -99,6 +99,21 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+def _check_cloud_client() -> tuple[bool, str | None]:
+    """Return whether the external Hindsight client imports cleanly.
+
+    Cloud and local_external modes both rely on ``hindsight-client``. If the
+    optional package is absent, report the provider as unavailable and disable
+    it during initialization instead of letting a late ImportError crash the
+    gateway.
+    """
+    try:
+        importlib.import_module("hindsight_client")
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
 # ---------------------------------------------------------------------------
 # Hindsight API capability probe — mirrors hindsight-integrations/openclaw.
 # ---------------------------------------------------------------------------
@@ -596,11 +611,15 @@ class HindsightMemoryProvider(MemoryProvider):
         try:
             cfg = _load_config()
             mode = cfg.get("mode", "cloud")
-            if mode in {"local", "local_embedded"}:
+            if mode in ("local", "local_embedded"):
                 available, _ = _check_local_runtime()
                 return available
             if mode == "local_external":
-                return True
+                available, _ = _check_cloud_client()
+                return available
+            client_available, _ = _check_cloud_client()
+            if not client_available:
+                return False
             has_key = bool(
                 cfg.get("apiKey")
                 or cfg.get("api_key")
@@ -910,7 +929,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
             else:
-                from hindsight_client import Hindsight
+                try:
+                    from hindsight_client import Hindsight
+                except Exception as exc:
+                    raise RuntimeError(
+                        "hindsight-client is not installed or could not be imported. "
+                        f"Install with: uv pip install 'hindsight-client>={_MIN_CLIENT_VERSION}'"
+                    ) from exc
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}
                 if self._api_key:
@@ -1127,6 +1152,16 @@ class HindsightMemoryProvider(MemoryProvider):
             if not available:
                 logger.warning(
                     "Hindsight local mode disabled because its runtime could not be imported: %s",
+                    reason,
+                )
+                self._mode = "disabled"
+                return
+        elif self._mode in {"cloud", "local_external"}:
+            available, reason = _check_cloud_client()
+            if not available:
+                logger.warning(
+                    "Hindsight %s mode disabled because hindsight-client could not be imported: %s",
+                    self._mode,
                     reason,
                 )
                 self._mode = "disabled"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -44,6 +44,19 @@ def _clean_env(monkeypatch):
         monkeypatch.delenv(key, raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _mock_cloud_client_available(monkeypatch):
+    """Default cloud/local_external tests to an installed hindsight-client.
+
+    Individual regression tests override this fixture to simulate the optional
+    dependency being absent.
+    """
+    monkeypatch.setattr(
+        "plugins.memory.hindsight._check_cloud_client",
+        lambda: (True, None),
+    )
+
+
 def _make_mock_client():
     """Create a mock Hindsight client with async methods."""
     async def _aretain(
@@ -1459,6 +1472,74 @@ class TestAvailability:
 
         p = HindsightMemoryProvider()
         p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        assert p._mode == "disabled"
+
+    def test_cloud_mode_unavailable_when_client_not_installed(self, tmp_path, monkeypatch):
+        """Cloud mode should not advertise availability without hindsight-client."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
+        )
+
+        p = HindsightMemoryProvider()
+
+        assert not p.is_available()
+
+    def test_local_external_mode_unavailable_when_client_not_installed(self, tmp_path, monkeypatch):
+        """local_external mode also requires the optional hindsight-client package."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_MODE", "local_external")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
+        )
+
+        p = HindsightMemoryProvider()
+
+        assert not p.is_available()
+
+    def test_initialize_disables_cloud_mode_when_client_not_installed(self, tmp_path, monkeypatch):
+        """initialize() should degrade gracefully instead of crashing the gateway."""
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "cloud", "apiKey": "test-key"}))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
+        )
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert p._mode == "disabled"
+
+    def test_initialize_disables_local_external_when_client_not_installed(self, tmp_path, monkeypatch):
+        """local_external initialization should also degrade gracefully."""
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({"mode": "local_external"}))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_cloud_client",
+            lambda: (False, "No module named 'hindsight_client'"),
+        )
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
         assert p._mode == "disabled"
 
 


### PR DESCRIPTION
## Summary
- add a Hindsight cloud/local_external client availability probe for the optional `hindsight-client` package
- make `is_available()` return `False` when cloud/local_external modes cannot import the client
- make `initialize()` disable those modes gracefully instead of letting the gateway crash later
- keep a guarded `_get_client()` fallback with an actionable install command
- add regression coverage for missing-client cloud and local_external paths

## Verification
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q` → 100 passed
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestAvailability -q` → 10 passed
- smoke-checked missing `hindsight_client` behavior: `available=False`, `_mode=disabled`

Fixes #18875
Fixes #18876
