### PR TITLE
fix(gateway): avoid hanging launchd restarts

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3051,7 +3051,6 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
-    drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 
     try:
@@ -3059,15 +3058,6 @@ def launchd_restart():
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             return
-        if pid is not None:
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
-            if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
-                if not exited:
-                    print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -554,14 +554,34 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
+    def test_launchd_restart_uses_launchctl_kickstart_without_pid_wait(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
-        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_pid_exit",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("launchd restart should not wait on a PID from an external CLI")
+            ),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_gateway_exit",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("launchd restart must wait for the old PID, not any gateway PID")
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("launchd kickstart -k should own process replacement")
+            ),
+        )
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -576,7 +596,6 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert calls == [
-            ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
         ]
 


### PR DESCRIPTION
## Summary
- Let macOS launchd own gateway process replacement via `launchctl kickstart -k` instead of manually terminating and waiting on gateway PIDs.
- Update the launchd restart regression test to assert the CLI does not wait on stale or replacement gateway PIDs.

## Test plan
- `venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery tests/hermes_cli/test_gateway.py::TestWaitForGatewayExit -q`
- `hermes gateway restart && hermes gateway status`

Note: Running `venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway.py -q` on macOS still reports pre-existing systemd user D-Bus preflight failures in systemd-specific tests.

Made with [Cursor](https://cursor.com)