### PR TITLE
fix(codex): recover streams with missing terminal output

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -784,6 +784,68 @@ class _CodexCompletionsAdapter:
                 # new failure mode for auxiliary calls.
                 pass
 
+        def _backfill_final_output(
+            final: Any,
+            collected_output_items: List[Any],
+            collected_text_deltas: List[str],
+            has_function_calls: bool,
+        ) -> None:
+            _output = getattr(final, "output", None)
+            if _output is not None and not (isinstance(_output, list) and not _output):
+                return
+            if collected_output_items:
+                final.output = list(collected_output_items)
+                logger.debug(
+                    "Codex auxiliary: backfilled %d output items from stream events",
+                    len(collected_output_items),
+                )
+            elif collected_text_deltas and not has_function_calls:
+                # Only synthesize text when no tool calls were streamed —
+                # a function_call response with incidental text should not
+                # be collapsed into a plain-text message.
+                assembled = "".join(collected_text_deltas)
+                final.output = [SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text=assembled)],
+                )]
+                logger.debug(
+                    "Codex auxiliary: synthesized from %d deltas (%d chars)",
+                    len(collected_text_deltas),
+                    len(assembled),
+                )
+
+        def _recover_stream_typeerror(
+            exc: TypeError,
+            collected_output_items: List[Any],
+            collected_text_deltas: List[str],
+            has_function_calls: bool,
+        ) -> Any:
+            if (
+                "'NoneType' object is not iterable" not in str(exc)
+                or (
+                    not collected_output_items
+                    and (has_function_calls or not collected_text_deltas)
+                )
+            ):
+                raise exc
+
+            final = SimpleNamespace(output=None, usage=None)
+            _backfill_final_output(
+                final,
+                collected_output_items,
+                collected_text_deltas,
+                has_function_calls,
+            )
+            logger.warning(
+                "Codex auxiliary stream terminal response had output=None; "
+                "recovered from streamed events (items=%d, chars=%d)",
+                len(collected_output_items),
+                sum(len(p) for p in collected_text_deltas),
+            )
+            return final
+
         try:
             # Collect output items and text deltas during streaming —
             # the Codex backend can return empty response.output from
@@ -797,44 +859,47 @@ class _CodexCompletionsAdapter:
                 timeout_timer.start()
             _check_cancelled()
             with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
+                try:
+                    for _event in stream:
+                        _check_cancelled()
+                        _etype = getattr(_event, "type", "")
+                        if _etype == "response.output_item.done":
+                            _done = getattr(_event, "item", None)
+                            if _done is not None:
+                                collected_output_items.append(_done)
+                        elif "output_text.delta" in _etype:
+                            _delta = getattr(_event, "delta", "")
+                            if _delta:
+                                collected_text_deltas.append(_delta)
+                        elif "function_call" in _etype:
+                            has_function_calls = True
+                except TypeError as exc:
+                    final = _recover_stream_typeerror(
+                        exc,
+                        collected_output_items,
+                        collected_text_deltas,
+                        has_function_calls,
+                    )
+                else:
                     _check_cancelled()
-                    _etype = getattr(_event, "type", "")
-                    if _etype == "response.output_item.done":
-                        _done = getattr(_event, "item", None)
-                        if _done is not None:
-                            collected_output_items.append(_done)
-                    elif "output_text.delta" in _etype:
-                        _delta = getattr(_event, "delta", "")
-                        if _delta:
-                            collected_text_deltas.append(_delta)
-                    elif "function_call" in _etype:
-                        has_function_calls = True
+                    try:
+                        final = stream.get_final_response()
+                    except TypeError as exc:
+                        final = _recover_stream_typeerror(
+                            exc,
+                            collected_output_items,
+                            collected_text_deltas,
+                            has_function_calls,
+                        )
                 _check_cancelled()
-                final = stream.get_final_response()
 
