### PR TITLE
fix(codex): narrow null-output stream recovery

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -182,6 +182,33 @@ def _responses_null_output_iterable_error(exc: BaseException) -> bool:
     return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
 
 
+def _recover_responses_null_output(agent, exc, collected_output_items, has_tool_calls, api_kwargs, active_client):
+    """Recover SDK null-output parser failures from already streamed events."""
+    if not _responses_null_output_iterable_error(exc):
+        raise exc
+    recovered = _codex_backfilled_response(
+        collected_output_items,
+        agent._codex_streamed_text_parts,
+        has_tool_calls=has_tool_calls,
+        model=api_kwargs.get("model"),
+    )
+    if recovered is not None:
+        logger.debug(
+            "Codex Responses stream parser hit response.output=None; "
+            "recovered from streamed events (items=%d, text_parts=%d). %s",
+            len(collected_output_items),
+            len(agent._codex_streamed_text_parts),
+            agent._client_log_context(),
+        )
+        return recovered
+    logger.debug(
+        "Codex Responses stream parser hit response.output=None without "
+        "recoverable events; falling back to create(stream=True). %s",
+        agent._client_log_context(),
+    )
+    return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+
+
 def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str = None):
     """Build a minimal Responses-like object from events already streamed."""
     if output_items:
@@ -225,7 +252,21 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         collected_output_items: list = []
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
-                for event in stream:
+                stream_iter = iter(stream)
+                while True:
+                    try:
+                        event = next(stream_iter)
+                    except StopIteration:
+                        break
+                    except TypeError as exc:
+                        return _recover_responses_null_output(
+                            agent,
+                            exc,
+                            collected_output_items,
+                            has_tool_calls,
+                            api_kwargs,
+                            active_client,
+                        )
                     # Mark stream activity for the TTFB watchdog in
                     # interruptible_api_call. The Codex backend can accept the
                     # connection but never emit a single event; this timestamp
@@ -277,7 +318,17 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    return _recover_responses_null_output(
+                        agent,
+                        exc,
+                        collected_output_items,
+                        has_tool_calls,
+                        api_kwargs,
+                        active_client,
+                    )
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
@@ -314,30 +365,6 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
-        except TypeError as exc:
-            if _responses_null_output_iterable_error(exc):
-                recovered = _codex_backfilled_response(
-                    collected_output_items,
-                    agent._codex_streamed_text_parts,
-                    has_tool_calls=has_tool_calls,
-                    model=api_kwargs.get("model"),
-                )
-                if recovered is not None:
-                    logger.debug(
-                        "Codex Responses stream parser hit response.output=None; "
-                        "recovered from streamed events (items=%d, text_parts=%d). %s",
-                        len(collected_output_items),
-                        len(agent._codex_streamed_text_parts),
-                        agent._client_log_context(),
-                    )
-                    return recovered
-                logger.debug(
-                    "Codex Responses stream parser hit response.output=None without "
-                    "recoverable events; falling back to create(stream=True). %s",
-                    agent._client_log_context(),
-                )
-                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
-            raise
         except RuntimeError as exc:
             err_text = str(exc)
             missing_completed = "response.completed" in err_text

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -207,6 +207,27 @@ class _IteratorTypeErrorStream:
         raise AssertionError("get_final_response should not be reached")
 
 
+class _FakeResponsesStreamFinalResponseAfterEvents:
+    def __init__(self, events, final_response=None, final_error=None):
+        self._events = list(events)
+        self._final_response = final_response
+        self._final_error = final_error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_response(self):
+        if self._final_error is not None:
+            raise self._final_error
+        return self._final_response
+
+
 def _codex_request_kwargs():
     return {
         "model": "gpt-5-codex",
@@ -537,6 +558,60 @@ def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(mo
     assert calls["stream"] == 1
     assert response.output == [output_item]
     assert response.status == "completed"
+
+
+def test_run_codex_stream_recovers_when_final_response_parses_null_output(monkeypatch):
+    """Recover SDK null-output parser failures from get_final_response only."""
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="final parser item survived")],
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStreamFinalResponseAfterEvents(
+                [
+                    SimpleNamespace(type="response.output_item.done", item=output_item),
+                ],
+                final_error=TypeError("'NoneType' object is not iterable"),
+            ),
+            create=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("create fallback should not run")
+            ),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.output == [output_item]
+    assert response.status == "completed"
+
+
+def test_run_codex_stream_does_not_recover_callback_type_error(monkeypatch):
+    """Only SDK null-output parser failures should trigger Codex stream recovery."""
+    agent = _build_agent(monkeypatch)
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStreamFinalResponseAfterEvents(
+                [
+                    SimpleNamespace(type="response.output_text.delta", delta="callback text"),
+                ],
+                _codex_message_response("unused final"),
+            ),
+            create=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("create fallback should not run")
+            ),
+        )
+    )
+
+    def _raise_callback_type_error(_text):
+        raise TypeError("'NoneType' object is not iterable")
+
+    agent._fire_stream_delta = _raise_callback_type_error
+
+    with pytest.raises(TypeError, match="NoneType"):
+        agent._run_codex_stream(_codex_request_kwargs())
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Narrow the Codex Responses null-output recovery added in #32963 so it only handles SDK parser failures while advancing the SDK stream iterator or calling `get_final_response()`.

Before this change, the broad outer `except TypeError` could also catch a Hermes-side callback/handler error whose message happened to contain `NoneType` + `not iterable`. If streamed deltas/items had already been collected, Hermes could recover and return a partial response instead of surfacing the local bug.

This keeps the #32963 recovery behavior for SDK `response.output=None` failures, but lets unrelated callback `TypeError`s propagate.

## Related Issue

Related to #11179 and #32963.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_runtime.py`: move null-output `TypeError` recovery into the SDK iterator / `get_final_response()` boundaries.
- `tests/run_agent/test_run_agent_codex_responses.py`: add regressions proving:
  - stream-iteration SDK null-output failures still recover;
  - final-response SDK null-output failures still recover;
  - Hermes callback `TypeError("'NoneType' object is not iterable")` propagates instead of being recovered.

## How to Test

1. `python3 -m py_compile agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py`
2. `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -- -q -k 'null_output or callback_type_error'`
3. `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -- -q`

Validation run on CT 216 (`pc-hermes-test`, Linux container):

```text
scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -- -q -k 'null_output or callback_type_error'
3 tests passed

scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py -- -q
68 tests passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: CT 216 Linux container (`pc-hermes-test`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix, the callback regression failed on upstream `main`:

```text
FAILED tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_does_not_recover_callback_type_error
E Failed: DID NOT RAISE <class 'TypeError'>
```

After fix, the targeted Codex Responses test file passes as shown above.
