### PR TITLE
fix: recover Codex streams with null output

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -872,6 +872,16 @@ def _extract_responses_reasoning_text(item: Any) -> str:
     return ""
 
 
+def _safe_response_output_text(response: Any) -> str:
+    """Read ``response.output_text`` without letting SDK convenience accessors crash."""
+    try:
+        out_text = getattr(response, "output_text", None)
+    except Exception as exc:
+        logger.debug("Codex response.output_text access failed: %s", exc)
+        return ""
+    return out_text.strip() if isinstance(out_text, str) else ""
+
+
 # ---------------------------------------------------------------------------
 # Full response normalization
 # ---------------------------------------------------------------------------
@@ -883,15 +893,15 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         # The Codex backend can return empty output when the answer was
         # delivered entirely via stream events. Check output_text as a
         # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
-        if isinstance(out_text, str) and out_text.strip():
+        out_text = _safe_response_output_text(response)
+        if out_text:
             logger.debug(
                 "Codex response has empty output but output_text is present (%d chars); "
-                "synthesizing output item.", len(out_text.strip()),
+                "synthesizing output item.", len(out_text),
             )
             output = [SimpleNamespace(
                 type="message", role="assistant", status="completed",
-                content=[SimpleNamespace(type="output_text", text=out_text.strip())],
+                content=[SimpleNamespace(type="output_text", text=out_text)],
             )]
             response.output = output
         else:
@@ -1024,10 +1034,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
-        out_text = getattr(response, "output_text", "")
-        if isinstance(out_text, str):
-            final_text = out_text.strip()
+    if not final_text:
+        final_text = _safe_response_output_text(response)
 
     # ── Tool-call leak recovery ──────────────────────────────────
     # gpt-5.x on the Codex Responses API sometimes degenerates and emits
@@ -1076,7 +1084,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         finish_reason = "incomplete"
     elif has_incomplete_items or (saw_commentary_phase and not saw_final_answer_phase):
         finish_reason = "incomplete"
-    elif reasoning_items_raw and not final_text:
+    elif (reasoning_items_raw or reasoning_parts) and not final_text:
         # Response contains only reasoning (encrypted thinking state) with
         # no visible content or tool calls.  The model is still thinking and
         # needs another turn to produce the actual answer.  Marking this as

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -182,28 +182,94 @@ def _responses_null_output_iterable_error(exc: BaseException) -> bool:
     return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
 
 
