### PR TITLE
fix(codex): handle output=None from chatgpt.com response.completed

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -251,7 +251,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -862,6 +862,61 @@ class TestCodexStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == 3
 
+    def test_codex_stream_backfills_output_when_final_response_output_is_none(self):
+        """Regression: chatgpt.com/backend-api/codex omits the ``output`` field
+        from its ``response.completed`` SSE payload, so the OpenAI SDK builds
+        a Response where ``output is None`` (not ``[]``). The backfill guard
+        must treat ``None`` the same as the empty-list case or downstream
+        code crashes with ``'NoneType' object is not iterable``.
+        """
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        streamed_item = SimpleNamespace(
+            type="message",
+            role="assistant",
+            status="completed",
+            content=[SimpleNamespace(type="output_text", text="Hi!")],
+        )
+        events = [
+            SimpleNamespace(type="response.output_text.delta", delta="Hi"),
+            SimpleNamespace(type="response.output_text.delta", delta="!"),
+            SimpleNamespace(type="response.output_item.done", item=streamed_item),
+            SimpleNamespace(type="response.completed", delta=""),
+        ]
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.__iter__ = MagicMock(return_value=iter(events))
+        # Simulate the chatgpt.com codex backend behavior: response.completed
+        # SSE payload has no ``output`` key, so the SDK's Response object
+        # ends up with ``output = None``.
+        mock_stream.get_final_response.return_value = SimpleNamespace(
+            output=None,
+            status="completed",
+        )
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = mock_stream
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response.output is not None, (
+            "Backfill must populate output when final_response.output is None"
+        )
+        assert response.output == [streamed_item]
+
     def test_codex_remote_protocol_error_falls_back_to_create_stream(self):
         from run_agent import AIAgent
         import httpx


### PR DESCRIPTION
  ## Summary

  The `chatgpt.com/backend-api/codex` SSE stream omits the `output` field entirely from its `response.completed` event payload. The OpenAI SDK parses this into a `Response` object where
  `output is None` (not `[]`).

  The existing backfill at `agent/codex_runtime.py:254` only triggers when `output == []`, so the `None` case slipped through and downstream code crashed with `TypeError: 'NoneType' object
  is not iterable` — observed on every `gpt-5.x-codex` turn against a ChatGPT account, completely blocking the codex provider for affected users.

  ## Symptom

  ⚠️   API call failed (attempt 1/3): TypeError
     🔌 Provider: openai-codex  Model: gpt-5.3-codex
     🌐 Endpoint: https://chatgpt.com/backend-api/codex
     📝 Error: 'NoneType' object is not iterable
  ❌ Non-retryable client error (HTTP None): 'NoneType' object is not iterable

  The `HTTP None` is the giveaway — there's no HTTP status because the stream closed cleanly and the parser died on the SDK response object, not on the wire.

  ## Root cause

  Captured the raw SSE stream from `chatgpt.com/backend-api/codex/responses` with curl and compared event payloads:

  - `response.created` → `response.output = []`
  - `response.output_item.done` → streams the actual message item(s)
  - `response.completed` → 35 keys present, **no `output` field at all**

  The OpenAI SDK's `stream.get_final_response()` builds the final Response from the `response.completed` event, so `output` ends up `None`. The PATCH block at `codex_runtime.py:250-272` was
  written for the case where the same backend sometimes returns `output=[]`, but the guard `isinstance(_out, list) and not _out` returns `False` for `None`, so the backfill is skipped and
  the caller iterates `None`.

  ## Fix

  One-line guard change:

  ```python
  # before
  if isinstance(_out, list) and not _out:
  # after
  if _out is None or (isinstance(_out, list) and not _out):

  The already-collected response.output_item.done items (or text-delta synthesis path) now populate final_response.output in both the empty-list and None cases.

  Test plan

  - [x] New regression test test_codex_stream_backfills_output_when_final_response_output_is_none in tests/run_agent/test_streaming.py mocks the chatgpt.com behavior (get_final_response()
  returns output=None with response.output_item.done events in the stream) and asserts the backfill runs.
  - [x] Test fails on main, passes with the fix.
  - [x] Full TestCodexStreamCallbacks suite still passes (5/5).
  - [x] Manually verified end-to-end: hermes -z "hello" against an affected ChatGPT-auth codex profile (gpt-5.3-codex) returns a response instead of crashing.
