### PR TITLE
refactor(docker): drop build-essential from apt install (#27507)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # hermes process, the dashboard, and per-profile gateways.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
+    curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 # ---------- s6-overlay install ----------


### PR DESCRIPTION
Salvages #27507 (@emonty).

Drops `build-essential` from the apt install line. The Dockerfile already
installs `gcc + python3-dev + libffi-dev` explicitly, which covers the C-ext
compile paths `lazy_deps` may hit at first boot. `g++`, `make`, and `dpkg-dev`
(the rest of what `build-essential` pulls in) aren't reached by the resolved
`[all] + [messaging]` dependency tree on current `main`.

## Validation

Built both variants `--no-cache` against current `origin/main` (`81a4f280d`)
and ran the same smoke battery on each.

### Image size

| | size | layers |
|---|---|---|
| baseline (`origin/main`) | 3,272,362,571 B (3.05 GiB) | 25 |
| salvage (this PR)        | 3,206,599,975 B (2.99 GiB) | 25 |
| **delta**                | **63 MiB (-2.01%)**         | 0 |

### Smoke tests (identical on both images)

- `hermes --version` → `Hermes Agent v0.14.0 (2026.5.16)`
- `hermes_cli` imports cleanly inside the venv
- `_tui_need_npm_install()` returns `False` (no runtime npm reinstall)
- `hermes --tui` non-interactive path → clean no-TTY exit
- `tools.lazy_deps` imports (runtime ext-install path intact)
- `gcc --version` → `gcc (Debian 14.2.0-19) 14.2.0` (still present)

The only behavioral delta between the two images is `make` no longer
present in the salvage. `make` wasn't used by any current
`Dockerfile`/`.dockerignore`/build step or by any sdist in the resolved
`[all] + [messaging]` dependency tree (verified via `uv sync --frozen
--dry-run`).

### Trade-off

This reduces the runtime safety margin for `lazy_deps`. If a future
optional extra (a user's lazy-installed package) ever pulls an sdist that
needs `make` or `g++` at first-use, the install would fail with
`/bin/sh: make: not found`. Today none of the lazy-install candidates in
`tools/lazy_deps.py` hit that path, but worth noting if the universe of
lazy-installable packages broadens.

### Authorship

Original change by @emonty in #27507. Their branch was on a pre-s6-overlay
base and the cherry-pick conflicted with a much larger commit that
reverted s6-overlay → tini; reconstructed just the stated `build-essential`
removal against current `main` and preserved attribution via
`Co-authored-by:`.

Closes #27507.
