### PR TITLE
[codex] fix(agent): preserve Codex recovered stream usage

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -113,10 +113,23 @@ def _responses_null_output_iterable_error(exc: BaseException) -> bool:
     return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
 
 
-def _responses_backfilled_response(output_items: List[Any], text_parts: List[str], *, has_function_calls: bool, model: str = None) -> Optional[Any]:
+def _responses_usage_from_exception(exc: BaseException) -> Any:
+    """Extract terminal Responses usage from the SDK traceback if available."""
+    tb = exc.__traceback__
+    while tb:
+        event = tb.tb_frame.f_locals.get("sse_event")
+        response = getattr(event, "response", None)
+        usage = getattr(response, "usage", None) if response is not None else None
+        if usage is not None:
+            return usage
+        tb = tb.tb_next
+    return None
+
+
+def _responses_backfilled_response(output_items: List[Any], text_parts: List[str], *, has_function_calls: bool, model: str = None, usage: Any = None) -> Optional[Any]:
     """Build a minimal Responses-like object from already streamed events."""
     if output_items:
-        return SimpleNamespace(output=list(output_items), usage=None, status="completed", model=model)
+        return SimpleNamespace(output=list(output_items), usage=usage, status="completed", model=model)
     if text_parts and not has_function_calls:
         assembled = "".join(text_parts)
         return SimpleNamespace(
@@ -126,7 +139,7 @@ def _responses_backfilled_response(output_items: List[Any], text_parts: List[str
                 status="completed",
                 content=[SimpleNamespace(type="output_text", text=assembled)],
             )],
-            usage=None,
+            usage=usage,
             status="completed",
             model=model,
         )
@@ -848,6 +861,7 @@ class _CodexCompletionsAdapter:
                         collected_text_deltas,
                         has_function_calls=has_function_calls,
                         model=resp_kwargs.get("model"),
+                        usage=_responses_usage_from_exception(exc),
                     )
                     if final is None:
                         raise

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -182,12 +182,25 @@ def _responses_null_output_iterable_error(exc: BaseException) -> bool:
     return isinstance(exc, TypeError) and "NoneType" in text and "not iterable" in text
 
 
-def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str = None):
+def _responses_usage_from_exception(exc: BaseException) -> Any:
+    """Extract terminal Responses usage from the SDK traceback if available."""
+    tb = exc.__traceback__
+    while tb:
+        event = tb.tb_frame.f_locals.get("sse_event")
+        response = getattr(event, "response", None)
+        usage = getattr(response, "usage", None) if response is not None else None
+        if usage is not None:
+            return usage
+        tb = tb.tb_next
+    return None
+
+
+def _codex_backfilled_response(output_items: list, text_parts: list, *, has_tool_calls: bool, model: str = None, usage: Any = None):
     """Build a minimal Responses-like object from events already streamed."""
     if output_items:
         return SimpleNamespace(
             output=list(output_items),
-            usage=None,
+            usage=usage,
             status="completed",
             model=model,
         )
@@ -321,6 +334,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                     agent._codex_streamed_text_parts,
                     has_tool_calls=has_tool_calls,
                     model=api_kwargs.get("model"),
+                    usage=_responses_usage_from_exception(exc),
                 )
                 if recovered is not None:
                     logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2562,6 +2562,11 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
             type="message",
             content=[SimpleNamespace(type="output_text", text="aux survived")],
         )
+        usage = SimpleNamespace(
+            input_tokens=17,
+            output_tokens=23,
+            total_tokens=40,
+        )
 
         class NullOutputParseStream:
             def __enter__(self):
@@ -2572,6 +2577,10 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
 
             def __iter__(self):
                 yield SimpleNamespace(type="response.output_item.done", item=output_item)
+                sse_event = SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(output=None, usage=usage),
+                )
                 raise TypeError("'NoneType' object is not iterable")
 
             def get_final_response(self):  # pragma: no cover - iterator fails first
@@ -2590,6 +2599,9 @@ class TestCodexAuxiliaryAdapterNullOutputRecovery:
         response = adapter.create(messages=[{"role": "user", "content": "summarize"}])
 
         assert response.choices[0].message.content == "aux survived"
+        assert response.usage.prompt_tokens == 17
+        assert response.usage.completion_tokens == 23
+        assert response.usage.total_tokens == 40
         fake_client.responses.create.assert_not_called()
 
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -189,8 +189,9 @@ class _FakeCreateStream:
 class _IteratorTypeErrorStream:
     """Mimic the SDK raising while parsing response.completed.output=None."""
 
-    def __init__(self, events_before_error):
+    def __init__(self, events_before_error, *, terminal_event=None):
         self._events_before_error = list(events_before_error)
+        self._terminal_event = terminal_event
 
     def __enter__(self):
         return self
@@ -201,6 +202,7 @@ class _IteratorTypeErrorStream:
     def __iter__(self):
         for event in self._events_before_error:
             yield event
+        sse_event = self._terminal_event
         raise TypeError("'NoneType' object is not iterable")
 
     def get_final_response(self):  # pragma: no cover - iterator fails first
@@ -517,13 +519,22 @@ def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(mo
         status="completed",
         content=[SimpleNamespace(type="output_text", text="stream item survived")],
     )
+    usage = SimpleNamespace(
+        input_tokens=17,
+        output_tokens=23,
+        total_tokens=40,
+    )
     calls = {"stream": 0}
 
     def _fake_stream(**kwargs):
         calls["stream"] += 1
-        return _IteratorTypeErrorStream([
-            SimpleNamespace(type="response.output_item.done", item=output_item),
-        ])
+        return _IteratorTypeErrorStream(
+            [SimpleNamespace(type="response.output_item.done", item=output_item)],
+            terminal_event=SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(output=None, usage=usage),
+            ),
+        )
 
     def _unexpected_create(**kwargs):  # pragma: no cover - recovery should avoid fallback call
         raise AssertionError("create fallback should not be needed when output items were collected")
@@ -537,6 +548,7 @@ def test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output(mo
     assert calls["stream"] == 1
     assert response.output == [output_item]
     assert response.status == "completed"
+    assert response.usage is usage
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary

- preserve terminal `response.completed.response.usage` when recovering Codex Responses streams after `response.output = null`
- carry recovered usage through both the main Codex stream path and auxiliary Codex adapter
- add regressions that reproduce iterator-time SDK `TypeError` recovery while asserting exact usage is retained

## Root Cause

#32963 recovers already-streamed output when the OpenAI SDK raises `TypeError: 'NoneType' object is not iterable` while parsing a terminal Codex Responses event with `output = null`.

That terminal event can still contain accurate `usage`, but the synthesized recovered response used `usage=None`, so token accounting state such as `context_compressor.last_prompt_tokens`, session counters, and footer/context display could remain at `0`.

## Validation

```text
python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_codex_stream_falls_back_when_stream_iteration_parses_null_output tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterNullOutputRecovery::test_recovers_output_item_when_sdk_raises_during_iteration -q
# 2 passed

python -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_auxiliary_client.py -q
# 243 passed
```

Fixes #33019
