### PR TITLE
fix: restore corrupted warning emoji in batch_runner checkpoint handler

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1010,7 +1010,7 @@ class BatchRunner:
             checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
-            print(f"âš ï¸  Warning: Failed to save final checkpoint: {ckpt_err}")
+            print(f"⚠️   Warning: Failed to save final checkpoint: {ckpt_err}")
         
         # Calculate success rates
         for tool_name in total_tool_stats:


### PR DESCRIPTION
## Summary

Fixes a mojibake-encoded warning emoji in `batch_runner.py`. The UTF-8 bytes `\xc3\xa2\xc5\xa1\xc2\xa0\xc3\xaf\xc2\xb8\xc2\x8f` were double-encoded before being written to the source file, producing the garbled text `âš ï¸ ` instead of the intended `⚠️`.

This was identified as item 9 in issue #32848 (collection of minor bugs, typos, and inconsistencies).

## Changes

- `batch_runner.py` line 1013: replace corrupted bytes with the correct `⚠️` emoji

## Testing

- `python3 -m py_compile batch_runner.py` — passes
- `git diff --check` — clean