-            # Backfill empty output from collected stream events
-            _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
-                if collected_output_items:
-                    final.output = list(collected_output_items)
-                    logger.debug(
-                        "Codex auxiliary: backfilled %d output items from stream events",
-                        len(collected_output_items),
-                    )
-                elif collected_text_deltas and not has_function_calls:
-                    # Only synthesize text when no tool calls were streamed —
-                    # a function_call response with incidental text should not
-                    # be collapsed into a plain-text message.
-                    assembled = "".join(collected_text_deltas)
-                    final.output = [SimpleNamespace(
-                        type="message", role="assistant", status="completed",
-                        content=[SimpleNamespace(type="output_text", text=assembled)],
-                    )]
-                    logger.debug(
-                        "Codex auxiliary: synthesized from %d deltas (%d chars)",
-                        len(collected_text_deltas), len(assembled),
-                    )
+            # Backfill empty/None output from collected stream events.
+            _backfill_final_output(
+                final,
+                collected_output_items,
+                collected_text_deltas,
+                has_function_calls,
+            )
 
             # Extract text and tool calls from the Responses output.
             # Items may be SDK objects (attrs) or dicts (raw/fallback paths),

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -26,6 +26,83 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
+def _codex_stream_typeerror_is_empty_output(exc: TypeError) -> bool:
+    return "'NoneType' object is not iterable" in str(exc)
+
+
+def _backfill_codex_response_output(
+    response: Any,
+    *,
+    collected_output_items: list,
+    collected_text_deltas: list,
+    has_tool_calls: bool = False,
+    log_prefix: str = "Codex stream",
+) -> Any:
+    """Fill empty/None terminal output from already streamed data."""
+    _out = getattr(response, "output", None)
+    if _out is not None and not (isinstance(_out, list) and not _out):
+        return response
+
+    if collected_output_items:
+        response.output = list(collected_output_items)
+        logger.debug(
+            "%s: backfilled %d output items from stream events",
+            log_prefix,
+            len(collected_output_items),
+        )
+    elif collected_text_deltas and not has_tool_calls:
+        assembled = "".join(collected_text_deltas)
+        response.output = [SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text=assembled)],
+        )]
+        logger.debug(
+            "%s: synthesized output from %d text deltas (%d chars)",
+            log_prefix,
+            len(collected_text_deltas),
+            len(assembled),
+        )
+    return response
+
+
+def _recover_codex_stream_typeerror(
+    agent,
+    exc: TypeError,
+    *,
+    collected_output_items: list,
+    collected_text_deltas: list,
+    has_tool_calls: bool = False,
+) -> Any:
+    """Recover when the SDK tries to parse a terminal response with output=None."""
+    if (
+        not _codex_stream_typeerror_is_empty_output(exc)
+        or (
+            not collected_output_items
+            and (has_tool_calls or not collected_text_deltas)
+        )
+    ):
+        raise exc
+
+    response = SimpleNamespace(output=None, status="completed", output_text=None, usage=None)
+    _backfill_codex_response_output(
+        response,
+        collected_output_items=collected_output_items,
+        collected_text_deltas=collected_text_deltas,
+        has_tool_calls=has_tool_calls,
+        log_prefix="Codex stream TypeError recovery",
+    )
+    logger.warning(
+        "Codex Responses stream terminal response had output=None; recovered from "
+        "streamed events (items=%d, chars=%d). %s",
+        len(collected_output_items),
+        sum(len(p) for p in collected_text_deltas),
+        agent._client_log_context(),
+    )
+    return response
+
+
 def run_codex_app_server_turn(
     agent,
     *,
@@ -194,82 +271,86 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         collected_output_items: list = []
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
-                for event in stream:
-                    # Mark stream activity for the TTFB watchdog in
-                    # interruptible_api_call. The Codex backend can accept the
-                    # connection but never emit a single event; this timestamp
-                    # staying None tells the watchdog no bytes are flowing.
-                    agent._codex_stream_last_event_ts = time.time()
-                    agent._touch_activity("receiving stream response")
-                    if agent._interrupt_requested:
-                        break
-                    event_type = getattr(event, "type", "")
-                    # Fire callbacks on text content deltas (suppress during tool calls)
-                    if "output_text.delta" in event_type or event_type == "response.output_text.delta":
-                        delta_text = getattr(event, "delta", "")
-                        if delta_text:
-                            agent._codex_streamed_text_parts.append(delta_text)
-                        if delta_text and not has_tool_calls:
-                            if not first_delta_fired:
-                                first_delta_fired = True
-                                if on_first_delta:
-                                    try:
-                                        on_first_delta()
-                                    except Exception:
-                                        pass
-                            agent._fire_stream_delta(delta_text)
-                    # Track tool calls to suppress text streaming
-                    elif "function_call" in event_type:
-                        has_tool_calls = True
-                    # Fire reasoning callbacks
-                    elif "reasoning" in event_type and "delta" in event_type:
-                        reasoning_text = getattr(event, "delta", "")
-                        if reasoning_text:
-                            agent._fire_reasoning_delta(reasoning_text)
-                    # Collect completed output items — some backends
-                    # (chatgpt.com/backend-api/codex) stream valid items
-                    # via response.output_item.done but the SDK's
-                    # get_final_response() returns an empty output list.
-                    elif event_type == "response.output_item.done":
-                        done_item = getattr(event, "item", None)
-                        if done_item is not None:
-                            collected_output_items.append(done_item)
-                    # Log non-completed terminal events for diagnostics
-                    elif event_type in {"response.incomplete", "response.failed"}:
-                        resp_obj = getattr(event, "response", None)
-                        status = getattr(resp_obj, "status", None) if resp_obj else None
-                        incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
-                        logger.warning(
-                            "Codex Responses stream received terminal event %s "
-                            "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
-                            event_type, status, incomplete_details,
-                            sum(len(p) for p in agent._codex_streamed_text_parts),
-                            agent._client_log_context(),
-                        )
-                final_response = stream.get_final_response()
-                # PATCH: ChatGPT Codex backend streams valid output items
-                # but get_final_response() can return an empty output list.
-                # Backfill from collected items or synthesize from deltas.
-                _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        final_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex stream: backfilled %d output items from stream events",
-                            len(collected_output_items),
-                        )
-                    elif agent._codex_streamed_text_parts and not has_tool_calls:
-                        assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex stream: synthesized output from %d text deltas (%d chars)",
-                            len(agent._codex_streamed_text_parts), len(assembled),
-                        )
+                try:
+                    for event in stream:
+                        # Mark stream activity for the TTFB watchdog in
+                        # interruptible_api_call. The Codex backend can accept the
+                        # connection but never emit a single event; this timestamp
+                        # staying None tells the watchdog no bytes are flowing.
+                        agent._codex_stream_last_event_ts = time.time()
+                        agent._touch_activity("receiving stream response")
+                        if agent._interrupt_requested:
+                            break
+                        event_type = getattr(event, "type", "")
+                        # Fire callbacks on text content deltas (suppress during tool calls)
+                        if "output_text.delta" in event_type or event_type == "response.output_text.delta":
+                            delta_text = getattr(event, "delta", "")
+                            if delta_text:
+                                agent._codex_streamed_text_parts.append(delta_text)
+                            if delta_text and not has_tool_calls:
+                                if not first_delta_fired:
+                                    first_delta_fired = True
+                                    if on_first_delta:
+                                        try:
+                                            on_first_delta()
+                                        except Exception:
+                                            pass
+                                agent._fire_stream_delta(delta_text)
+                        # Track tool calls to suppress text streaming
+                        elif "function_call" in event_type:
+                            has_tool_calls = True
+                        # Fire reasoning callbacks
+                        elif "reasoning" in event_type and "delta" in event_type:
+                            reasoning_text = getattr(event, "delta", "")
+                            if reasoning_text:
+                                agent._fire_reasoning_delta(reasoning_text)
+                        # Collect completed output items — some backends
+                        # (chatgpt.com/backend-api/codex) stream valid items
+                        # via response.output_item.done but the SDK's terminal
+                        # response can have output=None or an empty output list.
+                        elif event_type == "response.output_item.done":
+                            done_item = getattr(event, "item", None)
+                            if done_item is not None:
+                                collected_output_items.append(done_item)
+                        # Log non-completed terminal events for diagnostics
+                        elif event_type in {"response.incomplete", "response.failed"}:
+                            resp_obj = getattr(event, "response", None)
+                            status = getattr(resp_obj, "status", None) if resp_obj else None
+                            incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
+                            logger.warning(
+                                "Codex Responses stream received terminal event %s "
+                                "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
+                                event_type, status, incomplete_details,
+                                sum(len(p) for p in agent._codex_streamed_text_parts),
+                                agent._client_log_context(),
+                            )
+                except TypeError as exc:
+                    return _recover_codex_stream_typeerror(
+                        agent,
+                        exc,
+                        collected_output_items=collected_output_items,
+                        collected_text_deltas=agent._codex_streamed_text_parts,
+                        has_tool_calls=has_tool_calls,
+                    )
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    return _recover_codex_stream_typeerror(
+                        agent,
+                        exc,
+                        collected_output_items=collected_output_items,
+                        collected_text_deltas=agent._codex_streamed_text_parts,
+                        has_tool_calls=has_tool_calls,
+                    )
+                # ChatGPT Codex backends may stream valid output items while
+                # the SDK terminal snapshot has missing/empty output. Backfill
+                # from collected items or synthesize from deltas.
+                _backfill_codex_response_output(
+                    final_response,
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=agent._codex_streamed_text_parts,
+                    has_tool_calls=has_tool_calls,
+                )
                 return final_response
         except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
             if attempt < max_stream_retries:
