### PR TITLE
fix(docker): targeted chown to preserve host file ownership in HERMES_HOME (#19795)

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -33,6 +33,14 @@ if [ -n "${HERMES_GID:-}" ] && [ "$HERMES_GID" != "$(id -g hermes)" ]; then
 fi
 
 # --- Fix ownership of data volume ---
+# When HERMES_UID is remapped or the top-level $HERMES_HOME isn't owned by
+# the runtime hermes UID, restore ownership to hermes — but ONLY for the
+# directories hermes actually writes to. The full $HERMES_HOME may be a
+# host-mounted bind containing unrelated user files; `chown -R` would
+# silently destroy host ownership of those (see issue #19788).
+#
+# The canonical list of hermes-owned subdirs is the same one the s6-setuidgid
+# mkdir -p block below seeds. Keep them in sync if the seed list changes.
 actual_hermes_uid=$(id -u hermes)
 needs_chown=false
 if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "10000" ]; then
@@ -41,14 +49,29 @@ elif [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; the
     needs_chown=true
 fi
 if [ "$needs_chown" = true ]; then
-    echo "[stage2] Fixing ownership of $HERMES_HOME to hermes ($actual_hermes_uid)"
+    echo "[stage2] Fixing ownership of $HERMES_HOME (targeted) to hermes ($actual_hermes_uid)"
     # In rootless Podman the container's "root" is mapped to an
     # unprivileged host UID — chown will fail. That's fine: the volume
     # is already owned by the mapped user on the host side.
-    chown -R hermes:hermes "$HERMES_HOME" 2>/dev/null || \
-        echo "[stage2] Warning: chown failed (rootless container?) — continuing"
+    #
+    # Top-level $HERMES_HOME: chown the directory itself (not its contents)
+    # so hermes can mkdir new subdirs but bind-mounted host files keep
+    # their existing ownership.
+    chown hermes:hermes "$HERMES_HOME" 2>/dev/null || \
+        echo "[stage2] Warning: chown $HERMES_HOME failed (rootless container?) — continuing"
+    # Hermes-owned subdirs: recursive chown is safe here because these are
+    # created and managed exclusively by hermes (see the s6-setuidgid mkdir
+    # -p block below for the canonical list).
+    for sub in cron sessions logs hooks memories skills skins plans workspace home profiles; do
+        if [ -e "$HERMES_HOME/$sub" ]; then
+            chown -R hermes:hermes "$HERMES_HOME/$sub" 2>/dev/null || \
+                echo "[stage2] Warning: chown $HERMES_HOME/$sub failed (rootless container?) — continuing"
+        fi
+    done
     # The .venv must also be re-chowned when UID is remapped, otherwise
     # lazy_deps.py cannot install platform packages (discord.py, etc.).
+    # This is under $INSTALL_DIR, not $HERMES_HOME, so the bind-mount
+    # concern doesn't apply — recursive is fine.
     chown -R hermes:hermes "$INSTALL_DIR/.venv" 2>/dev/null || \
         echo "[stage2] Warning: chown .venv failed (rootless container?) — continuing"
 fi


### PR DESCRIPTION
Salvages #19795 (@ptichalouf, issue #19788).

## Problem

`docker/stage2-hook.sh` does `chown -R hermes:hermes "$HERMES_HOME"` whenever
the runtime hermes UID doesn't match the directory owner (typically: on first
boot or when `HERMES_UID` is remapped). When `$HERMES_HOME` is a bind-mounted
host directory that contains files not managed by hermes, the recursive
chown silently rewrites every file's ownership — destroying host-side file
ownership permanently.

## Fix

Targeted chown:

- **Top-level `$HERMES_HOME`** itself is chowned (not its contents), so hermes
  can `mkdir` new subdirs.
- **Hermes-owned subdirs** get recursive chown — these are the same dirs
  seeded by the `s6-setuidgid mkdir -p` block below
  (`cron sessions logs hooks memories skills skins plans workspace home profiles`).
- **Everything else** in `$HERMES_HOME` (host files, host subdirs) keeps its
  original ownership.

## Validation

Built three images: baseline (`origin/main`), the salvage in this PR, and ran
the same chown E2E harness against each.

The E2E harness:
1. Creates a host dir with a pre-existing host-owned `HOST_FILE.txt` and a
   `host-owned-subdir/note.txt`
2. Mounts it as `/opt/data` and runs `docker run -e HERMES_UID=12345 --version`
3. Inspects post-run ownership from inside the volume (via root-privileged
   helper container — host UID can no longer stat into a 12345-owned dir)

### Baseline (`origin/main`, current behavior)

```
✓ stage2 chown path triggered: [stage2] Fixing ownership of /opt/data to hermes (12345)
✗ HOST_FILE.txt UID changed (1000 → 12345) — BUG #19788 PRESENT
✗ host-owned-subdir/note.txt UID changed (1000 → 12345) — recursive chown leaked
✓ HOST_FILE.txt content preserved (only the metadata, not the bytes)
✓ $HERMES_HOME/cron owned by 12345 (the remapped hermes UID)

Result: 5 pass, 2 fail — bug reproduces cleanly
```

### Salvage (this PR)

```
✓ stage2 chown path triggered: [stage2] Fixing ownership of /opt/data (targeted) to hermes (12345)
✓ HOST_FILE.txt UID preserved (1000 → 1000) — bug #19788 not present
✓ host-owned-subdir/note.txt UID preserved (1000 → 1000)
✓ HOST_FILE.txt content preserved verbatim
✓ $HERMES_HOME/cron owned by 12345 (the remapped hermes UID)
✓ top-level $HERMES_HOME chowned to 12345 (hermes can create new subdirs)

Result: 7 pass, 0 fail
```

Also confirmed via the standard image smoke battery (6/6 pass): `--version`,
`hermes_cli` import inside venv, `_tui_need_npm_install: False`, `--tui`
no-TTY exit, `tools.lazy_deps` imports, `gcc` still present.

## Authorship

Original change by @ptichalouf in #19795. Their branch targeted
`docker/entrypoint.sh` (a deprecated shim since the s6-overlay rework — the
real cont-init logic moved to `docker/stage2-hook.sh`); retargeted the
fix accordingly. Preserved attribution via `Co-authored-by:`.

Closes #19795.
Fixes #19788.
