### PR TITLE
fix(codex): urgently recover when streamed terminal output is null

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -791,30 +791,128 @@ class _CodexCompletionsAdapter:
             collected_output_items: List[Any] = []
             collected_text_deltas: List[str] = []
             has_function_calls = False
+            terminal_event_response = None
             if total_timeout:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
             with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
+                try:
+                    for _event in stream:
+                        _check_cancelled()
+                        _etype = getattr(_event, "type", "")
+                        if _etype == "response.output_item.done":
+                            _done = getattr(_event, "item", None)
+                            if _done is not None:
+                                collected_output_items.append(_done)
+                        elif "output_text.delta" in _etype:
+                            _delta = getattr(_event, "delta", "")
+                            if _delta:
+                                collected_text_deltas.append(_delta)
+                        elif "function_call" in _etype:
+                            has_function_calls = True
+                        elif _etype == "response.completed":
+                            terminal_event_response = getattr(_event, "response", None)
                     _check_cancelled()
-                    _etype = getattr(_event, "type", "")
-                    if _etype == "response.output_item.done":
-                        _done = getattr(_event, "item", None)
-                        if _done is not None:
-                            collected_output_items.append(_done)
-                    elif "output_text.delta" in _etype:
-                        _delta = getattr(_event, "delta", "")
-                        if _delta:
-                            collected_text_deltas.append(_delta)
-                    elif "function_call" in _etype:
-                        has_function_calls = True
-                _check_cancelled()
-                final = stream.get_final_response()
+                    try:
+                        final = stream.get_final_response()
+                    except TypeError as exc:
+                        if (
+                            str(exc) == "'NoneType' object is not iterable"
+                            and terminal_event_response is not None
+                        ):
+                            logger.debug(
+                                "Codex auxiliary: recovered from SDK final-response parse failure using terminal event payload"
+                            )
+                            final = terminal_event_response
+                        else:
+                            raise
+                except TypeError as exc:
+                    if str(exc) == "'NoneType' object is not iterable":
+                        logger.warning(
+                            "Codex SDK parser bug detected in auxiliary stream: terminal response carried output=None after streamed items/text. Recovering from streamed payload."
+                        )
+                        if terminal_event_response is not None:
+                            logger.debug(
+                                "Codex auxiliary: recovered from SDK parser failure using terminal event payload"
+                            )
+                            final = terminal_event_response
+                            _terminal_output = getattr(final, "output", None)
+                            if collected_output_items and (not isinstance(_terminal_output, list) or not _terminal_output):
+                                final.output = list(collected_output_items)
+                            elif collected_text_deltas and not has_function_calls and (not isinstance(_terminal_output, list) or not _terminal_output):
+                                assembled = "".join(collected_text_deltas)
+                                _status = getattr(terminal_event_response, "status", None)
+                                logger.debug(
+                                    "Codex auxiliary: recovered from SDK parser failure using %d streamed text deltas (%d chars)",
+                                    len(collected_text_deltas), len(assembled),
+                                )
+                                _message_kwargs = {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [SimpleNamespace(type="output_text", text=assembled)],
+                                }
+                                if isinstance(_status, str) and _status.strip():
+                                    _message_kwargs["status"] = _status.strip()
+                                final.output = [SimpleNamespace(**_message_kwargs)]
+                            elif getattr(final, "output", None) is None:
+                                final.output = []
+                        elif collected_output_items:
+                            logger.debug(
+                                "Codex auxiliary: recovered from SDK parser failure using %d collected output items",
+                                len(collected_output_items),
+                            )
+                            _response_kwargs: dict[str, Any] = {"output": list(collected_output_items)}
+                            _status = next(
+                                (
+                                    _item_status
+                                    for item in collected_output_items
+                                    for _item_status in [getattr(item, "status", None)]
+                                    if isinstance(_item_status, str) and _item_status.strip()
+                                ),
+                                None,
+                            )
+                            if isinstance(_status, str) and _status.strip():
+                                _response_kwargs["status"] = _status.strip()
+                            final = SimpleNamespace(**_response_kwargs)
+                        elif collected_text_deltas and not has_function_calls:
+                            assembled = "".join(collected_text_deltas)
+                            _status = getattr(terminal_event_response, "status", None)
+                            logger.debug(
+                                "Codex auxiliary: recovered from SDK parser failure using %d streamed text deltas (%d chars)",
+                                len(collected_text_deltas), len(assembled),
+                            )
+                            _message_kwargs = {
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [SimpleNamespace(type="output_text", text=assembled)],
+                            }
+                            if isinstance(_status, str) and _status.strip():
+                                _message_kwargs["status"] = _status.strip()
+                            _response_kwargs: dict[str, Any] = {
+                                "output": [SimpleNamespace(**_message_kwargs)],
+                            }
+                            _usage = getattr(terminal_event_response, "usage", None)
+                            if isinstance(_status, str) and _status.strip():
+                                _response_kwargs["status"] = _status.strip()
+                            if _usage is not None:
+                                _response_kwargs["usage"] = _usage
+                            final = SimpleNamespace(**_response_kwargs)
+                        else:
+                            raise
+                    else:
+                        raise
 
