### PR TITLE
chore(release): map wangpuv contributor email

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -48,6 +48,7 @@ AUTHOR_MAP = {
     "9592417+adam91holt@users.noreply.github.com": "adam91holt",
     "45688690+fujinice@users.noreply.github.com": "fujinice",
     "276689385+carltonawong@users.noreply.github.com": "carltonawong",
+    "wangpuv@hotmail.com": "wangpuv",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "kenyon1977@gmail.com": "kenyonxu",


### PR DESCRIPTION
Pre-merge AUTHOR_MAP entry for @wangpuv (real-email contributor) so the contributor-check workflow passes when #32933 (Codex image-gen SSE fix for the gpt-image-2 outage) lands.