### PR TITLE
docs: document 'pip install hermes-agent' as a quick-install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 ## Quick Install
 
+### PyPI (pip)
+
+If you already have a working Python 3.11+ environment, the simplest install is straight from PyPI:
+
+```bash
+pip install hermes-agent
+hermes
+```
+
+The wheel ships with the Ink TUI bundle and the shell launcher, so the full experience works out of the box. (Released in [v0.14.0](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.16).)
+
+If you'd rather have the installer set up everything (uv, Python 3.11, Node.js, ripgrep, ffmpeg, …) for you, use one of the platform installers below.
+
 ### Linux, macOS, WSL2, Termux
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,21 @@
 
 ## 快速安装
 
+### PyPI (pip)
+
+如果已有 Python 3.11+ 环境，最简单的方式是直接从 PyPI 安装：
+
+```bash
+pip install hermes-agent
+hermes
+```
+
+wheel 已打包 Ink TUI 与 shell 启动器，开箱即用完整体验。（[v0.14.0](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.16) 已支持。）
+
+若需安装程序自动准备 uv、Python 3.11、Node.js、ripgrep、ffmpeg 等系统依赖，请使用下方的平台脚本。
+
+### Linux、macOS、WSL2、Termux
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 ```


### PR DESCRIPTION
## Summary
The [v0.14.0 release](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.16) shipped Hermes Agent on PyPI:

> **\`pip install hermes-agent && hermes\`** — Hermes Agent is now a real PyPI package. No more cloning the repo or running shell installers — one pip command and you're running. The wheel ships with the Ink TUI bundle and the shell launcher, so the full experience comes out of the box. (#26593, #26148)

The Quick Install sections of `README.md` and `README.zh-CN.md` still only document the `curl | bash` and PowerShell installer paths, so users land on the README without seeing that pip is a one-line option.

## Changes
- **README.md**: Add a new `### PyPI (pip)` subsection at the top of `## Quick Install`, above the existing `### Linux, macOS, WSL2, Termux` and `### Windows (native, PowerShell)` sections. Note that the platform installer scripts are still the right pick when uv / Python 3.11 / Node.js / ripgrep / ffmpeg need to be set up.
- **README.zh-CN.md**: Mirror the same new subsection in the 中文 README so both stay in sync.

Verified the package is live: https://pypi.org/project/hermes-agent/

## Test plan
- [x] Markdown renders correctly on GitHub
- [x] No existing content removed; only an additive subsection
- [ ] Reviewer can sanity-check the wording matches the release-notes framing