### PR TITLE
fix: use proper typing.Any and typing.Callable in type annotations

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -25,7 +25,7 @@ import ssl
 import threading
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.conversation_compression import conversation_history_after_compression
@@ -521,7 +521,7 @@ def run_conversation(
     system_message: str = None,
     conversation_history: List[Dict[str, Any]] = None,
     task_id: str = None,
-    stream_callback: Optional[callable] = None,
+    stream_callback: Optional[Callable[..., Any]] = None,
     persist_user_message: Optional[str] = None,
     persist_user_timestamp: Optional[float] = None,
     moa_config: Optional[dict[str, Any]] = None,

--- a/cli.py
+++ b/cli.py
@@ -3609,7 +3609,7 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
     return parsed
 
 
-def save_config_value(key_path: str, value: any) -> bool:
+def save_config_value(key_path: str, value: Any) -> bool:
     """
     Save a value to the active config file at the specified key path.
     

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -26,7 +26,7 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 try:
     from hermes_constants import get_hermes_home
@@ -425,7 +425,7 @@ def quick() -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def deep(
-    confirm: Optional[callable] = None,
+    confirm: Optional[Callable[..., Any]] = None,
 ) -> Dict[str, Any]:
     """Deep cleanup.
 

--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -214,7 +214,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
## Summary

Fixes three type annotation issues identified during a code audit (items 10 and 13 in issue #32848):

- `toolset_distributions.py:223` — `Dict[str, any]` → `Dict[str, Any]`
- `cli.py:2835` — `value: any` → `value: Any`
- `agent/conversation_loop.py:269` — `Optional[callable]` → `Optional[Callable[..., Any]]`
- `plugins/disk-cleanup/disk_cleanup.py:343` — `Optional[callable]` → `Optional[Callable[..., Any]]`

In each case, the lowercase builtin (`any` / `callable`) was used instead of the proper `typing` module types. While these work at runtime due to Python's late binding, they are incorrect type annotations.

## Testing

- `python3 -m py_compile` on all four files — passes
- `ruff check` on all four files — clean
- `git diff --check` — clean
