### PR TITLE
fix: clean Mattermost progress breadcrumbs

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -236,6 +236,25 @@ class MattermostAdapter(BasePlatformAdapter):
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
 
+    async def _api_delete(self, path: str) -> bool:
+        """DELETE /api/v4/{path}."""
+        import aiohttp
+        url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
+        try:
+            async with self._session.delete(
+                url,
+                headers=self._headers(),
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error("MM API DELETE %s → %s: %s", path, resp.status, body[:200])
+                    return False
+                return True
+        except aiohttp.ClientError as exc:
+            logger.error("MM API DELETE %s network error: %s", path, exc)
+            return False
+
     async def _upload_file(
         self, channel_id: str, file_data: bytes, filename: str, content_type: str = "application/octet-stream"
     ) -> Optional[str]:
@@ -406,6 +425,18 @@ class MattermostAdapter(BasePlatformAdapter):
         if not data or "id" not in data:
             return SendResult(success=False, error="Failed to edit post")
         return SendResult(success=True, message_id=data["id"])
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Mattermost post.
+
+        Mattermost post IDs are globally unique, so the channel ID is not
+        needed by the REST endpoint.  The gateway only tracks IDs returned from
+        sends it performed itself; Mattermost enforces token permissions server
+        side if a caller ever passes an invalid/unauthorized post ID.
+        """
+        if not message_id:
+            return False
+        return await self._api_delete(f"posts/{message_id}")
 
     async def send_image(
         self,

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -476,6 +476,35 @@ class TestMattermostSend:
 
         assert result.success is False
 
+    @pytest.mark.asyncio
+    async def test_delete_message_calls_api_delete(self):
+        """delete_message() should delete the Mattermost post by ID."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.delete = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.delete_message("channel_1", "post_to_delete")
+
+        assert result is True
+        call_args = self.adapter._session.delete.call_args
+        assert "/api/v4/posts/post_to_delete" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_delete_message_failure_returns_false(self):
+        mock_resp = AsyncMock()
+        mock_resp.status = 403
+        mock_resp.text = AsyncMock(return_value="Forbidden")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.delete = MagicMock(return_value=mock_resp)
+
+        assert await self.adapter.delete_message("channel_1", "post_to_delete") is False
+
 
 # ---------------------------------------------------------------------------
 # WebSocket event parsing


### PR DESCRIPTION
## Summary\n- add Mattermost post deletion support so cleanup_progress can remove temporary progress/status bubbles\n- sanitize noisy provider retry/fallback errors for Mattermost like Telegram\n- cover Mattermost cleanup and provider-noise behavior with focused tests\n\n## Tests\n- python -m pytest tests/gateway/test_telegram_noise_filter.py::test_mattermost_status_suppresses_retry_noise tests/gateway/test_telegram_noise_filter.py::test_mattermost_status_sanitizes_raw_provider_errors tests/gateway/test_telegram_noise_filter.py::test_mattermost_final_response_sanitizes_raw_provider_errors tests/gateway/test_mattermost.py::TestMattermostSend::test_delete_message_calls_api_delete tests/gateway/test_mattermost.py::TestMattermostSend::test_delete_message_failure_returns_false -q -o 'addopts='\n