### PR TITLE
Recover Codex stream output after finalization failure

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -271,6 +271,36 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            err_text = str(exc)
+            if "NoneType" in err_text and "iterable" in err_text:
+                if collected_output_items:
+                    logger.warning(
+                        "Codex stream finalization raised %r; recovering from %d collected output item(s).",
+                        err_text, len(collected_output_items),
+                    )
+                    return SimpleNamespace(
+                        output=list(collected_output_items),
+                        status="completed",
+                        output_text="",
+                    )
+                if agent._codex_streamed_text_parts and not has_tool_calls:
+                    assembled = "".join(agent._codex_streamed_text_parts)
+                    logger.warning(
+                        "Codex stream finalization raised %r; recovering from %d streamed text delta(s).",
+                        err_text, len(agent._codex_streamed_text_parts),
+                    )
+                    return SimpleNamespace(
+                        output=[SimpleNamespace(
+                            type="message",
+                            role="assistant",
+                            status="completed",
+                            content=[SimpleNamespace(type="output_text", text=assembled)],
+                        )],
+                        status="completed",
+                        output_text=assembled,
+                    )
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -166,7 +167,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -482,6 +483,38 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_recovers_when_final_response_iteration_fails(monkeypatch):
+    """chatgpt.com/backend-api/codex can stream valid output items but then
+    fail while the SDK finalizes the response object.
+
+    In that case, preserve the collected stream output instead of surfacing a
+    false provider failure after the user-visible answer already arrived.
+    """
+    agent = _build_agent(monkeypatch)
+    streamed_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="stream recovered")],
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                events=[
+                    SimpleNamespace(type="response.output_item.done", item=streamed_item),
+                ],
+                final_error=TypeError("'NoneType' object is not iterable"),
+            ),
+            create=lambda **kwargs: _codex_message_response("unexpected fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert response.output == [streamed_item]
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a Codex Responses streaming edge case observed with `chatgpt.com/backend-api/codex`: the backend can stream valid `response.output_item.done` items, then the SDK finalization step can raise `TypeError("'NoneType' object is not iterable")` while building `get_final_response()`.

When valid streamed output was already collected, Hermes should preserve that output instead of surfacing a false provider failure after the answer was received. This PR recovers from that finalization failure by returning the collected streamed output items, or synthesizing a text response from collected text deltas when no tool calls are present.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/codex_runtime.py`
  - Recover from the Codex stream finalization `TypeError` when valid streamed output items were already collected.
  - Fall back to synthesized streamed text when only text deltas were collected and no tool calls are present.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - Extend `_FakeResponsesStream` to emit stream events.
  - Add a regression test for the streamed-output-then-finalization-failure path.

## How to Test

```bash
python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_recovers_when_final_response_iteration_fails -q
python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q
```

Verified locally:

```text
1 passed
66 passed, 1 warning
```

## Checklist

- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 on WSL2
- [x] Documentation update: N/A
- [x] Config keys update: N/A
