### PR TITLE
test(codex): cover null Responses stream output recovery

### DIFF
--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2592,6 +2592,44 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
         assert response.choices[0].message.content == "aux survived"
         fake_client.responses.create.assert_not_called()
 
+    def test_backfills_output_none_returned_by_final_response(self):
+        output_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="aux survived")],
+        )
+        final_response = SimpleNamespace(output=None, usage=None)
+
+        class NullOutputFinalStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter([
+                    SimpleNamespace(type="response.output_item.done", item=output_item),
+                ])
+
+            def get_final_response(self):
+                return final_response
+
+        class FakeResponses:
+            def __init__(self):
+                self.create = MagicMock()
+
+            def stream(self, **kwargs):
+                return NullOutputFinalStream()
+
+        fake_client = SimpleNamespace(responses=FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        response = adapter.create(messages=[{"role": "user", "content": "summarize"}])
+
+        assert final_response.output == [output_item]
+        assert response.choices[0].message.content == "aux survived"
+        fake_client.responses.create.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Issue #23432 — auxiliary timeout poisons cached client; later aux calls fail

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -539,6 +539,74 @@ def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(mo
     assert response.status == "completed"
 
 
+def test_run_codex_stream_recovers_when_final_response_parse_sees_null_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="stream item survived")],
+    )
+
+    class FinalResponseTypeErrorStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            return iter([
+                SimpleNamespace(type="response.output_item.done", item=output_item),
+            ])
+
+        def get_final_response(self):
+            raise TypeError("'NoneType' object is not iterable")
+
+    def _unexpected_create(**kwargs):  # pragma: no cover - recovery should avoid fallback call
+        raise AssertionError("create fallback should not be needed when output items were collected")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: FinalResponseTypeErrorStream(),
+            create=_unexpected_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.output == [output_item]
+    assert response.status == "completed"
+
+
+def test_codex_create_stream_fallback_backfills_none_terminal_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="fallback item survived")],
+    )
+    terminal = SimpleNamespace(
+        output=None,
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+        status="completed",
+        model="gpt-5-codex",
+    )
+    create_stream = _FakeCreateStream([
+        SimpleNamespace(type="response.output_item.done", item=output_item),
+        SimpleNamespace(type="response.completed", response=terminal),
+    ])
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: create_stream)
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+
+    assert create_stream.closed is True
+    assert response is terminal
+    assert response.output == [output_item]
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary
- add regression coverage for Codex Responses streams where streamed output items exist but `get_final_response()` still raises `TypeError: 'NoneType' object is not iterable`
- add coverage for the `create(stream=True)` fallback when the terminal `response.completed` payload has `response.output = null`
- add auxiliary adapter coverage for a terminal final response with `output = null`

## Context
Related to #11179. Latest `main` now has the recovery code; this PR keeps the edge cases covered so the Codex runtime split and auxiliary path do not regress.

## Testing
- `python -m py_compile tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py`
- `pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_recovers_when_final_response_parse_sees_null_output tests/run_agent/test_run_agent_codex_responses.py::test_codex_create_stream_fallback_backfills_none_terminal_output tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterNullOutputRecovery::test_backfills_output_none_returned_by_final_response -q`
- `pytest tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py -q`