-def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str = None):
-    """Build a minimal Responses-like object from events already streamed."""
-    if output_items:
-        return SimpleNamespace(
-            output=list(output_items),
-            usage=None,
-            status="completed",
-            model=model,
+def _backfill_codex_response_output(
+    response: Any,
+    *,
+    collected_output_items: list,
+    text_deltas: list,
+    reasoning_deltas: list,
+    has_tool_calls: bool,
+    log_label: str,
+) -> bool:
+    """Patch missing/empty Responses output from stream events already seen."""
+    _out = getattr(response, "output", None)
+    if isinstance(_out, list) and _out:
+        return False
+
+    if collected_output_items:
+        response.output = list(collected_output_items)
+        logger.debug(
+            "%s: backfilled %d output items from stream events",
+            log_label,
+            len(collected_output_items),
         )
-    if text_parts and not has_tool_calls:
-        assembled = "".join(text_parts)
-        return SimpleNamespace(
-            output=[SimpleNamespace(
-                type="message",
-                role="assistant",
-                status="completed",
-                content=[SimpleNamespace(type="output_text", text=assembled)],
-            )],
-            usage=None,
+        return True
+
+    if text_deltas and not has_tool_calls:
+        assembled = "".join(text_deltas)
+        response.output = [SimpleNamespace(
+            type="message",
+            role="assistant",
             status="completed",
-            model=model,
+            content=[SimpleNamespace(type="output_text", text=assembled)],
+        )]
+        logger.debug(
+            "%s: synthesized output from %d text deltas (%d chars)",
+            log_label,
+            len(text_deltas),
+            len(assembled),
         )
+        return True
+
+    reasoning_text = "".join(reasoning_deltas).strip()
+    if reasoning_text:
+        response.output = [SimpleNamespace(
+            type="reasoning",
+            status="completed",
+            summary=[SimpleNamespace(type="summary_text", text=reasoning_text)],
+        )]
+        if not getattr(response, "status", None):
+            response.status = "incomplete"
+        logger.debug(
+            "%s: synthesized reasoning-only output from %d deltas (%d chars)",
+            log_label,
+            len(reasoning_deltas),
+            len(reasoning_text),
+        )
+        return True
+
+    return False
+
+
+def _synthesize_codex_response_from_stream(
+    *,
+    collected_output_items: list,
+    text_deltas: list,
+    reasoning_deltas: list,
+    has_tool_calls: bool,
+    reason: str,
+) -> Any | None:
+    response = SimpleNamespace(
+        output=[],
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason=reason),
+        error=None,
+    )
+    if _backfill_codex_response_output(
+        response,
+        collected_output_items=collected_output_items,
+        text_deltas=text_deltas,
+        reasoning_deltas=reasoning_deltas,
+        has_tool_calls=has_tool_calls,
+        log_label="Codex stream recovery",
+    ):
+        # Completed output items/text deltas represent a usable assistant
+        # response. Reasoning-only recovery stays incomplete so the normal
+        # Codex continuation path can ask for visible final content.
+        if collected_output_items or (text_deltas and not has_tool_calls):
+            response.status = "completed"
+            response.incomplete_details = None
+        return response
     return None
 
 
@@ -223,6 +289,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        collected_reasoning_deltas: list = []
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
                 for event in stream:
@@ -256,6 +323,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     elif "reasoning" in event_type and "delta" in event_type:
                         reasoning_text = getattr(event, "delta", "")
                         if reasoning_text:
+                            collected_reasoning_deltas.append(reasoning_text)
                             agent._fire_reasoning_delta(reasoning_text)
                     # Collect completed output items — some backends
                     # (chatgpt.com/backend-api/codex) stream valid items
@@ -281,22 +349,14 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
-                _out = getattr(final_response, "output", None)
-                if _out is None or (isinstance(_out, list) and not _out):
-                    recovered = _codex_backfilled_response(
-                        collected_output_items,
-                        agent._codex_streamed_text_parts,
-                        has_tool_calls=has_tool_calls,
-                        model=api_kwargs.get("model"),
-                    )
-                    if recovered is not None:
-                        final_response.output = recovered.output
-                        logger.debug(
-                            "Codex stream: backfilled missing output from stream events "
-                            "(items=%d, text_parts=%d)",
-                            len(collected_output_items),
-                            len(agent._codex_streamed_text_parts),
-                        )
+                _backfill_codex_response_output(
+                    final_response,
+                    collected_output_items=collected_output_items,
+                    text_deltas=agent._codex_streamed_text_parts,
+                    reasoning_deltas=collected_reasoning_deltas,
+                    has_tool_calls=has_tool_calls,
+                    log_label="Codex stream",
+                )
                 return final_response
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
@@ -316,27 +376,30 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
         except TypeError as exc:
             if _responses_null_output_iterable_error(exc):
-                recovered = _codex_backfilled_response(
-                    collected_output_items,
-                    agent._codex_streamed_text_parts,
-                    has_tool_calls=has_tool_calls,
-                    model=api_kwargs.get("model"),
-                )
-                if recovered is not None:
-                    logger.debug(
-                        "Codex Responses stream parser hit response.output=None; "
-                        "recovered from streamed events (items=%d, text_parts=%d). %s",
-                        len(collected_output_items),
-                        len(agent._codex_streamed_text_parts),
-                        agent._client_log_context(),
-                    )
-                    return recovered
-                logger.debug(
-                    "Codex Responses stream parser hit response.output=None without "
-                    "recoverable events; falling back to create(stream=True). %s",
+                logger.warning(
+                    "Codex Responses stream parser failed on missing output; "
+                    "falling back to create(stream=True). %s err=%s",
                     agent._client_log_context(),
+                    exc,
                 )
-                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+                try:
+                    return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+                except Exception:
+                    recovered = _synthesize_codex_response_from_stream(
+                        collected_output_items=collected_output_items,
+                        text_deltas=agent._codex_streamed_text_parts,
+                        reasoning_deltas=collected_reasoning_deltas,
+                        has_tool_calls=has_tool_calls,
+                        reason="stream_parser_recovered_none_output",
+                    )
+                    if recovered is not None:
+                        logger.warning(
+                            "Codex Responses stream parser failed and fallback failed; "
+                            "returning synthesized incomplete response. %s",
+                            agent._client_log_context(),
+                        )
+                        return recovered
+                    raise
             raise
         except RuntimeError as exc:
             err_text = str(exc)
@@ -406,6 +469,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
     terminal_response = None
     collected_output_items: list = []
     collected_text_deltas: list = []
+    collected_reasoning_deltas: list = []
     has_tool_calls = False
     try:
         for event in stream_or_response:
@@ -458,6 +522,12 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                     collected_text_deltas.append(delta)
             elif event_type and "function_call" in event_type:
                 has_tool_calls = True
+            elif event_type and "reasoning" in event_type and "delta" in event_type:
+                delta = getattr(event, "delta", "")
+                if not delta and isinstance(event, dict):
+                    delta = event.get("delta", "")
+                if delta:
+                    collected_reasoning_deltas.append(delta)
 
             if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
                 continue
@@ -467,22 +537,14 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                 terminal_response = event.get("response")
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
-                _out = getattr(terminal_response, "output", None)
-                if _out is None or (isinstance(_out, list) and not _out):
-                    recovered = _codex_backfilled_response(
-                        collected_output_items,
-                        collected_text_deltas,
-                        has_tool_calls=has_tool_calls,
-                        model=fallback_kwargs.get("model"),
-                    )
-                    if recovered is not None:
-                        terminal_response.output = recovered.output
-                        logger.debug(
-                            "Codex fallback stream: backfilled missing output "
-                            "(items=%d, text_parts=%d)",
-                            len(collected_output_items),
-                            len(collected_text_deltas),
-                        )
+                _backfill_codex_response_output(
+                    terminal_response,
+                    collected_output_items=collected_output_items,
+                    text_deltas=collected_text_deltas,
+                    reasoning_deltas=collected_reasoning_deltas,
+                    has_tool_calls=has_tool_calls,
+                    log_label="Codex fallback stream",
+                )
                 return terminal_response
     finally:
         close_fn = getattr(stream_or_response, "close", None)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1224,7 +1224,14 @@ def run_conversation(
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
-                                _out_text = getattr(response, "output_text", None)
+                                try:
+                                    _out_text = getattr(response, "output_text", None)
+                                except Exception as exc:
+                                    logger.debug(
+                                        "Codex response.output_text access failed during validation: %s",
+                                        exc,
+                                    )
+                                    _out_text = None
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:
                                     logger.debug(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -453,6 +453,34 @@ class TestCodexNormalizeResponse:
         assert tc.name == "terminal"
         assert '"command"' in tc.arguments
 
+    def test_reasoning_only_response_with_broken_output_text_is_incomplete(self, transport):
+        """SDK output_text access can fail when output contains no final message."""
+
+        class BrokenOutputTextResponse(SimpleNamespace):
+            @property
+            def output_text(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        r = BrokenOutputTextResponse(
+            output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    summary=[SimpleNamespace(type="summary_text", text="Still thinking")],
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == ""
+        assert nr.reasoning == "Still thinking"
+        assert nr.finish_reason == "incomplete"
+
 
 
 class TestCodexTransportTimeout:


### PR DESCRIPTION
## Summary
- Harden Codex Responses normalization when the SDK exposes `output_text` via a broken/partial accessor.
- Backfill missing/empty Codex stream output from output items, text deltas, or reasoning deltas across the primary and fallback streaming paths.
- Preserve reasoning-only recoveries as incomplete so the existing continuation path can produce visible final content.

Fixes #32883

## Test Plan
- `/Users/lit/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py -q -o addopts=`
- `/Users/lit/.hermes/hermes-agent/venv/bin/python -m ruff check agent/codex_responses_adapter.py agent/codex_runtime.py agent/conversation_loop.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py`
