### PR TITLE
fix(hermes_time): add missing reset_cache() function

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -34,6 +34,18 @@ _cached_tz_name: Optional[str] = None
 _cache_resolved: bool = False
 
 
+def reset_cache() -> None:
+    """Force the timezone cache to be re-resolved on the next call.
+
+    Call this after modifying the ``timezone`` key in config.yaml or
+    changing the ``HERMES_TIMEZONE`` environment variable.
+    """
+    global _cached_tz, _cached_tz_name, _cache_resolved
+    _cached_tz = None
+    _cached_tz_name = None
+    _cache_resolved = False
+
+
 def _resolve_timezone_name() -> str:
     """Read the configured IANA timezone string (or empty string).
 


### PR DESCRIPTION
## Summary

Adds the `reset_cache()` function that is referenced in both the module-level comment and the `get_timezone()` docstring, but was never implemented. This was item 2 in issue #32848.

## Changes

- `hermes_time.py`: add `reset_cache()` function that clears the three timezone cache globals (`_cached_tz`, `_cached_tz_name`, `_cache_resolved`) so that the next call to `get_timezone()` re-resolves from the environment/config.

## Why

The module comment and `get_timezone()` docstring both say:

> Call `reset_cache()` to force re-resolution (e.g. after config changes).

But the function did not exist, so callers who followed this guidance would get a `NameError`. Now the documented API is functional.

## Testing

- `python3 -m py_compile hermes_time.py` — passes
- `ruff check hermes_time.py` — clean
- `python3 -m pytest tests/test_timezone.py -q` — 20 passed
