### PR TITLE
fix(codex): tolerate None response.output from chatgpt.com backend

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -245,7 +245,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
                         logger.debug(
@@ -329,6 +329,26 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 )
                 return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             raise
+        except TypeError as exc:
+            # OpenAI SDK bug (openai/lib/_parsing/_responses.py: ``for output
+            # in response.output:``): the accumulator's parse_response()
+            # iterates ``response.output`` without guarding for None, so when
+            # the chatgpt.com backend-api streams an accumulated snapshot
+            # whose output field is None, the SDK raises ``TypeError:
+            # 'NoneType' object is not iterable`` mid-iteration and the
+            # whole stream dies.  The create(stream=True) fallback
+            # consumes raw SSE events via getattr(event, "response", None)
+            # and never invokes parse_response, so it sidesteps the bug.
+            err_text = str(exc)
+            if "not iterable" not in err_text:
+                raise
+            logger.debug(
+                "Codex Responses stream hit SDK None-output accumulator bug; "
+                "falling back to create(stream=True). %s err=%s",
+                agent._client_log_context(),
+                err_text,
+            )
+            return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
 
 
 
@@ -408,7 +428,7 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is not None:
                 # Backfill empty output from collected stream events
                 _out = getattr(terminal_response, "output", None)
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
                         logger.debug(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1125,8 +1125,17 @@ def run_conversation(
                                 error_details.append(f"response.status={_codex_resp_status}: {_codex_error_msg}")
                             else:
                                 # output_text fallback: stream backfill may have failed
-                                # but normalize can still recover from output_text
-                                _out_text = getattr(response, "output_text", None)
+                                # but normalize can still recover from output_text.
+                                # The SDK's Response.output_text property iterates
+                                # self.output without a None guard (openai/types/
+                                # responses/response.py), so calling it when output
+                                # is None raises TypeError instead of returning the
+                                # documented empty string.  getattr() only catches
+                                # AttributeError, not arbitrary getter exceptions.
+                                try:
+                                    _out_text = getattr(response, "output_text", None)
+                                except TypeError:
+                                    _out_text = None
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:
                                     logger.debug(


### PR DESCRIPTION
## Summary

Around 2026-05-26 the `chatgpt.com/backend-api/codex` Responses endpoint
started streaming accumulated snapshots whose `response.output` field
arrives as `None` rather than a list. The OpenAI SDK does not guard
against this in three places, and the entire Codex API call dies with

```
TypeError: 'NoneType' object is not iterable
```

…before any tool turn can run. Three guards added — none touch the
documented public OpenAI Responses API path, only the chatgpt.com
private endpoint shape that hermes already reverse-engineers against.

## What broke

1. **SDK stream accumulator.** `responses.stream(...)` → `__stream__`
   → `accumulate_event` → `parse_response` iterates
   `response.output` at `openai/lib/_parsing/_responses.py:61`. With
   `output=None` it raises mid-iteration and `_run_codex_stream`'s
   `for event in stream:` loop blows up.

2. **Hermes' empty-output backfill.** `run_codex_stream` and
   `run_codex_create_stream_fallback` both already handle the case
   where chatgpt.com returns the final response with an empty
   `output` list (the existing comment: _"The Codex backend can
   return empty output when the answer was delivered entirely via
   stream events"_) — but the guard was `isinstance(_out, list) and
   not _out`, so `output is None` skipped the backfill and returned
   the broken response to the caller.

3. **conversation_loop `output_text` recovery.** When validation
   sees an empty/None `output`, the code tries
   `getattr(response, "output_text", None)` as a last-resort
   recovery. But the SDK's `Response.output_text` property (see
   `openai/types/responses/response.py`) also iterates
   `self.output` without a None guard. `getattr(..., default)`
   only catches `AttributeError`, so the property's TypeError
   propagates and aborts the whole turn.

## What this PR does

```diff
 # agent/codex_runtime.py: run_codex_stream — None-vs-[] backfill
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):

 # agent/codex_runtime.py: run_codex_stream — catch SDK None-output crash
+        except TypeError as exc:
+            err_text = str(exc)
+            if "not iterable" not in err_text:
+                raise
+            return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)

 # agent/codex_runtime.py: run_codex_create_stream_fallback — same None-vs-[]
-                if isinstance(_out, list) and not _out:
+                if _out is None or (isinstance(_out, list) and not _out):

 # agent/conversation_loop.py: output_text TypeError guard
-                                _out_text = getattr(response, "output_text", None)
+                                try:
+                                    _out_text = getattr(response, "output_text", None)
+                                except TypeError:
+                                    _out_text = None
```

The TypeError fallback routes to `run_codex_create_stream_fallback`
because that path consumes raw SSE events via
`getattr(event, "response", None)` and never calls `parse_response`
— it sidesteps the SDK bug entirely. Matches the prior pattern used
for `RuntimeError("Expected to have received response.created")`
prelude errors and missing-`response.completed` postlude errors.

## Test plan

- [x] Apply patches to a live gateway running v0.14.0 (2026.5.16).
- [x] Confirm the `grafana-anomaly-alerts` cron job (which hits the
  bug on every tick due to reasoning replay across a 100+ message
  conversation history) succeeds end-to-end:
  - Before: every tick dies at ~5s with `TypeError: 'NoneType'
    object is not iterable` before any tool call runs.
  - After: ticks complete normally (6 Codex calls + 5 tool turns
    + delivery in ~4 min, validated across multiple consecutive
    runs).
- [x] No upstream-clean code paths touched — diff is exclusively
  the chatgpt.com private-endpoint resilience.
- [ ] Unit test for `output is None` backfill (open question — let
  me know if the maintainers want one and I'll add it; the related
  `output == []` case doesn't seem to have explicit coverage either).

## Notes

- The OpenAI SDK has the same bug on the documented public Responses
  API too — it just hasn't fired because `api.openai.com/v1/responses`
  doesn't (yet) send `output=None`. Worth a separate upstream issue
  against `openai/openai-python` for the None guards in both
  `parse_response()` and the `Response.output_text` property.
- No SDK upgrade needed for this fix — the route-around in
  `codex_runtime.py` and the property guard in `conversation_loop.py`
  cover both paths the SDK exposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)