-            # Backfill empty output from collected stream events
+            # Backfill output from collected stream events
             _output = getattr(final, "output", None)
+            if collected_output_items and not isinstance(_output, list):
+                final.output = list(collected_output_items)
+                logger.debug(
+                    "Codex auxiliary: backfilled %d output items after missing/non-list terminal output",
+                    len(collected_output_items),
+                )
+                _output = final.output
             if isinstance(_output, list) and not _output:
                 if collected_output_items:
                     final.output = list(collected_output_items)
@@ -827,10 +925,15 @@ class _CodexCompletionsAdapter:
                     # a function_call response with incidental text should not
                     # be collapsed into a plain-text message.
                     assembled = "".join(collected_text_deltas)
-                    final.output = [SimpleNamespace(
-                        type="message", role="assistant", status="completed",
-                        content=[SimpleNamespace(type="output_text", text=assembled)],
-                    )]
+                    _message_kwargs = {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [SimpleNamespace(type="output_text", text=assembled)],
+                    }
+                    _status = getattr(final, "status", None)
+                    if isinstance(_status, str) and _status.strip():
+                        _message_kwargs["status"] = _status.strip()
+                    final.output = [SimpleNamespace(**_message_kwargs)]
                     logger.debug(
                         "Codex auxiliary: synthesized from %d deltas (%d chars)",
                         len(collected_text_deltas), len(assembled),

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -192,6 +192,7 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
         if agent._interrupt_requested:
             raise InterruptedError("Agent interrupted before Codex stream retry")
         collected_output_items: list = []
+        terminal_event_response = None
         try:
             with active_client.responses.stream(**api_kwargs) as stream:
                 for event in stream:
@@ -246,11 +247,41 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             sum(len(p) for p in agent._codex_streamed_text_parts),
                             agent._client_log_context(),
                         )
-                final_response = stream.get_final_response()
+                    elif event_type == "response.completed":
+                        terminal_event_response = getattr(event, "response", None)
+                try:
+                    final_response = stream.get_final_response()
+                except TypeError as exc:
+                    # openai-python 2.24.0 assumes the terminal response always
+                    # includes ``output`` and crashes with
+                    # ``'NoneType' object is not iterable`` when the ChatGPT
+                    # Codex backend emits ``response.completed`` carrying
+                    # ``response.output=None`` even though the real items were
+                    # already streamed via ``response.output_item.done``.
+                    if (
+                        str(exc) == "'NoneType' object is not iterable"
+                        and terminal_event_response is not None
+                    ):
+                        logger.debug(
+                            "Codex stream: recovered from SDK final-response parse failure using "
+                            "terminal event payload. %s",
+                            agent._client_log_context(),
+                        )
+                        final_response = terminal_event_response
+                    else:
+                        raise
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.
                 _out = getattr(final_response, "output", None)