@@ -412,26 +493,13 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is None and isinstance(event, dict):
                 terminal_response = event.get("response")
             if terminal_response is not None:
-                # Backfill empty output from collected stream events
-                _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
-                    if collected_output_items:
-                        terminal_response.output = list(collected_output_items)
-                        logger.debug(
-                            "Codex fallback stream: backfilled %d output items",
-                            len(collected_output_items),
-                        )
-                    elif collected_text_deltas:
-                        assembled = "".join(collected_text_deltas)
-                        terminal_response.output = [SimpleNamespace(
-                            type="message", role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
-                        logger.debug(
-                            "Codex fallback stream: synthesized from %d deltas (%d chars)",
-                            len(collected_text_deltas), len(assembled),
-                        )
+                # Backfill empty/None output from collected stream events.
+                _backfill_codex_response_output(
+                    terminal_response,
+                    collected_output_items=collected_output_items,
+                    collected_text_deltas=collected_text_deltas,
+                    log_prefix="Codex fallback stream",
+                )
                 return terminal_response
     finally:
         close_fn = getattr(stream_or_response, "close", None)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2476,6 +2476,65 @@ class TestVisionAutoSkipsKimiCoding:
 
 
 class TestCodexAuxiliaryAdapterTimeout:
+    def test_recovers_typeerror_during_completed_event_from_output_item(self):
+        done_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="OK")],
+        )
+
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=done_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - iteration raises first
+                raise AssertionError("should recover before get_final_response")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert response.choices[0].message.content == "OK"
+
+    def test_recovers_typeerror_in_get_final_response_from_text_deltas(self):
+        class FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter([
+                    SimpleNamespace(type="response.output_text.delta", delta="O"),
+                    SimpleNamespace(type="response.output_text.delta", delta="K"),
+                ])
+
+            def get_final_response(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        class FakeResponses:
+            def stream(self, **kwargs):
+                return FakeStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert response.choices[0].message.content == "OK"
+
     def test_forwards_timeout_to_responses_stream(self):
         class FakeStream:
             def __enter__(self):

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -811,6 +811,77 @@ class TestCodexStreamCallbacks:
         response = agent._run_codex_stream({}, client=mock_client)
         assert "Hello from Codex!" in deltas
 
+    def test_codex_stream_typeerror_during_completed_event_backfills_output_item(self):
+        from run_agent import AIAgent
+
+        done_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="OK")],
+        )
+
+        def event_iter():
+            yield SimpleNamespace(type="response.output_item.done", item=done_item)
+            raise TypeError("'NoneType' object is not iterable")
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.__iter__ = MagicMock(return_value=event_iter())
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = mock_stream
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response.status == "completed"
+        assert response.output == [done_item]
+
+    def test_codex_stream_typeerror_in_get_final_response_synthesizes_delta_text(self):
+        from run_agent import AIAgent
+
+        events = [
+            SimpleNamespace(type="response.output_text.delta", delta="O"),
+            SimpleNamespace(type="response.output_text.delta", delta="K"),
+        ]
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.__iter__ = MagicMock(return_value=iter(events))
+        mock_stream.get_final_response.side_effect = TypeError(
+            "'NoneType' object is not iterable"
+        )
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = mock_stream
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response.status == "completed"
+        assert response.output[0].content[0].text == "OK"
+
     def test_codex_stream_refreshes_activity_on_every_event(self):
         from run_agent import AIAgent
 


### PR DESCRIPTION
## Summary
- recover Codex Responses streams when the SDK terminal snapshot has missing/empty output
- backfill final output from streamed response.output_item.done events, or synthesize text output from accumulated output_text deltas when no tool calls were present
- add regression coverage for TypeError during stream iteration and get_final_response()

## Context
ChatGPT Codex backend can stream valid output items/text deltas, but the terminal response.completed payload may have output=null. OpenAI SDK parsing then raises TypeError("'NoneType' object is not iterable") while iterating response.output, which makes Hermes treat an otherwise successful Codex turn as a provider failure and fall through to fallbacks.

I reproduced this on multiple Hermes agents using openai-codex/gpt-5.5 against https://chatgpt.com/backend-api/codex. Updating to Hermes v0.14.0 alone did not fix it. With this patch, the same real request completed with content OK.

## Verification
- /Users/cms/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_streaming.py -k 'codex_stream_typeerror or codex_text_delta_fires_callback or codex_stream_refreshes_activity'
- /Users/cms/.hermes/hermes-agent/venv/bin/python -m ruff check agent/codex_runtime.py tests/run_agent/test_streaming.py
- real openai-codex/gpt-5.5 stream smoke test returned {"status": "completed", "content": "OK", "finish": "stop"}