### PR TITLE
fix(codex): harden fallback stream null-output recovery

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -484,6 +484,28 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                             len(collected_text_deltas),
                         )
                 return terminal_response
+    except TypeError as exc:
+        if not _responses_null_output_iterable_error(exc):
+            raise
+        recovered = _codex_backfilled_response(
+            collected_output_items,
+            collected_text_deltas,
+            has_tool_calls=has_tool_calls,
+            model=fallback_kwargs.get("model"),
+        )
+        if recovered is not None:
+            logger.warning(
+                "Codex fallback stream: SDK TypeError recovered from "
+                "collected events (items=%d, text_parts=%d). error=%s",
+                len(collected_output_items),
+                len(collected_text_deltas),
+                exc,
+            )
+            return recovered
+        raise RuntimeError(
+            f"Codex fallback stream failed with null output and no "
+            f"collected events to recover from: {exc}"
+        ) from exc
     finally:
         close_fn = getattr(stream_or_response, "close", None)
         if callable(close_fn):

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2822,6 +2822,10 @@ def run_conversation(
                 # provider/network failure (malformed response body,
                 # truncated stream, routing layer corruption), not a
                 # local programming bug, and should be retried (#14782).
+                _is_sdk_nonetype_bug = (
+                    isinstance(api_error, TypeError)
+                    and "'NoneType' object is not iterable" in str(api_error)
+                )
                 is_local_validation_error = (
                     isinstance(api_error, (ValueError, TypeError))
                     and not isinstance(
@@ -2835,6 +2839,7 @@ def run_conversation(
                     # ssl.SSLError explicitly so the error classifier's
                     # retryable=True mapping takes effect instead.
                     and not isinstance(api_error, ssl.SSLError)
+                    and not _is_sdk_nonetype_bug
                 )
                 # ``FailoverReason.billing`` (HTTP 402) is NOT in this
                 # exclusion set.  By the time we reach this block:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2041,3 +2041,84 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     # IDs must be stripped — with store=False the API 404s on id lookups.
     for it in reasoning_items:
         assert "id" not in it
+
+
+class _CreateStreamTypeError:
+    """Like _FakeCreateStream but raises TypeError partway through iteration."""
+
+    def __init__(self, events_before_error):
+        self._events = list(events_before_error)
+        self.closed = False
+
+    def __iter__(self):
+        for event in self._events:
+            yield event
+        raise TypeError("'NoneType' object is not iterable")
+
+    def close(self):
+        self.closed = True
+
+
+def test_run_codex_create_stream_fallback_typeerror_recovers_with_deltas(monkeypatch):
+    """Fallback path itself hits SDK TypeError but has collected deltas to recover from."""
+    agent = _build_agent(monkeypatch)
+    output_item = SimpleNamespace(
+        type="message",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="recovered text")],
+    )
+    create_stream = _CreateStreamTypeError([
+        SimpleNamespace(type="response.output_item.done", item=output_item),
+    ])
+
+    def _fake_create(**kwargs):
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+
+    response = agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert response.output == [output_item]
+    assert response.status == "completed"
+    assert create_stream.closed is True
+
+
+def test_run_codex_create_stream_fallback_typeerror_no_data_raises_runtime(monkeypatch):
+    """Fallback path hits SDK TypeError with no collected events — must raise RuntimeError."""
+    agent = _build_agent(monkeypatch)
+    create_stream = _CreateStreamTypeError([])
+
+    def _fake_create(**kwargs):
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create),
+    )
+
+    with pytest.raises(RuntimeError, match="null output"):
+        agent._run_codex_create_stream_fallback(_codex_request_kwargs())
+    assert create_stream.closed is True
+
+
+def test_run_codex_stream_no_deltas_typeerror_falls_back_to_create(monkeypatch):
+    """When run_codex_stream gets TypeError with no collected deltas, it should
+    fall back to create(stream=True) instead of re-raising."""
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _IteratorTypeErrorStream([])
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        return _codex_message_response("create fallback recovered")
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=_fake_stream, create=_fake_create),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert calls["create"] == 1
+    assert response.output[0].content[0].text == "create fallback recovered"


### PR DESCRIPTION
## Summary

Harden the Codex Responses `create(stream=True)` fallback against the same SDK null-output crash handled by the main stream path.

The previous null-output recovery can still fall through when the fallback iterator itself raises `TypeError: 'NoneType' object is not iterable`, especially before a terminal response object is available. This PR recovers from collected stream events when possible and turns the no-data case into a retryable runtime failure instead of treating it as a local validation/programming error.

## Changes

- Catch the SDK null-output `TypeError` inside `run_codex_create_stream_fallback()`.
- Recover from collected `response.output_item.done` or text delta events when fallback streaming crashes.
- Raise a clearer `RuntimeError` when fallback streaming crashes with no collected events to recover from.
- Exclude this SDK null-output TypeError from the conversation loop's local validation error classification so it can follow retry/fallback handling.
- Add regression coverage for fallback recovery, no-data failure, and main stream fallback-to-create behavior.

## Validation

- `uv run --with pytest --with pytest-timeout --with pytest-asyncio python -m pytest tests/run_agent/test_run_agent_codex_responses.py`
- Result: `69 passed in 60.74s`

## Notes

This replacement branch is rebased onto the latest `NousResearch/main` (`1e5884e38`) and intentionally contains only one target commit / three changed files, avoiding the broad fork history diff that affected the closed PR.