### PR TITLE
fix(acp): recover silently lost tool completion events with retry mechanism

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -89,8 +89,11 @@ def _send_update(
     session_id: str,
     loop: asyncio.AbstractEventLoop,
     update: Any,
-) -> None:
-    """Fire-and-forget an ACP session update from a worker thread."""
+) -> bool:
+    """Send an ACP session update from a worker thread with recovery support.
+
+    Returns True on success, False on failure.
+    """
     from agent.async_utils import safe_schedule_threadsafe
 
     future = safe_schedule_threadsafe(
@@ -100,11 +103,18 @@ def _send_update(
         log_message="Failed to send ACP update",
     )
     if future is None:
-        return
+        return False
     try:
         future.result(timeout=5)
+        return True
     except Exception:
-        logger.debug("Failed to send ACP update", exc_info=True)
+        logger.warning(
+            "Failed to send ACP update for session %s: %s",
+            session_id,
+            type(update).__name__,
+            exc_info=True
+        )
+        return False
 
 
 # ------------------------------------------------------------------
@@ -248,8 +258,18 @@ def make_step_cb(
                         function_args=function_args or meta.get("args"),
                         snapshot=meta.get("snapshot"),
                     )
-                    _send_update(conn, session_id, loop, update)
-                    if tool_name == "todo":
+                    sent = _send_update(conn, session_id, loop, update)
+                    if not sent:
+                        # Re-queue for retry on next step callback
+                        queue.appendleft(tc_id)
+                        tool_call_meta[tc_id] = meta
+                        logger.warning(
+                            "Re-queued tool completion %s for retry (session %s, tool %s)",
+                            tc_id,
+                            session_id,
+                            tool_name
+                        )
+                    elif tool_name == "todo":
                         plan_update = _build_plan_update_from_todo_result(result)
                         if plan_update is not None:
                             _send_update(conn, session_id, loop, plan_update)

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -420,3 +420,56 @@ class TestSendUpdate:
             and "_session_update" in str(w.message)
         ]
         assert runtime_warnings == []
+
+class TestSendUpdateRetry(unittest.TestCase):
+    """Test _send_update retry and recovery mechanism."""
+
+    def test_send_update_returns_bool(self):
+        """Verify _send_update returns True on success, False on failure."""
+        import acp
+        from unittest.mock import MagicMock, patch
+        import asyncio
+
+        conn = MagicMock(spec=acp.Client)
+        conn.session_update = MagicMock(return_value=asyncio.sleep(0))
+        session_id = "test-session"
+        loop = asyncio.new_event_loop()
+
+        # Test successful send
+        from acp_adapter.events import _send_update
+        update = {"type": "test"}
+        result = _send_update(conn, session_id, loop, update)
+        self.assertTrue(result)
+
+        loop.close()
+
+    def test_failed_send_update_logs_warning(self):
+        """Verify failed _send_update logs at WARNING level."""
+        import acp
+        from unittest.mock import MagicMock, patch
+        import asyncio
+
+        conn = MagicMock(spec=acp.Client)
+        # Simulate timeout
+        async def slow_update():
+            await asyncio.sleep(10)
+        conn.session_update = MagicMock(return_value=slow_update())
+        session_id = "test-session"
+        loop = asyncio.new_event_loop()
+
+        from acp_adapter.events import _send_update
+        update = {"type": "test"}
+
+        with patch("acp_adapter.events.logger") as mock_logger:
+            result = _send_update(conn, session_id, loop, update)
+            self.assertFalse(result)
+            # Verify warning was logged
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0]
+            self.assertIn("Failed to send ACP update", call_args[0])
+
+        loop.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import gc
+import unittest
 import warnings
 from concurrent.futures import Future
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -424,51 +425,60 @@ class TestSendUpdate:
 class TestSendUpdateRetry(unittest.TestCase):
     """Test _send_update retry and recovery mechanism."""
 
-    def test_send_update_returns_bool(self):
-        """Verify _send_update returns True on success, False on failure."""
-        import acp
+    def test_send_update_returns_true_on_success(self):
+        """Verify _send_update returns True when safe_schedule_threadsafe succeeds."""
         from unittest.mock import MagicMock, patch
-        import asyncio
+        from concurrent.futures import Future
 
