### PR TITLE
fix(gateway): align MEDIA: regex whitelist with SUPPORTED_DOCUMENT_TYPES

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2412,8 +2412,18 @@ class BasePlatformAdapter(ABC):
         
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
+        #
+        # The extension whitelist below MUST stay aligned with the union of:
+        #   - SUPPORTED_IMAGE_TYPES, SUPPORTED_VIDEO_TYPES, SUPPORTED_AUDIO_TYPES
+        #   - SUPPORTED_DOCUMENT_TYPES (the document-attachment whitelist)
+        # If a file extension is delivery-eligible per those tables but missing
+        # here, MEDIA:<path> for that extension is silently stripped from the
+        # response with no WARNING — the gateway just doesn't see a directive.
+        # That bug surfaced in 2026-05 for ``.md`` reports: agents emitted
+        # ``MEDIA:/path/to/report.md`` and users saw the path vanish from the
+        # rendered text without an attachment.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa|md|log|json|xml|ya?ml|toml|ini|cfg|ts|py|sh)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -361,6 +361,46 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    # ---- Document-extension regression tests ------------------------------
+    # The MEDIA: regex extension whitelist must stay aligned with
+    # SUPPORTED_DOCUMENT_TYPES. Prior to this fix, ``.md`` (and several
+    # other document types listed as deliverable) were silently dropped
+    # from response text because the regex didn't list them.
+
+    @pytest.mark.parametrize(
+        "ext",
+        ["md", "log", "json", "xml", "yaml", "yml", "toml", "ini", "cfg",
+         "ts", "py", "sh"],
+    )
+    def test_media_tag_recognizes_document_extensions(self, ext):
+        """Each extension in SUPPORTED_DOCUMENT_TYPES must be matched by
+        the MEDIA: regex; otherwise the directive is silently stripped
+        instead of dispatched to the document-attachment codepath."""
+        content = f"Here is your file:\nMEDIA:/tmp/report.{ext}"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [(f"/tmp/report.{ext}", False)], (
+            f".{ext} should be a recognized MEDIA: extension. "
+            f"If this fails, the MEDIA: regex in extract_media() drifted out "
+            f"of sync with SUPPORTED_DOCUMENT_TYPES."
+        )
+        assert "MEDIA:" not in cleaned
+        assert "Here is your file" in cleaned
+
+    def test_media_tag_recognizes_markdown_with_quoted_path(self):
+        """The original bug report: ``.md`` with a real-world path layout."""
+        content = (
+            "主报告：\nMEDIA:/Users/echo/.hermes/cache/documents/"
+            "mastercard-agentpay-vs-tempo-mpp-20260526.md\n"
+        )
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            (
+                "/Users/echo/.hermes/cache/documents/"
+                "mastercard-agentpay-vs-tempo-mpp-20260526.md",
+                False,
+            )
+        ]
+
 
 class TestMediaDeliveryPathValidation:
     def _patch_roots(self, monkeypatch, *roots):


### PR DESCRIPTION
## Summary

The `MEDIA:<path>` regex in `extract_media()` (gateway/platforms/base.py) carries its own hard-coded extension whitelist that has drifted out of sync with `SUPPORTED_DOCUMENT_TYPES`. Extensions registered as deliverable documents but missing from the regex are **silently stripped** from response text — no WARNING is logged because the path never reaches `validate_media_delivery_path()`.

This PR aligns the two whitelists and adds a regression test.

## Reproduction (before the fix)

```python
from gateway.platforms.base import BasePlatformAdapter

content = "Here is your report:\nMEDIA:/tmp/report.md"
media, cleaned = BasePlatformAdapter.extract_media(content)

# Expected: media == [("/tmp/report.md", False)]
# Actual:   media == []  (path silently stripped, never dispatched)
```

Same failure mode for `.json`, `.yaml`, `.toml`, `.ini`, `.cfg`, `.log`, `.ts`, `.py`, `.sh`, `.xml` — all listed in `SUPPORTED_DOCUMENT_TYPES` (line ~1023) but absent from the regex (line ~2416).

## Real-world impact

Surfaced when delivering a `.md` research report on Telegram. The `MEDIA:` line vanished from the rendered message; no document attachment; `gateway.log` showed:

```
response ready: ... response=404 chars
[Telegram] Sending response (198 chars) to ...
```

…with no `Skipping unsafe MEDIA directive path outside allowed roots` warning that normally accompanies allowlist rejection. The 206-char delta corresponds to the three stripped `MEDIA:` lines.

## Fix

Add the missing extensions to the regex alternation:
`md | log | json | xml | ya?ml | toml | ini | cfg | ts | py | sh`

…and a comment block above the pattern documenting the alignment contract so the next person who edits either side knows to update the other.

## Tests

- **Parametrized regression** (`test_media_tag_recognizes_document_extensions`) covers every newly-allowed extension.
- **Real-world reproduction** (`test_media_tag_recognizes_markdown_with_quoted_path`) — `.md` path with a leading non-ASCII context line, mirroring the original failure.

### Verification

Reverted the `gateway/platforms/base.py` hunk and re-ran the new tests against the un-fixed code: **13 failures**, exactly as expected (12 parametrized + 1 real-world). Restored the fix → **27 passed** in `TestExtractMedia`. Full `tests/gateway/test_platform_base.py` suite: **114 passed, 2 skipped**.

```
$ pytest tests/gateway/test_platform_base.py
======================== 114 passed, 2 skipped in 0.67s ========================
```

## Scope

Minimal, additive — only adds extensions already enumerated as deliverable per `SUPPORTED_DOCUMENT_TYPES`. Does not touch `extract_local_files()` (which already supports these via its own broader list), `validate_media_delivery_path()`, or the document dispatch path.

A follow-up PR could refactor the regex to construct its alternation from `SUPPORTED_DOCUMENT_TYPES` programmatically, eliminating the drift class entirely. That's deliberately out of scope here to keep this fix small and reviewable.
