### PR TITLE
fix: omit empty tools for Codex Responses

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -101,10 +101,10 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
             ),
-            "tools": response_tools,
             "store": False,
         }
         if response_tools:
+            kwargs["tools"] = response_tools
             kwargs["tool_choice"] = "auto"
             kwargs["parallel_tool_calls"] = True
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -54,6 +54,18 @@ class TestCodexBuildKwargs:
         assert "input" in kw
         assert kw["store"] is False
 
+    def test_omits_tools_when_none(self, transport):
+        """OpenAI SDK Responses.stream() treats tools=None as iterable input."""
+        messages = [{"role": "user", "content": "Hello"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=None,
+        )
+        assert "tools" not in kw
+        assert "tool_choice" not in kw
+        assert "parallel_tool_calls" not in kw
+
     def test_system_extracted_from_messages(self, transport):
         messages = [
             {"role": "system", "content": "Custom system prompt"},


### PR DESCRIPTION
## Summary
- omit the Responses API tools kwarg when no converted tools are available
- keep tool_choice and parallel_tool_calls gated on actual tools
- add regression coverage for tools=None

## Test plan
- ./scripts/run_tests.sh tests/agent/transports/test_codex_transport.py
- ./scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py tests/run_agent/test_413_compression.py tests/agent/transports/test_codex_transport.py
- git diff --check