-        conn = MagicMock(spec=acp.Client)
-        conn.session_update = MagicMock(return_value=asyncio.sleep(0))
+        conn = MagicMock()
         session_id = "test-session"
-        loop = asyncio.new_event_loop()
-
-        # Test successful send
-        from acp_adapter.events import _send_update
-        update = {"type": "test"}
-        result = _send_update(conn, session_id, loop, update)
-        self.assertTrue(result)
-
-        loop.close()
-
-    def test_failed_send_update_logs_warning(self):
-        """Verify failed _send_update logs at WARNING level."""
-        import acp
-        from unittest.mock import MagicMock, patch
-        import asyncio
-
-        conn = MagicMock(spec=acp.Client)
-        # Simulate timeout
-        async def slow_update():
-            await asyncio.sleep(10)
-        conn.session_update = MagicMock(return_value=slow_update())
-        session_id = "test-session"
-        loop = asyncio.new_event_loop()
-
-        from acp_adapter.events import _send_update
+        loop = MagicMock()
         update = {"type": "test"}
 
-        with patch("acp_adapter.events.logger") as mock_logger:
+        # Create a resolved future
+        resolved = Future()
+        resolved.set_result(None)
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", return_value=resolved):
+            from acp_adapter.events import _send_update
+            result = _send_update(conn, session_id, loop, update)
+            self.assertTrue(result)
+
+    def test_send_update_returns_false_on_schedule_failure(self):
+        """Verify _send_update returns False when safe_schedule_threadsafe returns None."""
+        from unittest.mock import MagicMock, patch
+
+        conn = MagicMock()
+        session_id = "test-session"
+        loop = MagicMock()
+        update = {"type": "test"}
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", return_value=None):
+            from acp_adapter.events import _send_update
             result = _send_update(conn, session_id, loop, update)
             self.assertFalse(result)
-            # Verify warning was logged
-            mock_logger.warning.assert_called_once()
-            call_args = mock_logger.warning.call_args[0]
-            self.assertIn("Failed to send ACP update", call_args[0])
 
-        loop.close()
+    def test_send_update_returns_false_on_timeout(self):
+        """Verify _send_update returns False and logs warning on timeout."""
+        from unittest.mock import MagicMock, patch
+        from concurrent.futures import Future
+
+        conn = MagicMock()
+        session_id = "test-session"
+        loop = MagicMock()
+        update = {"type": "test"}
+
+        # Create a future that raises TimeoutError
+        failed = Future()
+        failed.set_exception(TimeoutError())
+
+        with patch("agent.async_utils.safe_schedule_threadsafe", return_value=failed):
+            with patch("acp_adapter.events.logger") as mock_logger:
+                from acp_adapter.events import _send_update
+                result = _send_update(conn, session_id, loop, update)
+                self.assertFalse(result)
+                mock_logger.warning.assert_called_once()
+                self.assertIn("Failed to send ACP update", mock_logger.warning.call_args[0][0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

When Hermes Agent is connected to an ACP client (AionUI, VS Code, Zed, JetBrains), tool completion events can be **silently lost** due to a fire-and-forget pattern with silent exception swallowing in `acp_adapter/events.py`. This causes the ACP client to display tools as permanently "in progress" with no recovery path, even though the tool has already completed on the agent side.

The root cause involved two layers of silently swallowed failures:

1. **`_send_update()`** — fire-and-forget with 5s timeout + silent exception (DEBUG-level log)
2. **`make_step_cb()`** — tool call ID and metadata popped from queues before sending, no retry mechanism

## Related Issue

Fixes #33023

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence

- **Analyzed**: `acp_adapter/events.py` (`_send_update`, `make_step_cb`)
- **Blast radius**: LOW-MEDIUM
  - Direct impact: ACP adapter only (acp clients: AionUI, VS Code, Zed, JetBrains)
  - No changes to agent core or other adapters
- **Related patterns**: 
  - Fire-and-forget pattern is common in async adapters; this fix makes it recoverable
  - Retry-on-failure pattern matches existing patterns in `gateway/platforms/*` adapters

## Checklist

- [x] Code compiles without errors
- [x] Regression tests added for new behavior
- [x] Follows existing code style and patterns
- [x] PR body includes Code Intelligence section
- [x] Fix is minimal and focused on the reported issue