### PR TITLE
fix(codex): recover streamed output after nullable parser error

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -25,6 +25,35 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _synthesize_codex_stream_response(agent, collected_output_items: list, *, has_tool_calls: bool = False):
+    """Build a minimal Responses object from stream events after SDK finalization fails."""
+    output = []
+    if collected_output_items:
+        output = list(collected_output_items)
+    elif getattr(agent, "_codex_streamed_text_parts", None) and not has_tool_calls:
+        assembled = "".join(agent._codex_streamed_text_parts)
+        if assembled:
+            output = [SimpleNamespace(
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=assembled)],
+            )]
+    if not output:
+        return None
+    return SimpleNamespace(
+        id=None,
+        object="response",
+        created_at=None,
+        status="completed",
+        error=None,
+        incomplete_details=None,
+        output=output,
+        output_text="".join(getattr(agent, "_codex_streamed_text_parts", []) or []),
+        usage=None,
+    )
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -240,7 +269,26 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    # The chatgpt.com Codex backend can stream a valid answer,
+                    # then hit an OpenAI SDK final-response parser bug where a
+                    # nullable field is treated as iterable. Preserve the
+                    # already streamed output instead of failing the turn.
+                    if "NoneType" not in str(exc) or "iterable" not in str(exc):
+                        raise
+                    final_response = _synthesize_codex_stream_response(
+                        agent, collected_output_items, has_tool_calls=has_tool_calls
+                    )
+                    if final_response is None:
+                        raise
+                    logger.warning(
+                        "Codex stream finalization failed after valid stream output; "
+                        "synthesized response from collected events. %s error=%s",
+                        agent._client_log_context(),
+                        exc,
+                    )
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
@@ -265,6 +313,21 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             len(agent._codex_streamed_text_parts), len(assembled),
                         )
                 return final_response
+        except TypeError as exc:
+            if "NoneType" not in str(exc) or "iterable" not in str(exc):
+                raise
+            synthesized = _synthesize_codex_stream_response(
+                agent, collected_output_items, has_tool_calls=has_tool_calls
+            )
+            if synthesized is None:
+                raise
+            logger.warning(
+                "Codex stream iteration failed after valid stream output; "
+                "synthesized response from collected events. %s error=%s",
+                agent._client_log_context(),
+                exc,
+            )
+            return synthesized
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
                 logger.debug(

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -862,6 +862,44 @@ class TestCodexStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == 3
 
+    def test_codex_stream_none_iterable_after_text_returns_streamed_response(self):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            model="gpt-5.5",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        class _BrokenAfterTextStream:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, exc_type, exc, tb):
+                return False
+
+            def __iter__(self_inner):
+                yield SimpleNamespace(type="response.output_text.delta", delta="ok")
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self_inner):
+                raise AssertionError("final response should not be requested after iterator failure")
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = _BrokenAfterTextStream()
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response.status == "completed"
+        assert response.output_text == "ok"
+        assert response.output[0].type == "message"
+        assert response.output[0].content[0].text == "ok"
+
     def test_codex_remote_protocol_error_falls_back_to_create_stream(self):
         from run_agent import AIAgent
         import httpx


### PR DESCRIPTION
## Summary
- recover Codex streamed output when the SDK/parser raises `TypeError("'NoneType' object is not iterable")` after valid stream text has arrived
- synthesize a minimal completed Responses object from collected stream output
- add regression coverage for the streamed-text-then-parser-error case

## Tests
- `python -m pytest tests/run_agent/test_streaming.py::TestCodexStreamCallbacks -q`
- live local smoke against `openai-codex` / `gpt-5.5`: prompt `Reply with exactly: ok` returned `ok`