+                if collected_output_items and not isinstance(_out, list):
+                    final_response.output = list(collected_output_items)
+                    logger.debug(
+                        "Codex stream: backfilled %d output items from stream events after "
+                        "missing/non-list terminal output",
+                        len(collected_output_items),
+                    )
+                    _out = final_response.output
                 if isinstance(_out, list) and not _out:
                     if collected_output_items:
                         final_response.output = list(collected_output_items)
@@ -260,12 +291,15 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                         )
                     elif agent._codex_streamed_text_parts and not has_tool_calls:
                         assembled = "".join(agent._codex_streamed_text_parts)
-                        final_response.output = [SimpleNamespace(
-                            type="message",
-                            role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
+                        _message_kwargs = {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [SimpleNamespace(type="output_text", text=assembled)],
+                        }
+                        _status = getattr(final_response, "status", None)
+                        if isinstance(_status, str) and _status.strip():
+                            _message_kwargs["status"] = _status.strip()
+                        final_response.output = [SimpleNamespace(**_message_kwargs)]
                         logger.debug(
                             "Codex stream: synthesized output from %d text deltas (%d chars)",
                             len(agent._codex_streamed_text_parts), len(assembled),
@@ -287,6 +321,82 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                 exc,
             )
             return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+        except TypeError as exc:
+            # openai-python 2.24.0 parses ``response.completed`` eagerly while
+            # iterating the stream and crashes with ``'NoneType' object is not
+            # iterable`` when the ChatGPT Codex backend supplies
+            # ``response.output=None``.  By the time this trips we've often
+            # already received the real payload via ``response.output_item.done``
+            # and/or text deltas, so salvage those first to avoid replaying the
+            # whole turn and duplicating streamed text in the UI.
+            if str(exc) == "'NoneType' object is not iterable":
+                logger.warning(
+                    "Codex SDK parser bug detected: stream raised TypeError because the terminal response carried output=None after streamed items/text. Recovering from streamed payload. %s",
+                    agent._client_log_context(),
+                )
+                if terminal_event_response is not None:
+                    logger.debug(
+                        "Codex stream: recovered from SDK parser failure using terminal event payload. %s",
+                        agent._client_log_context(),
+                    )
+                    final_response = terminal_event_response
+                    _out = getattr(final_response, "output", None)
+                    if collected_output_items and (not isinstance(_out, list) or not _out):
+                        final_response.output = list(collected_output_items)
+                    elif agent._codex_streamed_text_parts and not has_tool_calls and (not isinstance(_out, list) or not _out):
+                        assembled = "".join(agent._codex_streamed_text_parts)
+                        _message_kwargs = {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [SimpleNamespace(type="output_text", text=assembled)],
+                        }
+                        _status = getattr(final_response, "status", None)
+                        if isinstance(_status, str) and _status.strip():
+                            _message_kwargs["status"] = _status.strip()
+                        final_response.output = [SimpleNamespace(**_message_kwargs)]
+                    elif getattr(final_response, "output", None) is None:
+                        final_response.output = []
+                    return final_response
+                if collected_output_items:
+                    logger.debug(
+                        "Codex stream: recovered from SDK parser failure using %d collected output items. %s",
+                        len(collected_output_items),
+                        agent._client_log_context(),
+                    )
+                    _response_kwargs: dict[str, Any] = {"output": list(collected_output_items)}
+                    _status = next(
+                        (
+                            _item_status
+                            for item in collected_output_items
+                            for _item_status in [getattr(item, "status", None)]
+                            if isinstance(_item_status, str) and _item_status.strip()
+                        ),
+                        None,
+                    )
+                    if isinstance(_status, str) and _status.strip():
+                        _response_kwargs["status"] = _status.strip()
+                    return SimpleNamespace(**_response_kwargs)
+                if agent._codex_streamed_text_parts and not has_tool_calls:
+                    assembled = "".join(agent._codex_streamed_text_parts)
+                    logger.debug(
+                        "Codex stream: recovered from SDK parser failure using %d streamed text deltas (%d chars). %s",
+                        len(agent._codex_streamed_text_parts),
+                        len(assembled),
+                        agent._client_log_context(),
+                    )
+                    return SimpleNamespace(
+                        output=[SimpleNamespace(
+                            type="message",
+                            role="assistant",
+                            content=[SimpleNamespace(type="output_text", text=assembled)],
+                        )],
+                    )
+                logger.debug(
+                    "Codex stream parser failed before any salvageable items arrived; falling back to create(stream=True). %s",
+                    agent._client_log_context(),
+                )
+                return agent._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            raise
         except RuntimeError as exc:
             err_text = str(exc)
             missing_completed = "response.completed" in err_text
@@ -412,8 +522,18 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
             if terminal_response is None and isinstance(event, dict):
                 terminal_response = event.get("response")
             if terminal_response is not None:
-                # Backfill empty output from collected stream events
+                # Backfill output from collected stream events. The ChatGPT
+                # Codex backend can emit ``response.completed`` with
+                # ``response.output=None`` even when the real payload already
+                # arrived via ``response.output_item.done``.
                 _out = getattr(terminal_response, "output", None)
+                if collected_output_items and not isinstance(_out, list):
+                    terminal_response.output = list(collected_output_items)
+                    logger.debug(
+                        "Codex fallback stream: backfilled %d output items after missing/non-list terminal output",
+                        len(collected_output_items),
+                    )
+                    _out = terminal_response.output
                 if isinstance(_out, list) and not _out:
                     if collected_output_items:
                         terminal_response.output = list(collected_output_items)
@@ -423,11 +543,15 @@ def run_codex_create_stream_fallback(agent, api_kwargs: dict, client: Any = None
                         )
                     elif collected_text_deltas:
                         assembled = "".join(collected_text_deltas)
-                        terminal_response.output = [SimpleNamespace(
-                            type="message", role="assistant",
-                            status="completed",
-                            content=[SimpleNamespace(type="output_text", text=assembled)],
-                        )]
+                        _message_kwargs = {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [SimpleNamespace(type="output_text", text=assembled)],
+                        }
+                        _status = getattr(terminal_response, "status", None)
+                        if isinstance(_status, str) and _status.strip():
+                            _message_kwargs["status"] = _status.strip()
+                        terminal_response.output = [SimpleNamespace(**_message_kwargs)]
                         logger.debug(
                             "Codex fallback stream: synthesized from %d deltas (%d chars)",
                             len(collected_text_deltas), len(assembled),

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -20,6 +20,7 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -165,6 +166,9 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
 
+    terminal_event_response = None
+    collected_output_items: list[Any] = []
+
     with client.responses.stream(
         model=_CODEX_CHAT_MODEL,
         store=False,
@@ -189,23 +193,72 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
             "tools": [{"type": "image_generation"}],
         },
     ) as stream:
-        for event in stream:
-            event_type = getattr(event, "type", "")
-            if event_type == "response.output_item.done":
-                item = getattr(event, "item", None)
-                if getattr(item, "type", None) == "image_generation_call":
-                    result = getattr(item, "result", None)
-                    if isinstance(result, str) and result:
-                        image_b64 = result
-            elif event_type == "response.image_generation_call.partial_image":
-                partial = getattr(event, "partial_image_b64", None)
-                if isinstance(partial, str) and partial:
-                    image_b64 = partial
-        final = stream.get_final_response()
+        try:
+            for event in stream:
+                event_type = getattr(event, "type", "")
+                if event_type == "response.output_item.done":
+                    item = getattr(event, "item", None)
+                    if item is not None:
+                        collected_output_items.append(item)
+                    if getattr(item, "type", None) == "image_generation_call":
+                        result = getattr(item, "result", None)
+                        if isinstance(result, str) and result:
+                            image_b64 = result
+                elif event_type == "response.image_generation_call.partial_image":
+                    partial = getattr(event, "partial_image_b64", None)
+                    if isinstance(partial, str) and partial:
+                        image_b64 = partial
+                elif event_type == "response.completed":
+                    terminal_event_response = getattr(event, "response", None)
+            try:
+                final = stream.get_final_response()
+            except TypeError as exc:
+                if (
+                    str(exc) == "'NoneType' object is not iterable"
+                    and terminal_event_response is not None
+                ):
+                    final = terminal_event_response
+                else:
+                    raise
+        except TypeError as exc:
+            if str(exc) == "'NoneType' object is not iterable":
+                logger.warning(
+                    "Codex SDK parser bug detected in image_generation stream: terminal response carried output=None after streamed items. Recovering from streamed payload."
+                )
+                if terminal_event_response is not None:
+                    final = terminal_event_response
+                    _terminal_output = getattr(final, "output", None)
+                    if collected_output_items and (not isinstance(_terminal_output, list) or not _terminal_output):
+                        final.output = list(collected_output_items)
+                    elif getattr(final, "output", None) is None:
+                        final.output = []
+                elif collected_output_items:
+                    _response_kwargs: dict[str, Any] = {"output": list(collected_output_items)}
+                    _status = next(
+                        (
+                            _item_status
+                            for item in collected_output_items
+                            for _item_status in [getattr(item, "status", None)]
+                            if isinstance(_item_status, str) and _item_status.strip()
+                        ),
+                        None,
+                    )
+                    if isinstance(_status, str) and _status.strip():
+                        _response_kwargs["status"] = _status.strip()
+                    final = SimpleNamespace(**_response_kwargs)
+                else:
+                    raise
+            else:
+                raise
+
+    output_items = getattr(final, "output", None)
+    if collected_output_items and not isinstance(output_items, list):
+        final.output = list(collected_output_items)
+        output_items = final.output
 
     # Final-response sweep covers the case where the stream finished before
     # we observed the ``output_item.done`` event for the image call.
-    for item in getattr(final, "output", None) or []:
+    for item in output_items or []:
         if getattr(item, "type", None) == "image_generation_call":
             result = getattr(item, "result", None)
             if isinstance(result, str) and result:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2371,6 +2371,158 @@ class TestCodexAdapterReasoningTranslation:
         assert captured.get("reasoning") == {"effort": "medium", "summary": "auto"}
         assert captured.get("include") == ["reasoning.encrypted_content"]
 
+    def test_recovers_when_sdk_final_parse_hits_none_output(self):
+        """Auxiliary Codex calls use ``responses.stream()`` too, so they must
+        recover from the SDK's ``TypeError`` when ChatGPT Codex emits a
+        terminal response with ``output=None`` despite having streamed the real
+        ``response.output_item.done`` payload already.
+        """
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+        completed_response = SimpleNamespace(
+            output=None,
+            status="completed",
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+        )
+
+        class _FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def __iter__(self):
+                return iter([
+                    SimpleNamespace(type="response.output_item.done", item=message_item),
+                    SimpleNamespace(type="response.completed", response=completed_response),
+                ])
+
+            def get_final_response(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        real_client = MagicMock()
+        real_client.responses.stream = lambda **kwargs: _FakeStream()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.3-codex")
+
+        resp = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert resp.choices[0].message.content == "hi"
+        assert resp.usage.total_tokens == 2
+
+    def test_recovers_when_sdk_raises_during_iteration(self):
+        """The SDK can raise the same parser error during stream iteration,
+        before ``get_final_response()`` runs. The adapter should still salvage
+        the already-collected output item instead of bubbling the TypeError.
+        """
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+
+        class _BrokenIterStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=message_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        real_client = MagicMock()
+        real_client.responses.stream = lambda **kwargs: _BrokenIterStream()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.3-codex")
+
+        resp = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert resp.choices[0].message.content == "hi"
+
+    def test_iteration_parse_failure_preserves_item_status_when_no_terminal_response(self):
+        """If only streamed output items survive the parser crash, preserve
+        any item-level status instead of inventing a bare success object.
+        """
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        message_item = SimpleNamespace(
+            type="message",
+            status="incomplete",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+
+        class _BrokenIterStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=message_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        real_client = MagicMock()
+        real_client.responses.stream = lambda **kwargs: _BrokenIterStream()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.3-codex")
+
+        resp = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert resp.choices[0].message.content == "hi"
+
+    def test_iteration_parse_failure_prefers_terminal_event_payload_when_seen(self):
+        """If the terminal response event was already observed before the SDK
+        crashes, keep that object so recovered usage/status metadata survive.
+        """
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="hi")],
+        )
+        terminal_response = SimpleNamespace(
+            output=None,
+            status="incomplete",
+            usage=SimpleNamespace(input_tokens=7, output_tokens=4, total_tokens=11),
+        )
+
+        class _BrokenAfterCompletedStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=message_item)
+                yield SimpleNamespace(type="response.completed", response=terminal_response)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        real_client = MagicMock()
+        real_client.responses.stream = lambda **kwargs: _BrokenAfterCompletedStream()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.3-codex")
+
+        resp = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+        assert resp is not None
+        assert resp.choices[0].message.content == "hi"
+        assert resp.usage.total_tokens == 11
+
 
 class TestVisionAutoSkipsKimiCoding:
     """_resolve_auto vision branch skips providers that have no vision on

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -245,6 +245,125 @@ class TestGenerate:
         assert result["success"] is True
         assert Path(result["image"]).exists()
 
+    def test_completed_event_with_none_output_recovers_image(self, provider, monkeypatch):
+        """ChatGPT Codex can send ``response.completed`` with
+        ``response.output=None``; the plugin should recover from the streamed
+        ``response.output_item.done`` event instead of crashing inside the SDK.
+        """
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        output_item = SimpleNamespace(
+            type="image_generation_call",
+            status="completed",
+            id="ig_final",
+            result=_b64_png(),
+        )
+        terminal_response = SimpleNamespace(output=None, status="completed", output_text="")
+
+        class _BrokenFinalStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter([
+                    SimpleNamespace(type="response.output_item.done", item=output_item),
+                    SimpleNamespace(type="response.completed", response=terminal_response),
+                ])
+
+            def get_final_response(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        fake_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                stream=lambda **kwargs: _BrokenFinalStream()
+            )
+        )
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert Path(result["image"]).exists()
+
+    def test_iteration_parse_failure_recovers_image(self, provider, monkeypatch):
+        """The SDK can raise the ``NoneType`` parser failure while iterating
+        the stream, before ``get_final_response()`` is called. The plugin
+        should still recover the streamed image_generation item.
+        """
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        output_item = SimpleNamespace(
+            type="image_generation_call",
+            status="completed",
+            id="ig_iter",
+            result=_b64_png(),
+        )
+
+        class _BrokenIterStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=output_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        fake_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                stream=lambda **kwargs: _BrokenIterStream()
+            )
+        )
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert Path(result["image"]).exists()
+
+    def test_partial_image_only_typeerror_with_terminal_none_output_keeps_preview(self, provider, monkeypatch):
+        """If only preview frames arrived before the SDK trips on a terminal
+        response carrying ``output=None``, keep the latest partial image rather
+        than throwing the preview away."""
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        partial_event = SimpleNamespace(
+            type="response.image_generation_call.partial_image",
+            partial_image_b64=_b64_png(),
+        )
+        terminal_response = SimpleNamespace(output=None, status="completed", output_text="")
+
+        class _BrokenPartialOnlyStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield partial_event
+                yield SimpleNamespace(type="response.completed", response=terminal_response)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        fake_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                stream=lambda **kwargs: _BrokenPartialOnlyStream()
+            )
+        )
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert Path(result["image"]).exists()
+
     def test_empty_response_returns_error(self, provider, monkeypatch):
         monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
 

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -862,6 +862,200 @@ class TestCodexStreamCallbacks:
 
         assert touch_calls.count("receiving stream response") == 3
 
+    def test_codex_stream_recovers_when_sdk_final_parse_hits_none_output(self):
+        """chatgpt.com/backend-api/codex can emit ``response.completed`` with
+        ``response.output=None`` even though ``response.output_item.done``
+        already carried the real message item. The OpenAI SDK then raises
+        ``TypeError: 'NoneType' object is not iterable`` from
+        ``stream.get_final_response()``. Hermes must recover from the streamed
+        items instead of surfacing the SDK parser failure to the user.
+        """
+        from run_agent import AIAgent
+
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="Hello from Codex!")],
+        )
+        completed_response = SimpleNamespace(
+            output=None,
+            status="completed",
+            usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        )
+
+        mock_stream = MagicMock()
+        mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+        mock_stream.__exit__ = MagicMock(return_value=False)
+        mock_stream.__iter__ = MagicMock(return_value=iter([
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(type="response.completed", response=completed_response),
+        ]))
+        mock_stream.get_final_response.side_effect = TypeError("'NoneType' object is not iterable")
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = mock_stream
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        setattr(agent, "api_mode", "codex_responses")
+        agent._interrupt_requested = False
+
+        response = agent._run_codex_stream({}, client=mock_client)
+        output = getattr(response, "output", None)
+
+        assert response is completed_response
+        assert isinstance(output, list)
+        assert output == [message_item]
+
+    def test_codex_stream_recovers_when_sdk_raises_during_iteration(self):
+        """The OpenAI SDK can raise the same ``NoneType`` parser failure while
+        iterating the stream itself, before ``get_final_response()`` is ever
+        called. Hermes should salvage the already-collected output items.
+        """
+        from run_agent import AIAgent
+
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="Hello from Codex!")],
+        )
+
+        class _BrokenIterStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=message_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = _BrokenIterStream()
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        setattr(agent, "api_mode", "codex_responses")
+        agent._interrupt_requested = False
+
+        response = agent._run_codex_stream({}, client=mock_client)
+        output = getattr(response, "output", None)
+
+        assert isinstance(output, list)
+        assert output == [message_item]
+        assert getattr(response, "status", None) is None
+
+    def test_codex_stream_iteration_parse_failure_preserves_item_status_when_no_terminal_response(self):
+        """If only streamed output items survive the SDK parser crash, preserve
+        any item-level status instead of fabricating a bare successful object.
+        """
+        from run_agent import AIAgent
+
+        message_item = SimpleNamespace(
+            type="message",
+            status="incomplete",
+            content=[SimpleNamespace(type="output_text", text="partial")],
+        )
+
+        class _BrokenIterStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=message_item)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = _BrokenIterStream()
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        setattr(agent, "api_mode", "codex_responses")
+        agent._interrupt_requested = False
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert getattr(response, "status", None) == "incomplete"
+
+    def test_codex_stream_iteration_parse_failure_prefers_terminal_event_payload_when_seen(self):
+        """If the SDK trips after we already observed ``response.completed``,
+        Hermes should keep that terminal response so status/usage survive.
+        """
+        from run_agent import AIAgent
+
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="Hello from Codex!")],
+        )
+        terminal_response = SimpleNamespace(
+            output=None,
+            status="incomplete",
+            usage=SimpleNamespace(input_tokens=13, output_tokens=8, total_tokens=21),
+        )
+
+        class _BrokenAfterCompletedStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(type="response.output_item.done", item=message_item)
+                yield SimpleNamespace(type="response.completed", response=terminal_response)
+                raise TypeError("'NoneType' object is not iterable")
+
+            def get_final_response(self):  # pragma: no cover - should not run
+                raise AssertionError("get_final_response should not be called")
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.return_value = _BrokenAfterCompletedStream()
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        setattr(agent, "api_mode", "codex_responses")
+        agent._interrupt_requested = False
+
+        response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response is not None
+        assert response is terminal_response
+        assert response.output == [message_item]
+        assert response.status == "incomplete"
+        assert response.usage.total_tokens == 21
+
     def test_codex_remote_protocol_error_falls_back_to_create_stream(self):
         from run_agent import AIAgent
         import httpx
@@ -944,6 +1138,54 @@ class TestCodexStreamCallbacks:
         )
 
         assert touch_calls.count("receiving stream response") == len(events)
+
+    def test_codex_create_stream_fallback_backfills_none_output_terminal_response(self):
+        """The fallback path iterates raw SSE events directly, so it sees the
+        completed response object before any SDK parsing. When that terminal
+        response carries ``output=None`` the fallback must still stitch in the
+        streamed ``response.output_item.done`` payload instead of returning a
+        broken response that later crashes in normalization.
+        """
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        setattr(agent, "api_mode", "codex_responses")
+
+        message_item = SimpleNamespace(
+            type="message",
+            content=[SimpleNamespace(type="output_text", text="Hello")],
+        )
+        terminal_response = SimpleNamespace(output=None, status="completed")
+        events = [
+            SimpleNamespace(type="response.output_item.done", item=message_item),
+            SimpleNamespace(type="response.completed", response=terminal_response),
+        ]
+
+        class _FakeCreateStream:
+            def __iter__(self_inner):
+                return iter(events)
+
+            def close(self_inner):
+                return None
+
+        mock_client = MagicMock()
+        mock_client.responses.create.return_value = _FakeCreateStream()
+
+        response = agent._run_codex_create_stream_fallback(
+            {"model": "test/model", "instructions": "hi", "input": []},
+            client=mock_client,
+        )
+        output = getattr(response, "output", None)
+
+        assert response is terminal_response
+        assert output == [message_item]
 
 
 class TestAnthropicStreamCallbacks:


### PR DESCRIPTION
## Summary
Urgent bug fix for the ChatGPT Codex / Responses streaming path.

This fixes a live regression where Hermes fails against `https://chatgpt.com/backend-api/codex` with:

`TypeError: 'NoneType' object is not iterable`

Root cause: `openai==2.24.0` can crash while parsing a Codex `responses.stream()` turn when the terminal `response.completed` payload carries `output=None`, even though the real payload already arrived earlier via streamed events (`response.output_item.done`, `response.output_text.delta`, or image partials).

This patch makes Hermes recover from the streamed payload instead of surfacing the SDK parser failure to users.

## What this fixes
- main Codex agent streaming path
- Codex auxiliary client wrapper
- Codex image-generation plugin path
- explicit logging so operators can immediately identify the SDK/parser bug in logs

## Implementation details
- recover from the SDK `NoneType` parser failure both when it happens during iteration and when it happens in `get_final_response()`
- preserve terminal response metadata (`status`, `usage`) when a terminal event payload was already observed
- backfill/synthesize output from streamed items or text deltas when possible
- keep partial image previews on the image-generation path instead of dropping them
- add regression coverage for the broken cases

## Reproduction
Live repro against a real Codex-authenticated environment before this patch:
- `hermes chat -q 'hello' --provider openai-codex -m gpt-5.5 -Q`
- failed with `TypeError: 'NoneType' object is not iterable`

After this patch, the same command returns successfully.

## Test plan
Ran:
- `python -m pytest tests/run_agent/test_streaming.py tests/agent/test_auxiliary_client.py tests/plugins/image_gen/test_openai_codex_provider.py -q`
- `hermes chat -q 'hello' --provider openai-codex -m gpt-5.5 -Q`

Targeted suite result locally: 246 passed.

## Why this is urgent
This is a user-facing breakage on a supported provider path (`openai-codex`) that can cause normal replies, auxiliary calls, and image generation to fail. The issue is reproducible against the live backend and blocks regular use.
