### PR TITLE
Recover Codex streams when final output is null

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -869,6 +869,41 @@ class _CodexCompletionsAdapter:
                     completion_tokens=getattr(resp_usage, "output_tokens", 0),
                     total_tokens=getattr(resp_usage, "total_tokens", 0),
                 )
+        except TypeError as exc:
+            err_text = str(exc)
+            if "NoneType" not in err_text or "iterable" not in err_text:
+                raise
+            if collected_text_deltas and not has_function_calls:
+                text_parts.append("".join(collected_text_deltas))
+                logger.debug(
+                    "Codex auxiliary stream parser failed after text deltas; "
+                    "synthesized %d chars",
+                    sum(len(part) for part in collected_text_deltas),
+                )
+            elif collected_output_items:
+                for item in collected_output_items:
+                    item_type = getattr(item, "type", None)
+                    if item_type == "message":
+                        for part in (getattr(item, "content", None) or []):
+                            ptype = getattr(part, "type", None)
+                            if ptype in {"output_text", "text"}:
+                                text_parts.append(getattr(part, "text", "") or "")
+                    elif item_type == "function_call":
+                        tool_calls_raw.append(SimpleNamespace(
+                            id=getattr(item, "call_id", "") or "",
+                            type="function",
+                            function=SimpleNamespace(
+                                name=getattr(item, "name", "") or "",
+                                arguments=getattr(item, "arguments", "{}") or "{}",
+                            ),
+                        ))
+                logger.debug(
+                    "Codex auxiliary stream parser failed after output items; "
+                    "synthesized from %d items",
+                    len(collected_output_items),
+                )
+            else:
+                raise
         except Exception as exc:
             if timed_out.is_set():
                 raise TimeoutError(_timeout_message()) from exc

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -246,7 +246,45 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    err_text = str(exc)
+                    if "NoneType" not in err_text or "iterable" not in err_text:
+                        raise
+                    if collected_output_items:
+                        logger.debug(
+                            "Codex stream finalizer failed after output items; "
+                            "synthesizing final response from %d collected items",
+                            len(collected_output_items),
+                        )
+                        final_response = SimpleNamespace(
+                            output=list(collected_output_items),
+                            status="completed",
+                            model=api_kwargs.get("model"),
+                            usage=None,
+                        )
+                    elif agent._codex_streamed_text_parts and not has_tool_calls:
+                        assembled = "".join(agent._codex_streamed_text_parts)
+                        logger.debug(
+                            "Codex stream finalizer failed after text deltas; "
+                            "synthesizing final response from %d chars",
+                            len(assembled),
+                        )
+                        final_response = SimpleNamespace(
+                            output=[SimpleNamespace(
+                                type="message",
+                                role="assistant",
+                                status="completed",
+                                content=[SimpleNamespace(type="output_text", text=assembled)],
+                            )],
+                            output_text=assembled,
+                            status="completed",
+                            model=api_kwargs.get("model"),
+                            usage=None,
+                        )
+                    else:
+                        raise
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
@@ -271,6 +309,42 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            err_text = str(exc)
+            if "NoneType" not in err_text or "iterable" not in err_text:
+                raise
+            if collected_output_items:
+                logger.debug(
+                    "Codex stream parser failed after output items; "
+                    "synthesizing final response from %d collected items",
+                    len(collected_output_items),
+                )
+                return SimpleNamespace(
+                    output=list(collected_output_items),
+                    status="completed",
+                    model=api_kwargs.get("model"),
+                    usage=None,
+                )
+            if agent._codex_streamed_text_parts and not has_tool_calls:
+                assembled = "".join(agent._codex_streamed_text_parts)
+                logger.debug(
+                    "Codex stream parser failed after text deltas; "
+                    "synthesizing final response from %d chars",
+                    len(assembled),
+                )
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        role="assistant",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text=assembled)],
+                    )],
+                    output_text=assembled,
+                    status="completed",
+                    model=api_kwargs.get("model"),
+                    usage=None,
+                )
+            raise
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2476,6 +2476,34 @@ class TestVisionAutoSkipsKimiCoding:
 
 
 class TestCodexAuxiliaryAdapterTimeout:
+    def test_recovers_when_sdk_parser_crashes_after_text_delta(self):
+        class ParserCrashStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_text.delta", delta="summary")
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - iterator raises first
+                raise AssertionError("get_final_response should not be reached")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return ParserCrashStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses(), close=lambda: None)
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "summarize this"}],
+        )
+
+        assert response.choices[0].message.content == "summary"
+
     def test_forwards_timeout_to_responses_stream(self):
         class FakeStream:
             def __enter__(self):

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -155,9 +155,11 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None, iter_error=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
+        self._iter_error = iter_error
 
     def __enter__(self):
         return self
@@ -166,7 +168,10 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        for event in self._events:
+            yield event
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -419,6 +424,58 @@ def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):
     response = agent._run_codex_stream(_codex_request_kwargs())
     assert calls["stream"] == 2
     assert response.output[0].content[0].text == "stream ok"
+
+
+def test_run_codex_stream_recovers_when_sdk_parser_crashes_after_text_delta(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="parser-safe"),
+            ],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert response.output_text == "parser-safe"
+    assert response.output[0].content[0].text == "parser-safe"
+
+
+def test_run_codex_stream_recovers_when_sdk_parser_crashes_after_output_item(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="item-safe")],
+    )
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[SimpleNamespace(type="response.output_item.done", item=item)],
+            iter_error=TypeError("'NoneType' object is not iterable"),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.status == "completed"
+    assert response.output == [item]
 
 
 def test_run_codex_stream_falls_back_to_create_after_stream_completion_error(monkeypatch):


### PR DESCRIPTION
## Summary

Recover Codex Responses streams when the OpenAI SDK stream finalizer raises
`TypeError: 'NoneType' object is not iterable` after usable stream output has
already arrived.

## Root Cause

Some Codex-style Responses streams can emit valid text deltas or
`response.output_item.done` events, then terminate with a final response payload
whose `response.output` is `null`. The OpenAI Python SDK tries to iterate that
field while accumulating/parsing the terminal event and raises before Hermes can
run its existing empty-output backfill logic.

That makes a successful streamed model response look like a provider/API
failure.

## Changes

- Recover the main Codex stream path when the SDK parser/finalizer raises the
  exact `NoneType` iterable failure after collected output exists.
- Synthesize a completed Responses-style object from collected output items or
  text deltas.
- Apply the same recovery to the auxiliary Codex adapter used by title,
  compression, and other background calls.
- Add regression coverage for:
  - parser crash after text deltas
  - parser crash after output items
  - auxiliary adapter parser crash after text deltas

## Validation

```bash
/Users/sunday/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/agent/test_auxiliary_client.py -q
```

Result:

```text
244 passed in 49.37s
```

Also verified with a live isolated Codex OAuth profile before and after the
patch: before, the model streamed `OK` and Hermes reported the `NoneType`
failure; after, the same request returned cleanly with exit 0.
