### PR TITLE
Preserve Codex usage during null-output recovery

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -113,10 +113,25 @@ def _responses_null_output_iterable_error(exc: BaseException) -> bool:
     return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
 
 
-def _responses_backfilled_response(output_items: List[Any], text_parts: List[str], *, has_function_calls: bool, model: str = None) -> Optional[Any]:
+def _responses_usage_from_null_output_traceback(exc: BaseException) -> Any:
+    """Best-effort extraction of usage from the terminal SDK SSE frame."""
+    tb = exc.__traceback__
+    while tb is not None:
+        frame = tb.tb_frame
+        for local_name in ("sse_event", "event", "_event"):
+            event = frame.f_locals.get(local_name)
+            response = getattr(event, "response", None) if event is not None else None
+            usage = getattr(response, "usage", None) if response is not None else None
+            if usage is not None:
+                return usage
+        tb = tb.tb_next
+    return None
+
+
+def _responses_backfilled_response(output_items: List[Any], text_parts: List[str], *, has_function_calls: bool, model: str | None = None, usage: Any = None) -> Optional[Any]:
     """Build a minimal Responses-like object from already streamed events."""
     if output_items:
-        return SimpleNamespace(output=list(output_items), usage=None, status="completed", model=model)
+        return SimpleNamespace(output=list(output_items), usage=usage, status="completed", model=model)
     if text_parts and not has_function_calls:
         assembled = "".join(text_parts)
         return SimpleNamespace(
@@ -126,7 +141,7 @@ def _responses_backfilled_response(output_items: List[Any], text_parts: List[str
                 status="completed",
                 content=[SimpleNamespace(type="output_text", text=assembled)],
             )],
-            usage=None,
+            usage=usage,
             status="completed",
             model=model,
         )
@@ -848,6 +863,7 @@ class _CodexCompletionsAdapter:
                         collected_text_deltas,
                         has_function_calls=has_function_calls,
                         model=resp_kwargs.get("model"),
+                        usage=_responses_usage_from_null_output_traceback(exc),
                     )
                     if final is None:
                         raise

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -182,12 +182,32 @@ def _responses_null_output_iterable_error(exc: BaseException) -> bool:
     return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
 
 
-def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str = None):
+def _codex_usage_from_null_output_traceback(exc: BaseException) -> Any:
+    """Best-effort extraction of usage from the terminal SDK SSE frame.
+
+    The OpenAI SDK raises while parsing response.completed.output=None before
+    yielding the completed event. The traceback still contains the raw SSE event
+    frame in SDK internals, and that response can carry accurate usage.
+    """
+    tb = exc.__traceback__
+    while tb is not None:
+        frame = tb.tb_frame
+        for local_name in ("sse_event", "event", "_event"):
+            event = frame.f_locals.get(local_name)
+            response = getattr(event, "response", None) if event is not None else None
+            usage = getattr(response, "usage", None) if response is not None else None
+            if usage is not None:
+                return usage
+        tb = tb.tb_next
+    return None
+
+
+def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str | None = None, usage: Any = None):
     """Build a minimal Responses-like object from events already streamed."""
     if output_items:
         return SimpleNamespace(
             output=list(output_items),
-            usage=None,
+            usage=usage,
             status="completed",
             model=model,
         )
@@ -200,7 +220,7 @@ def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool
                 status="completed",
                 content=[SimpleNamespace(type="output_text", text=assembled)],
             )],
-            usage=None,
+            usage=usage,
             status="completed",
             model=model,
         )
@@ -321,6 +341,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     agent._codex_streamed_text_parts,
                     has_tool_calls=has_tool_calls,
                     model=api_kwargs.get("model"),
+                    usage=_codex_usage_from_null_output_traceback(exc),
                 )
                 if recovered is not None:
                     logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2572,6 +2572,12 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
 
             def __iter__(self):
                 yield SimpleNamespace(type="response.output_item.done", item=output_item)
+                sse_event = SimpleNamespace(
+                    response=SimpleNamespace(
+                        usage=SimpleNamespace(input_tokens=17, output_tokens=23, total_tokens=40)
+                    )
+                )
+                _ = sse_event  # keep the raw terminal event available in the traceback frame
                 raise TypeError("'NoneType' object is not iterable")
 
             def get_final_response(self):  # pragma: no cover - iterator fails first
@@ -2590,6 +2596,9 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
         response = adapter.create(messages=[{"role": "user", "content": "summarize"}])
 
         assert response.choices[0].message.content == "aux survived"
+        assert response.usage.prompt_tokens == 17
+        assert response.usage.completion_tokens == 23
+        assert response.usage.total_tokens == 40
         fake_client.responses.create.assert_not_called()
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -201,6 +201,12 @@ class _IteratorTypeErrorStream:
     def __iter__(self):
         for event in self._events_before_error:
             yield event
+        sse_event = SimpleNamespace(
+            response=SimpleNamespace(
+                usage=SimpleNamespace(input_tokens=17, output_tokens=23, total_tokens=40)
+            )
+        )
+        _ = sse_event  # keep the raw terminal event available in the traceback frame
         raise TypeError("'NoneType' object is not iterable")
 
     def get_final_response(self):  # pragma: no cover - iterator fails first
@@ -537,6 +543,9 @@ def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(mo
     assert calls["stream"] == 1
     assert response.output == [output_item]
     assert response.status == "completed"
+    assert response.usage.input_tokens == 17
+    assert response.usage.output_tokens == 23
+    assert response.usage.total_tokens == 40
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up to #32963: preserve backend-reported token usage when Codex null-output recovery has to synthesize a response from already-streamed events.

#32963 restores the assistant output when `openai-python` raises while parsing a terminal `response.completed` frame with `response.output=None`. However, the synthesized recovered response used `usage=None`, even though the raw terminal SSE frame can still carry accurate `response.usage`.

This PR extracts that usage from the SDK traceback frame locals and passes it into the recovered response so token/accounting state can still update.

## Why

Without usage preservation, a recovered message succeeds but accounting can remain stale, including:

- session token counters
- footer/context usage display
- context compressor prompt-token state

## Changes

- Add best-effort usage extraction from null-output SDK traceback frames.
- Preserve usage in main Codex stream null-output recovery.
- Preserve usage in auxiliary Codex Responses recovery.
- Add regressions for main and auxiliary recovered responses carrying usage.

## Verification

```text
venv/bin/python -m py_compile agent/codex_runtime.py agent/auxiliary_client.py

venv/bin/python -m pytest -q \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/agent/test_auxiliary_client.py

243 passed, 1 warning

venv/bin/python -m ruff check \
  agent/codex_runtime.py \
  agent/auxiliary_client.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/agent/test_auxiliary_client.py

All checks passed!
```

Closes/follows up: https://github.com/NousResearch/hermes-agent/pull/32963#issuecomment-4551032125
