### PR TITLE
Handle Codex stream responses with null output

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -251,7 +251,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -287,6 +287,21 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+        except TypeError as exc:
+            err_text = str(exc)
+            none_output_parse = (
+                "NoneType" in err_text
+                and "not iterable" in err_text
+            )
+            if none_output_parse:
+                logger.warning(
+                    "Codex Responses stream parser received response.output=None; "
+                    "falling back to create(stream=True). %s err=%s",
+                    agent._client_log_context(),
+                    err_text,
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
         except RuntimeError as exc:
             err_text = str(exc)
             missing_completed = "response.completed" in err_text
@@ -414,7 +429,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2355,6 +2355,7 @@ def run_conversation(
                     error_type,
                     agent._client_log_context(),
                     _error_summary,
+                    exc_info=True,
                 )
 
                 _provider = getattr(agent, "provider", "unknown")
@@ -2917,7 +2918,12 @@ def run_conversation(
                                 agent._vprint(f"{agent.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
                     else:
                         agent._vprint(f"{agent.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
-                    logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
+                    logger.error(
+                        "%sNon-retryable client error: %s",
+                        agent.log_prefix,
+                        api_error,
+                        exc_info=True,
+                    )
                     # Skip session persistence when the error is likely
                     # context-overflow related (status 400 + large session).
                     # Persisting the failed user message would make the

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -6,6 +6,7 @@ Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 """
 
 import copy
+from contextlib import contextmanager
 import json
 import logging
 import shutil
@@ -14,7 +15,7 @@ import threading
 import os
 import re
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Union
@@ -37,11 +38,14 @@ except ImportError:
 HERMES_DIR = get_hermes_home().resolve()
 CRON_DIR = HERMES_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
+DIRECTIVES_FILE = CRON_DIR / "directives.json"
+DIRECTIVE_EVENTS_FILE = CRON_DIR / "directive_events.jsonl"
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.Lock()
+_directives_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
@@ -50,6 +54,7 @@ ONESHOT_GRACE_SECONDS = 120
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
 _IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_DIRECTIVE_STATUSES = frozenset({"pending", "consumed", "expired", "cancelled", "invalid"})
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -179,6 +184,491 @@ def ensure_dirs():
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     _secure_dir(CRON_DIR)
     _secure_dir(OUTPUT_DIR)
+
+
+class CronDirectiveError(RuntimeError):
+    """Fail-closed directive handoff error raised before a cron runner starts."""
+
+    def __init__(self, message: str, event_type: str = "invalid", directive: Optional[Dict[str, Any]] = None):
+        super().__init__(message)
+        self.event_type = event_type
+        self.directive = directive or {}
+
+
+def _utcnow() -> datetime:
+    return _hermes_now().astimezone(timezone.utc)
+
+
+def _iso_now() -> str:
+    return _utcnow().isoformat()
+
+
+def _parse_directive_time(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"directive field {field!r} must be an ISO timestamp")
+    parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+@contextmanager
+def _directive_store_lock():
+    """Cross-process lock for directive load/modify/save cycles."""
+    ensure_dirs()
+    lock_path = CRON_DIR / ".directives.lock"
+    with _directives_file_lock:
+        with open(lock_path, "a+", encoding="utf-8") as lock_fd:
+            try:
+                if os.name != "nt":
+                    import fcntl
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                else:
+                    import msvcrt
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_LOCK, 1)
+            except (ImportError, OSError):
+                pass
+            try:
+                yield
+            finally:
+                try:
+                    if os.name != "nt":
+                        import fcntl
+                        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                    else:
+                        import msvcrt
+                        msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (ImportError, OSError):
+                    pass
+
+
+def append_directive_event(
+    event_type: str,
+    job_id: Optional[str],
+    directive_id: Optional[str] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Append one directive audit event with O_APPEND semantics."""
+    ensure_dirs()
+    event = {
+        "timestamp": _iso_now(),
+        "directive_id": directive_id,
+        "job_id": job_id,
+        "event_type": event_type,
+        "context": context or {},
+    }
+    payload = (json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    fd = os.open(str(DIRECTIVE_EVENTS_FILE), os.O_CREAT | os.O_WRONLY | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, payload)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    _secure_file(DIRECTIVE_EVENTS_FILE)
+    return event
+
+
+def _load_directive_store_unlocked() -> Dict[str, Any]:
+    ensure_dirs()
+    if not DIRECTIVES_FILE.exists():
+        return {"directives": [], "updated_at": None}
+    try:
+        with open(DIRECTIVES_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        append_directive_event(
+            "parse-failed",
+            None,
+            None,
+            {"path": str(DIRECTIVES_FILE), "error": str(exc)},
+        )
+        raise CronDirectiveError(
+            f"Directive store is unparseable: {exc}",
+            event_type="parse-failed",
+        ) from exc
+    if not isinstance(data, dict) or not isinstance(data.get("directives"), list):
+        append_directive_event(
+            "parse-failed",
+            None,
+            None,
+            {"path": str(DIRECTIVES_FILE), "error": "store root must contain directives list"},
+        )
+        raise CronDirectiveError(
+            "Directive store is unparseable: expected object with directives list",
+            event_type="parse-failed",
+        )
+    return data
+
+
+def load_directive_store() -> Dict[str, Any]:
+    with _directive_store_lock():
+        return copy.deepcopy(_load_directive_store_unlocked())
+
+
+def _save_directive_store_unlocked(store: Dict[str, Any]) -> None:
+    ensure_dirs()
+    store["updated_at"] = _iso_now()
+    fd, tmp_path = tempfile.mkstemp(dir=str(DIRECTIVES_FILE.parent), suffix=".tmp", prefix=".directives_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(store, f, indent=2, sort_keys=True)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, DIRECTIVES_FILE)
+        _secure_file(DIRECTIVES_FILE)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _validate_directive_record(record: Any) -> Dict[str, Any]:
+    if not isinstance(record, dict):
+        raise ValueError("directive record must be an object")
+    directive_id = str(record.get("directive_id") or "").strip()
+    job_id = str(record.get("job_id") or "").strip()
+    directive_text = record.get("directive_text")
+    created_by = str(record.get("created_by") or "").strip()
+    status = str(record.get("status") or "").strip()
+    version = record.get("version")
+    if not directive_id:
+        raise ValueError("directive_id is required")
+    if not job_id:
+        raise ValueError("job_id is required")
+    if not isinstance(directive_text, str) or not directive_text.strip():
+        raise ValueError("directive_text is required")
+    if not created_by:
+        raise ValueError("created_by is required")
+    if status not in _DIRECTIVE_STATUSES:
+        raise ValueError(f"invalid directive status: {status!r}")
+    if not isinstance(version, int) or version < 1:
+        raise ValueError("version must be a positive integer")
+    _parse_directive_time(record.get("created_at"), "created_at")
+    _parse_directive_time(record.get("expires_at"), "expires_at")
+    return record
+
+
+def _latest_directive_for_job(store: Dict[str, Any], job_id: str) -> Optional[Dict[str, Any]]:
+    matches = [d for d in store.get("directives", []) if isinstance(d, dict) and d.get("job_id") == job_id]
+    if not matches:
+        return None
+    return matches[-1]
+
+
+def _latest_unconsumed_directive_for_job(store: Dict[str, Any], job_id: str) -> Optional[Dict[str, Any]]:
+    matches = [
+        d for d in store.get("directives", [])
+        if isinstance(d, dict) and d.get("job_id") == job_id and d.get("status") != "consumed"
+    ]
+    if not matches:
+        return None
+    return matches[-1]
+
+
+def _find_directive(store: Dict[str, Any], directive_id: str) -> Optional[Dict[str, Any]]:
+    for directive in store.get("directives", []):
+        if isinstance(directive, dict) and directive.get("directive_id") == directive_id:
+            return directive
+    return None
+
+
+def _expire_pending_directives_unlocked(store: Dict[str, Any], now: Optional[datetime] = None) -> None:
+    now_dt = now or _utcnow()
+    for directive in store.get("directives", []):
+        if not isinstance(directive, dict) or directive.get("status") != "pending":
+            continue
+        try:
+            if _parse_directive_time(directive.get("expires_at"), "expires_at") <= now_dt:
+                directive["status"] = "expired"
+                directive["version"] = int(directive.get("version") or 1) + 1
+                append_directive_event(
+                    "expired",
+                    directive.get("job_id"),
+                    directive.get("directive_id"),
+                    {"reason": "ttl_expired"},
+                )
+        except Exception as exc:
+            directive["status"] = "invalid"
+            directive["version"] = int(directive.get("version") or 1) + 1
+            append_directive_event(
+                "invalid",
+                directive.get("job_id"),
+                directive.get("directive_id"),
+                {"reason": str(exc)},
+            )
+
+
+def create_operator_directive(
+    job_id: str,
+    directive_text: str,
+    created_by: str,
+    *,
+    expires_at: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Create one pending operator directive for a cron job."""
+    canonical_job_id = str(job_id or "").strip()
+    text = str(directive_text or "").strip()
+    actor = str(created_by or "").strip()
+    if not canonical_job_id:
+        raise ValueError("job_id is required")
+    if not text:
+        raise ValueError("directive_text is required")
+    if not actor:
+        raise ValueError("created_by is required")
+    now = _utcnow()
+    if expires_at:
+        expiry = _parse_directive_time(expires_at, "expires_at")
+    else:
+        ttl = int(ttl_seconds if ttl_seconds is not None else 3600)
+        if ttl <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        expiry = now + timedelta(seconds=ttl)
+    if expiry <= now:
+        raise ValueError("expires_at must be in the future")
+
+    with _directive_store_lock():
+        store = _load_directive_store_unlocked()
+        _expire_pending_directives_unlocked(store, now)
+        existing = _latest_directive_for_job(store, canonical_job_id)
+        if existing and existing.get("status") == "pending":
+            raise ValueError(f"job_id {canonical_job_id!r} already has a pending directive")
+        directive = {
+            "directive_id": str(uuid.uuid4()),
+            "job_id": canonical_job_id,
+            "directive_text": text,
+            "created_at": now.isoformat(),
+            "created_by": actor,
+            "expires_at": expiry.isoformat(),
+            "status": "pending",
+            "consumed_at": None,
+            "consumed_run_id": None,
+            "version": 1,
+        }
+        store.setdefault("directives", []).append(directive)
+        _save_directive_store_unlocked(store)
+    append_directive_event(
+        "created",
+        canonical_job_id,
+        directive["directive_id"],
+        {"created_by": actor, "expires_at": directive["expires_at"]},
+    )
+    return directive
+
+
+def inspect_operator_directive(job_id: str) -> Dict[str, Any]:
+    canonical_job_id = str(job_id or "").strip()
+    with _directive_store_lock():
+        store = _load_directive_store_unlocked()
+        _expire_pending_directives_unlocked(store)
+        _save_directive_store_unlocked(store)
+        directives = [
+            copy.deepcopy(d)
+            for d in store.get("directives", [])
+            if isinstance(d, dict) and d.get("job_id") == canonical_job_id
+        ]
+    return {
+        "job_id": canonical_job_id,
+        "current": directives[-1] if directives else None,
+        "directives": directives,
+    }
+
+
+def cancel_operator_directive(job_id: str) -> Dict[str, Any]:
+    canonical_job_id = str(job_id or "").strip()
+    with _directive_store_lock():
+        store = _load_directive_store_unlocked()
+        _expire_pending_directives_unlocked(store)
+        directive = _latest_directive_for_job(store, canonical_job_id)
+        if not directive:
+            raise ValueError(f"No directive found for job_id {canonical_job_id!r}")
+        _validate_directive_record(directive)
+        if directive.get("status") != "pending":
+            append_directive_event(
+                "cancelled",
+                canonical_job_id,
+                directive.get("directive_id"),
+                {"reason": f"cannot_cancel_status_{directive.get('status')}"},
+            )
+            raise CronDirectiveError(
+                f"Directive is not pending: {directive.get('status')}",
+                event_type="cancelled",
+                directive=directive,
+            )
+        directive["status"] = "cancelled"
+        directive["version"] = int(directive.get("version") or 1) + 1
+        _save_directive_store_unlocked(store)
+    append_directive_event("cancelled", canonical_job_id, directive.get("directive_id"), {"reason": "operator_cancelled"})
+    return copy.deepcopy(directive)
+
+
+def list_directive_events(
+    job_id: Optional[str] = None,
+    event_type: Optional[str] = None,
+    limit: int = 50,
+) -> List[Dict[str, Any]]:
+    ensure_dirs()
+    if not DIRECTIVE_EVENTS_FILE.exists():
+        return []
+    events: List[Dict[str, Any]] = []
+    with open(DIRECTIVE_EVENTS_FILE, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if job_id and event.get("job_id") != job_id:
+                continue
+            if event_type and event.get("event_type") != event_type:
+                continue
+            events.append(event)
+    return events[-max(1, int(limit or 50)):]
+
+
+def consume_operator_directive_for_run(
+    job_id: str,
+    run_id: str,
+    *,
+    directive_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return and atomically consume a valid pending directive, or None if absent."""
+    canonical_job_id = str(job_id or "").strip()
+    with _directive_store_lock():
+        store = _load_directive_store_unlocked()
+        now = _utcnow()
+        if directive_id:
+            directive = _find_directive(store, directive_id)
+        else:
+            directive = _latest_unconsumed_directive_for_job(store, canonical_job_id)
+        if directive is None:
+            if directive_id:
+                append_directive_event(
+                    "missing-in-supervised-context",
+                    canonical_job_id,
+                    directive_id,
+                    {"reason": "directive_id_not_found"},
+                )
+                raise CronDirectiveError(
+                    "Supervised operator directive was requested but not found",
+                    event_type="missing-in-supervised-context",
+                )
+            return None
+        try:
+            _validate_directive_record(directive)
+        except Exception as exc:
+            append_directive_event(
+                "invalid",
+                canonical_job_id,
+                directive.get("directive_id") if isinstance(directive, dict) else None,
+                {"reason": str(exc)},
+            )
+            raise CronDirectiveError(f"Invalid operator directive: {exc}", event_type="invalid", directive=directive if isinstance(directive, dict) else None) from exc
+        if directive.get("job_id") != canonical_job_id:
+            append_directive_event(
+                "mismatch",
+                canonical_job_id,
+                directive.get("directive_id"),
+                {"expected_job_id": directive.get("job_id"), "actual_job_id": canonical_job_id},
+            )
+            raise CronDirectiveError(
+                "Operator directive job_id does not match runner job_id",
+                event_type="mismatch",
+                directive=directive,
+            )
+        if directive.get("status") != "pending":
+            append_directive_event(
+                directive.get("status") if directive.get("status") in {"expired", "cancelled", "invalid"} else "invalid",
+                canonical_job_id,
+                directive.get("directive_id"),
+                {"reason": f"directive_status_{directive.get('status')}"},
+            )
+            raise CronDirectiveError(
+                f"Operator directive is not pending: {directive.get('status')}",
+                event_type=str(directive.get("status") or "invalid"),
+                directive=directive,
+            )
+        if _parse_directive_time(directive.get("expires_at"), "expires_at") <= now:
+            directive["status"] = "expired"
+            directive["version"] = int(directive.get("version") or 1) + 1
+            _save_directive_store_unlocked(store)
+            append_directive_event("expired", canonical_job_id, directive.get("directive_id"), {"reason": "ttl_expired"})
+            raise CronDirectiveError("Operator directive is expired", event_type="expired", directive=directive)
+
+        observed_version = int(directive["version"])
+        current = _find_directive(store, directive["directive_id"])
+        if current is None or current.get("version") != observed_version or current.get("status") != "pending":
+            append_directive_event(
+                "invalid",
+                canonical_job_id,
+                directive.get("directive_id"),
+                {"reason": "version_conflict", "observed_version": observed_version},
+            )
+            raise CronDirectiveError("Operator directive changed before consumption", event_type="invalid", directive=directive)
+        current["status"] = "consumed"
+        current["consumed_at"] = now.isoformat()
+        current["consumed_run_id"] = str(run_id or "")
+        current["version"] = observed_version + 1
+        consumed = copy.deepcopy(current)
+        _save_directive_store_unlocked(store)
+    append_directive_event(
+        "consumed",
+        canonical_job_id,
+        consumed.get("directive_id"),
+        {"run_id": run_id, "version": consumed.get("version")},
+    )
+    return consumed
+
+
+def reject_operator_directive_for_no_agent(job_id: str, run_id: str) -> Optional[Dict[str, Any]]:
+    """Fail closed when a directive exists for a no_agent job.
+
+    Operator directives require an agent runtime so there is nowhere safe to
+    inject directive_text for no_agent script-only jobs. If a directive was
+    written manually or by an older tool version, mark it invalid before the
+    script can run.
+    """
+    canonical_job_id = str(job_id or "").strip()
+    with _directive_store_lock():
+        store = _load_directive_store_unlocked()
+        directive = _latest_unconsumed_directive_for_job(store, canonical_job_id)
+        if directive is None:
+            return None
+        try:
+            _validate_directive_record(directive)
+        except Exception as exc:
+            append_directive_event(
+                "invalid",
+                canonical_job_id,
+                directive.get("directive_id") if isinstance(directive, dict) else None,
+                {"reason": str(exc), "run_id": run_id, "job_mode": "no_agent"},
+            )
+            raise CronDirectiveError(
+                f"Invalid operator directive for no_agent job: {exc}",
+                event_type="invalid",
+                directive=directive if isinstance(directive, dict) else None,
+            ) from exc
+        if directive.get("status") == "pending":
+            directive["status"] = "invalid"
+            directive["version"] = int(directive.get("version") or 1) + 1
+            _save_directive_store_unlocked(store)
+        append_directive_event(
+            "invalid",
+            canonical_job_id,
+            directive.get("directive_id"),
+            {
+                "reason": "no_agent_jobs_do_not_support_operator_directives",
+                "run_id": run_id,
+                "job_mode": "no_agent",
+                "directive_status": directive.get("status"),
+            },
+        )
+        raise CronDirectiveError(
+            "Operator directives require an agent runtime; no_agent jobs cannot consume directives",
+            event_type="invalid",
+            directive=directive,
+        )
 
 
 # =============================================================================

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -147,7 +147,16 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    CronDirectiveError,
+    append_directive_event,
+    consume_operator_directive_for_run,
+    get_due_jobs,
+    mark_job_run,
+    reject_operator_directive_for_no_agent,
+    save_job_output,
+    advance_next_run,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1001,7 +1010,11 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
-def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
+def _build_job_prompt(
+    job: dict,
+    prerun_script: Optional[tuple] = None,
+    operator_directive: Optional[str] = None,
+) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
     Args:
@@ -1011,6 +1024,8 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             When provided, the script is not re-executed and the cached
             result is used for prompt injection. When omitted, the script
             (if any) runs inline as before.
+        operator_directive: Optional one-time supervised directive consumed
+            from the cron directive store before prompt assembly.
     """
     prompt = str(job.get("prompt") or "")
     skills = job.get("skills")
@@ -1032,8 +1047,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     f"{prompt}"
                 )
             else:
-                # Script produced no output — nothing to report, skip AI call.
-                return None
+                if not operator_directive:
+                    # Script produced no output — nothing to report, skip AI call.
+                    return None
         else:
             prompt = (
                 "## Script Error\n"
@@ -1088,6 +1104,16 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
             except (OSError, PermissionError) as e:
                 logger.warning("context_from: failed to read output for job %r: %s", source_job_id, e)
                 # silent skip — do not pollute the prompt with error messages
+
+    if operator_directive:
+        prompt = (
+            "## Operator Directive\n"
+            "This run is supervised by an operator directive. Follow this "
+            "directive before any autonomous slice selection or prioritization.\n\n"
+            f"{operator_directive.strip()}\n\n"
+            "## Stored Job Prompt\n\n"
+            f"{prompt}"
+        )
 
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
@@ -1208,6 +1234,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         return _run_job_impl(job)
 
 
+def _directive_blocked_output(job: dict, job_name: str, message: str) -> str:
+    return (
+        f"# Cron Job: {job_name} (BLOCKED)\n\n"
+        f"**Job ID:** {job.get('id')}\n"
+        f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        f"**Schedule:** {job.get('schedule_display', 'N/A')}\n"
+        "**Status:** BLOCKED\n\n"
+        "The cron runner was halted before prompt finalization because an "
+        "operator directive was present but could not be used safely.\n\n"
+        f"**Directive error:** {message}\n"
+    )
+
+
 def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -1217,6 +1256,21 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    consumed_directive = None
+    _directive_failure_reported = False
+
+    def _record_consumed_directive_failure(error: str) -> None:
+        nonlocal _directive_failure_reported
+        if not consumed_directive or _directive_failure_reported:
+            return
+        append_directive_event(
+            "consumed-but-runner-failed",
+            job_id,
+            consumed_directive.get("directive_id"),
+            {"run_id": _cron_session_id, "error": str(error)},
+        )
+        _directive_failure_reported = True
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -1237,6 +1291,22 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     #                               the whole point of no_agent is that there
     #                               is no agent to wake
     if job.get("no_agent"):
+        try:
+            reject_operator_directive_for_no_agent(job_id, _cron_session_id)
+        except CronDirectiveError as directive_exc:
+            logger.error(
+                "Job '%s' (ID: %s): blocked by operator directive handoff — %s",
+                job_name,
+                job_id,
+                directive_exc,
+            )
+            return (
+                False,
+                _directive_blocked_output(job, job_name, str(directive_exc)),
+                "",
+                str(directive_exc),
+            )
+
         script_path = job.get("script")
         if not script_path:
             err = "no_agent=True but no script is set for this job"
@@ -1338,6 +1408,26 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     except Exception as e:
         logger.debug("Job '%s': SQLite session store not available: %s", job.get("id", "?"), e)
 
+    try:
+        consumed_directive = consume_operator_directive_for_run(
+            job_id,
+            _cron_session_id,
+            directive_id=job.get("operator_directive_id"),
+        )
+    except CronDirectiveError as directive_exc:
+        logger.error(
+            "Job '%s' (ID: %s): blocked by operator directive handoff — %s",
+            job_name,
+            job_id,
+            directive_exc,
+        )
+        return (
+            False,
+            _directive_blocked_output(job, job_name, str(directive_exc)),
+            "",
+            str(directive_exc),
+        )
+
     # Wake-gate: if this job has a pre-check script, run it BEFORE building
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
     # the whole agent run. We pass the result into _build_job_prompt so
@@ -1345,23 +1435,49 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script(script_path)
-        _ran_ok, _script_output = prerun_script
-        if _ran_ok and not _parse_wake_gate(_script_output):
-            logger.info(
-                "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
-                job_name, job_id,
-            )
-            silent_doc = (
-                f"# Cron Job: {job_name}\n\n"
-                f"**Job ID:** {job_id}\n"
-                f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
-                "Script gate returned `wakeAgent=false` — agent skipped.\n"
-            )
-            return True, silent_doc, SILENT_MARKER, None
+        try:
+            prerun_script = _run_job_script(script_path)
+            _ran_ok, _script_output = prerun_script
+            if _ran_ok and not consumed_directive and not _parse_wake_gate(_script_output):
+                logger.info(
+                    "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
+                    job_name, job_id,
+                )
+                silent_doc = (
+                    f"# Cron Job: {job_name}\n\n"
+                    f"**Job ID:** {job_id}\n"
+                    f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
+                    "Script gate returned `wakeAgent=false` — agent skipped.\n"
+                )
+                return True, silent_doc, SILENT_MARKER, None
+        except Exception as script_exc:
+            error_msg = f"{type(script_exc).__name__}: {script_exc}"
+            logger.exception("Job '%s' failed during pre-run script: %s", job_name, error_msg)
+            _record_consumed_directive_failure(error_msg)
+            output = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+
+## Error
+
+```
+{error_msg}
+```
+"""
+            return False, output, "", error_msg
 
     try:
-        prompt = _build_job_prompt(job, prerun_script=prerun_script)
+        prompt = _build_job_prompt(
+            job,
+            prerun_script=prerun_script,
+            operator_directive=(
+                consumed_directive.get("directive_text")
+                if consumed_directive
+                else None
+            ),
+        )
     except CronPromptInjectionBlocked as block_exc:
         # Assembled prompt (user prompt + loaded skill content) tripped the
         # injection scanner. Refuse to run the agent this tick and surface
@@ -1384,13 +1500,34 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "and the match is a false positive, rephrase the content to avoid "
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
+        _record_consumed_directive_failure(str(block_exc))
         return False, blocked_doc, "", str(block_exc)
+    except Exception as prompt_exc:
+        error_msg = f"{type(prompt_exc).__name__}: {prompt_exc}"
+        logger.exception("Job '%s' failed during prompt assembly: %s", job_name, error_msg)
+        _record_consumed_directive_failure(error_msg)
+        output = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+
+## Error
+
+```
+{error_msg}
+```
+"""
+        return False, output, "", error_msg
     if prompt is None:
+        if consumed_directive:
+            error_msg = "Prompt assembly returned no prompt after consuming an operator directive"
+            logger.error("Job '%s' failed: %s", job_name, error_msg)
+            _record_consumed_directive_failure(error_msg)
+            return False, _directive_blocked_output(job, job_name, error_msg), "", error_msg
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
         return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
-    _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
-
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
 
@@ -1793,6 +1930,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
+        _record_consumed_directive_failure(error_msg)
         
         output = f"""# Cron Job: {job_name} (FAILED)
 

--- a/tests/cron/test_operator_directives.py
+++ b/tests/cron/test_operator_directives.py
@@ -1,0 +1,335 @@
+import json
+import sys
+import types
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from cron.jobs import (
+    CronDirectiveError,
+    append_directive_event,
+    cancel_operator_directive,
+    consume_operator_directive_for_run,
+    create_operator_directive,
+    list_directive_events,
+)
+from cron.scheduler import _build_job_prompt, run_job
+
+
+@pytest.fixture(autouse=True)
+def _cron_paths(tmp_path, monkeypatch):
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr("cron.jobs.CRON_DIR", cron_dir)
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr("cron.jobs.DIRECTIVES_FILE", cron_dir / "directives.json")
+    monkeypatch.setattr("cron.jobs.DIRECTIVE_EVENTS_FILE", cron_dir / "directive_events.jsonl")
+    yield cron_dir
+
+
+def _job(job_id="job-a"):
+    return {
+        "id": job_id,
+        "name": "Directive test",
+        "prompt": "Pick the next autonomous slice.",
+        "schedule_display": "manual",
+    }
+
+
+def test_valid_directive_is_created_consumed_injected_and_audited(_cron_paths):
+    directive = create_operator_directive(
+        "job-a",
+        "Slice source: Operator-named: backend deployed-SHA exposure.",
+        "operator-test",
+        ttl_seconds=600,
+    )
+
+    consumed = consume_operator_directive_for_run("job-a", "cron_job-a_1")
+    assert consumed["directive_id"] == directive["directive_id"]
+    assert consumed["status"] == "consumed"
+    assert consumed["consumed_run_id"] == "cron_job-a_1"
+
+    prompt = _build_job_prompt(_job(), operator_directive=consumed["directive_text"])
+    assert "## Operator Directive" in prompt
+    assert "backend deployed-SHA exposure" in prompt
+    assert prompt.index("## Operator Directive") < prompt.index("Pick the next autonomous slice.")
+
+    events = list_directive_events(job_id="job-a")
+    assert [event["event_type"] for event in events] == ["created", "consumed"]
+    assert (_cron_paths / "directive_events.jsonl").exists()
+
+
+def test_consumed_directive_cannot_be_reused_by_id():
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+    consume_operator_directive_for_run("job-a", "cron_job-a_1")
+
+    with pytest.raises(CronDirectiveError) as exc:
+        consume_operator_directive_for_run(
+            "job-a",
+            "cron_job-a_2",
+            directive_id=directive["directive_id"],
+        )
+
+    assert "not pending" in str(exc.value)
+
+
+def test_concurrent_consumers_cannot_both_consume():
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+
+    def consume_once(run_id):
+        return consume_operator_directive_for_run("job-a", run_id)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(consume_once, ["cron_job-a_1", "cron_job-a_2"]))
+
+    consumed = [result for result in results if result is not None]
+    misses = [result for result in results if result is None]
+    assert len(consumed) == 1
+    assert len(misses) == 1
+    assert consumed[0]["directive_id"] == directive["directive_id"]
+    assert consumed[0]["status"] == "consumed"
+
+    events = list_directive_events(job_id="job-a", event_type="consumed")
+    assert len(events) == 1
+    assert events[0]["directive_id"] == directive["directive_id"]
+
+
+def test_expired_directive_fails_closed():
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+    store_path = Path("unused")
+    from cron import jobs as cron_jobs
+
+    store_path = cron_jobs.DIRECTIVES_FILE
+    data = json.loads(store_path.read_text(encoding="utf-8"))
+    data["directives"][0]["expires_at"] = "2000-01-01T00:00:00+00:00"
+    store_path.write_text(json.dumps(data), encoding="utf-8")
+
+    with pytest.raises(CronDirectiveError) as exc:
+        consume_operator_directive_for_run("job-a", "cron_job-a_1")
+
+    assert exc.value.event_type == "expired"
+    events = list_directive_events(job_id="job-a")
+    assert events[-1]["event_type"] == "expired"
+    assert events[-1]["directive_id"] == directive["directive_id"]
+
+
+def test_cancelled_directive_fails_closed():
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+    cancel_operator_directive("job-a")
+
+    with pytest.raises(CronDirectiveError) as exc:
+        consume_operator_directive_for_run("job-a", "cron_job-a_1")
+
+    assert exc.value.event_type == "cancelled"
+    events = list_directive_events(job_id="job-a")
+    assert events[-1]["event_type"] == "cancelled"
+    assert events[-1]["directive_id"] == directive["directive_id"]
+
+
+def test_mismatched_job_id_fails_closed():
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+
+    with pytest.raises(CronDirectiveError) as exc:
+        consume_operator_directive_for_run(
+            "job-b",
+            "cron_job-b_1",
+            directive_id=directive["directive_id"],
+        )
+
+    assert exc.value.event_type == "mismatch"
+    events = list_directive_events()
+    assert events[-1]["event_type"] == "mismatch"
+    assert events[-1]["context"]["actual_job_id"] == "job-b"
+
+
+def test_missing_explicit_supervised_directive_fails_closed():
+    with pytest.raises(CronDirectiveError) as exc:
+        consume_operator_directive_for_run(
+            "job-a",
+            "cron_job-a_1",
+            directive_id="missing-directive",
+        )
+
+    assert exc.value.event_type == "missing-in-supervised-context"
+    events = list_directive_events()
+    assert events[-1]["event_type"] == "missing-in-supervised-context"
+
+
+def test_unparseable_store_fails_closed_and_logs_parse_failed(_cron_paths):
+    from cron import jobs as cron_jobs
+
+    cron_jobs.ensure_dirs()
+    cron_jobs.DIRECTIVES_FILE.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(CronDirectiveError) as exc:
+        consume_operator_directive_for_run("job-a", "cron_job-a_1")
+
+    assert exc.value.event_type == "parse-failed"
+    events = list_directive_events()
+    assert events[-1]["event_type"] == "parse-failed"
+
+
+def test_autonomous_no_directive_remains_unchanged():
+    assert consume_operator_directive_for_run("job-a", "cron_job-a_1") is None
+    baseline = _build_job_prompt(_job())
+    unchanged = _build_job_prompt(_job(), operator_directive=None)
+    assert unchanged == baseline
+    assert "## Operator Directive" not in unchanged
+
+
+def test_supervised_directive_forces_prompt_when_script_output_empty():
+    job = {**_job(), "script": "noop.py"}
+    autonomous = _build_job_prompt(job, prerun_script=(True, ""), operator_directive=None)
+    supervised = _build_job_prompt(
+        job,
+        prerun_script=(True, ""),
+        operator_directive="Run the operator-named slice anyway.",
+    )
+
+    assert autonomous is None
+    assert supervised is not None
+    assert "Run the operator-named slice anyway." in supervised
+
+
+def test_consumed_directive_prompt_assembly_failure_audited_once(monkeypatch):
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=object),
+    )
+
+    def fail_build(*args, **kwargs):
+        raise RuntimeError("prompt assembly exploded")
+
+    monkeypatch.setattr("cron.scheduler._build_job_prompt", fail_build)
+
+    success, output, final_response, error = run_job(_job())
+
+    assert success is False
+    assert final_response == ""
+    assert "prompt assembly exploded" in error
+    assert "prompt assembly exploded" in output
+    events = list_directive_events(job_id="job-a", event_type="consumed-but-runner-failed")
+    assert len(events) == 1
+    assert events[0]["directive_id"] == directive["directive_id"]
+
+
+def test_consumed_directive_prerun_script_failure_audited_once(monkeypatch):
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=object),
+    )
+
+    def fail_script(*args, **kwargs):
+        raise RuntimeError("pre-run script exploded")
+
+    monkeypatch.setattr("cron.scheduler._run_job_script", fail_script)
+
+    success, output, final_response, error = run_job({**_job(), "script": "noop.py"})
+
+    assert success is False
+    assert final_response == ""
+    assert "pre-run script exploded" in error
+    assert "pre-run script exploded" in output
+    events = list_directive_events(job_id="job-a", event_type="consumed-but-runner-failed")
+    assert len(events) == 1
+    assert events[0]["directive_id"] == directive["directive_id"]
+
+
+def test_consumed_directive_agent_execution_failure_audited_once(monkeypatch):
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def run_conversation(self, prompt):
+            raise RuntimeError("agent execution exploded")
+
+        def close(self):
+            pass
+
+    class FakeSessionDB:
+        def end_session(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    class FakeAuthError(Exception):
+        pass
+
+    monkeypatch.setitem(
+        sys.modules,
+        "run_agent",
+        types.SimpleNamespace(AIAgent=FakeAgent),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_state",
+        types.SimpleNamespace(SessionDB=FakeSessionDB),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        types.SimpleNamespace(
+            resolve_runtime_provider=lambda **kwargs: {
+                "provider": "test",
+                "api_key": "test-key",
+                "base_url": "http://127.0.0.1",
+                "api_mode": "chat_completions",
+            },
+            format_runtime_provider_error=lambda exc: str(exc),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.auth",
+        types.SimpleNamespace(AuthError=FakeAuthError),
+    )
+    monkeypatch.setattr("cron.scheduler._deliver_result", lambda *args, **kwargs: None)
+
+    success, output, final_response, error = run_job(_job())
+
+    assert success is False
+    assert final_response == ""
+    assert "agent execution exploded" in error
+    assert "agent execution exploded" in output
+
+    consumed_events = list_directive_events(job_id="job-a", event_type="consumed")
+    assert len(consumed_events) == 1
+    assert consumed_events[0]["directive_id"] == directive["directive_id"]
+
+    failure_events = list_directive_events(job_id="job-a", event_type="consumed-but-runner-failed")
+    assert len(failure_events) == 1
+    assert failure_events[0]["directive_id"] == directive["directive_id"]
+
+
+def test_no_agent_job_with_manual_directive_fails_closed_before_script(monkeypatch):
+    directive = create_operator_directive("job-a", "Do the named slice.", "operator-test", ttl_seconds=600)
+
+    def script_should_not_run(*args, **kwargs):
+        raise AssertionError("no_agent script should not run when directive is present")
+
+    monkeypatch.setattr("cron.scheduler._run_job_script", script_should_not_run)
+    success, output, final_response, error = run_job({**_job(), "no_agent": True, "script": "noop.py"})
+
+    assert success is False
+    assert final_response == ""
+    assert "no_agent jobs cannot consume directives" in error
+    assert "BLOCKED" in output
+    events = list_directive_events(job_id="job-a", event_type="invalid")
+    assert len(events) == 1
+    assert events[0]["directive_id"] == directive["directive_id"]
+    assert events[0]["context"]["reason"] == "no_agent_jobs_do_not_support_operator_directives"
+
+
+def test_atomic_append_event_file_is_writable(_cron_paths):
+    append_directive_event("invalid", "job-a", "directive-x", {"reason": "dry-check"})
+    events_file = _cron_paths / "directive_events.jsonl"
+    assert events_file.exists()
+    assert json.loads(events_file.read_text(encoding="utf-8").strip())["event_type"] == "invalid"

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -213,6 +213,8 @@ class TestUnifiedCronjobTool:
         monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
         monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
         monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        monkeypatch.setattr("cron.jobs.DIRECTIVES_FILE", tmp_path / "cron" / "directives.json")
+        monkeypatch.setattr("cron.jobs.DIRECTIVE_EVENTS_FILE", tmp_path / "cron" / "directive_events.jsonl")
 
     def test_create_and_list(self):
         created = json.loads(
@@ -230,6 +232,60 @@ class TestUnifiedCronjobTool:
         assert listing["count"] == 1
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
+
+    def test_directive_tooling_round_trip(self):
+        created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))
+        job_id = created["job_id"]
+
+        directive_set = json.loads(
+            cronjob(
+                action="directive_set",
+                job_id=job_id,
+                directive_text="Slice source: Operator-named dry check.",
+                ttl_seconds=600,
+                created_by="pytest",
+            )
+        )
+        assert directive_set["success"] is True
+        assert directive_set["directive"]["job_id"] == job_id
+
+        inspected = json.loads(cronjob(action="directive_inspect", job_id=job_id))
+        assert inspected["success"] is True
+        assert inspected["current"]["status"] == "pending"
+
+        cancelled = json.loads(cronjob(action="directive_cancel", job_id=job_id))
+        assert cancelled["success"] is True
+        assert cancelled["directive"]["status"] == "cancelled"
+
+        events = json.loads(cronjob(action="directive_events", job_id=job_id))
+        assert events["success"] is True
+        assert [event["event_type"] for event in events["events"]] == [
+            "created",
+            "cancelled",
+        ]
+
+    def test_directive_set_rejects_no_agent_job(self):
+        from cron.jobs import create_job
+
+        job = create_job(
+            prompt="",
+            schedule="every 1h",
+            script="noop.py",
+            no_agent=True,
+        )
+
+        result = json.loads(
+            cronjob(
+                action="directive_set",
+                job_id=job["id"],
+                directive_text="Slice source: Operator-named dry check.",
+                ttl_seconds=600,
+                created_by="pytest",
+            )
+        )
+
+        assert result["success"] is False
+        assert "no_agent jobs" in result["error"]
 
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -22,8 +22,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cron.jobs import (
     AmbiguousJobReference,
+    cancel_operator_directive,
     create_job,
+    create_operator_directive,
     get_job,
+    inspect_operator_directive,
+    list_directive_events,
     list_jobs,
     parse_schedule,
     pause_job,
@@ -439,6 +443,12 @@ def cronjob(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    directive_text: Optional[str] = None,
+    expires_at: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+    created_by: Optional[str] = None,
+    event_type: Optional[str] = None,
+    limit: Optional[int] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -528,6 +538,21 @@ def cronjob(
             jobs = [_format_job(job) for job in list_jobs(include_disabled=include_disabled)]
             return json.dumps({"success": True, "count": len(jobs), "jobs": jobs}, indent=2)
 
+        if normalized in {"directive_events", "events", "audit_directives"}:
+            events = list_directive_events(
+                job_id=job_id,
+                event_type=event_type,
+                limit=limit or 50,
+            )
+            return json.dumps(
+                {
+                    "success": True,
+                    "count": len(events),
+                    "events": events,
+                },
+                indent=2,
+            )
+
         if not job_id:
             return tool_error(f"job_id is required for action '{normalized}'", success=False)
 
@@ -557,6 +582,32 @@ def cronjob(
             )
         # Resolve to canonical ID (supports name-based lookup)
         job_id = job["id"]
+
+        if normalized in {"directive_set", "set_directive"}:
+            if not directive_text:
+                return tool_error("directive_text is required for directive_set", success=False)
+            if job.get("no_agent"):
+                return tool_error(
+                    "directive_set is not supported for no_agent jobs because "
+                    "operator directives require an agent runtime.",
+                    success=False,
+                )
+            directive = create_operator_directive(
+                job_id,
+                directive_text,
+                created_by=created_by or "operator",
+                expires_at=expires_at,
+                ttl_seconds=ttl_seconds,
+            )
+            return json.dumps({"success": True, "directive": directive}, indent=2)
+
+        if normalized in {"directive_inspect", "inspect_directive"}:
+            state = inspect_operator_directive(job_id)
+            return json.dumps({"success": True, **state}, indent=2)
+
+        if normalized in {"directive_cancel", "cancel_directive"}:
+            directive = cancel_operator_directive(job_id)
+            return json.dumps({"success": True, "directive": directive}, indent=2)
 
         if normalized == "remove":
             removed = remove_job(job_id)
@@ -689,6 +740,7 @@ CRONJOB_SCHEMA = {
 Use action='create' to schedule a new job from a prompt or one or more skills.
 Use action='list' to inspect jobs.
 Use action='update', 'pause', 'resume', 'remove', or 'run' to manage an existing job.
+Use action='directive_set', 'directive_inspect', 'directive_cancel', or 'directive_events' to manage one-time operator directives.
 
 To stop a job the user no longer wants: first action='list' to find the job_id, then action='remove' with that job_id. Never guess job IDs — always list first.
 
@@ -706,7 +758,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run"
+                "description": "One of: create, list, update, pause, resume, remove, run, directive_set, directive_inspect, directive_cancel, directive_events"
             },
             "job_id": {
                 "type": "string",
@@ -800,6 +852,30 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": "Optional Hermes profile name to run the job under. When set, the scheduler resolves that profile, applies a context-local Hermes home override, loads that profile's config/.env for the run, and bridges HERMES_HOME into subprocesses. Any temporary process-environment changes from profile .env loading are restored after the job exits. Use 'default' for the root Hermes profile. Named profiles must already exist. When unset (default), preserves the scheduler's existing profile. On update, pass an empty string to clear. Jobs with profile run sequentially (not parallel) to keep profile-scoped runtime state isolated."
             },
+            "directive_text": {
+                "type": "string",
+                "description": "For directive_set: one-time operator directive text for the next supervised run of this job. A valid pending directive is consumed before prompt finalization and injected before autonomous slice selection."
+            },
+            "expires_at": {
+                "type": "string",
+                "description": "For directive_set: optional ISO-8601 expiry timestamp. Must be in the future. If omitted, ttl_seconds is used."
+            },
+            "ttl_seconds": {
+                "type": "integer",
+                "description": "For directive_set: optional directive TTL in seconds. Defaults to 3600 when expires_at is omitted."
+            },
+            "created_by": {
+                "type": "string",
+                "description": "For directive_set: operator/session identifier recorded in the directive audit trail. Defaults to 'operator'."
+            },
+            "event_type": {
+                "type": "string",
+                "description": "For directive_events: optional event type filter such as created, consumed, expired, cancelled, invalid, mismatch, parse-failed, or consumed-but-runner-failed."
+            },
+            "limit": {
+                "type": "integer",
+                "description": "For directive_events: maximum recent events to return. Defaults to 50."
+            },
         },
         "required": ["action"]
     }
@@ -856,6 +932,12 @@ registry.register(
         workdir=args.get("workdir"),
         profile=args.get("profile"),
         no_agent=args.get("no_agent"),
+        directive_text=args.get("directive_text"),
+        expires_at=args.get("expires_at"),
+        ttl_seconds=args.get("ttl_seconds"),
+        created_by=args.get("created_by"),
+        event_type=args.get("event_type"),
+        limit=args.get("limit"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
Fixes a gateway failure where the OpenAI SDK Responses stream parser raises TypeError when the ChatGPT Codex backend emits a completed response with output=None. Routes that condition to the existing create(stream=True) fallback path and preserves traceback logging for future provider failures.