### PR TITLE
feat(provider): add ByteDance Coding Plan and Xiaomi Token Plan as first-class providers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -269,6 +269,16 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "z-ai/glm5",
         "openai/gpt-oss-120b",
     ],
+    "bytedance": [
+        "bytedance-seed-code",
+        "dola-seed-2.0-pro",
+        "dola-seed-2.0-lite",
+        "dola-seed-2.0-code",
+        "glm-5.1",
+        "glm-4.7",
+        "gpt-oss-120b",
+        "kimi-k2.5",
+    ],
     "kimi-coding": [
         "kimi-k2.6",
         "kimi-k2.5",

--- a/plugins/model-providers/bytedance/__init__.py
+++ b/plugins/model-providers/bytedance/__init__.py
@@ -1,0 +1,34 @@
+"""ByteDance / BytePlus / Volcengine Coding Plan provider profile.
+
+Targets the international coding endpoint:
+  - Anthropic API: https://ark.ap-southeast.bytepluses.com/api/coding
+  - OpenAI API:    https://ark.ap-southeast.bytepluses.com/api/coding/v3
+
+This profile uses the OpenAI-compatible path by default.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+bytedance = ProviderProfile(
+    name="bytedance",
+    aliases=("byte-dance", "byteplus", "volcengine", "doubao"),
+    display_name="Bytedance Coding Plan",
+    description="Bytedance / BytePlus / Volcengine Coding Plan — Doubao & Seed models",
+    signup_url="https://www.byteplus.com/",
+    env_vars=("BYTEDANCE_API_KEY", "BYTEPLUS_API_KEY", "VOLCENGINE_API_KEY"),
+    base_url="https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+    auth_type="api_key",
+    fallback_models=(
+        "bytedance-seed-code",
+        "dola-seed-2.0-pro",
+        "dola-seed-2.0-lite",
+        "dola-seed-2.0-code",
+        "glm-5.1",
+        "glm-4.7",
+        "gpt-oss-120b",
+        "kimi-k2.5",
+    ),
+)
+
+register_provider(bytedance)

--- a/plugins/model-providers/bytedance/plugin.yaml
+++ b/plugins/model-providers/bytedance/plugin.yaml
@@ -1,0 +1,5 @@
+name: bytedance-provider
+kind: model-provider
+version: 1.0.0
+description: Bytedance Coding Plan
+author: Nous Research

--- a/plugins/model-providers/xiaomi-token-plan/__init__.py
+++ b/plugins/model-providers/xiaomi-token-plan/__init__.py
@@ -1,0 +1,26 @@
+"""Xiaomi Token Plan provider profile.
+
+Region-neutral: defaults to the Singapore endpoint. Users on other regions
+can override via the XIAOMI_TOKEN_BASE_URL env var:
+
+  Europe (Amsterdam): https://token-plan-ams.xiaomimimo.com/v1
+  Singapore:          https://token-plan-sgp.xiaomimimo.com/v1
+  China:              https://token-plan-cn.xiaomimimo.com/v1
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+xiaomi_token = ProviderProfile(
+    name="xiaomi-token-plan",
+    aliases=("xiaomi-token", "mimo-token"),
+    display_name="Xiaomi Mimo Token Plan",
+    description="Xiaomi Mimo Token Plan — region-selectable via XIAOMI_TOKEN_BASE_URL",
+    signup_url="https://platform.xiaomimimo.com/#/docs",
+    env_vars=("XIAOMI_API_KEY",),
+    base_url="https://token-plan-sgp.xiaomimimo.com/v1",
+    auth_type="api_key",
+    supports_health_check=False,  # /v1/models returns 401 even with valid key
+)
+
+register_provider(xiaomi_token)

--- a/plugins/model-providers/xiaomi-token-plan/plugin.yaml
+++ b/plugins/model-providers/xiaomi-token-plan/plugin.yaml
@@ -1,0 +1,5 @@
+name: xiaomi-token-plan-provider
+kind: model-provider
+version: 1.0.0
+description: Xiaomi Mimo Token Plan
+author: Nous Research


### PR DESCRIPTION
## Summary

Add two new model-provider plugins following the standard ProviderProfile structure:

### ByteDance Coding Plan (bytedance)
- Targets the international coding endpoint at ark.ap-southeast.bytepluses.com
- Supports Doubao and Seed models with curated fallback list
- Auth via BYTEDANCE_API_KEY, BYTEPLUS_API_KEY, or VOLCENGINE_API_KEY
- Curated model list in `_PROVIDER_MODELS` (8 coding-relevant models) prevents the setup flow from fetching all 47 models from the live /v1/models endpoint (which includes image gen, video, 3D, and embedding models irrelevant for coding)

### Xiaomi Mimo Token Plan (xiaomi-token-plan)
- Region-neutral default (Singapore endpoint)
- Users can override via XIAOMI_TOKEN_BASE_URL for Europe (Amsterdam) or China endpoints
- Shares XIAOMI_API_KEY with the existing xiaomi provider
- supports_health_check=False (same as upstream xiaomi — /v1/models returns 401)

Both plugins include plugin.yaml manifests and follow the same conventions as existing providers (e.g. novita, alibaba-coding-plan, xiaomi).

Supersedes #32114 and #32874.
